### PR TITLE
Input hint fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -129,6 +129,8 @@
 
   * Fix question order on instructor assessment instance page (Matt West).
 
+  * Fix bug in display of input element tolerances (Tim Bretl).
+
   * Change to Bootstrap 4 (Nathan Walters).
 
   * Change to NodeJS 8.x LTS (Matt West).

--- a/elements/pl_matrix_input/pl_matrix_input.py
+++ b/elements/pl_matrix_input/pl_matrix_input.py
@@ -33,13 +33,21 @@ def render(element_html, element_index, data):
         if comparison == 'relabs':
             rtol = pl.get_float_attrib(element, 'rtol', 1e-2)
             atol = pl.get_float_attrib(element, 'atol', 1e-8)
-            info_params = {'format': True, 'relabs': True, 'rtol': rtol, 'atol': atol}
+            if (rtol < 0):
+                raise ValueError('Attribute rtol = {:g} must be non-negative'.format(rtol))
+            if (atol < 0):
+                raise ValueError('Attribute atol = {:g} must be non-negative'.format(atol))
+            info_params = {'format': True, 'relabs': True, 'rtol': '{:g}'.format(rtol), 'atol': '{:g}'.format(atol)}
         elif comparison == 'sigfig':
             digits = pl.get_integer_attrib(element, 'digits', 2)
-            info_params = {'format': True, 'sigfig': True, 'digits': digits, 'comparison_eps': 0.51 * (10**-(digits - 1))}
+            if (digits < 0):
+                raise ValueError('Attribute digits = {:d} must be non-negative'.format(digits))
+            info_params = {'format': True, 'sigfig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 1))}
         elif comparison == 'decdig':
             digits = pl.get_integer_attrib(element, 'digits', 2)
-            info_params = {'format': True, 'decdig': True, 'digits': digits, 'comparison_eps': 0.51 * (10**-(digits - 0))}
+            if (digits < 0):
+                raise ValueError('Attribute digits = {:d} must be non-negative'.format(digits))
+            info_params = {'format': True, 'decdig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 0))}
         else:
             raise ValueError('method of comparison "%s" is not valid (must be "relabs", "sigfig", or "decdig")' % comparison)
         info_params['allow_complex'] = pl.get_boolean_attrib(element, 'allow_complex', False)

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -37,13 +37,21 @@ def render(element_html, element_index, data):
         if comparison == 'relabs':
             rtol = pl.get_float_attrib(element, 'rtol', 1e-2)
             atol = pl.get_float_attrib(element, 'atol', 1e-8)
-            info_params = {'format': True, 'relabs': True, 'rtol': rtol, 'atol': atol}
+            if (rtol < 0):
+                raise ValueError('Attribute rtol = {:g} must be non-negative'.format(rtol))
+            if (atol < 0):
+                raise ValueError('Attribute atol = {:g} must be non-negative'.format(atol))
+            info_params = {'format': True, 'relabs': True, 'rtol': '{:g}'.format(rtol), 'atol': '{:g}'.format(atol)}
         elif comparison == 'sigfig':
             digits = pl.get_integer_attrib(element, 'digits', 2)
-            info_params = {'format': True, 'sigfig': True, 'digits': digits, 'comparison_eps': 0.51 * (10**-(digits - 1))}
+            if (digits < 0):
+                raise ValueError('Attribute digits = {:d} must be non-negative'.format(digits))
+            info_params = {'format': True, 'sigfig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 1))}
         elif comparison == 'decdig':
             digits = pl.get_integer_attrib(element, 'digits', 2)
-            info_params = {'format': True, 'decdig': True, 'digits': digits, 'comparison_eps': 0.51 * (10**-(digits - 0))}
+            if (digits < 0):
+                raise ValueError('Attribute digits = {:d} must be non-negative'.format(digits))
+            info_params = {'format': True, 'decdig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 0))}
         else:
             raise ValueError('method of comparison "%s" is not valid (must be "relabs", "sigfig", or "decdig")' % comparison)
         info_params['allow_complex'] = pl.get_boolean_attrib(element, 'allow_complex', False)


### PR DESCRIPTION
Displays zero tolerances properly in `pl_matrix_input` and `pl_number_input`. Throws an exception if tolerances are negative.

Fixes #1117.
