### PR TITLE
Add translation to threejs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@
 
   * Add `pl_threejs` element (Tim Bretl).
 
+  * Add translation to `pl_threejs` element (Tim Bretl).
+
   * Change sigfig and decdig method of comparison to reduce tolerance (Tim Bretl).
 
   * Change default relative tolerance from 1e-5 to 1e-2 (Tim Bretl).

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -302,22 +302,25 @@ Display the partial score for a specific answer variable.
 </pl_threejs>
 ```
 
-This element displays a 3D scene with objects that the student can (optionally) rotate. It can be used only for output (e.g., as part of a question that asks for something else to be submitted). Or, it can be used for input (e.g., comparing a submitted orientation of the body-fixed objects to a correct orientation). Information about the current orientation can be hidden from the student and, if visible, can be displayed in a variety of formats, so the element can be used for many different types of questions.
+This element displays a 3D scene with objects that the student can (optionally) translate and/or rotate. It can be used only for output (e.g., as part of a question that asks for something else to be submitted). Or, it can be used for input (e.g., comparing a submitted pose of the body-fixed objects to a correct orientation). Information about the current pose can be hidden from the student and, if visible, can be displayed in a variety of formats, so the element can be used for many different types of questions.
 
 Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answer_name` | string | — | Variable name to store data in.
+`body_position` | list | [0, 0, 0] | Initial position of body as `[x, y, z]`.
 `body_orientation` | list | special | Initial orientation of body. Defaults to zero orientation (body frame aligned with space frame). Interpretation depends on `body_pose_format`.
-`camera_position` | list | [5, 2, 2] | Initial position of body as `[x, y, z]`.
-`body_canmove` | boolean | true | If you can move the body in the UI.
+`camera_position` | list | [5, 2, 2] | Initial position of camera as `[x, y, z]`.
+`body_cantranslate` | boolean | true | If you can translate the body in the UI.
+`body_canrotate` | boolean | true | If you can rotate the body in the UI.
 `camera_canmove` | boolean | true | If you can move the camera (i.e., change the view) in the UI.
 `body_pose_format` | string | rpy | Determines how `body_orientation` is interpreted. If `rpy` then `[roll, pitch, yaw]`. If `matrix` then 3x3 rotation matrix `[[...], [...], [...]]`. If `quaternion` then `[x, y, z, w]`. If `axisangle` then `[x, y, z, theta]` where `x, y, z` are coordinates of axis and `theta` is angle.
-`answer_pose_format` | string | rpy | Determines how the orientation `data['correct_answer'][answer_name]` is interpreted. If `rpy` then `[roll, pitch, yaw]`. If `matrix` then 3x3 rotation matrix `[[...], [...], [...]]`. If `quaternion` then `[x, y, z, w]`. If `axisangle` then `[x, y, z, theta]` where `x, y, z` are coordinates of axis and `theta` is angle.
-`text_pose_format` | string | matrix | Determines how the orientation of the body is displayed as text. If `matrix` then 3x3 rotation matrix. If `quaternion` then `[x, y, z, w]`.
-`show_pose_in_question` | boolean | true | If the current orientation of the body is displayed in the question panel.
-`show_pose_in_correct_answer` | boolean | true | If the current orientation of the body is displayed in the correct answer panel.
-`show_pose_in_submitted_answer` | boolean | true | If the current orientation of the body is displayed in the submitted answer panel.
-`tol_degrees` | float | 5.0 | Angular error must be no more than this for the answer to be marked correct.
+`answer_pose_format` | string | rpy | Determines how the answer `data['correct_answer'][answer_name]` is interpreted. If `homogeneous`, then the answer must be a 4x4 homogeneous transformation matrix `[[...], [...], [...], [...]]`. Otherwise, the answer must be a list with two elements. The first element must describe position as `[x, y, z]`. The second element must describe orientation, interpreted based on `answer_pose_format`. If `rpy` then `[roll, pitch, yaw]`. If `matrix` then 3x3 rotation matrix `[[...], [...], [...]]`. If `quaternion` then `[x, y, z, w]`. If `axisangle` then `[x, y, z, theta]` where `x, y, z` are coordinates of axis and `theta` is angle.
+`text_pose_format` | string | matrix | Determines how the pose of the body is displayed as text. If `matrix` then position is `[x, y, z]` and orientation is a 3x3 rotation matrix. If `quaternion` then position is `[x, y, z]` and orientation is `[x, y, z, w]`. If `homogeneous` then pose is a 4x4 homogeneous transformation matrix.
+`show_pose_in_question` | boolean | true | If the current pose of the body is displayed in the question panel.
+`show_pose_in_correct_answer` | boolean | true | If the current pose of the body is displayed in the correct answer panel.
+`show_pose_in_submitted_answer` | boolean | true | If the current pose of the body is displayed in the submitted answer panel.
+`tol_position` | float | 0.5 | Error in position must be no more than this for the answer to be marked correct.
+`tol_rotation` | float | 5.0 | Error in rotation must be no more than this for the answer to be marked correct.
 `grade` | boolean | true | If the element will be graded, i.e., if it is being used to ask a question. If `grade` is `false`, then this element will never produce any html in the answer panel or in the submission panel.
 
 A `pl_threejs_stl` element inside a `pl_threejs` element allows you to add a mesh described by an `stl` file to the scene, and has these attributes:

--- a/elements/pl_threejs/pl_threejs.js
+++ b/elements/pl_threejs/pl_threejs.js
@@ -733,6 +733,44 @@ PLThreeJS.prototype.updateDisplayOfPose = function() {
         s += '])';
         return s;
     }
+    
+    function homToMatlab(R) {
+        var s = '% The pose of the body frame as a homogeneous transformation matrix.\n';
+        s += 'T = [ ';
+        for (var i = 0; i < 4; i++) {
+            for (var j = 0; j < 4; j++) {
+                s += numToString(R[i + 4*j], 4, 7);
+                if (j < 3) {
+                    s += ' ';
+                }
+            }
+            if (i < 3) {
+                s += ' ;\n      ';
+            }
+        }
+        s += ' ];';
+        return s;
+    }
+
+    function homToPython(R) {
+        var s = '# The pose of the body frame as a homogeneous transformation matrix.\n';
+        s += 'T = np.array([';
+        for (var i = 0; i < 4; i++) {
+            s += '[ ';
+            for (var j = 0; j < 4; j++) {
+                s += numToString(R[i + 4*j], 4, 7);
+                if (j < 3) {
+                    s += ', ';
+                }
+            }
+            s += ' ]';
+            if (i < 3) {
+                s += ',\n              ';
+            }
+        }
+        s += '])';
+        return s;
+    }
 
     if (this.textPoseFormat == 'matrix') {
         // preamble
@@ -757,6 +795,16 @@ PLThreeJS.prototype.updateDisplayOfPose = function() {
         // orientation
         matlabText += quatToMatlab(this.bodyGroup.quaternion.toArray());
         pythonText += quatToPython(this.bodyGroup.quaternion.toArray());
+        // result
+        this.matlabText.text(matlabText);
+        this.pythonText.text(pythonText);
+    } else if (this.textPoseFormat == 'homogeneous') {
+        // preamble
+        var matlabText = '';
+        var pythonText = 'import numpy as np\n\n';
+        // both position and orientation
+        matlabText += homToMatlab(this.bodyGroup.matrix.elements);
+        pythonText += homToPython(this.bodyGroup.matrix.elements);
         // result
         this.matlabText.text(matlabText);
         this.pythonText.text(pythonText);

--- a/elements/pl_threejs/pl_threejs.js
+++ b/elements/pl_threejs/pl_threejs.js
@@ -182,7 +182,7 @@ function PLThreeJS(options) {
 
             // mouse control of body pose
             $(this.renderer.domElement).mousedown(PLThreeJS.prototype.onmousedown.bind(this));
-            $(document).mousemove(PLThreeJS.prototype.onmousemove.bind(this));
+            $(this.renderer.domElement).mousemove(PLThreeJS.prototype.onmousemove.bind(this));
             $(document).mouseup(PLThreeJS.prototype.onmouseup.bind(this));
 
             // buttons to rotate body about coordinate axes of body frame
@@ -239,7 +239,7 @@ function PLThreeJS(options) {
 PLThreeJS.prototype.render = function() {
     this.renderer.render(this.scene, this.camera);
     this.updateHiddenInput();
-    this.updateDisplayOfOrientation();
+    this.updateDisplayOfPose();
 };
 
 PLThreeJS.prototype.xPlus = function() {
@@ -640,5 +640,125 @@ PLThreeJS.prototype.updateDisplayOfOrientation = function() {
         var q = this.bodyGroup.quaternion.toArray();
         this.matlabText.text(quatToMatlab(q));
         this.pythonText.text(quatToPython(q));
+    }
+};
+
+PLThreeJS.prototype.updateDisplayOfPose = function() {
+    function numToString(n, decimals, digits) {
+        var s = n.toFixed(decimals);
+        s = ' '.repeat(digits - s.length) + s;
+        return s;
+    }
+
+    function posToMatlab(p) {
+        var s = '% The position of the body frame.\n';
+        s += 'p = [ ';
+        s += numToString(p.x, 4, 7) + ' ;\n      ';
+        s += numToString(p.y, 4, 7) + ' ;\n      ';
+        s += numToString(p.z, 4, 7) + ' ];';
+        return s;
+    }
+
+    function posToPython(p) {
+        var s = '# The position of the body frame.\n';
+        s += 'p = np.array([';
+        s += '[ ' + numToString(p.x, 4, 7) + ' ],\n              ';
+        s += '[ ' + numToString(p.y, 4, 7) + ' ],\n              ';
+        s += '[ ' + numToString(p.z, 4, 7) + ' ]])';
+        return s;
+    }
+
+    function quatToMatlab(q) {
+        var s = '% The orientation of the body frame as a quaternion [x, y, z, w].\n';
+        s += 'q = [ ';
+        for (var i = 0; i < 4; i++) {
+            s += numToString(q[i], 4, 7);
+            if (i < 3) {
+                s += ' ';
+            } else {
+                s += ' ];';
+            }
+        }
+        return s;
+    }
+
+    function quatToPython(q) {
+        var s = '# The orientation of the body frame as a quaternion [x, y, z, w].\n';
+        s += 'q = np.array([ ';
+        for (var i = 0; i < 4; i++) {
+            s += numToString(q[i], 4, 7);
+            if (i < 3) {
+                s += ', ';
+            } else {
+                s += ' ])';
+            }
+        }
+        return s;
+    }
+
+    function rotToMatlab(R) {
+        var s = '% The orientation of the body frame as a rotation matrix.\n';
+        s += 'R = [ ';
+        for (var i = 0; i < 3; i++) {
+            for (var j = 0; j < 3; j++) {
+                s += numToString(R[i + 4*j], 4, 7);
+                if (j < 2) {
+                    s += ' ';
+                }
+            }
+            if (i < 2) {
+                s += ' ;\n      ';
+            }
+        }
+        s += ' ];';
+        return s;
+    }
+
+    function rotToPython(R) {
+        var s = '# The orientation of the body frame as a rotation matrix.\n';
+        s += 'R = np.array([';
+        for (var i = 0; i < 3; i++) {
+            s += '[ ';
+            for (var j = 0; j < 3; j++) {
+                s += numToString(R[i + 4*j], 4, 7);
+                if (j < 2) {
+                    s += ', ';
+                }
+            }
+            s += ' ]';
+            if (i < 2) {
+                s += ',\n              ';
+            }
+        }
+        s += '])';
+        return s;
+    }
+
+    if (this.textPoseFormat == 'matrix') {
+        // preamble
+        var matlabText = '';
+        var pythonText = 'import numpy as np\n\n';
+        // position
+        matlabText += posToMatlab(this.bodyGroup.position) + '\n\n';
+        pythonText += posToPython(this.bodyGroup.position) + '\n\n';
+        // orientation
+        matlabText += rotToMatlab(this.bodyGroup.matrix.elements);
+        pythonText += rotToPython(this.bodyGroup.matrix.elements);
+        // result
+        this.matlabText.text(matlabText);
+        this.pythonText.text(pythonText);
+    } else if (this.textPoseFormat == 'quaternion') {
+        // preamble
+        var matlabText = '';
+        var pythonText = 'import numpy as np\n\n';
+        // position
+        matlabText += posToMatlab(this.bodyGroup.position) + '\n\n';
+        pythonText += posToPython(this.bodyGroup.position) + '\n\n';
+        // orientation
+        matlabText += quatToMatlab(this.bodyGroup.quaternion.toArray());
+        pythonText += quatToPython(this.bodyGroup.quaternion.toArray());
+        // result
+        this.matlabText.text(matlabText);
+        this.pythonText.text(pythonText);
     }
 };

--- a/elements/pl_threejs/pl_threejs.js
+++ b/elements/pl_threejs/pl_threejs.js
@@ -167,7 +167,7 @@ function PLThreeJS(options) {
 
             // state for mouse control of body pose
             this.isDragging = false;
-            this.isTranslating = true;
+            this.isTranslating = this.bodyCanTranslate;
             // - rotation
             this.previousMousePosition = {};
             // - translation

--- a/elements/pl_threejs/pl_threejs.js
+++ b/elements/pl_threejs/pl_threejs.js
@@ -81,8 +81,6 @@ function PLThreeJS(options) {
     this.spaceGroup.add(this.spaceFrame);
     this.bodyGroup.add(this.bodyFrame);
 
-    var objects_to_drag = [];
-
     async.series([
         // Load font
         (function(callback) {
@@ -555,94 +553,6 @@ PLThreeJS.prototype.updateHiddenInput = function() {
     this.hiddenInput.val(btoa(JSON.stringify(val)));
 };
 
-PLThreeJS.prototype.updateDisplayOfOrientation = function() {
-    function numToString(n, decimals, digits) {
-        var s = n.toFixed(decimals);
-        s = ' '.repeat(digits - s.length) + s;
-        return s;
-    }
-
-    function quatToMatlab(q) {
-        var s = '% The quaternion [x, y, z, w] describing the orientation of\n';
-        s += '% the body frame in the coordinates of the space frame.\n\n';
-        s += 'q = [ ';
-        for (var i = 0; i < 4; i++) {
-            s += numToString(q[i], 4, 7);
-            if (i < 3) {
-                s += ' ';
-            } else {
-                s += ' ];';
-            }
-        }
-        return s;
-    }
-
-    function quatToPython(q) {
-        var s = '# The quaternion [x, y, z, w] describing the orientation of\n';
-        s += '# the body frame in the coordinates of the space frame.\n\n';
-        s += 'import numpy as np\n\nq = np.array([ ';
-        for (var i = 0; i < 4; i++) {
-            s += numToString(q[i], 4, 7);
-            if (i < 3) {
-                s += ', ';
-            } else {
-                s += ' ])';
-            }
-        }
-        return s;
-    }
-
-    function rotToMatlab(R) {
-        var s = '% The rotation matrix describing the orientation of the body\n';
-        s += '% frame in the coordinates of the space frame.\n\n';
-        s += 'R = [ ';
-        for (var i = 0; i < 3; i++) {
-            for (var j = 0; j < 3; j++) {
-                s += numToString(R[i + 4*j], 4, 7);
-                if (j < 2) {
-                    s += ' ';
-                }
-            }
-            if (i < 2) {
-                s += ' ;\n      ';
-            }
-        }
-        s += ' ];';
-        return s;
-    }
-
-    function rotToPython(R) {
-        var s = '# The rotation matrix describing the orientation of the body\n';
-        s += '# frame in the coordinates of the space frame.\n\n';
-        s += 'import numpy as np\n\nR = np.array([';
-        for (var i = 0; i < 3; i++) {
-            s += '[ ';
-            for (var j = 0; j < 3; j++) {
-                s += numToString(R[i + 4*j], 4, 7);
-                if (j < 2) {
-                    s += ', ';
-                }
-            }
-            s += ' ]';
-            if (i < 2) {
-                s += ',\n              ';
-            }
-        }
-        s += '])';
-        return s;
-    }
-
-    if (this.textPoseFormat == 'matrix') {
-        var R = this.bodyGroup.matrix.elements;
-        this.matlabText.text(rotToMatlab(R));
-        this.pythonText.text(rotToPython(R));
-    } else if (this.textPoseFormat == 'quaternion') {
-        var q = this.bodyGroup.quaternion.toArray();
-        this.matlabText.text(quatToMatlab(q));
-        this.pythonText.text(quatToPython(q));
-    }
-};
-
 PLThreeJS.prototype.updateDisplayOfPose = function() {
     function numToString(n, decimals, digits) {
         var s = n.toFixed(decimals);
@@ -733,7 +643,7 @@ PLThreeJS.prototype.updateDisplayOfPose = function() {
         s += '])';
         return s;
     }
-    
+
     function homToMatlab(R) {
         var s = '% The pose of the body frame as a homogeneous transformation matrix.\n';
         s += 'T = [ ';
@@ -772,41 +682,27 @@ PLThreeJS.prototype.updateDisplayOfPose = function() {
         return s;
     }
 
+    var matlabText = '';
+    var pythonText = 'import numpy as np\n\n';
     if (this.textPoseFormat == 'matrix') {
-        // preamble
-        var matlabText = '';
-        var pythonText = 'import numpy as np\n\n';
         // position
         matlabText += posToMatlab(this.bodyGroup.position) + '\n\n';
         pythonText += posToPython(this.bodyGroup.position) + '\n\n';
         // orientation
         matlabText += rotToMatlab(this.bodyGroup.matrix.elements);
         pythonText += rotToPython(this.bodyGroup.matrix.elements);
-        // result
-        this.matlabText.text(matlabText);
-        this.pythonText.text(pythonText);
     } else if (this.textPoseFormat == 'quaternion') {
-        // preamble
-        var matlabText = '';
-        var pythonText = 'import numpy as np\n\n';
         // position
         matlabText += posToMatlab(this.bodyGroup.position) + '\n\n';
         pythonText += posToPython(this.bodyGroup.position) + '\n\n';
         // orientation
         matlabText += quatToMatlab(this.bodyGroup.quaternion.toArray());
         pythonText += quatToPython(this.bodyGroup.quaternion.toArray());
-        // result
-        this.matlabText.text(matlabText);
-        this.pythonText.text(pythonText);
     } else if (this.textPoseFormat == 'homogeneous') {
-        // preamble
-        var matlabText = '';
-        var pythonText = 'import numpy as np\n\n';
         // both position and orientation
         matlabText += homToMatlab(this.bodyGroup.matrix.elements);
         pythonText += homToPython(this.bodyGroup.matrix.elements);
-        // result
-        this.matlabText.text(matlabText);
-        this.pythonText.text(pythonText);
     }
+    this.matlabText.text(matlabText);
+    this.pythonText.text(pythonText);
 };

--- a/elements/pl_threejs/pl_threejs.mustache
+++ b/elements/pl_threejs/pl_threejs.mustache
@@ -17,7 +17,7 @@ $(function() {
     <div class="card mb-4">
         <div class="card-body">
             <span>
-                The angular error must be no greater than <strong>{{angle}} degrees</strong> in order for your answer to be marked correct. This error is the smallest angle through which the submitted orientation would have to rotate in order to be aligned with the correct orientation.
+                The error in position must be no greater than <strong>{{tol_translation}} units</strong> and error in orientation must be no greater than <strong>{{tol_rotation}} degrees</strong> in order for your answer to be marked correct. The error in orientation is the smallest angle through which the submitted orientation would have to rotate in order to be aligned with the correct orientation.
                 {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
                 {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
                 {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
@@ -30,7 +30,7 @@ $(function() {
     <div class="card mb-4">
         <div class="card-body">
             <span>
-                The angular error is <strong>{{angle}} degrees</strong>. This error is the smallest angle through which the submitted orientation would have to rotate in order to be aligned with the correct orientation.
+                The error in position is <strong>{{error_in_translation}} units</strong> and the error in orientation is <strong>{{error_in_rotation}} degrees</strong>. The error in orientation is the smallest angle through which the submitted orientation would have to rotate in order to be aligned with the correct orientation.
                 {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
                 {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
                 {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
@@ -129,57 +129,3 @@ $(function() {
     </div>
     {{/show_pose}}
 </div>
-
-
-{{#noshow}}
-<script>
-<!-- init copy button -->
-$(function(){
-    PrairieUtil.initCopyButton('#pl-threejs-output-{{uuid}} .copy-button');
-});
-</script>
-<div id="pl-threejs-output-{{uuid}}" class="card mb-4">
-    <div class="card-header">
-        <ul class="nav nav-tabs card-header-tabs" role="tablist">
-            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_matlab}} active{{/default_is_matlab}}" href="#matlab-{{uuid}}" aria-controls="matlab-{{uuid}}" role="tab" data-toggle="pill">matlab</a></li>
-            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_python}} active{{/default_is_python}}" href="#python-{{uuid}}" aria-controls="python-{{uuid}}" role="tab" data-toggle="pill">python</a></li>
-            <li class="nav-item" role="presentation"></li>
-        </ul>
-    </div>
-    <div class="card-body">
-        <div class="tab-content">
-            <div role="tabpanel" class="tab-pane {{#default_is_matlab}}active{{/default_is_matlab}}" id="matlab-{{uuid}}">
-
-                <pre class="bg-dark text-white rounded p-2" id="matlab-data-{{uuid}}">
-% The {{data_format}} describing the orientation of the body
-% frame in the coordinates of the space frame.
-
-{{data_label}} = {{matlab_data}};</pre>
-
-                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#matlab-data-{{uuid}}">
-                    copy this text
-                </button>
-            </div>
-            <div role="tabpanel" class="tab-pane {{#default_is_python}}active{{/default_is_python}}" id="python-{{uuid}}">
-
-                <pre class="bg-dark text-white rounded p-2" id="python-data-{{uuid}}">
-# The {{data_format}} describing the orientation of the body
-# frame in the coordinates of the space frame.
-
-{{data_label}} = {{python_data}}</pre>
-
-                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{uuid}}">
-                    copy this text
-                </button>
-            </div>
-        </div>
-    </div>
-    {{#show_footer}}
-    <div class="card-footer">
-        {{#correct}}<span>Angle error is {{angle}} degrees.</span>&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
-        {{#partial}}<span>Angle error is {{angle}} degrees.</span>&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
-        {{#incorrect}}<span>Angle error is {{angle}} degrees.</span>&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
-    </div>
-    {{/show_footer}}
-</div>
-{{/noshow}}

--- a/elements/pl_threejs/pl_threejs.mustache
+++ b/elements/pl_threejs/pl_threejs.mustache
@@ -51,7 +51,7 @@ $(function() {
     <div class="btn-toolbar" role="toolbar">
         {{#show_reset}}
         <div class="btn-group btn-group-sm mr-2 mb-2" role="group">
-            <button id="reset-button-{{uuid}}" type="button" class="btn btn-secondary active">reset</button>
+            <button id="reset-button-{{uuid}}" type="button" class="btn btn-secondary">reset</button>
         </div>
         {{/show_reset}}
         {{#show_toggle}}

--- a/elements/pl_threejs/pl_threejs.mustache
+++ b/elements/pl_threejs/pl_threejs.mustache
@@ -51,13 +51,13 @@ $(function() {
     <div class="btn-toolbar" role="toolbar">
         {{#show_reset}}
         <div class="btn-group btn-group-sm mr-2 mb-2" role="group">
-            <button id="reset-button-{{uuid}}" type="button" class="btn btn-secondary active" data-toggle="button" aria-pressed="true">reset</button>
+            <button id="reset-button-{{uuid}}" type="button" class="btn btn-secondary active">reset</button>
         </div>
         {{/show_reset}}
         {{#show_toggle}}
-        <div class="btn-group btn-group-sm btn-group-toggle mr-2 mb-2" data-toggle="buttons" role="group" id="toggle-view-{{uuid}}">
+        <div class="btn-group btn-group-sm btn-group-toggle mr-2 mb-2" data-toggle="buttons" role="group" id="toggle-type-of-motion-{{uuid}}">
             <label class="btn btn-secondary active">
-                <input type="radio" autocomplete="off" checked>rotate view</input>
+                <input type="radio" autocomplete="off" checked>translate object</input>
             </label>
             <label class="btn btn-secondary">
                 <input type="radio" autocomplete="off">rotate object</input>
@@ -67,29 +67,29 @@ $(function() {
         {{#show_bodybuttons}}
         <div class="input-group input-group-sm mr-2 mb-2" id="x-group-{{uuid}}">
             <div class="input-group-prepend">
-                <button id="x-minus-{{uuid}}" class="btn btn-secondary" type="button" disabled><i class="fa fa-redo" aria-hidden="true"></i></button>
+                <button id="x-minus-{{uuid}}" class="btn btn-secondary" type="button"><i id="x-minus-icon-{{uuid}}" class="fa fa-arrow-left" aria-hidden="true"></i></button>
                 <span class="input-group-text">x</span>
             </div>
             <div class="input-group-append">
-                <button id="x-plus-{{uuid}}" class="btn btn-secondary" type="button" disabled><i class="fa fa-redo fa-flip-horizontal" aria-hidden="true"></i></button>
+                <button id="x-plus-{{uuid}}" class="btn btn-secondary" type="button"><i id="x-plus-icon-{{uuid}}" class="fa fa-arrow-right" aria-hidden="true"></i></button>
             </div>
         </div>
         <div class="input-group input-group-sm mr-2 mb-2" id="y-group-{{uuid}}">
             <div class="input-group-prepend">
-                <button id="y-minus-{{uuid}}" class="btn btn-secondary" type="button" disabled><i class="fa fa-redo" aria-hidden="true"></i></button>
+                <button id="y-minus-{{uuid}}" class="btn btn-secondary" type="button"><i id="y-minus-icon-{{uuid}}" class="fa fa-arrow-left" aria-hidden="true"></i></button>
                 <span class="input-group-text">y</span>
             </div>
             <div class="input-group-append">
-                <button id="y-plus-{{uuid}}" class="btn btn-secondary" type="button" disabled><i class="fa fa-redo fa-flip-horizontal" aria-hidden="true"></i></button>
+                <button id="y-plus-{{uuid}}" class="btn btn-secondary" type="button"><i id="y-plus-icon-{{uuid}}" class="fa fa-arrow-right" aria-hidden="true"></i></button>
             </div>
         </div>
         <div class="input-group input-group-sm mr-2 mb-2" id="z-group-{{uuid}}">
             <div class="input-group-prepend">
-                <button id="z-minus-{{uuid}}" class="btn btn-secondary" type="button" disabled><i class="fa fa-redo" aria-hidden="true"></i></button>
+                <button id="z-minus-{{uuid}}" class="btn btn-secondary" type="button"><i id="z-minus-icon-{{uuid}}" class="fa fa-arrow-left" aria-hidden="true"></i></button>
                 <span class="input-group-text">z</span>
             </div>
             <div class="input-group-append">
-                <button id="z-plus-{{uuid}}" class="btn btn-secondary" type="button" disabled><i class="fa fa-redo fa-flip-horizontal" aria-hidden="true"></i></button>
+                <button id="z-plus-{{uuid}}" class="btn btn-secondary" type="button"><i id="z-plus-icon-{{uuid}}" class="fa fa-arrow-right" aria-hidden="true"></i></button>
             </div>
         </div>
         {{/show_bodybuttons}}

--- a/elements/pl_threejs/pl_threejs.py
+++ b/elements/pl_threejs/pl_threejs.py
@@ -17,7 +17,8 @@ def prepare(element_html, element_index, data):
     optional_attribs = [
         'body_orientation',     # [x, y, z, w] or [roll, pitch, yaw] or rotation matrix (3x3 ndarray) or exponential coordinates [wx, wy, wz]
         'camera_position',      # [x, y, z] - camera is z up and points at origin of space frame
-        'body_canmove',         # true (default) or false
+        'body_cantranslate',         # true (default) or false
+        'body_canrotate',         # true (default) or false
         'camera_canmove',       # true (default) or false
         'body_pose_format',       # 'rpy' (default), 'quaternion', 'matrix', 'axisangle'
         'answer_pose_format',     # 'rpy' (default), 'quaternion', 'matrix', 'axisangle'
@@ -121,7 +122,8 @@ def render(element_html, element_index, data):
 
     body_orientation = get_orientation(element, 'body_orientation', 'body_pose_format')
     camera_position = get_camera_position(element)
-    body_canmove = pl.get_boolean_attrib(element, 'body_canmove', True)
+    body_cantranslate = pl.get_boolean_attrib(element, 'body_cantranslate', True)
+    body_canrotate = pl.get_boolean_attrib(element, 'body_canrotate', True)
     camera_canmove = pl.get_boolean_attrib(element, 'camera_canmove', True)
     text_pose_format = pl.get_string_attrib(element, 'text_pose_format', 'matrix')
     if text_pose_format not in ['matrix', 'quaternion']:
@@ -148,7 +150,8 @@ def render(element_html, element_index, data):
             'uuid': uuid,
             'pose': dict_to_b64(pose),
             'pose_default': dict_to_b64(pose_default),
-            'body_canmove': body_canmove,
+            'body_cantranslate': body_cantranslate,
+            'body_canrotate': body_canrotate,
             'camera_canmove': camera_canmove,
             'text_pose_format': text_pose_format,
             'objects': objects
@@ -159,9 +162,9 @@ def render(element_html, element_index, data):
             'question': True,
             'uuid': uuid,
             'answer_name': answer_name,
-            'show_bodybuttons': body_canmove,
-            'show_toggle': body_canmove and camera_canmove,
-            'show_reset': body_canmove or camera_canmove,
+            'show_bodybuttons': body_cantranslate or body_canrotate,
+            'show_toggle': body_cantranslate and body_canrotate,
+            'show_reset': body_cantranslate or body_canrotate or camera_canmove,
             'show_pose': show_pose,
             'show_instructions': will_be_graded,
             'angle': '{:.1f}'.format(pl.get_float_attrib(element, 'tol_degrees', 5)),
@@ -185,7 +188,8 @@ def render(element_html, element_index, data):
         options = {
             'uuid': uuid,
             'pose': dict_to_b64(pose),
-            'body_canmove': False,
+            'body_cantranslate': False,
+            'body_canrotate': False,
             'camera_canmove': False,
             'text_pose_format': text_pose_format,
             'objects': objects
@@ -248,7 +252,8 @@ def render(element_html, element_index, data):
         options = {
             'uuid': uuid,
             'pose': dict_to_b64(pose),
-            'body_canmove': False,
+            'body_cantranslate': False,
+            'body_canrotate': False,
             'camera_canmove': False,
             'text_pose_format': text_pose_format,
             'objects': objects

--- a/elements/pl_threejs/pl_threejs.py
+++ b/elements/pl_threejs/pl_threejs.py
@@ -22,7 +22,7 @@ def prepare(element_html, element_index, data):
         'camera_canmove',       # true (default) or false
         'body_pose_format',       # 'rpy' (default), 'quaternion', 'matrix', 'axisangle'
         'answer_pose_format',     # 'rpy' (default), 'quaternion', 'matrix', 'axisangle'
-        'text_pose_format',    # 'matrix' (default), 'quaternion'
+        'text_pose_format',    # 'matrix' (default), 'quaternion', 'homogeneous'
         'show_pose_in_question',            # true (default) or false
         'show_pose_in_correct_answer',      # true (default) or false
         'show_pose_in_submitted_answer',    # true (default) or false
@@ -126,8 +126,8 @@ def render(element_html, element_index, data):
     body_canrotate = pl.get_boolean_attrib(element, 'body_canrotate', True)
     camera_canmove = pl.get_boolean_attrib(element, 'camera_canmove', True)
     text_pose_format = pl.get_string_attrib(element, 'text_pose_format', 'matrix')
-    if text_pose_format not in ['matrix', 'quaternion']:
-        raise Exception('attribute "text_pose_format" must be either "matrix" or "quaternion"')
+    if text_pose_format not in ['matrix', 'quaternion', 'homogeneous']:
+        raise Exception('attribute "text_pose_format" must be either "matrix", "quaternion", or homogeneous')
     objects = get_objects(element, data)
 
     if data['panel'] == 'question':
@@ -277,29 +277,6 @@ def render(element_html, element_index, data):
         raise Exception('Invalid panel type: %s' % data['panel'])
 
     return html
-
-
-def convert_quaternion_to_display(f, q, digits=4):
-    if f == 'matrix':
-        R = q.rotation_matrix
-        matlab_data = pl.numpy_to_matlab(R, ndigits=digits)
-        python_data = str(R.round(digits).tolist())
-        data_format = 'rotation matrix'
-        data_label = 'R'
-    elif f == 'quaternion':
-        q = np.roll(q.elements, -1).tolist()
-        matlab_data = pl.numpy_to_matlab(np.array([q]), ndigits=digits)
-        python_data = str(np.array(q).round(digits).tolist())
-        data_format = 'quaternion [x,y,z,w]'
-        data_label = 'q'
-    else:
-        raise Exception('attribute "text_pose_format" must be either "matrix" or "quaternion": {:s}'.format(f))
-    return {
-        'matlab_data': matlab_data,
-        'python_data': python_data,
-        'data_format': data_format,
-        'data_label': data_label
-    }
 
 
 def parse(element_html, element_index, data):

--- a/elements/pl_threejs/pl_threejs.py
+++ b/elements/pl_threejs/pl_threejs.py
@@ -15,6 +15,7 @@ def prepare(element_html, element_index, data):
         'answer_name',          # key for 'submitted_answers' and 'true_answers'
     ]
     optional_attribs = [
+        'body_position',        # [x, y, z]
         'body_orientation',     # [x, y, z, w] or [roll, pitch, yaw] or rotation matrix (3x3 ndarray) or exponential coordinates [wx, wy, wz]
         'camera_position',      # [x, y, z] - camera is z up and points at origin of space frame
         'body_cantranslate',         # true (default) or false
@@ -26,7 +27,8 @@ def prepare(element_html, element_index, data):
         'show_pose_in_question',            # true (default) or false
         'show_pose_in_correct_answer',      # true (default) or false
         'show_pose_in_submitted_answer',    # true (default) or false
-        'tol_degrees',          # 5 (default : float > 0)
+        'tol_translation',      # 0.5 (default : float > 0)
+        'tol_rotation',          # 5 (default : float > 0)
         'grade'                 # true (default) or false
     ]
     pl.check_attribs(element, required_attribs=required_attribs, optional_attribs=optional_attribs)
@@ -120,8 +122,9 @@ def render(element_html, element_index, data):
 
     uuid = pl.get_uuid()
 
+    body_position = get_position(element, 'body_position', default=[0, 0, 0])
     body_orientation = get_orientation(element, 'body_orientation', 'body_pose_format')
-    camera_position = get_camera_position(element)
+    camera_position = get_position(element, 'camera_position', default=[5, 2, 2], must_be_nonzero=True)
     body_cantranslate = pl.get_boolean_attrib(element, 'body_cantranslate', True)
     body_canrotate = pl.get_boolean_attrib(element, 'body_canrotate', True)
     camera_canmove = pl.get_boolean_attrib(element, 'camera_canmove', True)
@@ -140,7 +143,7 @@ def render(element_html, element_index, data):
         # at the origin of the space frame).
         pose_default = {
             'body_quaternion': body_orientation,
-            'body_position': [0, 0, 0],
+            'body_position': body_position,
             'camera_position': camera_position
         }
         pose = data['submitted_answers'].get(answer_name, pose_default)
@@ -167,7 +170,8 @@ def render(element_html, element_index, data):
             'show_reset': body_cantranslate or body_canrotate or camera_canmove,
             'show_pose': show_pose,
             'show_instructions': will_be_graded,
-            'angle': '{:.1f}'.format(pl.get_float_attrib(element, 'tol_degrees', 5)),
+            'tol_translation': '{:.2f}'.format(pl.get_float_attrib(element, 'tol_translation', 0.5)),
+            'tol_rotation': '{:.1f}'.format(pl.get_float_attrib(element, 'tol_rotation', 5)),
             'default_is_python': True,
             'options': json.dumps(options)
         }
@@ -209,7 +213,8 @@ def render(element_html, element_index, data):
 
         partial_score = data['partial_scores'].get(answer_name, None)
         if partial_score is not None:
-            html_params['angle'] = str(np.abs(np.round(partial_score['feedback'], 1)))
+            html_params['error_in_translation'] = str(np.abs(np.round(partial_score['feedback']['error_in_translation'], 2)))
+            html_params['error_in_rotation'] = str(np.abs(np.round(partial_score['feedback']['error_in_rotation'], 1)))
             html_params['show_feedback'] = True
             score = partial_score.get('score', None)
             if score is not None:
@@ -243,7 +248,8 @@ def render(element_html, element_index, data):
 
         # Convert correct answer to Quaternion, then to [x, y, z, w]
         f = pl.get_string_attrib(element, 'answer_pose_format', 'rpy')
-        q = np.roll(convert_correct_answer_to_quaternion(f, a).elements, -1).tolist()
+        p, q = parse_correct_answer(f, a)
+        q = np.roll(q.elements, -1).tolist()
 
         # Replace body pose with correct answer
         pose['body_quaternion'] = q
@@ -320,74 +326,98 @@ def grade(element_html, element_index, data):
     if a is None:
         return
 
+    # Get submitted position (as np.array([x, y, z]))
+    p_sub = np.array(state['body_position'])
+
+    # Get submitted orientation (as Quaternion - first, roll [x,y,z,w] to [w,x,y,z])
+    q_sub = pyquaternion.Quaternion(np.roll(state['body_quaternion'], 1))
+
     # Get format of correct answer
     f = pl.get_string_attrib(element, 'answer_pose_format', 'rpy')
 
-    # Convert submitted answer to Quaternion (first, roll [x,y,z,w] to [w,x,y,z])
-    q_sub = pyquaternion.Quaternion(np.roll(state['body_quaternion'], 1))
+    # Get correct position (as np.array([x, y, z])) and orientation (as Quaternion)
+    p_tru, q_tru = parse_correct_answer(f, a)
 
-    # Convert correct answer to Quaternion
-    q_tru = convert_correct_answer_to_quaternion(f, a)
+    # Find distance between submitted position and correct position
+    error_in_translation = np.linalg.norm(p_sub - p_tru)
 
     # Find smallest angle of rotation between submitted orientation and correct orientation
-    angle = np.abs((q_tru.inverse * q_sub).degrees)
+    error_in_rotation = np.abs((q_tru.inverse * q_sub).degrees)
 
-    # Get tolerance
-    tol = pl.get_float_attrib(element, 'tol_degrees', 5)
-    if (tol <= 0):
-        raise Exception('tolerance must be a positive real number (angle in degrees): {:g}'.format(tol))
+    # Get tolerances
+    tol_translation = pl.get_float_attrib(element, 'tol_translation', 0.1)
+    tol_rotation = pl.get_float_attrib(element, 'tol_rotation', 5)
+    if (tol_translation <= 0):
+        raise Exception('tol_translation must be a positive real number: {:g}'.format(tol_translation))
+    if (tol_rotation <= 0):
+        raise Exception('tol_rotation must be a positive real number (angle in degrees): {:g}'.format(tol_rotation))
 
     # Check if angle is no greater than tolerance
-    if (angle <= tol):
-        data['partial_scores'][answer_name] = {'score': 1, 'weight': weight, 'feedback': angle}
+    if ((error_in_rotation <= tol_rotation) and (error_in_translation <= tol_translation)):
+        data['partial_scores'][answer_name] = {'score': 1, 'weight': weight, 'feedback': {'error_in_rotation': error_in_rotation, 'error_in_translation': error_in_translation}}
     else:
-        data['partial_scores'][answer_name] = {'score': 0, 'weight': weight, 'feedback': angle}
+        data['partial_scores'][answer_name] = {'score': 0, 'weight': weight, 'feedback': {'error_in_rotation': error_in_rotation, 'error_in_translation': error_in_translation}}
 
 
-def convert_correct_answer_to_quaternion(f, a):
-    if f == 'rpy':
+def parse_correct_answer(f, a):
+    if f == 'homogeneous':
         try:
-            rpy = np.array(a, dtype=np.float64)
+            T = np.array(a, dtype=np.float64)
+            if T.shape == (4, 4):
+                R = T[0:3, 0:3]
+                p = T[0:3, 3:4]
+                return np.reshape(p, (3,)), pyquaternion.Quaternion(matrix=R)
+            else:
+                raise ValueError()
+        except:
+            raise Exception('correct answer must be a 4x4 homogeneous transformation matrix with format "[[...], [...], [...], [...]]"')
+    elif f == 'rpy':
+        try:
+            p = np.reshape(np.array(a[0], dtype=np.float64), (3,))
+            rpy = np.array(a[1], dtype=np.float64)
             if rpy.shape == (3,):
                 qx = pyquaternion.Quaternion(axis=[1, 0, 0], degrees=rpy[0])
                 qy = pyquaternion.Quaternion(axis=[0, 1, 0], degrees=rpy[1])
                 qz = pyquaternion.Quaternion(axis=[0, 0, 1], degrees=rpy[2])
-                return qx * qy * qz
+                return np.reshape(p, (3,)), qx * qy * qz
             else:
                 raise ValueError()
         except:
-            raise Exception('correct answer must be a set of roll, pitch, yaw angles in degrees with format "[roll, pitch, yaw]"')
+            raise Exception('correct answer must be a list [position, orientation], where position is [x, y, z] and orientation is a set of roll, pitch, yaw angles in degrees with format "[roll, pitch, yaw]"')
     elif f == 'quaternion':
         try:
-            q = np.array(a, dtype=np.float64)
+            p = np.reshape(np.array(a[0], dtype=np.float64), (3,))
+            q = np.array(a[1], dtype=np.float64)
             if (q.shape == (4,)) and np.allclose(np.linalg.norm(q), 1.0):
-                return pyquaternion.Quaternion(np.roll(q, 1))
+                return np.reshape(p, (3,)), pyquaternion.Quaternion(np.roll(q, 1))
             else:
                 raise ValueError()
         except:
-            raise Exception('correct answer must be a unit quaternion with format "[x, y, z, w]"')
+            raise Exception('correct answer must be a list [position, orientation], where position is [x, y, z] and orientation is a unit quaternion with format "[x, y, z, w]"')
     elif f == 'matrix':
         try:
-            R = np.array(a, dtype=np.float64)
-            return pyquaternion.Quaternion(matrix=R)
+            p = np.reshape(np.array(a[0], dtype=np.float64), (3,))
+            R = np.array(a[1], dtype=np.float64)
+            return np.reshape(p, (3,)), pyquaternion.Quaternion(matrix=R)
         except:
-            raise Exception('correct answer must be a 3x3 rotation matrix with format "[[ ... ], [ ... ], [ ... ]]"')
+            raise Exception('correct answer must be a list [position, orientation], where position is [x, y, z] and orientation is a 3x3 rotation matrix with format "[[ ... ], [ ... ], [ ... ]]"')
     elif f == 'axisangle':
         try:
-            q = np.array(json.loads(a), dtype=np.float64)
+            p = np.reshape(np.array(a[0], dtype=np.float64), (3,))
+            q = np.array(json.loads(a[1]), dtype=np.float64)
             if (q.shape == (4,)):
                 axis = q[0:3]
                 angle = q[3]
                 if np.allclose(np.linalg.norm(axis), 1.0):
-                    return np.roll(pyquaternion.Quaternion(axis=axis, degrees=angle).elements, -1).tolist()
+                    return np.reshape(p, (3,)), np.roll(pyquaternion.Quaternion(axis=axis, degrees=angle).elements, -1).tolist()
                 else:
                     raise ValueError()
             else:
                 raise ValueError()
         except:
-            raise Exception('correct answer must be "[x, y, z, angle]" where (x, y, z) are the components of a unit vector and where the angle is in degrees')
+            raise Exception('correct answer must be a list [position, orientation], where position is [x, y, z] and orientation is "[x, y, z, angle]" where (x, y, z) are the components of a unit vector and where the angle is in degrees')
     else:
-        raise Exception('"answer_pose_format" must be "rpy", "quaternion", "matrix", or "axisangle": {:s}'.format(f))
+        raise Exception('"answer_pose_format" must be "rpy", "quaternion", "matrix", "axisangle", or "homogeneous": {:s}'.format(f))
 
 
 def dict_to_b64(d):
@@ -470,13 +500,18 @@ def get_orientation(element, name_orientation, name_format):
         raise Exception('attribute "{:s}" must be "rpy", "quaternion", "matrix", or "axisangle": {:s}'.format(name_format, f))
 
 
-def get_camera_position(element):
-    p = pl.get_string_attrib(element, 'camera_position', '[5, 2, 2]')
+def get_position(element, name_position, default=[0, 0, 0], must_be_nonzero=False):
+    s = pl.get_string_attrib(element, name_position, None)
+    if s is None:
+        return default
     try:
-        p_arr = np.array(json.loads(p), dtype=np.float64)
-        if (p_arr.shape == (3,)) and not np.allclose(p_arr, np.array([0, 0, 0])):
-            return p_arr.tolist()
+        p = np.array(json.loads(s), dtype=np.float64)
+        if p.shape == (3,):
+            if must_be_nonzero and np.allclose(p, np.array([0, 0, 0])):
+                raise ValueError('attribute "{:s}" must be non-zero'.format(name_position))
+            else:
+                return p.tolist()
         else:
             raise ValueError()
     except:
-        raise Exception('attribute "camera_position" must have format [x, y, z] and must be non-zero: {:s}'.format(p))
+        raise Exception('attribute "{:s}" must have format "[x, y, z]": {:s}'.format(name_position, s))

--- a/exampleCourse/questions/rotateObject/info.json
+++ b/exampleCourse/questions/rotateObject/info.json
@@ -1,6 +1,6 @@
 {
     "uuid": "e64f7842-6fee-48dd-93f3-5bd60f286723",
-    "title": "Rotate a cube to match a given orientation",
+    "title": "Rotate an object to match a given orientation",
     "topic": "Test",
     "tags": ["tbretl", "v3"],
     "type": "v3"

--- a/exampleCourse/questions/rotateObject/question.html
+++ b/exampleCourse/questions/rotateObject/question.html
@@ -1,9 +1,9 @@
 <pl_question_panel>
     <p>
-        Rotate the body by 45 degrees about the $y$ axis.
+        Translate the body by 1 unit along the $x$ axis and rotate the body by 45 degrees about the $y$ axis with respect to the space frame.
     </p>
 </pl_question_panel>
-<pl_threejs answer_name="a" answer_pose_format="rpy">
+<pl_threejs answer_name="a" answer_pose_format="rpy" text_pose_format="matrix" >
     <pl_threejs_stl file_name="MAKE_Robot_V6.stl" frame="body" scale="0.1" />
     <pl_threejs_txt frame="body" position="[-1,1,2.6]" orientation="[0,0,30]">mini-me</pl_threejs_txt>
     <pl_threejs_stl file_name="MAKE_Robot_V6.stl" frame="body" scale="0.025" position="[-1,1,2]" orientation="[0,0,30]" />

--- a/exampleCourse/questions/rotateObject/server.py
+++ b/exampleCourse/questions/rotateObject/server.py
@@ -2,4 +2,4 @@ import random
 import numpy
 
 def generate(data):
-    data['correct_answers']['a'] = [0, 45, 0]
+    data['correct_answers']['a'] = [[1, 0, 0], [0, 45, 0]]


### PR DESCRIPTION
Body-fixed objects can now be translated (as a group) as well as rotated in the `<pl_threejs>` element. Improved UI. Made minor changes to attributes.