### PR TITLE
Add options schema for v3 questions

### DIFF
--- a/schemas/questionOptionsv3.json
+++ b/schemas/questionOptionsv3.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "v3 question options",
+    "description": "Options for a v3 question.",
+    "type": "object",
+    "properties": {
+    }
+}


### PR DESCRIPTION
This was missing, so using options in v3 `info.json` files breaks on sync.