### PR TITLE
Add ability to restore original file in pl_file_editor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -73,6 +73,8 @@
 
   * Add documentation for the `shuffleQuestions` option (Matt West).
 
+  * Add ability to restore original file in `pl_file_editor` (Nathan Walters).
+
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).

--- a/elements/pl_file_editor/pl_file_editor.js
+++ b/elements/pl_file_editor/pl_file_editor.js
@@ -6,9 +6,14 @@ window.PLFileEditor = function(uuid, options) {
     if (!this.element) {
         throw new Error('File upload element ' + elementId + ' was not found!');
     }
+    this.originalContents = options.originalContents || '';
 
     this.inputElement = this.element.find('input');
     this.editorElement = this.element.find('.editor');
+    this.restoreOriginalButton = this.element.find('.restore-original');
+    this.restoreOriginalConfirmContainer = this.element.find('.restore-original-confirm-container');
+    this.restoreOriginalConfirm = this.element.find('.restore-original-confirm');
+    this.restoreOriginalCancel = this.element.find('.restore-original-cancel');
     this.editor = ace.edit(this.editorElement.get(0));
     this.editor.setTheme('ace/theme/chrome');
     this.editor.getSession().setUseWrapMode(true);
@@ -29,7 +34,32 @@ window.PLFileEditor = function(uuid, options) {
     if (options.currentContents) {
         currentContents = this.b64DecodeUnicode(options.currentContents);
     }
-    this.editor.setValue(currentContents);
+    this.setEditorContents(currentContents);
+
+    this.initRestoreOriginalButton();
+};
+
+window.PLFileEditor.prototype.initRestoreOriginalButton = function() {
+    var that = this;
+    this.restoreOriginalButton.click(function() {
+        that.restoreOriginalButton.hide();
+        that.restoreOriginalConfirmContainer.show();
+    });
+
+    this.restoreOriginalConfirm.click(function() {
+        that.restoreOriginalConfirmContainer.hide();
+        that.restoreOriginalButton.show();
+        that.setEditorContents(that.b64DecodeUnicode(that.originalContents));
+    });
+
+    this.restoreOriginalCancel.click(function() {
+        that.restoreOriginalConfirmContainer.hide();
+        that.restoreOriginalButton.show();
+    });
+};
+
+window.PLFileEditor.prototype.setEditorContents = function(contents) {
+    this.editor.setValue(contents);
     this.editor.gotoLine(1, 0);
     this.editor.focus();
     this.syncFileToHiddenInput();

--- a/elements/pl_file_editor/pl_file_editor.mustache
+++ b/elements/pl_file_editor/pl_file_editor.mustache
@@ -16,6 +16,15 @@ $(function() {
     <div class="card">
         <div class="card-header">{{file_name}}</div>
         <div class="editor"></div>
+        <div class="card-footer d-flex">
+            <div class="ml-auto">
+                <a class="btn btn-outline-secondary btn-sm restore-original" role="button" tabindex="-1">Restore original file</a>
+                <div class="restore-original-confirm-container" style="display: none;">
+                    <a class="btn btn-success btn-sm restore-original-confirm" role="button" tabindex="-1">Confirm restore original</a>
+                    <a class="btn btn-secondary btn-sm restore-original-cancel" role="button" tabindex="-1">Cancel</a>
+                </div>
+            </div>
+        </div>
     </div>
     {{submission}}
 </div>


### PR DESCRIPTION
Adds a footer to the editor with a "Restore original file" button that asks you to confirm because this action is potentially destructive.

Fixes #1119.