### PR TITLE
Only prevent changing the role of superusers

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -445,10 +445,15 @@ var loadCourseInfo = function(callback) {
         courseInfo.title = info.title;
         if (info.userRoles) {
             _(info.userRoles).forEach(function(value, key) {
-                // only add new role if role doesn't currently exist, so we can't overwrite superusers
-                if (!config.roles[key]) {
-                    config.roles[key] = value;
+                if (!PrairieRole.isRoleValid(value)) {
+                    logger.warn("Invalid role '" + value + "' in courseInfo.json; ignoring.");
+                    return;
                 }
+                // Don't allow adding or removing superusers
+                if (config.roles[key] === 'Superuser' || value === 'Superuser') {
+                    return;
+                }
+                config.roles[key] = value;
             });
         }
         courseInfo.gitCourseBranch = config.gitCourseBranch;


### PR DESCRIPTION
I didn't think it was worth it to update the frontend (see the commit message for reasoning); if you think it's needed, I'll go figure out how frontend things work :).

I'm also not a big fan of hardcoding `Superuser`; would something like `PrairieRole.rankToRole(PrairieRole.SUPERUSER)` (or something else) be better?