### PR TITLE
JSON serialization helper functions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,8 @@
   * Add maximum statistics for grading jobs (Matt West).
 
   * Add index on `grading_jobs.date` to speed up statistics (Matt West).
+  
+  * Add `to_json()` and `from_json()` to `prairielearn.py` to help JSON serialize standard types (Tim Bretl).
 
   * Split installing documentation into separate method sections (Matt West).
 

--- a/elements/pl_matrix_input/pl_matrix_input.py
+++ b/elements/pl_matrix_input/pl_matrix_input.py
@@ -64,7 +64,7 @@ def render(element_html, element_index, data):
 
     elif data['panel'] == 'answer':
         # Get true answer - do nothing if it does not exist
-        a_tru = data['correct_answers'].get(name, None)
+        a_tru = pl.from_json(data['correct_answers'].get(name, None))
         if a_tru is not None:
             a_tru = np.array(a_tru)
 
@@ -135,7 +135,7 @@ def grade(element_html, element_index, data):
 
     # Get true answer (if it does not exist, create no grade - leave it
     # up to the question code)
-    a_tru = data['correct_answers'].get(name, None)
+    a_tru = pl.from_json(data['correct_answers'].get(name, None))
     if a_tru is None:
         return data
     # Convert true answer to numpy

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -79,7 +79,7 @@ def render(element_html, element_index, data):
         with open('pl_number_input.mustache', 'r') as f:
             html = chevron.render(f, html_params).strip()
     elif data['panel'] == 'answer':
-        a_tru = data['correct_answers'].get(name, None)
+        a_tru = pl.from_json(data['correct_answers'].get(name, None))
         if a_tru is not None:
 
             # Get comparison parameters
@@ -143,7 +143,7 @@ def grade(element_html, element_index, data):
 
     # Get true answer (if it does not exist, create no grade - leave it
     # up to the question code)
-    a_tru = data['correct_answers'].get(name, None)
+    a_tru = pl.from_json(data['correct_answers'].get(name, None))
     if a_tru is None:
         return data
 
@@ -187,7 +187,7 @@ def test(element_html, element_index, data):
 
     # FIXME: randomize tests
 
-    data['raw_submitted_answers'][name] = '%f' % data['correct_answers'][name]
+    data['raw_submitted_answers'][name] = '%f' % pl.from_json(data['correct_answers'][name])
     data['partial_scores'][name] = {'score': 1, 'weight': weight}
 
     return data

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -79,7 +79,7 @@ def render(element_html, element_index, data):
         with open('pl_number_input.mustache', 'r') as f:
             html = chevron.render(f, html_params).strip()
     elif data['panel'] == 'answer':
-        a_tru = pl.from_json(data['correct_answers'].get(name, None))
+        a_tru = data['correct_answers'].get(name, None)
         if a_tru is not None:
 
             # Get comparison parameters
@@ -143,7 +143,7 @@ def grade(element_html, element_index, data):
 
     # Get true answer (if it does not exist, create no grade - leave it
     # up to the question code)
-    a_tru = pl.from_json(data['correct_answers'].get(name, None))
+    a_tru = data['correct_answers'].get(name, None)
     if a_tru is None:
         return data
 
@@ -187,7 +187,7 @@ def test(element_html, element_index, data):
 
     # FIXME: randomize tests
 
-    data['raw_submitted_answers'][name] = '%f' % pl.from_json(data['correct_answers'][name])
+    data['raw_submitted_answers'][name] = '%f' % data['correct_answers'][name]
     data['partial_scores'][name] = {'score': 1, 'weight': weight}
 
     return data

--- a/elements/pl_symbolic_input/pl_symbolic_input.py
+++ b/elements/pl_symbolic_input/pl_symbolic_input.py
@@ -73,7 +73,7 @@ def render(element_html, element_index, data):
             html = chevron.render(f, html_params).strip()
 
     elif data['panel'] == 'answer':
-        a_tru = data['correct_answers'].get(name, None)
+        a_tru = pl.from_json(data['correct_answers'].get(name, None))
         if a_tru is not None:
             if isinstance(a_tru, str):
                 a_tru = convert_string_to_sympy(a_tru, variables)
@@ -128,7 +128,7 @@ def grade(element_html, element_index, data):
 
     # Get true answer (if it does not exist, create no grade - leave it
     # up to the question code)
-    a_tru = data['correct_answers'].get(name, None)
+    a_tru = pl.from_json(data['correct_answers'].get(name, None))
     if a_tru is None:
         return data
 
@@ -162,10 +162,10 @@ def test(element_html, element_index, data):
 
     result = random.choices(['correct', 'incorrect', 'invalid'], [5, 5, 1])[0]
     if result == 'correct':
-        data['raw_submitted_answers'][name] = data['correct_answers'][name]
+        data['raw_submitted_answers'][name] = str(pl.from_json(data['correct_answers'][name]))
         data['partial_scores'][name] = {'score': 1, 'weight': weight}
     elif result == 'incorrect':
-        data['raw_submitted_answers'][name] = data['correct_answers'][name] + ' + {:d}'.format(random.randint(1, 100))
+        data['raw_submitted_answers'][name] = str(pl.from_json(data['correct_answers'][name])) + ' + {:d}'.format(random.randint(1, 100))
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
     elif result == 'invalid':
         if random.choice([True, False]):


### PR DESCRIPTION
This is a small update to add `to_json()` and `from_json()` helper functions to `prairielearn.py`, to help instructors with JSON serialization of these types:
* complex number
* real-valued ndarray
* complex-valued ndarray
* sympy expression
* sympy matrix

I did not yet document these helper functions. Existing input elements (`pl_number_input`, `pl_matrix_input`, and `pl_symbolic_input`) support the format created by `to_json()`.