### PR TITLE
Fix none submission bug in plthreejs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,8 @@
 
   * Fix bug in `pl_threejs` that showed wrong body position in answer panel (Tim Bretl).
 
+  * Fix bug in `pl_threejs` to handle case when submitted answer is None (Tim Bretl).
+
   * Update question card coloring; collapse past submissions by default (Nathan Walters).
 
   * Fix issues on instructor question page (Nathan Walters).


### PR DESCRIPTION
Now handles the case when `submitted_answer` exists but is `None`.

This might happen due to an error in transmission of data through the hidden input element (e.g., when course content is being synced at exactly the time of submission). If it happens, students got stuck because `render()` used `submitted_answer` to initialize body and camera pose.

The fixed code checks carefully for `None` and handles this case appropriately.