### PR TITLE
Checkbox

### DIFF
--- a/elements/pl_checkbox/pl_checkbox.py
+++ b/elements/pl_checkbox/pl_checkbox.py
@@ -201,6 +201,7 @@ def grade(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers_name')
     weight = pl.get_integer_attrib(element, 'weight', 1)
+    partial_credit = pl.get_boolean_attrib(element, 'partial_credit', False)
 
     submitted_keys = data['submitted_answers'].get(name, [])
     correct_answer_list = data['correct_answers'].get(name, [])
@@ -208,13 +209,11 @@ def grade(element_html, element_index, data):
 
     submittedSet = set(submitted_keys)
     correctSet = set(correct_keys)
-    if len(submittedSet - correctSet) > 0:
-        score = 0
-    else:
+    score = 0
+    if partial_credit and len(submittedSet - correctSet) == 0:
         score = 1.0*len(submittedSet)/len(correctSet)
-    # score = 0
-    # if set(submitted_keys) == set(correct_keys):
-    #     score = 1
+    elif submittedSet == correctSet:
+        score = 1
 
     data['partial_scores'][name] = {'score': score, 'weight': weight}
     return data

--- a/elements/pl_checkbox/pl_checkbox.py
+++ b/elements/pl_checkbox/pl_checkbox.py
@@ -7,7 +7,7 @@ import math
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers_name']
-    optional_attribs = ['weight', 'number_answers', 'min_correct', 'max_correct', 'fixed_order', 'inline']
+    optional_attribs = ['weight', 'number_answers', 'min_correct', 'max_correct', 'fixed_order', 'inline', 'partial_credit']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers_name')
 
@@ -206,9 +206,15 @@ def grade(element_html, element_index, data):
     correct_answer_list = data['correct_answers'].get(name, [])
     correct_keys = [answer['key'] for answer in correct_answer_list]
 
-    score = 0
-    if set(submitted_keys) == set(correct_keys):
-        score = 1
+    submittedSet = set(submitted_keys)
+    correctSet = set(correct_keys)
+    if len(submittedSet - correctSet) > 0:
+        score = 0
+    else:
+        score = 1.0*len(submittedSet)/len(correctSet)
+    # score = 0
+    # if set(submitted_keys) == set(correct_keys):
+    #     score = 1
 
     data['partial_scores'][name] = {'score': score, 'weight': weight}
     return data

--- a/exampleCourse/infoCourse.json
+++ b/exampleCourse/infoCourse.json
@@ -23,6 +23,7 @@
         {"name": "tpl101", "color": "gray1", "description": "Question originally written for the TPL 101 template course"},
         {"name": "fa17", "color": "gray1", "description": "Question written in Fall 2017"},
         {"name": "v2", "color": "red1", "description": "v2 generation question"},
-        {"name": "v3", "color": "green1", "description": "v3 generation question (freeform)"}
+        {"name": "v3", "color": "green1", "description": "v3 generation question (freeform)"},
+        {"name": "pearl", "color": "yellow3", "description": "Question originally written by pearl"}
     ]
 }

--- a/exampleCourse/questions/checkbox/info.json
+++ b/exampleCourse/questions/checkbox/info.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "47609392-f25b-4f34-a280-a193666d7307",
+    "title": "check true answer",
+    "topic": "Test",
+    "tags": ["pearl", "fa17", "tpl101", "v3"],
+    "type": "v3"
+}

--- a/exampleCourse/questions/checkbox/question.html
+++ b/exampleCourse/questions/checkbox/question.html
@@ -1,0 +1,15 @@
+<p>
+  answer = 1
+</p>
+<p>
+  <pl_number_input answers_name="num_ans" weight="1" comparison="sigfig" digits="3" label="answer = ">
+</p>
+<p>
+  Select true answers
+  <pl_checkbox answers_name="ans" fixed_order="true" weight="1">
+    <pl_answer correct="true">true1</pl_answer>
+    <pl_answer correct="true">true2</pl_answer>
+    <pl_answer>              false1</pl_answer>
+    <pl_answer correct="true">true4</pl_answer>
+  </pl_checkbox>
+</p>

--- a/exampleCourse/questions/checkbox/question.html
+++ b/exampleCourse/questions/checkbox/question.html
@@ -1,12 +1,15 @@
 <p>
-  answer = 1
+  Select true answers (without partial credit)
+  <pl_checkbox answers_name="ans1" fixed_order="true" weight="1">
+    <pl_answer correct="true">true1</pl_answer>
+    <pl_answer correct="true">true2</pl_answer>
+    <pl_answer>              false1</pl_answer>
+    <pl_answer correct="true">true4</pl_answer>
+  </pl_checkbox>
 </p>
 <p>
-  <pl_number_input answers_name="num_ans" weight="1" comparison="sigfig" digits="3" label="answer = ">
-</p>
-<p>
-  Select true answers
-  <pl_checkbox answers_name="ans" fixed_order="true" weight="1">
+  Select true answers (with partial credit)
+  <pl_checkbox answers_name="ans2" fixed_order="true" weight="1" partial_credit="true">
     <pl_answer correct="true">true1</pl_answer>
     <pl_answer correct="true">true2</pl_answer>
     <pl_answer>              false1</pl_answer>

--- a/exampleCourse/questions/checkbox/question.html
+++ b/exampleCourse/questions/checkbox/question.html
@@ -9,7 +9,7 @@
 </p>
 <p>
   Select true answers (with partial credit)
-  <pl_checkbox answers_name="ans2" fixed_order="true" weight="1" partial_credit="true">
+  <pl_checkbox answers_name="ans2" fixed_order="true" weight="1" partial_credit="true" number_answers="3">
     <pl_answer correct="true">true1</pl_answer>
     <pl_answer correct="true">true2</pl_answer>
     <pl_answer>              false1</pl_answer>

--- a/exampleCourse/questions/checkbox/server.py
+++ b/exampleCourse/questions/checkbox/server.py
@@ -1,0 +1,5 @@
+import random
+
+def generate(data):
+    data["correct_answers"]["num_ans"] = 1;
+    return data


### PR DESCRIPTION
I enabled partial credit option for checkbox. Now, users may specify that they want to give students partial credit on checkbox question by setting the partial_credit attribute to true:
partial_credit="true"
Note that the default value of partial_credit is false.
Students will only be granted partial credit if their choices is a subset of the correct answers. This is to prevent them from getting a full credit by selecting all of the choices.