### PR TITLE
Yet another symbolic input fix (handling E and I)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,8 @@
 
   * Add personal access token management (Nathan Walters).
 
+  * Add `allow-complex` attribute for `pl-symbolic-input` (Tim Bretl).
+
   * Fix `pl-file-editor` to allow display empty text editor and add option to include text from source file (Mariana Silva).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -67,6 +67,8 @@
 
   * Fix bug in `pl-symbolic-input` to handle submissions that simplify to invalid expressions (Tim Bretl).
 
+  * Fix bug in `pl-symbolic-input` to handle the sympy constants I and E properly (Tim Bretl).
+
   * Change `pl-code` to display code from a source file OR inline text (Mariana Silva).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -136,6 +136,18 @@ Attribute | Type | Default | Description
 `label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
 `variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
+`allow-complex` | boolean | False | Whether complex numbers (expressions with `i` or `j` as the imaginary unit) are allowed.
+
+Correct answers are best created as `sympy` expressions and converted to json using:
+```python
+import prairielearn as pl
+import sympy
+
+def generate(data):
+    sympy.var('x y')
+    data['correct_answer']['ans'] = pl.to_json(x + y + 1)
+```
+Do not use `i` or `j` in the correct answer if `allow-complex="true"`. Avoid using `e`, as `exp(x)` will be rendered as `e^x` (for example).
 
 ## `pl-matrix-input` element
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -150,7 +150,7 @@ def generate(data):
 ```
 It is also possible to specify the correct answer simply as a string, e.g., `x + y + 1`.
 
-Do not use `i` or `j` in the correct answer if `allow-complex="true"`. Do not use any other reserved name for an instructor-defined variable (`e`, `pi`, `cos`, `sin`, etc.) The element code will check for (and disallow) conflicts between defined variables and reserved names.
+Do not include `i` or `j` in the list of `variables` if `allow-complex="true"`. Do not include any other reserved name in your list of `variables` (`e`, `pi`, `cos`, `sin`, etc.) The element code will check for (and disallow) conflicts between your list of `variables` and reserved names.
 
 
 ## `pl-matrix-input` element

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -137,6 +137,7 @@ Attribute | Type | Default | Description
 `display` | "block" or "inline" | "inline" | How to display the input field.
 `variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
 `allow-complex` | boolean | False | Whether complex numbers (expressions with `i` or `j` as the imaginary unit) are allowed.
+`imaginary-unit-for-display` | string | `i` | The imaginary unit that is used for display. It must be either `i` or `j`. Again, this is *only* for display. Both `i` and `j` can be used by the student in their submitted answer, when `allow-complex="true"`.
 
 Correct answers are best created as `sympy` expressions and converted to json using:
 ```python
@@ -147,7 +148,10 @@ def generate(data):
     sympy.var('x y')
     data['correct_answer']['ans'] = pl.to_json(x + y + 1)
 ```
-Do not use `i` or `j` in the correct answer if `allow-complex="true"`. Avoid using `e`, as `exp(x)` will be rendered as `e^x` (for example).
+It is also possible to specify the correct answer simply as a string, e.g., `x + y + 1`.
+
+Do not use `i` or `j` in the correct answer if `allow-complex="true"`. Do not use any other reserved name for an instructor-defined variable (`e`, `pi`, `cos`, `sin`, etc.) The element code will check for (and disallow) conflicts between defined variables and reserved names.
+
 
 ## `pl-matrix-input` element
 

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -65,7 +65,19 @@ ${{a_tru}}$
 {{/answer}}
 
 {{#format}}
-Your answer must be a symbolic expression. All numbers must be rational - so, <code>1/2</code> instead of <code>0.5</code>.<hr><h5><small class='text-uppercase'>Allowable Operators</small></h5><pre>{{operators}}</pre><p>All operations must be explicit - examples of valid expressions are <code>cos(1)</code> and <code>2*(3)</code>. Examples of invalid expressions are <code>cos 1</code> and <code>2(3)</code>. Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p><hr><h5><small class='text-uppercase'>Allowable Constants</small></h5><pre>{{constants}}</pre>{{#variables}}<hr><h5><small class='text-uppercase'>Allowable Variables</small></h5><pre>{{variables}}</pre>{{/variables}}
+Your answer must be a symbolic expression. All numbers must be rational - so, <code>1/2</code> instead of <code>0.5</code>.
+{{^allow_complex}}Complex numbers are not allowed.{{/allow_complex}}
+<hr>
+<h5><small class='text-uppercase'>Allowable Operators</small></h5>
+<pre>{{operators}}</pre>
+<p>All operations must be explicit - examples of valid expressions are <code>cos(1)</code> and <code>2*(3)</code>. Examples of invalid expressions are <code>cos 1</code> and <code>2(3)</code>. Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p>
+<hr>
+<h5><small class='text-uppercase'>Allowable Constants</small></h5>
+<pre>{{constants}}</pre>{{#variables}}
+{{#allow_complex}}<p>Either <code>i</code> or <code>j</code> can be used to denote the imaginary unit. Examples of valid complex numbers are <code>1 + 2 * i</code> and <code>-3 * j</code>.</p>{{/allow_complex}}
+<hr>
+<h5><small class='text-uppercase'>Allowable Variables</small></h5>
+<pre>{{variables}}</pre>{{/variables}}
 {{/format}}
 
 {{#shortformat}}

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -49,7 +49,7 @@ def render(element_html, data):
         raw_submitted_answer = data['raw_submitted_answers'].get(name, None)
 
         operators = ', '.join(['cos', 'sin', 'tan', 'exp', 'log', 'sqrt', '( )', '+', '-', '*', '/', '^', '**'])
-        constants = ', '.join(['pi'])
+        constants = ', '.join(['pi, e'])
 
         info_params = {
             'format': True,

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -209,6 +209,8 @@ def parse(element_html, data):
     except phs.HasComplexError as err:
         s = 'Your answer contains the complex number ' + str(err.n) + '. '
         s += 'All numbers must be expressed as integers (or ratios of integers). '
+        if allow_complex:
+            s += 'To include a complex number in your expression, write it as the product of an integer with the imaginary unit <code>i</code> or <code>j</code>. '
         s += '<br><br><pre>' + phs.point_to_error(a_sub, err.offset) + '</pre>'
         data['format_errors'][name] = s
         data['submitted_answers'][name] = None

--- a/exampleCourse/courseInstances/Sp15/assessments/plelementexamples/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/plelementexamples/infoAssessment.json
@@ -36,7 +36,8 @@
 				{"id": "examplesCheckbox",           "points": 2, "maxPoints": 10},
 				{"id": "examplesStringInput",           "points": 2, "maxPoints": 10},
 				{"id": "elementsMatrixLatexDisplay",        "points": 2, "maxPoints": 10},
-                {"id": "examplesMatrixInput",        "points": 2, "maxPoints": 10}
+                {"id": "examplesMatrixInput",        "points": 2, "maxPoints": 10},
+                {"id": "examplesSymbolicInput",        "points": 2, "maxPoints": 10}
             ]
         }
     ]

--- a/exampleCourse/questions/examplesSymbolicInput/info.json
+++ b/exampleCourse/questions/examplesSymbolicInput/info.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "cffe78ed-a500-4b0a-a3fe-5b4e9d63c810",
+    "title": "Symbolic answers with pl-symbolic-input",
+    "topic": "Test",
+    "tags": [ "tbretl", "v3"],
+    "type": "v3"
+}

--- a/exampleCourse/questions/examplesSymbolicInput/question.html
+++ b/exampleCourse/questions/examplesSymbolicInput/question.html
@@ -33,3 +33,15 @@
         <pl-symbolic-input answers-name="I" variables="V, R" label="$I=$"></pl-symbolic-input>
     </div>
 </div>
+
+<div class="card my-2">
+    <div class="card-header">
+        An example in which we specify a different imaginary unit for display (<code>imaginary-unit-for-display="j"</code>)
+    </div>
+    <div class="card-body">
+        <pl-question-panel>
+            <p>Write an expression for the complex number $c$ whose real part is $a$ and whose imaginary part is $b$.</p>
+        </pl-question-panel>
+        <pl-symbolic-input answers-name="c" variables="a, b" allow-complex="true" imaginary-unit-for-display="j" label="$c=$"></pl-symbolic-input>
+    </div>
+</div>

--- a/exampleCourse/questions/examplesSymbolicInput/question.html
+++ b/exampleCourse/questions/examplesSymbolicInput/question.html
@@ -1,0 +1,23 @@
+<div class="card my-2">
+    <div class="card-header">
+        An example in which complex numbers are not allowed
+    </div>
+    <div class="card-body">
+        <pl-question-panel>
+            <p>Suppose $$y = a x + b.$$ Assuming that $a \neq 0$, solve for $x$.</p>
+        </pl-question-panel>
+        <pl-symbolic-input answers-name="x" variables="a, b, y" label="$x=$"></pl-symbolic-input>
+    </div>
+</div>
+
+<div class="card my-2">
+    <div class="card-header">
+        An example in which complex numbers are allowed
+    </div>
+    <div class="card-body">
+        <pl-question-panel>
+            <p>Write an expression for the complex number $z$ whose argument is $a$ (in radians) and whose modulus is $m$.</p>
+        </pl-question-panel>
+        <pl-symbolic-input answers-name="z" variables="a, m" allow-complex="true" label="$z=$"></pl-symbolic-input>
+    </div>
+</div>

--- a/exampleCourse/questions/examplesSymbolicInput/question.html
+++ b/exampleCourse/questions/examplesSymbolicInput/question.html
@@ -1,6 +1,6 @@
 <div class="card my-2">
     <div class="card-header">
-        An example in which complex numbers are not allowed
+        An example in which complex numbers are not allowed (<code>allow-complex="false"</code>)
     </div>
     <div class="card-body">
         <pl-question-panel>
@@ -12,12 +12,24 @@
 
 <div class="card my-2">
     <div class="card-header">
-        An example in which complex numbers are allowed
+        An example in which complex numbers are allowed (<code>allow-complex="true"</code>)
     </div>
     <div class="card-body">
         <pl-question-panel>
             <p>Write an expression for the complex number $z$ whose argument is $a$ (in radians) and whose modulus is $m$.</p>
         </pl-question-panel>
         <pl-symbolic-input answers-name="z" variables="a, m" allow-complex="true" label="$z=$"></pl-symbolic-input>
+    </div>
+</div>
+
+<div class="card my-2">
+    <div class="card-header">
+        An example in which the correct answer is specified as a string in <code>server.py</code>
+    </div>
+    <div class="card-body">
+        <pl-question-panel>
+            <p>Write an expression for the current $I$ in a resistor if the voltage is $V$ and the resistance is $R$.</p>
+        </pl-question-panel>
+        <pl-symbolic-input answers-name="I" variables="V, R" label="$I=$"></pl-symbolic-input>
     </div>
 </div>

--- a/exampleCourse/questions/examplesSymbolicInput/server.py
+++ b/exampleCourse/questions/examplesSymbolicInput/server.py
@@ -1,0 +1,9 @@
+import sympy
+import prairielearn as pl
+
+def generate(data):
+    sympy.var('y b a m')
+    x = (y - b) / a
+    z = m * (sympy.cos(a) + sympy.I * sympy.sin(a))
+    data['correct_answers']['x'] = pl.to_json(x)
+    data['correct_answers']['z'] = pl.to_json(z)

--- a/exampleCourse/questions/examplesSymbolicInput/server.py
+++ b/exampleCourse/questions/examplesSymbolicInput/server.py
@@ -5,6 +5,8 @@ def generate(data):
     sympy.var('y b a m')
     x = (y - b) / a
     z = m * (sympy.cos(a) + sympy.I * sympy.sin(a))
+    c = a + sympy.I * b
     data['correct_answers']['x'] = pl.to_json(x)
     data['correct_answers']['z'] = pl.to_json(z)
     data['correct_answers']['I'] = 'V / R'
+    data['correct_answers']['c'] = pl.to_json(c)

--- a/exampleCourse/questions/examplesSymbolicInput/server.py
+++ b/exampleCourse/questions/examplesSymbolicInput/server.py
@@ -7,3 +7,4 @@ def generate(data):
     z = m * (sympy.cos(a) + sympy.I * sympy.sin(a))
     data['correct_answers']['x'] = pl.to_json(x)
     data['correct_answers']['z'] = pl.to_json(z)
+    data['correct_answers']['I'] = 'V / R'

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -2,6 +2,36 @@ import sympy
 import ast
 import sys
 
+# Create a new instance of this class to access the member dictionaries. This
+# is to avoid accidentally modifying these dictionaries.
+class _Constants:
+    def __init__(self):
+        self.helpers = {
+            '_Integer': sympy.Integer,
+        }
+        self.variables = {
+            'pi': sympy.pi,
+        }
+        self.hidden_variables = {
+            '_Exp1': sympy.E,
+        }
+        self.complex_variables = {
+            'i': sympy.I,
+            'j': sympy.I,
+        }
+        self.hidden_complex_variables = {
+            '_ImaginaryUnit': sympy.I,
+        }
+        self.functions = {
+            # These are shown to the student
+            'cos': sympy.cos,
+            'sin': sympy.sin,
+            'tan': sympy.tan,
+            'exp': sympy.exp,
+            'log': sympy.log,
+            'sqrt': sympy.sqrt,
+        }
+
 # Safe evaluation of user input to convert from string to sympy expression.
 #
 # Adapted from:
@@ -187,10 +217,22 @@ def evaluate(expr, locals_for_eval={}):
         locals = {**locals, **locals_for_eval[key]}
     return eval(compile(root, '<ast>', 'eval'), {'__builtins__': None}, locals)
 
-def convert_string_to_sympy(a, variables):
+def convert_string_to_sympy(a, variables, allow_hidden=False, allow_complex=False):
+    const = _Constants()
+
     # Create a whitelist of valid functions and variables (and a special flag
     # for numbers that are converted to sympy integers).
-    locals_for_eval = {'functions': {'cos': sympy.cos, 'sin': sympy.sin, 'tan': sympy.tan, 'exp': sympy.exp, 'log': sympy.log, 'sqrt': sympy.sqrt}, 'variables': {'pi': sympy.pi}, 'helpers': {'_Integer': sympy.Integer}}
+    locals_for_eval = {
+        'functions': const.functions,
+        'variables': const.variables,
+        'helpers': const.helpers,
+    }
+    if allow_hidden:
+        locals_for_eval['variables'] = {**locals_for_eval['variables'], **const.hidden_variables}
+    if allow_complex:
+        locals_for_eval['variables'] = {**locals_for_eval['variables'], **const.complex_variables}
+        if allow_hidden:
+            locals_for_eval['variables'] = {**locals_for_eval['variables'], **const.hidden_complex_variables}
 
     # If there is a list of variables, add each one to the whitelist
     if variables is not None:
@@ -204,3 +246,37 @@ def point_to_error(s, ind, w = 5):
     w_left = ind - max(0, ind-w)
     w_right = min(ind+w, len(s)) - ind
     return s[ind-w_left:ind+w_right] + '\n' + ' '*w_left + '^' + ' '*w_right
+
+def sympy_to_json(a, allow_complex=True):
+    const = _Constants()
+
+    # Get list of variables in the sympy expression
+    variables = [str(v) for v in a.free_symbols]
+
+    # Check that variables do not conflict with reserved names
+    reserved = {**const.helpers, **const.variables, **const.hidden_variables, **const.functions}
+    if allow_complex:
+        reserved = {**reserved, **const.complex_variables, **const.hidden_complex_variables}
+    for k in reserved.keys():
+        for v in variables:
+            if k == v:
+                raise ValueError('sympy expression has a variable with a reserved name: {:s}'.format(k))
+
+    # Apply substitutions for hidden variables
+    a = a.subs([(const.hidden_variables[key], key) for key in const.hidden_variables.keys()])
+    if allow_complex:
+        a = a.subs([(const.hidden_complex_variables[key], key) for key in const.hidden_complex_variables.keys()])
+
+    return {'_type': 'sympy', '_value': str(a), '_variables': variables}
+
+def json_to_sympy(a, allow_complex=True):
+    if not '_type' in a:
+        raise ValueError('json must have key _type for conversion to sympy')
+    if a['_type'] != 'sympy':
+        raise ValueError('json must have _type == "sympy" for conversion to sympy')
+    if not '_value' in a:
+        raise ValueError('json must have key _value for conversion to sympy')
+    if not '_variables' in a:
+        a['_variables'] = None
+
+    return convert_string_to_sympy(a['_value'], a['_variables'], allow_hidden=True, allow_complex=allow_complex)

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -11,6 +11,7 @@ class _Constants:
         }
         self.variables = {
             'pi': sympy.pi,
+            'e': sympy.E,
         }
         self.hidden_variables = {
             '_Exp1': sympy.E,

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -4,6 +4,8 @@ import numpy as np
 import uuid
 import sympy
 from python_helper_sympy import convert_string_to_sympy
+from python_helper_sympy import sympy_to_json
+from python_helper_sympy import json_to_sympy
 import re
 
 
@@ -36,8 +38,7 @@ def to_json(v):
         elif np.iscomplexobj(v):
             return {'_type': 'complex_ndarray', '_value': {'real': v.real.tolist(), 'imag': v.imag.tolist()}, '_dtype': str(v.dtype)}
     elif isinstance(v, sympy.Expr):
-        s = [str(a) for a in v.free_symbols]
-        return {'_type': 'sympy', '_value': str(v), '_variables': s}
+        return sympy_to_json(v)
     elif isinstance(v, sympy.Matrix) or isinstance(v, sympy.ImmutableMatrix):
         s = [str(a) for a in v.free_symbols]
         num_rows, num_cols = v.shape
@@ -97,10 +98,7 @@ def from_json(v):
                 else:
                     raise Exception('variable of type complex_ndarray should have value with real and imaginary pair')
             elif v['_type'] == 'sympy':
-                if ('_value' in v) and ('_variables' in v):
-                    return convert_string_to_sympy(v['_value'], v['_variables'])
-                else:
-                    raise Exception('variable of type sympy should have value and variables')
+                return json_to_sympy(v)
             elif v['_type'] == 'sympy_matrix':
                 if ('_value' in v) and ('_variables' in v) and ('_shape' in v):
                     value = v['_value']


### PR DESCRIPTION
This time the issue was handling `sympy.E`.

Before, if the submitted answer were to contain something like `exp(1)`, then it would be parsed to `sympy.E`, which would be converted to the string `E`, which - upon the double-check parse - would raise an exception, because `E` wouldn't be in the list of variables (and if it were, that would be even worse).

Now, we handle this properly, by substituting a hidden helper variable for `sympy.E`.

We also handle `sympy.I` properly now, and - as a bonus - add an option to allow symbolic inputs with complex numbers, which wasn't ever allowed before.