### PR TITLE
Restructure Dockerfile to reduce churn, improve style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,36 @@
 FROM centos:7
 
-COPY requirements.txt /PrairieLearn/requirements.txt
-
 RUN yum -y install \
-    epel-release \
-    https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm \
-    https://rpm.nodesource.com/pub_7.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
-    && yum -y install postgresql96-server postgresql96-contrib nodejs scipy sympy \
+        epel-release \
+        https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm \
+        https://rpm.nodesource.com/pub_7.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
+        https://centos7.iuscommunity.org/ius-release.rpm \
+    && yum -y install \
+        postgresql96-server \
+        postgresql96-contrib \
+        nodejs \
+        scipy \
+        sympy \
+        python36u \
+        python36u-pip \
     && yum clean all \
     && mkdir /var/postgres && chown postgres:postgres /var/postgres \
     && su postgres -c "/usr/pgsql-9.6/bin/initdb -D /var/postgres && mkdir /var/postgres/pg_log" \
-    && yum install -y https://centos7.iuscommunity.org/ius-release.rpm \
-    && yum install -y python36u python36u-pip \
-    && ln -s /usr/bin/python3.6 /usr/bin/python3 \
-    && python3.6 -m pip install -r /PrairieLearn/requirements.txt
+    && ln -s /usr/bin/python3.6 /usr/bin/python3
+
+# Install Python/NodeJS dependencies before copying code to limit download size
+# when code changes.
+COPY requirements.txt package.json /PrairieLearn/
+RUN python3.6 -m pip install --no-cache-dir -r /PrairieLearn/requirements.txt \
+    && cd /PrairieLearn \
+    && npm install \
+    && npm cache clean
 
 # NOTE: Modify .dockerignore to whitelist files/directories to copy.
 COPY . /PrairieLearn/
 
 RUN chmod +x /PrairieLearn/docker/init.sh \
     && mv /PrairieLearn/docker/config.json /PrairieLearn \
-    && mkdir /course \
-    && cd /PrairieLearn && npm install
+    && mkdir /course
 
 CMD /PrairieLearn/docker/init.sh


### PR DESCRIPTION
The current Docker image incurs a pretty large download whenever code changes, as node dependencies are installed after anything is copied over.

In exchange for an added layer, we can pre-copy `requirements.txt` and `package.json` to install dependencies early, then copy the code later. This pattern is shown in the [Dockerfile best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy) page.

Comparing the two images in total (plj is the new version):
```
REPOSITORY                  TAG                 IMAGE ID            CREATED             SIZE
plj                         latest              efab05904bf6        3 minutes ago       1.27GB
prairielearn/prairielearn   latest              e96445423003        3 days ago          1.54GB
```

The new version is 300MB smaller, mostly due to me moving new yum packages to be installed with the rest, before `yum clean`, and disabling/clearing caches for `pip` and `npm`.

Looking at `docker history` (read from bottom up, as the base layer is at the bottom):
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
e96445423003        3 days ago          /bin/sh -c #(nop)  CMD ["/bin/sh" "-c" "/P...   0B                  
<missing>           3 days ago          /bin/sh -c chmod +x /PrairieLearn/docker/i...   207MB               
<missing>           3 days ago          /bin/sh -c #(nop) COPY dir:b6a6f0e74a97c1e...   20.2MB              
<missing>           3 days ago          /bin/sh -c yum -y install     epel-release...   1.12GB              
<missing>           4 weeks ago         /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop)  LABEL name=CentOS Base ...   0B                  
<missing>           4 weeks ago         /bin/sh -c #(nop) ADD file:63492ba809361c5...   193MB        
```

The 20.2MB layer is added before another 200MB of dependencies. The restructured version looks like:

```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
efab05904bf6        5 minutes ago       /bin/sh -c #(nop)  CMD ["/bin/sh" "-c" "/P...   0B                  
4d6425f79dbf        5 minutes ago       /bin/sh -c chmod +x /PrairieLearn/docker/i...   87B                 
c9fe96b1aeb7        6 minutes ago       /bin/sh -c #(nop) COPY dir:e2535060a42f20f...   20.2MB              
7899ed3e61c4        6 minutes ago       /bin/sh -c python3.6 -m pip install --no-c...   616MB               
4a6fc916a58a        15 minutes ago      /bin/sh -c #(nop) COPY multi:f227bbc6b42af...   1.94kB              
7903cfd6749a        27 minutes ago      /bin/sh -c yum -y install         epel-rel...   437MB               
a8493f5f50ff        4 months ago        /bin/sh -c #(nop)  CMD ["/bin/bash"]            0B                  
<missing>           4 months ago        /bin/sh -c #(nop)  LABEL name=CentOS Base ...   0B                  
<missing>           4 months ago        /bin/sh -c #(nop) ADD file:807143da05d7013...   192MB               
```

So changing code and no dependencies will only make users redownload ~20MB of code (which should be compressed when downloaded from the docker hub).

In addition to the restructure, I reformatted some things and reordered some newer statements that were inconsistent with best practices.