### PR TITLE
Import require-frontend after reading config

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,6 @@
 var logger = require("./logger");
 var config = require("./config");
 var db = require("./db");
-var courseDB = require("./course-db");
 
 var _ = require("underscore");
 var fs = require("fs");
@@ -24,6 +23,7 @@ if (config.logFilename) {
 }
 
 var requireFrontend = require("./require-frontend");
+var courseDB = require("./course-db");
 var hmacSha256 = require("crypto-js/hmac-sha256");
 var gamma = require("gamma");
 var numeric = require("numeric");


### PR DESCRIPTION
This was a regression caused by e330482 ("split json-load.js and
course-db.js out of server.js"). course-db requires require-frontend,
which sets up the config for requirejs. However, when course-db is
required, config.json hasn't been read yet. As a result, requirejs is
loaded with the default config, which has 'courseDir:
"../exampleCourse"'. This, in turn, breaks course code that uses
"serverCode" and "clientCode".