### PR TITLE
Improve symbolic input parsing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -67,6 +67,8 @@
 
   * Shift most `exampleCourse` to the external `pl-template` repository.
 
+  * Shift symbolic input parser to `lib/python_helper_sympy.py` (Tim Bretl).
+
   * Fix external graders with invalid submissions (Nathan Walters).
 
   * Fix handling of too-large file uploads (Matt West).
@@ -102,6 +104,10 @@
   * Fix file downloads as zip for v2 questions (Matt West).
 
   * Fix `pl_number_input` to allow suffix for units with `display=inline` (Tim Bretl).
+
+  * Fix symbolic input parser to eliminate use of `sympy.sympify` (Tim Bretl).
+
+  * Fix bug that prevented numbers from being converted in sympy equivalents in symbolic input parser (Tim Bretl).
 
 * __2.10.1__ - 2017-05-24
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -109,6 +109,8 @@
 
   * Fix bug that prevented numbers from being converted in sympy equivalents in symbolic input parser (Tim Bretl).
 
+  * Fix bug that prevented use of multiple symbols in `pl_symbolic_input` (Tim Bretl).
+
 * __2.10.1__ - 2017-05-24
 
   * Fix display of saved submissions for Exam assessments.

--- a/elements/pl_symbolic_input/pl_symbolic_input.py
+++ b/elements/pl_symbolic_input/pl_symbolic_input.py
@@ -6,12 +6,14 @@ import sympy
 import random
 from python_helper_sympy import convert_string_to_sympy
 
+
 def get_variables_list(variables_string):
     if variables_string is not None:
         variables_list = [variable.strip() for variable in variables_string.split(',')]
         return variables_list
     else:
         return []
+
 
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -51,16 +51,6 @@ class ReplaceNumbers(ast.NodeTransformer):
             return ast.Call(func=ast.Name(id='_Integer', ctx=ast.Load()), args=[node], keywords=[])
         elif isinstance(node.n, float):
             return ast.Call(func=ast.Name(id='_Float', ctx=ast.Load()), args=[node], keywords=[])
-        elif isinstance(node.n, complex):
-            # The node is a complex number. It should have zero real part. If it
-            # has non-zero real part, we are confused and will simply return the
-            # node without modification.
-            if (node.n.real != 0):
-                return node
-            elif node.n.imag.is_integer():
-                return ast.BinOp(left=ast.Call(func=ast.Name(id='_Integer', ctx=ast.Load()), args=[ast.Num(node.n.imag)], keywords=[]), op=ast.Mult(), right=ast.Name(id='_I', ctx=ast.Load()))
-            else:
-                return ast.BinOp(left=ast.Call(func=ast.Name(id='_Float', ctx=ast.Load()), args=[ast.Num(node.n.imag)], keywords=[]), op=ast.Mult(), right=ast.Name(id='_I', ctx=ast.Load()))
         return node
 
 class CheckWhiteList(ast.NodeVisitor):
@@ -84,7 +74,7 @@ def evaluate(expr, locals={}):
         node = ast.parse(expr.strip(), mode='eval')
         # Check that all AST expressions are on a whitelist
         CheckWhiteList().visit(node)
-        # Replace all numbers (int, float, complex) with sympy equivalents
+        # Replace all int and float (not complex) numbers with sympy equivalents
         node = ReplaceNumbers().visit(node)
         # Clean up lineno and col_offset attributes
         ast.fix_missing_locations(node)
@@ -96,7 +86,7 @@ def evaluate(expr, locals={}):
 
 def convert_string_to_sympy(a, variables):
     # Define a list of valid expressions and their mapping to sympy
-    locals_for_eval = {'cos': sympy.cos, 'sin': sympy.sin, 'tan': sympy.tan, 'exp': sympy.exp, 'log': sympy.log, 'sqrt': sympy.sqrt, 'pi': sympy.pi, '_Integer': sympy.Integer, '_Float': sympy.Float, '_I': sympy.I}
+    locals_for_eval = {'cos': sympy.cos, 'sin': sympy.sin, 'tan': sympy.tan, 'exp': sympy.exp, 'log': sympy.log, 'sqrt': sympy.sqrt, 'pi': sympy.pi, '_Integer': sympy.Integer, '_Float': sympy.Float}
 
     # If there is a list of variables, add each one to the list of expressions
     if variables is not None:

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -1,0 +1,112 @@
+import sympy
+import ast
+
+# Safe evaluation of user input to convert from string to sympy expression.
+#
+# Adapted from:
+# https://stackoverflow.com/a/30516254
+#
+# Documentation of ast:
+# https://docs.python.org/3/library/ast.html
+#
+# More documentation of ast:
+# https://greentreesnakes.readthedocs.io/
+#
+# FIXME: As of 2017-08-27 there is an open sympy issue discussing a
+# similar approach: https://github.com/sympy/sympy/issues/10805 and an
+# associated PR: https://github.com/sympy/sympy/pull/12524 but it is
+# unclear when/if they will be merged. We should check once sympy 1.2
+# is released and see whether we can switch to using
+# `sympify(..., safe=True)`.
+#
+# For examples of the type of attacks that we are avoiding:
+# https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+# http://blog.delroth.net/2013/03/escaping-a-python-sandbox-ndh-2013-quals-writeup/
+#
+# Another class of attacks is those that try and consume excessive
+# memory or CPU (e.g., `10**100**100`). We handle these attacks by the
+# fact that the entire element code runs in an isolated subprocess, so
+# this type of input will be caught and treated as a question code
+# failure.
+#
+# Other approaches for safe(r) eval in Python are:
+#
+# PyParsing:
+#     http://pyparsing.wikispaces.com
+#     http://pyparsing.wikispaces.com/file/view/fourFn.py
+#
+# RestrictedPython:
+#     https://pypi.python.org/pypi/RestrictedPython
+#     http://restrictedpython.readthedocs.io/
+#
+# Handling timeouts explicitly:
+#     http://code.activestate.com/recipes/496746-restricted-safe-eval/
+#
+# A similar (but more complex) approach to us:
+#     https://github.com/newville/asteval
+
+class ReplaceNumbers(ast.NodeTransformer):
+    def visit_Num(self, node):
+        if isinstance(node.n, int):
+            return ast.Call(func=ast.Name(id='_Integer', ctx=ast.Load()), args=[node], keywords=[])
+        elif isinstance(node.n, float):
+            return ast.Call(func=ast.Name(id='_Float', ctx=ast.Load()), args=[node], keywords=[])
+        elif isinstance(node.n, complex):
+            # The node is a complex number. It should have zero real part. If it
+            # has non-zero real part, we are confused and will simply return the
+            # node without modification.
+            if (node.n.real != 0):
+                return node
+            elif node.n.imag.is_integer():
+                return ast.BinOp(left=ast.Call(func=ast.Name(id='_Integer', ctx=ast.Load()), args=[ast.Num(node.n.imag)], keywords=[]), op=ast.Mult(), right=ast.Name(id='_I', ctx=ast.Load()))
+            else:
+                return ast.BinOp(left=ast.Call(func=ast.Name(id='_Float', ctx=ast.Load()), args=[ast.Num(node.n.imag)], keywords=[]), op=ast.Mult(), right=ast.Name(id='_I', ctx=ast.Load()))
+        return node
+
+class CheckWhiteList(ast.NodeVisitor):
+    def visit(self, node):
+        if not isinstance(node, self.whitelist):
+            raise ValueError(node)
+        return super().visit(node)
+
+    # Be very careful about adding to the list below. In particular,
+    # do not add `ast.Attribute` without fully understanding the
+    # reflection-based attacks described by
+    # https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+    # http://blog.delroth.net/2013/03/escaping-a-python-sandbox-ndh-2013-quals-writeup/
+    whitelist = (ast.Module, ast.Expr, ast.Load, ast.Expression, ast.Call, ast.Name, ast.Num, ast.UnaryOp, ast.UAdd, ast.USub, ast.BinOp, ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Mod, ast.Pow)
+
+def evaluate(expr, locals={}):
+    if any(elem in expr for elem in '\n#'):
+        raise ValueError(expr)
+    try:
+        # Convert string to AST
+        node = ast.parse(expr.strip(), mode='eval')
+        # Check that all AST expressions are on a whitelist
+        CheckWhiteList().visit(node)
+        # Replace all numbers (int, float, complex) with sympy equivalents
+        node = ReplaceNumbers().visit(node)
+        # Clean up lineno and col_offset attributes
+        ast.fix_missing_locations(node)
+        # Convert AST to code and evaluate it with no global expressions and with
+        # a whitelist of local expressions
+        return eval(compile(node, '<ast>', 'eval'), {'__builtins__': None}, locals)
+    except Exception:
+        raise ValueError(expr)
+
+def convert_string_to_sympy(a, variables):
+    # Define a list of valid expressions and their mapping to sympy
+    locals_for_eval = {'cos': sympy.cos, 'sin': sympy.sin, 'tan': sympy.tan, 'exp': sympy.exp, 'log': sympy.log, 'sqrt': sympy.sqrt, 'pi': sympy.pi, '_Integer': sympy.Integer, '_Float': sympy.Float, '_I': sympy.I}
+
+    # If there is a list of variables, add each one to the list of expressions
+    if variables is not None:
+        for variable in variables:
+            locals_for_eval[variable] = sympy.Symbol(variable)
+
+    # Do the conversion
+    return evaluate(a, locals_for_eval)
+
+
+# # Replace '^' with '**' wherever it appears. In MATLAB, either can be used
+# # for exponentiation. In python, only the latter can be used.
+# a = a.replace('^', '**')


### PR DESCRIPTION
* Move parser to `lib/python_helper_sympy.py`
* Eliminate use of `sympy.sympify`
* Walk AST to convert int and float numbers to sympy equivalents