### PR TITLE
add /ping health check handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,6 +71,8 @@ if (config.devMode) {
     app.use(require('./middlewares/undefCourseCode'));
 }
 
+app.get('/ping', function(req, res, next) {res.send('.');})
+
 // redirect / to /pl
 app.use(/^\/?$/, function(req, res, next) {res.redirect('/pl');});
 


### PR DESCRIPTION
This adds a handler `/ping` which writes a single byte as a response. This should be placed outside of Shib's paths so an external health checker can make sure that the server is still handling requests without simply hitting Shib and "passing" (and this should already be true in our case).

I chose not to use a webhook, as the line to just do it in `server.js` is shorter than making a separate file and requiring it.

`/ping` with `.` is my personal preference, but this can be modified.