### PR TITLE
Add help text to pl_checkbox element (close #1058)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,8 @@
 
   * Add docs for generating LaTeX label images with Docker (Matt West).
 
+  * Add form help text indicating multiple answer can be selected for `pl_checkbox` (James Balamuta).
+
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).
@@ -105,6 +107,8 @@
 
   * Change to Python 3.6 in `centos7-base` grader image (Matt West).
 
+  * Change `pl_checkbox` to display form help text by default (James Balamuta).
+  
   * Remove HackIllinois advertisement (Matt West).
 
   * Add option to enable networking access on external grading containers (Nathan Walters).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,6 +43,8 @@
 
   * Add form help text indicating multiple answer can be selected for `pl_checkbox` (James Balamuta).
 
+  * Add demo question showcasing all options for `pl_checkbox` (James Balamuta).
+  
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -49,6 +49,8 @@ Attribute | Type | Default | Description
 `min_correct` | integer | special | The minimum number of correct answers to display. Defaults to displaying all correct answers.
 `max_correct` | integer | special | The maximum number of correct answers to display. Defaults to displaying all correct answers.
 `fixed_order` | boolean | false | Disable the randomization of answer order.
+`hide_inst_prompt` | boolean | false | Hide help text stating to pick one or more optinos. 
+`detailed_inst_prompt` | boolean | false | Display detailed information about the number of options to choose. 
 
 A `pl_checkbox` element displays a subset of the answers in a random order as checkboxes.
 

--- a/elements/pl_checkbox/pl_checkbox.py
+++ b/elements/pl_checkbox/pl_checkbox.py
@@ -7,7 +7,7 @@ import math
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers_name']
-    optional_attribs = ['weight', 'number_answers', 'min_correct', 'max_correct', 'fixed_order', 'inline']
+    optional_attribs = ['weight', 'number_answers', 'min_correct', 'max_correct', 'fixed_order', 'inline', 'hide_inst_prompt', 'detailed_inst_prompt']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers_name')
 
@@ -98,6 +98,7 @@ def render(element_html, element_index, data):
         score = partial_score.get('score', None)
 
         html = ''
+        
         for answer in display_answers:
             item = '  <label class="form-check-label">\n' \
                 + '    <input type="checkbox" class="form-check-input"' \
@@ -128,6 +129,27 @@ def render(element_html, element_index, data):
                     html = html + '&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>'
             except Exception:
                 raise ValueError('invalid score' + score)
+                
+        
+        # Adds decorative help text per bootstrap formatting guidelines:
+        # http://getbootstrap.com/docs/4.0/components/forms/#help-text
+        
+        # Determine whether we should add a choice selection requirement
+        if not pl.get_boolean_attrib(element, 'hide_inst_prompt', False):
+            
+            # Should we reveal the depth of the choice? 
+            if pl.get_boolean_attrib(element, 'detailed_inst_prompt', False):
+                min_correct = pl.get_integer_attrib(element, 'min_correct', 0)
+                max_correct = pl.get_integer_attrib(element, 'max_correct', len(correct_answer_list))
+                if min_correct != max_correct:
+                    html = html + '<small class="form-text text-muted"> Select between <b>%d</b> and <b>%d</b> options.</small>' % (min_correct, max_correct)
+                else:
+                    html = html + '<small class="form-text text-muted"> Select exactly <b>%d</b> options. </small>' % (max_correct)
+            # Generic prompt to differentiate from a radio input
+            else:
+                html = html + '<small class="form-text text-muted">  Select all possible options that apply.</small>'
+        
+        
     elif data['panel'] == 'submission':
         if len(submitted_keys) == 0:
             html = 'No selected answers'

--- a/exampleCourse/courseInstances/Sp15/assessments/homework2/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/homework2/infoAssessment.json
@@ -45,7 +45,8 @@
                 {"id": "customElement",              "points": 1, "maxPoints": 1},
                 {"id": "differentiatePolynomial",    "points": 2, "maxPoints": 10},
                 {"id": "functionValueFromPlot",      "points": 2, "maxPoints": 10},
-                {"id": "rotateObject",               "points": 2, "maxPoints": 10}
+                {"id": "rotateObject",               "points": 2, "maxPoints": 10},
+                {"id": "checkboxExamples",           "points": 2, "maxPoints": 10}
             ]
         }
     ]

--- a/exampleCourse/infoCourse.json
+++ b/exampleCourse/infoCourse.json
@@ -20,6 +20,7 @@
         {"name": "exampleCourse", "color": "gray1", "description": "Question originally written for exampleCourse"},
         {"name": "mwest", "color": "gray1", "description": "Question originally written by mwest"},
         {"name": "tbretl", "color": "blue1", "description": "Question originally written by tbretl"},
+        {"name": "balamut2", "color": "orange1", "description": "Question originally written by balamut2"},
         {"name": "tpl101", "color": "gray1", "description": "Question originally written for the TPL 101 template course"},
         {"name": "fa17", "color": "gray1", "description": "Question written in Fall 2017"},
         {"name": "sp18", "color": "gray1", "description": "Question written in Spring 2018"},

--- a/exampleCourse/questions/checkboxExamples/info.json
+++ b/exampleCourse/questions/checkboxExamples/info.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "78f68188-12ea-4775-9c6c-5a4263a6c0d8",
+    "title": "Examples Showing Choice Selection Techniques via pl_checkbox",
+    "topic": "Test",
+    "tags": ["balamut2", "v3", "MC"],
+    "type": "v3"
+}

--- a/exampleCourse/questions/checkboxExamples/question.html
+++ b/exampleCourse/questions/checkboxExamples/question.html
@@ -1,0 +1,106 @@
+<pl_question_panel>
+    <p>
+        Questions below were designed to showcase the different features of 
+		<a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_checkbox-element"><code>pl_checkbox</code></a>. 
+		The goal of <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_checkbox-element"><code>pl_checkbox</code></a>
+		is to allow users to select <b>multiple options</b> from a list of choices. To restrict choice to only one option, e.g. 
+		what comes from a standard multiple choice, please consider using  <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_multiple_choice-element"><code>pl_multiple_choice</code></a>.
+    </p>
+</pl_question_panel>
+
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+<pl_question_panel>
+    <p>Within this question, you can observe the default behavior of the <code>pl_checkbox</code> element.
+	   In particular, all options are shown after being randomized with help text at the bottom to remind users to select <b> all possible </b> options. </p>
+	<p> </p>
+    <p> Group work provides which of the following benefits: </p>
+</pl_question_panel>
+
+<pl_checkbox answers_name="group_ans_original">
+  <pl_answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl_answer>
+  <pl_answer correct="true">Improved creativity and overall work quality.</pl_answer>
+  <pl_answer>               The ability to work on a project by yourself.</pl_answer>
+  <pl_answer>               Having only one person make all of the decisions.</pl_answer>
+  <pl_answer correct="true">Constructive dialog and increased internal group motivation.</pl_answer>
+  <pl_answer correct="true">Personal accountability to the team to work on a project.</pl_answer>
+  <pl_answer correct="true">Friendship.</pl_answer>
+  <pl_answer>               The resources to work on a small project instead of a large project. </pl_answer>
+  <pl_answer correct="true">Prepares you for a team-environment in the workplace or a research group.</pl_answer>
+</pl_checkbox>
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+
+<pl_question_panel>
+    <p>In this variant, the <code>pl_checkbox</code> element is restrict to displaying no more than <b>5</b> choices with between <b>2</b> to <b>4</b> correct answers.
+	   Information regarding the range of correct answers users should select can be displayed by setting <code>detailed_inst_prompt="true"</code></p>
+	<p> </p>
+    <p> Group work provides which of the following benefits: </p>
+</pl_question_panel>
+
+<pl_checkbox answers_name="group_ans_restricted" min_correct="2" max_correct = "4" number_answers = "5" detailed_inst_prompt="true">
+  <pl_answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl_answer>
+  <pl_answer correct="true">Improved creativity and overall work quality.</pl_answer>
+  <pl_answer>               The ability to work on a project by yourself.</pl_answer>
+  <pl_answer>               Having only one person make all of the decisions.</pl_answer>
+  <pl_answer correct="true">Constructive dialog and increased internal group motivation.</pl_answer>
+  <pl_answer correct="true">Personal accountability to the team to work on a project.</pl_answer>
+  <pl_answer correct="true">Friendship.</pl_answer>
+  <pl_answer>               The resources to work on a small project instead of a large project. </pl_answer>
+  <pl_answer correct="true">Prepares you for a team-environment in the workplace or a research group.</pl_answer>
+</pl_checkbox>
+
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+
+<pl_question_panel>
+    <p>For this question, the <code>pl_checkbox</code> element displays options as they were written, e.g. <code>fixed_order="true"</code>, and gives more point weight to this question vs. priors, e.g. <code>weight="3"</code>  </p>
+	<p> </p>
+    <p> Group work provides which of the following benefits: </p>
+</pl_question_panel>
+
+<pl_checkbox answers_name="group_ans_fixed" fixed_order="true" weight="3">
+  <pl_answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl_answer>
+  <pl_answer correct="true">Improved creativity and overall work quality.</pl_answer>
+  <pl_answer>               The ability to work on a project by yourself.</pl_answer>
+  <pl_answer>               Having only one person make all of the decisions.</pl_answer>
+  <pl_answer correct="true">Constructive dialog and increased internal group motivation.</pl_answer>
+  <pl_answer correct="true">Personal accountability to the team to work on a project.</pl_answer>
+  <pl_answer correct="true">Friendship.</pl_answer>
+  <pl_answer>               The resources to work on a small project instead of a large project. </pl_answer>
+  <pl_answer correct="true">Prepares you for a team-environment in the workplace or a research group.</pl_answer>
+</pl_checkbox>
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+
+<pl_question_panel>
+    <p>The last two options are to display options together on the same line, e.g. <code>inline="true"</code>, and to
+		suppress the help text prompt, e.g. <code>hide_inst_prompt = "true"</code>.
+		Displaying options inline is only ideal if the choice options are not verbose and the number of choices is low. </p>
+	<p> </p>
+    <p> Group work provides which of the following benefits: </p>
+</pl_question_panel>
+
+<pl_checkbox answers_name="group_ans_v3" inline="true" number_answers = "3" hide_inst_prompt="true">
+  <pl_answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl_answer>
+  <pl_answer correct="true">Improved creativity and overall work quality.</pl_answer>
+  <pl_answer>               The ability to work on a project by yourself.</pl_answer>
+  <pl_answer>               Having only one person make all of the decisions.</pl_answer>
+  <pl_answer correct="true">Constructive dialog and increased internal group motivation.</pl_answer>
+  <pl_answer correct="true">Personal accountability to the team to work on a project.</pl_answer>
+  <pl_answer correct="true">Friendship.</pl_answer>
+  <pl_answer>               The resources to work on a small project instead of a large project. </pl_answer>
+  <pl_answer correct="true">Prepares you for a team-environment in the workplace or a research group.</pl_answer>
+</pl_checkbox>


### PR DESCRIPTION
In this PR:

- `pl_checkbox` element receives [form help text in the style of bootstrap](http://getbootstrap.com/docs/4.0/components/forms/#help-text) to indicate that students should select **all possible** options. 
    - `hide_inst_prompt = "true"` displays the prompt.
    - `detailed_inst_prompt = "true"` displays the range of options to select. If the `min` is the same as the `max`, then an exact number is specified.
- New `pl_checkbox` question that showcases different form attributes.


Example on a current question "Understanding motion from a position-time graph."

![Form help text current question](https://user-images.githubusercontent.com/833642/36938362-fda7df78-1ee5-11e8-9a30-962d9dd3f459.png)

Example question showing options:

![pl_checkbox example question](https://user-images.githubusercontent.com/833642/36938463-7e8421aa-1ee7-11e8-8c31-a95daefd9ec2.png)
