### PR TITLE
Handle missing `assessments` directory on course instance sync

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
   * Fix Google auth using new API (Matt West).
 
   * Fix several issues with various elements (Nathan Walters).
+  
+  * Fix sync failure if a course instance has no `assessments` directory and add warning in sync log (Ray Essick).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@
   * Fix Google auth using new API (Matt West).
 
   * Fix several issues with various elements (Nathan Walters).
-  
+
   * Fix sync failure if a course instance has no `assessments` directory and add warning in sync log (Ray Essick).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).

--- a/doc/courseInstance.md
+++ b/doc/courseInstance.md
@@ -5,7 +5,7 @@
 
 ## Directory layout
 
-A _course instance_ corresponds to a single offering of a [course](course.md), such as "Fall 2016", or possibly "Fall 2016, Section 1". A course instance like `Fa16` is contained in one directory and has a configuration file (`infoCourseInstance.json`) and a list of [assessments](assessment.md) in an `assessments` subdirectory.
+A _course instance_ corresponds to a single offering of a [course](course.md), such as "Fall 2016", or possibly "Fall 2016, Section 1". A course instance like `Fa16` is contained in one directory and has a configuration file (`infoCourseInstance.json`) and a subdirectory (`assessments`) containing a list of [assessments](assessment.md). The `assessments` directory should always exist, but may be empty if no assessments have been added.
 
 ```text
 exampleCourse

--- a/lib/course-db.js
+++ b/lib/course-db.js
@@ -189,23 +189,21 @@ module.exports.loadFullCourse = function(courseDir, logger, callback) {
             var assessmentsDir = path.join(course.courseInfo.courseInstancesDir, courseInstanceDir, 'assessments');
             courseInstance.assessmentDB = {};
             // Check that the assessments folder exists and is accessible before loading from it
-            fs.lstat(assessmentsDir, function(err, fileStats) {
-                // If lstat errors, determine why
+            fs.access(assessmentsDir, function(err) {
                 if (err) {
                     // If the directory does not exist, warn and skip assessment loading
                     if (err.code == 'ENOENT') {
-                        logger.warn("Warning: " + courseInstanceDir + " has no 'assessments' directory.");
+                        logger.warn('Warning: ' + courseInstanceDir + ' has no `assessments` directory.');
                     
                     }
                     // Report the error code for any other error and skip assessment loading
                     else {
-                        logger.warn("Warning: " + courseInstanceDir + " assessment directory inaccessible (lstat error code: " + err.code + ").");
+                        logger.warn('Warning: ' + courseInstanceDir + ' `assessment` directory inaccessible (lstat error code: ' + err.code + ').');
                     }
                     // The above handles the error
                     callback(null);
                 }
                 else {
-                    // Load the assessment info for this courseInstance
                     that.loadInfoDB(courseInstance.assessmentDB, 'tid', assessmentsDir, 'infoAssessment.json', defaultAssessmentInfo, 'schemas/infoAssessment.json', null, null, course.courseInfo, logger, function(err) {
                     if (ERR(err, callback)) return;
                     callback(null);

--- a/lib/course-db.js
+++ b/lib/course-db.js
@@ -189,18 +189,24 @@ module.exports.loadFullCourse = function(courseDir, logger, callback) {
             var assessmentsDir = path.join(course.courseInfo.courseInstancesDir, courseInstanceDir, 'assessments');
             courseInstance.assessmentDB = {};
             // Check that the assessments folder exists and is accessible before loading from it
-            fs.access(assessmentsDir, function(err) {
+            fs.lstat(assessmentsDir, function(err, stats) {
                 if (err) {
-                    // If the directory does not exist, warn and skip assessment loading
+                    // ENOENT: Directory does not exist
                     if (err.code == 'ENOENT') {
                         logger.warn(`Warning: ${courseInstanceDir} has no \`assessments\` directory (lstat error code ENOENT).`);
                     
                     }
-                    // Report the error code for any other error and skip assessment loading
+                    // Other access permissions error
                     else {
                         logger.warn(`Warning: \`${courseInstanceDir}/assessments\` is inaccessible (lstat error code ${err.code}).`)
                     }
                     // The above handles the error
+                    callback(null);
+                }
+                // ENOTDIR: `assessments` is not a directory
+                else if (!stats.isDirectory()) {
+                    logger.warn(`Warning: \`${courseInstanceDir}/assessments\` is not a directory.`);
+                    // This handles the error
                     callback(null);
                 }
                 else {

--- a/lib/course-db.js
+++ b/lib/course-db.js
@@ -188,9 +188,30 @@ module.exports.loadFullCourse = function(courseDir, logger, callback) {
         async.forEachOf(course.courseInstanceDB, function(courseInstance, courseInstanceDir, callback) {
             var assessmentsDir = path.join(course.courseInfo.courseInstancesDir, courseInstanceDir, 'assessments');
             courseInstance.assessmentDB = {};
-            that.loadInfoDB(courseInstance.assessmentDB, 'tid', assessmentsDir, 'infoAssessment.json', defaultAssessmentInfo, 'schemas/infoAssessment.json', null, null, course.courseInfo, logger, function(err) {
-                if (ERR(err, callback)) return;
-                callback(null);
+            // Check that the assessments folder exists and is accessible before loading from it
+            fs.lstat(assessmentsDir, function(err, fileStats) {
+                // If lstat errors, determine why
+                if (err) {
+                    // If the directory does not exist, warn and skip assessment loading
+                    if (err.code == 'ENOENT') {
+                        logger.warn("Warning: " + courseInstanceDir + " has no 'assessments' directory.");
+                    
+                    }
+                    // Report the error code for any other error and skip assessment loading
+                    else {
+                        logger.warn("Warning: " + courseInstanceDir + " assessment directory inaccessible (lstat error code: " + err.code + ").");
+                    }
+                    // The above handles the error
+                    callback(null);
+                }
+                else {
+                    // Load the assessment info for this courseInstance
+                    that.loadInfoDB(courseInstance.assessmentDB, 'tid', assessmentsDir, 'infoAssessment.json', defaultAssessmentInfo, 'schemas/infoAssessment.json', null, null, course.courseInfo, logger, function(err) {
+                    if (ERR(err, callback)) return;
+                    callback(null);
+                    });
+                }
+                
             });
         }, function(err) {
             if (ERR(err, callback)) return;

--- a/lib/course-db.js
+++ b/lib/course-db.js
@@ -193,12 +193,12 @@ module.exports.loadFullCourse = function(courseDir, logger, callback) {
                 if (err) {
                     // If the directory does not exist, warn and skip assessment loading
                     if (err.code == 'ENOENT') {
-                        logger.warn('Warning: ' + courseInstanceDir + ' has no `assessments` directory.');
+                        logger.warn(`Warning: ${courseInstanceDir} has no \`assessments\` directory (lstat error code ENOENT).`);
                     
                     }
                     // Report the error code for any other error and skip assessment loading
                     else {
-                        logger.warn('Warning: ' + courseInstanceDir + ' `assessment` directory inaccessible (lstat error code: ' + err.code + ').');
+                        logger.warn(`Warning: \`${courseInstanceDir}/assessments\` is inaccessible (lstat error code ${err.code}).`)
                     }
                     // The above handles the error
                     callback(null);


### PR DESCRIPTION
Currently an empty `assessments` directory syncs correctly, but a missing `assessments` causes syncs to fail. This explicitly checks for the existence of `assessments` and warns if the directory is missing (skipping the sync).

Fixes #999 