### PR TITLE
Show all submissions to a question in exam mode

### DIFF
--- a/v2/exampleCourse/courseInstances/Sp15/assessments/pastsubmissions/info.json
+++ b/v2/exampleCourse/courseInstances/Sp15/assessments/pastsubmissions/info.json
@@ -1,0 +1,28 @@
+{
+    "type": "Exam",
+    "title": "Past Submission Testing",
+    "set": "Exam",
+    "number": 1,
+    "allowAccess": [
+        {
+            "mode": "Public",
+            "role": "TA",
+            "credit": 100
+        },
+        {
+            "mode": "Exam",
+            "credit": 100,
+            "startDate": "2014-07-07T23:59:59",
+            "endDate": "2014-07-10T23:59:59"
+        }
+    ],
+    "options": {
+        "zones": [
+            {
+                "questions": [
+                    {"qid": "addVectors", "points": [10,9,7,5,3,1]}
+                ]
+            }
+        ]
+    }
+}

--- a/v2/exampleCourse/courseInstances/Sp15/assessments/v2workingproblems/info.json
+++ b/v2/exampleCourse/courseInstances/Sp15/assessments/v2workingproblems/info.json
@@ -1,6 +1,6 @@
 {
     "type": "Exam",
-    "title": "Past Submission Testing",
+    "title": "PrairieLearn v2 Working Problem Types",
     "set": "Exam",
     "number": 1,
     "allowAccess": [
@@ -19,6 +19,7 @@
     "options": {
         "zones": [
             {
+                "title" : "'Calculation'-type problem",
                 "questions": [
                     {"qid": "addVectors", "points": [10,9,7,5,3,1]}
                 ]

--- a/v2/exampleCourse/questions/addVectors/client.js
+++ b/v2/exampleCourse/questions/addVectors/client.js
@@ -1,4 +1,4 @@
 
-define(["SimpleClient", "text!./question.html", "text!./answer.html"], function(SimpleClient, questionTemplate, answerTemplate) {
-    return new SimpleClient.SimpleClient({questionTemplate: questionTemplate, answerTemplate: answerTemplate});
+define(["SimpleClient", "text!./question.html", "text!./answer.html", "text!./submission.html"], function(SimpleClient, questionTemplate, answerTemplate, submissionTemplate) {
+    return new SimpleClient.SimpleClient({questionTemplate: questionTemplate, answerTemplate: answerTemplate, submissionTemplate: submissionTemplate});
 });

--- a/v2/exampleCourse/questions/addVectors/info.json
+++ b/v2/exampleCourse/questions/addVectors/info.json
@@ -2,6 +2,6 @@
     "title": "Addition of vectors in Cartesian coordinates",
     "topic": "Vectors",
     "tags": ["Numeric"],
-    "clientFiles": ["client.js", "question.html", "answer.html", "fig1.png"],
+    "clientFiles": ["client.js", "question.html", "answer.html", "submission.html", "fig1.png"],
     "type": "Calculation"
 }

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -50,7 +50,7 @@
             
             <% if (showAllSubmissions) { %>
             <div class="panel-group">
-                <% allSubmissions.forEach(function (thisSubmission, sNum, allSubmissions) {
+                <% allSubmissions.forEach(function(thisSubmission, sNum) {
                     if (thisSubmission.correct === null) {
                         submissionLabel = "<span class='label label-primary'>saved, not graded</span>";
                     } else if (thisSubmission.correct) {
@@ -60,7 +60,7 @@
                     } %>
                 <div class="panel panel-info submission-block">
                     <div class="panel-heading">
-                        <h3 class="panel-title">Submission <%= allSubmissions.length - sNum %> <%- submissionLabel %></h3>
+                        <h3 class="panel-title">Submission <%= allSubmissions.length - sNum %> <%- submissionLabel %> (submitted at <%- thisSubmission.formatted_date %>)</h3>
                     </div>
                     <div class="panel-body submission-body" id="submission<%= sNum %>-body">
                     

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -47,6 +47,14 @@
               </div>
             </div>
             <% } %>
+            
+            <% allSubmissionsHtml = "Showing all submissions!"; showAllSubmissions = true; %> <!--- DELETE ME --->
+            
+            <% if (showAllSubmissions) { %>
+            <div class="panel-group">
+               <%- allSubmissionsHtml %>
+            </div>
+            <% } %>
 
           </div> <!-- question-container -->
         </div>

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -50,21 +50,15 @@
             
             <% if (showAllSubmissions) { %>
             <div class="panel-group">
-                <% for (sNum = 0; sNum < allSubmissions.length; sNum++) { 
-                thisSubmission = allSubmissions[sNum]; 
-                if (thisSubmission.correct === null) {
-                    panelType = "panel-info"; 
-                    submissionLabel = "<span class='label label-primary'>saved, not graded</span>"; 
-                }
-                else if (thisSubmission.correct) {
-                    panelType = "panel-success";
-                    submissionLabel = "<span class='label label-success'>correct</span>";
-                }
-                else {
-                    panelType = "panel-danger";
-                    submissionLabel = "<span class='label label-danger'>incorrect</span>";
-                } %>
-                <div class="panel <%= panelType %> submission-block">
+                <% allSubmissions.forEach(function (thisSubmission, sNum, allSubmissions) {
+                    if (thisSubmission.correct === null) {
+                        submissionLabel = "<span class='label label-primary'>saved, not graded</span>";
+                    } else if (thisSubmission.correct) {
+                        submissionLabel = "<span class='label label-success'>correct</span>";
+                    } else {
+                        submissionLabel = "<span class='label label-danger'>incorrect</span>";
+                    } %>
+                <div class="panel panel-info submission-block">
                     <div class="panel-heading">
                         <h3 class="panel-title">Submission <%= allSubmissions.length - sNum %> <%- submissionLabel %></h3>
                     </div>
@@ -72,7 +66,7 @@
                     
                     </div>
                </div>
-               <% } %>
+               <% }); %>
             </div>
             <% } %>
 

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -48,11 +48,33 @@
             </div>
             <% } %>
             
-            <% allSubmissionsHtml = "Showing all submissions!"; %> <!--- DELETE ME --->
+            <% allSubmissionsHtml = "A submission goes here."; // DELETE ME %>
             
             <% if (showAllSubmissions) { %>
             <div class="panel-group">
-               <%- allSubmissionsHtml %>
+                <% for (sNum = 0; sNum < allSubmissions.length; sNum++) { 
+                thisSubmission = allSubmissions[sNum]; 
+                if (thisSubmission.correct === null) {
+                    panelType = "panel-info"; 
+                    submissionLabel = "<span class='label label-primary'>saved, not graded</span>"; 
+                }
+                else if (thisSubmission.correct) {
+                    panelType = "panel-success";
+                    submissionLabel = "<span class='label label-success'>correct</span>";
+                }
+                else {
+                    panelType = "panel-danger";
+                    submissionLabel = "<span class='label label-danger'>incorrect</span>";
+                } %>
+                <div class="panel <%= panelType %> submission-block">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Submission <%= allSubmissions.length - sNum %> <%- submissionLabel %></h3>
+                    </div>
+                    <div class="panel-body submission-body" id="submission<%= sNum %>-body">
+                        <%- allSubmissionsHtml %>
+                    </div>
+               </div>
+               <% } %>
             </div>
             <% } %>
 

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -48,8 +48,6 @@
             </div>
             <% } %>
             
-            <% allSubmissionsHtml = "A submission goes here."; // DELETE ME %>
-            
             <% if (showAllSubmissions) { %>
             <div class="panel-group">
                 <% for (sNum = 0; sNum < allSubmissions.length; sNum++) { 
@@ -71,7 +69,7 @@
                         <h3 class="panel-title">Submission <%= allSubmissions.length - sNum %> <%- submissionLabel %></h3>
                     </div>
                     <div class="panel-body submission-body" id="submission<%= sNum %>-body">
-                        <%- allSubmissionsHtml %>
+                    
                     </div>
                </div>
                <% } %>

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -48,7 +48,7 @@
             </div>
             <% } %>
             
-            <% allSubmissionsHtml = "Showing all submissions!"; showAllSubmissions = true; %> <!--- DELETE ME --->
+            <% allSubmissionsHtml = "Showing all submissions!"; %> <!--- DELETE ME --->
             
             <% if (showAllSubmissions) { %>
             <div class="panel-group">

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -60,7 +60,7 @@
                     } %>
                 <div class="panel panel-info submission-block">
                     <div class="panel-heading">
-                        <h3 class="panel-title">Saved Answer <%= allSubmissions.length - sNum %> <%- submissionLabel %> (submitted at <%- thisSubmission.formatted_date %>)</h3>
+                        <h3 class="panel-title">Saved Answer <%= allSubmissions.length - sNum %> <%- submissionLabel %> (saved at <%- thisSubmission.formatted_date %>)</h3>
                     </div>
                     <div class="panel-body submission-body" id="submission<%= sNum %>-body">
                     

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -17,7 +17,7 @@
 
           <div id="question-0" class="question-container">
             <script type="application/json" class="question-data"><%- questionJson  %></script>
-            
+
             <div class="panel panel-primary question-block">
               <div class="panel-heading">
                 <h3 class="panel-title"><%= instance_question_info.question_number %>. <%= question.title %></h3>
@@ -47,7 +47,7 @@
               </div>
             </div>
             <% } %>
-            
+
             <% if (showAllSubmissions) { %>
             <div class="panel-group">
                 <% allSubmissions.forEach(function(thisSubmission, sNum) {
@@ -63,7 +63,7 @@
                         <h3 class="panel-title">Saved Answer <%= allSubmissions.length - sNum %> <%- submissionLabel %> (saved at <%- thisSubmission.formatted_date %>)</h3>
                     </div>
                     <div class="panel-body submission-body" id="submission<%= sNum %>-body">
-                    
+
                     </div>
                </div>
                <% }); %>
@@ -113,7 +113,7 @@
             <table class="table table-condensed">
               <tbody>
                 <% if (assessment_instance.open) { %>
-                
+
                 <tr>
                   <td>Current value:</td>
                   <td><%= instance_question.current_value %></td>
@@ -132,7 +132,7 @@
                 </tr>
 
                 <% } else { %> <!-- assessment_instance.open -->
-                
+
                 <tr>
                   <td>Number of attempts:</td>
                   <td><%= instance_question.number_attempts %></td>
@@ -175,7 +175,7 @@
             <a class="btn btn-warning" href="#youtubemodal" data-toggle="modal">Help video</a>
           </p>
           <% } %>
-          
+
         </div>
       </div>
     </div>

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -60,7 +60,7 @@
                     } %>
                 <div class="panel panel-info submission-block">
                     <div class="panel-heading">
-                        <h3 class="panel-title">Submission <%= allSubmissions.length - sNum %> <%- submissionLabel %> (submitted at <%- thisSubmission.formatted_date %>)</h3>
+                        <h3 class="panel-title">Saved Answer <%= allSubmissions.length - sNum %> <%- submissionLabel %> (submitted at <%- thisSubmission.formatted_date %>)</h3>
                     </div>
                     <div class="panel-body submission-body" id="submission<%= sNum %>-body">
                     

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.ejs
@@ -58,11 +58,11 @@
                     } else {
                         submissionLabel = "<span class='label label-danger'>incorrect</span>";
                     } %>
-                <div class="panel panel-info submission-block">
+                <div class="panel panel-info pastsubmission-block">
                     <div class="panel-heading">
                         <h3 class="panel-title">Saved Answer <%= allSubmissions.length - sNum %> <%- submissionLabel %> (saved at <%- thisSubmission.formatted_date %>)</h3>
                     </div>
-                    <div class="panel-body submission-body" id="submission<%= sNum %>-body">
+                    <div class="panel-body pastsubmission-body" id="pastsubmission<%= sNum %>-body">
 
                     </div>
                </div>

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
@@ -5,6 +5,7 @@ var async = require('async');
 var csvStringify = require('csv').stringify;
 var express = require('express');
 var router = express.Router();
+var fs = require('fs');
 
 var error = require('../../lib/error');
 var questionServers = require('../../question-servers');
@@ -93,7 +94,8 @@ router.get('/', function(req, res, next) {
         // We can probably combine the previous function with the following one, and eliminate sql.get_submission
         function(callback) {
             res.locals.showAllSubmissions = false;
-            hasSubmissionTemplate = true; // How to test the existence of questionFilePath/submission.html?
+            submissionFilePath = path.join(res.locals.course.path, "questions", res.locals.question.directory, "submission.html");
+            hasSubmissionTemplate = fs.existsSync(submissionFilePath);
             if (hasSubmissionTemplate) {
                 var params = {variant_id: res.locals.variant.id};
                 sqldb.query(sql.get_all_submissions, params, function(err, result) {

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
@@ -94,23 +94,18 @@ router.get('/', function(req, res, next) {
         // We can probably combine the previous function with the following one, and eliminate sql.get_submission
         function(callback) {
             res.locals.showAllSubmissions = false;
-            submissionFilePath = path.join(res.locals.course.path, "questions", res.locals.question.directory, "submission.html");
-            hasSubmissionTemplate = fs.existsSync(submissionFilePath);
-            if (hasSubmissionTemplate) {
-                var params = {variant_id: res.locals.variant.id};
-                sqldb.query(sql.get_all_submissions, params, function(err, result) {
-                    if (ERR(err, callback)) return;
-                    if (result.rowCount >= 1) {
-                        res.locals.showAllSubmissions = true;
-                        res.locals.allSubmissions = [];
-                        for (sNum = 0; sNum < result.rowCount; sNum++) {
-                            res.locals.allSubmissions[sNum] = result.rows[sNum];
-                        }
+            var params = {variant_id: res.locals.variant.id};
+            sqldb.query(sql.get_all_submissions, params, function(err, result) {
+                if (ERR(err, callback)) return;
+                if (result.rowCount >= 1) {
+                    res.locals.showAllSubmissions = true;
+                    res.locals.allSubmissions = [];
+                    for (sNum = 0; sNum < result.rowCount; sNum++) {
+                        res.locals.allSubmissions[sNum] = result.rows[sNum];
                     }
-                    callback(null);
-                });
-            } 
-            else callback(null);
+                }
+                callback(null);
+            });
         },
         function(callback) {
             questionServers.getModule(res.locals.question.type, function(err, qm) {

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
@@ -90,6 +90,26 @@ router.get('/', function(req, res, next) {
                 callback(null);
             });
         },
+        // We can probably combine the previous function with the following one, and eliminate sql.get_submission
+        function(callback) {
+            res.locals.showAllSubmissions = false;
+            hasSubmissionTemplate = true; // How to test the existence of questionFilePath/submission.html?
+            if (hasSubmissionTemplate) {
+                var params = {variant_id: res.locals.variant.id};
+                sqldb.query(sql.get_all_submissions, params, function(err, result) {
+                    if (ERR(err, callback)) return;
+                    if (result.rowCount >= 1) {
+                        res.locals.showAllSubmissions = true;
+                        res.locals.allSubmissions = [];
+                        for (sNum = 0; sNum < result.rowCount; sNum++) {
+                            res.locals.allSubmissions[sNum] = result.rows[sNum];
+                        }
+                    }
+                    callback(null);
+                });
+            } 
+            else callback(null);
+        },
         function(callback) {
             questionServers.getModule(res.locals.question.type, function(err, qm) {
                 if (ERR(err, callback)) return;

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
@@ -99,10 +99,7 @@ router.get('/', function(req, res, next) {
                 if (ERR(err, callback)) return;
                 if (result.rowCount >= 1) {
                     res.locals.showAllSubmissions = true;
-                    res.locals.allSubmissions = [];
-                    for (sNum = 0; sNum < result.rowCount; sNum++) {
-                        res.locals.allSubmissions[sNum] = result.rows[sNum];
-                    }
+                    res.locals.allSubmissions = result.rows;
                 }
                 callback(null);
             });

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.js
@@ -168,6 +168,7 @@ router.get('/', function(req, res, next) {
                 submittedAnswer: res.locals.submission ? res.locals.submission.submitted_answer : null,
                 feedback: (res.locals.showFeedback && res.locals.submission) ? res.locals.submission.feedback : null,
                 trueAnswer: res.locals.showTrueAnswer ? res.locals.variant.true_answer : null,
+                allSubmissions : res.locals.showAllSubmissions ? res.locals.allSubmissions : null,
             });
             res.locals.video = null;
             callback(null);

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.sql
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.sql
@@ -20,7 +20,8 @@ LIMIT 1;
 
 -- BLOCK get_all_submissions
 SELECT
-    s.*
+    s.*,
+    format_date_full_compact(s.date) AS formatted_date
 FROM
     submissions AS s
 WHERE

--- a/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.sql
+++ b/v2/pages/userInstanceQuestionExam/userInstanceQuestionExam.sql
@@ -18,6 +18,15 @@ WHERE
 ORDER BY s.date DESC
 LIMIT 1;
 
+-- BLOCK get_all_submissions
+SELECT
+    s.*
+FROM
+    submissions AS s
+WHERE
+    s.variant_id = $variant_id
+ORDER BY s.date DESC;
+
 -- BLOCK new_submission
 INSERT INTO submissions AS s
     ( variant_id,  auth_user_id,  submitted_answer,  type,  credit,  mode)

--- a/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.ejs
+++ b/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.ejs
@@ -77,6 +77,28 @@
             </div>
             <% } %>
 
+            <% if (showAllSubmissions) { %>
+            <div class="panel-group">
+                <% allSubmissions.forEach(function(thisSubmission, sNum) {
+                    if (thisSubmission.correct === null) {
+                        submissionLabel = "<span class='label label-primary'>saved, not graded</span>";
+                    } else if (thisSubmission.correct) {
+                        submissionLabel = "<span class='label label-success'>correct</span>";
+                    } else {
+                        submissionLabel = "<span class='label label-danger'>incorrect</span>";
+                    } %>
+                <div class="panel panel-info pastsubmission-block">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Saved Answer <%= allSubmissions.length - sNum %> <%- submissionLabel %> (saved at <%- thisSubmission.formatted_date %>)</h3>
+                    </div>
+                    <div class="panel-body pastsubmission-body" id="pastsubmission<%= sNum %>-body">
+
+                    </div>
+               </div>
+               <% }); %>
+            </div>
+            <% } %>
+
           </div> <!-- question-container -->
         </div>
 

--- a/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.ejs
+++ b/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.ejs
@@ -17,7 +17,7 @@
 
           <div id="question-0" class="question-container">
             <script type="application/json" class="question-data"><%- questionJson  %></script>
-            
+
             <div class="panel panel-primary question-block">
               <div class="panel-heading">
                 <h3 class="panel-title"><%= instance_question_info.question_number %>. <%= question.title %></h3>
@@ -164,7 +164,7 @@
             <a class="btn btn-warning" href="#youtubemodal" data-toggle="modal">Help video</a>
           </p>
           <% } %>
-          
+
         </div>
       </div>
     </div>

--- a/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.js
+++ b/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.js
@@ -52,7 +52,7 @@ function getSubmission(variant_id, callback) {
         } else {
             return callback(null, null);
         }
-    });    
+    });
 }
 
 function processSubmission(req, res, callback) {
@@ -126,6 +126,18 @@ function processGet(req, res, variant_id, callback) {
             });
         },
         function(callback) {
+            res.locals.showAllSubmissions = false;
+            var params = {variant_id: res.locals.variant.id};
+            sqldb.query(sql.get_all_submissions, params, function(err, result) {
+                if (ERR(err, callback)) return;
+                if (result.rowCount >= 1) {
+                    res.locals.showAllSubmissions = true;
+                    res.locals.allSubmissions = result.rows;
+                }
+                callback(null);
+            });
+        },
+        function(callback) {
             questionServers.getModule(res.locals.question.type, function(err, qm) {
                 if (ERR(err, callback)) return;
                 questionModule = qm;
@@ -183,6 +195,7 @@ function processGet(req, res, variant_id, callback) {
                 submittedAnswer: (res.locals.showSubmission && res.locals.submission) ? res.locals.submission.submitted_answer : null,
                 feedback: (res.locals.showFeedback && res.locals.submission) ? res.locals.submission.feedback : null,
                 trueAnswer: res.locals.showTrueAnswer ? res.locals.variant.true_answer : null,
+                allSubmissions : res.locals.showAllSubmissions ? res.locals.allSubmissions : null,
             });
             res.locals.video = null;
             callback(null);

--- a/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.sql
+++ b/v2/pages/userInstanceQuestionHomework/userInstanceQuestionHomework.sql
@@ -45,6 +45,16 @@ WHERE
 ORDER BY s.date DESC
 LIMIT 1;
 
+-- BLOCK get_all_submissions
+SELECT
+    s.*,
+    format_date_full_compact(s.date) AS formatted_date
+FROM
+    submissions AS s
+WHERE
+    s.variant_id = $variant_id
+ORDER BY s.date DESC;
+
 -- BLOCK get_variant
 SELECT v.* FROM variants AS v WHERE v.id = $variant_id AND v.available;
 

--- a/v2/public/localscripts/calculationQuestion/SimpleClient.js
+++ b/v2/public/localscripts/calculationQuestion/SimpleClient.js
@@ -297,7 +297,7 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
         this.options = _.defaults(options || {}, {
             questionTemplate: "",
             answerTemplate: "",
-            submissionTemplate: "Submission not shown.",
+            submissionTemplate: "Saved answer not shown.",
             templateTwice: false,
         });
     }

--- a/v2/public/localscripts/calculationQuestion/SimpleClient.js
+++ b/v2/public/localscripts/calculationQuestion/SimpleClient.js
@@ -29,7 +29,7 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
         },
         routine: function(el, value) {
             var _ref;
-            
+
             el = $(el);
             if ((value != null ? value.toString() : void 0) !== ((_ref = el.val()) != null ? _ref.toString() : void 0)) {
                 return el.val(value != null ? value : '');
@@ -248,9 +248,9 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
             this.remove();
         },
     });
-    
+
     var SubmissionView = Backbone.View.extend({
-        
+
         initialize: function() {
             this.questionDataModel = this.options.questionDataModel,
             this.appModel = this.options.appModel,
@@ -260,7 +260,7 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
             this.rivetsBindingsActive = false;
             this.render();
         },
-        
+
         render: function() {
             if (this.rivetsBindingsActive)
                 this.rivetsView.unbind();
@@ -282,16 +282,16 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
             //this.rivetsBindingsActive = true;
             if (window.MathJax)
                 MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-            //this.trigger("renderFinished"); 
+            //this.trigger("renderFinished");
             return this;
         },
-        
+
         close: function() {
             if (this.rivetsBindingsActive)
                 this.rivetsView.unbind();
             this.remove();
         },
-    }); 
+    });
 
     function SimpleClient(options) {
         this.options = _.defaults(options || {}, {
@@ -326,7 +326,7 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
         this.answerView.render();
         this.listenTo(this.answerView, "renderFinished", function() {that.trigger("renderAnswerFinished");});
     };
-    
+
     SimpleClient.prototype.renderSubmission = function(submissionDivID, questionDataModel, appModel, submission, submissionIndex) {
         var that = this;
         this.submissionViews[submissionIndex] = new SubmissionView({el: submissionDivID, template: this.options.submissionTemplate, model: this.model, questionDataModel: questionDataModel, appModel: appModel, params: this.params, thisSubmission: submission.submitted_answer, templateTwice: this.options.templateTwice});

--- a/v2/public/localscripts/calculationQuestion/SimpleClient.js
+++ b/v2/public/localscripts/calculationQuestion/SimpleClient.js
@@ -297,7 +297,7 @@ define(["jquery", "underscore", "backbone", "rivets", "PrairieTemplate"], functi
         this.options = _.defaults(options || {}, {
             questionTemplate: "",
             answerTemplate: "",
-            submissionTemplate: "",
+            submissionTemplate: "Submission not shown.",
             templateTwice: false,
         });
     }

--- a/v2/public/localscripts/question.js
+++ b/v2/public/localscripts/question.js
@@ -9,7 +9,7 @@ $(function() {
         clients[questionContainer.attr('id')] = client;
         client.initialize(questionData, callback);
     };
-    
+
     var render = function(questionContainer) {
         var client = clients[questionContainer.attr('id')];
 

--- a/v2/public/localscripts/question.js
+++ b/v2/public/localscripts/question.js
@@ -17,7 +17,7 @@ $(function() {
         questionContainer.find(".question-data").each(function(i, x) {questionData = JSON.parse(x.innerHTML);});
 
         questionContainer.find(".question-body").each(function(i, x) {client.renderQuestion(x, questionData);});
-        questionContainer.find(".submission-body").each(function(i, x) {client.renderSubmission(x, questionData);});
+        questionContainer.find(".submission-body").each(function(i, x) {client.renderSubmission(x, questionData, i);});
         questionContainer.find(".answer-body").each(function(i, x) {client.renderAnswer(x, questionData);});
     };
 

--- a/v2/public/localscripts/question.js
+++ b/v2/public/localscripts/question.js
@@ -17,7 +17,7 @@ $(function() {
         questionContainer.find(".question-data").each(function(i, x) {questionData = JSON.parse(x.innerHTML);});
 
         questionContainer.find(".question-body").each(function(i, x) {client.renderQuestion(x, questionData);});
-        questionContainer.find(".submission-body").each(function(i, x) {client.renderSubmission(x, questionData, i);});
+        questionContainer.find(".pastsubmission-body").each(function(i, x) {client.renderSubmission(x, questionData, i);});
         questionContainer.find(".answer-body").each(function(i, x) {client.renderAnswer(x, questionData);});
     };
 

--- a/v2/public/localscripts/questionCalculation.js
+++ b/v2/public/localscripts/questionCalculation.js
@@ -62,7 +62,7 @@ CalculationClient.prototype.initialize = function(questionData, callback) {
                 that.qClient.setTrueAnswer(questionData.trueAnswer);
             }
             if (questionData.feedback) {
-                that.qClient.feedback(questionData.feedback);
+                that.qClient.setFeedback(questionData.feedback);
             }
             callback(null);
         });

--- a/v2/public/localscripts/questionCalculation.js
+++ b/v2/public/localscripts/questionCalculation.js
@@ -73,8 +73,8 @@ CalculationClient.prototype.renderQuestion = function(container, questionData) {
     this.qClient.renderQuestion(container, function() {}, this.questionDataModel, this.appModel);
 };
 
-CalculationClient.prototype.renderSubmission = function(container, questionData) {
-    //this.qClient.renderSubmission(container, function() {}, this.questionDataModel, this.appModel);
+CalculationClient.prototype.renderSubmission = function(container, questionData, submissionIndex) {
+    this.qClient.renderSubmission(container, this.questionDataModel, this.appModel, questionData.allSubmissions[submissionIndex], submissionIndex);
 };
 
 CalculationClient.prototype.renderAnswer = function(container, questionData) {


### PR DESCRIPTION
Addresses #255 (and some portion of #29 )

I've left the extra assessment "pastsubmissions" within exampleCourse for testing (the other exams don't load because they include unsupported question types). Once everything checks out, I can make an additional commit to remove the unnecessary assessment.

If you like, I can also combine the two functions in userInstanceQuestionExam.js at lines 84-93 and 95-114, and remove the get_submission BLOCK (lines 11-19) from userInstanceQuestionExam.sql -- getting the most recent submission could be done while getting all the submissions.
