### PR TITLE
Change query to support >1 PS course linked to a PL course

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,7 @@
   * Fix copy button after `clipboard.js` package update (Tim Bretl).
 
   * Fix `pl-multiple-choice` so feedback is inside label and so inline option produces valid HTML (Tim Bretl).
+  
   * Fix PrairieLearn / PrairieSchedule exam access linking (Dave Mussulman).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -38,6 +38,7 @@
   * Fix copy button after `clipboard.js` package update (Tim Bretl).
 
   * Fix `pl-multiple-choice` so feedback is inside label and so inline option produces valid HTML (Tim Bretl).
+  * Fix PrairieLearn / PrairieSchedule exam access linking (Dave Mussulman).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).
 

--- a/sprocs/check_assessment_access_rule.sql
+++ b/sprocs/check_assessment_access_rule.sql
@@ -77,15 +77,6 @@ BEGIN
             a.id = assessment_access_rule.assessment_id;
         EXIT schedule_access WHEN NOT FOUND; -- no linked PS course, skip this check
 
-        -- do we actually want to enforce PrairieSchedule linking?
---        SELECT ci.ps_linked INTO ps_linked
---        FROM
---            assessments AS a
---            JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
---        WHERE
---            a.id = assessment_access_rule.assessment_id;
---        EXIT schedule_access WHEN NOT ps_linked; -- don't want linking, skip this check
-
         -- is there a current checked-in reservation that links back to this assessment?
         SELECT r.*
         INTO reservation

--- a/sprocs/check_assessment_access_rule.sql
+++ b/sprocs/check_assessment_access_rule.sql
@@ -64,6 +64,7 @@ BEGIN
         EXIT schedule_access WHEN NOT use_date_check;
 
         -- is there a corresponding PrairieSchedule course?
+        -- that we actually want to enforce? (ci.ps_linked true)
         SELECT ps_c.course_id
         INTO ps_course_id
         FROM
@@ -72,26 +73,30 @@ BEGIN
             JOIN pl_courses AS pl_c ON (pl_c.id = ci.course_id)
             JOIN courses as ps_c ON (ps_c.pl_course_id = pl_c.id)
         WHERE
+            ci.ps_linked IS TRUE AND
             a.id = assessment_access_rule.assessment_id;
         EXIT schedule_access WHEN NOT FOUND; -- no linked PS course, skip this check
 
         -- do we actually want to enforce PrairieSchedule linking?
-        SELECT ci.ps_linked INTO ps_linked
-        FROM
-            assessments AS a
-            JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-        WHERE
-            a.id = assessment_access_rule.assessment_id;
-        EXIT schedule_access WHEN NOT ps_linked; -- don't want linking, skip this check
+--        SELECT ci.ps_linked INTO ps_linked
+--        FROM
+--            assessments AS a
+--            JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+--        WHERE
+--            a.id = assessment_access_rule.assessment_id;
+--        EXIT schedule_access WHEN NOT ps_linked; -- don't want linking, skip this check
 
-        -- is there a current checked-in reservation?
+        -- is there a current checked-in reservation that links back to this assessment?
         SELECT r.*
         INTO reservation
         FROM
-            reservations AS r
-            JOIN exams AS e USING (exam_id)
+            assessments AS a
+            JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+            JOIN courses AS ps_c ON (ps_c.pl_course_id = ci.course_id)
+            JOIN exams AS e ON (e.course_id = ps_c.course_id)
+            JOIN reservations AS r USING(exam_id)
         WHERE
-            e.course_id = ps_course_id
+            a.id = assessment_access_rule.assessment_id
             AND r.user_id = check_assessment_access_rule.user_id
             AND r.delete_date IS NULL
             AND date BETWEEN r.access_start AND r.access_end

--- a/tests/testAccess.js
+++ b/tests/testAccess.js
@@ -449,6 +449,24 @@ describe('Access control', function() {
         });
     });
 
+    describe('13.1. Set course instance to not enforce ps_link', function(callback) {
+        it ('setting ci.ps_link=false should succeed', function(callback) {
+            sqldb.query(sql.update_ci_ps_linked, [false], function(err, _result) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        });
+        it('should enable access to the assessment instance', function(callback) {
+            getAssessmentInstance(cookiesStudentExam(), 200, callback);
+        });
+        it ('setting ci.ps_link=true should succeed', function(callback) {
+            sqldb.query(sql.update_ci_ps_linked, [true], function(err, _result) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        });
+    });
+
     describe('14. Insert PrairieSchedule reservation', function() {
         it('should succeed', function(callback) {
             var params = {user_id: user.user_id};

--- a/tests/testAccess.sql
+++ b/tests/testAccess.sql
@@ -37,11 +37,11 @@ WITH
 insert_course_result AS (
     INSERT INTO courses
             (course_id, pl_course_id, rubric)
-    VALUES (1, 1, 'TPL 101')
+    VALUES (1, 1, 'TPL 101 Old Semester'), (2, 1, 'TPL 101 New Semester')
 )
 INSERT INTO exams
         (exam_id, course_id, exam_string)
-VALUES (1, 1, 'Exam 1');
+VALUES (1, 2, 'Exam 1');
 
 -- BLOCK delete_ps_course_link
 UPDATE courses

--- a/tests/testAccess.sql
+++ b/tests/testAccess.sql
@@ -43,6 +43,10 @@ INSERT INTO exams
         (exam_id, course_id, exam_string)
 VALUES (1, 2, 'Exam 1');
 
+-- BLOCK update_ci_ps_linked
+UPDATE course_instances
+SET ps_linked = $1;
+
 -- BLOCK delete_ps_course_link
 UPDATE courses
 SET pl_course_id = NULL;


### PR DESCRIPTION
Closes #987 

Needs more testing before merge, but I wanted to get Travis on it.

Impact would be that `courses.pl_course_id` doesn't have to be updated for previous semester each semester. We would just need to update the `pl_course_id` for the new PS courses.
