### PR TITLE
New question renderer with feature flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
   * Add `pl-prairiedraw-figure` element and update PrairieDraw graphics documentation. (Ray Essick).
 
   * Add `pl-matrix-component-input` element (Mariana Silva).
+
   * Add new question renderer behind feature flag (Nathan Walters).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
   * Add `pl-prairiedraw-figure` element and update PrairieDraw graphics documentation. (Ray Essick).
 
   * Add `pl-matrix-component-input` element (Mariana Silva).
+  * Add new question renderer behind feature flag (Nathan Walters).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).
 

--- a/doc/question.md
+++ b/doc/question.md
@@ -84,7 +84,6 @@ def generate(data):
 
 ```
 
-
 ## Question `question.html`
 
 The `question.html` is a template used to render the question to the student. A complete `question.html` example looks like:
@@ -112,3 +111,97 @@ When a question is displayed to a student, there are three "panels" that will be
 All three panels display the same `question.html` template, but elements will render differently in each panel. For example, the `<pl-number-input>` element displays an input box in the "question" panel, the submitted answer in the "submissions" panel, and the correct answer in the "answer" panel.
 
 Text in `question.html` can be set to only display in the "question" panel by wrapping it in the `<pl-question-panel>` element. This is useful for the question prompt, which doesn't need to be repeated in the "submission" and "answer" panels. There are also elements that only render in the other two panels.
+
+## How questions are rendered
+
+Questions are rendered in two possible ways: with the "legacy renderer" and the "new renderer". Currently, the legacy renderer is the default, but the new renderer will eventually replace the legacy renderer entirely. The new renderer uses a different HTML parser, which behaves differently than the old one for malformed HTML and could result in breaking changes.
+
+**TL;DR** If you're starting a new course, you should write questions with the new renderer in mind, as it will soon become the default.
+
+> Aside: when we say "renderer", we're really talking about how we traverse the tree of elements in a question to process them. However, the way in which this occurs typically only matters during the "render" phase, so we talk about it as a "renderer".
+
+### The legacy renderer
+
+The legacy renderer uses a naive approach to rendering: it renders elements in order of name. This poses some performance problems: if an element will never actually have its output rendered on screen (for instance, it's inside a `<pl-question-panel>` and the current panel being rendered is the "answer" panel), it's possible that we'll still perform some expensive IPC to try to render a panel that will never be shown! Internally, the architecture provides inconsistent support for nested elements. For instance, if you wanted to use figures in multiple choice answers, they may not be rendered correctly:
+
+```html
+<pl-multiple-choice>
+  <pl-answer correct="true">
+    <pl-figure file-name="fig1.png">
+  </pl-answer>
+  <pl-answer correct="false">
+    <pl-figure file-name="fig2.png">
+  </pl-answer>
+</pl-multiple-choice>
+```
+
+Based on the order that the elements get rendered, the inner `<pl-figure>` elements might not get processed correctly. This is due to behavior in a dependency called [cheerio](https://github.com/cheeriojs/cheerio) that we use to build up the rendered HTML for a question. One benefit of this dependency is that its parser is more forgiving when encountering invalid HTML. However, this also made it more difficult to process the question properly as a tree. Which brings us to...
+
+### The new renderer
+
+The new renderer is rewritten from the ground up to solve the problems inherent in the old renderer. Questions are now properly processed like a tree in a deterministic order. Let's reconsider the example above:
+
+```html
+<pl-multiple-choice answers-name="student">
+  <pl-answer correct="true">
+    <pl-figure file-name="fig1.png"></pl-figure>
+  </pl-answer>
+  <pl-answer correct="false">
+    <pl-figure file-name="fig2.png"></pl-figure>
+  </pl-answer>
+</pl-multiple-choice>
+```
+
+If you imagine this being parsed into an abstract syntax tree, we have a `<pl-multiple-choice>` element with two `<pl-answer>` children elements, each of which has a `<pl-figure>` child element. When rendering this question, we first render the `<pl-multiple-choice>` element, which will produce some hypothetical markup that wraps each answer:
+
+```html
+<div class="foo">
+  <input type="radio" name="student">
+  <pl-figure file-name="fig1.png"></pl-figure>
+</div>
+<div class="foo">
+  <input type="radio" name="student">
+  <pl-figure file-name="fig2.png"></pl-figure>
+</div>
+```
+
+We then re-parse this tree and again begin looking for more elements to render. We'll then come across each `<pl-figure>` in turn and they will be rendered, with their markup re-inserted into the tree:
+
+```html
+<div class="foo">
+  <input type="radio" name="student">
+  <img src="fig1.png">
+</div>
+<div class="foo">
+  <input type="radio" name="student">
+  <img src="fig2.png">
+</div>
+```
+
+And then we're done! This is an obviously more correct way to process questions, and it will soon become the default. However, this change required introducing a new HTML parser that behaves differently in the precense of malformed HTML, such as missing closing tags or self-closing PrairieLearn elements. So, we are making this new renderer opt-in for the time being until we can ensure that everyone's questions have been properly updated.
+
+To opt in to the new renderer, add the following to your `infoCourse.json` file:
+
+```json
+{
+    "options": {
+        "useNewQuestionRenderer": true
+    },
+}
+```
+
+Note that this will apply to all questions, so make sure to check that you've been writing valid HTML.
+
+Example of invalid HTML:
+
+```html
+<p>This is a picture of a bird
+<pl-figure file-name="bird.html"/>
+```
+
+Example of valid HTML:
+
+```html
+<p>This is a picture of a bird</p>
+<pl-figure file-name="bird.html"></pl-figure>
+```

--- a/exampleCourse/infoCourse.json
+++ b/exampleCourse/infoCourse.json
@@ -2,8 +2,10 @@
     "uuid": "fcc5282c-a752-4146-9bd6-ee19aac53fc5",
     "name": "XC 101",
     "title": "Example Course",
-    "assessmentSets": [
-    ],
+    "options": {
+        "useNewQuestionRenderer": true
+    },
+    "assessmentSets": [],
     "topics": [
         {"name": "Algebra", "color": "red3", "description": "Basic algebra."},
         {"name": "Calculus", "color": "yellow3", "description": "Single and multiple variable calculus."},

--- a/exampleCourse/questions/chooseMatrices/info.json
+++ b/exampleCourse/questions/chooseMatrices/info.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "60228129-8d2a-4d12-8304-cfde9cd4d4d3",
+  "title": "Choose the matrices with the given dimension",
+  "topic": "Linear algebra",
+  "type": "v3",
+  "tags": ["v3"]
+}

--- a/exampleCourse/questions/chooseMatrices/question.html
+++ b/exampleCourse/questions/chooseMatrices/question.html
@@ -1,0 +1,25 @@
+<pl-question-panel>
+  <p>
+    Select the matrices below with dimensions ${{params.N}}\times{{params.N}}$:
+  </p>
+</pl-question-panel>
+<pl-checkbox answers-name='students'>
+  <pl-answer correct="true">
+    $<pl-matrix-latex params-name="N1"></pl-matrix-latex>$
+  </pl-answer>
+  <pl-answer correct="true">
+    $<pl-matrix-latex params-name="N2"></pl-matrix-latex>$
+  </pl-answer>
+  <pl-answer correct="false">
+    $<pl-matrix-latex params-name="M1"></pl-matrix-latex>$
+  </pl-answer>
+  <pl-answer correct="false">
+    $<pl-matrix-latex params-name="M2"></pl-matrix-latex>$
+  </pl-answer>
+  <pl-answer correct="false">
+    $<pl-matrix-latex params-name="M3"></pl-matrix-latex>$
+  </pl-answer>
+  <pl-answer correct="false">
+    $<pl-matrix-latex params-name="M4"></pl-matrix-latex>$
+  </pl-answer>
+</pl-checkbox>

--- a/exampleCourse/questions/chooseMatrices/server.py
+++ b/exampleCourse/questions/chooseMatrices/server.py
@@ -1,0 +1,19 @@
+import random, math
+import numpy as np
+import numpy.linalg as la
+import scipy.linalg as sla
+import prairielearn as pl
+
+def generate(data):
+    N = random.choice([2,3])
+    data["params"]["N"] = N
+    for i in range(2):
+        X = np.random.rand(N,N)
+        name = "N" + str(i+1)
+        data["params"][name] = pl.to_json(X)
+    for i in range(4):
+        M = random.choice([j for j in range(2,5) if j not in [N]])
+        X = np.random.rand(M,M)
+        name = "M" + str(i+1)
+        data["params"][name] = pl.to_json(X)
+    return data

--- a/lib/course-db.js
+++ b/lib/course-db.js
@@ -75,6 +75,11 @@ module.exports.loadCourseInfo = function(courseInfo, courseDir, logger, callback
                 courseInfo.tags.push(tag);
             }
         });
+
+        // Course options
+        courseInfo.options = {};
+        courseInfo.options.useNewQuestionRenderer = _.get(info, 'options.useNewQuestionRenderer', false);
+
         courseInfo.jsonFilename = info.jsonFilename;
         callback(null);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7375,6 +7375,11 @@
             "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
             "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
         },
+        "parse5": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.0.0.tgz",
+            "integrity": "sha512-0ywuiUOnpWWeil5grH2rxjyTJoeQVwyBuO2si6QIU9dWtj2npjuyK1HaY1RbLnVfDhEbhyAPNUBKRK0Xj2xE0w=="
+        },
         "parseqs": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "nodemon": "^1.17.5",
         "numeric": "^1.2.6",
         "on-finished": "^2.3.0",
+        "parse5": "^5.0.0",
         "passport": "^0.4.0",
         "passport-azure-ad": "^3.0.12",
         "pg": "^7.4.3",

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -5,6 +5,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const mustache = require('mustache');
 const cheerio = require('cheerio');
+const parse5 = require('parse5');
 
 const logger = require('../lib/logger');
 const codeCaller = require('../lib/code-caller');
@@ -154,7 +155,29 @@ module.exports = {
         return path.join(element.directory, element.controller);
     },
 
-    elementFunction: function(pc, fcn, elementName, $, element, index, data, context, callback) {
+    elementFunction: async function(pc, fcn, elementName, elementHtml, index, data, context) {
+        return new Promise((resolve, reject) => {
+            const resolvedElement = module.exports.resolveElement(elementName, context);
+            const cwd = resolvedElement.directory;
+            const controller = resolvedElement.controller;
+            const pythonArgs = [elementHtml, index, data];
+            const pythonFile = controller.replace(/\.[pP][yY]$/, '');
+            const opts = {
+                cwd,
+                paths: [path.join(__dirname, 'freeformPythonLib')],
+            };
+            pc.call(pythonFile, fcn, pythonArgs, opts, (err, ret, consoleLog) => {
+                if (err instanceof codeCaller.FunctionMissingError) {
+                    // function wasn't present in server
+                    return resolve([module.exports.defaultElementFunctionRet(fcn, data), '']);
+                }
+                if (ERR(err, reject)) return;
+                resolve([ret, consoleLog]);
+            });
+        });
+    },
+
+    legacyElementFunction: function(pc, fcn, elementName, $, element, index, data, context, callback) {
         let resolvedElement;
         try {
             resolvedElement = module.exports.resolveElement(elementName, context);
@@ -240,12 +263,12 @@ module.exports = {
     },
 
     execTemplate: function(htmlFilename, data, callback) {
-        fs.readFile(htmlFilename, {encoding: 'utf8'}, (err, raw_file) => {
+        fs.readFile(htmlFilename, { encoding: 'utf8' }, (err, rawFile) => {
             if (ERR(err, callback)) return;
             let html;
             err = null;
             try {
-                html = mustache.render(raw_file, data);
+                html = mustache.render(rawFile, data);
             } catch (e) {
                 err = e;
             }
@@ -329,104 +352,217 @@ module.exports = {
         return null;
     },
 
+    travserseQuestionAndExecuteFunctions: async function(phase, pc, data, context, html, callback) {
+        const origData = JSON.parse(JSON.stringify(data));
+        const renderedElementNames = [];
+        const courseIssues = [];
+        let fileData = Buffer.from('');
+        let index = 0;
+        const questionElements = new Set([..._.keys(coreElementsCache), ..._.keys(context.course_elements)]);
+
+        const visitNode = async (node) => {
+            if (node.tagName && questionElements.has(node.tagName)) {
+                const elementName = node.tagName;
+                const elementFile = module.exports.getElementController(elementName, context);
+                if (phase === 'render' && !_.includes(renderedElementNames, elementName)) {
+                    renderedElementNames.push(elementName);
+                }
+                // We need to wrap it in another node, since only child nodes
+                // are serialized
+                const serializedNode = parse5.serialize({
+                    childNodes: [node],
+                });
+                let ret_val, consoleLog;
+                try {
+                    [ret_val, consoleLog] = await module.exports.elementFunction(pc, phase, elementName, serializedNode, index, data, context);
+                } catch (e) {
+                    const courseIssue = new Error(`${elementFile}: Error calling ${phase}(): ${e.toString()}`);
+                    courseIssue.data = e.data;
+                    courseIssue.fatal = true;
+                    // We'll catch this and add it to the course issues list
+                    throw courseIssue;
+                }
+                if (_.isString(consoleLog) && consoleLog.length > 0) {
+                    const courseIssue = new Error(`${elementFile}: output logged on console during ${phase}()`);
+                    courseIssue.data = { outputBoth: consoleLog };
+                    courseIssue.fatal = false;
+                    courseIssues.push(courseIssue);
+                }
+                if (phase == 'render') {
+                    if (!_.isString(ret_val)) {
+                        const courseIssue = new Error(`${elementFile}: Error calling ${phase}(): return value is not a string`);
+                        courseIssue.data = { ret_val };
+                        courseIssue.fatal = true;
+                        throw courseIssue;
+                    }
+                    node = parse5.parseFragment(ret_val);
+                } else if (phase == 'file') {
+                    // Convert ret_val from base64 back to buffer (this always works,
+                    // whether or not ret_val is valid base64)
+                    const buf = Buffer.from(ret_val, 'base64');
+                    // If the buffer has non-zero length...
+                    if (buf.length > 0) {
+                        if (fileData.length > 0) {
+                            // If fileData already has non-zero length, throw an error
+                            const courseIssue = new Error(`${elementFile}: Error calling ${phase}(): attempting to overwrite non-empty fileData`);
+                            courseIssue.fatal = true;
+                            throw courseIssue;
+                        } else {
+                            // If not, replace fileData with buffer
+                            fileData = buf;
+                        }
+                    }
+                } else {
+                    data = ret_val;
+                    const checkErr = module.exports.checkData(data, origData, phase);
+                    if (checkErr) {
+                        const courseIssue = new Error(`${elementFile}: Invalid state after ${phase}(): ${checkErr}`);
+                        courseIssue.fatal = true;
+                        throw courseIssue;
+                    }
+                }
+                index++;
+            }
+            const newChildren = [];
+            for (let i = 0; i < (node.childNodes || []).length; i++) {
+                const childRes = await visitNode(node.childNodes[i]);
+                if (childRes) {
+                    if (childRes.nodeName === '#document-fragment') {
+                        newChildren.push(...childRes.childNodes);
+                    } else {
+                        newChildren.push(childRes);
+                    }
+                }
+            }
+            node.childNodes = newChildren;
+            return node;
+        };
+        let questionHtml = '';
+        try {
+            const res = await visitNode(parse5.parseFragment(html));
+            questionHtml = parse5.serialize(res);
+        } catch (e) {
+            courseIssues.push(e);
+        }
+        callback(courseIssues, data, questionHtml, fileData, renderedElementNames);
+    },
+
+    legacyTraverseQuestionAndExecuteFunctions: function(phase, pc, data, context, $, callback) {
+        const origData = JSON.parse(JSON.stringify(data));
+        const renderedElementNames = [];
+        const courseIssues = [];
+        let fileData = Buffer.from('');
+        const questionElements = new Set([..._.keys(coreElementsCache), ..._.keys(context.course_elements)]).values();
+
+        let index = 0;
+        async.eachSeries(questionElements, (elementName, callback) => {
+            async.eachSeries($(elementName).toArray(), (element, callback) => {
+                if (phase === 'render' && !_.includes(renderedElementNames, element)) {
+                    renderedElementNames.push(elementName);
+                }
+
+                const elementFile = module.exports.getElementController(elementName, context);
+
+                module.exports.legacyElementFunction(pc, phase, elementName, $, element, index, data, context, (err, ret_val, consoleLog) => {
+                    if (err) {
+                        const courseIssue = new Error(elementFile + ': Error calling ' + phase + '(): ' + err.toString());
+                        courseIssue.data = err.data;
+                        courseIssue.fatal = true;
+                        courseIssues.push(courseIssue);
+                        return callback(courseIssue);
+                    }
+                    if (_.isString(consoleLog) && consoleLog.length > 0) {
+                        const courseIssue = new Error(elementFile + ': output logged on console during ' + phase + '()');
+                        courseIssue.data = { outputBoth: consoleLog };
+                        courseIssue.fatal = false;
+                        courseIssues.push(courseIssue);
+                    }
+
+                    if (phase == 'render') {
+                        if (!_.isString(ret_val)) {
+                            const courseIssue = new Error(elementFile + ': Error calling ' + phase + '(): return value is not a string');
+                            courseIssue.data = { ret_val };
+                            courseIssue.fatal = true;
+                            courseIssues.push(courseIssue);
+                            return callback(courseIssue);
+                        }
+                        $(element).replaceWith(ret_val);
+                    } else if (phase == 'file') {
+                        // Convert ret_val from base64 back to buffer (this always works,
+                        // whether or not ret_val is valid base64)
+                        var buf = Buffer.from(ret_val, 'base64');
+
+                        // If the buffer has non-zero length...
+                        if (buf.length > 0) {
+                            if (fileData.length > 0) {
+                                // If fileData already has non-zero length, throw an error
+                                const courseIssue = new Error(elementFile + ': Error calling ' + phase + '(): attempting to overwrite non-empty fileData');
+                                courseIssue.fatal = true;
+                                courseIssues.push(courseIssue);
+                                return callback(courseIssue);
+                            } else {
+                                // If not, replace fileData with buffer
+                                fileData = buf;
+                            }
+                        }
+                    } else {
+                        data = ret_val;
+                        const checkErr = module.exports.checkData(data, origData, phase);
+                        if (checkErr) {
+                            const courseIssue = new Error(elementFile + ': Invalid state after ' + phase + '(): ' + checkErr);
+                            courseIssue.fatal = true;
+                            courseIssues.push(courseIssue);
+                            return callback(courseIssue);
+                        }
+                    }
+
+                    index++;
+                    callback(null);
+                });
+            }, (err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        }, (err) => {
+            if (ERR(err, callback)) return;
+            callback(courseIssues, data, $.html(), fileData, renderedElementNames);
+        });
+    },
+
     processQuestionHtml: function(phase, pc, data, context, callback) {
         const courseIssues = [];
         const origData = JSON.parse(JSON.stringify(data));
-        const renderedElementNames = [];
-
-        var fileData = Buffer.from('');
 
         const checkErr = module.exports.checkData(data, origData, phase);
         if (checkErr) {
             const courseIssue = new Error('Invalid state before ' + phase + ': ' + checkErr);
             courseIssue.fatal = true;
             courseIssues.push(courseIssue);
-            return callback(null, courseIssues, data, '', fileData);
+            return callback(null, courseIssues, data, '', Buffer.from(''));
         }
 
         const htmlFilename = path.join(context.question_dir, 'question.html');
-        this.execTemplate(htmlFilename, data, (err, html, $) => {
+        module.exports.execTemplate(htmlFilename, data, (err, html, $) => {
             if (err) {
                 const courseIssue = new Error(htmlFilename + ': ' + err.toString());
                 courseIssue.fatal = true;
                 courseIssues.push(courseIssue);
-                return callback(null, courseIssues, data, '', fileData);
+                return callback(null, courseIssues, data, '', Buffer.from(''));
             }
 
-            const questionElements = new Set([..._.keys(coreElementsCache), ..._.keys(context.course_elements)]).values();
+            // Switch based on which renderer is enabled for this course
+            const useLegacyRenderer = false;
+            let processFunction;
+            let args;
+            if (useLegacyRenderer) {
+                processFunction = module.exports.legacyTraverseQuestionAndExecuteFunctions;
+                args = [phase, pc, data, context, $];
+            } else {
+                processFunction = module.exports.travserseQuestionAndExecuteFunctions;
+                args = [phase, pc, data, context, html];
+            }
 
-            let index = 0;
-            async.eachSeries(questionElements, (elementName, callback) => {
-                async.eachSeries($(elementName).toArray(), (element, callback) => {
-                    if (phase === 'render' && !_.includes(renderedElementNames, element)) {
-                        renderedElementNames.push(elementName);
-                    }
-
-                    const elementFile = module.exports.getElementController(elementName, context);
-
-                    this.elementFunction(pc, phase, elementName, $, element, index, data, context, (err, ret_val, consoleLog) => {
-                        if (err) {
-                            const courseIssue = new Error(elementFile + ': Error calling ' + phase + '(): ' + err.toString());
-                            courseIssue.data = err.data;
-                            courseIssue.fatal = true;
-                            courseIssues.push(courseIssue);
-                            return callback(courseIssue);
-                        }
-                        if (_.isString(consoleLog) && consoleLog.length > 0) {
-                            const courseIssue = new Error(elementFile + ': output logged on console during ' + phase + '()');
-                            courseIssue.data = {outputBoth: consoleLog};
-                            courseIssue.fatal = false;
-                            courseIssues.push(courseIssue);
-                        }
-
-                        if (phase == 'render') {
-                            if (!_.isString(ret_val)) {
-                                const courseIssue = new Error(elementFile + ': Error calling ' + phase + '(): return value is not a string');
-                                courseIssue.data = {ret_val};
-                                courseIssue.fatal = true;
-                                courseIssues.push(courseIssue);
-                                return callback(courseIssue);
-                            }
-                            $(element).replaceWith(ret_val);
-                        } else if (phase == 'file') {
-                            // Convert ret_val from base64 back to buffer (this always works,
-                            // whether or not ret_val is valid base64)
-                            var buf = Buffer.from(ret_val, 'base64');
-
-                            // If the buffer has non-zero length...
-                            if (buf.length > 0) {
-                                if (fileData.length > 0) {
-                                    // If fileData already has non-zero length, throw an error
-                                    const courseIssue = new Error(elementFile + ': Error calling ' + phase + '(): attempting to overwrite non-empty fileData');
-                                    courseIssue.fatal = true;
-                                    courseIssues.push(courseIssue);
-                                    return callback(courseIssue);
-                                } else {
-                                    // If not, replace fileData with buffer
-                                    fileData = buf;
-                                }
-                            }
-                        } else {
-                            data = ret_val;
-                            const checkErr = module.exports.checkData(data, origData, phase);
-                            if (checkErr) {
-                                const courseIssue = new Error(elementFile + ': Invalid state after ' + phase + '(): ' + checkErr);
-                                courseIssue.fatal = true;
-                                courseIssues.push(courseIssue);
-                                return callback(courseIssue);
-                            }
-                        }
-
-                        index++;
-                        callback(null);
-                    });
-                }, (err) => {
-                    if (ERR(err, callback)) return;
-                    callback(null);
-                });
-            }, (err) => {
-                ERR(err, () => {});
-
+            processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {
                 if (phase == 'grade' || phase == 'test') {
                     if (context.question.partial_credit) {
                         let total_weight = 0, total_weight_score = 0;
@@ -448,7 +584,7 @@ module.exports = {
                     }
                 }
 
-                callback(null, courseIssues, data, $.html(), fileData, renderedElementNames);
+                callback(null, courseIssues, data, questionHtml, fileData, renderedElementNames);
             });
         });
     },
@@ -465,7 +601,7 @@ module.exports = {
             return callback(null, courseIssues, data, '');
         }
 
-        this.execPythonServer(pc, phase, data, html, context, (err, ret_val, consoleLog) => {
+        module.exports.execPythonServer(pc, phase, data, html, context, (err, ret_val, consoleLog) => {
             if (err) {
                 const serverFile = path.join(context.question_dir, 'server.py');
                 const courseIssue = new Error(serverFile + ': Error calling ' + phase + '(): ' + err.toString());
@@ -477,7 +613,7 @@ module.exports = {
             if (_.isString(consoleLog) && consoleLog.length > 0) {
                 const serverFile = path.join(context.question_dir, 'server.py');
                 const courseIssue = new Error(serverFile + ': output logged on console');
-                courseIssue.data = {outputBoth: consoleLog};
+                courseIssue.data = { outputBoth: consoleLog };
                 courseIssue.fatal = false;
                 courseIssues.push(courseIssue);
             }
@@ -763,7 +899,7 @@ module.exports = {
                                     }
                                 } else {
                                     const courseIssue = new Error(`Error getting dependencies for ${resolvedElement.name}: "${type}" is not an array`);
-                                    courseIssue.data = {elementDependencies};
+                                    courseIssue.data = { elementDependencies };
                                     courseIssue.fatal = true;
                                     courseIssues.push(courseIssue);
                                 }

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -551,15 +551,15 @@ module.exports = {
             }
 
             // Switch based on which renderer is enabled for this course
-            const useLegacyRenderer = false;
+            const useNewQuestionRenderer = _.get(context, 'course.options.useNewQuestionRenderer', false);
             let processFunction;
             let args;
-            if (useLegacyRenderer) {
-                processFunction = module.exports.legacyTraverseQuestionAndExecuteFunctions;
-                args = [phase, pc, data, context, $];
-            } else {
+            if (useNewQuestionRenderer) {
                 processFunction = module.exports.travserseQuestionAndExecuteFunctions;
                 args = [phase, pc, data, context, html];
+            } else {
+                processFunction = module.exports.legacyTraverseQuestionAndExecuteFunctions;
+                args = [phase, pc, data, context, $];
             }
 
             processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -524,7 +524,8 @@ module.exports = {
                 callback(null);
             });
         }, (err) => {
-            if (ERR(err, callback)) return;
+            // Black-hole any errors, they were (should have been) handled by course issues
+            ERR(err, () => {});
             callback(courseIssues, data, $.html(), fileData, renderedElementNames);
         });
     },

--- a/schemas/infoCourse.json
+++ b/schemas/infoCourse.json
@@ -26,6 +26,18 @@
             "type": "string",
             "default": "America/Chicago"
         },
+        "options": {
+            "description": "Options for this course.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "useNewQuestionRenderer": {
+                    "description": "Feature flag to enable the new question renderer.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
         "assessmentSets": {
             "description": "Assessment sets.",
             "type": "array",

--- a/sync/fromDisk/courseInfo.js
+++ b/sync/fromDisk/courseInfo.js
@@ -1,29 +1,26 @@
-var ERR = require('async-stacktrace');
-var _ = require('lodash');
-var path = require('path');
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
 
-var error = require('@prairielearn/prairielib/error');
-var config = require('../../lib/config');
-var sqldb = require('@prairielearn/prairielib/sql-db');
-var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const error = require('@prairielearn/prairielib/error');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
-var sql = sqlLoader.loadSqlEquiv(__filename);
+const sql = sqlLoader.loadSqlEquiv(__filename);
 
-module.exports = {
-    sync: function(courseInfo, course_id, callback) {
-        var params = {
-            course_id: course_id,
-            short_name: courseInfo.name,
-            title: courseInfo.title,
-            display_timezone: courseInfo.timezone || null,
-            grading_queue: courseInfo.name.toLowerCase().replace(' ', ''),
-        };
-        sqldb.queryZeroOrOneRow(sql.update_course, params, function(err, result) {
-            if (ERR(err, callback)) return;
-            if (result.rowCount != 1) return callback(error.makeWithData('Unable to find course', {course_id, courseInfo}));
-            courseInfo.courseId = course_id;
-            courseInfo.timezone = result.rows[0].display_timezone;
-            callback(null);
-        });
-    },
-};
+module.exports.sync = (courseInfo, course_id, callback) => {
+    const params = {
+        course_id: course_id,
+        short_name: courseInfo.name,
+        title: courseInfo.title,
+        display_timezone: courseInfo.timezone || null,
+        grading_queue: courseInfo.name.toLowerCase().replace(' ', ''),
+        options: courseInfo.options,
+    };
+    sqldb.queryZeroOrOneRow(sql.update_course, params, (err, result) => {
+        if (ERR(err, callback)) return;
+        if (result.rowCount !== 1) return callback(error.makeWithData('Unable to find course', {course_id, courseInfo}));
+        courseInfo.courseId = course_id;
+        courseInfo.timezone = result.rows[0].display_timezone;
+        callback(null);
+    });
+}

--- a/sync/fromDisk/courseInfo.sql
+++ b/sync/fromDisk/courseInfo.sql
@@ -4,7 +4,8 @@ SET
     short_name = $short_name,
     title = $title,
     display_timezone = CASE WHEN $display_timezone::text IS NOT NULL THEN $display_timezone::text ELSE display_timezone END,
-    grading_queue = $grading_queue
+    grading_queue = $grading_queue,
+    options = $options
 WHERE
     c.id = $course_id
 RETURNING


### PR DESCRIPTION
I told @mfsilva22 I'd have this ready ASAP, but my parents will be in town for the next week, meaning that most of my free time will be family time 🙂this is a continuation of my work from #1188 - it's basically the same code, but leaving the legacy question parsing + rendering in place. The thought is to have the new renderer behind a feature flag so that courses who know what they're doing can opt in while we get our act together re: question migrations.

The remaining thing to be done is to actually add the feature flag. It looks like the `pl_courses` table has an unused column `options` that isn't ever populated during sync, which could probably be used for this purpose. For an example (abbreviated) `infoCourse.json`:

```json
{
    "name": "CS 225",
    "options": {
        "useNewQuestionRenderer": true
    }
}
```

This would then be available as `context.course.options.?useNewQuestionRenderer` inside the question server functions. I don't have time to wrap this up now, but it should be pretty quick to get this PR to completion. To test, I've been putting a `<pl-figure>` inside a `<pl-multiple-choice>` answer. It won't render with the old renderer, but it will with the new.

This probably also requires testing support, as we'll want to ensure both renderers keep working for now.