### PR TITLE
Fix copy button

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@
 
   * Fix assessment time limits (Matt West).
 
+  * Fix copy button after `clipboard.js` package update (Tim Bretl).
+
   * Change element names to use dashes instead of underscores (Nathan Walters).
 
   * Change deprecated `new Buffer()` calls to `Buffer.from()` (Ray Essick).
@@ -36,7 +38,7 @@
   * Change `centos7-ocaml` grader image to `ocaml-4.05` (Matt West).
 
   * Change TravisCI tasks to run linters first (Matt West, h/t James Balamuta).
-  
+
   * Change element attributes to use hyphens instead of underscores (Nathan Walters).
 
   * Change assessment password protection method (Dave Mussulman).

--- a/public/javascripts/PrairieUtil.js
+++ b/public/javascripts/PrairieUtil.js
@@ -17,7 +17,7 @@
 
         var successMessage = options.success || 'copied to clipboard!';
 
-        var clipboard = new Clipboard(selector);
+        var clipboard = new ClipboardJS(selector);
         var clicked = false;
         clipboard.on('success', function(e) {
             var contents = options.contents || $(e.trigger).text();


### PR DESCRIPTION
After package update, the constructor for `clipboard.js` is `ClipboardJS` and not `Clipboard`. Changed one line in `PrairieUtil.js` to the correct form of this constructor, which is used to create a copy button.

Fixes #1203 