### PR TITLE
Fix division by zero in non-exam zero maxPoints assignments

### DIFF
--- a/assessments/homework.sql
+++ b/assessments/homework.sql
@@ -68,7 +68,8 @@ WITH results AS (
     SET
         points = CASE WHEN $correct THEN least(iq.points + iq.current_value, aq.max_points) ELSE iq.points END,
         points_in_grading = 0,
-        score_perc = CASE WHEN $correct THEN least(iq.points + iq.current_value, aq.max_points) / aq.max_points * 100 ELSE iq.score_perc END,
+        score_perc = CASE WHEN $correct THEN least(iq.points + iq.current_value, aq.max_points)
+            / (CASE WHEN aq.max_points > 0 THEN aq.max_points ELSE 1 END) * 100 ELSE iq.score_perc END,
         score_perc_in_grading = 0,
         current_value = CASE WHEN $correct THEN least(iq.current_value + aq.init_points, aq.max_points) ELSE aq.init_points END,
         number_attempts = iq.number_attempts + 1
@@ -93,7 +94,8 @@ INSERT INTO question_score_logs
 UPDATE instance_questions AS iq
 SET
     points_in_grading = least(iq.points + iq.current_value, aq.max_points) - iq.points,
-    score_perc_in_grading = least(iq.points + iq.current_value, aq.max_points) / aq.max_points * 100 - iq.score_perc
+    score_perc_in_grading = least(iq.points + iq.current_value, aq.max_points)
+        / (CASE WHEN aq.max_points > 0 THEN aq.max_points ELSE 1 END) * 100 - iq.score_perc
 FROM
     assessment_questions AS aq
 WHERE

--- a/sprocs/assessment_points_homework.sql
+++ b/sprocs/assessment_points_homework.sql
@@ -40,7 +40,8 @@ BEGIN
     points := least(total_points, max_points);
 
     -- compute the score as a percentage, applying credit bonus/limits
-    score_perc := points / max_points * 100;
+    score_perc := points
+        / (CASE WHEN max_points > 0 THEN max_points ELSE 1 END) * 100;
     IF credit < 100 THEN
         score_perc := least(score_perc, credit);
     ELSIF (credit > 100) AND (points = max_points) THEN
@@ -60,7 +61,8 @@ BEGIN
     total_points_in_grading := max_possible_points - points;
 
     -- compute max achieveable score_perc if all grading points are awarded
-    max_possible_score_perc := max_possible_points / max_points * 100;
+    max_possible_score_perc := max_possible_points
+        / (CASE WHEN max_points > 0 THEN max_points ELSE 1 END) * 100;
     IF credit < 100 THEN
         max_possible_score_perc := least(max_possible_score_perc, credit);
     ELSIF (credit > 100) AND (max_possible_points = max_points) THEN


### PR DESCRIPTION
This fixes division by zero for homeworks/practice exams when maxPoints is set to zero (no credit), done in the same way as the fix for #509.