### PR TITLE
Add -devel package for python so pip package installs using gcc don't fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN yum -y install \
         nodejs \
         python36u \
         python36u-pip \
+        python36u-devel \
         gcc \
     && yum clean all \
     && mkdir /var/postgres && chown postgres:postgres /var/postgres \


### PR DESCRIPTION
The IUS repo bumped to 3.6.3, and either added the `-devel` package or forgot something while packaging.

Fixes docker builds and CI issues.