### PR TITLE
Fix tol bug in threejs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@
 
   * Fix broken popovers in input elements (Tim Bretl).
 
+  * Fix bug in `pl_threejs` that applied different error tolerances to render and grade (Tim Bretl).
+
   * Update question card coloring; collapse past submissions by default (Nathan Walters).
 
   * Fix issues on instructor question page (Nathan Walters).

--- a/elements/pl_threejs/pl_threejs.py
+++ b/elements/pl_threejs/pl_threejs.py
@@ -95,7 +95,7 @@ def get_objects(element, data):
             else:
                 raise ValueError()
         except:
-            raise Exception('attribute "position" must have format [x, y, z] and must be non-zero: {:s}'.format(p))
+            raise Exception('attribute "position" must have format [x, y, z]: {:s}'.format(p))
         # - orientation (and format)
         orientation = get_orientation(child, 'orientation', 'format')
         # - scale
@@ -345,7 +345,7 @@ def grade(element_html, element_index, data):
     error_in_rotation = np.abs((q_tru.inverse * q_sub).degrees)
 
     # Get tolerances
-    tol_translation = pl.get_float_attrib(element, 'tol_translation', 0.1)
+    tol_translation = pl.get_float_attrib(element, 'tol_translation', 0.5)
     tol_rotation = pl.get_float_attrib(element, 'tol_rotation', 5)
     if (tol_translation <= 0):
         raise Exception('tol_translation must be a positive real number: {:g}'.format(tol_translation))


### PR DESCRIPTION
Small emergency bug fix in `pl_threejs`.

The attribute `tol_translation` was being read in two places, `render()` and `grade()`. A different default was being applied in each place. The consequence was that submitted answers were being checked against a stricter tolerance than the student was told.