### PR TITLE
Add R to centos7-plbase Docker Image

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,8 @@
   * Add blocked-event-loop monitor (Matt West).
 
   * Add per-job load tracking (Matt West).
+  
+  * Add _R_ to the `centos7-plbase` Docker Image (James Balamuta).
 
   * All `centos7-plbase` Docker image (Matt West).
 

--- a/environments/centos7-plbase/Dockerfile
+++ b/environments/centos7-plbase/Dockerfile
@@ -18,9 +18,27 @@ RUN yum -y install \
         python36u-devel \
         gcc \
         make \
+        readline-devel \       # needed for rpy2
+        libcurl-devel \        # needed for rvest (for R)
+        openssl-devel \        # needed for rvest (for R)
+        libxml2-devel \        # needed for xml2 (for R)
+        libpng-devel \         # needed for png (for R)
+        libjpeg-turbo-devel \  # needed for jpeg (for R)
+        R \
     && yum clean all \
     && mkdir /var/postgres && chown postgres:postgres /var/postgres \
     && su postgres -c "/usr/pgsql-9.6/bin/initdb -D /var/postgres && mkdir /var/postgres/pg_log" \
     && ln -s /usr/bin/python3.6 /usr/bin/python3
+
+# r-requirements.R contains a list of R packages
+# that should be installed from the Rstudio CRAN mirror
+COPY r-requirements.R /PrairieLearn/
+
+# Install a list of R packages to work with
+RUN chmod +x /PrairieLearn/r-requirements.R \
+    && mkdir -p /usr/share/doc/R-3.4.3/html/ \
+    && touch /usr/share/doc/R-3.4.3/html/packages.html \
+    && touch /usr/share/doc/R-3.4.3/html/R.css \
+    && su root -c "Rscript /PrairieLearn/r-requirements.R"
 
 CMD /bin/bash

--- a/environments/centos7-plbase/r-requirements.R
+++ b/environments/centos7-plbase/r-requirements.R
@@ -1,0 +1,12 @@
+#! /usr/bin/env RScript
+
+# R Code Ahead to install packages!
+
+# The following are packages used in STAT 385
+pkg_list = c('tidyverse', 'RcppArmadillo', 'rmarkdown',
+             'rbenchmark', 'microbenchmark', 
+             'maps', 'maptools', 'mapproj', 'mapdata', 'ggmap',
+             'fivethirtyeight')
+
+install.packages(pkg_list, repos = "https://cran.rstudio.com")
+


### PR DESCRIPTION
This PR has components that were split from PR #1023, which tried to solve adding `rpy2` as indicated in #1009. 

In particular, this PR adds _R_ and the _R_ packages dependencies for @stat385uiuc -- which unfortunately take a while to compile as no prebuilt binaries are available on CentOS -- to the `centos-plbase` docker image that was added to #1027 