### PR TITLE
Fixing pg_diff output truncation

### DIFF
--- a/lib/databaseDiff.js
+++ b/lib/databaseDiff.js
@@ -102,7 +102,7 @@ function diff(db1, db2, options, callback) {
                     const mark = part.added ? '+ ' : part.removed ? '- ' : '  ';
                     let change = part.value.split('\n').join(`\n${mark}`);
                     if (index == 0) {
-                        change = change.slice(1, part.value.length);
+                        change = change.slice(1, change.length);
                     }
                     result += formatText(change, part.added ? colors.green : part.removed ? colors.red : null);
                 });


### PR DESCRIPTION
I was using the wrong string when computing length for a slice operation. Oops!

Fixes #678