### PR TITLE
Fix pl_number_input bug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -227,6 +227,8 @@
   * Fix display of assessment score to 2 decimal places (Nathan Walters).
 
   * Fix gradebook to choose best score rather than worst (Matt West).
+  
+  * Fix bug in `pl_number_input` that crashed on submission of large integers (Tim Bretl).
 
 * __2.10.1__ - 2017-05-24
 

--- a/elements/pl_number_input/pl_number_input.mustache
+++ b/elements/pl_number_input/pl_number_input.mustache
@@ -83,7 +83,7 @@
 {{/answer}}
 
 {{#format}}
-No symbolic expressions (those that involve fractions, square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., 1.2e03). {{#relabs}}Your answer must be accurate to within relative tolerance {{rtol}} and absolute tolerance {{atol}}.{{/relabs}}{{#sigfig}}Your answer must be accurate to {{digits}} significant figures.{{/sigfig}}{{#decdig}}Your answer must be accurate to {{digits}} digits after the decimal.{{/decdig}}
+Your answer must be a real number between -1e100 and 1e100. No symbolic expressions (those that involve fractions, square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., 1.2e03). {{#relabs}}Your answer must be accurate to within relative tolerance {{rtol}} and absolute tolerance {{atol}}.{{/relabs}}{{#sigfig}}Your answer must be accurate to {{digits}} significant figures.{{/sigfig}}{{#decdig}}Your answer must be accurate to {{digits}} digits after the decimal.{{/decdig}}
 {{/format}}
 
 {{#shortformat}}

--- a/elements/pl_number_input/pl_number_input.mustache
+++ b/elements/pl_number_input/pl_number_input.mustache
@@ -83,7 +83,7 @@
 {{/answer}}
 
 {{#format}}
-Your answer must be a real number between -1e100 and 1e100. No symbolic expressions (those that involve fractions, square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., 1.2e03). {{#relabs}}Your answer must be accurate to within relative tolerance {{rtol}} and absolute tolerance {{atol}}.{{/relabs}}{{#sigfig}}Your answer must be accurate to {{digits}} significant figures.{{/sigfig}}{{#decdig}}Your answer must be accurate to {{digits}} digits after the decimal.{{/decdig}}
+Your answer must be a real number between -1e308 and 1e308 (i.e., it must be interpretable as a double-precision floating-point number). No symbolic expressions (those that involve fractions, square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., 1.2e03). {{#relabs}}Your answer must be accurate to within relative tolerance {{rtol}} and absolute tolerance {{atol}}.{{/relabs}}{{#sigfig}}Your answer must be accurate to {{digits}} significant figures.{{/sigfig}}{{#decdig}}Your answer must be accurate to {{digits}} digits after the decimal.{{/decdig}}
 {{/format}}
 
 {{#shortformat}}

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -156,12 +156,12 @@ def parse(element_html, element_index, data):
 
     # Convert to float
     try:
-        a_sub_float = float(a_sub)
+        a_sub_float = np.float64(a_sub)
         if not np.isfinite(a_sub_float):
             raise ValueError('submitted answer must be a finite real number but was either "inf" or "nan"')
         data['submitted_answers'][name] = a_sub_float
     except ValueError:
-        data['format_errors'][name] = 'Invalid format (either not a real number or not a number between -1e100 and 1e100).'
+        data['format_errors'][name] = 'Invalid format. The submitted answer could not be interpreted as a double-precision floating-point number.'
         data['submitted_answers'][name] = None
 
 
@@ -184,7 +184,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
         return
 
-    # Cast both submitted and true answers as floats, because...
+    # Cast both submitted and true answers as np.float64, because...
     #
     #   If the method of comparison is relabs (i.e., using relative and
     #   absolute tolerance) then np.allclose is applied to check if the
@@ -199,11 +199,11 @@ def grade(element_html, element_index, data):
     #       the inputs could not be safely coerced to any supported types
     #       according to the casting rule ''safe''
     #
-    #   Casting as float avoids this error. This is reasonable in any case,
-    #   because <pl_number_input> accepts floats, not ints.
+    #   Casting as np.float64 avoids this error. This is reasonable in any case,
+    #   because <pl_number_input> accepts double-precision floats, not ints.
     #
-    a_sub = float(a_sub)
-    a_tru = float(a_tru)
+    a_sub = np.float64(a_sub)
+    a_tru = np.float64(a_tru)
 
     # Get method of comparison, with relabs as default
     comparison = pl.get_string_attrib(element, 'comparison', 'relabs')


### PR DESCRIPTION
Casts both submitted and true answers as `np.float64` (double-precision floating-point numbers) to avoid a crash when submitted answer is a too-large integer. This crash is caused by an error thrown by `np.allclose(a, b)` - used for grading when the method of comparison is `relabs` - when either `a` or `b` is an integer that cannot be represented as `np.int64`.

Modifies help text to make clear what the upper and lower bounds on the submitted answer are.

This fixes #953.