### PR TITLE
Make local grading consistent with PrairieGrader.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -75,6 +75,8 @@
 
   * Add ability to de-link course instances from PrairieSchedule (Matt West).
 
+  * Add size limits for grading jobs (100 KiB) (Nathan Walters).
+
   * Split installing documentation into separate method sections (Matt West).
 
   * Remove unused dead code (`/lib/db.js`, `question-servers/shortAnswer.js`,

--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -143,9 +143,9 @@ class Grader {
                             results.succeeded = false;
                         } else {
                             if (Buffer.byteLength(data) > 100 * 1024) {
-                                // Cap output at 100KB
+                                // Cap output at 100 KiB
                                 results.succeeded = false;
-                                results.message = 'The grading results were larger than 100KB. ' +
+                                results.message = 'The grading results were larger than 100 KiB. ' +
                                 'Try removing print statements from your code to reduce the output size. ' +
                                 'If the problem persists, please contact course staff or a proctor.';
                             } else {

--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -142,15 +142,23 @@ class Grader {
                             logger.error('Could not read results.json');
                             results.succeeded = false;
                         } else {
-                            try {
-                                logger.info('parsing!');
-                                results.results = JSON.parse(data);
-                                results.succeeded = true;
-                            } catch (e) {
-                                logger.error('Could not parse results.json');
-                                logger.error(e);
+                            if (Buffer.byteLength(data) > 100 * 1024) {
+                                // Cap output at 100KB
                                 results.succeeded = false;
-                                results.message = 'Could not parse the grading results.';
+                                results.message = 'The grading results were larger than 100KB. ' +
+                                'Try removing print statements from your code to reduce the output size. ' +
+                                'If the problem persists, please contact course staff or a proctor.';
+                            } else {
+                                try {
+                                    logger.info('parsing!');
+                                    results.results = JSON.parse(data);
+                                    results.succeeded = true;
+                                } catch (e) {
+                                    logger.error('Could not parse results.json');
+                                    logger.error(e);
+                                    results.succeeded = false;
+                                    results.message = 'Could not parse the grading results.';
+                                }
                             }
                         }
                         return callback(null, externalGraderCommon.makeGradingResult(grading_job.id, results));


### PR DESCRIPTION
This makes local grading reject results that are larger than 100KB.