### PR TITLE
Fix exploit where students could upload arbitrary files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,6 +44,8 @@
 
   * Fix bug in sigfig method of comparison when correct answer is zero (Tim Bretl).
 
+  * Fix bug in pl_file_upload where students could upload arbitrary files (Nathan Walters).
+
 * __2.10.1__ - 2017-05-24
 
   * Fix display of saved submissions for Exam assessments.

--- a/elements/pl_file_upload/pl_file_upload.py
+++ b/elements/pl_file_upload/pl_file_upload.py
@@ -72,6 +72,7 @@ def render(element_html, element_index, data):
 def parse(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     raw_file_names = pl.get_string_attrib(element, 'file_names', '')
+    required_file_names = get_file_names_as_array(raw_file_names)
     answer_name = get_answer_name(raw_file_names)
 
     # Get submitted answer or return parse_error if it does not exist
@@ -85,6 +86,9 @@ def parse(element_html, element_index, data):
     except ValueError:
         add_format_error(data, 'Could not parse submitted files.')
 
+    # Filter out any files that were not listed in file_names
+    parsed_files = [x for x in parsed_files if x.get('name', '') in required_file_names]
+
     if data['submitted_answers'].get('_files', None) is None:
         data['submitted_answers']['_files'] = parsed_files
     elif isinstance(data['submitted_answers'].get('_files', None), list):
@@ -94,7 +98,6 @@ def parse(element_html, element_index, data):
 
     # Validate that all required files are present
     if parsed_files is not None:
-        required_file_names = get_file_names_as_array(pl.get_string_attrib(element, 'file_names', ''))
         submitted_file_names = map(lambda x: x.get('name', ''), parsed_files)
         missing_files = [x for x in required_file_names if x not in submitted_file_names]
 


### PR DESCRIPTION
A particularly enterprising student could add any files to be uploaded by modifying the json in the hidden input. This strips out any files not present in the `file_names` attribute.