### PR TITLE
Add optional async render for all requests

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -87,6 +87,8 @@
 
   * Add developer docs about question rendering (Matt West).
 
+  * Add async response rendering (Nathan Walters).
+
   * Fix broken file upload element (Nathan Walters).
 
   * Fix broken popover and improve assessment label styles (Nathan Walters).

--- a/lib/assessmentStatDescriptions.js
+++ b/lib/assessmentStatDescriptions.js
@@ -1,4 +1,5 @@
-var stat_descriptions = {
+
+module.exports = {
     MEAN_SCORE: {
         title: 'Mean (μ)',
         non_html_title: 'Mean',
@@ -125,9 +126,3 @@ var stat_descriptions = {
         description: 'Quintiles show the average scores on the question for students in the lowest 20% of the class, the next 20%, etc, where the quintiles are determined by total assessment score.',
     },
 };
-
-module.exports = function(req, res, next) {
-  res.locals.stat_descriptions = stat_descriptions;
-  next();
-};
-

--- a/middlewares/injectRenderAsync.js
+++ b/middlewares/injectRenderAsync.js
@@ -1,0 +1,28 @@
+const Pool = require('threads').Pool;
+
+const pool = new Pool(10);
+
+pool.run(([filename, locals], done) => {
+    const ejs = require('ejs');
+    ejs.renderFile(filename, locals, null, (err, str) => {
+        if (err) {
+            done(['error', err.stack.toString()]);
+        } else {
+            done(['success', str]);
+        }
+    });
+});
+
+module.exports = function(req, res, next) {
+    res.renderAsync = function(filename, data) {
+        const renderJob = pool.send([filename, data]);
+        renderJob.on('done', ([status, data]) => {
+            if (status === 'error') {
+                next(new Error(data));
+            } else {
+                res.send(data);
+            }
+        });
+    };
+    next();
+};

--- a/middlewares/injectRenderAsync.js
+++ b/middlewares/injectRenderAsync.js
@@ -1,6 +1,6 @@
 const Pool = require('threads').Pool;
 
-const pool = new Pool(10);
+const pool = new Pool();
 
 pool.run(([filename, locals], done) => {
     const ejs = require('ejs');
@@ -22,6 +22,9 @@ module.exports = function(req, res, next) {
             } else {
                 res.send(data);
             }
+        });
+        renderJob.on('error', (err) => {
+            next(err);
         });
     };
     next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
             "integrity": "sha512-gGuftCqx2aLY4IEv0ffD/1kzQCGJam+2JTgFth0WSDebPLD4a+7Hzn+KJUfcAd5iJ5h4yEj6pNQsvz5p4DyKJA==",
             "requires": {
                 "async-stacktrace": "0.0.2",
-                "debug": "3.1.0",
-                "lodash": "4.17.5",
-                "pg": "7.4.1"
+                "debug": "^3.1.0",
+                "lodash": "^4.17.5",
+                "pg": "^7.4.1"
             },
             "dependencies": {
                 "lodash": {
@@ -29,9 +29,9 @@
                         "js-string-escape": "1.0.1",
                         "packet-reader": "0.3.1",
                         "pg-connection-string": "0.1.3",
-                        "pg-pool": "2.0.3",
-                        "pg-types": "1.12.1",
-                        "pgpass": "1.0.2",
+                        "pg-pool": "~2.0.3",
+                        "pg-types": "~1.12.1",
+                        "pgpass": "1.x",
                         "semver": "4.3.2"
                     }
                 },
@@ -48,7 +48,7 @@
             "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
             "requires": {
                 "jsonparse": "0.0.5",
-                "through": "2.3.8"
+                "through": ">=2.2.7 <3"
             }
         },
         "abbrev": {
@@ -61,7 +61,7 @@
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
             "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
             "requires": {
-                "mime-types": "2.1.17",
+                "mime-types": "~2.1.16",
                 "negotiator": "0.6.1"
             }
         },
@@ -77,7 +77,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -103,10 +103,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -120,9 +120,9 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -135,7 +135,7 @@
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             }
         },
         "ansi-escapes": {
@@ -154,7 +154,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
             "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "^1.9.0"
             }
         },
         "anymatch": {
@@ -162,8 +162,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "archiver": {
@@ -171,14 +171,14 @@
             "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.0.tgz",
             "integrity": "sha1-0t8ujVdzqCwdzOklzMQUUOqZmv0=",
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.0",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.2",
-                "lodash": "4.17.4",
-                "readable-stream": "2.3.3",
-                "tar-stream": "1.5.5",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^1.3.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "zip-stream": "^1.2.0"
             }
         },
         "archiver-utils": {
@@ -186,12 +186,12 @@
             "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
             "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.4",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.3"
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.8.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "argparse": {
@@ -200,7 +200,7 @@
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -208,7 +208,7 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -227,7 +227,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -262,9 +262,9 @@
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
             "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert-plus": {
@@ -283,7 +283,7 @@
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.14.0"
             }
         },
         "async-each": {
@@ -313,7 +313,7 @@
             "requires": {
                 "buffer": "4.9.1",
                 "crypto-browserify": "1.0.9",
-                "events": "1.1.1",
+                "events": "^1.1.1",
                 "jmespath": "0.15.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
@@ -346,9 +346,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -369,11 +369,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -382,7 +382,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -404,7 +404,7 @@
             "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
             "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
             "requires": {
-                "underscore": "1.8.3"
+                "underscore": ">=1.8.3"
             }
         },
         "backo2": {
@@ -443,7 +443,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "better-assert": {
@@ -464,7 +464,7 @@
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
             "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "blob": {
@@ -494,15 +494,15 @@
             "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "http-errors": "1.6.2",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.15"
+                "type-is": "~1.6.15"
             },
             "dependencies": {
                 "debug": {
@@ -525,7 +525,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
             }
         },
         "bootstrap": {
@@ -538,13 +538,13 @@
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.3.0",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -559,7 +559,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -568,9 +568,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "brorand": {
@@ -589,9 +589,9 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "requires": {
-                "base64-js": "1.2.1",
-                "ieee754": "1.1.8",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-crc32": {
@@ -614,10 +614,10 @@
             "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
             "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
             "requires": {
-                "dtrace-provider": "0.8.5",
-                "moment": "2.20.1",
-                "mv": "2.1.1",
-                "safe-json-stringify": "1.0.4"
+                "dtrace-provider": "~0.8",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
             }
         },
         "byline": {
@@ -649,8 +649,8 @@
                     "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
                     "integrity": "sha1-tcvwFVbBaWb+vlTO7A+03JDfbCg=",
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.1",
+                        "yallist": "^2.0.0"
                     }
                 }
             }
@@ -661,7 +661,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsite": {
@@ -697,7 +697,7 @@
             "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
             "dev": true,
             "requires": {
-                "underscore-contrib": "0.3.0"
+                "underscore-contrib": "~0.3.0"
             }
         },
         "center-align": {
@@ -706,8 +706,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chai": {
@@ -716,12 +716,12 @@
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
             "dev": true,
             "requires": {
-                "assertion-error": "1.0.2",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.5"
+                "assertion-error": "^1.0.1",
+                "check-error": "^1.0.1",
+                "deep-eql": "^3.0.0",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.0.0",
+                "type-detect": "^4.0.0"
             }
         },
         "chalk": {
@@ -729,9 +729,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
             "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
             "requires": {
-                "ansi-styles": "3.2.0",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.5.0"
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
             }
         },
         "chardet": {
@@ -751,22 +751,22 @@
             "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
             "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash.assignin": "4.2.0",
-                "lodash.bind": "4.2.1",
-                "lodash.defaults": "4.2.0",
-                "lodash.filter": "4.6.0",
-                "lodash.flatten": "4.4.0",
-                "lodash.foreach": "4.5.0",
-                "lodash.map": "4.6.0",
-                "lodash.merge": "4.6.0",
-                "lodash.pick": "4.4.0",
-                "lodash.reduce": "4.6.0",
-                "lodash.reject": "4.6.0",
-                "lodash.some": "4.6.0"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash.assignin": "^4.0.9",
+                "lodash.bind": "^4.1.4",
+                "lodash.defaults": "^4.0.1",
+                "lodash.filter": "^4.4.0",
+                "lodash.flatten": "^4.2.0",
+                "lodash.foreach": "^4.3.0",
+                "lodash.map": "^4.4.0",
+                "lodash.merge": "^4.4.0",
+                "lodash.pick": "^4.2.1",
+                "lodash.reduce": "^4.4.0",
+                "lodash.reject": "^4.4.0",
+                "lodash.some": "^4.4.0"
             }
         },
         "chokidar": {
@@ -774,15 +774,15 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.1.3",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             }
         },
         "chownr": {
@@ -807,7 +807,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-width": {
@@ -821,9 +821,9 @@
             "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
             "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
             "requires": {
-                "good-listener": "1.2.2",
-                "select": "1.1.2",
-                "tiny-emitter": "2.0.2"
+                "good-listener": "^1.2.2",
+                "select": "^1.1.2",
+                "tiny-emitter": "^2.0.0"
             }
         },
         "cliui": {
@@ -832,8 +832,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -860,7 +860,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -879,7 +879,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -908,10 +908,10 @@
             "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.3"
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "concat-map": {
@@ -924,9 +924,9 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
             "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "typedarray": "0.0.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "~2.0.0",
+                "typedarray": "~0.0.5"
             },
             "dependencies": {
                 "readable-stream": {
@@ -934,12 +934,12 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -954,12 +954,12 @@
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
             "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.1.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "content-disposition": {
@@ -1002,11 +1002,11 @@
             "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
             "dev": true,
             "requires": {
-                "js-yaml": "3.10.0",
-                "lcov-parse": "0.0.10",
-                "log-driver": "1.2.5",
-                "minimist": "1.2.0",
-                "request": "2.83.0"
+                "js-yaml": "^3.6.1",
+                "lcov-parse": "^0.0.10",
+                "log-driver": "^1.2.5",
+                "minimist": "^1.2.0",
+                "request": "^2.79.0"
             },
             "dependencies": {
                 "minimist": {
@@ -1027,8 +1027,8 @@
             "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "requires": {
-                "crc": "3.5.0",
-                "readable-stream": "2.3.3"
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
             }
         },
         "create-error-class": {
@@ -1036,7 +1036,7 @@
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -1044,9 +1044,9 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -1054,7 +1054,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
             "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
             "requires": {
-                "boom": "5.2.0"
+                "boom": "5.x.x"
             },
             "dependencies": {
                 "boom": {
@@ -1062,7 +1062,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                     }
                 }
             }
@@ -1087,10 +1087,10 @@
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-what": {
@@ -1103,10 +1103,10 @@
             "resolved": "https://registry.npmjs.org/csv/-/csv-2.0.0.tgz",
             "integrity": "sha1-DVHY+j7OJ4tUCfeVcX/PzVrOmz4=",
             "requires": {
-                "csv-generate": "2.0.0",
-                "csv-parse": "2.0.0",
-                "csv-stringify": "2.0.1",
-                "stream-transform": "1.0.0"
+                "csv-generate": "^2.0.0",
+                "csv-parse": "^2.0.0",
+                "csv-stringify": "^2.0.0",
+                "stream-transform": "^1.0.0"
             }
         },
         "csv-generate": {
@@ -1124,7 +1124,7 @@
             "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-2.0.1.tgz",
             "integrity": "sha512-qoWgXJHmANfwIZFogezZjfN7KeaALrSe2zA5velb2tVEx0r7tgVuMfideB5gq12x5Z7LkvgOayXplOwlKcXnKQ==",
             "requires": {
-                "lodash.get": "4.4.2"
+                "lodash.get": "~4.4.2"
             }
         },
         "cycle": {
@@ -1137,7 +1137,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "debug": {
@@ -1159,7 +1159,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.5"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-extend": {
@@ -1179,13 +1179,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.4.5"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "pify": {
@@ -1227,9 +1227,9 @@
             "integrity": "sha512-pkXB9p7KWagegOXm2NsbVDBluQQLCBJzX9uYJzVbL6CHwe4d2sSbcACJ4K8ISX1l1JUUmFSiwNkBKc1uTiU4MA==",
             "requires": {
                 "JSONStream": "0.10.0",
-                "debug": "2.6.9",
-                "readable-stream": "1.0.34",
-                "split-ca": "1.0.1"
+                "debug": "^2.6.0",
+                "readable-stream": "~1.0.26-4",
+                "split-ca": "^1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -1250,10 +1250,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1268,9 +1268,9 @@
             "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.5.3.tgz",
             "integrity": "sha512-LQKXR5jyI+G/+5OhZCi40m0ArY4j46g7Tl71Vtn10Ekt5TiyDzZAoqXOCS6edQpEuGbdFgSDJxleFqLxACpKJg==",
             "requires": {
-                "concat-stream": "1.5.2",
-                "docker-modem": "1.0.4",
-                "tar-fs": "1.12.0"
+                "concat-stream": "~1.5.1",
+                "docker-modem": "^1.0.0",
+                "tar-fs": "~1.12.0"
             }
         },
         "doctrine": {
@@ -1279,7 +1279,7 @@
             "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "dom-serializer": {
@@ -1287,8 +1287,8 @@
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1308,7 +1308,7 @@
             "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
             "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1316,8 +1316,8 @@
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dot-prop": {
@@ -1325,7 +1325,7 @@
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "double-ended-queue": {
@@ -1339,7 +1339,7 @@
             "integrity": "sha1-mOu6Ihr6xG4cOf02hY2Pk2dSS5I=",
             "optional": true,
             "requires": {
-                "nan": "2.8.0"
+                "nan": "^2.3.3"
             }
         },
         "duplexer": {
@@ -1358,7 +1358,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "ecdsa-sig-formatter": {
@@ -1366,8 +1366,8 @@
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
             "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
             "requires": {
-                "base64url": "2.0.0",
-                "safe-buffer": "5.1.1"
+                "base64url": "^2.0.0",
+                "safe-buffer": "^5.0.1"
             }
         },
         "ee-first": {
@@ -1385,13 +1385,13 @@
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "encodeurl": {
@@ -1404,7 +1404,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
             "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "engine.io": {
@@ -1415,10 +1415,10 @@
                 "accepts": "1.3.3",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "2.6.9",
-                "engine.io-parser": "2.1.2",
-                "uws": "0.14.5",
-                "ws": "3.3.3"
+                "debug": "~2.6.9",
+                "engine.io-parser": "~2.1.0",
+                "uws": "~0.14.4",
+                "ws": "~3.3.1"
             },
             "dependencies": {
                 "accepts": {
@@ -1426,7 +1426,7 @@
                     "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                     "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
                     "requires": {
-                        "mime-types": "2.1.17",
+                        "mime-types": "~2.1.11",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -1447,14 +1447,14 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "2.6.9",
-                "engine.io-parser": "2.1.2",
+                "debug": "~2.6.9",
+                "engine.io-parser": "~2.1.1",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "3.3.3",
-                "xmlhttprequest-ssl": "1.5.4",
+                "ws": "~3.3.1",
+                "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             },
             "dependencies": {
@@ -1474,10 +1474,10 @@
             "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
             "requires": {
                 "after": "0.8.2",
-                "arraybuffer.slice": "0.0.7",
+                "arraybuffer.slice": "~0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.4",
-                "has-binary2": "1.0.2"
+                "has-binary2": "~1.0.2"
             }
         },
         "entities": {
@@ -1501,43 +1501,43 @@
             "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.3.0",
-                "concat-stream": "1.6.0",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.0.2",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.2",
-                "esquery": "1.0.0",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.1.0",
-                "ignore": "3.3.7",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.0.1",
-                "js-yaml": "3.10.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.4",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.4.1",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
-                "table": "4.0.2",
-                "text-table": "0.2.0"
+                "ajv": "^5.3.0",
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.1.0",
+                "concat-stream": "^1.6.0",
+                "cross-spawn": "^5.1.0",
+                "debug": "^3.1.0",
+                "doctrine": "^2.0.2",
+                "eslint-scope": "^3.7.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^3.5.2",
+                "esquery": "^1.0.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.0.1",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^3.0.6",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.9.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.3.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "~2.0.1",
+                "table": "^4.0.1",
+                "text-table": "~0.2.0"
             },
             "dependencies": {
                 "concat-stream": {
@@ -1546,9 +1546,9 @@
                     "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.3",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                     }
                 }
             }
@@ -1559,8 +1559,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.0",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-visitor-keys": {
@@ -1575,8 +1575,8 @@
             "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
             "dev": true,
             "requires": {
-                "acorn": "5.3.0",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.2.1",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -1591,7 +1591,7 @@
             "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -1600,8 +1600,8 @@
             "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0",
-                "object-assign": "4.1.1"
+                "estraverse": "^4.1.0",
+                "object-assign": "^4.0.1"
             }
         },
         "estraverse": {
@@ -1626,14 +1626,19 @@
             "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
+        },
+        "eventemitter3": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+            "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
         },
         "events": {
             "version": "1.1.1",
@@ -1645,13 +1650,13 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "expand-brackets": {
@@ -1659,7 +1664,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -1667,7 +1672,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "express": {
@@ -1675,36 +1680,36 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
             "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "~1.3.4",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.1",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.0",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.2",
+                "proxy-addr": "~2.0.2",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.1",
                 "serve-static": "1.13.1",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.3.1",
-                "type-is": "1.6.15",
+                "statuses": "~1.3.1",
+                "type-is": "~1.6.15",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "debug": {
@@ -1738,9 +1743,9 @@
             "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
             "dev": true,
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.19",
-                "tmp": "0.0.33"
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -1748,7 +1753,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "extsprintf": {
@@ -1783,7 +1788,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -1792,8 +1797,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "filename-regex": {
@@ -1806,11 +1811,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "finalhandler": {
@@ -1819,12 +1824,12 @@
             "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.3.1",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -1847,7 +1852,7 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "flat-cache": {
@@ -1856,10 +1861,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "for-in": {
@@ -1872,7 +1877,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -1885,9 +1890,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
             "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "forwarded": {
@@ -1910,9 +1915,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-minipass": {
@@ -1920,7 +1925,7 @@
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.3.tgz",
             "integrity": "sha512-u1pHCXDx+CElfM6CuIeHDTKvb1Ya9ZhsMk7xTHTh6zHSRLK6O0DTVBN+E3wg8fruxAFp4oE07owrrzQfDA0b5Q==",
             "requires": {
-                "minipass": "2.2.1"
+                "minipass": "^2.2.1"
             }
         },
         "fs.realpath": {
@@ -1934,8 +1939,8 @@
             "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
             "optional": true,
             "requires": {
-                "nan": "2.8.0",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.39"
             },
             "dependencies": {
                 "abbrev": {
@@ -1948,8 +1953,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -1966,8 +1971,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -2004,28 +2009,28 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
                     "version": "0.0.9",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
                     "version": "2.10.1",
                     "bundled": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.7",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2051,7 +2056,7 @@
                     "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -2070,7 +2075,7 @@
                     "version": "2.0.5",
                     "bundled": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
@@ -2078,7 +2083,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2120,7 +2125,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -2142,9 +2147,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "fs.realpath": {
@@ -2155,10 +2160,10 @@
                     "version": "1.0.11",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
@@ -2166,9 +2171,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -2176,14 +2181,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
@@ -2191,7 +2196,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2205,12 +2210,12 @@
                     "version": "7.1.2",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -2227,8 +2232,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "has-unicode": {
@@ -2240,10 +2245,10 @@
                     "version": "3.1.3",
                     "bundled": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -2255,17 +2260,17 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2281,7 +2286,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -2303,7 +2308,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -2321,7 +2326,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -2360,14 +2365,14 @@
                     "version": "2.1.15",
                     "bundled": true,
                     "requires": {
-                        "mime-db": "1.27.0"
+                        "mime-db": "~1.27.0"
                     }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2391,17 +2396,17 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
+                        "detect-libc": "^1.0.2",
                         "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
                         "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^2.2.1",
+                        "tar-pack": "^3.4.0"
                     }
                 },
                 "nopt": {
@@ -2409,8 +2414,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npmlog": {
@@ -2418,10 +2423,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2442,7 +2447,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2460,8 +2465,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2492,10 +2497,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2509,13 +2514,13 @@
                     "version": "2.2.9",
                     "bundled": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
@@ -2523,35 +2528,35 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
                     "version": "2.6.1",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2577,7 +2582,7 @@
                     "version": "1.0.9",
                     "bundled": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
@@ -2585,15 +2590,15 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2607,16 +2612,16 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -2628,7 +2633,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2640,9 +2645,9 @@
                     "version": "2.2.1",
                     "bundled": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
@@ -2650,14 +2655,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
@@ -2665,7 +2670,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -2673,7 +2678,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -2708,7 +2713,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2733,7 +2738,7 @@
             "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -2757,7 +2762,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -2765,12 +2770,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2778,8 +2783,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
@@ -2787,7 +2792,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "global-dirs": {
@@ -2795,7 +2800,7 @@
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "globals": {
@@ -2810,12 +2815,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -2831,7 +2836,7 @@
             "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
             "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
             "requires": {
-                "delegate": "3.2.0"
+                "delegate": "^3.1.2"
             }
         },
         "google-auth-library": {
@@ -2839,11 +2844,11 @@
             "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-0.12.0.tgz",
             "integrity": "sha512-79qCXtJ1VweBmmLr4yLq9S4clZB2p5Y+iACvuKk9gu4JitEnPc+bQFmYvtCYehVR44MQzD1J8DVmYW2w677IEw==",
             "requires": {
-                "gtoken": "1.2.3",
-                "jws": "3.1.4",
-                "lodash.isstring": "4.0.1",
-                "lodash.merge": "4.6.0",
-                "request": "2.83.0"
+                "gtoken": "^1.2.3",
+                "jws": "^3.1.4",
+                "lodash.isstring": "^4.0.1",
+                "lodash.merge": "^4.6.0",
+                "request": "^2.81.0"
             }
         },
         "google-p12-pem": {
@@ -2851,7 +2856,7 @@
             "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-0.1.2.tgz",
             "integrity": "sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=",
             "requires": {
-                "node-forge": "0.7.1"
+                "node-forge": "^0.7.1"
             }
         },
         "googleapis": {
@@ -2869,17 +2874,17 @@
             "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -2898,10 +2903,10 @@
             "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-1.2.3.tgz",
             "integrity": "sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==",
             "requires": {
-                "google-p12-pem": "0.1.2",
-                "jws": "3.1.4",
-                "mime": "1.4.1",
-                "request": "2.83.0"
+                "google-p12-pem": "^0.1.0",
+                "jws": "^3.0.0",
+                "mime": "^1.4.1",
+                "request": "^2.72.0"
             }
         },
         "handlebars": {
@@ -2909,10 +2914,10 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "async": {
@@ -2932,8 +2937,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -2942,7 +2947,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2983,8 +2988,8 @@
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "hawk": {
@@ -2992,10 +2997,10 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
             "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.1.0"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
             }
         },
         "he": {
@@ -3009,9 +3014,9 @@
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoek": {
@@ -3024,12 +3029,12 @@
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.1",
-                "domutils": "1.5.1",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-errors": {
@@ -3040,7 +3045,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.3.1 < 2"
             }
         },
         "http-signature": {
@@ -3048,9 +3053,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
@@ -3094,8 +3099,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -3114,20 +3119,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.0.0",
-                "chalk": "2.3.0",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.1.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.4",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             }
         },
         "invert-kv": {
@@ -3145,7 +3150,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -3163,7 +3168,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -3186,7 +3191,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-installed-globally": {
@@ -3194,8 +3199,8 @@
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-my-json-valid": {
@@ -3203,10 +3208,10 @@
             "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
             "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-npm": {
@@ -3219,7 +3224,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -3239,7 +3244,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -3247,7 +3252,7 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-posix-bracket": {
@@ -3357,8 +3362,8 @@
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.9",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "js2xmlparser": {
@@ -3367,7 +3372,7 @@
             "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
             "dev": true,
             "requires": {
-                "xmlcreate": "1.0.2"
+                "xmlcreate": "^1.0.1"
             }
         },
         "jsbn": {
@@ -3383,17 +3388,17 @@
             "dev": true,
             "requires": {
                 "babylon": "7.0.0-beta.19",
-                "bluebird": "3.5.1",
-                "catharsis": "0.8.9",
-                "escape-string-regexp": "1.0.5",
-                "js2xmlparser": "3.0.0",
-                "klaw": "2.0.0",
-                "marked": "0.3.9",
-                "mkdirp": "0.5.1",
-                "requizzle": "0.2.1",
-                "strip-json-comments": "2.0.1",
+                "bluebird": "~3.5.0",
+                "catharsis": "~0.8.9",
+                "escape-string-regexp": "~1.0.5",
+                "js2xmlparser": "~3.0.0",
+                "klaw": "~2.0.0",
+                "marked": "~0.3.6",
+                "mkdirp": "~0.5.1",
+                "requizzle": "~0.2.1",
+                "strip-json-comments": "~2.0.1",
                 "taffydb": "2.6.2",
-                "underscore": "1.8.3"
+                "underscore": "~1.8.3"
             }
         },
         "json-schema": {
@@ -3422,7 +3427,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonparse": {
@@ -3454,7 +3459,7 @@
                 "base64url": "2.0.0",
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.9",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "jwk-to-pem": {
@@ -3462,9 +3467,9 @@
             "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-1.2.6.tgz",
             "integrity": "sha1-1QfOzkAInFJI4J7GgmaiAwqcYyU=",
             "requires": {
-                "asn1.js": "4.9.2",
-                "elliptic": "6.4.0",
-                "safe-buffer": "5.1.1"
+                "asn1.js": "^4.5.2",
+                "elliptic": "^6.2.3",
+                "safe-buffer": "^5.0.1"
             }
         },
         "jws": {
@@ -3472,9 +3477,9 @@
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
             "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
             "requires": {
-                "base64url": "2.0.0",
-                "jwa": "1.1.5",
-                "safe-buffer": "5.1.1"
+                "base64url": "^2.0.0",
+                "jwa": "^1.1.4",
+                "safe-buffer": "^5.0.1"
             }
         },
         "kind-of": {
@@ -3482,7 +3487,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "klaw": {
@@ -3491,7 +3496,7 @@
             "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.9"
             }
         },
         "latest-version": {
@@ -3499,7 +3504,7 @@
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             }
         },
         "lazy-cache": {
@@ -3513,7 +3518,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -3521,7 +3526,7 @@
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "lcov-parse": {
@@ -3536,8 +3541,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "locate-path": {
@@ -3545,8 +3550,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -3645,8 +3650,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
             "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "make-dir": {
@@ -3654,7 +3659,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
             "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "map-stream": {
@@ -3683,7 +3688,7 @@
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "requires": {
-                "mimic-fn": "1.1.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "merge-descriptors": {
@@ -3706,19 +3711,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             }
         },
         "mime": {
@@ -3736,7 +3741,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "mimic-fn": {
@@ -3759,7 +3764,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -3772,7 +3777,7 @@
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
             "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
             "requires": {
-                "yallist": "3.0.2"
+                "yallist": "^3.0.0"
             },
             "dependencies": {
                 "yallist": {
@@ -3787,7 +3792,7 @@
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
             "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
             "requires": {
-                "minipass": "2.2.1"
+                "minipass": "^2.2.1"
             }
         },
         "mkdirp": {
@@ -3828,7 +3833,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -3860,9 +3865,9 @@
             "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
             "optional": true,
             "requires": {
-                "mkdirp": "0.5.1",
-                "ncp": "2.0.0",
-                "rimraf": "2.4.5"
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
             }
         },
         "nan": {
@@ -3870,6 +3875,11 @@
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
             "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
             "optional": true
+        },
+        "native-promise-only": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+            "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -3898,14 +3908,14 @@
             "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.14.7.tgz",
             "integrity": "sha512-uEguLNr+QIk4TVd8swNvw7kHqOE/sjvNsIwhnc8CM7QdI+ezFvvkMRtCpCJ+DEVyIopLSTu2eayZ/ELKtswcbg==",
             "requires": {
-                "chokidar": "1.7.0",
-                "debug": "2.6.9",
-                "ignore-by-default": "1.0.1",
-                "minimatch": "3.0.4",
-                "pstree.remy": "1.1.0",
-                "touch": "3.1.0",
+                "chokidar": "^1.7.0",
+                "debug": "^2.6.8",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "pstree.remy": "^1.1.0",
+                "touch": "^3.1.0",
                 "undefsafe": "0.0.3",
-                "update-notifier": "2.3.0"
+                "update-notifier": "^2.3.0"
             },
             "dependencies": {
                 "debug": {
@@ -3923,7 +3933,7 @@
             "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
             "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-path": {
@@ -3931,7 +3941,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "notepack.io": {
@@ -3944,7 +3954,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "nth-check": {
@@ -3952,7 +3962,7 @@
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "number-is-nan": {
@@ -3971,33 +3981,33 @@
             "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "arrify": "1.0.1",
-                "caching-transform": "1.0.1",
-                "convert-source-map": "1.5.1",
-                "debug-log": "1.0.1",
-                "default-require-extensions": "1.0.0",
-                "find-cache-dir": "0.1.1",
-                "find-up": "2.1.0",
-                "foreground-child": "1.5.6",
-                "glob": "7.1.2",
-                "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.9.1",
-                "istanbul-lib-report": "1.1.2",
-                "istanbul-lib-source-maps": "1.2.2",
-                "istanbul-reports": "1.1.3",
-                "md5-hex": "1.3.0",
-                "merge-source-map": "1.0.4",
-                "micromatch": "2.3.11",
-                "mkdirp": "0.5.1",
-                "resolve-from": "2.0.0",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "spawn-wrap": "1.4.2",
-                "test-exclude": "4.1.1",
-                "yargs": "10.0.3",
-                "yargs-parser": "8.0.0"
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^1.0.0",
+                "convert-source-map": "^1.3.0",
+                "debug-log": "^1.0.1",
+                "default-require-extensions": "^1.0.0",
+                "find-cache-dir": "^0.1.1",
+                "find-up": "^2.1.0",
+                "foreground-child": "^1.5.3",
+                "glob": "^7.0.6",
+                "istanbul-lib-coverage": "^1.1.1",
+                "istanbul-lib-hook": "^1.1.0",
+                "istanbul-lib-instrument": "^1.9.1",
+                "istanbul-lib-report": "^1.1.2",
+                "istanbul-lib-source-maps": "^1.2.2",
+                "istanbul-reports": "^1.1.3",
+                "md5-hex": "^1.2.0",
+                "merge-source-map": "^1.0.2",
+                "micromatch": "^2.3.11",
+                "mkdirp": "^0.5.0",
+                "resolve-from": "^2.0.0",
+                "rimraf": "^2.5.4",
+                "signal-exit": "^3.0.1",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^4.1.1",
+                "yargs": "^10.0.3",
+                "yargs-parser": "^8.0.0"
             },
             "dependencies": {
                 "align-text": {
@@ -4005,9 +4015,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2",
-                        "longest": "1.0.1",
-                        "repeat-string": "1.6.1"
+                        "kind-of": "^3.0.2",
+                        "longest": "^1.0.1",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "amdefine": {
@@ -4030,7 +4040,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "default-require-extensions": "1.0.0"
+                        "default-require-extensions": "^1.0.0"
                     }
                 },
                 "archy": {
@@ -4043,7 +4053,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "arr-flatten": {
@@ -4071,9 +4081,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "esutils": "2.0.2",
-                        "js-tokens": "3.0.2"
+                        "chalk": "^1.1.3",
+                        "esutils": "^2.0.2",
+                        "js-tokens": "^3.0.2"
                     }
                 },
                 "babel-generator": {
@@ -4081,14 +4091,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-messages": "6.23.0",
-                        "babel-runtime": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "detect-indent": "4.0.0",
-                        "jsesc": "1.3.0",
-                        "lodash": "4.17.4",
-                        "source-map": "0.5.7",
-                        "trim-right": "1.0.1"
+                        "babel-messages": "^6.23.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "detect-indent": "^4.0.0",
+                        "jsesc": "^1.3.0",
+                        "lodash": "^4.17.4",
+                        "source-map": "^0.5.6",
+                        "trim-right": "^1.0.1"
                     }
                 },
                 "babel-messages": {
@@ -4096,7 +4106,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "6.26.0"
+                        "babel-runtime": "^6.22.0"
                     }
                 },
                 "babel-runtime": {
@@ -4104,8 +4114,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "core-js": "2.5.3",
-                        "regenerator-runtime": "0.11.1"
+                        "core-js": "^2.4.0",
+                        "regenerator-runtime": "^0.11.0"
                     }
                 },
                 "babel-template": {
@@ -4113,11 +4123,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "6.26.0",
-                        "babel-traverse": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "lodash": "4.17.4"
+                        "babel-runtime": "^6.26.0",
+                        "babel-traverse": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "lodash": "^4.17.4"
                     }
                 },
                 "babel-traverse": {
@@ -4125,15 +4135,15 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-code-frame": "6.26.0",
-                        "babel-messages": "6.23.0",
-                        "babel-runtime": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "debug": "2.6.9",
-                        "globals": "9.18.0",
-                        "invariant": "2.2.2",
-                        "lodash": "4.17.4"
+                        "babel-code-frame": "^6.26.0",
+                        "babel-messages": "^6.23.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "debug": "^2.6.8",
+                        "globals": "^9.18.0",
+                        "invariant": "^2.2.2",
+                        "lodash": "^4.17.4"
                     }
                 },
                 "babel-types": {
@@ -4141,10 +4151,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "6.26.0",
-                        "esutils": "2.0.2",
-                        "lodash": "4.17.4",
-                        "to-fast-properties": "1.0.3"
+                        "babel-runtime": "^6.26.0",
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.4",
+                        "to-fast-properties": "^1.0.3"
                     }
                 },
                 "babylon": {
@@ -4162,7 +4172,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -4171,9 +4181,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "builtin-modules": {
@@ -4186,9 +4196,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-hex": "1.3.0",
-                        "mkdirp": "0.5.1",
-                        "write-file-atomic": "1.3.4"
+                        "md5-hex": "^1.2.0",
+                        "mkdirp": "^0.5.1",
+                        "write-file-atomic": "^1.1.4"
                     }
                 },
                 "camelcase": {
@@ -4203,8 +4213,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "0.1.4",
-                        "lazy-cache": "1.0.4"
+                        "align-text": "^0.1.3",
+                        "lazy-cache": "^1.0.3"
                     }
                 },
                 "chalk": {
@@ -4212,11 +4222,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "cliui": {
@@ -4225,8 +4235,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     },
                     "dependencies": {
@@ -4268,8 +4278,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.1",
-                        "which": "1.3.0"
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
                     }
                 },
                 "debug": {
@@ -4295,7 +4305,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-bom": "2.0.0"
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "detect-indent": {
@@ -4303,7 +4313,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "error-ex": {
@@ -4311,7 +4321,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-arrayish": "0.2.1"
+                        "is-arrayish": "^0.2.1"
                     }
                 },
                 "escape-string-regexp": {
@@ -4329,13 +4339,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -4343,9 +4353,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "4.1.1",
-                                "shebang-command": "1.2.0",
-                                "which": "1.3.0"
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
                             }
                         }
                     }
@@ -4355,7 +4365,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "expand-range": {
@@ -4363,7 +4373,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fill-range": "2.2.3"
+                        "fill-range": "^2.1.0"
                     }
                 },
                 "extglob": {
@@ -4371,7 +4381,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "filename-regex": {
@@ -4384,11 +4394,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^1.1.3",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "find-cache-dir": {
@@ -4396,9 +4406,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "commondir": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "pkg-dir": "1.0.0"
+                        "commondir": "^1.0.1",
+                        "mkdirp": "^0.5.1",
+                        "pkg-dir": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -4406,7 +4416,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 },
                 "for-in": {
@@ -4419,7 +4429,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "foreground-child": {
@@ -4427,8 +4437,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "4.0.2",
-                        "signal-exit": "3.0.2"
+                        "cross-spawn": "^4",
+                        "signal-exit": "^3.0.0"
                     }
                 },
                 "fs.realpath": {
@@ -4451,12 +4461,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-base": {
@@ -4464,8 +4474,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob-parent": "2.0.0",
-                        "is-glob": "2.0.1"
+                        "glob-parent": "^2.0.0",
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "glob-parent": {
@@ -4473,7 +4483,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "globals": {
@@ -4491,10 +4501,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "1.5.2",
-                        "optimist": "0.6.1",
-                        "source-map": "0.4.4",
-                        "uglify-js": "2.8.29"
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
                     },
                     "dependencies": {
                         "source-map": {
@@ -4502,7 +4512,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "amdefine": "1.0.1"
+                                "amdefine": ">=0.0.4"
                             }
                         }
                     }
@@ -4512,7 +4522,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "has-flag": {
@@ -4535,8 +4545,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -4549,7 +4559,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "loose-envify": "1.3.1"
+                        "loose-envify": "^1.0.0"
                     }
                 },
                 "invert-kv": {
@@ -4572,7 +4582,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtin-modules": "1.1.1"
+                        "builtin-modules": "^1.0.0"
                     }
                 },
                 "is-dotfile": {
@@ -4585,7 +4595,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-primitive": "2.0.0"
+                        "is-primitive": "^2.0.0"
                     }
                 },
                 "is-extendable": {
@@ -4603,7 +4613,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -4611,7 +4621,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-glob": {
@@ -4619,7 +4629,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-number": {
@@ -4627,7 +4637,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-posix-bracket": {
@@ -4678,7 +4688,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "append-transform": "0.4.0"
+                        "append-transform": "^0.4.0"
                     }
                 },
                 "istanbul-lib-instrument": {
@@ -4686,13 +4696,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "babel-generator": "6.26.0",
-                        "babel-template": "6.26.0",
-                        "babel-traverse": "6.26.0",
-                        "babel-types": "6.26.0",
-                        "babylon": "6.18.0",
-                        "istanbul-lib-coverage": "1.1.1",
-                        "semver": "5.4.1"
+                        "babel-generator": "^6.18.0",
+                        "babel-template": "^6.16.0",
+                        "babel-traverse": "^6.18.0",
+                        "babel-types": "^6.18.0",
+                        "babylon": "^6.18.0",
+                        "istanbul-lib-coverage": "^1.1.1",
+                        "semver": "^5.3.0"
                     }
                 },
                 "istanbul-lib-report": {
@@ -4700,10 +4710,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "1.1.1",
-                        "mkdirp": "0.5.1",
-                        "path-parse": "1.0.5",
-                        "supports-color": "3.2.3"
+                        "istanbul-lib-coverage": "^1.1.1",
+                        "mkdirp": "^0.5.1",
+                        "path-parse": "^1.0.5",
+                        "supports-color": "^3.1.2"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -4711,7 +4721,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "has-flag": "1.0.0"
+                                "has-flag": "^1.0.0"
                             }
                         }
                     }
@@ -4721,11 +4731,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "3.1.0",
-                        "istanbul-lib-coverage": "1.1.1",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "source-map": "0.5.7"
+                        "debug": "^3.1.0",
+                        "istanbul-lib-coverage": "^1.1.1",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.6.1",
+                        "source-map": "^0.5.3"
                     },
                     "dependencies": {
                         "debug": {
@@ -4743,7 +4753,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "4.0.11"
+                        "handlebars": "^4.0.3"
                     }
                 },
                 "js-tokens": {
@@ -4761,7 +4771,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "lazy-cache": {
@@ -4775,7 +4785,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -4783,11 +4793,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "locate-path": {
@@ -4795,8 +4805,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                     },
                     "dependencies": {
                         "path-exists": {
@@ -4821,7 +4831,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "js-tokens": "3.0.2"
+                        "js-tokens": "^3.0.0"
                     }
                 },
                 "lru-cache": {
@@ -4829,8 +4839,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "md5-hex": {
@@ -4838,7 +4848,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "0.1.1"
+                        "md5-o-matic": "^0.1.1"
                     }
                 },
                 "md5-o-matic": {
@@ -4851,7 +4861,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.1.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "merge-source-map": {
@@ -4859,7 +4869,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "^0.5.6"
                     }
                 },
                 "micromatch": {
@@ -4867,19 +4877,19 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "mimic-fn": {
@@ -4892,7 +4902,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -4918,10 +4928,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "2.5.0",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.4.1",
-                        "validate-npm-package-license": "3.0.1"
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     }
                 },
                 "normalize-path": {
@@ -4929,7 +4939,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "1.1.0"
+                        "remove-trailing-separator": "^1.0.1"
                     }
                 },
                 "npm-run-path": {
@@ -4937,7 +4947,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-key": "2.0.1"
+                        "path-key": "^2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -4955,8 +4965,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "for-own": "0.1.5",
-                        "is-extendable": "0.1.1"
+                        "for-own": "^0.1.4",
+                        "is-extendable": "^0.1.1"
                     }
                 },
                 "once": {
@@ -4964,7 +4974,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "optimist": {
@@ -4972,8 +4982,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimist": "0.0.8",
-                        "wordwrap": "0.0.3"
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
                     }
                 },
                 "os-homedir": {
@@ -4986,9 +4996,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "p-finally": {
@@ -5006,7 +5016,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-limit": "1.1.0"
+                        "p-limit": "^1.1.0"
                     }
                 },
                 "parse-glob": {
@@ -5014,10 +5024,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob-base": "0.3.0",
-                        "is-dotfile": "1.0.3",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1"
+                        "glob-base": "^0.3.0",
+                        "is-dotfile": "^1.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "parse-json": {
@@ -5025,7 +5035,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -5033,7 +5043,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -5056,9 +5066,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -5076,7 +5086,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pinkie": "2.0.4"
+                        "pinkie": "^2.0.0"
                     }
                 },
                 "pkg-dir": {
@@ -5084,7 +5094,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2"
+                        "find-up": "^1.0.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -5092,8 +5102,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -5113,8 +5123,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-number": "3.0.0",
-                        "kind-of": "4.0.0"
+                        "is-number": "^3.0.0",
+                        "kind-of": "^4.0.0"
                     },
                     "dependencies": {
                         "is-number": {
@@ -5122,7 +5132,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -5130,7 +5140,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -5140,7 +5150,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5150,9 +5160,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -5160,8 +5170,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -5169,8 +5179,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -5185,7 +5195,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-equal-shallow": "0.1.3"
+                        "is-equal-shallow": "^0.1.3"
                     }
                 },
                 "remove-trailing-separator": {
@@ -5208,7 +5218,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-finite": "1.0.2"
+                        "is-finite": "^1.0.0"
                     }
                 },
                 "require-directory": {
@@ -5232,7 +5242,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "0.1.4"
+                        "align-text": "^0.1.1"
                     }
                 },
                 "rimraf": {
@@ -5240,7 +5250,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "semver": {
@@ -5258,7 +5268,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "1.0.0"
+                        "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -5286,12 +5296,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "foreground-child": "1.5.6",
-                        "mkdirp": "0.5.1",
-                        "os-homedir": "1.0.2",
-                        "rimraf": "2.6.2",
-                        "signal-exit": "3.0.2",
-                        "which": "1.3.0"
+                        "foreground-child": "^1.5.6",
+                        "mkdirp": "^0.5.0",
+                        "os-homedir": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.2",
+                        "which": "^1.3.0"
                     }
                 },
                 "spdx-correct": {
@@ -5299,7 +5309,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-license-ids": "1.2.2"
+                        "spdx-license-ids": "^1.0.2"
                     }
                 },
                 "spdx-expression-parse": {
@@ -5317,8 +5327,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -5336,7 +5346,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -5346,7 +5356,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-bom": {
@@ -5354,7 +5364,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-eof": {
@@ -5372,11 +5382,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arrify": "1.0.1",
-                        "micromatch": "2.3.11",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "require-main-filename": "1.0.1"
+                        "arrify": "^1.0.1",
+                        "micromatch": "^2.3.11",
+                        "object-assign": "^4.1.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-main-filename": "^1.0.1"
                     }
                 },
                 "to-fast-properties": {
@@ -5395,9 +5405,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -5406,9 +5416,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -5425,8 +5435,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "1.0.2",
-                        "spdx-expression-parse": "1.0.4"
+                        "spdx-correct": "~1.0.0",
+                        "spdx-expression-parse": "~1.0.0"
                     }
                 },
                 "which": {
@@ -5434,7 +5444,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 },
                 "which-module": {
@@ -5458,8 +5468,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                     },
                     "dependencies": {
                         "string-width": {
@@ -5467,9 +5477,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         }
                     }
@@ -5484,9 +5494,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "slide": "1.1.6"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "slide": "^1.1.5"
                     }
                 },
                 "y18n": {
@@ -5504,18 +5514,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "8.0.0"
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^8.0.0"
                     },
                     "dependencies": {
                         "cliui": {
@@ -5523,9 +5533,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wrap-ansi": "2.1.0"
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wrap-ansi": "^2.0.0"
                             },
                             "dependencies": {
                                 "string-width": {
@@ -5533,9 +5543,9 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "code-point-at": "1.1.0",
-                                        "is-fullwidth-code-point": "1.0.0",
-                                        "strip-ansi": "3.0.1"
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
                                     }
                                 }
                             }
@@ -5547,7 +5557,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -5585,8 +5595,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "on-finished": {
@@ -5602,7 +5612,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -5611,7 +5621,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.1.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optimist": {
@@ -5619,8 +5629,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "optionator": {
@@ -5629,12 +5639,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             },
             "dependencies": {
                 "wordwrap": {
@@ -5650,9 +5660,9 @@
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
             }
         },
         "os-tmpdir": {
@@ -5671,7 +5681,7 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -5679,7 +5689,7 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-try": {
@@ -5692,10 +5702,10 @@
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.1",
-                "registry-url": "3.1.0",
-                "semver": "5.4.1"
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "packet-reader": {
@@ -5708,10 +5718,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "parseqs": {
@@ -5719,7 +5729,7 @@
             "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseuri": {
@@ -5727,7 +5737,7 @@
             "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseurl": {
@@ -5740,7 +5750,7 @@
             "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
             "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
             "requires": {
-                "passport-strategy": "1.0.0",
+                "passport-strategy": "1.x.x",
                 "pause": "0.0.1"
             }
         },
@@ -5749,18 +5759,18 @@
             "resolved": "https://registry.npmjs.org/passport-azure-ad/-/passport-azure-ad-3.0.9.tgz",
             "integrity": "sha1-+771YzutPLmSutJTc7qS7MHgo+s=",
             "requires": {
-                "async": "1.5.2",
-                "base64url": "2.0.0",
-                "bunyan": "1.8.12",
-                "cache-manager": "2.6.0",
-                "jwk-to-pem": "1.2.6",
-                "jws": "3.1.4",
-                "lodash": "4.17.4",
+                "async": "^1.5.2",
+                "base64url": "^2.0.0",
+                "bunyan": "^1.8.0",
+                "cache-manager": "^2.0.0",
+                "jwk-to-pem": "^1.2.6",
+                "jws": "^3.1.3",
+                "lodash": "^4.11.2",
                 "oauth": "0.9.14",
-                "passport": "0.3.2",
-                "pkginfo": "0.4.1",
-                "request": "2.83.0",
-                "valid-url": "1.0.9"
+                "passport": "^0.3.2",
+                "pkginfo": "^0.4.0",
+                "request": "^2.72.0",
+                "valid-url": "^1.0.6"
             },
             "dependencies": {
                 "async": {
@@ -5773,7 +5783,7 @@
                     "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
                     "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
                     "requires": {
-                        "passport-strategy": "1.0.0",
+                        "passport-strategy": "1.x.x",
                         "pause": "0.0.1"
                     }
                 }
@@ -5825,7 +5835,7 @@
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "performance-now": {
@@ -5842,9 +5852,9 @@
                 "js-string-escape": "1.0.1",
                 "packet-reader": "0.3.1",
                 "pg-connection-string": "0.1.3",
-                "pg-pool": "2.0.3",
-                "pg-types": "1.12.1",
-                "pgpass": "1.0.2",
+                "pg-pool": "~2.0.3",
+                "pg-types": "~1.12.1",
+                "pgpass": "1.x",
                 "semver": "4.3.2"
             },
             "dependencies": {
@@ -5870,10 +5880,10 @@
             "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
             "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
             "requires": {
-                "postgres-array": "1.0.2",
-                "postgres-bytea": "1.0.0",
-                "postgres-date": "1.0.3",
-                "postgres-interval": "1.1.1"
+                "postgres-array": "~1.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.0",
+                "postgres-interval": "^1.1.0"
             }
         },
         "pgpass": {
@@ -5881,7 +5891,7 @@
             "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
             "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
             "requires": {
-                "split": "1.0.1"
+                "split": "^1.0.0"
             },
             "dependencies": {
                 "split": {
@@ -5889,7 +5899,7 @@
                     "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
                     "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
                     "requires": {
-                        "through": "2.3.8"
+                        "through": "2"
                     }
                 }
             }
@@ -5911,7 +5921,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkginfo": {
@@ -5950,7 +5960,7 @@
             "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
             "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
             "requires": {
-                "xtend": "4.0.1"
+                "xtend": "^4.0.0"
             }
         },
         "prelude-ls": {
@@ -5985,7 +5995,7 @@
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
             "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.5.2"
             }
         },
@@ -5994,7 +6004,7 @@
             "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
             "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
             "requires": {
-                "event-stream": "3.3.4"
+                "event-stream": "~3.3.0"
             }
         },
         "pseudomap": {
@@ -6007,7 +6017,7 @@
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.0.tgz",
             "integrity": "sha512-q5I5vLRMVtdWa8n/3UEzZX7Lfghzrg9eG2IKk2ENLSofKRCXVqMvMUHxCKgXNaqH/8ebhBxrqftHWnyTFweJ5Q==",
             "requires": {
-                "ps-tree": "1.1.0"
+                "ps-tree": "^1.1.0"
             }
         },
         "pump": {
@@ -6015,8 +6025,8 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
             "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
             "requires": {
-                "end-of-stream": "1.4.0",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "punycode": {
@@ -6044,8 +6054,8 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -6053,7 +6063,7 @@
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6061,7 +6071,7 @@
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6071,7 +6081,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6097,10 +6107,10 @@
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
             "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
             "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
                 "minimist": {
@@ -6115,13 +6125,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -6129,10 +6139,10 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.3",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "redis": {
@@ -6140,9 +6150,9 @@
             "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
             "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
             "requires": {
-                "double-ended-queue": "2.1.0-0",
-                "redis-commands": "1.3.1",
-                "redis-parser": "2.6.0"
+                "double-ended-queue": "^2.1.0-0",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^2.6.0"
             }
         },
         "redis-commands": {
@@ -6160,7 +6170,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "registry-auth-token": {
@@ -6168,8 +6178,8 @@
             "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
             "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
             "requires": {
-                "rc": "1.2.2",
-                "safe-buffer": "5.1.1"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -6177,7 +6187,7 @@
             "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "requires": {
-                "rc": "1.2.2"
+                "rc": "^1.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -6200,28 +6210,28 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
             "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             }
         },
         "request-promise-core": {
@@ -6229,7 +6239,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.13.1"
             }
         },
         "request-promise-native": {
@@ -6238,8 +6248,8 @@
             "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.3"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
             }
         },
         "require-directory": {
@@ -6258,8 +6268,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requirejs": {
@@ -6273,7 +6283,7 @@
             "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
             "dev": true,
             "requires": {
-                "underscore": "1.6.0"
+                "underscore": "~1.6.0"
             },
             "dependencies": {
                 "underscore": {
@@ -6296,8 +6306,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "right-align": {
@@ -6306,7 +6316,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -6314,7 +6324,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
             "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
             "requires": {
-                "glob": "6.0.4"
+                "glob": "^6.0.1"
             },
             "dependencies": {
                 "glob": {
@@ -6322,11 +6332,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -6337,7 +6347,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx-lite": {
@@ -6352,7 +6362,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "s3-upload-stream": {
@@ -6396,7 +6406,7 @@
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "requires": {
-                "semver": "5.4.1"
+                "semver": "^5.0.3"
             }
         },
         "send": {
@@ -6405,18 +6415,18 @@
             "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.1",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.2",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -6439,10 +6449,10 @@
             "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz",
             "integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
             "requires": {
-                "etag": "1.8.1",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
                 "ms": "2.0.0",
-                "parseurl": "1.3.2",
+                "parseurl": "~1.3.2",
                 "safe-buffer": "5.1.1"
             }
         },
@@ -6451,9 +6461,9 @@
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
             "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
             "requires": {
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.1"
             }
         },
@@ -6477,7 +6487,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -6496,7 +6506,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             }
         },
         "sntp": {
@@ -6504,7 +6514,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
             "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
             }
         },
         "socket.io": {
@@ -6512,11 +6522,11 @@
             "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
             "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
             "requires": {
-                "debug": "2.6.9",
-                "engine.io": "3.1.4",
-                "socket.io-adapter": "1.1.1",
+                "debug": "~2.6.6",
+                "engine.io": "~3.1.0",
+                "socket.io-adapter": "~1.1.0",
                 "socket.io-client": "2.0.4",
-                "socket.io-parser": "3.1.2"
+                "socket.io-parser": "~3.1.1"
             },
             "dependencies": {
                 "debug": {
@@ -6543,14 +6553,14 @@
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "2.6.9",
-                "engine.io-client": "3.1.4",
+                "debug": "~2.6.4",
+                "engine.io-client": "~3.1.0",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "3.1.2",
+                "socket.io-parser": "~3.1.1",
                 "to-array": "0.1.4"
             },
             "dependencies": {
@@ -6570,8 +6580,8 @@
             "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "2.6.9",
-                "has-binary2": "1.0.2",
+                "debug": "~2.6.4",
+                "has-binary2": "~1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -6595,10 +6605,10 @@
             "resolved": "https://registry.npmjs.org/socket.io-redis/-/socket.io-redis-5.2.0.tgz",
             "integrity": "sha1-j+KtlEX8UIhvtwq8dZ1nQD1Ymd8=",
             "requires": {
-                "debug": "2.6.9",
-                "notepack.io": "2.1.2",
-                "redis": "2.8.0",
-                "socket.io-adapter": "1.1.1",
+                "debug": "~2.6.8",
+                "notepack.io": "~2.1.2",
+                "redis": "~2.8.0",
+                "socket.io-adapter": "~1.1.0",
                 "uid2": "0.0.3"
             },
             "dependencies": {
@@ -6617,7 +6627,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
         },
         "split": {
@@ -6625,7 +6635,7 @@
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-ca": {
@@ -6644,14 +6654,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stack-trace": {
@@ -6674,7 +6684,7 @@
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-transform": {
@@ -6692,8 +6702,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string_decoder": {
@@ -6701,7 +6711,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -6714,7 +6724,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             }
         },
         "strip-eof": {
@@ -6732,7 +6742,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
             "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
             }
         },
         "table": {
@@ -6741,12 +6751,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.3.0",
-                "lodash": "4.17.4",
+                "ajv": "^5.2.3",
+                "ajv-keywords": "^2.1.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "taffydb": {
@@ -6760,12 +6770,12 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-4.2.0.tgz",
             "integrity": "sha512-8c4LjonehF+KArauze53Tbx1tfPsWiF94cS8wK8s94wSGTWHwdVMLCRxvqe0u8fzTXfnAjlpkpOAQl240K/anw==",
             "requires": {
-                "chownr": "1.0.1",
-                "fs-minipass": "1.2.3",
-                "minipass": "2.2.1",
-                "minizlib": "1.1.0",
-                "mkdirp": "0.5.1",
-                "yallist": "3.0.2"
+                "chownr": "^1.0.1",
+                "fs-minipass": "^1.2.3",
+                "minipass": "^2.2.1",
+                "minizlib": "^1.1.0",
+                "mkdirp": "^0.5.0",
+                "yallist": "^3.0.2"
             },
             "dependencies": {
                 "yallist": {
@@ -6780,9 +6790,9 @@
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
             "integrity": "sha1-pqgFU9ilTHPeHQrg553ncDVgXh0=",
             "requires": {
-                "mkdirp": "0.5.1",
-                "pump": "1.0.3",
-                "tar-stream": "1.5.5"
+                "mkdirp": "^0.5.0",
+                "pump": "^1.0.0",
+                "tar-stream": "^1.1.2"
             }
         },
         "tar-stream": {
@@ -6790,10 +6800,10 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
             "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
             "requires": {
-                "bl": "1.2.1",
-                "end-of-stream": "1.4.0",
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "end-of-stream": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "term-size": {
@@ -6801,7 +6811,7 @@
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
         },
         "text-table": {
@@ -6809,6 +6819,15 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
+        },
+        "threads": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/threads/-/threads-0.11.0.tgz",
+            "integrity": "sha512-Wvr0ZrMchpyvQwwGaJWmtAryQTOHN3tvciuIgMG+OA1co18YwiZIW4lGPE0Z0+kFZbEzyIbIX5s2Lq7H46tCTA==",
+            "requires": {
+                "eventemitter3": "^2.0.2",
+                "native-promise-only": "^0.8.1"
+            }
         },
         "three": {
             "version": "0.89.0",
@@ -6836,7 +6855,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-array": {
@@ -6849,7 +6868,7 @@
             "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
             "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
             "requires": {
-                "nopt": "1.0.10"
+                "nopt": "~1.0.10"
             }
         },
         "tough-cookie": {
@@ -6857,7 +6876,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -6872,7 +6891,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -6887,7 +6906,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
@@ -6902,7 +6921,7 @@
             "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.17"
+                "mime-types": "~2.1.15"
             }
         },
         "typedarray": {
@@ -6916,9 +6935,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6933,9 +6952,9 @@
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -6989,7 +7008,7 @@
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "universalify": {
@@ -7012,15 +7031,15 @@
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
             "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.3.0",
-                "configstore": "3.1.1",
-                "import-lazy": "2.1.0",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "url": {
@@ -7037,7 +7056,7 @@
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "util-deprecate": {
@@ -7076,9 +7095,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "which": {
@@ -7086,7 +7105,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -7099,7 +7118,7 @@
             "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
             "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
         },
         "window-size": {
@@ -7113,12 +7132,12 @@
             "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
             "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
             "requires": {
-                "async": "1.0.0",
-                "colors": "1.0.3",
-                "cycle": "1.0.3",
-                "eyes": "0.1.8",
-                "isstream": "0.1.2",
-                "stack-trace": "0.0.10"
+                "async": "~1.0.0",
+                "colors": "1.0.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "stack-trace": "0.0.x"
             },
             "dependencies": {
                 "async": {
@@ -7143,8 +7162,8 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7157,7 +7176,7 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -7165,9 +7184,9 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -7175,7 +7194,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 }
             }
@@ -7191,7 +7210,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
@@ -7199,9 +7218,9 @@
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "ws": {
@@ -7209,9 +7228,9 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
             "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
             "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "ultron": "1.1.1"
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0",
+                "ultron": "~1.1.0"
             }
         },
         "xdg-basedir": {
@@ -7224,8 +7243,8 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
             "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
             "requires": {
-                "sax": "1.2.1",
-                "xmlbuilder": "4.2.1"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
             }
         },
         "xmlbuilder": {
@@ -7233,7 +7252,7 @@
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
             "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.0.0"
             }
         },
         "xmlcreate": {
@@ -7267,18 +7286,18 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.0.tgz",
             "integrity": "sha512-dXobF3oU7ETAU6GWXIkQVFlce4cOxDs6GD11PCn0yK6h68B5CcKPA0sJ9/8zCgqpoP+qdcbs9BABejM0QUlbLg==",
             "requires": {
-                "cliui": "4.0.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "8.1.0"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7291,9 +7310,9 @@
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
                     "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -7301,7 +7320,7 @@
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
                     "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -7311,7 +7330,7 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
             "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7331,10 +7350,10 @@
             "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
             "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.4",
-                "readable-stream": "2.3.3"
+                "archiver-utils": "^1.3.0",
+                "compress-commons": "^1.2.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "socket.io-client": "^2.0.4",
         "socket.io-redis": "^5.2.0",
         "tar": "^4.2.0",
+        "threads": "^0.11.0",
         "three": "^0.89.0",
         "uuid": "^3.2.1",
         "winston": "^2.4.0",

--- a/pages/instructorAssessment/instructorAssessment.ejs
+++ b/pages/instructorAssessment/instructorAssessment.ejs
@@ -563,6 +563,7 @@
                     <%= row.number %>. <%= row.qid %>
                 </a>
               </td>
+              <%- include('../partials/floatFormatter') %>
               <td class="text-center">
                 <%= formatFloat(row.mean_question_score, 1) %>
               </td>

--- a/pages/instructorAssessment/instructorAssessment.js
+++ b/pages/instructorAssessment/instructorAssessment.js
@@ -14,6 +14,7 @@ var dataFiles = require('../../lib/data-files');
 var assessment = require('../../lib/assessment');
 var sqldb = require('@prairielearn/prairielib/sql-db');
 var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+var assessmentStatDescriptions = require('../../lib/assessmentStatDescriptions');
 
 var sql = sqlLoader.loadSqlEquiv(__filename);
 
@@ -66,8 +67,9 @@ router.get('/', function(req, res, next) {
           });
         },
         function(callback) {
-            debug('set filenames');
+            debug('setup locals');
             _.assign(res.locals, filenames(res.locals));
+            res.locals.stat_descriptions = assessmentStatDescriptions;
             callback(null);
         },
         function(callback) {
@@ -423,8 +425,8 @@ router.get('/:filename', function(req, res, next) {
             var questionStatsList = result.rows;
             var csvData = [];
             var csvHeaders = ['Question number', 'Question title', 'Tags'];
-            Object.keys(res.locals.stat_descriptions).forEach(key => {
-                csvHeaders.push(res.locals.stat_descriptions[key].non_html_title);
+            Object.keys(assessmentStatDescriptions).forEach(key => {
+                csvHeaders.push(assessmentStatDescriptions[key].non_html_title);
             });
 
             csvData.push(csvHeaders);

--- a/pages/instructorAssessment/instructorAssessment.js
+++ b/pages/instructorAssessment/instructorAssessment.js
@@ -142,7 +142,7 @@ router.get('/', function(req, res, next) {
     ], function(err) {
         if (ERR(err, next)) return;
         debug('render page');
-        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+        res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });
 

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -180,6 +180,7 @@
               I-<%= row.number %>.
               <a href="<%= urlPrefix %>/question/<%= row.question_id %>/"><%= row.qid %></a>
             </td>
+            <%- include('../partials/floatFormatter') %>
             <td><%= row.some_submission %></td>
             <td><%= row.some_perfect_submission %></td>
             <td><%= row.some_nonzero_submission %></td>

--- a/pages/instructorGradebook/instructorGradebook.js
+++ b/pages/instructorGradebook/instructorGradebook.js
@@ -30,7 +30,7 @@ router.get('/', function(req, res, next) {
             if (ERR(err, next)) return;
 
             res.locals.user_scores = result.rows;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+            res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });
     });
 });

--- a/pages/instructorQuestion/instructorQuestion.ejs
+++ b/pages/instructorQuestion/instructorQuestion.ejs
@@ -132,6 +132,7 @@
                 <a href="/pl/course_instance/<%= row.course_instance_id %>/instructor/assessment/<%= row.assessment_id %>/" class="badge color-<%=
                   row.color %> color-hover" role="button"><%= row.label %></a>
               </td>
+              <%- include('../partials/floatFormatter') %>
               <td class="text-center">
                   <%= formatFloat(row.mean_question_score, 1) %>
               </td>

--- a/pages/instructorQuestions/instructorQuestions.js
+++ b/pages/instructorQuestions/instructorQuestions.js
@@ -1,7 +1,6 @@
 var ERR = require('async-stacktrace');
 var express = require('express');
 var router = express.Router();
-const spawn = require('threads').spawn;
 
 var sqldb = require('@prairielearn/prairielib/sql-db');
 var sqlLoader = require('@prairielearn/prairielib/sql-loader');

--- a/pages/instructorQuestions/instructorQuestions.js
+++ b/pages/instructorQuestions/instructorQuestions.js
@@ -1,6 +1,7 @@
 var ERR = require('async-stacktrace');
 var express = require('express');
 var router = express.Router();
+const spawn = require('threads').spawn;
 
 var sqldb = require('@prairielearn/prairielib/sql-db');
 var sqlLoader = require('@prairielearn/prairielib/sql-loader');
@@ -29,8 +30,7 @@ router.get('/', function(req, res, next) {
             sqldb.query(sql.assessments, params, function(err, result) {
                 if (ERR(err, next)) return;
                 res.locals.all_assessments = result.rows;
-
-                res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+                res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
             });
         });
     });

--- a/pages/partials/floatFormatter.ejs
+++ b/pages/partials/floatFormatter.ejs
@@ -1,13 +1,10 @@
-
-module.exports = function(req, res, next) {
-    res.locals.formatFloat = function(x, numDecDigits) {
+<%
+    formatFloat = function(x, numDecDigits) {
         if (numDecDigits == null) numDecDigits = 2;
         if (Number.isFinite(x)) {
             return x.toFixed(numDecDigits);
         } else {
             return '—';
         }
-    };
-    next();
-};
-
+    }
+%>

--- a/server.js
+++ b/server.js
@@ -227,19 +227,14 @@ app.use('/pl/course_instance/:course_instance_id/instructor/assessments', [
 ]);
 app.use('/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id', [
     require('./middlewares/selectAndAuthzAssessment'),
-    require('./pages/shared/assessmentStatDescriptions'),
-    require('./pages/shared/floatFormatters'),
     require('./pages/instructorAssessment/instructorAssessment'),
 ]);
 app.use('/pl/course_instance/:course_instance_id/instructor/assessment_instance/:assessment_instance_id', [
     require('./middlewares/selectAndAuthzAssessmentInstance'),
-    require('./pages/shared/floatFormatters'),
     require('./pages/instructorAssessmentInstance/instructorAssessmentInstance'),
 ]);
 app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id', [
     require('./middlewares/selectAndAuthzInstructorQuestion'),
-    require('./pages/shared/assessmentStatDescriptions'),
-    require('./pages/shared/floatFormatters'),
     require('./pages/instructorQuestion/instructorQuestion'),
 ]);
 app.use('/pl/course_instance/:course_instance_id/instructor/gradebook', require('./pages/instructorGradebook/instructorGradebook'));

--- a/server.js
+++ b/server.js
@@ -75,6 +75,7 @@ if (config.blockedWarnEnable) {
 const app = express();
 app.set('views', path.join(__dirname, 'pages'));
 app.set('view engine', 'ejs');
+app.enable('view cache');
 
 config.devMode = (app.get('env') == 'development');
 
@@ -144,6 +145,7 @@ app.use('/pl/azure_callback', require('./pages/authCallbackAzure/authCallbackAzu
 app.use(require('./middlewares/authn')); // authentication, set res.locals.authn_user
 app.use(require('./middlewares/csrfToken')); // sets and checks res.locals.__csrf_token
 app.use(require('./middlewares/logRequest'));
+app.use(require('./middlewares/injectRenderAsync'));
 
 // load accounting for authenticated accesses
 app.use(function(req, res, next) {load.startJob('authed_request', res.locals.response_id); next();});

--- a/server.js
+++ b/server.js
@@ -75,7 +75,6 @@ if (config.blockedWarnEnable) {
 const app = express();
 app.set('views', path.join(__dirname, 'pages'));
 app.set('view engine', 'ejs');
-app.enable('view cache');
 
 config.devMode = (app.get('env') == 'development');
 


### PR DESCRIPTION
This allows us to prevent long-running page renders from blocking the main thread. It creates a pool of Node workers that will render pages and then pass the results back to the main process to be sent to the client.