### PR TITLE
Preserve dtype in json

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -57,6 +57,8 @@
 
   * Add Redis to support websockets when running with multiple servers (Nathan Walters).
 
+  * Add support for dtype in `pl.to_json` and `pl.from_json` (Tim Bretl).
+
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).


### PR DESCRIPTION
Formerly, the functions `to_json` and `from_json` in the library `prairielearn.py` made no attempt to preserve the `dtype` of an ndarray. Forgetting about this can cause trouble - for example, the ndarray `array([[1.0]])` with `dtype=np.float64` becomes `array([[1]])` with `dtype=np.int64` after conversion, with consequences that may be hard to debug.

Because these functions are meant to help folks who don't want to understand the details of jsonification, I thought it best to change them to support preservation of `dtype`. This was done by adding a third field `_dtype` to the encoded object when appropriate.

This change is backward-compatible. All previously encoded objects (without `_dtype`) will be recovered by `from_json` as they always were.