### PR TITLE
jsonify standard types

### DIFF
--- a/exampleCourse/questions/magnitudeOfComplexNumber/info.json
+++ b/exampleCourse/questions/magnitudeOfComplexNumber/info.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "c52e13de-c307-446d-92d1-6b1be10d253a",
+    "title": "Find magnitude of complex number",
+    "topic": "Algebra",
+    "tags": ["tbretl", "fa17", "tpl101", "v3"],
+    "type": "v3"
+}

--- a/exampleCourse/questions/magnitudeOfComplexNumber/question.html
+++ b/exampleCourse/questions/magnitudeOfComplexNumber/question.html
@@ -1,5 +1,16 @@
 <pl_question_panel>
-  <p> What is the magnitude of the complex number ${{params.z}}$? </p>
+    <p>
+        Consider the complex number $z={{params.z_tex}}$.
+    </p>
+    <hr>
+    <pl_matrix_output digits="2">
+        <variable params_name="z">z</variable>
+    </pl_matrix_output>
+    <hr>
+    <p>
+        What is the magnitude of $z$?
+    </p>
+    <hr>
 </pl_question_panel>
 
-<p>$\| {{params.z}} \| = $ <pl_number_input answers_name="zmag" comparison="sigfig" digits="3" />
+<p>$|z| = $ <pl_number_input answers_name="zmag" comparison="sigfig" digits="3" />

--- a/exampleCourse/questions/magnitudeOfComplexNumber/question.html
+++ b/exampleCourse/questions/magnitudeOfComplexNumber/question.html
@@ -1,0 +1,5 @@
+<pl_question_panel>
+  <p> What is the magnitude of the complex number ${{params.z}}$? </p>
+</pl_question_panel>
+
+<p>$\| {{params.z}} \| = $ <pl_number_input answers_name="zmag" comparison="sigfig" digits="3" />

--- a/exampleCourse/questions/magnitudeOfComplexNumber/server.py
+++ b/exampleCourse/questions/magnitudeOfComplexNumber/server.py
@@ -1,0 +1,20 @@
+import random
+
+def generate(data):
+
+    # Sample a non-zero complex number
+    while True:
+        x = round(random.uniform(-10,10),2)
+        y = round(random.uniform(-10,10),2)
+        if (x != 0) or (y != 0):
+            break
+    z = complex(x,y)
+
+    # Compute its magnitude a.k.a. modulus a.k.a. absolute value
+    zmag = abs(z)
+
+    # Add result to params and correct_answers
+    data["params"]["z"] = z
+    data["correct_answers"]["zmag"] = zmag
+    
+    return data

--- a/exampleCourse/questions/magnitudeOfComplexNumber/server.py
+++ b/exampleCourse/questions/magnitudeOfComplexNumber/server.py
@@ -15,6 +15,7 @@ def generate(data):
 
     # Add result to params and correct_answers
     data["params"]["z"] = z
+    data["params"]["z_tex"] = '{:.2f}'.format(z)
     data["correct_answers"]["zmag"] = zmag
-    
+
     return data

--- a/lib/python-caller-trampoline.py
+++ b/lib/python-caller-trampoline.py
@@ -16,6 +16,7 @@
 # Exceptions are not caught and so will trigger a process exit with non-zero exit code (signaling an error)
 
 import sys, os, json, importlib, copy, base64, io, matplotlib
+from python_helper_jsonify import *
 matplotlib.use('PDF')
 
 saved_path = copy.copy(sys.path)
@@ -56,6 +57,9 @@ with open(3, 'w', encoding='utf-8') as outf:
         if hasattr(mod, fcn):
             # call the desired function in the loaded module
             method = getattr(mod, fcn)
+            for arg in args:
+                if isinstance(arg, dict):
+                    decode_from_json(arg)
             val = method(*args)
 
             if fcn=="file":
@@ -72,6 +76,9 @@ with open(3, 'w', encoding='utf-8') as outf:
                 # if this next call does not work, it will throw an error, because
                 # the thing returned by file() does not have the correct format
                 val = base64.b64encode(val).decode()
+            elif isinstance(val, dict):
+                encode_to_json(val)
+
 
             output = {"present": True, "val": val}
         else:

--- a/lib/python_helper_jsonify.py
+++ b/lib/python_helper_jsonify.py
@@ -1,13 +1,71 @@
+import numpy as np
+import sympy
 
+# FIXME: It would be possible to extract a list of variables from a sympy
+# expression or sympy matrix and to encode/decode with these variables as
+# well, using a safe method of conversion via AST and a whitelist as is
+# being done in <pl_symbolic_input>.
+#
+# Here is a security risk. Suppose a student is asked to input a dictionary
+# and they submit the string '{'type': 'sympy', 'value': 'something horrible'}.
+# The result may be to add {'type': 'sympy', 'value': 'something horrible'} as
+# a key-value pair to submitted_answers. When this is decoded on the next call
+# to python-called-trampoline, it will do sympy.sympify('something horrible'),
+# which could indeed result in something horrible.
+#
+# Again, this is only going to happen if the student is allowed to submit
+# arbitrary key-value pairs. We may wish to accept this risk for now.
 
 def encode_to_json(d):
+    """encode_to_json(d)
+
+    Walks through the mutable dict d to replace any value v of standard types
+    with a {'type':..., 'value':...} pair that can be json serialized:
+
+        complex -> 'type': 'complex'
+        non-complex ndarray (assumes each element can be json serialized) -> 'type': 'ndarray'
+        complex ndarray -> 'type': 'complex_ndarray'
+        sympy.Expr (i.e., any scalar sympy expression) -> 'type': 'sympy'
+        sympy.Matrix -> 'type': 'sympy_matrix'
+
+    This function does not try to preserve information like the dtype of an
+    ndarray or the assumptions on variables in a sympy expression.
+    """
     for k, v in d.items():
         if isinstance(v, dict):
             encode_to_json(v)
-        elif isinstance(v, complex):
+        elif np.isscalar(v) and np.iscomplexobj(v):
             d[k] = {'type': 'complex', 'value': {'real': v.real, 'imag': v.imag}}
+        elif isinstance(v, np.ndarray):
+            if np.isrealobj(v):
+                d[k] = {'type': 'ndarray', 'value': v.tolist()}
+            elif np.iscomplexobj(v):
+                d[k] = {'type': 'complex_ndarray', 'value': {'real': v.real.tolist(), 'imag': v.imag.tolist()}}
+        elif isinstance(v, sympy.Expr):
+            d[k] = {'type': 'sympy', 'value': str(d[k])}
+        elif isinstance(v, sympy.Matrix):
+            d[k] = {'type': 'sympy_matrix', 'value': str(d[k])}
 
 def decode_from_json(d):
+    """encode_to_json(d)
+
+    Walks through the mutable dict d to replace any {'type':..., 'value':...}
+    pair with its standard type:
+
+        'type': 'complex' -> complex
+        'type': 'ndarray' -> non-complex ndarray
+        'type': 'complex_ndarray' -> complex ndarray
+        'type': 'sympy' -> sympy.Expr
+        'type': 'sympy_matrix' -> sympy.Matrix
+
+    This function does not try to recover information like the dtype of an
+    ndarray or the assumptions on variables in a sympy expression.
+
+    WARNING: This function uses sympy.sympify to decode type 'sympy' and
+    'sympy_matrix'. This, in turn, uses 'eval'. It is not safe and should not
+    be applied to untrusted input.
+    """
+
     for k, v in d.items():
         if isinstance(v, dict):
             if 'type' in v:
@@ -16,6 +74,26 @@ def decode_from_json(d):
                         d[k] = complex(v['value']['real'], v['value']['imag'])
                     else:
                         raise Exception('variable {:s} of type complex should have value with real and imaginary pair'.format(k))
+                elif v['type'] == 'ndarray':
+                    if ('value' in v):
+                        d[k] = np.array(v['value'])
+                    else:
+                        raise Exception('variable {:s} of type ndarray should have value'.format(k))
+                elif v['type'] == 'complex_ndarray':
+                    if ('value' in v) and ('real' in v['value']) and ('imag' in v['value']):
+                        d[k] = np.array(v['value']['real']) + np.array(v['value']['imag'])*1j
+                    else:
+                        raise Exception('variable {:s} of type complex_ndarray should have value with real and imaginary pair'.format(k))
+                elif v['type'] == 'sympy':
+                    if ('value' in v):
+                        d[k] = sympy.sympify(v['value'])
+                    else:
+                        raise Exception('variable {:s} of type sympy should have value'.format(k))
+                elif v['type'] == 'sympy_matrix':
+                    if ('value' in v):
+                        d[k] = sympy.sympify(v['value'])
+                    else:
+                        raise Exception('variable {:s} of type sympy_matrix should have value'.format(k))
                 else:
                     raise Exception('variable {:s} has unknown type {:s}'.format(k, v['type']))
             else:

--- a/lib/python_helper_jsonify.py
+++ b/lib/python_helper_jsonify.py
@@ -1,0 +1,22 @@
+
+
+def encode_to_json(d):
+    for k, v in d.items():
+        if isinstance(v, dict):
+            encode_to_json(v)
+        elif isinstance(v, complex):
+            d[k] = {'type': 'complex', 'value': {'real': v.real, 'imag': v.imag}}
+
+def decode_from_json(d):
+    for k, v in d.items():
+        if isinstance(v, dict):
+            if 'type' in v:
+                if v['type'] == 'complex':
+                    if ('value' in v) and ('real' in v['value']) and ('imag' in v['value']):
+                        d[k] = complex(v['value']['real'], v['value']['imag'])
+                    else:
+                        raise Exception('variable {:s} of type complex should have value with real and imaginary pair'.format(k))
+                else:
+                    raise Exception('variable {:s} has unknown type {:s}'.format(k, v['type']))
+            else:
+                decode_from_json(v)


### PR DESCRIPTION
Automatically encode and decode the following standard types by walking input and output dictionaries in the method called by `python-caller-trampoline` and converting these types to/from {'type': ..., 'value': ...} pairs:
* complex
* non-complex ndarray (assumes each element can be serialized)
* complex ndarray
* sympy expression
* sympy matrix
Currently, `sympy.sympify` is being used to do the decoding of sympy expressions and sympy matrices. This is not safe when applied to untrusted data. See `python_helper_jsonify.py` for a brief discussion of security risks and a possible alternative.