### PR TITLE
Add option to disable selecting on pl-code element

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@
 
   * Add partial credit option to `pl-checkbox` element (Mariana Silva).
 
+  * Add `prevent-select` attribute to `pl-code` element (Nathan Walters).
+
   * Fix `pl-file-editor` to allow display empty text editor and add option to include text from source file (Mariana Silva).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -498,6 +498,7 @@ Attribute | Type | Default | Description
 `language` | string | — | The programming language syntax highlighting to use. See below for options.
 `no-highlight` | boolean | false | Disable highlighting.
 `source-file-name` | text | - | Name of the source file with existing code to be displayed as a code block (instead of writing the existing code between the element tags as illustrated in the above code snippet).
+`prevent-select` | booelan | false | Applies methods to make the source code more difficult to copy, like preventing selection or right-clicking. Note that the source code is still accessible in the page source, which will always be visible to students.
 
 The `language` can be one of the following values.
 

--- a/elements/pl-code/pl-code.mustache
+++ b/elements/pl-code/pl-code.mustache
@@ -1,3 +1,4 @@
+{{#prevent_select}}<!-- Well aren't you clever ;) -->{{/prevent_select}}
 <pre class="pl-code"><code
 {{#no_highlight}}class="nohighlight"{{/no_highlight}}
 {{#specify_language}}class="language-{{language}}"{{/specify_language}}

--- a/elements/pl-code/pl-code.mustache
+++ b/elements/pl-code/pl-code.mustache
@@ -1,4 +1,11 @@
 <pre class="pl-code"><code
 {{#no_highlight}}class="nohighlight"{{/no_highlight}}
 {{#specify_language}}class="language-{{language}}"{{/specify_language}}
+{{#prevent_select}}
+style="-moz-user-select: none; -webkit-user-select: none; -ms-user-select:none; user-select:none;-o-user-select:none;"
+unselectable="on"
+onselectstart="return false;"
+onmousedown="return false;"
+oncontextmenu="return false;"
+{{/prevent_select}}
 >{{code}}</code></pre>

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -42,7 +42,7 @@ allowed_languages = [
 def prepare(element_html, element_index, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
-    optional_attribs = ['language', 'no-highlight', 'source-file-name']
+    optional_attribs = ['language', 'no-highlight', 'source-file-name', 'prevent-select']
     pl.check_attribs(element, required_attribs, optional_attribs)
     source_file_name = pl.get_string_attrib(element, 'source-file-name', None)
 
@@ -62,6 +62,7 @@ def render(element_html, element_index, data):
     no_highlight = pl.get_boolean_attrib(element, 'no-highlight', False)
     specify_language = (language is not None) and (not no_highlight)
     source_file_name = pl.get_string_attrib(element, 'source-file-name', None)
+    prevent_select = pl.get_boolean_attrib(element, 'prevent-select', False)
 
     if source_file_name is not None:
         base_path = data['options']['question_path']
@@ -95,6 +96,7 @@ def render(element_html, element_index, data):
         'language': language,
         'no_highlight': no_highlight,
         'code': code,
+        'prevent_select': prevent_select,
     }
 
     with open('pl-code.mustache', 'r', encoding='utf-8') as f:

--- a/exampleCourse/questions/codeHighlight/question.html
+++ b/exampleCourse/questions/codeHighlight/question.html
@@ -4,6 +4,12 @@ def square(x):
     return x * x
 </pl-code>
 
+<pl-code language="python" prevent-select="true">
+# Here's a version that's had selection, right-clicking, etc. disabled
+def square(x):
+    return x * x
+</pl-code>
+
 <p>How many arguments does the function <code>square()</code> take?</p>
 </pl-question-panel>
 


### PR DESCRIPTION
This adds an option to attempt to prevent students from copy/pasting the source code of a `pl-code` element. It disables selection, clicking, and right-clicking on the code. It's still relatively easy to see the source - just going to "View source" on the page and grepping for the code will reveal it. But frankly, I don't care that much 🙂 

Resolves #1224 