### PR TITLE
Improve support for extremely large downloads

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 
 * __next version__ - XXXX-XX-XX
 
+  * Add improved support for very large file downloads (Nathan Walters).
+
   * Fix migration 111 to allow re-running (Matt West).
 
 * 2.12.0 - 2018-05-19
@@ -56,8 +58,6 @@
   * Add example of how to use PL to learn student names (Tim Bretl).
 
   * Add exception handling to python caller to display what can't be converted to valid JSON (Tim Bretl).
-
-  * Add imporved support for very large file downloads (Nathan Walters).
 
   * Add tags list to question stats CSV (Matt West).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,6 +57,8 @@
 
   * Add exception handling to python caller to display what can't be converted to valid JSON (Tim Bretl).
 
+  * Add imporved support for very large file downloads (Nathan Walters).
+
   * Add tags list to question stats CSV (Matt West).
 
   * Add Redis to support websockets when running with multiple servers (Nathan Walters).

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -2,7 +2,7 @@ const ERR = require('async-stacktrace');
 const _ = require('lodash');
 const async = require('async');
 
-const sqldb = require('./sqldb');
+const sqldb = require('@prairielearn/prairielib/sql-db');
 
 module.exports = {
     pages(chosenPage, count, pageSize) {

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,4 +1,8 @@
+const ERR = require('async-stacktrace');
 const _ = require('lodash');
+const async = require('async');
+
+const sqldb = require('./sqldb');
 
 module.exports = {
     pages(chosenPage, count, pageSize) {
@@ -16,5 +20,34 @@ module.exports = {
         nextPage = Math.max(1, Math.min(lastPage, nextPage));
 
         return {currPage, prevPage, nextPage, lastPage};
+    },
+
+    /**
+     * Utility function to facilitate extremely large queries whose results
+     * cannot fit in memory all at once. The given query must accept an "offset"
+     * param that will be used to paginate the query. The "receiveRow" callback
+     * will be called once for each row in the result set. The "done" callback
+     * is called either if an error has occurred or when all rows have been
+     * delivered.
+     */
+    paginateQuery(sql, params, opts, receiveRows, done) {
+        const _params = Object.assign({}, params);
+        let offset = 0;
+        async.doWhilst((callback) => {
+            _params.offset = offset;
+            sqldb.query(sql, _params, (err, result) => {
+                if (ERR(err, callback)) return;
+                async.eachSeries(result.rows, receiveRows, (err) => {
+                    if (ERR(err, callback)) return;
+                    offset += result.rows.length;
+                    callback(null, result.rows.length);
+                });
+            });
+        }, (count) => {
+            return count > 0;
+        }, (err) => {
+            if (ERR(err, done)) return;
+            done(null);
+        });
     },
 };

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -30,14 +30,14 @@ module.exports = {
      * is called either if an error has occurred or when all rows have been
      * delivered.
      */
-    paginateQuery(sql, params, opts, receiveRows, done) {
+    paginateQuery(sql, params, receiveRow, done) {
         const _params = Object.assign({}, params);
         let offset = 0;
         async.doWhilst((callback) => {
             _params.offset = offset;
             sqldb.query(sql, _params, (err, result) => {
                 if (ERR(err, callback)) return;
-                async.eachSeries(result.rows, receiveRows, (err) => {
+                async.eachSeries(result.rows, receiveRow, (err) => {
                     if (ERR(err, callback)) return;
                     offset += result.rows.length;
                     callback(null, result.rows.length);

--- a/pages/instructorAssessment/instructorAssessment.js
+++ b/pages/instructorAssessment/instructorAssessment.js
@@ -1,21 +1,22 @@
-var ERR = require('async-stacktrace');
-var _ = require('lodash');
-var async = require('async');
-var csvStringify = require('csv').stringify;
-var express = require('express');
-var router = express.Router();
-var debug = require('debug')('prairielearn:instructorAssessment');
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
+const async = require('async');
+const csvStringify = require('csv').stringify;
+const express = require('express');
+const router = express.Router();
+const debug = require('debug')('prairielearn:instructorAssessment');
+const archiver = require('archiver');
 
-var error = require('@prairielearn/prairielib/error');
-var logger = require('../../lib/logger');
-var serverJobs = require('../../lib/server-jobs');
-var csvMaker = require('../../lib/csv-maker');
-var dataFiles = require('../../lib/data-files');
-var assessment = require('../../lib/assessment');
-var sqldb = require('@prairielearn/prairielib/sql-db');
-var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const error = require('@prairielearn/prairielib/error');
+const logger = require('../../lib/logger');
+const serverJobs = require('../../lib/server-jobs');
+const csvMaker = require('../../lib/csv-maker');
+const { paginateQuery } = require('../../lib/paginate');
+const assessment = require('../../lib/assessment');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
-var sql = sqlLoader.loadSqlEquiv(__filename);
+const sql = sqlLoader.loadSqlEquiv(__filename);
 
 var sanitizeName = function(name) {
     return name.replace(/[^a-zA-Z0-9]/g, '_');
@@ -395,23 +396,29 @@ router.get('/:filename', function(req, res, next) {
     } else if (req.params.filename == res.locals.allFilesZipFilename
                || req.params.filename == res.locals.finalFilesZipFilename
                || req.params.filename == res.locals.bestFilesZipFilename) {
-        let include_all = (req.params.filename == res.locals.allFilesZipFilename);
-        let include_final = (req.params.filename == res.locals.finalFilesZipFilename);
-        let include_best = (req.params.filename == res.locals.bestFilesZipFilename);
-        let params = {
+        const include_all = (req.params.filename == res.locals.allFilesZipFilename);
+        const include_final = (req.params.filename == res.locals.finalFilesZipFilename);
+        const include_best = (req.params.filename == res.locals.bestFilesZipFilename);
+        const params = {
             assessment_id: res.locals.assessment.id,
+            limit: 100,
             include_all,
             include_final,
             include_best,
         };
-        sqldb.query(sql.assessment_instance_files, params, function(err, result) {
+
+        const archive = archiver('zip');
+        const dirname = (res.locals.assessment_set.name + res.locals.assessment.number).replace(' ', '');
+        const prefix = `${dirname}/`;
+        archive.append(null, { name: prefix });
+        res.attachment(req.params.filename);
+        archive.pipe(res);
+        paginateQuery(sql.assessment_instance_files, params, (row, callback) => {
+            archive.append(row.contents, { name: prefix + row.filename });
+            callback(null);
+        }, (err) => {
             if (ERR(err, next)) return;
-            var dirname = (res.locals.assessment_set.name + res.locals.assessment.number).replace(' ', '');
-            dataFiles.filesToZipBuffer(result.rows, dirname, function(err, zipBuffer) {
-                if (ERR(err, next)) return;
-                res.attachment(req.params.filename);
-                res.send(zipBuffer);
-            });
+            archive.finalize();
         });
     } else if (req.params.filename === res.locals.questionStatsCsvFilename) {
         var params = {

--- a/pages/instructorAssessment/instructorAssessment.sql
+++ b/pages/instructorAssessment/instructorAssessment.sql
@@ -373,7 +373,11 @@ SELECT
 FROM
     all_files
 ORDER BY
-    uid, assessment_instance_number, qid, variant_number, date;
+    uid, assessment_instance_number, qid, variant_number, date
+LIMIT
+    $limit
+OFFSET
+    $offset;
 
 
 -- BLOCK open

--- a/pages/instructorAssessments/instructorAssessments.ejs
+++ b/pages/instructorAssessments/instructorAssessments.ejs
@@ -79,9 +79,13 @@
         </div>
 
         <div class="card-footer">
-          <p class="mb-0">
+          <p>
             Download <a href="<%= urlPrefix %>/assessments/<%= csvFilename %>"><%= csvFilename %></a>
             (includes more statistics columns than displayed above)
+          </p>
+          <p class="mb-0">
+            Download <a href="<%= urlPrefix %>/assessments/<%= fileSubmissionsFilename %>"><%= fileSubmissionsFilename %></a>
+            (includes all files ever submitted for this course instance)
           </p>
         </div>
 

--- a/pages/instructorAssessments/instructorAssessments.js
+++ b/pages/instructorAssessments/instructorAssessments.js
@@ -1,15 +1,17 @@
-var ERR = require('async-stacktrace');
-var _ = require('lodash');
-var csvStringify = require('csv').stringify;
-var express = require('express');
-var router = express.Router();
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
+const csvStringify = require('csv').stringify;
+const express = require('express');
+const archiver = require('archiver');
+const router = express.Router();
 
-var sqldb = require('@prairielearn/prairielib/sql-db');
-var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const { paginateQuery } = require('../../lib/paginate');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
-var sql = sqlLoader.loadSqlEquiv(__filename);
+const sql = sqlLoader.loadSqlEquiv(__filename);
 
-var csvFilename = function(locals) {
+const csvFilename = (locals) => {
     return locals.course.short_name.replace(/\s+/g, '')
         + '_'
         + locals.course_instance.short_name.replace(/\s+/g, '')
@@ -17,8 +19,19 @@ var csvFilename = function(locals) {
         + 'assessment_stats.csv';
 };
 
+const fileSubmissionsName = (locals) => {
+    return locals.course.short_name.replace(/\s+/g, '')
+        + '_'
+        + locals.course_instance.short_name.replace(/\s+/g, '')
+        + '_'
+        + 'file_submissions';
+};
+
+const fileSubmissionsFilename = locals => `${fileSubmissionsName(locals)}.zip`;
+
 router.get('/', function(req, res, next) {
     res.locals.csvFilename = csvFilename(res.locals);
+    res.locals.fileSubmissionsFilename = fileSubmissionsFilename(res.locals);
     var params = {
         course_instance_id: res.locals.course_instance.id,
         authz_data: res.locals.authz_data,
@@ -77,6 +90,25 @@ router.get('/:filename', function(req, res, next) {
                 res.attachment(req.params.filename);
                 res.send(csv);
             });
+        });
+    } else if (req.params.filename == fileSubmissionsFilename(res.locals)) {
+        const params = {
+            course_instance_id: res.locals.course_instance.id,
+            limit: 100,
+        };
+
+        const archive = archiver('zip');
+        const dirname = fileSubmissionsName(res.locals);
+        const prefix = `${dirname}/`;
+        archive.append(null, { name: prefix });
+        res.attachment(req.params.filename);
+        archive.pipe(res);
+        paginateQuery(sql.course_instance_files, params, (row, callback) => {
+            archive.append(row.contents, { name: prefix + row.filename });
+            callback(null);
+        }, (err) => {
+            if (ERR(err, next)) return;
+            archive.finalize();
         });
     } else {
         next(new Error('Unknown filename: ' + req.params.filename));


### PR DESCRIPTION
For some queries (specifically the ones that generate archives of submitted files), the query results are so large that they can't fit in memory. This PR changes to fetching the rows in chunks and streaming the results through the zip archiver so that the total amount of memory in use at any moment remains minimal.

On my machine, this can compress and send ~2Mbps once things get up to speed. I'm able to download a zip of 200,000 files (100K 20B files and 100K 3KB files) in ~2:30.

This also adds an "all file submissions" link to the instructor assessments page; this download utilizes this new chunking+streaming method.