### PR TITLE
add pycryptodome for Python cryptography support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN yum -y install \
         nodejs \
         python36u \
         python36u-pip \
+        gcc \
     && yum clean all \
     && mkdir /var/postgres && chown postgres:postgres /var/postgres \
     && su postgres -c "/usr/pgsql-9.6/bin/initdb -D /var/postgres && mkdir /var/postgres/pg_log" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ lxml==3.8.0
 matplotlib==2.0.2
 numpy==1.13.1
 pandas==0.20.3
+pycryptodome==3.4.7
 scipy==0.19.1
 sympy==1.1.1


### PR DESCRIPTION
For the CS 126 terminal stuff.