### PR TITLE
to_json accepts sympy.Immutablematrix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,10 @@
 
   * Add docs for generating LaTeX label images with Docker (Matt West).
 
+  * Add option to enable networking access on external grading containers (Nathan Walters).
+
+  * Add `sympy.ImmutableMatrix` to list of types accepted by `prairielearn.to_json()` (Tim Bretl).
+
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).
@@ -108,8 +112,6 @@
   * Change to Python 3.6 in `centos7-base` grader image (Matt West).
 
   * Remove HackIllinois advertisement (Matt West).
-
-  * Add option to enable networking access on external grading containers (Nathan Walters).
 
 * __2.11.0__ - 2017-12-29
 

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -35,7 +35,7 @@ def to_json(v):
     elif isinstance(v, sympy.Expr):
         s = [str(a) for a in v.free_symbols]
         return {'_type': 'sympy', '_value': str(v), '_variables': s}
-    elif isinstance(v, sympy.Matrix):
+    elif isinstance(v, sympy.Matrix) or isinstance(v, sympy.ImmutableMatrix):
         s = [str(a) for a in v.free_symbols]
         num_rows, num_cols = v.shape
         M = []


### PR DESCRIPTION
Small fix to `to_json()` in `prairielearn.py` to convert `sympy.ImmutableMatrix` just like `sympy.Matrix`. I was not aware at the time I created `to_json()` that there was more than one `Matrix` type.

Also fixed an out-of-order ChangeLog entry.