### PR TITLE
Eliminate element_index from arguments passed to element functions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,6 +83,8 @@
 
   * Change maximum JSON POST size to 1MB or local grader (Nathan Walters).
 
+  * Remove `element_index` from list of arguments passed to elements (Tim Bretl).
+
 * __3.0.0__ - 2018-05-23
 
   * Add improved support for very large file downloads (Nathan Walters).

--- a/doc/devElements.md
+++ b/doc/devElements.md
@@ -55,7 +55,7 @@ And an `info.json` with the following contents:
 All element functions have the signature:
 
 ```python
-def fcn(element_html, element_index, data)
+def fcn(element_html, data)
 ```
 
 The arguments are:
@@ -63,7 +63,6 @@ The arguments are:
 Argument | Type | Description
 --- | --- | ---
 `element_html` | string | The template HTML for the element.
-`element_index` | integer | The number of the element in the template.
 `data` | dict | Mutable data for the question, which can be modified and returned.
 
 The `data` dictionary has the following possible keys (not all keys will be present in all element functions):

--- a/elements/pl-answer-panel/pl-answer-panel.py
+++ b/elements/pl-answer-panel/pl-answer-panel.py
@@ -2,12 +2,12 @@ import prairielearn as pl
 import lxml.html
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] == 'answer':
         element = lxml.html.fragment_fromstring(element_html)
         return pl.inner_html(element)

--- a/elements/pl-answer-panel/pl-answer-panel.py
+++ b/elements/pl-answer-panel/pl-answer-panel.py
@@ -2,12 +2,12 @@ import prairielearn as pl
 import lxml.html
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] == 'answer':
         element = lxml.html.fragment_fromstring(element_html)
         return pl.inner_html(element)

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -5,7 +5,7 @@ import math
 import chevron
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
 
     required_attribs = ['answers-name']
@@ -87,7 +87,7 @@ def prepare(element_html, element_index, data):
     data['correct_answers'][name] = correct_answer_list
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     partial_credit = pl.get_boolean_attrib(element, 'partial-credit', False)
@@ -290,7 +290,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
 
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
@@ -324,7 +324,7 @@ def parse(element_html, element_index, data):
             return
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)
@@ -357,7 +357,7 @@ def grade(element_html, element_index, data):
     data['partial_scores'][name] = {'score': score, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -5,7 +5,7 @@ import math
 import chevron
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     required_attribs = ['answers-name']
@@ -87,7 +87,7 @@ def prepare(element_html,  data):
     data['correct_answers'][name] = correct_answer_list
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     partial_credit = pl.get_boolean_attrib(element, 'partial-credit', False)
@@ -290,7 +290,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
 
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
@@ -324,7 +324,7 @@ def parse(element_html,  data):
             return
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)
@@ -357,7 +357,7 @@ def grade(element_html,  data):
     data['partial_scores'][name] = {'score': score, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -39,7 +39,7 @@ allowed_languages = [
 ]
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
     optional_attribs = ['language', 'no-highlight', 'source-file-name']
@@ -56,7 +56,7 @@ def prepare(element_html, element_index, data):
             raise Exception('Existing code cannot be added inside html element when "source-file-name" attribute is used.')
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     language = pl.get_string_attrib(element, 'language', None)
     no_highlight = pl.get_boolean_attrib(element, 'no-highlight', False)

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -39,7 +39,7 @@ allowed_languages = [
 ]
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
     optional_attribs = ['language', 'no-highlight', 'source-file-name']
@@ -56,7 +56,7 @@ def prepare(element_html,  data):
             raise Exception('Existing code cannot be added inside html element when "source-file-name" attribute is used.')
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     language = pl.get_string_attrib(element, 'language', None)
     no_highlight = pl.get_boolean_attrib(element, 'no-highlight', False)

--- a/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -3,14 +3,14 @@ import lxml.html
 import chevron
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
     optional_attribs = []
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] == 'submission':
         html_params = {'submission': True, 'graded': True, 'uuid': pl.get_uuid()}
 

--- a/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -3,14 +3,14 @@ import lxml.html
 import chevron
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
     optional_attribs = []
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] == 'submission':
         html_params = {'submission': True, 'graded': True, 'uuid': pl.get_uuid()}
 

--- a/elements/pl-figure/pl-figure.py
+++ b/elements/pl-figure/pl-figure.py
@@ -4,12 +4,12 @@ import chevron
 import os
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['width', 'type', 'directory'])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get file name or raise exception if one does not exist

--- a/elements/pl-figure/pl-figure.py
+++ b/elements/pl-figure/pl-figure.py
@@ -4,12 +4,12 @@ import chevron
 import os
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['width', 'type', 'directory'])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get file name or raise exception if one does not exist

--- a/elements/pl-file-download/pl-file-download.py
+++ b/elements/pl-file-download/pl-file-download.py
@@ -3,12 +3,12 @@ import lxml.html
 import os
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['type', 'directory', 'label'])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get file name or raise exception if one does not exist

--- a/elements/pl-file-download/pl-file-download.py
+++ b/elements/pl-file-download/pl-file-download.py
@@ -3,12 +3,12 @@ import lxml.html
 import os
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['type', 'directory', 'label'])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get file name or raise exception if one does not exist

--- a/elements/pl-file-editor/pl-file-editor.py
+++ b/elements/pl-file-editor/pl-file-editor.py
@@ -16,7 +16,7 @@ def add_format_error(data, error_string):
     data['format_errors']['_files'].append(error_string)
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['file-name']
     optional_attribs = ['ace-mode', 'ace-theme', 'editor-config-function', 'source-file-name']
@@ -32,7 +32,7 @@ def prepare(element_html,  data):
             raise Exception('Existing code cannot be added inside html element when "source-file-name" attribute is used.')
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] != 'question':
         return ''
 
@@ -81,7 +81,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     file_name = pl.get_string_attrib(element, 'file-name', '')
     answer_name = get_answer_name(file_name)

--- a/elements/pl-file-editor/pl-file-editor.py
+++ b/elements/pl-file-editor/pl-file-editor.py
@@ -16,7 +16,7 @@ def add_format_error(data, error_string):
     data['format_errors']['_files'].append(error_string)
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['file-name']
     optional_attribs = ['ace-mode', 'ace-theme', 'editor-config-function', 'source-file-name']
@@ -32,7 +32,7 @@ def prepare(element_html, element_index, data):
             raise Exception('Existing code cannot be added inside html element when "source-file-name" attribute is used.')
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] != 'question':
         return ''
 
@@ -81,7 +81,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     file_name = pl.get_string_attrib(element, 'file-name', '')
     answer_name = get_answer_name(file_name)

--- a/elements/pl-file-preview/pl-file-preview.py
+++ b/elements/pl-file-preview/pl-file-preview.py
@@ -4,14 +4,14 @@ import chevron
 import base64
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
     optional_attribs = []
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] != 'submission':
         return ''
 

--- a/elements/pl-file-preview/pl-file-preview.py
+++ b/elements/pl-file-preview/pl-file-preview.py
@@ -4,14 +4,14 @@ import chevron
 import base64
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = []
     optional_attribs = []
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] != 'submission':
         return ''
 

--- a/elements/pl-file-upload/pl-file-upload.py
+++ b/elements/pl-file-upload/pl-file-upload.py
@@ -27,7 +27,7 @@ def add_format_error(data, error_string):
     data['format_errors']['_files'].append(error_string)
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['file-names']
     optional_attribs = []
@@ -39,7 +39,7 @@ def prepare(element_html,  data):
     data['params']['_required_file_names'].extend(file_names)
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] != 'question':
         return ''
 
@@ -67,7 +67,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     raw_file_names = pl.get_string_attrib(element, 'file-names', '')
     required_file_names = get_file_names_as_array(raw_file_names)

--- a/elements/pl-file-upload/pl-file-upload.py
+++ b/elements/pl-file-upload/pl-file-upload.py
@@ -27,7 +27,7 @@ def add_format_error(data, error_string):
     data['format_errors']['_files'].append(error_string)
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['file-names']
     optional_attribs = []
@@ -39,7 +39,7 @@ def prepare(element_html, element_index, data):
     data['params']['_required_file_names'].extend(file_names)
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] != 'question':
         return ''
 
@@ -67,7 +67,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     raw_file_names = pl.get_string_attrib(element, 'file-names', '')
     required_file_names = get_file_names_as_array(raw_file_names)

--- a/elements/pl-integer-input/pl-integer-input.py
+++ b/elements/pl-integer-input/pl-integer-input.py
@@ -7,7 +7,7 @@ import numpy as np
 import random
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display']
@@ -21,7 +21,7 @@ def prepare(element_html, element_index, data):
         data['correct_answers'][name] = correct_answer
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -133,7 +133,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -157,7 +157,7 @@ def parse(element_html, element_index, data):
         data['submitted_answers'][name] = None
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -189,7 +189,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-integer-input/pl-integer-input.py
+++ b/elements/pl-integer-input/pl-integer-input.py
@@ -7,7 +7,7 @@ import numpy as np
 import random
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display']
@@ -21,7 +21,7 @@ def prepare(element_html,  data):
         data['correct_answers'][name] = correct_answer
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -133,7 +133,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -157,7 +157,7 @@ def parse(element_html,  data):
         data['submitted_answers'][name] = None
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -189,7 +189,7 @@ def grade(element_html,  data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
@@ -68,7 +68,7 @@
 {{#answer}}
 <div class="d-inline-block ml-2" id="pl-matrix-component-input-answer-{{uuid}}">
     {{#label}}<span>{{label}}</span>{{/label}}
-    <samp id="latex-data-{{element_index}}">{{latex_data}}</samp>
+    <samp id="latex-data-{{uuid}}">{{latex_data}}</samp>
 </div>
 {{/answer}}
 

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -7,14 +7,14 @@ import chevron
 import random
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-partial-credit', 'allow-feedback']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     # get the name of the element, in this case, the name of the array
     name = pl.get_string_attrib(element, 'answers-name')
@@ -196,7 +196,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -248,7 +248,7 @@ def parse(element_html,  data):
         data['submitted_answers'][name] = pl.to_json(A)
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     allow_partial_credit = pl.get_boolean_attrib(element, 'allow-partial-credit', False)
@@ -320,7 +320,7 @@ def grade(element_html,  data):
         data['partial_scores'][name] = {'score': score_value, 'weight': weight, 'feedback': feedback}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -182,7 +182,6 @@ def render(element_html, element_index, data):
                 'answer': True,
                 'label': label,
                 'latex_data': latex_data,
-                'element_index': element_index,
                 'uuid': pl.get_uuid()
             }
 

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -7,14 +7,14 @@ import chevron
 import random
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-partial-credit', 'allow-feedback']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     # get the name of the element, in this case, the name of the array
     name = pl.get_string_attrib(element, 'answers-name')
@@ -196,7 +196,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -248,7 +248,7 @@ def parse(element_html, element_index, data):
         data['submitted_answers'][name] = pl.to_json(A)
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     allow_partial_credit = pl.get_boolean_attrib(element, 'allow-partial-credit', False)
@@ -320,7 +320,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': score_value, 'weight': weight, 'feedback': feedback}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -59,27 +59,27 @@
 <div id="pl-matrix-input-answer-{{uuid}}" class="card mb-4 pl-matrix-input-answer ">
     <div class="card-header">
         <ul class="nav nav-tabs card-header-tabs" role="tablist">
-            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_matlab}} active{{/default_is_matlab}}" href="#matlab-{{element_index}}" aria-controls="matlab-{{element_index}}" role="tab" data-toggle="pill">matlab</a></li>
-            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_python}} active{{/default_is_python}}" href="#python-{{element_index}}" aria-controls="python-{{element_index}}" role="tab" data-toggle="pill">python</a></li>
+            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_matlab}} active{{/default_is_matlab}}" href="#matlab-{{uuid}}" aria-controls="matlab-{{uuid}}" role="tab" data-toggle="pill">matlab</a></li>
+            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_python}} active{{/default_is_python}}" href="#python-{{uuid}}" aria-controls="python-{{uuid}}" role="tab" data-toggle="pill">python</a></li>
         </ul>
     </div>
     <div class="card-body">
         <div class="tab-content">
-            <div role="tabpanel" class="tab-pane {{#default_is_matlab}}active{{/default_is_matlab}}" id="matlab-{{element_index}}">
+            <div role="tabpanel" class="tab-pane {{#default_is_matlab}}active{{/default_is_matlab}}" id="matlab-{{uuid}}">
                 <p>
                     {{#label}}<span>{{label}}</span>{{/label}}
-                    <samp id="matlab-data-{{element_index}}">{{matlab_data}}</samp>
+                    <samp id="matlab-data-{{uuid}}">{{matlab_data}}</samp>
                 </p>
-                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#matlab-data-{{element_index}}">
+                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#matlab-data-{{uuid}}">
                     copy this answer
                 </button>
             </div>
-            <div role="tabpanel" class="tab-pane {{#default_is_python}}active{{/default_is_python}}" id="python-{{element_index}}">
+            <div role="tabpanel" class="tab-pane {{#default_is_python}}active{{/default_is_python}}" id="python-{{uuid}}">
                 <p>
                     {{#label}}<span>{{label}}</span>{{/label}}
-                    <samp id="python-data-{{element_index}}">{{python_data}}</samp>
+                    <samp id="python-data-{{uuid}}">{{python_data}}</samp>
                 </p>
-                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{element_index}}">
+                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{uuid}}">
                     copy this answer
                 </button>
             </div>

--- a/elements/pl-matrix-input/pl-matrix-input.py
+++ b/elements/pl-matrix-input/pl-matrix-input.py
@@ -7,14 +7,14 @@ import math
 import chevron
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -180,7 +180,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     # By convention, this function returns at the first error found
 
     element = lxml.html.fragment_fromstring(element_html)
@@ -210,7 +210,7 @@ def parse(element_html,  data):
     data['submitted_answers']['_pl_matrix_input_format'][name] = info['format_type']
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -267,7 +267,7 @@ def grade(element_html,  data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-matrix-input/pl-matrix-input.py
+++ b/elements/pl-matrix-input/pl-matrix-input.py
@@ -162,7 +162,6 @@ def render(element_html, element_index, data):
                 'label': label,
                 'matlab_data': matlab_data,
                 'python_data': python_data,
-                'element_index': element_index,
                 'uuid': pl.get_uuid()
             }
 

--- a/elements/pl-matrix-input/pl-matrix-input.py
+++ b/elements/pl-matrix-input/pl-matrix-input.py
@@ -7,14 +7,14 @@ import math
 import chevron
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -180,7 +180,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     # By convention, this function returns at the first error found
 
     element = lxml.html.fragment_fromstring(element_html)
@@ -210,7 +210,7 @@ def parse(element_html, element_index, data):
     data['submitted_answers']['_pl_matrix_input_format'][name] = info['format_type']
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -267,7 +267,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-matrix-latex/pl-matrix-latex.py
+++ b/elements/pl-matrix-latex/pl-matrix-latex.py
@@ -3,14 +3,14 @@ import lxml.html
 import numpy as np
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['params-name']
     optional_attribs = ['digits', 'presentation-type']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get the number of digits to output

--- a/elements/pl-matrix-latex/pl-matrix-latex.py
+++ b/elements/pl-matrix-latex/pl-matrix-latex.py
@@ -3,14 +3,14 @@ import lxml.html
 import numpy as np
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['params-name']
     optional_attribs = ['digits', 'presentation-type']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
 
     # Get the number of digits to output

--- a/elements/pl-matrix-output/pl-matrix-output.mustache
+++ b/elements/pl-matrix-output/pl-matrix-output.mustache
@@ -7,21 +7,21 @@
 <div id="pl-matrix-output-{{uuid}}" class="card mb-4">
     <div class="card-header">
         <ul class="nav nav-tabs card-header-tabs" role="tablist">
-            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_matlab}} active{{/default_is_matlab}}" href="#matlab-{{element_index}}" aria-controls="matlab-{{element_index}}" role="tab" data-toggle="pill">matlab</a></li>
-            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_python}} active{{/default_is_python}}" href="#python-{{element_index}}" aria-controls="python-{{element_index}}" role="tab" data-toggle="pill">python</a></li>
+            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_matlab}} active{{/default_is_matlab}}" href="#matlab-{{uuid}}" aria-controls="matlab-{{uuid}}" role="tab" data-toggle="pill">matlab</a></li>
+            <li class="nav-item" role="presentation"><a class="nav-link{{#default_is_python}} active{{/default_is_python}}" href="#python-{{uuid}}" aria-controls="python-{{uuid}}" role="tab" data-toggle="pill">python</a></li>
         </ul>
     </div>
     <div class="card-body">
         <div class="tab-content">
-            <div role="tabpanel" class="tab-pane {{#default_is_matlab}}active{{/default_is_matlab}}" id="matlab-{{element_index}}">
-                <pre class="bg-dark text-white rounded p-2" id="matlab-data-{{element_index}}">{{matlab_data}}</pre>
-                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#matlab-data-{{element_index}}">
+            <div role="tabpanel" class="tab-pane {{#default_is_matlab}}active{{/default_is_matlab}}" id="matlab-{{uuid}}">
+                <pre class="bg-dark text-white rounded p-2" id="matlab-data-{{uuid}}">{{matlab_data}}</pre>
+                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#matlab-data-{{uuid}}">
                     copy this text
                 </button>
             </div>
-            <div role="tabpanel" class="tab-pane {{#default_is_python}}active{{/default_is_python}}" id="python-{{element_index}}">
-                <pre class="bg-dark text-white rounded p-2" id="python-data-{{element_index}}">{{python_data}}</pre>
-                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{element_index}}">
+            <div role="tabpanel" class="tab-pane {{#default_is_python}}active{{/default_is_python}}" id="python-{{uuid}}">
+                <pre class="bg-dark text-white rounded p-2" id="python-data-{{uuid}}">{{python_data}}</pre>
+                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{uuid}}">
                     copy this text
                 </button>
             </div>

--- a/elements/pl-matrix-output/pl-matrix-output.py
+++ b/elements/pl-matrix-output/pl-matrix-output.py
@@ -4,12 +4,12 @@ import numpy as np
 import chevron
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=['digits'])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     digits = pl.get_integer_attrib(element, 'digits', 2)
 

--- a/elements/pl-matrix-output/pl-matrix-output.py
+++ b/elements/pl-matrix-output/pl-matrix-output.py
@@ -53,7 +53,6 @@ def render(element_html, element_index, data):
         'default_is_matlab': True,
         'matlab_data': matlab_data,
         'python_data': python_data,
-        'element_index': element_index,
         'uuid': pl.get_uuid()
     }
 

--- a/elements/pl-matrix-output/pl-matrix-output.py
+++ b/elements/pl-matrix-output/pl-matrix-output.py
@@ -4,12 +4,12 @@ import numpy as np
 import chevron
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=['digits'])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     digits = pl.get_integer_attrib(element, 'digits', 2)
 

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -4,7 +4,7 @@ import random
 import math
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'number-answers', 'fixed-order', 'inline']
@@ -69,7 +69,7 @@ def prepare(element_html,  data):
     data['correct_answers'][name] = correct_answer
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -150,7 +150,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -166,7 +166,7 @@ def parse(element_html,  data):
         return
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)
@@ -181,7 +181,7 @@ def grade(element_html,  data):
     data['partial_scores'][name] = {'score': score, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -4,7 +4,7 @@ import random
 import math
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'number-answers', 'fixed-order', 'inline']
@@ -69,7 +69,7 @@ def prepare(element_html, element_index, data):
     data['correct_answers'][name] = correct_answer
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -150,7 +150,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -166,7 +166,7 @@ def parse(element_html, element_index, data):
         return
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)
@@ -181,7 +181,7 @@ def grade(element_html, element_index, data):
     data['partial_scores'][name] = {'score': score, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-number-input/pl-number-input.py
+++ b/elements/pl-number-input/pl-number-input.py
@@ -7,7 +7,7 @@ import numpy as np
 import random
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex']
@@ -21,7 +21,7 @@ def prepare(element_html,  data):
         data['correct_answers'][name] = correct_answer
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -172,7 +172,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     allow_complex = pl.get_boolean_attrib(element, 'allow-complex', False)
@@ -200,7 +200,7 @@ def parse(element_html,  data):
         data['submitted_answers'][name] = None
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -270,7 +270,7 @@ def grade(element_html,  data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-number-input/pl-number-input.py
+++ b/elements/pl-number-input/pl-number-input.py
@@ -7,7 +7,7 @@ import numpy as np
 import random
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex']
@@ -21,7 +21,7 @@ def prepare(element_html, element_index, data):
         data['correct_answers'][name] = correct_answer
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -172,7 +172,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     allow_complex = pl.get_boolean_attrib(element, 'allow-complex', False)
@@ -200,7 +200,7 @@ def parse(element_html, element_index, data):
         data['submitted_answers'][name] = None
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -270,7 +270,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-prairiedraw-figure/pl-prairiedraw-figure.py
+++ b/elements/pl-prairiedraw-figure/pl-prairiedraw-figure.py
@@ -4,7 +4,7 @@ import chevron
 import os
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['script-name']
     optional_attribs = ['param-names', 'width', 'height']
@@ -12,7 +12,7 @@ def prepare(element_html,  data):
     return data
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     script_name = pl.get_string_attrib(element, 'script-name', None)
 

--- a/elements/pl-prairiedraw-figure/pl-prairiedraw-figure.py
+++ b/elements/pl-prairiedraw-figure/pl-prairiedraw-figure.py
@@ -4,7 +4,7 @@ import chevron
 import os
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['script-name']
     optional_attribs = ['param-names', 'width', 'height']
@@ -12,7 +12,7 @@ def prepare(element_html, element_index, data):
     return data
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     script_name = pl.get_string_attrib(element, 'script-name', None)
 

--- a/elements/pl-question-panel/pl-question-panel.py
+++ b/elements/pl-question-panel/pl-question-panel.py
@@ -2,12 +2,12 @@ import prairielearn as pl
 import lxml.html
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] == 'question':
         element = lxml.html.fragment_fromstring(element_html)
         return pl.inner_html(element)

--- a/elements/pl-question-panel/pl-question-panel.py
+++ b/elements/pl-question-panel/pl-question-panel.py
@@ -2,12 +2,12 @@ import prairielearn as pl
 import lxml.html
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] == 'question':
         element = lxml.html.fragment_fromstring(element_html)
         return pl.inner_html(element)

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -6,7 +6,7 @@ import prairielearn as pl
 import random
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank']
@@ -21,7 +21,7 @@ def prepare(element_html, element_index, data):
         data['correct_answers'][name] = correct_answer
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -137,7 +137,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     # Get allow-blank option
@@ -157,7 +157,7 @@ def parse(element_html, element_index, data):
         data['submitted_answers'][name] = pl.to_json(a_sub)
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -199,7 +199,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -6,7 +6,7 @@ import prairielearn as pl
 import random
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank']
@@ -21,7 +21,7 @@ def prepare(element_html,  data):
         data['correct_answers'][name] = correct_answer
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -137,7 +137,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     # Get allow-blank option
@@ -157,7 +157,7 @@ def parse(element_html,  data):
         data['submitted_answers'][name] = pl.to_json(a_sub)
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -199,7 +199,7 @@ def grade(element_html,  data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-submission-panel/pl-submission-panel.py
+++ b/elements/pl-submission-panel/pl-submission-panel.py
@@ -2,12 +2,12 @@ import prairielearn as pl
 import lxml.html
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if data['panel'] == 'submission':
         element = lxml.html.fragment_fromstring(element_html)
         return pl.inner_html(element)

--- a/elements/pl-submission-panel/pl-submission-panel.py
+++ b/elements/pl-submission-panel/pl-submission-panel.py
@@ -2,12 +2,12 @@ import prairielearn as pl
 import lxml.html
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=[], optional_attribs=[])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if data['panel'] == 'submission':
         element = lxml.html.fragment_fromstring(element_html)
         return pl.inner_html(element)

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -16,7 +16,7 @@ def get_variables_list(variables_string):
         return []
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'variables', 'label', 'display']
@@ -30,7 +30,7 @@ def prepare(element_html, element_index, data):
         data['correct-answers'][name] = correct_answer
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -150,7 +150,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     variables = get_variables_list(pl.get_string_attrib(element, 'variables', None))
@@ -222,7 +222,7 @@ def parse(element_html, element_index, data):
         data['submitted_answers'][name] = None
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -256,7 +256,7 @@ def grade(element_html, element_index, data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html, element_index, data):
+def test(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -16,7 +16,7 @@ def get_variables_list(variables_string):
         return []
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
     optional_attribs = ['weight', 'correct-answer', 'variables', 'label', 'display']
@@ -30,7 +30,7 @@ def prepare(element_html,  data):
         data['correct-answers'][name] = correct_answer
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     label = pl.get_string_attrib(element, 'label', None)
@@ -150,7 +150,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     variables = get_variables_list(pl.get_string_attrib(element, 'variables', None))
@@ -222,7 +222,7 @@ def parse(element_html,  data):
         data['submitted_answers'][name] = None
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -256,7 +256,7 @@ def grade(element_html,  data):
         data['partial_scores'][name] = {'score': 0, 'weight': weight}
 
 
-def test(element_html,  data):
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
     weight = pl.get_integer_attrib(element, 'weight', 1)

--- a/elements/pl-threejs/pl-threejs.py
+++ b/elements/pl-threejs/pl-threejs.py
@@ -9,7 +9,7 @@ import pyquaternion
 import math
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = [
         'answer_name',          # key for 'submitted_answers' and 'true_answers'
@@ -116,7 +116,7 @@ def get_objects(element, data):
     return obj_list
 
 
-def render(element_html,  data):
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answer-name')
 
@@ -302,7 +302,7 @@ def render(element_html,  data):
     return html
 
 
-def parse(element_html,  data):
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answer-name')
 
@@ -326,7 +326,7 @@ def parse(element_html,  data):
     data['submitted_answers'][name] = a_sub
 
 
-def grade(element_html,  data):
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answer-name')
 

--- a/elements/pl-threejs/pl-threejs.py
+++ b/elements/pl-threejs/pl-threejs.py
@@ -9,7 +9,7 @@ import pyquaternion
 import math
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = [
         'answer_name',          # key for 'submitted_answers' and 'true_answers'
@@ -116,7 +116,7 @@ def get_objects(element, data):
     return obj_list
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answer-name')
 
@@ -302,7 +302,7 @@ def render(element_html, element_index, data):
     return html
 
 
-def parse(element_html, element_index, data):
+def parse(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answer-name')
 
@@ -326,7 +326,7 @@ def parse(element_html, element_index, data):
     data['submitted_answers'][name] = a_sub
 
 
-def grade(element_html, element_index, data):
+def grade(element_html,  data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answer-name')
 

--- a/elements/pl-variable-score/pl-variable-score.py
+++ b/elements/pl-variable-score/pl-variable-score.py
@@ -5,7 +5,7 @@ import math
 use_pl_variable_score = False
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     if not use_pl_variable_score:
         return
 
@@ -13,7 +13,7 @@ def prepare(element_html,  data):
     pl.check_attribs(element, required_attribs=['answers-name'], optional_attribs=[])
 
 
-def render(element_html,  data):
+def render(element_html, data):
     if not use_pl_variable_score:
         return ''
 

--- a/elements/pl-variable-score/pl-variable-score.py
+++ b/elements/pl-variable-score/pl-variable-score.py
@@ -5,7 +5,7 @@ import math
 use_pl_variable_score = False
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     if not use_pl_variable_score:
         return
 
@@ -13,7 +13,7 @@ def prepare(element_html, element_index, data):
     pl.check_attribs(element, required_attribs=['answers-name'], optional_attribs=[])
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     if not use_pl_variable_score:
         return ''
 

--- a/exampleCourse/elements/course-element/course-element.py
+++ b/exampleCourse/elements/course-element/course-element.py
@@ -2,12 +2,12 @@ import random
 import chevron
 
 
-def prepare(element_html, element_index, data):
+def prepare(element_html,  data):
     data['params']['random_number'] = random.random()
     return data
 
 
-def render(element_html, element_index, data):
+def render(element_html,  data):
     html_params = {
         'number': data['params']['random_number']
     }

--- a/exampleCourse/elements/course-element/course-element.py
+++ b/exampleCourse/elements/course-element/course-element.py
@@ -2,12 +2,12 @@ import random
 import chevron
 
 
-def prepare(element_html,  data):
+def prepare(element_html, data):
     data['params']['random_number'] = random.random()
     return data
 
 
-def render(element_html,  data):
+def render(element_html, data):
     html_params = {
         'number': data['params']['random_number']
     }

--- a/lib/python-caller-trampoline.py
+++ b/lib/python-caller-trampoline.py
@@ -72,12 +72,11 @@ with open(3, 'w', encoding='utf-8') as outf:
             # get the desired function in the loaded module
             method = getattr(mod, fcn)
 
-            # check if the desired function is a legacy element function - if so,
-            # we assume that ... and add argument for element_index
-            sig = signature(method)
-            if len(sig.parameters) == 3:
-                if all(p in sig.parameters for p in ['element_html', 'element_index', 'data']):
-                    args.insert(1, None)
+            # check if the desired function is a legacy element function - if
+            # so, we add an argument for element_index
+            arg_names = list(signature(method).parameters.keys())
+            if len(arg_names) == 3 and arg_names[0] == 'element_html' and arg_names[1] == 'element_index' and arg_names[2] == 'data':
+                args.insert(1, None)
 
             # call the desired function in the loaded module
             val = method(*args)

--- a/lib/python-caller-trampoline.py
+++ b/lib/python-caller-trampoline.py
@@ -16,7 +16,7 @@
 # Exceptions are not caught and so will trigger a process exit with non-zero exit code (signaling an error)
 
 import sys, os, json, importlib, copy, base64, io, matplotlib
-
+from inspect import signature
 
 # This function tries to convert a python object to valid JSON. If an exception
 # is raised, this function prints the object and re-raises the exception. This is
@@ -69,8 +69,17 @@ with open(3, 'w', encoding='utf-8') as outf:
 
         # check whether we have the desired fcn in the module
         if hasattr(mod, fcn):
-            # call the desired function in the loaded module
+            # get the desired function in the loaded module
             method = getattr(mod, fcn)
+
+            # check if the desired function is a legacy element function - if so,
+            # we assume that ... and add argument for element_index
+            sig = signature(method)
+            if len(sig.parameters) == 3:
+                if all(p in sig.parameters for p in ['element_html', 'element_index', 'data']):
+                    args.insert(1, None)
+
+            # call the desired function in the loaded module
             val = method(*args)
 
             if fcn=="file":

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -163,7 +163,8 @@ module.exports = {
             const resolvedElement = module.exports.resolveElement(elementName, context);
             const cwd = resolvedElement.directory;
             const controller = resolvedElement.controller;
-            const pythonArgs = [elementHtml, index, data];
+            // FIXME
+            const pythonArgs = [elementHtml, data];
             const pythonFile = controller.replace(/\.[pP][yY]$/, '');
             const opts = {
                 cwd,
@@ -194,7 +195,8 @@ module.exports = {
         if (_.isString(controller)) {
             // python module
             const elementHtml = $(element).clone().wrap('<container/>').parent().html();
-            const pythonArgs = [elementHtml, index, data];
+            // FIXME
+            const pythonArgs = [elementHtml, data];
             const pythonFile = controller.replace(/\.[pP][yY]$/, '');
             const opts = {
                 cwd,


### PR DESCRIPTION
The argument `element_index` is no longer passed to element functions. All element functions now have this signature:
```python
def fcn(element_html, data)
```
This change is backward compatible, in the sense that course elements that continue to use the old signature will still receive `element_index`, but the value of this argument will be `None`.

Instead of relying on `element_index` as a unique id, all core elements now rely on a UUID, generated within element code.

This eliminates any issues with the new renderer, with which `element_index` was no longer unique.

Fixes #1240