### PR TITLE
Fix invalid json

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -51,6 +51,8 @@
 
   * Add example of how to use PL to learn student names (Tim Bretl).
 
+  * Add exception handling to python caller to display what can't be converted to valid JSON (Tim Bretl).
+
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).
@@ -94,6 +96,8 @@
   * Fix tag order display (Dave Mussulman, h/t Pengyu Cheng).
 
   * Fix navbar role switching button text (Dave Mussulman).
+
+  * Fix all calls of `json.dumps` to make them produce valid JSON (Tim Bretl).
 
   * Change to Bootstrap 4 (Nathan Walters).
 

--- a/elements/pl_file_upload/pl_file_upload.py
+++ b/elements/pl_file_upload/pl_file_upload.py
@@ -47,7 +47,7 @@ def render(element_html, element_index, data):
     uuid = pl.get_uuid()
     raw_file_names = pl.get_string_attrib(element, 'file_names', '')
     file_names = get_file_names_as_array(raw_file_names)
-    file_names_json = json.dumps(file_names)
+    file_names_json = json.dumps(file_names, allow_nan=False)
     answer_name = get_answer_name(raw_file_names)
 
     html_params = {'name': answer_name, 'file_names': file_names_json, 'uuid': uuid}
@@ -57,7 +57,7 @@ def render(element_html, element_index, data):
         # Filter out any files not part of this element's file_names
         filtered_files = [x for x in files if x.get('name', '') in file_names]
         html_params['has_files'] = True
-        html_params['files'] = json.dumps(filtered_files)
+        html_params['files'] = json.dumps(filtered_files, allow_nan=False)
     else:
         html_params['has_files'] = False
 

--- a/elements/pl_threejs/pl_threejs.py
+++ b/elements/pl_threejs/pl_threejs.py
@@ -180,7 +180,7 @@ def render(element_html, element_index, data):
             'tol_translation': '{:.2f}'.format(pl.get_float_attrib(element, 'tol_translation', 0.5)),
             'tol_rotation': '{:.1f}'.format(pl.get_float_attrib(element, 'tol_rotation', 5)),
             'default_is_python': True,
-            'options': json.dumps(options)
+            'options': json.dumps(options, allow_nan=False)
         }
 
         with open('pl_threejs.mustache', 'r', encoding='utf-8') as f:
@@ -215,7 +215,7 @@ def render(element_html, element_index, data):
             'show_toggle': False,
             'show_pose': show_pose,
             'default_is_python': True,
-            'options': json.dumps(options)
+            'options': json.dumps(options, allow_nan=False)
         }
 
         partial_score = data['partial_scores'].get(answer_name, None)
@@ -291,7 +291,7 @@ def render(element_html, element_index, data):
             'show_toggle': False,
             'show_pose': show_pose,
             'default_is_python': True,
-            'options': json.dumps(options)
+            'options': json.dumps(options, allow_nan=False)
         }
 
         with open('pl_threejs.mustache', 'r', encoding='utf-8') as f:
@@ -446,7 +446,7 @@ def parse_correct_answer(f, a):
 
 
 def dict_to_b64(d):
-    return base64.b64encode(json.dumps(d).encode('utf-8')).decode()
+    return base64.b64encode(json.dumps(d, allow_nan=False).encode('utf-8')).decode()
 
 
 def b64_to_dict(b64):

--- a/environments/centos7-ocaml/main.py
+++ b/environments/centos7-ocaml/main.py
@@ -103,7 +103,7 @@ def finish(succeeded, info):
             final_data['event'] = 'grading_result'
             final_data['job_id'] = info['job_id']
 
-            r = requests.post(info['webhook_url'], data=json.dumps(final_data), headers=headers)
+            r = requests.post(info['webhook_url'], data=json.dumps(final_data, allow_nan=False), headers=headers)
 
     # We're all done now.
     sys.exit(0 if succeeded else 1)
@@ -204,7 +204,7 @@ def main():
             final_data['event'] = 'grading_start'
             final_data['job_id'] = info['job_id']
 
-            r = requests.post(info['webhook_url'], data=json.dumps(final_data), headers=headers)
+            r = requests.post(info['webhook_url'], data=json.dumps(final_data, allow_nan=False), headers=headers)
 
         # Load the job archive from S3
         jobs_bucket = info['jobs_bucket']

--- a/exampleCourse/serverFilesCourse/python_autograder/pltest.py
+++ b/exampleCourse/serverFilesCourse/python_autograder/pltest.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         grading_result['tests'] = results
         grading_result['score'] = float(earned_points) / float(max_points)
         grading_result['succeeded'] = True
-        print(json.dumps(grading_result))
+        print(json.dumps(grading_result, allow_nan=False))
 
         with open('results.json', mode='w') as out:
             json.dump(grading_result, out)


### PR DESCRIPTION
Adds `allow_nan=False` to all `json.dumps` calls to ensure that (except for repeated names) they produce valid JSON.

Also adds exception handling to `json.dumps` calls in `python-caller-trampoline.py` that displays any object that can't be converted to valid JSON. Doing so makes it much easier to debug problems with server-generated parts of `data`.

Fixes #1072 