### PR TITLE
Fix element styling + aria attributes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).
 
+  * Fix several issues with various elements (Nathan Walters).
+
 * __3.0.0__ - 2018-05-23
 
   * Add improved support for very large file downloads (Nathan Walters).

--- a/elements/pl_integer_input/pl_integer_input.mustache
+++ b/elements/pl_integer_input/pl_integer_input.mustache
@@ -12,12 +12,14 @@
     <span id="pl-integer-input-{{uuid}}" class="input-group pl-integer-input">
         {{#label}}
         <span class="input-group-prepend">
-            <span class="input-group-text">{{label}}</span>
+            <span class="input-group-text" id="pl-integer-input-{{uuid}}-label">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
+        <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-integer-input-{{uuid}}-label pl-integer-input-{{uuid}}-suffix" placeholder="{{shortinfo}}" />
         <span class="input-group-append">
-            {{#suffix}}<span class="input-group-text">{{suffix}}</span>{{/suffix}}
+            {{#suffix}}
+            <span class="input-group-text" id="pl-integer-input-{{uuid}}-suffix">{{suffix}}</span>
+            {{/suffix}}
             <a class="btn btn-light border" role="button" data-toggle="popover" data-html="true" title="Number" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
                 {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}

--- a/elements/pl_matrix_input/pl_matrix_input.mustache
+++ b/elements/pl_matrix_input/pl_matrix_input.mustache
@@ -8,10 +8,12 @@
     });
 </script>
 <div id="pl-matrix-input-{{uuid}}" class="input-group">
+    {{#label}}
     <span class="input-group-prepend">
-        {{#label}}<label class="input-group-text" id="basic-addon2">{{label}}</label>{{/label}}
+        <label class="input-group-text" id="pl-matrix-input-{{uuid}}-label">{{label}}</label>
     </span>
-    <input name="{{name}}" type="text" class="form-control" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
+    {{/label}}
+    <input name="{{name}}" type="text" class="form-control" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-matrix-input-{{uuid}}-label" placeholder="{{shortinfo}}" />
     <div class="input-group-append">
         <a class="btn btn-light border" role="button" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
             <i class="fa fa-question-circle" aria-hidden="true"></i>

--- a/elements/pl_symbolic_input/pl_symbolic_input.mustache
+++ b/elements/pl_symbolic_input/pl_symbolic_input.mustache
@@ -10,8 +10,8 @@
 
 <span class="form-inline d-inline-block">
     <span id="pl-symbolic-input-{{uuid}}" class="input-group pl-symbolic-input">
-        <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
-        <span class="input-group-btn" id="basic-addon1">
+        <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" />
+        <span class="input-group-append">
             <a class="btn btn-light border" role="button" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
                 {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}


### PR DESCRIPTION
Fixes to a few problems I noticed while testing something else

* `pl_symbolic_input` was using an old`input-group-btn` class; I've updated this to the Bootstrap 4 class.
* Some elements had `aria-describedby` attributes that references non-existent things. This adds the appropriate IDs and updates that attribute to refer to them.