### PR TITLE
Fixes tag display order

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -81,6 +81,8 @@
 
   * Fix Coveralls.io reporting (Dave Mussulman).
 
+  * Fix tag order display (Dave Mussulman, h/t Pengyu Cheng).
+
   * Change to Bootstrap 4 (Nathan Walters).
 
   * Change to NodeJS 8.x LTS (Matt West).

--- a/sprocs/tags_for_question.sql
+++ b/sprocs/tags_for_question.sql
@@ -7,7 +7,8 @@ SELECT
     JSONB_AGG(JSONB_BUILD_OBJECT(
         'name',tag.name,
         'id',tag.id,
-        'color',tag.color
+        'color',tag.color,
+        'number', tag.number
     ) ORDER BY tag.number, tag.id)
 FROM
     tags AS tag

--- a/sprocs/tags_for_question.sql
+++ b/sprocs/tags_for_question.sql
@@ -7,9 +7,8 @@ SELECT
     JSONB_AGG(JSONB_BUILD_OBJECT(
         'name',tag.name,
         'id',tag.id,
-        'color',tag.color,
-        'number', tag.number
-    ) ORDER BY tag.number, tag.id)
+        'color',tag.color
+    ) ORDER BY qt.number, tag.id)
 FROM
     tags AS tag
     JOIN question_tags AS qt ON (qt.tag_id = tag.id AND qt.question_id = tags_for_question.question_id)


### PR DESCRIPTION
Was sorting by `id` instead of the `number` field. Found by the HackIllinois graphical editor team.