### PR TITLE
File element improvements

### DIFF
--- a/elements/pl_file_editor/pl_file_editor.js
+++ b/elements/pl_file_editor/pl_file_editor.js
@@ -1,7 +1,12 @@
 /* eslint-env browser,jquery */
 /* global ace */
 window.PLFileEditor = function(uuid, options) {
-    this.element = $('#file-editor-' + uuid);
+    var elementId = '#file-editor-' + uuid;
+    this.element = $(elementId);
+    if (!this.element) {
+        throw new Error('File upload element ' + elementId + ' was not found!');
+    }
+
     this.inputElement = this.element.find('input');
     this.editorElement = this.element.find('.editor');
     this.editor = ace.edit(this.editorElement.get(0));

--- a/elements/pl_file_editor/pl_file_editor.py
+++ b/elements/pl_file_editor/pl_file_editor.py
@@ -14,6 +14,10 @@ def prepare(element_html, element_index, data):
     optional_attribs = ['ace_mode', 'ace_theme', 'editor_config_function']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
+    if '_required_file_names' not in data['params']:
+        data['params']['_required_file_names'] = []
+    data['params']['_required_file_names'].append(pl.get_string_attrib(element, 'file_name'))
+
     return data
 
 

--- a/elements/pl_file_preview/info.json
+++ b/elements/pl_file_preview/info.json
@@ -1,0 +1,11 @@
+{
+    "controller": "pl_file_preview.py",
+    "dependencies": {
+        "elementScripts": [
+            "pl_file_preview.js"
+        ],
+        "elementStyles": [
+            "pl_file_preview.css"
+        ]
+    }
+}

--- a/elements/pl_file_preview/info.json
+++ b/elements/pl_file_preview/info.json
@@ -1,9 +1,6 @@
 {
     "controller": "pl_file_preview.py",
     "dependencies": {
-        "elementScripts": [
-            "pl_file_preview.js"
-        ],
         "elementStyles": [
             "pl_file_preview.css"
         ]

--- a/elements/pl_file_preview/pl_file_preview.css
+++ b/elements/pl_file_preview/pl_file_preview.css
@@ -1,0 +1,56 @@
+[id^=file-preview] .file-status-container {
+  display: flex;
+  flex-direction: row;
+}
+
+[id^=file-preview] .file-status-container.has-preview {
+  cursor: pointer;
+}
+
+[id^=file-preview] .file-status-container-left {
+  display: block;
+  justify-self: left;
+  flex: 1;
+}
+
+[id^=file-preview] .file-status-container-right {
+  justify-self: right;
+  align-self: center;
+}
+
+[id^=file-preview] .file-status-icon {
+  margin-right: 10px;
+  transition: all 400ms;
+}
+
+[id^=file-preview] .fa.fa-check-circle {
+  color: #4CAF50;
+}
+
+[id^=file-preview] .file-status {
+  margin-bottom: 0px;
+  font-size: 0.8em;
+  color: #999;
+}
+
+[id^=file-preview] .file-preview-button::before {
+  content: 'Show preview';
+}
+
+[id^=file-preview] .file-status-container:not(.collapsed) .file-preview-button::before {
+  content: 'Hide preview';
+}
+
+[id^=file-preview] .file-preview-icon {
+  margin-left: 10px;
+  transition: all 400ms;
+}
+
+[id^=file-preview] .file-status-container:not(.collapsed) .file-preview-icon {
+  transform: rotateX(180deg);
+}
+
+[id^=file-preview] .file-preview pre {
+  margin-top: 10px;
+  max-height: 200px;
+}

--- a/elements/pl_file_preview/pl_file_preview.js
+++ b/elements/pl_file_preview/pl_file_preview.js
@@ -1,0 +1,5 @@
+/* eslint-env browser,jquery */
+/* global ace */
+window.PLFilePreview = function() {
+
+};

--- a/elements/pl_file_preview/pl_file_preview.js
+++ b/elements/pl_file_preview/pl_file_preview.js
@@ -1,5 +1,0 @@
-/* eslint-env browser,jquery */
-/* global ace */
-window.PLFilePreview = function() {
-
-};

--- a/elements/pl_file_preview/pl_file_preview.mustache
+++ b/elements/pl_file_preview/pl_file_preview.mustache
@@ -1,0 +1,38 @@
+<div id="file-preview-{{uuid}}">
+  {{#errors}}
+  <div class="alert alert-danger"><strong>Error:</strong> {{.}}</div>
+  {{/errors}}
+  <div class="file-upload-status" style="margin-top: 1ex;">
+    <div class="panel panel-default">
+      <div class="panel-heading"><h4 class="panel-title">Files</h4></div>
+      {{#has_files}}
+      <ul class="list-group">
+        {{#files}}
+        <li class="list-group-item" data-file="{{name}}">
+          <div class="file-status-container has-preview collapsed" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}">
+            <div class="file-status-container-left">
+              <i class="file-status-icon fa fa-check-circle" aria-hidden="true"></i>
+              {{name}}
+              <p class="file-status">uploaded</p>
+            </div>
+            <div class="file-status-container-right">
+              <button type="button" class="btn btn-default btn-xs file-preview-button">
+                <span class="file-preview-icon glyphicon glyphicon-chevron-down"></span>
+              </button>
+            </div>
+          </div>
+          <div class="file-preview collapse" id="file-preview-contents-{{uuid}}-{{index}}">
+            <pre><code>{{contents}}</code></pre>
+          </div>
+        </li>
+        {{/files}}
+      </ul>
+      {{/has_files}}
+      {{^has_files}}
+      <div class="panel-body">
+        No files were present in this submission.
+      </div>
+      {{/has_files}}
+    </div>
+  </div>
+</div>

--- a/elements/pl_file_preview/pl_file_preview.py
+++ b/elements/pl_file_preview/pl_file_preview.py
@@ -1,0 +1,61 @@
+import prairielearn as pl
+import lxml.html
+import chevron
+import base64
+
+
+def prepare(element_html, element_index, data):
+    element = lxml.html.fragment_fromstring(element_html)
+    required_attribs = []
+    optional_attribs = []
+    pl.check_attribs(element, required_attribs, optional_attribs)
+
+    return data
+
+
+def render(element_html, element_index, data):
+    if data['panel'] != 'submission':
+        return ''
+
+    html_params = {'uuid': pl.get_uuid()}
+
+    # Fetch the list of required files for this question
+    required_file_names = data['params'].get('_required_file_names', [])
+
+    # Fetch any submitted files
+    submitted_files = data['submitted_answers'].get('_files', [])
+
+    # Check for any missing files
+    submitted_file_names = map(lambda x: x.get('name', ''), submitted_files)
+    missing_files = [x for x in required_file_names if x not in submitted_file_names]
+
+    # Construct an array of errors, including format error from the file input elements
+    errors = data['format_errors'].get('_files', [])
+
+    if len(missing_files) > 0:
+        errors.append('The following required files were missing: {0}'.format(', '.join(missing_files)))
+
+    html_params['errors'] = errors
+
+    # Decode and reshape files into a useful form
+    if len(submitted_files) > 0:
+        files = []
+        for idx, file in enumerate(submitted_files):
+            try:
+                contents = base64.b64decode(file['contents'] or '').decode()
+            except UnicodeDecodeError:
+                contents = 'Unable to decode file.'
+            files.append({
+                'name': file['name'],
+                'contents': contents,
+                'index': idx
+            })
+        html_params['has_files'] = True
+        html_params['files'] = files
+    else:
+        html_params['has_files'] = False
+
+    with open('pl_file_preview.mustache', 'r') as f:
+        html = chevron.render(f, html_params).strip()
+
+    return html

--- a/elements/pl_file_upload/pl_file_upload.js
+++ b/elements/pl_file_upload/pl_file_upload.js
@@ -7,16 +7,15 @@ $(function() {
     }
 });
 
-window.PLFileUpload = function(wrapperId, options) {
-    this.uuid = options.uuid;
+window.PLFileUpload = function(uuid, options) {
+    this.uuid = uuid;
     this.files = options.files || [];
     this.acceptedFiles = options.acceptedFiles || [];
-    this.previewOnly = options.previewOnly || false;
 
-    this.elementId = wrapperId;
-    this.element = $(wrapperId);
+    var elementId = '#file-upload-' + uuid;
+    this.element = $(elementId);
     if (!this.element) {
-        throw new Error('File upload element ' + wrapperId + ' was not found!');
+        throw new Error('File upload element ' + elementId + ' was not found!');
     }
 
     this.syncFilesToHiddenInput();
@@ -150,20 +149,16 @@ window.PLFileUpload.prototype.renderFileList = function() {
         $file.append($fileStatusContainer);
         var $fileStatusContainerLeft = $('<div class="file-status-container-left"></div>');
         $fileStatusContainer.append($fileStatusContainerLeft);
-        if (!that.previewOnly) {
-            if (fileData) {
-                $fileStatusContainerLeft.append('<i class="file-status-icon fa fa-check-circle" aria-hidden="true"></i>');
-            } else {
-                $fileStatusContainerLeft.append('<i class="file-status-icon fa fa-circle-o" aria-hidden="true"></i>');
-            }
+        if (fileData) {
+            $fileStatusContainerLeft.append('<i class="file-status-icon fa fa-check-circle" aria-hidden="true"></i>');
+        } else {
+            $fileStatusContainerLeft.append('<i class="file-status-icon fa fa-circle-o" aria-hidden="true"></i>');
         }
         $fileStatusContainerLeft.append(fileName);
-        if (!that.previewOnly) {
-            if (!fileData) {
-                $fileStatusContainerLeft.append('<p class="file-status">not uploaded</p>');
-            } else {
-                $fileStatusContainerLeft.append('<p class="file-status">uploaded</p>');
-            }
+        if (!fileData) {
+            $fileStatusContainerLeft.append('<p class="file-status">not uploaded</p>');
+        } else {
+            $fileStatusContainerLeft.append('<p class="file-status">uploaded</p>');
         }
         if (fileData) {
             var $preview = $('<div class="file-preview collapse" id="file-preview-' + uuid + '-' + index + '"><pre><code></code></pre></div>');

--- a/elements/pl_file_upload/pl_file_upload.mustache
+++ b/elements/pl_file_upload/pl_file_upload.mustache
@@ -1,4 +1,3 @@
-{{#question}}
 <script>
 $(function() {
   // Turn off Dropzone autodiscover; we'll configure it manually
@@ -14,25 +13,8 @@ $(function() {
   });
 });
 </script>
-{{/question}}
-{{#submission}}
-<script>
-$(function() {
-  var ELEMENT_ID = "#file-upload-{{uuid}}";
-  var UUID = "{{uuid}}";
-
-  new window.PLFileUpload(ELEMENT_ID, {
-    uuid: UUID,
-    previewOnly: true,
-    acceptedFiles: {{&file_names}},
-    files: {{&files}}
-  });
-});
-</script>
-{{/submission}}
 
 <div id="file-upload-{{uuid}}">
-  {{#question}}
   <input type="hidden" name="{{name}}">
   <div class="dropzone">
     <div class="dz-message">
@@ -43,13 +25,6 @@ $(function() {
   </div>
   <div class="messages">
   </div>
-  {{/question}}
-  {{#submission}}
-  {{#parse_error}}
-  <div class="alert alert-danger"><strong>Error:</strong> {{parse_error}}</div>
-  {{/parse_error}}
-  {{/submission}}
-  {{^parse_error}}
   <div class="file-upload-status" style="margin-top: 1ex;">
     <div class="panel panel-default">
       <div class="panel-heading"><h4 class="panel-title">Files</h4></div>
@@ -57,4 +32,4 @@ $(function() {
       </ul>
     </div>
   </div>
-  {{/parse_error}}
+</div>

--- a/elements/pl_file_upload/pl_file_upload.mustache
+++ b/elements/pl_file_upload/pl_file_upload.mustache
@@ -3,11 +3,9 @@ $(function() {
   // Turn off Dropzone autodiscover; we'll configure it manually
   window.Dropzone.autoDiscover = false;
 
-  var ELEMENT_ID = "#file-upload-{{uuid}}";
   var UUID = "{{uuid}}";
 
-  new window.PLFileUpload(ELEMENT_ID, {
-    uuid: UUID,
+  new window.PLFileUpload(UUID, {
     acceptedFiles: {{&file_names}}
     {{#has_files}}, files: {{&files}}{{/has_files}}
   });

--- a/exampleCourse/questions/fibonacciEditor/question.html
+++ b/exampleCourse/questions/fibonacciEditor/question.html
@@ -10,13 +10,24 @@
     Write a Python function <tt>fib</tt> that takes a number <tt>n</tt>
     and returns the n<sup>th</sup> Fibonacci number.
   </p>
-</pl_question_panel>
-
-<pl_file_editor
-  file_name="fib.py"
-  ace_mode="ace/mode/python"
->
+  <pl_file_editor
+    file_name="fib.py"
+    ace_mode="ace/mode/python"
+  >
 def fib(n):
     pass
-</pl_file_editor>
-<pl_external_grader_results></pl_external_grader_results>
+  </pl_file_editor>
+  <pl_file_editor
+    file_name="fib2.py"
+    ace_mode="ace/mode/python"
+  >
+def fib(n):
+    print('Don\'t edit me!')
+    pass
+  </pl_file_editor>
+</pl_question_panel>
+
+<pl_submission_panel>
+  <pl_file_preview />
+  <pl_external_grader_results />
+</pl_submission_panel>

--- a/exampleCourse/questions/fibonacciEditor/question.html
+++ b/exampleCourse/questions/fibonacciEditor/question.html
@@ -17,14 +17,6 @@
 def fib(n):
     pass
   </pl_file_editor>
-  <pl_file_editor
-    file_name="fib2.py"
-    ace_mode="ace/mode/python"
-  >
-def fib(n):
-    print('Don\'t edit me!')
-    pass
-  </pl_file_editor>
 </pl_question_panel>
 
 <pl_submission_panel>

--- a/exampleCourse/questions/fibonacciUpload/question.html
+++ b/exampleCourse/questions/fibonacciUpload/question.html
@@ -7,7 +7,10 @@
     Write a Python function <tt>fib</tt> that takes a number <tt>n</tt>
     and returns the n<sup>th</sup> Fibonacci number.
   </p>
+  <pl_file_upload file_names="fib.py" />
 </pl_question_panel>
 
-<pl_file_upload file_names="fib.py"></pl_file_upload>
-<pl_external_grader_results></pl_external_grader_results>
+<pl_submission_panel>
+  <pl_file_preview />
+  <pl_external_grader_results />
+</pl_submission_panel>


### PR DESCRIPTION
Important changes:

- `pl_file_upload` and `pl_file_editor` now only render in the Question panel. To show the submitted files for a question in a Submission panel, use the new `pl_file_preview` element. This will automatically render and files present in the `_files` submitted answer.
- Support for using any number/combination of `pl_file_upload` and `pl_file_editor` elements on the same page. They will now collaboratively build the `_files` answer and combine any format errors into one array. These files and any errors are displayed by `pl_file_preview`.