### PR TITLE
Fix broken popovers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -155,6 +155,8 @@
 
   * Fix premature answer display for `pl_multiple_choice` and `pl_checkbox` (Matt West).
 
+  * Fix broken popovers in student exam questions (Tim Bretl).
+
 * __2.10.1__ - 2017-05-24
 
   * Fix display of saved submissions for Exam assessments.

--- a/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.ejs
+++ b/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.ejs
@@ -19,7 +19,7 @@
   <body>
     <script>
       $(function () {
-          $('[data-toggle="popover"]').popover()
+          $('[data-toggle="popover"]').popover({container: 'body'});
       });
     </script>
 


### PR DESCRIPTION
This is a small patch to fix broken popovers in student exam questions.

Popovers in button groups, input groups, and tables need the attribute `data-container="body"` in order to function properly (see [docs](https://getbootstrap.com/docs/3.3/javascript/#popovers)). This attribute is missing in some element code - it will be added in a future patch. The student exam question page was the **only** page that initialized popovers with

`$('[data-toggle="popover"]').popover();`

instead of with

`$('[data-toggle="popover"]').popover({container: 'body'});`

As a consequence, the student exam question page was the **only** page that did **not** specify `'body'` as the default container (doing so would correct for a missing `data-container="body"` attribute).

The reason this bug only showed up sometimes is that input element HTML code still includes a duplicate `$('[data-toggle="popover"]').popover({container: 'body'});` command, and so - depending on whether input elements are present, and depending on the order in which the popover initialization commands were executed - you either would or would not get the default container being `body`.

Again, this PR will be followed by another (separate) PR that is more comprehensive - that eliminates popover initialization in elements and that includes `data-container="body"` where appropriate. That will require more testing. For now, it's important to get this fix up quickly.