### PR TITLE
Add support for dynamically generated multiple choice questions

### DIFF
--- a/exampleCourse/courseInstances/Sp15/assessments/homework2/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/homework2/infoAssessment.json
@@ -34,6 +34,7 @@
         {
             "questions": [
                 {"id": "addVectors",                 "points": 1, "maxPoints": 5},
+                {"id": "addNumbersDynamicMC",        "points": 1, "maxPoints": 5},
                 {"id": "fibonacciEditor",            "points": 1, "maxPoints": 5},
                 {"id": "fibonacciUpload",            "points": 1, "maxPoints": 5},
                 {"id": "fossilFuelsRadio",           "points": 2, "maxPoints": 10},

--- a/exampleCourse/questions/addNumbersDynamicMC/info.json
+++ b/exampleCourse/questions/addNumbersDynamicMC/info.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "2784b11a-a624-449c-aa5b-8462032f0a2c",
+    "title": "Add two numbers (dynamic multiple choice)",
+    "topic": "Algebra",
+    "tags": ["v3"],
+    "type": "v3"
+}

--- a/exampleCourse/questions/addNumbersDynamicMC/question.html
+++ b/exampleCourse/questions/addNumbersDynamicMC/question.html
@@ -1,0 +1,6 @@
+<pl_question_panel>
+  <p> Consider two numbers $a = {{params.a}}$ and $b = {{params.b}}$.
+  <p> What is the sum $c = a + b$?
+</pl_question_panel>
+
+<p><pl_multiple_choice answers_name="c" answers_param="addition_answers"/></p>

--- a/exampleCourse/questions/addNumbersDynamicMC/server.py
+++ b/exampleCourse/questions/addNumbersDynamicMC/server.py
@@ -1,0 +1,23 @@
+import random
+from itertools import chain
+
+
+def generate(data):
+    answers = {}
+
+    a = random.randint(-15, 15)
+    b = random.randint(-15, 15)
+    c = a + b
+
+    data['params']['a'] = a
+    data['params']['b'] = b
+
+    # Generate the correct answer
+    answers['correct'] = [str(c)]
+
+    # Generate some incorrect answers
+    # Select 4 unique deltas in [-6, -1] U [1, 6]
+    deltas = random.sample(list(chain(range(-6, 0), range(1, 7))), 4)
+    answers['incorrect'] = [str(c + delta) for delta in deltas]
+
+    data['params']['addition_answers'] = answers


### PR DESCRIPTION
In response to # #937, this is my interpretation of what a dynamically-generated multiple choice question should look like. `server.py` should stick a dict like the following into `params` during `generate`:

```
data['params']['my_answers'] = {
    'correct': ['Pick me!'],
    'incorrect': ['Not me', 'Or me', 'Or me!']
}
```

You can then specify the name of that dict in `pl_multiple_choice`: `answers_param="my_answers"`. `pl_multiple_choice` will check for that dict and use it if it's present instead of getting options from `pl_answer` children.

If you all like how this looks, I'll add this to the docs for the `pl_multiple_choice` element.