### PR TITLE
Fix instructorAssessment page's missing questions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -101,6 +101,8 @@
 
   * Fix all calls of `json.dumps` to make them produce valid JSON (Tim Bretl).
 
+  * Fix questions without tags not displaying on instructor assessment page (Jake Bailey).
+
   * Change to Bootstrap 4 (Nathan Walters).
 
   * Change to NodeJS 8.x LTS (Matt West).

--- a/pages/instructorAssessment/instructorAssessment.sql
+++ b/pages/instructorAssessment/instructorAssessment.sql
@@ -60,7 +60,7 @@ FROM
     JOIN topics AS top ON (top.id = q.topic_id)
     JOIN assessments AS a ON (a.id = aq.assessment_id)
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-    JOIN tags_list ON (tags_list.assessment_question_id = aq.id)
+    LEFT JOIN tags_list ON (tags_list.assessment_question_id = aq.id)
     LEFT JOIN issue_count AS ic ON (ic.question_id = q.id)
     LEFT JOIN question_scores ON (question_scores.question_id = q.id)
 WHERE


### PR DESCRIPTION
The `JOIN` means that untagged questions will not appear. A `LEFT JOIN` will just leave the tags column blank for questions without them.