### PR TITLE
Remove the need to return data in python functions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -125,6 +125,8 @@
 
   * Remove detailed AzureAD logging (Matt West).
 
+  * Remove the need to return `data` in python functions (Tim Bretl).
+
   * Change `externalGradingOptions.files` to `.serverFilesCourse`
     (Nathan Walters).
 

--- a/elements/pl_answer_panel/pl_answer_panel.py
+++ b/elements/pl_answer_panel/pl_answer_panel.py
@@ -5,7 +5,6 @@ import lxml.html
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
-    return data
 
 
 def render(element_html, element_index, data):

--- a/elements/pl_checkbox/pl_checkbox.py
+++ b/elements/pl_checkbox/pl_checkbox.py
@@ -73,7 +73,6 @@ def prepare(element_html, element_index, data):
         raise Exception('duplicate correct_answers variable name: %s' % name)
     data['params'][name] = display_answers
     data['correct_answers'][name] = correct_answer_list
-    return data
 
 
 def render(element_html, element_index, data):
@@ -194,7 +193,6 @@ def render(element_html, element_index, data):
 
 def parse(element_html, element_index, data):
     # FIXME: check for invalid answers
-    return data
 
 
 def grade(element_html, element_index, data):
@@ -211,7 +209,6 @@ def grade(element_html, element_index, data):
         score = 1
 
     data['partial_scores'][name] = {'score': score, 'weight': weight}
-    return data
 
 
 def test(element_html, element_index, data):
@@ -246,5 +243,4 @@ def test(element_html, element_index, data):
         # FIXME: test invalid answers
     else:
         raise Exception('invalid result: %s' % result)
-
-    return data
+    

--- a/elements/pl_checkbox/pl_checkbox.py
+++ b/elements/pl_checkbox/pl_checkbox.py
@@ -193,6 +193,7 @@ def render(element_html, element_index, data):
 
 def parse(element_html, element_index, data):
     # FIXME: check for invalid answers
+    pass
 
 
 def grade(element_html, element_index, data):
@@ -243,4 +244,3 @@ def test(element_html, element_index, data):
         # FIXME: test invalid answers
     else:
         raise Exception('invalid result: %s' % result)
-    

--- a/elements/pl_external_grader_results/pl_external_grader_results.py
+++ b/elements/pl_external_grader_results/pl_external_grader_results.py
@@ -9,8 +9,6 @@ def prepare(element_html, element_index, data):
     optional_attribs = []
     pl.check_attribs(element, required_attribs, optional_attribs)
 
-    return data
-
 
 def render(element_html, element_index, data):
     if data['panel'] == 'submission':

--- a/elements/pl_figure/pl_figure.py
+++ b/elements/pl_figure/pl_figure.py
@@ -7,7 +7,6 @@ import os
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['file_name'], optional_attribs=['width', 'type', 'directory'])
-    return data
 
 
 def render(element_html, element_index, data):

--- a/elements/pl_file_download/pl_file_download.py
+++ b/elements/pl_file_download/pl_file_download.py
@@ -6,7 +6,6 @@ import os
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['file_name'], optional_attribs=['type', 'directory', 'label'])
-    return data
 
 
 def render(element_html, element_index, data):

--- a/elements/pl_file_editor/pl_file_editor.py
+++ b/elements/pl_file_editor/pl_file_editor.py
@@ -25,8 +25,6 @@ def prepare(element_html, element_index, data):
         data['params']['_required_file_names'] = []
     data['params']['_required_file_names'].append(pl.get_string_attrib(element, 'file_name'))
 
-    return data
-
 
 def render(element_html, element_index, data):
     if data['panel'] != 'question':
@@ -76,7 +74,7 @@ def parse(element_html, element_index, data):
     file_contents = data['submitted_answers'].get(answer_name, None)
     if not file_contents:
         add_format_error(data, 'No submitted answer for {0}'.format(file_name))
-        return data
+        return
 
     if data['submitted_answers'].get('_files', None) is None:
         data['submitted_answers']['_files'] = []
@@ -91,5 +89,3 @@ def parse(element_html, element_index, data):
         })
     else:
         add_format_error(data, '_files was present but was not an array.')
-
-    return data

--- a/elements/pl_file_preview/pl_file_preview.py
+++ b/elements/pl_file_preview/pl_file_preview.py
@@ -10,8 +10,6 @@ def prepare(element_html, element_index, data):
     optional_attribs = []
     pl.check_attribs(element, required_attribs, optional_attribs)
 
-    return data
-
 
 def render(element_html, element_index, data):
     if data['panel'] != 'submission':

--- a/elements/pl_file_upload/pl_file_upload.py
+++ b/elements/pl_file_upload/pl_file_upload.py
@@ -38,8 +38,6 @@ def prepare(element_html, element_index, data):
     file_names = get_file_names_as_array(pl.get_string_attrib(element, 'file_names'))
     data['params']['_required_file_names'].extend(file_names)
 
-    return data
-
 
 def render(element_html, element_index, data):
     if data['panel'] != 'question':
@@ -79,7 +77,7 @@ def parse(element_html, element_index, data):
     files = data['submitted_answers'].get(answer_name, None)
     if not files:
         add_format_error(data, 'No submitted answer for file upload.')
-        return data
+        return
 
     try:
         parsed_files = json.loads(files)
@@ -103,5 +101,3 @@ def parse(element_html, element_index, data):
 
         if len(missing_files) > 0:
             add_format_error(data, 'The following required files were missing: ' + ', '.join(missing_files))
-
-    return data

--- a/elements/pl_matrix_input/pl_matrix_input.py
+++ b/elements/pl_matrix_input/pl_matrix_input.py
@@ -12,7 +12,6 @@ def prepare(element_html, element_index, data):
     required_attribs = ['answers_name']
     optional_attribs = ['weight', 'correct_answer', 'label', 'comparison', 'rtol', 'atol', 'digits', 'eps_digits']
     pl.check_attribs(element, required_attribs, optional_attribs)
-    return data
 
 
 def render(element_html, element_index, data):
@@ -154,7 +153,7 @@ def parse(element_html, element_index, data):
     if not a_sub:
         data['format_errors'][name] = 'No submitted answer.'
         data['submitted_answers'][name] = None
-        return data
+        return
 
     # Replace unicode minus with hyphen minus wherever it occurs
     a_sub = a_sub.replace(u'\u2212', '-')
@@ -164,7 +163,7 @@ def parse(element_html, element_index, data):
     if a_sub_parsed is None:
         data['format_errors'][name] = info['format_error']
         data['submitted_answers'][name] = None
-        return data
+        return
 
     # Replace submitted answer with numpy array
     data['submitted_answers'][name] = a_sub_parsed.tolist()
@@ -173,8 +172,6 @@ def parse(element_html, element_index, data):
     if '_pl_matrix_input_format' not in data['submitted_answers']:
         data['submitted_answers']['_pl_matrix_input_format'] = {}
     data['submitted_answers']['_pl_matrix_input_format'][name] = info['format_type']
-
-    return data
 
 
 def grade(element_html, element_index, data):
@@ -188,7 +185,7 @@ def grade(element_html, element_index, data):
     # up to the question code)
     a_tru = pl.from_json(data['correct_answers'].get(name, None))
     if a_tru is None:
-        return data
+        return
     # Convert true answer to numpy
     a_tru = np.array(a_tru)
     # Throw an error if true answer is not a 2D numpy array
@@ -199,14 +196,14 @@ def grade(element_html, element_index, data):
     a_sub = data['submitted_answers'].get(name, None)
     if a_sub is None:
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
-        return data
+        return
     # Convert submitted answer to numpy
     a_sub = np.array(a_sub)
 
     # If true and submitted answers have different shapes, score is zero
     if not (a_sub.shape == a_tru.shape):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
-        return data
+        return
 
     # Get method of comparison, with relabs as default
     comparison = pl.get_string_attrib(element, 'comparison', 'relabs')
@@ -231,8 +228,6 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 1, 'weight': weight}
     else:
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
-
-    return data
 
 
 def test(element_html, element_index, data):
@@ -273,5 +268,3 @@ def test(element_html, element_index, data):
             data['format_errors'][name] = 'invalid'
         else:
             raise Exception('invalid result: %s' % result)
-
-    return data

--- a/elements/pl_matrix_output/pl_matrix_output.py
+++ b/elements/pl_matrix_output/pl_matrix_output.py
@@ -7,7 +7,6 @@ import chevron
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=['digits'])
-    return data
 
 
 def render(element_html, element_index, data):

--- a/elements/pl_multiple_choice/pl_multiple_choice.py
+++ b/elements/pl_multiple_choice/pl_multiple_choice.py
@@ -67,7 +67,6 @@ def prepare(element_html, element_index, data):
         raise Exception('duplicate correct_answers variable name: %s' % name)
     data['params'][name] = display_answers
     data['correct_answers'][name] = correct_answer
-    return data
 
 
 def render(element_html, element_index, data):
@@ -161,13 +160,11 @@ def parse(element_html, element_index, data):
 
     if submitted_key is None:
         data['format_errors'][name] = 'No submitted answer.'
-        return data
+        return
 
     if submitted_key not in all_keys:
         data['format_errors'][name] = 'INVALID choice: ' + submitted_key  # FIXME: escape submitted_key
-        return data
-
-    return data
+        return
 
 
 def grade(element_html, element_index, data):
@@ -183,7 +180,6 @@ def grade(element_html, element_index, data):
         score = 1
 
     data['partial_scores'][name] = {'score': score, 'weight': weight}
-    return data
 
 
 def test(element_html, element_index, data):
@@ -217,5 +213,3 @@ def test(element_html, element_index, data):
         # FIXME: add more invalid choices
     else:
         raise Exception('invalid result: %s' % result)
-
-    return data

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -20,8 +20,6 @@ def prepare(element_html, element_index, data):
             raise Exception('duplicate correct_answers variable name: %s' % name)
         data['correct_answers'][name] = correct_answer
 
-    return data
-
 
 def render(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
@@ -151,7 +149,7 @@ def parse(element_html, element_index, data):
     if not a_sub:
         data['format_errors'][name] = 'No submitted answer.'
         data['submitted_answers'][name] = None
-        return data
+        return
 
     # Replace unicode minus with hyphen minus wherever it occurs
     a_sub = a_sub.replace(u'\u2212', '-')
@@ -166,8 +164,6 @@ def parse(element_html, element_index, data):
         data['format_errors'][name] = 'Invalid format (not a real number).'
         data['submitted_answers'][name] = None
 
-    return data
-
 
 def grade(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
@@ -180,13 +176,13 @@ def grade(element_html, element_index, data):
     # up to the question code)
     a_tru = data['correct_answers'].get(name, None)
     if a_tru is None:
-        return data
+        return
 
     # Get submitted answer (if it does not exist, score is zero)
     a_sub = data['submitted_answers'].get(name, None)
     if a_sub is None:
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
-        return data
+        return
 
     # Get method of comparison, with relabs as default
     comparison = pl.get_string_attrib(element, 'comparison', 'relabs')
@@ -212,8 +208,6 @@ def grade(element_html, element_index, data):
     else:
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
-    return data
-
 
 def test(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
@@ -224,5 +218,3 @@ def test(element_html, element_index, data):
 
     data['raw_submitted_answers'][name] = '%f' % data['correct_answers'][name]
     data['partial_scores'][name] = {'score': 1, 'weight': weight}
-
-    return data

--- a/elements/pl_question_panel/pl_question_panel.py
+++ b/elements/pl_question_panel/pl_question_panel.py
@@ -5,8 +5,7 @@ import lxml.html
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
-    return data
-
+    
 
 def render(element_html, element_index, data):
     if data['panel'] == 'question':

--- a/elements/pl_question_panel/pl_question_panel.py
+++ b/elements/pl_question_panel/pl_question_panel.py
@@ -5,7 +5,7 @@ import lxml.html
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
-    
+
 
 def render(element_html, element_index, data):
     if data['panel'] == 'question':

--- a/elements/pl_submission_panel/pl_submission_panel.py
+++ b/elements/pl_submission_panel/pl_submission_panel.py
@@ -5,7 +5,6 @@ import lxml.html
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
-    return data
 
 
 def render(element_html, element_index, data):

--- a/elements/pl_symbolic_input/pl_symbolic_input.py
+++ b/elements/pl_symbolic_input/pl_symbolic_input.py
@@ -29,8 +29,6 @@ def prepare(element_html, element_index, data):
             raise Exception('duplicate correct_answers variable name: %s' % name)
         data['correct_answers'][name] = correct_answer
 
-    return data
-
 
 def render(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
@@ -130,7 +128,7 @@ def parse(element_html, element_index, data):
     if not a_sub:
         data['format_errors'][name] = 'No submitted answer.'
         data['submitted_answers'][name] = None
-        return data
+        return
 
     try:
         # Replace '^' with '**' wherever it appears. In MATLAB, either can be used
@@ -191,8 +189,6 @@ def parse(element_html, element_index, data):
         data['format_errors'][name] = 'Invalid format.'
         data['submitted_answers'][name] = None
 
-    return data
-
 
 def grade(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
@@ -205,13 +201,13 @@ def grade(element_html, element_index, data):
     # up to the question code)
     a_tru = pl.from_json(data['correct_answers'].get(name, None))
     if a_tru is None:
-        return data
+        return
 
     # Get submitted answer (if it does not exist, score is zero)
     a_sub = data['submitted_answers'].get(name, None)
     if a_sub is None:
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
-        return data
+        return
 
     # Parse both correct and submitted answer (will throw an error on fail).
     variables = get_variables_list(pl.get_string_attrib(element, 'variables', None))
@@ -226,8 +222,6 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 1, 'weight': weight}
     else:
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
-
-    return data
 
 
 def test(element_html, element_index, data):
@@ -290,5 +284,3 @@ def test(element_html, element_index, data):
             raise Exception('invalid invalid_type: %s' % invalid_type)
     else:
         raise Exception('invalid result: %s' % result)
-
-    return data

--- a/elements/pl_variable_score/pl_variable_score.py
+++ b/elements/pl_variable_score/pl_variable_score.py
@@ -7,11 +7,10 @@ use_pl_variable_score = False
 
 def prepare(element_html, element_index, data):
     if not use_pl_variable_score:
-        return data
+        return
 
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['answers_name'], optional_attribs=[])
-    return data
 
 
 def render(element_html, element_index, data):

--- a/exampleCourse/questions/addNumbers/server.py
+++ b/exampleCourse/questions/addNumbers/server.py
@@ -2,12 +2,16 @@ import random
 
 def generate(data):
 
+    # Sample two random integers between 5 and 10 (inclusive)
     a = random.randint(5, 10)
     b = random.randint(5, 10)
-    data["params"]["a"] = a
-    data["params"]["b"] = b
 
+    # Put these two integers into data['params']
+    data['params']['a'] = a
+    data['params']['b'] = b
+
+    # Compute the sum of these two integers
     c = a + b
-    data["correct_answers"]["c"] = c
 
-    return data
+    # Put the sum into data['correct_answers']
+    data['correct_answers']['c'] = c


### PR DESCRIPTION
Removes the need to return `data` in v3 element and server functions (it was always passed as a mutable argument to these functions). Here is what's done now:

* If nothing is returned, we use the passed (possibly modified) value of `data`.
* If something is returned:
  * If it does not differ from what is passed, we use it.
  * If it differs from what is passed, we use it, and log an issue.

To deep-compare what is passed with what is returned, we convert each to JSON (sorted) and compare that. We do this because it's a lot easier, and we have to convert at least one of these two things to JSON anyway.

An easy way to test this code is to use the module `copy`. For example:

```
import copy

def generate(data):
    # Modify a copy of data 
    data_copy = copy.deepcopy(data)
    data_copy['params']['a'] = 10
    
    # Modify data itself
    data['params']['a'] = 5
    
    return data_copy
```