### PR TITLE
External grading network config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -105,6 +105,8 @@
 
   * Remove HackIllinois advertisement (Matt West).
 
+  * Add option to enable networking access on external grading containers (Nathan Walters).
+
 * __2.11.0__ - 2017-12-29
 
   * Add support for partial credit in Homeworks (Tim Bretl).

--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -3,6 +3,7 @@ columns
     course_id: bigint not null
     deleted_at: timestamp with time zone
     directory: text
+    external_grading_enable_networking: boolean
     external_grading_enabled: boolean default false
     external_grading_entrypoint: text
     external_grading_files: text[] default ARRAY[]::text[]

--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -82,7 +82,7 @@ class Grader {
                     AttachStdout: true,
                     AttachStderr: true,
                     Tty: true,
-                    NetworkDisabled: true,
+                    NetworkDisabled: !question.external_grading_enable_networking,
                     HostConfig: {
                         Binds: [
                             `${hostDir}:/grade`,
@@ -95,7 +95,6 @@ class Grader {
                         CpuPeriod: 100000, // microseconds
                         CpuQuota: 90000, // portion of the CpuPeriod for this container
                         PidsLimit: 1024,
-                        NetworkMode: 'none',
                     },
                     Entrypoint: question.external_grading_entrypoint.split(' '),
                 }, (err, container) => {

--- a/lib/externalGraderSqs.js
+++ b/lib/externalGraderSqs.js
@@ -118,6 +118,7 @@ function sendJobToQueue(jobId, question, config, callback) {
                 webhookUrl: config.externalGradingWebhookUrl,
                 csrfToken: csrf.generateToken({url: '/pl/webhooks/grading'}, config.secretKey),
                 timeout: question.external_grading_timeout || config.externalGradingDefaultTimeout,
+                enableNetworking: question.external_grading_enable_networking || false,
             };
             const params = {
                 QueueUrl: QUEUE_URL,

--- a/migrations/106_questions__external_grading_enable_networking__add.sql
+++ b/migrations/106_questions__external_grading_enable_networking__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN IF NOT EXISTS external_grading_enable_networking BOOLEAN;

--- a/schemas/infoQuestion.json
+++ b/schemas/infoQuestion.json
@@ -112,6 +112,10 @@
                 "timeout": {
                     "description": "The number of seconds after which the grading job will timeout.",
                     "type": "integer"
+                },
+                "enableNetworking": {
+                    "description": "Whether the grading containers should have network access. Access is disabled by default.",
+                    "type": "boolean"
                 }
             }
         }

--- a/sync/fromDisk/questions.js
+++ b/sync/fromDisk/questions.js
@@ -83,7 +83,8 @@ module.exports = {
                         external_grading_image: (q.externalGradingOptions && q.externalGradingOptions.image),
                         external_grading_files: external_grading_files,
                         external_grading_entrypoint: (q.externalGradingOptions && q.externalGradingOptions.entrypoint),
-                        external_grading_timeout: (q.externalGradingOptions && q.externalGradingOptions.timeout)
+                        external_grading_timeout: (q.externalGradingOptions && q.externalGradingOptions.timeout),
+                        external_grading_enable_networking: (q.externalGradingOptions && q.externalGradingOptions.enableNetworking),
                     };
                     sqldb.queryOneRow(sql.insert_question, params, function(err, result) {
                         if (ERR(err, callback)) return;

--- a/sync/fromDisk/questions.sql
+++ b/sync/fromDisk/questions.sql
@@ -8,7 +8,8 @@ INSERT INTO questions
     external_grading_image,
     external_grading_files,
     external_grading_entrypoint,
-    external_grading_timeout)
+    external_grading_timeout,
+    external_grading_enable_networking)
 (SELECT
     $uuid, $qid, $qid,     $type::enum_question_type, $title, $options::JSONB, $client_files::TEXT[],
     $partial_credit, $course_id::integer, $grading_method::enum_grading_method, $single_variant,
@@ -18,7 +19,8 @@ INSERT INTO questions
     $external_grading_image,
     $external_grading_files,
     $external_grading_entrypoint,
-    $external_grading_timeout
+    $external_grading_timeout,
+    $external_grading_enable_networking
 )
 ON CONFLICT (uuid) DO UPDATE
 SET
@@ -38,7 +40,8 @@ SET
     external_grading_image = EXCLUDED.external_grading_image,
     external_grading_files = EXCLUDED.external_grading_files,
     external_grading_entrypoint = EXCLUDED.external_grading_entrypoint,
-    external_grading_timeout = EXCLUDED.external_grading_timeout
+    external_grading_timeout = EXCLUDED.external_grading_timeout,
+    external_grading_enable_networking = EXCLUDED.external_grading_enable_networking
 WHERE
     questions.course_id = $course_id
 RETURNING id;


### PR DESCRIPTION
This adds the ability to explicitly enable network access for external grading containers. It still defaults to disabling network access, and should be used only when absolutely necessary or when you're sure that student's can't/won't write networking code.