### PR TITLE
Auth redirect preserves originally requested URL

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -117,6 +117,8 @@
 
   * Change `pl_checkbox` to display form help text by default (James Balamuta).
 
+  * Change authenication redirects to preserve originally visited URL (Dave Mussulman).
+
   * Remove HackIllinois advertisement (Matt West).
 
 * __2.11.0__ - 2017-12-29

--- a/middlewares/authn.js
+++ b/middlewares/authn.js
@@ -54,6 +54,7 @@ module.exports = function(req, res, next) {
         //logger.error('no authn cookie');
         res.cookie('preAuthUrl', req.originalUrl);
         res.redirect('/');
+        return;
     }
     var authnData = csrf.getCheckedData(req.cookies.pl_authn, config.secretKey, {maxAge: 24 * 60 * 60 * 1000});
     if (authnData == null) {

--- a/middlewares/authn.js
+++ b/middlewares/authn.js
@@ -51,9 +51,9 @@ module.exports = function(req, res, next) {
 
     // otherwise look for auth cookies
     if (req.cookies.pl_authn == null) {
-        logger.error('no authn cookie');
+        //logger.error('no authn cookie');
+        res.cookie('postAuthUrl', req.originalUrl);
         res.redirect('/');
-        return;
     }
     var authnData = csrf.getCheckedData(req.cookies.pl_authn, config.secretKey, {maxAge: 24 * 60 * 60 * 1000});
     if (authnData == null) {

--- a/middlewares/authn.js
+++ b/middlewares/authn.js
@@ -52,7 +52,7 @@ module.exports = function(req, res, next) {
     // otherwise look for auth cookies
     if (req.cookies.pl_authn == null) {
         //logger.error('no authn cookie');
-        res.cookie('postAuthUrl', req.originalUrl);
+        res.cookie('preAuthUrl', req.originalUrl);
         res.redirect('/');
     }
     var authnData = csrf.getCheckedData(req.cookies.pl_authn, config.secretKey, {maxAge: 24 * 60 * 60 * 1000});

--- a/pages/authCallbackAzure/authCallbackAzure.js
+++ b/pages/authCallbackAzure/authCallbackAzure.js
@@ -31,7 +31,12 @@ router.all('/', function(req, res, next) {
             };
             var pl_authn = csrf.generateToken(tokenData, config.secretKey);
             res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-            res.redirect(res.locals.plainUrlPrefix);
+            var redirUrl = res.locals.plainUrlPrefix;
+            if ('preAuthUrl' in req.cookies) {
+                redirUrl = req.cookies.preAuthUrl;
+                res.clearCookie('preAuthUrl');
+            }
+            res.redirect(redirUrl);
         });
     })(req, res, next);
 });

--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -58,7 +58,12 @@ router.get('/', function(req, res, next) {
             };
             var pl_authn = csrf.generateToken(tokenData, config.secretKey);
             res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-            res.redirect(res.locals.plainUrlPrefix);
+            var redirUrl = res.locals.plainUrlPrefix;
+            if ('preAuthUrl' in req.cookies) {
+                redirUrl = req.cookies.preAuthUrl;
+                res.clearCookie('preAuthUrl');
+            }
+            res.redirect(redirUrl);
         });
     });
 });

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -31,7 +31,7 @@ router.get('/:action?/:target(*)?', function(req, res, next) {
         };
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-        if (req.params.action == 'redirect') return res.redirect('/' + req.params.target);
+        //if (req.params.action == 'redirect') return res.redirect('/' + req.params.target);
         var redirUrl = res.locals.plainUrlPrefix;
         if ('preAuthUrl' in req.cookies) {
             redirUrl = req.cookies.preAuthUrl;

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -31,10 +31,11 @@ router.get('/:action?/:target(*)?', function(req, res, next) {
         };
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
-        //if (req.params.action == 'redirect') return res.redirect('/' + req.params.target);
+        if (req.params.action == 'redirect') return res.redirect('/' + req.params.target);
         var redirUrl = res.locals.plainUrlPrefix;
         if ('preAuthUrl' in req.cookies) {
             redirUrl = req.cookies.preAuthUrl;
+            res.clearCookie('preAuthUrl');
         }
         res.redirect(redirUrl);
     });

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -32,7 +32,11 @@ router.get('/:action?/:target(*)?', function(req, res, next) {
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {maxAge: 24 * 60 * 60 * 1000});
         if (req.params.action == 'redirect') return res.redirect('/' + req.params.target);
-        res.redirect(res.locals.plainUrlPrefix);
+        var redirUrl = res.locals.plainUrlPrefix;
+        if ('preAuthUrl' in req.cookies) {
+            redirUrl = req.cookies.preAuthUrl;
+        }
+        res.redirect(redirUrl);
     });
 });
 

--- a/server.js
+++ b/server.js
@@ -143,7 +143,7 @@ if (config.devMode) {
 app.use(/^\/?$/, function(req, res, _next) {res.redirect('/pl');});
 
 // clear cookies on the homepage to reset any stale session state
-app.use(/^\/pl\/?/, require('./middlewares/clearCookies'));
+//app.use(/^\/pl\/?/, require('./middlewares/clearCookies'));
 
 // some pages don't need authorization
 app.use('/pl', require('./pages/home/home'));

--- a/server.js
+++ b/server.js
@@ -143,7 +143,7 @@ if (config.devMode) {
 app.use(/^\/?$/, function(req, res, _next) {res.redirect('/pl');});
 
 // clear cookies on the homepage to reset any stale session state
-//app.use(/^\/pl\/?/, require('./middlewares/clearCookies'));
+app.use(/^\/pl\/?/, require('./middlewares/clearCookies'));
 
 // some pages don't need authorization
 app.use('/pl', require('./pages/home/home'));


### PR DESCRIPTION
Previously, if you deep linked into something (i.e. `https://pl-dev.engr.illinois.edu/pl/course_instance/39/instructor/assessment/756/`) and were redirected out for authentication, post-login you were sent to `/pl`.

This PR stores the original URL request in a cookie so we can redirect back to it, allowing deep-linking with auth.