### PR TITLE
Have SimpleClient broadcast answerChange event

### DIFF
--- a/frontend/require/SimpleClient.js
+++ b/frontend/require/SimpleClient.js
@@ -260,6 +260,7 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
         this.listenTo(this.model, "answerChanged", changeCallback);
         this.questionView = new QuestionView({el: questionDivID, template: this.options.questionTemplate, model: this.model, questionDataModel: questionDataModel, appModel: appModel, params: this.params, submittedAnswer: this.submittedAnswer, trueAnswer: this.trueAnswer, feedback: this.feedback});
         this.listenTo(this.questionView, "renderFinished", function() {that.trigger("renderQuestionFinished");});
+        this.listenTo(this.model, "answerChanged", function() { that.trigger("answerChanged");});
         this.questionView.render();
     };
 


### PR DESCRIPTION
This is useful for client-side JS that wants to track when an answer is changed. (This enables behind-the-scenes processes to be spun up, for example.)