### PR TITLE
Show student names on issue reports (close #1136)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -126,6 +126,7 @@
   * Add `load-test` support for v2 questions (Matt West).
 
   * Add submission info modal with external grading stats (Nathan Walters).
+  * Add student name and clickable e-mail address to issue report on question page (James Balamuta).
 
   * Fix broken file upload element (Nathan Walters).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -125,9 +125,9 @@
 
   * Add developer docs about question rendering (Matt West).
 
-  * Add `load-test` support for v2 questions (Matt West).
-
   * Add submission info modal with external grading stats (Nathan Walters).
+
+  * Add `load-test` support for v2 questions (Matt West).
 
   * Fix broken file upload element (Nathan Walters).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 
 * __next version__ - XXXX-XX-XX
 
+  * Add student name and clickable e-mail address information to issue reports (James Balamuta).
+  
   * Upgrade to Node.js 10 and PostgreSQL 10 (Matt West).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).
@@ -126,7 +128,6 @@
   * Add `load-test` support for v2 questions (Matt West).
 
   * Add submission info modal with external grading stats (Nathan Walters).
-  * Add student name and clickable e-mail address to issue report on question page (James Balamuta).
 
   * Fix broken file upload element (Nathan Walters).
 

--- a/lib/question.sql
+++ b/lib/question.sql
@@ -1,11 +1,14 @@
 -- BLOCK select_issues
 SELECT
     i.*,
-    format_date_full(i.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date
+    format_date_full(i.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
+    u.uid AS user_uid,
+    u.name AS user_name
 FROM
     issues AS i
     LEFT JOIN course_instances AS ci ON (ci.id = i.course_instance_id)
     JOIN pl_courses AS c ON (c.id = i.course_id)
+    LEFT JOIN users AS u ON (u.user_id = i.user_id)
 WHERE
     i.variant_id = $variant_id
     AND i.course_caused

--- a/pages/instructorIssues/instructorIssues.ejs
+++ b/pages/instructorIssues/instructorIssues.ejs
@@ -177,9 +177,9 @@
                 <%= getFormattedMessage(row) %>
               </p>
               <% if (row.manually_reported) { %>
-              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a> )</small>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_name || '-' %> (<a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a>)</small>
               <% } else { %>
-              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a> )</small>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_name || '-' %> (<a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a>)</small>
               <% } %>
               <% if (row.manually_reported) { %>
               <span class="badge badge-info">Manually reported</span>

--- a/pages/instructorIssues/instructorIssues.ejs
+++ b/pages/instructorIssues/instructorIssues.ejs
@@ -177,9 +177,9 @@
                 <%= getFormattedMessage(row) %>
               </p>
               <% if (row.manually_reported) { %>
-              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>%20"><%= row.user_uid || '-' %></a> )</small>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a> )</small>
               <% } else { %>
-              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>%20"><%= row.user_uid || '-' %></a> )</small>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a> )</small>
               <% } %>
               <% if (row.manually_reported) { %>
               <span class="badge badge-info">Manually reported</span>

--- a/pages/instructorIssues/instructorIssues.ejs
+++ b/pages/instructorIssues/instructorIssues.ejs
@@ -177,11 +177,10 @@
                 <%= getFormattedMessage(row) %>
               </p>
               <% if (row.manually_reported) { %>
-              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_uid || '-' %></small>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>%20"><%= row.user_uid || '-' %></a> )</small>
               <% } else { %>
-              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_uid || '-' %></small>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_name || '-' %> ( <a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>%20"><%= row.user_uid || '-' %></a> )</small>
               <% } %>
-
               <% if (row.manually_reported) { %>
               <span class="badge badge-info">Manually reported</span>
               <% } else { %>

--- a/pages/instructorIssues/instructorIssues.sql
+++ b/pages/instructorIssues/instructorIssues.sql
@@ -28,6 +28,7 @@ SELECT
     i.question_id,
     q.directory AS question_qid,
     u.uid AS user_uid,
+    u.name AS user_name,
     i.student_message,
     i.variant_id,
     i.open,

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -16,7 +16,7 @@
     <table class="table table-sm table-hover two-column-description">
       <tbody>
         <% if (devMode || authz_data.has_instructor_view) { %>
-        <tr><th>Student:</th><td><%= issue.user_name || '-'  %> ( <a href="mailto:<%= issue.user_uid  || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= issue.user_name || '-'  %>%20"><%= issue.user_uid || '-' %></a> )</td></tr>
+        <tr><th>Student:</th><td><%= issue.user_name || '-'  %> ( <a href="mailto:<%= issue.user_uid  || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= issue.user_name %>,%0A%0ARegarding%20the%20issue%20of:%0A%0A%22<%= issue.student_message || '-' %>%22%0A%0AWe've..."><%= issue.user_uid || '-' %></a> )</td></tr>
         <tr><th>Student message:</th><td><%= issue.student_message %></td></tr>
         <tr><th>Instructor message:</th><td><%= issue.instructor_message %></td></tr>
         <% } else { %>

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -16,6 +16,7 @@
     <table class="table table-sm table-hover two-column-description">
       <tbody>
         <% if (devMode || authz_data.has_instructor_view) { %>
+        <tr><th>Student:</th><td><%= issue.user_name || '-'  %> ( <a href="mailto:<%= issue.user_uid  || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= issue.user_name || '-'  %>%20"><%= issue.user_uid || '-' %></a> )</td></tr>
         <tr><th>Student message:</th><td><%= issue.student_message %></td></tr>
         <tr><th>Instructor message:</th><td><%= issue.instructor_message %></td></tr>
         <% } else { %>

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -16,7 +16,7 @@
     <table class="table table-sm table-hover two-column-description">
       <tbody>
         <% if (devMode || authz_data.has_instructor_view) { %>
-        <tr><th>Student:</th><td><%= issue.user_name || '-'  %> ( <a href="mailto:<%= issue.user_uid  || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= issue.user_name %>,%0A%0ARegarding%20the%20issue%20of:%0A%0A%22<%= issue.student_message || '-' %>%22%0A%0AWe've..."><%= issue.user_uid || '-' %></a> )</td></tr>
+        <tr><th>Student:</th><td><%= issue.user_name || '-'  %> (<a href="mailto:<%= issue.user_uid  || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= issue.user_name %>,%0A%0ARegarding%20the%20issue%20of:%0A%0A%22<%= issue.student_message || '-' %>%22%0A%0AWe've..."><%= issue.user_uid || '-' %></a>)</td></tr>
         <tr><th>Student message:</th><td><%= issue.student_message %></td></tr>
         <tr><th>Instructor message:</th><td><%= issue.instructor_message %></td></tr>
         <% } else { %>


### PR DESCRIPTION
This PR incorporates the name of the student and a clickable e-mail template into the issue report interface for PL to address #1136. See images below for how the UI changes.

## UI Changes

### Issue View

**Old:**

![screen shot 2018-05-01 at 11 09 40 pm](https://user-images.githubusercontent.com/833642/39504952-d1c7b94a-4d94-11e8-9022-7e380836959f.png)

**New** issue information _without_ spaces around e-mail

![screen shot 2018-05-01 at 11 02 23 pm](https://user-images.githubusercontent.com/833642/39504792-c4994168-4d93-11e8-9097-f422097cf5e1.png)


**New** issue information with spaces around e-mail

![screen shot 2018-04-29 at 9 19 20 pm](https://user-images.githubusercontent.com/833642/39413749-96eb8596-4bf4-11e8-8619-1406945fb4e3.png)


### Issue Tracker

**Old:**

![screen shot 2018-05-01 at 11 09 49 pm](https://user-images.githubusercontent.com/833642/39504976-09026af4-4d95-11e8-9874-063d41724e28.png)


**New** issue tracker _without_ spaces around e-mail

![screen shot 2018-05-01 at 11 03 16 pm](https://user-images.githubusercontent.com/833642/39504838-1aaadf08-4d94-11e8-9a39-fdddb91049a1.png)

**New** issue tracker with spaces around e-mail

![screen shot 2018-04-29 at 9 18 20 pm](https://user-images.githubusercontent.com/833642/39413750-96f68c7a-4bf4-11e8-98fb-fd11f97240b1.png)


## New feature

Clicking on the e-mail launches the system default webmail client with the to field, subject, and body filled in.

![screen shot 2018-05-01 at 10 58 50 pm](https://user-images.githubusercontent.com/833642/39504747-7a791216-4d93-11e8-9206-182d843ecef2.png)
