### PR TITLE
Fix another submission bug in symbolic input element

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,8 +62,10 @@
   * Fix bug with rendering when the render cache is disabled (Nathan Walters).
 
   * Fix outdated pycryptdome version (to 3.6.6) (Matt West).
-  
+
   * Fig bug in `pl-symbolic-input` to handle submission of function names without arguments (Tim Bretl).
+
+  * Fix bug in `pl-symbolic-input` to handle submissions that simplify to invalid expressions (Tim Bretl).
 
   * Change `pl-code` to display code from a source file OR inline text (Mariana Silva).
 

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -38,6 +38,10 @@
             container: 'body',
             template: '<div class="popover pl-symbolic-input-popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
         });
+
+        $('#pl-symbolic-input-submission-{{uuid}} [data-toggle="popover"]').on('shown.bs.popover', function () {
+            MathJax.Hub.Queue(["Typeset", MathJax.Hub, '#pl-symbolic-input-submission-{{uuid}} [data-toggle="popover"]']);
+        });
     });
 </script>
 <span id="pl-symbolic-input-submission-{{uuid}}">

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -234,7 +234,7 @@ def parse(element_html, data):
     # Make sure we can parse the string again, with the same set of variables
     try:
         # Convert safely to sympy
-        a_sub_doubleparsed = phs.convert_string_to_sympy(a_sub_string, variables)
+        phs.convert_string_to_sympy(a_sub_string, variables)
 
         # Finally, store the result
         data['submitted_answers'][name] = a_sub_string

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -162,6 +162,7 @@ def parse(element_html, data):
         data['submitted_answers'][name] = None
         return
 
+    # Parse the submitted answer and put the result in a string
     try:
         # Replace '^' with '**' wherever it appears. In MATLAB, either can be used
         # for exponentiation. In python, only the latter can be used.
@@ -171,54 +172,75 @@ def parse(element_html, data):
         a_sub = a_sub.strip()
 
         # Convert safely to sympy
-        a_sub = phs.convert_string_to_sympy(a_sub, variables)
+        a_sub_parsed = phs.convert_string_to_sympy(a_sub, variables)
 
         # Store result as a string.
-        data['submitted_answers'][name] = str(a_sub)
+        a_sub_string = str(a_sub_parsed)
     except phs.HasFloatError as err:
         s = 'Your answer contains the floating-point number ' + str(err.n) + '. '
         s += 'All numbers must be expressed as integers (or ratios of integers). '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasComplexError as err:
         s = 'Your answer contains the complex number ' + str(err.n) + '. '
         s += 'All numbers must be expressed as integers (or ratios of integers). '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasInvalidExpressionError as err:
         s = 'Your answer has an invalid expression. '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasInvalidFunctionError as err:
         s = 'Your answer calls an invalid function "' + err.text + '". '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasInvalidVariableError as err:
         s = 'Your answer refers to an invalid variable "' + err.text + '". '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasParseError as err:
         s = 'Your answer has a syntax error. '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasEscapeError as err:
         s = 'Your answer must not contain the character "\\". '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except phs.HasCommentError as err:
         s = 'Your answer must not contain the character "#". '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None
+        return
     except Exception as err:
         data['format_errors'][name] = 'Invalid format.'
+        data['submitted_answers'][name] = None
+        return
+
+    # Make sure we can parse the string again, with the same set of variables
+    try:
+        # Convert safely to sympy
+        a_sub_doubleparsed = phs.convert_string_to_sympy(a_sub_string, variables)
+
+        # Finally, store the result
+        data['submitted_answers'][name] = a_sub_string
+    except Exception as err:
+        s = 'Your answer was simplified to this, which contains an invalid expression: $${:s}$$'.format(sympy.latex(a_sub_parsed))
+        data['format_errors'][name] = s
         data['submitted_answers'][name] = None
 
 


### PR DESCRIPTION
In `pl-symbolic-input`, it was possible for conversion of the submission string to a sympy expression in `parse()` to complete successfully, but for (re-)conversion of the string equivalent of this expression to an equivalent sympy expression in `grade()` to throw an error.

For example, if a student submitted the expression `sqrt(-1)`, it would parse successfully, but the result would be stored as the string `I`, which would result in an error on `grade()`.

We now round-trip conversion in `parse()` - we convert the string to a sympy expression, convert this expression back to a string, and make sure we can convert the result to a sympy expression again (with the same list of allowable variables and constants). If the reconversion fails, the submission is declared invalid, and appropriate feedback is given to the student.