### PR TITLE
Add attributes and doc to pl-symbolic-input

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@
 
   * Add partial credit option to `pl-checkbox` element (Mariana Silva).
 
+  * Add docs and two optional attributes, `display` and `label`, to `pl-symbolic-input` (Tim Bretl).
+
   * Fix `pl-file-editor` to allow display empty text editor and add option to include text from source file (Mariana Silva).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -122,6 +122,21 @@ Attribute | Type | Default | Description
 `remove-spaces` | boolean | False | Whether or not to remove blank spaces from the input string.
 `allow-blank` | boolean | False | Whether or not an empty input box is allowed. By default, empty input boxes will not be graded (invalid format).
 
+## `pl-symbolic-input` element
+
+```html
+<pl-sumbolic-input answers-name="ans"></pl-symbolic-input>
+```
+
+Attribute | Type | Default | Description
+--- | --- | --- | ---
+`answers-name` | string | — | Variable name to store data in. If the correct answer `ans` is a `sympy` object, you should use `import prairielearn as pl` and `data['correct_answer'][answers-name] = pl.to_json(ans)`.
+`weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
+`correct-answer` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
+`display` | "block" or "inline" | "inline" | How to display the input field.
+`variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
+
 ## `pl-matrix-input` element
 
 ```html

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -8,8 +8,13 @@
     });
 </script>
 
-<span class="form-inline d-inline-block">
+{{#inline}}<span class="form-inline d-inline-block ml-2">{{/inline}}
     <span id="pl-symbolic-input-{{uuid}}" class="input-group pl-symbolic-input">
+        {{#label}}
+        <span class="input-group-prepend">
+            <span class="input-group-text">{{label}}</span>
+        </span>
+        {{/label}}
         <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" />
         <span class="input-group-append">
             <a class="btn btn-light border" role="button" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
@@ -20,12 +25,12 @@
             </a>
         </span>
     </span>
-</span>
+{{#inline}}</span>{{/inline}}
 {{/question}}
 
 
 {{#submission}}
-<span class="d-inline-block">
+{{#inline}}<span class="d-inline-block">{{/inline}}
 {{#parse_error}}
 <script>
     $(function(){
@@ -47,7 +52,7 @@ ${{a_sub}}$
 {{#partial}}<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
 {{#incorrect}}<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
 {{/parse_error}}
-</span>
+{{#inline}}</span>{{/inline}}
 {{/submission}}
 
 {{#answer}}


### PR DESCRIPTION
The `pl-symbolic-input` element already exists and has worked fine for a long time. I added two optional attributes (`label` and `display`) that mirror other input elements, and added docs.