### PR TITLE
Mcrypt docs fix, popper version update

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@
 
   * Fix docs to provide workaround for `mcrypt` install error on OSX (Tim Bretl).
 
+  * Change `popper.js` to version `1.14.0` (Tim Bretl).
+
 * 2.12.0 - 2018-05-19
 
   * Add new issues page style and flexible filtering (Nathan Walters).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@
 
   * Fix migration 111 to allow re-running (Matt West).
 
+  * Fix docs to provide workaround for `mcrypt` install error on OSX (Tim Bretl).
+
 * 2.12.0 - 2018-05-19
 
   * Add new issues page style and flexible filtering (Nathan Walters).

--- a/doc/installingNative.md
+++ b/doc/installingNative.md
@@ -28,6 +28,18 @@ cd PrairieLearn
 npm install
 ```
 
+On OS X, it is possible that this process will fail on `node-gyp rebuild` during the install of `mcrypt`. In this case, use the following command instead:
+
+```sh
+npm install --python=PATH_TO_PYTHON2
+```
+
+For example, this might be:
+
+```sh
+npm install --python=/usr/bin/python2.7
+```
+
 * Make sure `python3` and `python3.6` will run the right version, and make executable links if needed:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "passport-azure-ad": "^3.0.9",
         "pg": "^7.4.0",
         "plist": "^2.1.0",
-        "popper.js": "^1.13.0",
+        "popper.js": "^1.14.0",
         "qrcode-svg": "^1.0.0",
         "redis": "^2.8.0",
         "request-promise-native": "^1.0.5",


### PR DESCRIPTION
- Adds doc with a workaround for error on `mcrypt` install (specify the use of python 2).
- Updates required `popper.js` version to `1.14.0`.