### PR TITLE
Shibboleth redirect path

### DIFF
--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -31,7 +31,7 @@ router.get('/:action?/:target(*)?', function(req, res, next) {
         };
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-        if (req.params.action == 'redirect') return res.redirect(req.params.target);
+        if (req.params.action == 'redirect') return res.redirect('/' + req.params.target);
         res.redirect(res.locals.plainUrlPrefix);
     });
 });

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -6,7 +6,7 @@ var config = require('../../lib/config');
 var csrf = require('../../lib/csrf');
 var sqldb = require('../../lib/sqldb');
 
-router.get('/', function(req, res, next) {
+router.get('/:action?/:target(*)?', function(req, res, next) {
     var authUid = null;
     var authName = null;
     var authUin = null;
@@ -31,7 +31,7 @@ router.get('/', function(req, res, next) {
         };
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-        if (req.query.redirect) return res.redirect(req.query.redirect);
+        if (req.params.action == 'redirect') return res.redirect(req.params.target);
         res.redirect(res.locals.plainUrlPrefix);
     });
 });

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -31,7 +31,7 @@ router.get('/', function(req, res, next) {
         };
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-        if (req.query.redirect) res.redirect(req.query.redirect);
+        if (req.query.redirect) return res.redirect(req.query.redirect);
         res.redirect(res.locals.plainUrlPrefix);
     });
 });

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -31,6 +31,7 @@ router.get('/', function(req, res, next) {
         };
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
+        if (req.query.redirect) res.redirect(req.query.redirect);
         res.redirect(res.locals.plainUrlPrefix);
     });
 });


### PR DESCRIPTION
Allows specifying a URL path to redirect to after verifying shibboleth auth. i.e.

https://pl-dev.engr.illinois.edu/pl/shibcallback/redirect/pl/course_instance/4/instructor/assessment/10/

Needs testing that it survives the single sign on from shibboleth, even if we don't have an active session on PrairieLearn

Branch is active on pl-dev right now if you want to poke at it.