### PR TITLE
Number input must be finite

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -189,6 +189,8 @@
   * Fix symbolic expression parsing bug by disallowing floating-point numbers (Tim Bretl).
 
   * Fix handling of broken questions on Homeworks (Matt West).
+  
+  * Fix handling of `inf` and `nan` submissions in `pl_number_input` (Tim Bretl).
 
 * __2.10.1__ - 2017-05-24
 

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -4,6 +4,7 @@ import chevron
 import to_precision
 import math
 import prairielearn as pl
+import numpy as np
 
 
 def prepare(element_html, element_index, data):
@@ -157,7 +158,10 @@ def parse(element_html, element_index, data):
 
     # Convert to float
     try:
-        data['submitted_answers'][name] = float(a_sub)
+        a_sub_float = float(a_sub)
+        if not np.isfinite(a_sub_float):
+            raise ValueError('submitted answer must be a finite real number but was either "inf" or "nan"')
+        data['submitted_answers'][name] = a_sub_float
     except ValueError:
         data['format_errors'][name] = 'Invalid format (not a real number).'
         data['submitted_answers'][name] = None


### PR DESCRIPTION
Checks that answer submitted to `<pl_number_input>` is finite, i.e., that it is not `inf` or `nan`. Does not parse or grade a non-finite submitted answer. This is consistent with `<pl_matrix_input>`. Without this fix, `inf` or `nan` would result in a PL error (`Error parsing submission`).