### PR TITLE
Add full system update and HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN yum -y install \
         https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm \
         https://rpm.nodesource.com/pub_7.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm \
         https://centos7.iuscommunity.org/ius-release.rpm \
+    && yum -y update \
     && yum -y install \
         postgresql96-server \
         postgresql96-contrib \
@@ -32,4 +33,5 @@ RUN chmod +x /PrairieLearn/docker/init.sh \
     && mv /PrairieLearn/docker/config.json /PrairieLearn \
     && mkdir /course
 
+HEALTHCHECK CMD curl --fail http://localhost:3000/pl/webhooks/ping || exit 1
 CMD /PrairieLearn/docker/init.sh


### PR DESCRIPTION
As per [this image monitoring service,](https://anchore.io/image/dockerhub/prairielearn%2Fprairielearn:latest) we aren't updating the main system, so are missing out on security updates in the docker image we give out (not deployment). It also suggests adding a healthcheck, which can't hurt, and we'll probably use one if/when prod gets deployed as a container.

The update command goes after the yum command to add the extra repos, since the repo packages themselves can have updates (mainly epel-release).