### PR TITLE
Fix external grading results display when score is missing

### DIFF
--- a/elements/pl_external_grader_results/pl_external_grader_results.mustache
+++ b/elements/pl_external_grader_results/pl_external_grader_results.mustache
@@ -1,9 +1,9 @@
 {{#graded}}
 <div class="pl-external-grader-results">
-  {{^succeeded}}
+  {{^grading_succeeded}}
     <h3>UNIDENTIFIED ERROR</h3>
-  {{/succeeded}}
-  {{#succeeded}}
+  {{/grading_succeeded}}
+  {{#grading_succeeded}}
     <h3>Score:
       <span style="color: {{results_color}}"
       {{#points}}
@@ -75,6 +75,6 @@
         </div>
       {{/tests}}
     {{/has_tests}}
-  {{/succeeded}}
+  {{/grading_succeeded}}
 </div>
 {{/graded}}

--- a/elements/pl_external_grader_results/pl_external_grader_results.py
+++ b/elements/pl_external_grader_results/pl_external_grader_results.py
@@ -18,13 +18,14 @@ def render(element_html, element_index, data):
 
         feedback = data['feedback']
         html_params['graded'] = bool(feedback)
-        html_params['succeeded'] = bool(feedback.get('succeeded', None))
+        html_params['grading_succeeded'] = bool(feedback.get('succeeded', None))
 
         results = feedback.get('results', None)
         if results:
-            html_params['score'] = format(results.get('score') * 100, '.2f').rstrip('0').rstrip('.')
-            html_params['achieved_max_points'] = (results['score'] == 1.0)
-            html_params['results_color'] = '#4CAF50' if (results['score'] == 1.0) else '#F44336'
+            html_params['succeeded'] = bool(results.get('succeeded', None))
+            html_params['score'] = format(results.get('score', 0) * 100, '.2f').rstrip('0').rstrip('.')
+            html_params['achieved_max_points'] = (results.get('score', 0) == 1.0)
+            html_params['results_color'] = '#4CAF50' if (results.get('score', 0) == 1.0) else '#F44336'
             html_params['has_message'] = bool(results.get('message', False))
             html_params['message'] = results.get('message', None)
             html_params['has_output'] = bool(results.get('output', False))


### PR DESCRIPTION
This ensures that the results display element won't crash if `score` is missing from the results.