### PR TITLE
Submit unanswered questions on finish test. Closes #193.

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2524,19 +2524,19 @@ var submitUnansweredQuestions = function(req, res, tInstance, test, callback) {
         var qiid = tInstance.qiidsByQid[qid];
         readQInstance(qiid, function(err, qInstance) {
             if (err) return callback("Error reading qInstance with qiid: " + qiid);
-            var submission = {
-                date: new Date(),
-                uid: tInstance.uid,
-                qid: qid,
-                qiid: qiid,
-                vid: tInstance.questionsByQID[qid].vid,
-                submittedAnswer: null,
-                score: 0,
-                trueAnswer: qInstance.trueAnswer
-            };
             newIDNoError(req, res, "sid", function(sid) {
+                var submission = {
+                    sid: sid,
+                    date: new Date(),
+                    uid: tInstance.uid,
+                    qid: qid,
+                    qiid: qiid,
+                    vid: tInstance.questionsByQID[qid].vid,
+                    submittedAnswer: null,
+                    score: 0,
+                    trueAnswer: qInstance.trueAnswer
+                };
                 var tid = tInstance.tid;
-                submission.sid = sid;
                 loadTestServer(tid, function(server) {
                     var uid = submission.uid;
                     try {


### PR DESCRIPTION
Generating blank submissions for each unanswered question gives the client access to the `trueAnswer` attribute for every question. The downside is that we can no longer tell whether a student left a question blank, which is bad for analytics, but this can be easily reintroduced by adding an extra flag to `submissions` to indicate that the question was left unanswered.