### PR TITLE
Add option to disable help text on pl_number_input (Close #1118)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,10 @@
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).
 
   * Fix Google auth using new API (Matt West).
+  
+  * Add option to toggle placeholder help text for `pl_number_input` (James Balamuta).
+
+  * Add demo question showcasing all options for `pl_number_input` (James Balamuta).
 
 * __3.0.0__ - 2018-05-23
 
@@ -80,10 +84,8 @@
   * Add `sympy.ImmutableMatrix` to list of types accepted by `prairielearn.to_json()` (Tim Bretl).
 
   * Add form help text indicating multiple answer can be selected for `pl_checkbox` (James Balamuta).
-  
-  * Add option to toggle placeholder help text for `pl_number_input` (James Balamuta).
 
-  * Add demo questions showcasing all options for `pl_checkbox` and `pl_number_input` (James Balamuta).
+  * Add demo question showcasing all options for `pl_checkbox` (James Balamuta).
 
   * Add example of how to use PL to learn student names (Tim Bretl).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -80,8 +80,10 @@
   * Add `sympy.ImmutableMatrix` to list of types accepted by `prairielearn.to_json()` (Tim Bretl).
 
   * Add form help text indicating multiple answer can be selected for `pl_checkbox` (James Balamuta).
+  
+  * Add option to toggle placeholder help text for `pl_number_input` (James Balamuta).
 
-  * Add demo question showcasing all options for `pl_checkbox` (James Balamuta).
+  * Add demo questions showcasing all options for `pl_checkbox` and `pl_number_input` (James Balamuta).
 
   * Add example of how to use PL to learn student names (Tim Bretl).
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -79,6 +79,7 @@ Attribute | Type | Default | Description
 `atol` | number | 1e-8 | Absolute tolerance for `comparison="relabs"`.
 `digits` | integer | 2 | number of digits that must be correct for `comparison="sigfig"` or `comparison="decdig"`.
 `allow_complex` | boolean | False | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answer'][answers_name] = pl.to_json(ans)`.
+`hide_help_text` | boolean | False | Hide help text stating the default comparison. 
 
 ## `pl_integer_input` element
 

--- a/elements/pl_number_input/pl_number_input.mustache
+++ b/elements/pl_number_input/pl_number_input.mustache
@@ -18,12 +18,14 @@
         <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
         <span class="input-group-append">
             {{#suffix}}<span class="input-group-text">{{suffix}}</span>{{/suffix}}
+            {{#shortinfo}}
             <a class="btn btn-light border" role="button" data-toggle="popover" data-html="true" title="Number" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
                 {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
                 {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
                 {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
             </a>
+            {{/shortinfo}}
         </span>
     </span>
 {{#inline}}</span>{{/inline}}

--- a/elements/pl_number_input/pl_number_input.py
+++ b/elements/pl_number_input/pl_number_input.py
@@ -10,7 +10,7 @@ import random
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers_name']
-    optional_attribs = ['weight', 'correct_answer', 'label', 'suffix', 'display', 'comparison', 'rtol', 'atol', 'digits', 'allow_complex']
+    optional_attribs = ['weight', 'correct_answer', 'label', 'suffix', 'display', 'comparison', 'rtol', 'atol', 'digits', 'allow_complex', 'hide_help_text']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers_name')
 
@@ -59,7 +59,9 @@ def render(element_html, element_index, data):
             info = chevron.render(f, info_params).strip()
         with open('pl_number_input.mustache', 'r', encoding='utf-8') as f:
             info_params.pop('format', None)
-            info_params['shortformat'] = True
+            # Within mustache, the shortformat generates the shortinfo that is used as a placeholder inside of the numeric entry.
+            # Here we opt to not generate the value, hence the placeholder is empty.
+            info_params['shortformat'] = not pl.get_boolean_attrib(element, 'hide_help_text', False)
             shortinfo = chevron.render(f, info_params).strip()
 
         html_params = {

--- a/exampleCourse/courseInstances/Sp15/assessments/plelementexamples/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/plelementexamples/infoAssessment.json
@@ -33,7 +33,8 @@
     "zones": [
         {
             "questions": [
-				{"id": "checkboxExamples",           "points": 2, "maxPoints": 10}
+				{"id": "checkboxExamples",           "points": 2, "maxPoints": 10},
+				{"id": "numberExamples",           "points": 2, "maxPoints": 10}
             ]
         }
     ]

--- a/exampleCourse/questions/numberExamples/info.json
+++ b/exampleCourse/questions/numberExamples/info.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "933849d9-d7ee-4462-b743-b50e43b03b9e",
+    "title": "Examples Showing Real and Imaginary Input via pl_number_input",
+    "topic": "Test",
+    "tags": ["balamut2", "Sp18", "tpl101", "v3", "numeric"],
+    "type": "v3"
+}

--- a/exampleCourse/questions/numberExamples/question.html
+++ b/exampleCourse/questions/numberExamples/question.html
@@ -1,9 +1,9 @@
 <pl_question_panel>
     <p>
         Questions below were designed to showcase the different features of 
-		<a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>. 
-		The goal of <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>
-		is to allow users to enter <b>real or imaginary values</b> to be checked within a specific tolerance. 
+        <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>. 
+        The goal of <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>
+        is to allow users to enter <b>real or imaginary values</b> to be checked within a specific tolerance. 
     </p>
 </pl_question_panel>
 
@@ -13,8 +13,8 @@
 
 <pl_question_panel>
     <p>Within this question, you can observe the default behavior of the <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> element.
-	   In particular, the default input field has help text as a placeholder as well as a question button and is set to use <code>"relabs"</code> to check the tolerance, which is a combination of relative (<code>"rtol"</code>) and absolute (<code>"atol"</code>) tolerances.</p>
-	<p> </p>
+       In particular, the default input field has help text as a placeholder as well as a question button and is set to use <code>"relabs"</code> to check the tolerance, which is a combination of relative (<code>"rtol"</code>) and absolute (<code>"atol"</code>) tolerances.</p>
+    <p> </p>
     <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
 </pl_question_panel>
 
@@ -26,7 +26,7 @@
 
 <pl_question_panel>
     <p>This question modifies the default relative tolerance (of <code>1e-3</code>) and absolute tolerance (of <code>1e-8</code>) underneath <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> element. Furthermore, we add a label to the front of the input field to specify what the field should receive. </p>
-	<p> </p>
+    <p> </p>
     <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
 </pl_question_panel>
 
@@ -38,7 +38,7 @@
 
 <pl_question_panel>
     <p>Under this variant, we opt to change the default comparison of <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>  from relative and absolute tolerances (<code>comparison="relabs"</code>) to significant digits (<code>comparison="sigfigs"</code>), which has a default of two digits. In addition, we've opted to add a suffix or a unit classification to the input via <code>suffix="$units$"</code>. </p>
-	<p> </p>
+    <p> </p>
     <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
 </pl_question_panel>
 
@@ -50,7 +50,7 @@
 
 <pl_question_panel>
     <p>Another option is to set the comparison for <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> to decimal digits (<code>"decdig"</code>) with a requirement for four digits (<code>digits="4'"</code>). Furthermore, we changed the weight of this question to be more impactful vs the previous entries via <code>weight="2"</code>. Lastly, we allow students to enter complex numbers by setting <code>allow_complex="true"</code>. </p>
-	<p> </p>
+    <p> </p>
     <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
 </pl_question_panel>
 
@@ -62,7 +62,7 @@
 
 <pl_question_panel>
     <p>As a final example, we remove the placeholder text found in <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> by setting <code>hide_help_text="true"</code>.</p>
-	<p> </p>
+    <p> </p>
     <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
 </pl_question_panel>
 

--- a/exampleCourse/questions/numberExamples/question.html
+++ b/exampleCourse/questions/numberExamples/question.html
@@ -1,0 +1,69 @@
+<pl_question_panel>
+    <p>
+        Questions below were designed to showcase the different features of 
+		<a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>. 
+		The goal of <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>
+		is to allow users to enter <b>real or imaginary values</b> to be checked within a specific tolerance. 
+    </p>
+</pl_question_panel>
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+<pl_question_panel>
+    <p>Within this question, you can observe the default behavior of the <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> element.
+	   In particular, the default input field has help text as a placeholder as well as a question button and is set to use <code>"relabs"</code> to check the tolerance, which is a combination of relative (<code>"rtol"</code>) and absolute (<code>"atol"</code>) tolerances.</p>
+	<p> </p>
+    <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
+</pl_question_panel>
+
+<pl_number_input answers_name="c" />
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+<pl_question_panel>
+    <p>This question modifies the default relative tolerance (of <code>1e-3</code>) and absolute tolerance (of <code>1e-8</code>) underneath <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> element. Furthermore, we add a label to the front of the input field to specify what the field should receive. </p>
+	<p> </p>
+    <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
+</pl_question_panel>
+
+<pl_number_input answers_name="c" label = "Enter the Value for $c$:" rtol = "1e-3" atol="1e-10"/>
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+<pl_question_panel>
+    <p>Under this variant, we opt to change the default comparison of <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a>  from relative and absolute tolerances (<code>comparison="relabs"</code>) to significant digits (<code>comparison="sigfigs"</code>), which has a default of two digits. In addition, we've opted to add a suffix or a unit classification to the input via <code>suffix="$units$"</code>. </p>
+	<p> </p>
+    <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
+</pl_question_panel>
+
+<pl_number_input answers_name="c" label = "Enter the Value for $c$:" comparison="sigfig" suffix="$units$"/>
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+<pl_question_panel>
+    <p>Another option is to set the comparison for <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> to decimal digits (<code>"decdig"</code>) with a requirement for four digits (<code>digits="4'"</code>). Furthermore, we changed the weight of this question to be more impactful vs the previous entries via <code>weight="2"</code>. Lastly, we allow students to enter complex numbers by setting <code>allow_complex="true"</code>. </p>
+	<p> </p>
+    <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
+</pl_question_panel>
+
+<pl_number_input answers_name="c" label = "Enter the Value for $c$:" comparison="decdig" digits="4" weight="2" allow_complex="true" suffix="$units$"/>
+
+<pl_question_panel>
+    <hr />
+</pl_question_panel>
+
+<pl_question_panel>
+    <p>As a final example, we remove the placeholder text found in <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl_number_input-element"><code>pl_number_input</code></a> by setting <code>hide_help_text="true"</code>.</p>
+	<p> </p>
+    <p> Solve for the value of $c$ given $c^2 = {{params.a}}^2 + {{params.b}}^2$ </p>
+</pl_question_panel>
+
+<pl_number_input answers_name="c" label = "Enter the Value for $c$:" hide_help_text="true" suffix="$units$"/>

--- a/exampleCourse/questions/numberExamples/server.py
+++ b/exampleCourse/questions/numberExamples/server.py
@@ -8,7 +8,7 @@ def generate(data):
     b = random.randint(2, 10)
     
     # Compute answer
-    c = math.sqrt(a^2 + b^2)
+    c = math.sqrt(a**2 + b**2)
     
     # Release parameters
     data["params"]["a"] = a

--- a/exampleCourse/questions/numberExamples/server.py
+++ b/exampleCourse/questions/numberExamples/server.py
@@ -1,0 +1,18 @@
+import random
+import math
+
+def generate(data):
+    
+    # Simulate values
+    a = random.randint(2, 10)
+    b = random.randint(2, 10)
+    
+    # Compute answer
+    c = math.sqrt(a^2 + b^2)
+    
+    # Release parameters
+    data["params"]["a"] = a
+    data["params"]["b"] = b
+    
+    # Release correct answer
+    data["correct_answers"]["c"] = c


### PR DESCRIPTION
This PR address #1118 by including:

- Enabled `hide_help_text` on `pl_number_input`
- Updated `doc/elements.md` with new change
- Added `pl_number_input` demo of options to the PL Element Gallery.

Example: 

![screen shot 2018-04-23 at 9 23 03 pm](https://user-images.githubusercontent.com/833642/39162738-a26e1e86-473c-11e8-80aa-6908f39ed51d.png)

Reviewer request: @mwest1066 @tbretl 