### PR TITLE
Fix error when rendering question score panel

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -101,6 +101,8 @@
 
   * Fix all calls of `json.dumps` to make them produce valid JSON (Tim Bretl).
 
+  * Fix error when rendering question score panel (Nathan Walters).
+
   * Change to Bootstrap 4 (Nathan Walters).
 
   * Change to NodeJS 8.x LTS (Matt West).

--- a/lib/question.js
+++ b/lib/question.js
@@ -1378,6 +1378,8 @@ module.exports = {
                         assessment_question,
                         assessment_instance,
                         assessment,
+                        variant,
+                        __csrf_token: csrfToken,
                     };
                     const templatePath = path.join(__dirname, '..', 'pages', 'partials', 'questionScorePanel.ejs');
                     ejs.renderFile(templatePath, renderParams, (err, html) => {


### PR DESCRIPTION
If a question was part of an assessment and issue reporting was enabled, the async panel rerender would crash because `variant` and `__csrf_token` weren't available.

Fixes #1073