### PR TITLE
Sorting tests by due date first and then available date

### DIFF
--- a/frontend/require/app.js
+++ b/frontend/require/app.js
@@ -69,7 +69,7 @@ function(  $,        jqueryCookie,    _,            Backbone,   bootstrap,   Mus
 
     var TestCollection = Backbone.Collection.extend({
         model: TestModel.TestModel,
-        comparator: function(test) {return -(new Date(test.get("availDate"))).getTime();}, // sort by negative time, so later dates first
+        comparator: function(test) {return -(new Date(test.get("dueDate") || test.get("availDate"))).getTime();}, // sort by negative time, so later dates first
     });
 
     var UserModel = Backbone.Model.extend({


### PR DESCRIPTION
In 233 this semester, we've had multiple homeworks released on the same day, so sorting by due date does the right thing and sorting by date available does not. The sort still falls back to the date available in case the due date is not provided.