### PR TITLE
DB initialization and migrations at Docker build

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -107,6 +107,8 @@
 
   * Add option to enable networking access on external grading containers (Nathan Walters).
 
+  * Change Docker postgresql to do initializations/migrations at build (Dave Mussulman).
+
 * __2.11.0__ - 2017-12-29
 
   * Add support for partial credit in Homeworks (Tim Bretl).

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,11 @@ RUN chmod +x /PrairieLearn/docker/init.sh \
     && mv /PrairieLearn/docker/config.json /PrairieLearn \
     && mkdir /course
 
+# Run migrations on blank DB at docker build time
+RUN /PrairieLearn/docker/start_postgres.sh \
+    && cd /PrairieLearn \
+    && node server.js --migrate-and-exit \
+    && /PrairieLearn/docker/start_postgres.sh stop
+
 HEALTHCHECK CMD curl --fail http://localhost:3000/pl/webhooks/ping || exit 1
 CMD /PrairieLearn/docker/init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,11 @@ RUN python3 -m pip install --no-cache-dir -r /PrairieLearn/requirements.txt \
 # NOTE: Modify .dockerignore to whitelist files/directories to copy.
 COPY . /PrairieLearn/
 
+# set up PrairieLearn and run migrations to initialize the DB
 RUN chmod +x /PrairieLearn/docker/init.sh \
     && mv /PrairieLearn/docker/config.json /PrairieLearn \
-    && mkdir /course
-
-# Run migrations on blank DB at docker build time
-RUN /PrairieLearn/docker/start_postgres.sh \
+    && mkdir /course \
+    && /PrairieLearn/docker/start_postgres.sh \
     && cd /PrairieLearn \
     && node server.js --migrate-and-exit \
     && /PrairieLearn/docker/start_postgres.sh stop

--- a/docker/start_postgres.sh
+++ b/docker/start_postgres.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-su postgres -c '/usr/pgsql-9.6/bin/pg_ctl -D /var/postgres -l /var/postgres/pg_log/logfile start'
+if [[ -z "$1" ]]; then
+    ACTION=start
+else
+    ACTION=$1
+fi
 
-# wait for postgres to start
-until /usr/pgsql-9.6/bin/pg_isready -q ; do sleep 1 ; done
+su postgres -c "/usr/pgsql-9.6/bin/pg_ctl -D /var/postgres -l /var/postgres/pg_log/logfile $ACTION"
+
+if [[ "$ACTION" == "start" ]]; then
+    # wait for postgres to start
+    until /usr/pgsql-9.6/bin/pg_isready -q ; do sleep 1 ; done
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -7188,6 +7188,12 @@
                 "yargs-parser": "8.1.0"
             },
             "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
                 "cliui": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
@@ -7198,14 +7204,22 @@
                         "strip-ansi": "4.0.0",
                         "wrap-ansi": "2.1.0"
                     }
+                },
+                "yargs-parser": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+                    "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0"
+                    }
                 }
             }
         },
         "yargs-parser": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-            "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-            "dev": true,
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+            "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "requires": {
                 "camelcase": "4.1.0"
             },
@@ -7213,8 +7227,7 @@
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-                    "dev": true
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         "tar": "^4.2.0",
         "three": "^0.89.0",
         "uuid": "^3.2.1",
-        "winston": "^2.4.0"
+        "winston": "^2.4.0",
+        "yargs-parser": "^9.0.2"
     },
     "devDependencies": {
         "chai": "^4.1.2",

--- a/server.js
+++ b/server.js
@@ -30,21 +30,21 @@ var freeformServer = require('./question-servers/freeform.js');
 
 // If there is only one argument, legacy it into the config option
 if (argv['_'].length == 1) {
-	argv['config'] = argv['_'][0];
-	argv['_'] = [];
+    argv['config'] = argv['_'][0];
+    argv['_'] = [];
 }
 
 if ('h' in argv || 'help' in argv) {
-	var msg = `PrairieLearn command line options:
-	-h, --help                          Display this help and exit
-	--config <filename>
-	<filename> and no other args        Load an alternative config filename
-	--migrate-and-exit					Run the DB initialization parts and exit
-	--exit                              Run all the initialization and exit
-	`;
+    var msg = `PrairieLearn command line options:
+    -h, --help                          Display this help and exit
+    --config <filename>
+    <filename> and no other args        Load an alternative config filename
+    --migrate-and-exit					Run the DB initialization parts and exit
+    --exit                              Run all the initialization and exit
+`;
 
-	console.log(msg); // eslint-disable-line no-console
-	process.exit(0);
+    console.log(msg); // eslint-disable-line no-console
+    process.exit(0);
 }
 
 if (config.startServer) {
@@ -461,14 +461,17 @@ if (config.startServer) {
         function(callback) {
             sprocs.init(function(err) {
                 if (ERR(err, callback)) return;
-				if ('migrate-and-exit' in argv && argv['migrate-and-exit']) {
-					logger.info('option --migrate-and-exit passed, running DB setup and exiting');
-					process.exit(0);
-				} else {
-					callback(null);
-				}
-			});
-		},
+                callback(null);
+            });
+        },
+        function(callback) {
+            if ('migrate-and-exit' in argv && argv['migrate-and-exit']) {
+                logger.info('option --migrate-and-exit passed, running DB setup and exiting');
+                process.exit(0);
+            } else {
+                callback(null);
+            }
+        },
         function(callback) {
             cron.init(function(err) {
                 if (ERR(err, callback)) return;

--- a/server.js
+++ b/server.js
@@ -29,7 +29,10 @@ var serverJobs = require('./lib/server-jobs');
 var freeformServer = require('./question-servers/freeform.js');
 
 // If there is only one argument, legacy it into the config option
-if (argv['_'].length == 1) { argv['config'] = argv['_'][0]; argv['_'] = [] }
+if (argv['_'].length == 1) {
+	argv['config'] = argv['_'][0];
+	argv['_'] = [];
+}
 
 if ('h' in argv || 'help' in argv) {
 	var msg = `PrairieLearn command line options:
@@ -464,8 +467,8 @@ if (config.startServer) {
 				} else {
 					callback(null);
 				}
-            });
-        },
+			});
+		},
         function(callback) {
             cron.init(function(err) {
                 if (ERR(err, callback)) return;

--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ if ('h' in argv || 'help' in argv) {
     -h, --help                          Display this help and exit
     --config <filename>
     <filename> and no other args        Load an alternative config filename
-    --migrate-and-exit					Run the DB initialization parts and exit
+    --migrate-and-exit                  Run the DB initialization parts and exit
     --exit                              Run all the initialization and exit
 `;
 

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ var https = require('https');
 var blocked = require('blocked-at');
 var onFinished = require('on-finished');
 var uuidv4 = require('uuid/v4');
+var argv = require('yargs-parser') (process.argv.slice(2));
 
 var logger = require('./lib/logger');
 var config = require('./lib/config');
@@ -27,12 +28,28 @@ var socketServer = require('./lib/socket-server');
 var serverJobs = require('./lib/server-jobs');
 var freeformServer = require('./question-servers/freeform.js');
 
+// If there is only one argument, legacy it into the config option
+if (argv['_'].length == 1) { argv['config'] = argv['_'][0]; argv['_'] = [] }
+
+if ('h' in argv || 'help' in argv) {
+	var msg = `PrairieLearn command line options:
+	-h, --help                          Display this help and exit
+	--config <filename>
+	<filename> and no other args        Load an alternative config filename
+	--migrate-and-exit					Run the DB initialization parts and exit
+	--exit                              Run all the initialization and exit
+	`;
+
+	console.log(msg); // eslint-disable-line no-console
+	process.exit(0);
+}
+
 if (config.startServer) {
     logger.info('PrairieLearn server start');
 
     var configFilename = 'config.json';
-    if (process.argv.length > 2) {
-        configFilename = process.argv[2];
+    if ('config' in argv) {
+        configFilename = argv['config'];
     }
 
     config.loadConfig(configFilename);
@@ -441,7 +458,12 @@ if (config.startServer) {
         function(callback) {
             sprocs.init(function(err) {
                 if (ERR(err, callback)) return;
-                callback(null);
+				if ('migrate-and-exit' in argv && argv['migrate-and-exit']) {
+					logger.info('option --migrate-and-exit passed, running DB setup and exiting');
+					process.exit(0);
+				} else {
+					callback(null);
+				}
             });
         },
         function(callback) {
@@ -510,6 +532,7 @@ if (config.startServer) {
             if (config.devMode) {
                 logger.info('Go to ' + config.serverType + '://localhost:' + config.serverPort + '/pl');
             }
+            if ('exit' in argv) { logger.info('exit option passed, quitting...'); process.exit(0); }
         }
     });
 }


### PR DESCRIPTION
PrairieLearn's first run, which does all the migrations, can take a while to run. Since this is visible when starting a docker container, moving that initialization to the Docker build stage makes it quicker to load for the user. On Dave's test box, this saved about 10s on startup with the database pre-migrated in the container.

Adds smarter command line parsing to PL (`yarg-parser`) and `stop` functionality to `docker/start_postgres.sh`

Closes #948 