### PR TITLE
Implementing basic external grading stats and nightly opsbot summaries

### DIFF
--- a/cron/sendExternalGraderStats.js
+++ b/cron/sendExternalGraderStats.js
@@ -1,0 +1,46 @@
+const ERR = require('async-stacktrace');
+
+const logger = require('../lib/logger');
+const opsbot = require('../lib/opsbot');
+const sqldb = require('../lib/sqldb');
+
+module.exports = {};
+
+module.exports.run = (callback) => {
+    sqldb.call('grading_jobs_stats_day', [], function(err, result) {
+        if (ERR(err, callback)) return;
+        const {
+            count,
+            average_duration,
+            total_duration
+        } = result.rows[0];
+
+        let msg = '_Autograder stats, past 24 hours_\n';
+        msg +=    `Count: *${count}*\n`;
+        msg +=    `Average duration: *${Number(average_duration).toFixed(1)}s*\n`;
+        msg +=    `Total duration: *${Number(total_duration).toFixed(0)}s*\n`;
+
+        opsbot.sendMessage(msg, (err, res, body) => {
+            if (ERR(err, callback)) return;
+            if (res.statusCode != 200) {
+                logger.error('Error posting external grading stats to slack [status code ${res.statusCode}]');
+                logger.error(body);
+            }
+            callback(null);
+        });
+    });
+};
+
+// Both given in ms
+module.exports.shouldRun = (currentTime, cronInterval) => {
+    // Only run if we have a place to send the message
+    if (!opsbot.canSendMessages()) {
+        return false;
+    }
+
+    // Corresponds to 2am UTC (9pm central)
+    const desiredTime = 3 * 60 * 60 * 1000;
+    // Computes time of day in milliseconds since midnight
+    const dayTime = currentTime % (24 * 60 * 60 * 1000);
+    return (desiredTime <= dayTime && dayTime <= desiredTime + cronInterval) || true;
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,6 +23,7 @@ config.cronIntervalMS = 10 * 60 * 1000;
 config.autoFinishAgeMins = 6 * 60;
 config.questionDefaultsDir = 'question-servers/default-calculation';
 config.secretKey = 'THIS_IS_THE_SECRET_KEY'; // override in config.json
+config.secretSlackOpsBotEndpoint = null; // override in config.json
 config.externalGradingUseAws = false;
 config.externalGradingJobsS3Bucket = 'prairielearn.dev.grading.jobs';
 config.externalGradingResultsS3Bucket = 'prairielearn.dev.grading.results';

--- a/lib/opsbot.js
+++ b/lib/opsbot.js
@@ -1,0 +1,28 @@
+const ERR = require('async-stacktrace');
+const request = require('request');
+const config = require('./config');
+
+module.exports = {};
+
+module.exports.canSendMessages = () => {
+    return !!config.secretSlackOpsBotEndpoint;
+};
+
+module.exports.sendMessage = (msg, callback) => {
+    // No-op if there's no url specified
+    if (!module.exports.canSendMessages()) {
+        callback(null);
+    }
+
+    const options = {
+        uri: config.secretSlackOpsBotEndpoint,
+        method: 'POST',
+        json: {
+            text: msg
+        }
+    };
+    request(options, (err, res, body) => {
+        if (ERR(err, callback)) return;
+        callback(null, res, body);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "mongodb": "2.2.x",
         "numeric": "1.2.x",
         "pg": "6.1.x",
+        "request": "2.81.x",
         "requirejs": "2.3.x",
         "s3-upload-stream": "1.0.x",
         "serve-favicon": "2.3.x",

--- a/pages/courseOverview/courseOverview.ejs
+++ b/pages/courseOverview/courseOverview.ejs
@@ -31,7 +31,7 @@
           </tbody>
         </table>
       </div>
-      
+
       <!-------------------------------------------------------------------------------->
       <!-------------------------------------------------------------------------------->
       <!-------------------------------------------------------------------------------->
@@ -151,6 +151,45 @@
             <% }); %>
           </tbody>
         </table>
+      </div>
+
+      <!-------------------------------------------------------------------------------->
+      <!-------------------------------------------------------------------------------->
+      <!-------------------------------------------------------------------------------->
+      <!-- External Grading ------------------------------------------------------------>
+
+      <div class="panel panel-primary">
+        <div class="panel-heading">
+          <h3 class="panel-title">External grading</h3>
+        </div>
+        <div class="panel-body">
+          <% if (external_grading_stats_all.total > 0) { %>
+          <div>
+            <ul class="nav nav-pills" role="tablist" style="margin-bottom: 15px;">
+              <li role="presentation" class="active"><a href="#external-day" role="tab" data-toggle="tab">Past day</a></li>
+              <li role="presentation"><a href="#external-week" role="tab" data-toggle="tab">Past week</a></li>
+              <li role="presentation"><a href="#external-all" role="tab" data-toggle="tab">All time</a></li>
+            </ul>
+            <div class="tab-content">
+              <div role="tabpanel" class="tab-pane active" id="external-day">
+                <%- include('../partials/externalGradingOverview', {stats: external_grading_stats_day}); %>
+              </div>
+              <div role="tabpanel" class="tab-pane" id="external-week">
+                <%- include('../partials/externalGradingOverview', {stats: external_grading_stats_week}); %>
+              </div>
+              <div role="tabpanel" class="tab-pane" id="external-all">
+                <%- include('../partials/externalGradingOverview', {stats: external_grading_stats_all}); %>
+              </div>
+            </div>
+          </div>
+          <a class="btn btn-primary pull-right" onclick="alert('External grading dashboard coming soon!')">
+            External grading dashboard <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+          </a>
+          <% } else { %>
+            It looks like your course doesn't have any externally graded questions yet.
+            Why not <a href="http://prairielearn.readthedocs.io/en/latest/externalGrading/">add one now</a>?
+          <% } %>
+        </div>
       </div>
 
       <!-------------------------------------------------------------------------------->

--- a/pages/courseOverview/courseOverview.sql
+++ b/pages/courseOverview/courseOverview.sql
@@ -37,14 +37,125 @@ select_tags AS (
         tags AS tag
     WHERE
         tag.course_id = $course_id
+),
+select_grading_jobs AS (
+    SELECT
+        gj.*
+    FROM
+        grading_jobs AS gj
+        JOIN submissions AS s ON (s.id = gj.submission_id)
+        JOIN variants AS v ON (v.id = s.variant_id)
+        JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+        JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+        JOIN assessments AS a ON (a.id = ai.assessment_id)
+        JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+    WHERE
+        ci.id = $course_id
+),
+select_grading_jobs_day AS (
+    SELECT *
+    FROM select_grading_jobs
+    WHERE grading_requested_at >= NOW() - '1 day'::INTERVAL
+),
+select_grading_jobs_week AS (
+    SELECT *
+    FROM select_grading_jobs
+    WHERE grading_requested_at >= NOW() - '1 week'::INTERVAL
+),
+select_grading_jobs_stats_day_all AS (
+    SELECT
+        COUNT(id) AS total
+    FROM
+        select_grading_jobs_day
+),
+select_grading_jobs_stats_day_completed AS (
+    SELECT
+        COUNT(id) AS completed,
+        AVG(EXTRACT(EPOCH FROM (graded_at - grading_requested_at))) AS duration
+    FROM
+        select_grading_jobs_day
+    WHERE
+        graded_at IS NOT NULL
+),
+select_grading_jobs_stats_day AS (
+    SELECT row_to_json(row) AS stats
+    FROM (
+        SELECT
+            select_grading_jobs_stats_day_all.total,
+            select_grading_jobs_stats_day_completed.completed,
+            select_grading_jobs_stats_day_completed.duration
+        FROM
+            select_grading_jobs_stats_day_all,
+            select_grading_jobs_stats_day_completed
+    ) row
+),
+select_grading_jobs_stats_week_all AS (
+    SELECT
+        COUNT(id) AS total
+    FROM
+        select_grading_jobs_week
+),
+select_grading_jobs_stats_week_completed AS (
+    SELECT
+        COUNT(id) AS completed,
+        AVG(EXTRACT(EPOCH FROM (graded_at - grading_requested_at))) AS duration
+    FROM
+        select_grading_jobs_week
+    WHERE
+        graded_at IS NOT NULL
+),
+select_grading_jobs_stats_week AS (
+    SELECT row_to_json(row) AS stats
+    FROM (
+        SELECT
+            select_grading_jobs_stats_week_all.total,
+            select_grading_jobs_stats_week_completed.completed,
+            select_grading_jobs_stats_week_completed.duration
+        FROM
+            select_grading_jobs_stats_week_all,
+            select_grading_jobs_stats_week_completed
+    ) row
+),
+select_grading_jobs_stats_all_all AS (
+    SELECT
+        COUNT(id) AS total
+    FROM
+        select_grading_jobs
+),
+select_grading_jobs_stats_all_completed AS (
+    SELECT
+        COUNT(id) AS completed,
+        AVG(EXTRACT(EPOCH FROM (graded_at - grading_requested_at))) AS duration
+    FROM
+        select_grading_jobs
+    WHERE
+        graded_at IS NOT NULL
+),
+select_grading_jobs_stats_all AS (
+    SELECT row_to_json(row) AS stats
+    FROM (
+        SELECT
+            select_grading_jobs_stats_all_all.total,
+            select_grading_jobs_stats_all_completed.completed,
+            select_grading_jobs_stats_all_completed.duration
+        FROM
+            select_grading_jobs_stats_all_all,
+            select_grading_jobs_stats_all_completed
+    ) row
 )
 SELECT
     select_course_users.course_users,
     select_assessment_sets.assessment_sets,
     select_topics.topics,
-    select_tags.tags
+    select_tags.tags,
+    select_grading_jobs_stats_day.stats AS external_grading_stats_day,
+    select_grading_jobs_stats_week.stats AS external_grading_stats_week,
+    select_grading_jobs_stats_all.stats AS external_grading_stats_all
 FROM
     select_course_users,
     select_assessment_sets,
     select_topics,
-    select_tags;
+    select_tags,
+    select_grading_jobs_stats_day,
+    select_grading_jobs_stats_week,
+    select_grading_jobs_stats_all;

--- a/pages/partials/externalGradingOverview.ejs
+++ b/pages/partials/externalGradingOverview.ejs
@@ -1,0 +1,5 @@
+<ul class="list-group">
+  <li class="list-group-item"><b>Total jobs:</b> <%- stats.total %></li>
+  <li class="list-group-item"><b>Completed jobs:</b> <%- stats.completed %></li>
+  <li class="list-group-item"><b>Average duration:</b> <%- (stats.duration && Number(stats.duration).toFixed(1) + 's') || 'N/A' %></li>
+</ul>

--- a/sprocs/grading_jobs_stats_day.sql
+++ b/sprocs/grading_jobs_stats_day.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION
+    grading_jobs_stats_day()
+    RETURNS TABLE(count bigint, average_duration real, total_duration real) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        COUNT(*)::bigint AS count,
+        AVG(EXTRACT(EPOCH FROM (graded_at - grading_requested_at)))::real AS average_duration,
+        SUM(EXTRACT(EPOCH FROM (graded_at - grading_requested_at)))::real AS total_duration
+    FROM
+        grading_jobs
+    WHERE
+        grading_requested_at >= NOW() - '1 day'::INTERVAL;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/sprocs/index.js
+++ b/sprocs/index.js
@@ -74,6 +74,7 @@ module.exports = {
             'config_select.sql',
             'users_select_or_insert.sql',
             'dump_to_csv.sql',
+            'grading_jobs_stats_day.sql'
         ], function(filename, callback) {
             logger.verbose('Loading ' + filename);
             fs.readFile(path.join(__dirname, filename), 'utf8', function(err, sql) {


### PR DESCRIPTION
Initial work on an external grading dashboard. I'm planning on merging all work on this into `external-grading-dashboard` before ultimately merging that into master so I can avoid shipping half-finished things, but I'm open to rolling these changes out piecemeal if the functionality would be useful right now.

* Adds basic external grading stats (from past day, week, and forever) to course overview pages
  * Total jobs, completed jobs, average duration (_What other useful aggregate stats should we offer? How else can we group these stats?_)
* Modifies our "cron" module to run jobs on startup, which made debugging easier. This may or may not be desirable to keep around in production.
* Extends the "cron" module to support jobs that run conditionally based on current time and cron period
  * This lets us support jobs that only run once a day, which is important for...
* Adds a cronjob that sends nightly summaries of external grader usage for that day

I'm particularly interested in feedback on my new queries, as I'm still pretty new to this SQL stuff :smile: 

This will require a PR to `ansible-pl` to add the new `secretSlackOpsBotEndpoint` to the production `config.json`.