### PR TITLE
Assign OAuth credentials directly

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,8 @@
 
   * Fix styling of file upload element (Nathan Walters).
 
+  * Fix Google OAuth login (James Wang)
+
 * __2.11.0__ - 2017-12-29
 
   * Add support for partial credit in Homeworks (Tim Bretl).

--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -32,7 +32,7 @@ router.get('/', function(req, res, next) {
         if (ERR(err, next)) return;
         try {
             logger.verbose('Got Google auth tokens: ' + JSON.stringify(tokens));
-            oauth2Client.setCredentials(tokens);
+            oauth2Client.credentials = tokens;
             // tokens.id_token is a JWT (JSON Web Token)
             // http://openid.net/specs/draft-jones-json-web-token-07.html
             // A JWT has the form HEADER.PAYLOAD.SIGNATURE


### PR DESCRIPTION
Trying to log into PrairieLearn using Google raises an error that says `setCredentials is not a function`.
![image](https://user-images.githubusercontent.com/9091144/35125312-ccfab678-fc6e-11e7-87f8-a52783f5af55.png)

The setCredentials function seems to have been accidentally deleted, so this PR fixes that by assigning the credentials directly. See https://github.com/google/google-api-nodejs-client/issues/869 for more details.