### PR TITLE
Refactor to share results processing code in local dev and production

### DIFF
--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -246,11 +246,78 @@ module.exports = {
     },
 
     /**
+     * Generates an object that can be passed to assessment.processGradingResult.
+     * This function can be passed a parsed results object, or it can be passed a
+     * string or buffer to attempt to parse it and mark the grading job as failed when
+     * parsing fails.
+     *
+     * @param {Object|string} data - The grading results
+     */
+    makeGradingResult(data) {
+        if (typeof data === 'string' || Buffer.isBuffer(data)) {
+            try {
+                data = JSON.parse(data);
+            } catch (e) {
+                return {
+                    gradingId: data.job_id,
+                    grading: {
+                        score: 0,
+                        startTime: null,
+                        endTime: null,
+                        feedback: {
+                            succeeded: false,
+                        },
+                    },
+                };
+            }
+        }
+
+        if (!data.succeeded) {
+            return {
+                gradingId: data.job_id,
+                grading: {
+                    startTime: data.start_time || null,
+                    endTime: data.end_time || null,
+                    score: 0,
+                    feedback: data
+                }
+            };
+        }
+
+        // TODO: once we have better error handling in place, account for these errors
+        /*
+        if (!data.results) {
+            return callback(new Error('results.json did not contain \'results\' object.'));
+        }
+
+        if (typeof data.results.score !== 'number' || Number.isNaN(data.results.score)) {
+            return callback(new Error('Score did not exist or is not a number!'));
+        }
+        */
+
+        let score = 0.0;
+        if (data.results && typeof data.results.score === 'number' && !Number.isNaN(data.results.score)) {
+            score = data.results.score;
+        }
+
+        return {
+            gradingId: data.job_id,
+            grading: {
+                startTime: data.start_time,
+                endTime: data.end_time,
+                score: score,
+                feedback: data
+            }
+        };
+    },
+
+    /**
      * Process the result of an external grading job.
      *
      * @param {Obect} content - The grading job data to process.
      */
     processGradingResult(content) {
+        console.log(content);
         async.series([
             (callback) => {
                 if (!_(content.grading).isObject()) {

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -251,7 +251,7 @@ module.exports = {
      * string or buffer to attempt to parse it and mark the grading job as failed when
      * parsing fails.
      *
-     * @param {Object|string} data - The grading results
+     * @param {Object|string|Buffer} data - The grading results
      */
     makeGradingResult(data) {
         if (typeof data === 'string' || Buffer.isBuffer(data)) {
@@ -317,7 +317,6 @@ module.exports = {
      * @param {Obect} content - The grading job data to process.
      */
     processGradingResult(content) {
-        console.log(content);
         async.series([
             (callback) => {
                 if (!_(content.grading).isObject()) {

--- a/lib/messageQueue.js
+++ b/lib/messageQueue.js
@@ -16,11 +16,8 @@ var path = require('path');
 var os = require('os');
 var Docker = require('dockerode');
 
-module.exports = {
-};
-
-module.exports.init = function(processGradingResult, callback) {
-    module.exports.processGradingResult = processGradingResult;
+module.exports.init = function(assessment, callback) {
+    module.exports.assessment = assessment;
     if (config.externalGradingUseAws) {
         // So, this is terrible, but AWS will look relative to the Node working
         // directory, not the current directory. So aws-config.json should be
@@ -58,7 +55,7 @@ module.exports.sendToGradingQueue = function(grading_job, submission, variant, q
         };
 
         // Send the grade out for processing and display
-        module.exports.processGradingResult(ret);
+        module.exports.assessment.processGradingResult(ret);
         return;
     }
 
@@ -226,62 +223,10 @@ module.exports.sendToGradingQueue = function(grading_job, submission, variant, q
                 fs.readFile(path.join(dir, 'results.json'), (err, data) => {
                     if (ERR(err, callback)) return;
 
-                    // Handle the case where JSON is improperly formed
-                    try {
-                        data = JSON.parse(data);
-                    } catch (e) {
-                        const gradingResult = {
-                            gradingId: grading_job.id,
-                            grading: {
-                                score: 0,
-                                startTime: null,
-                                endTime: null,
-                                feedback: {
-                                    succeeded: false,
-                                },
-                            },
-                        };
-
-                        return callback(null, gradingResult);
-                    }
-
-                    if (!data.succeeded) {
-                        const gradingResult = {
-                            gradingId: data.job_id,
-                            grading: {
-                                startTime: data.start_time || null,
-                                endTime: data.end_time || null,
-                                score: 0,
-                                feedback: data
-                            }
-                        };
-                        return callback(null, gradingResult);
-                    }
-
-                    if (!data.results) {
-                        return callback(new Error('results.json did not contain \'results\' object.'));
-                    }
-
-                    if (typeof data.results.score !== 'number' || Number.isNaN(data.results.score)) {
-                        return callback(new Error('Score did not exist or is not a number!'));
-                    }
-
-                    // TODO move this to somewhere that can be shared with the webhook
-                    const gradingResult = {
-                        gradingId: data.job_id,
-                        grading: {
-                            startTime: data.start_time,
-                            endTime: data.end_time,
-                            score: data.results.score,
-                            feedback: data
-                        }
-                    };
-
-                    return callback(null, gradingResult);
+                    return callback(null, module.exports.assessment.makeGradingResult(data));
                 });
             },
         ], (err, gradingResult) => {
-            //fs.remove(dir)
             if (err) {
                 logger.error(`Error processing external grading job ${grading_job.id}`);
                 logger.error(err);
@@ -299,7 +244,7 @@ module.exports.sendToGradingQueue = function(grading_job, submission, variant, q
             } else {
                 logger.info(`Successfully processed external grading job ${grading_job.id}`);
             }
-            module.exports.processGradingResult(gradingResult);
+            module.exports.assessment.processGradingResult(gradingResult);
         });
     }
 };

--- a/server.js
+++ b/server.js
@@ -380,7 +380,7 @@ if (config.startServer) {
             });
         },
         function(callback) {
-            messageQueue.init(assessment.processGradingResult, function(err) {
+            messageQueue.init(assessment, function(err) {
                 if (ERR(err, callback)) return;
                 callback(null);
             });

--- a/webhooks/grading/grading.js
+++ b/webhooks/grading/grading.js
@@ -11,32 +11,8 @@ var sqlLoader = require('../../lib/sql-loader');
 var sql = sqlLoader.loadSqlEquiv(__filename);
 var externalGradingSocket = require('../../lib/external-grading-socket');
 
-// FIXME move this to lib/assessment.js for better code reuse; pull the nice
-// error-handling logic from messageQueue.js into this function as well
 function processResults(data) {
-    let gradingResult;
-    if (!data.succeeded || !data.results) {
-        gradingResult = {
-            gradingId: data.job_id,
-            grading: {
-                startTime: data.start_time || null,
-                endTime: data.end_time || null,
-                score: 0,
-                feedback: data
-            }
-        };
-    } else {
-        gradingResult = {
-            gradingId: data.job_id,
-            grading: {
-                startTime: data.start_time || null,
-                endTime: data.end_time || null,
-                score: data.results.score,
-                feedback: data
-            }
-        };
-    }
-
+    const gradingResult = assessment.makeGradingResult(data);
     assessment.processGradingResult(gradingResult);
 }
 
@@ -82,7 +58,7 @@ router.post('/', function(req, res, next) {
             };
             new AWS.S3().getObject(params, (err, data) => {
                 if (ERR(err, (err) => logger.error(err))) return;
-                processResults(JSON.parse(data.Body));
+                processResults(data.Body);
             });
         }
 


### PR DESCRIPTION
Sharing code between local dev and production means more consistent behavior, yay!

The one quirk here is there was a cyclical dependency between `assessment.js`, `question.js`, and `messageQueue.js`, which I broke by passing `assessment` to `messageQueue.init`. This could be solved properly by not assigning directly to `module.exports`, but instead assigning to `module.exports.functionNameHere` in all involved modules, but I'm out of time to do that right :)