### PR TITLE
Add personal access token management

### DIFF
--- a/migrations/122_access_tokens__create.sql
+++ b/migrations/122_access_tokens__create.sql
@@ -1,0 +1,7 @@
+CREATE TABLE access_tokens (
+    id bigserial PRIMARY KEY,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    user_id BIGINT NOT NULL REFERENCES users ON DELETE CASCADE ON UPDATE CASCADE,
+    name TEXT NOT NULL,
+    token_hash TEXT UNIQUE NOT NULL
+)

--- a/migrations/122_access_tokens__create.sql
+++ b/migrations/122_access_tokens__create.sql
@@ -3,5 +3,6 @@ CREATE TABLE access_tokens (
     created_at timestamp with time zone NOT NULL DEFAULT NOW(),
     user_id BIGINT NOT NULL REFERENCES users ON DELETE CASCADE ON UPDATE CASCADE,
     name TEXT NOT NULL,
+    token TEXT,
     token_hash TEXT UNIQUE NOT NULL
 )

--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -55,7 +55,7 @@ if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) {
             <%= displayedName %>
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item" href="#">Settings</a>
+            <a class="dropdown-item" href="<%= plainUrlPrefix %>/settings">Settings</a>
             <% if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) { %>
             <a class="dropdown-item" href="<%= urlPrefix %>/effectiveUser">Change effective user</a>
             <% } %>

--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -26,23 +26,40 @@
     <!-------------------------------------------------------------------------------->
     <!-- User and logout ------------------------------------------------------------->
 
+<%
+var displayedName = '';
+if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) {
+    if (authz_data.user.name) {
+        displayedName = authz_data.user.name;
+    } else {
+        displayedName = authz_data.user.uid;
+    }
+    displayedName += '(' + authz_data.role;
+	if (authz_data.mode != 'Public') {
+        displayedName += ', ' + authz_data.mode;
+    }
+    displayedName += ')';
+} else {
+    if (typeof authn_user == 'undefined') {
+        displayedName = '(No user)';
+    } else if (is_administrator) {
+        displayedName = authn_user.name + '(Administrator)';
+    } else {
+        displayedName = authn_user.name;
+    }
+}
+%>
 <ul class="nav navbar-nav" id="username-nav">
-    <li class="nav-item mb-2 mb-md-0 mr-2 <% if (navPage == "effective") { %>active<% } %>">
-    <% if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) { %>
-        <a class="nav-link" href="<%= urlPrefix %>/effectiveUser">
-        <% if (authz_data.user.name) { %><%= authz_data.user.name %><% } else { %><%= authz_data.user.uid %><% } %>
-	(<%= authz_data.role %><% if (authz_data.mode != 'Public') { %>, <%= authz_data.mode %><% } %>)
-        <i class="fa fa-edit" aria-hidden="true"></i>
+    <li class="nav-item dropdown mb-2 mb-md-0 mr-2 <% if (navPage == "effective") { %>active<% } %>">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= displayedName %>
         </a>
-    <% } else { // authn_has_instructor_view %>
-        <% if (typeof authn_user == 'undefined') { %>
-        <span class="navbar-text">(No user)</span>
-        <% } else if (is_administrator) { %>
-        <span class="navbar-text"><%= authn_user.name %> (Administrator)</span>
-        <% } else { // is_administrator %>
-        <span class="navbar-text"><%= authn_user.name %></span>
-        <% } // is_administrator %>
-    <% } // authn_has_instructor_view %>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+            <a class="dropdown-item" href="#">Settings</a>
+            <% if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) { %>
+            <a class="dropdown-item" href="<%= urlPrefix %>/effectiveUser">Change effective user</a>
+            <% } %>
+        </div>
     </li>
 
 <%

--- a/pages/userSettings/generateTokenForm.ejs
+++ b/pages/userSettings/generateTokenForm.ejs
@@ -1,0 +1,12 @@
+<form name="generate-token-form" method="post">
+  <input type="hidden" name="__action" value="generate_token">
+  <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+  <div class="form-group">
+    <label for="token_name">Name:</label>
+    <input type="text" class="form-control" id="token_name" name="token_name" placeholder="My token">
+  </div>
+  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
+    Cancel
+  </button>
+  <button type="submit" class="btn btn-primary">Generate token</button>
+</form>

--- a/pages/userSettings/tokenDeleteForm.ejs
+++ b/pages/userSettings/tokenDeleteForm.ejs
@@ -1,0 +1,10 @@
+<form name="add-user-form" method="POST">
+  <input type="hidden" name="__action" value="token_delete">
+  <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+  <input type="hidden" name="token_id" value="<%= token_id %>">
+  <p>Once you delete this token, any applications using it will no longer be able to access the API. You cannot undo this action.</p>
+  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
+    Cancel
+  </button>
+  <button type="submit" class="btn btn-danger">Delete token</button>
+</form>

--- a/pages/userSettings/tokenGenerateForm.ejs
+++ b/pages/userSettings/tokenGenerateForm.ejs
@@ -1,5 +1,5 @@
 <form name="generate-token-form" method="post">
-  <input type="hidden" name="__action" value="generate_token">
+  <input type="hidden" name="__action" value="token_generate">
   <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
   <div class="form-group">
     <label for="token_name">Name:</label>

--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -15,11 +15,11 @@
             type="button" class="btn btn-light btn-sm ml-auto"
             data-toggle="popover" data-container="body"
             data-html="true" data-placement="auto" title="Generate new token"
-            data-content="<%= include('generateTokenForm', {id: 'generateTokenButton'}) %>"
+            data-content="<%= include('tokenGenerateForm', {id: 'generateTokenButton'}) %>"
             data-trigger="manual" onclick="$(this).popover('show')">
             <i class="fa fa-plus" aria-hidden="true"></i>
             <span class="d-none d-sm-inline">Generate new token</span>
-          </a>
+          </button>
         </div>
         <div class="card-body">
           <p class="mb-0">You can generate tokens in order to access the PrairieLearn API.</p>
@@ -38,11 +38,20 @@
             <span class="text-muted">You don't currently have any access tokens</span>
           </li>
           <% } else { %>
-          <% accessTokens.forEach(function (accessToken) { %>
+          <% accessTokens.forEach(function (token) { %>
           <li class="list-group-item d-flex align-items-center">
-            <span class="mr-3"><%= accessToken.name %></span>
-            <span><%= accessToken.token %></span>
-            <button type="button" class="btn btn-outline-danger ml-auto">Delete</button>
+            <div class="d-flex flex-column mr-3">
+              <strong><%= token.name %></strong>
+              <span class="text-muted">Created at <%= token.created_at %></span>
+            </div>
+            <button id="generateTokenButton"
+              type="button" class="btn btn-outline-danger btn-sm ml-auto"
+              data-toggle="popover" data-container="body"
+              data-html="true" data-placement="auto" title="Delete this token"
+              data-content="<%= include('tokenDeleteForm', {id: 'deleteTokenButton' + token.id, token_id: token.id }) %>"
+              data-trigger="manual" onclick="$(this).popover('show')">
+              <span class="d-none d-sm-inline">Delete</span>
+            </button>
           </li>
           <% })}; %>
         </ul>

--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head'); %>
+  </head>
+  <body>
+    <%- include('../partials/navbar', {navPage: 'user_settings'}); %>
+    <div id="content" class="container">
+      <h1 class="mb-4">Settings</h1>
+      <h3>Personal Access Tokens</h3>
+      <p>You can generate tokens in order to access the PrairieLearn API.</p>
+      <ul class="list-group">
+        <li class="list-group-item d-flex align-items-center">
+          <span class="mr-3">My access token</span>
+          <button type="button" class="btn btn-outline-danger ml-auto">Delete</button>
+        </li>
+        <li class="list-group-item d-flex align-items-center">
+          <span class="mr-3">My other access token</span>
+          <button type="button" class="btn btn-outline-danger ml-auto">Delete</button>
+        </li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -23,13 +23,15 @@
         </div>
         <div class="card-body">
           <p class="mb-0">You can generate tokens in order to access the PrairieLearn API.</p>
-          <% if (newAccessToken !== undefined) { %>
+          <% if (newAccessTokens.length > 0) { %>
             <div class="alert alert-primary mt-3" role="alert">
               New access token created! Be sure to copy it now, as you won't be able to see it later.
             </div>
+            <% newAccessTokens.forEach(function(token) { %>
             <div class="alert alert-success mb-0" role="alert">
-              <%= newAccessToken %>
+              <%= token %>
             </div>
+            <% }); %>
           <% } %>
         </div>
         <ul class="list-group list-group-flush">

--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -7,18 +7,46 @@
     <%- include('../partials/navbar', {navPage: 'user_settings'}); %>
     <div id="content" class="container">
       <h1 class="mb-4">Settings</h1>
-      <h3>Personal Access Tokens</h3>
-      <p>You can generate tokens in order to access the PrairieLearn API.</p>
-      <ul class="list-group">
-        <li class="list-group-item d-flex align-items-center">
-          <span class="mr-3">My access token</span>
-          <button type="button" class="btn btn-outline-danger ml-auto">Delete</button>
-        </li>
-        <li class="list-group-item d-flex align-items-center">
-          <span class="mr-3">My other access token</span>
-          <button type="button" class="btn btn-outline-danger ml-auto">Delete</button>
-        </li>
-      </ul>
+
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white d-flex align-items-center">
+          Personal Access Tokens
+          <button id="generateTokenButton"
+            type="button" class="btn btn-light btn-sm ml-auto"
+            data-toggle="popover" data-container="body"
+            data-html="true" data-placement="auto" title="Generate new token"
+            data-content="<%= include('generateTokenForm', {id: 'generateTokenButton'}) %>"
+            data-trigger="manual" onclick="$(this).popover('show')">
+            <i class="fa fa-plus" aria-hidden="true"></i>
+            <span class="d-none d-sm-inline">Generate new token</span>
+          </a>
+        </div>
+        <div class="card-body">
+          <p class="mb-0">You can generate tokens in order to access the PrairieLearn API.</p>
+          <% if (newAccessToken !== undefined) { %>
+            <div class="alert alert-primary mt-3" role="alert">
+              New access token created! Be sure to copy it now, as you won't be able to see it later.
+            </div>
+            <div class="alert alert-success mb-0" role="alert">
+              <%= newAccessToken %>
+            </div>
+          <% } %>
+        </div>
+        <ul class="list-group list-group-flush">
+          <% if (accessTokens.length === 0) { %>
+          <li class="list-group-item">
+            <span class="text-muted">You don't currently have any access tokens</span>
+          </li>
+          <% } else { %>
+          <% accessTokens.forEach(function (accessToken) { %>
+          <li class="list-group-item d-flex align-items-center">
+            <span class="mr-3"><%= accessToken.name %></span>
+            <span><%= accessToken.token %></span>
+            <button type="button" class="btn btn-outline-danger ml-auto">Delete</button>
+          </li>
+          <% })}; %>
+        </ul>
+      </div>
     </div>
   </body>
 </html>

--- a/pages/userSettings/userSettings.js
+++ b/pages/userSettings/userSettings.js
@@ -17,7 +17,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 const hashTokenMap = {};
 
 router.post('/', (req, res, next) => {
-    if (req.body.__action === 'generate_token') {
+    if (req.body.__action === 'token_generate') {
         const name = req.body.token_name;
         const token = uuidv4();
         const tokenHash = crypto.createHash('sha256').update(token, 'utf8').digest('hex');
@@ -33,6 +33,17 @@ router.post('/', (req, res, next) => {
             hashTokenMap[tokenHash] = token;
             res.redirect(req.originalUrl);
         });
+    } else if (req.body.__action === 'token_delete') {
+        const params = {
+            user_id: res.locals.authn_user.user_id,
+            id: req.body.token_id,
+        };
+        sqldb.query(sql.delete_access_token, params, (err) => {
+            if (ERR(err, next)) return;
+            res.redirect(req.originalUrl);
+        });
+    } else {
+        return next(error.make(400, 'unknown __action', {locals: res.locals, body: req.body}));
     }
 });
 

--- a/pages/userSettings/userSettings.js
+++ b/pages/userSettings/userSettings.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', function(req, res, _next) {
+    res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+});
+
+module.exports = router;

--- a/pages/userSettings/userSettings.js
+++ b/pages/userSettings/userSettings.js
@@ -1,8 +1,62 @@
+const ERR = require('async-stacktrace');
 const express = require('express');
 const router = express.Router();
+const crypto = require('crypto');
+const uuidv4 = require('uuid/v4');
 
-router.get('/', function(req, res, _next) {
-    res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+const error = require('@prairielearn/prairielib/error');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
+
+const sql = sqlLoader.loadSqlEquiv(__filename);
+
+// Poor man's flash messages: we'll maintain a mapping from hashes to tokens
+// between the POST that creates the token and the GET that renders it.
+// Immediately after rendering it on the GET request, we'll delete it from
+// this dict.
+const hashTokenMap = {};
+
+router.post('/', (req, res, next) => {
+    if (req.body.__action === 'generate_token') {
+        const name = req.body.token_name;
+        const token = uuidv4();
+        const tokenHash = crypto.createHash('sha256').update(token, 'utf8').digest('hex');
+
+        const params = {
+            user_id: res.locals.authn_user.user_id,
+            name,
+            token_hash: tokenHash,
+        };
+        sqldb.queryOneRow(sql.insert_access_token, params, (err) => {
+            if (ERR(err, next)) return;
+            // If this was successful, persist the token temporarily
+            hashTokenMap[tokenHash] = token;
+            res.redirect(req.originalUrl);
+        });
+    }
+});
+
+router.get('/', (req, res, next) => {
+    const params = {
+        user_id: res.locals.authn_user.user_id,
+    };
+    sqldb.query(sql.select_access_tokens, params, (err, result) => {
+        if (ERR(err, next)) return;
+
+        // If the raw tokens are present for any of these hashes, include them
+        // in this response and then delete them from memory
+        let newAccessToken;
+        result.rows.forEach((row) => {
+            if (row.token_hash in hashTokenMap) {
+                newAccessToken = hashTokenMap[row.token_hash];
+                // delete hashTokenMap[row.token_hash];
+            }
+        });
+
+        res.locals.accessTokens = result.rows;
+        res.locals.newAccessToken = newAccessToken;
+        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+    });
 });
 
 module.exports = router;

--- a/pages/userSettings/userSettings.sql
+++ b/pages/userSettings/userSettings.sql
@@ -1,17 +1,23 @@
 -- BLOCK select_access_tokens
 SELECT
-    a.id,
-    a.name,
-    a.token_hash,
-    format_date_full_compact(a.created_at, config_select('display_timezone')) AS created_at
+    id,
+    name,
+    token_hash,
+    format_date_full_compact(created_at, config_select('display_timezone')) AS created_at
 FROM
-    access_tokens as a
+    access_tokens
 WHERE
-    a.user_id = $user_id
-ORDER BY a.created_at DESC;
+    user_id = $user_id
+ORDER BY created_at DESC;
 
 -- BLOCK insert_access_token
-INSERT INTO access_tokens AS a
+INSERT INTO access_tokens
     (name, user_id, token_hash)
 VALUES
     ($name, $user_id, $token_hash);
+
+-- BLOCK delete_access_token
+DELETE FROM access_tokens
+WHERE
+    user_id = $user_id
+    AND id = $id;

--- a/pages/userSettings/userSettings.sql
+++ b/pages/userSettings/userSettings.sql
@@ -1,0 +1,17 @@
+-- BLOCK select_access_tokens
+SELECT
+    a.id,
+    a.name,
+    a.token_hash,
+    format_date_full_compact(a.created_at, config_select('display_timezone')) AS created_at
+FROM
+    access_tokens as a
+WHERE
+    a.user_id = $user_id
+ORDER BY a.created_at DESC;
+
+-- BLOCK insert_access_token
+INSERT INTO access_tokens AS a
+    (name, user_id, token_hash)
+VALUES
+    ($name, $user_id, $token_hash);

--- a/pages/userSettings/userSettings.sql
+++ b/pages/userSettings/userSettings.sql
@@ -2,6 +2,7 @@
 SELECT
     id,
     name,
+    token,
     token_hash,
     format_date_full_compact(created_at, config_select('display_timezone')) AS created_at
 FROM
@@ -12,9 +13,14 @@ ORDER BY created_at DESC;
 
 -- BLOCK insert_access_token
 INSERT INTO access_tokens
-    (name, user_id, token_hash)
+    (name, user_id, token, token_hash)
 VALUES
-    ($name, $user_id, $token_hash);
+    ($name, $user_id, $token, $token_hash);
+
+-- BLOCK clear_tokens_for_user
+UPDATE access_tokens
+SET token = NULL
+WHERE user_id = $user_id;
 
 -- BLOCK delete_access_token
 DELETE FROM access_tokens

--- a/server.js
+++ b/server.js
@@ -177,6 +177,7 @@ app.use(/^\/pl\/?/, require('./middlewares/clearCookies'));
 // some pages don't need authorization
 app.use('/', require('./pages/home/home'));
 app.use('/pl', require('./pages/home/home'));
+app.use('/pl/settings', require('./pages/userSettings/userSettings'));
 app.use('/pl/enroll', require('./pages/enroll/enroll'));
 app.use('/pl/logout', require('./pages/authLogout/authLogout'));
 app.use('/pl/password', require('./pages/authPassword/authPassword'));


### PR DESCRIPTION
This PR adds the ability to create, view, and delete personal access tokens; this is the first part of #1243. Tokens aren't currently used for anything, but I felt it best to break #1243 into multiple PRs to avoid a single monolithic PR that's impossible to review.

## Security concerns

I did my best to design this with security in mind. The generated token is only persisted in the database for a short period of time; this is necessary to display it back to the user on the new request. Immediately after the token list is rendered, all tokens for that user are removed from the database. I originally stored the token only in memory, but that will break in a multi-server architecture.

We only permanently store a SHA256 hash of the token in the database. SHA256 is not _necessarily_ good for passwords, but given that the tokens are guaranteed to be 36 characters long, I'm not too concerned about the weakness of SHA256 when used to hash passwords (it's a very fast algorithm and can thus be brute-forced comparatively faster than something like bcrypt). I would have used bcrypt itself, but its reliance on a native component means that the "mount the PL repo into Docker" development paradigm would break.

Here's what the page looks like to a user:

<img width="1220" alt="screen shot 2018-09-08 at 3 41 52 pm" src="https://user-images.githubusercontent.com/1476544/45258701-e477a700-b381-11e8-8a6a-d847e3b18741.png">
