### PR TITLE
Format matches comparison method

### DIFF
--- a/exampleCourse/questions/multiplyTwoMatrices/question.html
+++ b/exampleCourse/questions/multiplyTwoMatrices/question.html
@@ -3,12 +3,12 @@
 Two matrices $A$ and $B$ are given in MATLAB format as follows:
 </p>
 <pl_matrix_output>
-    <variable name="A">A</variable>
-    <variable name="B">B</variable>
+    <variable params_name="A">A</variable>
+    <variable params_name="B">B</variable>
 </pl_matrix_output>
 <p>
 Find the product of these two matrices and express it in MATLAB format:
 </p>
 </pl_question_panel>
 
-<pl_matrix_input name="C" points="1" comparison="sigfig" digits="3" label="$AB=$" />
+<pl_matrix_input answers_name="C" points="1" comparison="sigfig" digits="3" label="$AB=$" />

--- a/exampleCourse/questions/multiplyTwoMatrices/server.py
+++ b/exampleCourse/questions/multiplyTwoMatrices/server.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def get_data(data, options):
+def get_data(data):
 
     # Dimensions
     nInnerMin = 2
@@ -25,6 +25,6 @@ def get_data(data, options):
     # Modify data and return
     data["params"]["A"] = A.tolist()
     data["params"]["B"] = B.tolist()
-    data["true_answer"]["C"] = C.tolist()
+    data["correct_answers"]["C"] = C.tolist()
 
     return data

--- a/exampleCourse/questions/multiplyTwoNumbers/question.html
+++ b/exampleCourse/questions/multiplyTwoNumbers/question.html
@@ -11,6 +11,6 @@ The product of ${{params.a}}$ and ${{params.b}}$ is
 Find the sum of $a={{params.a}}$ and $b={{params.b}}$:
 </p>
 </pl_question_panel>
-<pl_number_input name="d" points="1" comparison="relabs" digits="3" display="block" label="$a+b=$" suffix="units"/>
+<pl_number_input name="d" points="1" comparison="relabs" rtol="1e-3" atol="1e-5" display="block" label="$a+b=$" suffix="units"/>
 
 <pl_variable_score name="d" />

--- a/exampleCourse/questions/multiplyTwoNumbers/question.html
+++ b/exampleCourse/questions/multiplyTwoNumbers/question.html
@@ -1,6 +1,6 @@
 <p>
 The product of ${{params.a}}$ and ${{params.b}}$ is
-<pl_number_input name="c" points="1" comparison="sigfig" digits="3" display="inline" />
+<pl_number_input answers_name="c" points="1" comparison="sigfig" digits="3" display="inline" />
 . <pl_variable_score name="c" />
 </p>
 
@@ -11,6 +11,6 @@ The product of ${{params.a}}$ and ${{params.b}}$ is
 Find the sum of $a={{params.a}}$ and $b={{params.b}}$:
 </p>
 </pl_question_panel>
-<pl_number_input name="d" points="1" comparison="relabs" rtol="1e-3" atol="1e-5" display="block" label="$a+b=$" suffix="units"/>
+<pl_number_input answers_name="d" points="1" comparison="relabs" rtol="1e-3" atol="1e-5" display="block" label="$a+b=$" suffix="units"/>
 
 <pl_variable_score name="d" />

--- a/exampleCourse/questions/multiplyTwoNumbers/server.py
+++ b/exampleCourse/questions/multiplyTwoNumbers/server.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def get_data(data, options):
+def get_data(data):
     # Maximum number of digits after the decimal
     nDigits = 1
 
@@ -23,7 +23,7 @@ def get_data(data, options):
     # Modify data and return
     data["params"]["a"] = a
     data["params"]["b"] = b
-    data["true_answer"]["c"] = c
-    data["true_answer"]["d"] = d
+    data["correct_answers"]["c"] = c
+    data["correct_answers"]["d"] = d
 
     return data

--- a/exampleCourse/questions/positionTimeGraph/question.html
+++ b/exampleCourse/questions/positionTimeGraph/question.html
@@ -3,7 +3,7 @@
     An object's motion is described by the position-time graph below.
   </p>
 
-  <pl_figure name="graph.png" />
+  <pl_figure file_name="graph.png" />
 </pl_question_panel>
 
 <pl_question_panel><hr></pl_question_panel>
@@ -44,7 +44,7 @@
 <p>4. <pl_question_panel>What is the average velocity of the object during the time interval from $t = 0\rm\ s$ to $t = 5\rm\ s$?
     <p>
   </pl_question_panel>
-  $v_{\rm avg} = $ <pl_number_input name="v_avg" true_answer="0.8" comparison="sigfig" digits="2" weight="1"/> $\rm\ m/s$
+  $v_{\rm avg} = $ <pl_number_input answers_name="v_avg" true_answer="0.8" comparison="sigfig" digits="2" weight="1"/> $\rm\ m/s$
 <pl_variable_score name="v_avg" />
 
 <pl_question_panel><hr></pl_question_panel>

--- a/question-servers/elements/pl_figure.py
+++ b/question-servers/elements/pl_figure.py
@@ -10,7 +10,7 @@ def render(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get file name or raise exception if one does not exist
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "file_name")
 
     # Get base directory or raise exception if one does not exist
     # FIXME: put client_files_question_url at top level in options?

--- a/question-servers/elements/pl_matrix_input.py
+++ b/question-servers/elements/pl_matrix_input.py
@@ -11,7 +11,7 @@ def prepare(element_html, element_index, data):
 
 def render(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
     label = pl.get_string_attrib(element,"label",None)
 
     if data["panel"] == "question":
@@ -97,7 +97,7 @@ def parse(element_html, element_index, data):
     # By convention, this function returns at the first error found
 
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
 
     # Get submitted answer or return parse_error if it does not exist
     a_sub = data["submitted_answers"].get(name,None)
@@ -120,7 +120,7 @@ def parse(element_html, element_index, data):
 
 def grade(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
 
     # Get weight
     weight = pl.get_integer_attrib(element, "weight", 1)

--- a/question-servers/elements/pl_matrix_input.py
+++ b/question-servers/elements/pl_matrix_input.py
@@ -64,8 +64,25 @@ def render(element_html, element_index, data):
         if a_tru is not None:
             a_tru = np.array(a_tru)
 
+            # Get comparison parameters
+            comparison = pl.get_string_attrib(element, "comparison","relabs")
+            if comparison=="relabs":
+                rtol = pl.get_float_attrib(element,"rtol",1e-5)
+                atol = pl.get_float_attrib(element,"atol",1e-8)
+                # FIXME: render correctly with respect to rtol and atol
+                a_tru = pl.numpy_to_matlab(a_tru,ndigits=12,wtype='g')
+            elif comparison=="sigfig":
+                digits = pl.get_integer_attrib(element,"digits",2)
+                a_tru = pl.numpy_to_matlab_sf(a_tru,ndigits=digits)
+            elif comparison=="decdig":
+                digits = pl.get_integer_attrib(element,"digits",2)
+                a_tru = pl.numpy_to_matlab(a_tru,ndigits=digits,wtype='f')
+            else:
+                raise ValueError('method of comparison "%s" is not valid (must be "relabs", "sigfig", or "decdig")' % comparison)
+
+
             # FIXME: render correctly with respect to method of comparison
-            html_params = {'answer': True, 'label': label, 'a_tru': pl.numpy_to_matlab(a_tru,ndigits=12,wtype='g')}
+            html_params = {'answer': True, 'label': label, 'a_tru': a_tru}
             with open('pl_matrix_input.mustache','r') as f:
                 html = chevron.render(f,html_params).strip()
         else:

--- a/question-servers/elements/pl_matrix_input.py
+++ b/question-servers/elements/pl_matrix_input.py
@@ -52,7 +52,7 @@ def render(element_html, element_index, data):
             a_sub = np.array(data["submitted_answers"][name])
             html_params['a_sub'] = pl.numpy_to_matlab(a_sub,ndigits=12,wtype='g')
         else:
-            raw_submitted_answer = data["raw_submitted_answer"].get(name, None)
+            raw_submitted_answer = data["raw_submitted_answers"].get(name, None)
             if raw_submitted_answer is not None:
                 html_params['raw_submitted_answer'] = escape(raw_submitted_answer)
         with open('pl_matrix_input.mustache','r') as f:

--- a/question-servers/elements/pl_matrix_output.py
+++ b/question-servers/elements/pl_matrix_output.py
@@ -10,7 +10,7 @@ def render(element_html, element_index, data):
     html = "<pre>\n"
     for child in element:
         if child.tag == "variable":
-            var_name = pl.get_string_attrib(child, "name")
+            var_name = pl.get_string_attrib(child, "params_name")
             var_data = data["params"].get(var_name,None)
             if var_data is None:
                 raise Exception('No value in data["params"] for variable %s in matrix_output element' % var_name)

--- a/question-servers/elements/pl_number_input.py
+++ b/question-servers/elements/pl_number_input.py
@@ -6,7 +6,7 @@ import prairielearn as pl
 
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
 
     correct_answer = pl.get_float_attrib(element, "correct_answer", None)
     if correct_answer is not None:
@@ -18,7 +18,7 @@ def prepare(element_html, element_index, data):
 
 def render(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
     label = pl.get_string_attrib(element,"label",None)
     suffix = pl.get_string_attrib(element,"suffix",None)
     display = pl.get_string_attrib(element,"display","inline")
@@ -106,7 +106,7 @@ def render(element_html, element_index, data):
 
 def parse(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
 
     # Get submitted answer or return parse_error if it does not exist
     a_sub = data["submitted_answers"].get(name,None)
@@ -125,7 +125,7 @@ def parse(element_html, element_index, data):
 
 def grade(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
-    name = pl.get_string_attrib(element, "name")
+    name = pl.get_string_attrib(element, "answers_name")
 
     # Get weight
     weight = pl.get_integer_attrib(element, "weight", 1)

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -1,4 +1,5 @@
 import lxml.html
+import to_precision
 import numpy as np
 
 def inner_html(element):
@@ -120,6 +121,30 @@ def numpy_to_matlab(A,ndigits=2,wtype='f'):
         for i in range(0,m):
             for j in range(0,n):
                 A_str += '{:.{indigits}{iwtype}}'.format(A[i,j],indigits=ndigits,iwtype=wtype)
+                if j==n-1:
+                    if i==m-1:
+                        A_str += '];'
+                    else:
+                        A_str += '; '
+                else:
+                    A_str += ' '
+        return A_str
+
+# This function assumes that A is either a floating-point number or a
+# real-valued numpy array. It returns A as a MATLAB-formatted string
+# in which each entry has ndigits significant digits.
+def numpy_to_matlab_sf(A,ndigits=2):
+    if np.isscalar(A):
+        A_str = to_precision.to_precision(A,ndigits)
+        return A_str
+    else:
+        s = A.shape
+        m = s[0]
+        n = s[1]
+        A_str = '['
+        for i in range(0,m):
+            for j in range(0,n):
+                A_str += to_precision.to_precision(A[i,j],ndigits)
                 if j==n-1:
                     if i==m-1:
                         A_str += '];'

--- a/question-servers/freeformPythonLib/to_precision.py
+++ b/question-servers/freeformPythonLib/to_precision.py
@@ -1,0 +1,196 @@
+__author__ = 'William Rusnack github.com/BebeSparkelSparkel linkedin.com/in/williamrusnack williamrusnack@gmail.com'
+
+import math
+
+
+def to_precision(value, precision, notation='auto', filler='e'):
+  '''
+  converts a value to the specified notation and precision
+  value - any type that can be converted to a float
+  predision - integer that is greater than zero
+  notation - string
+    'auto' - selects standard notation when -1000 < value < 1000 else returns scientific notation
+    'sci' or 'scientific' - returns scientific notation
+      ref: https://www.mathsisfun.com/numbers/scientific-notation.html
+    'eng' or 'engineering' - returns engineering notation
+      ref: http://www.mathsisfun.com/definitions/engineering-notation.html
+    'std' or 'standard' - returns standard notation
+      ref: http://www.mathsisfun.com/definitions/standard-notation.html
+  '''
+  value = float(value)
+
+  if notation == 'auto':
+    if -1000 < value < 1000:
+      converter = std_notation
+    else:
+      converter = sci_notation
+
+  elif notation in ('sci', 'scientific'):
+    converter = sci_notation
+
+  elif notation in ('eng', 'engineering'):
+    converter = eng_notation
+
+  elif notation in ('std', 'standard'):
+    converter = std_notation
+
+  else:
+    raise ValueError('Unknown notation: ' + str(notation))
+
+  return converter(value, precision, filler)
+
+
+def std_notation(value, precision, extra=None):
+  '''
+  standard notation (US version)
+  ref: http://www.mathsisfun.com/definitions/standard-notation.html
+
+  returns a string of value with the proper precision
+
+  ex:
+    std_notation(5, 2) => 5.0
+    std_notation(5.36, 2) => 5.4
+    std_notation(5360, 2) => 5400
+    std_notation(0.05363, 3) => 0.0536
+
+    created by William Rusnack
+      github.com/BebeSparkelSparkel
+      linkedin.com/in/williamrusnack/
+      williamrusnack@gmail.com
+  '''
+  sig_digits, power, is_neg = _number_profile(value, precision)
+
+  return ('-' if is_neg else '') + _place_dot(sig_digits, power)
+
+
+def sci_notation(value, precision, filler):
+  '''
+  scientific notation
+  ref: https://www.mathsisfun.com/numbers/scientific-notation.html
+
+  returns a string of value with the proper precision and 10s exponent
+  filler is placed between the decimal value and 10s exponent
+
+  ex:
+    sci_notation(123, 1, 'E') => 1E2
+    sci_notation(123, 3, 'E') => 1.23E2
+    sci_notation(.126, 2, 'E') => 1.3E-1
+
+    created by William Rusnack
+      github.com/BebeSparkelSparkel
+      linkedin.com/in/williamrusnack/
+      williamrusnack@gmail.com
+  '''
+  is_neg, sig_digits, dot_power, ten_power = _sci_notation(value, precision)
+
+  return ('-' if is_neg else '') + _place_dot(sig_digits, dot_power) + filler + str(ten_power)
+
+
+def eng_notation(value, precision, filler):
+  '''
+  engineering notation
+  ref: http://www.mathsisfun.com/definitions/engineering-notation.html
+
+  returns a string of value with the proper precision and 10s exponent that is divisable by 3
+  filler is placed between the decimal value and 10s exponent
+
+  ex:
+    sci_notation(123, 1, 'E') => 100E0
+    sci_notation(1230, 3, 'E') => 1.23E3
+    sci_notation(.126, 2, 'E') => 120E-3
+
+  created by William Rusnack
+    github.com/BebeSparkelSparkel
+    linkedin.com/in/williamrusnack/
+    williamrusnack@gmail.com
+  '''
+  is_neg, sig_digits, sci_dot, sci_power = _sci_notation(value, precision)
+
+  eng_power = int(3 * math.floor(sci_power / 3))
+  eng_dot = sci_dot + sci_power - eng_power
+
+  return ('-' if is_neg else '') + _place_dot(sig_digits, eng_dot) + filler + str(eng_power)
+
+
+def _sci_notation(value, precision):
+  '''
+  returns the properties for to construct a scientific notation number
+  used in sci_notation and eng_notation
+
+  created by William Rusnack
+    github.com/BebeSparkelSparkel
+    linkedin.com/in/williamrusnack/
+    williamrusnack@gmail.com
+  '''
+  sig_digits, power, is_neg = _number_profile(value, precision)
+
+  dot_power = -(precision - 1)
+  ten_power = power + precision - 1
+
+  return is_neg, sig_digits, dot_power, ten_power
+
+
+def _place_dot(digits, power):
+  '''
+  places the dot in the correct spot in the digits
+  if the dot is outside the range of the digits zeros will be added
+
+  ex:
+    _place_dot(123, 2) => 12300
+    _place_dot(123, -2) => 1.23
+    _place_dot(123, 3) => 0.123
+    _place_dot(123, 5) => 0.00123
+
+    created by William Rusnack
+      github.com/BebeSparkelSparkel
+      linkedin.com/in/williamrusnack/
+      williamrusnack@gmail.com
+  '''
+  if power > 0:
+    out = digits + '0' * power
+
+  elif power < 0:
+    power = abs(power)
+    precision = len(digits)
+
+    if power < precision:
+      out = digits[:-power] + '.' + digits[-power:]
+
+    else:
+      out = '0.' + '0' * (power - precision) + digits
+
+  else:
+    out = digits + ('.' if digits[-1] == '0' else '')
+
+  return out
+
+
+def _number_profile(value, precision):
+  '''
+  returns:
+    string of significant digits
+    10s exponent to get the dot to the proper location in the significant digits
+    bool that's true if value is less than zero else false
+
+    created by William Rusnack
+      github.com/BebeSparkelSparkel
+      linkedin.com/in/williamrusnack/
+      williamrusnack@gmail.com
+  '''
+  if value == 0:
+    sig_digits = '0' * precision
+    power = -(1 - precision)
+    is_neg = False
+
+  else:
+    if value < 0:
+      value = abs(value)
+      is_neg = True
+    else:
+      is_neg = False
+
+    power = -1 * math.floor(math.log10(value)) + precision - 1
+    sig_digits = str(int(round(abs(value) * 10.0**power)))
+
+  return sig_digits, int(-power), is_neg
+


### PR DESCRIPTION
* In `number_input` and `matrix_input` elements, the correct answer is displayed in a way that better matches the method of comparison (`relabs`, `sigfig`, or `decdig`).
* Also, in element attributes, changes `name` to `params_name`, `answers_name`, or `file_name` as appropriate to be more explicit about the link between HTML and data.