### PR TITLE
Disallow floats in symbolic inputs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -167,6 +167,8 @@
 
   * Fix canceling of grading jobs on a new submission (Matt West).
 
+  * Fix symbolic expression parsing bug by disallowing floating-point numbers (Tim Bretl).
+
 * __2.10.1__ - 2017-05-24
 
   * Fix display of saved submissions for Exam assessments.

--- a/elements/pl_symbolic_input/pl_symbolic_input.mustache
+++ b/elements/pl_symbolic_input/pl_symbolic_input.mustache
@@ -59,7 +59,7 @@ ${{a_tru}}$
 {{/answer}}
 
 {{#format}}
-Your answer must be a symbolic expression.<hr><h5><small class='text-uppercase'>Allowable Operators</small></h5><pre>{{operators}}</pre><p>All operations must be explicit - examples of valid expressions are <code>cos(1)</code> and <code>2*(3)</code>. Examples of invalid expressions are <code>cos 1</code> and <code>2(3)</code>. Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p><hr><h5><small class='text-uppercase'>Allowable Constants</small></h5><pre>{{constants}}</pre>{{#variables}}<hr><h5><small class='text-uppercase'>Allowable Variables</small></h5><pre>{{variables}}</pre>{{/variables}}
+Your answer must be a symbolic expression. All numbers must be rational - so, <code>1/2</code> instead of <code>0.5</code>.<hr><h5><small class='text-uppercase'>Allowable Operators</small></h5><pre>{{operators}}</pre><p>All operations must be explicit - examples of valid expressions are <code>cos(1)</code> and <code>2*(3)</code>. Examples of invalid expressions are <code>cos 1</code> and <code>2(3)</code>. Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p><hr><h5><small class='text-uppercase'>Allowable Constants</small></h5><pre>{{constants}}</pre>{{#variables}}<hr><h5><small class='text-uppercase'>Allowable Variables</small></h5><pre>{{variables}}</pre>{{/variables}}
 {{/format}}
 
 {{#shortformat}}

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -86,7 +86,27 @@ def evaluate(expr, locals={}):
 
 def convert_string_to_sympy(a, variables):
     # Define a list of valid expressions and their mapping to sympy
-    locals_for_eval = {'cos': sympy.cos, 'sin': sympy.sin, 'tan': sympy.tan, 'exp': sympy.exp, 'log': sympy.log, 'sqrt': sympy.sqrt, 'pi': sympy.pi, '_Integer': sympy.Integer, '_Float': sympy.Float}
+    #
+    # If we wanted to allow floating-point numbers in symbolic expressions, we
+    # would add this to locals_for_eval:
+    #
+    #   '_Float': sympy.Float
+    #
+    # We don't want to allow floating-point numbers, though. They make checking
+    # for equality problematic. For example:
+    #
+    #   (2*pi)**(0.5)
+    #
+    # is parsed as
+    #
+    #   1.4142135623731*pi**0.5
+    #
+    # and is not considered the same as
+    #
+    #   sqrt(2*pi)
+    #
+    # If a floating-point number is present, evaluate will throw an exception.
+    locals_for_eval = {'cos': sympy.cos, 'sin': sympy.sin, 'tan': sympy.tan, 'exp': sympy.exp, 'log': sympy.log, 'sqrt': sympy.sqrt, 'pi': sympy.pi, '_Integer': sympy.Integer}
 
     # If there is a list of variables, add each one to the list of expressions
     if variables is not None:
@@ -95,8 +115,3 @@ def convert_string_to_sympy(a, variables):
 
     # Do the conversion
     return evaluate(a, locals_for_eval)
-
-
-# # Replace '^' with '**' wherever it appears. In MATLAB, either can be used
-# # for exponentiation. In python, only the latter can be used.
-# a = a.replace('^', '**')


### PR DESCRIPTION
fixes #896

We don't want to allow floating-point numbers in symbolic expressions. They cause unpredictable behavior when comparing expressions for equality. Example: `(2*pi)**(0.5)` is parsed as `1.4142135623731*pi**0.5` and is not considered the same as `sqrt(2*pi)` or as `(2*pi)**(1/2)`.