### PR TITLE
Insert page view to variant_view_logs and access_logs

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -11,7 +11,7 @@ Next, clone your forked repository to your local machine and set up the main rep
 
 ```sh
 git clone git@github.com/$user_name/PrairieLearn.git
-git remote add upstream git@github.com/PrairieLearn/PrairieLearn.git
+git remote add upstream git@github.com:PrairieLearn/PrairieLearn.git
 ```
 
 This means that you now have three key repositories to keep track of:

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -11,7 +11,7 @@ Next, clone your forked repository to your local machine and set up the main rep
 
 ```sh
 git clone git@github.com/$user_name/PrairieLearn.git
-git remote add upstream git@github.com:PrairieLearn/PrairieLearn.git
+git remote add upstream git@github.com/PrairieLearn/PrairieLearn.git
 ```
 
 This means that you now have three key repositories to keep track of:

--- a/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
+++ b/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
@@ -7,6 +7,8 @@ var error = require('../../lib/error');
 var question = require('../../lib/question');
 var assessment = require('../../lib/assessment');
 var sqldb = require('../../lib/sqldb');
+var sqlLoader = require('../../lib/sql-loader');
+var sql = sqlLoader.loadSqlEquiv(__filename);
 
 function processSubmission(req, res, callback) {
     if (!res.locals.assessment_instance.open) return callback(error.make(400, 'assessment_instance is closed'));
@@ -116,6 +118,13 @@ router.get('/', function(req, res, next) {
     const variant_id = null;
     question.getAndRenderVariant(variant_id, res.locals, function(err) {
         if (ERR(err, next)) return;
+        var insert_viewlog_key = {
+          date: new Date(),
+          variant_id: res.locals.variant.id,
+          };
+        sqldb.queryOneRow(sql.log_into_view_log, insert_viewlog_key, function(err){
+          if(ERR(err, next)) return;
+        });
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });

--- a/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.sql
+++ b/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.sql
@@ -1,0 +1,7 @@
+-- BLOCK log_into_view_log
+WITH new_access_id AS (
+  INSERT INTO access_logs (date) VALUES ($date)
+  RETURNING *
+)
+INSERT INTO variant_view_logs (access_log_id,variant_id) VALUES ((SELECT id FROM new_access_id),$variant_id)
+RETURNING variant_view_logs.id;


### PR DESCRIPTION
This pull request update on inserting the page view log to access_logs and variant_view_logs each time student click on the page in the Exam mode. 
There is no modification on the database schema, the question duration calculation will come later since it's gonna to make change on the database schema and additional stored procedure. Once we have the page logs we can easily calculate the question duration, it's better to log the page views first in this final exam period.