### PR TITLE
Create initial database during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && rm -f /tmp/s6-overlay-amd64.tar
     && chown -R pl /pl \
     && mv /pl/exampleCourse /course
 
-EXPOSE 3000
-
 COPY docker /
+
+RUN etc/cont-init.d/01-postgres-init
+
+EXPOSE 3000
 
 CMD ["/init"]

--- a/docker/etc/cont-init.d/01-postgres-init
+++ b/docker/etc/cont-init.d/01-postgres-init
@@ -1,11 +1,9 @@
 #!/usr/bin/execlineb -P
 
-with-contenv
-
-import -D /var/lib/postgresql PGDATA
+define PGDATA /var/lib/postgresql
 export PGDATA ${PGDATA}
 
-import -D postgres POSTGRES_USER
+define POSTGRES_USER postgres
 
 ifthenelse { test -f ${PGDATA}/postgresql.conf }
 { echo "Database directory already exists" }

--- a/docker/etc/services.d/postgresql/run
+++ b/docker/etc/services.d/postgresql/run
@@ -1,10 +1,8 @@
 #!/usr/bin/execlineb -P
 
-with-contenv
-
-import -D /var/lib/postgresql PGDATA
+define PGDATA /var/lib/postgresql
 export PGDATA ${PGDATA}
 
-import -D postgres POSTGRES_USER
+define POSTGRES_USER postgres
 
 s6-setuidgid ${POSTGRES_USER} postgres

--- a/docker/etc/services.d/prairielearn/run
+++ b/docker/etc/services.d/prairielearn/run
@@ -1,6 +1,5 @@
 #!/usr/bin/execlineb -P
 
-with-contenv
 cd /pl
 foreground {
     loopwhilex -x 0 foreground { psql -U postgres -c "select 1" -d postgres } sleep 1


### PR DESCRIPTION
This requires not using `with-contenv`, which means that you can't
override PGDATA; however, the container wasn't really designed to do
that anyway.