### PR TITLE
Fix Font Awesome icon for editing course roles

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -77,6 +77,8 @@
 
   * Fix `readthedocs` build (Matt West).
 
+  * Fix course role edit icon (Nathan Walters).
+
   * Change to Bootstrap 4 (Nathan Walters).
 
   * Change to NodeJS 8.x LTS (Matt West).

--- a/pages/courseOverview/courseOverview.ejs
+++ b/pages/courseOverview/courseOverview.ejs
@@ -77,7 +77,7 @@
                                    uid: course_user.uid, user_id: course_user.user_id,
                                    course_role: course_user.course_role}) %>"
                      data-trigger="manual" onclick="$(this).popover('show')">
-                    <i class="fa fa-pencil" aria-hidden="true"></i> Change
+                    <i class="fa fa-edit" aria-hidden="true"></i> Change
                   </a>
 
                   <a id="coursePermissionsDeleteButton<%= i %>"


### PR DESCRIPTION
I missed this when upgrading to Font Awesome 5...