### PR TITLE
Download MathJax as part of the container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 !pages/
 !public/
 public/MathJax
+!public/MathJax/package.json
 !question-servers/
 !schemas/
 !sprocs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !models/
 !pages/
 !public/
+public/MathJax
 !question-servers/
 !schemas/
 !sprocs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,14 @@ RUN yum -y install \
     && mkdir /var/postgres && chown postgres:postgres /var/postgres \
     && su postgres -c "/usr/pgsql-9.6/bin/initdb -D /var/postgres && mkdir /var/postgres/pg_log" \
     && mkdir -p /PrairieLearn/public/MathJax \
-    && curl -L https://github.com/mathjax/MathJax/archive/2.6.0.tar.gz | tar xz --strip-components=1 -C /PrairieLearn/public/MathJax
+    && curl -L https://github.com/mathjax/MathJax/archive/2.6.0.tar.gz | tar xz --strip-components=1 -C /PrairieLearn/public/MathJax \
+    && cp /PrairieLearn/public/MathJax/package.json /tmp/mathjax-dl-package.json
 
 # NOTE: Modify .dockerignore to whitelist files/directories to copy.
 COPY . /PrairieLearn/
 
-RUN chmod +x /PrairieLearn/docker/init.sh \
+RUN diff -q /PrairieLearn/public/MathJax/package.json /tmp/mathjax-dl-package.json >&2 \
+    && chmod +x /PrairieLearn/docker/init.sh \
     && mv /PrairieLearn/docker/config.json /PrairieLearn \
     && mkdir /course \
     && cd /PrairieLearn && npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN yum -y install \
     && yum -y install postgresql96-server postgresql96-contrib nodejs \
     && yum clean all \
     && mkdir /var/postgres && chown postgres:postgres /var/postgres \
-    && su postgres -c "/usr/pgsql-9.6/bin/initdb -D /var/postgres && mkdir /var/postgres/pg_log"
+    && su postgres -c "/usr/pgsql-9.6/bin/initdb -D /var/postgres && mkdir /var/postgres/pg_log" \
+    && mkdir -p /PrairieLearn/public/MathJax \
+    && curl -L https://github.com/mathjax/MathJax/archive/2.6.0.tar.gz | tar xz --strip-components=1 -C /PrairieLearn/public/MathJax
 
 # NOTE: Modify .dockerignore to whitelist files/directories to copy.
 COPY . /PrairieLearn/


### PR DESCRIPTION
This allows us to add public/MathJax to .dockerignore, which speeds up
builds because Docker doesn't have to scan all of MathJax.

On my laptop, this decreased the build time (with `--no-cache`) from ~2:28 to ~1:35; it also makes `docker build` not (appear to) hang when first starting.