### PR TITLE
remove unnecessary line in python caller that was for debugging

### DIFF
--- a/lib/python-caller-trampoline.py
+++ b/lib/python-caller-trampoline.py
@@ -40,8 +40,6 @@ with open(3, 'w', encoding='utf-8') as outf:
         cwd = inp['cwd']
         paths = inp['paths']
 
-        original_data_str = str(args[-1])
-
         # reset and then set up the path
         sys.path = copy.copy(saved_path)
         for path in reversed(paths):


### PR DESCRIPTION
It causes no harm but should be removed. Was introduced when debugging the python caller when removing the need to return `data`.