### PR TITLE
Add "text" stanza formula sheet example back

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -79,6 +79,8 @@
 
   * Fix restart of Python `codeCallers` with no active child (Matt West).
 
+  * Fix exampleCourse exam1 to include formula sheet example per docs (Dave Mussulman).
+
   * Change `pl-code` to display code from a source file OR inline text (Mariana Silva).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).

--- a/exampleCourse/courseInstances/Sp15/assessments/exam1/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam1/infoAssessment.json
@@ -30,5 +30,6 @@
                 {"id": "partialCredit3",          "points": [13, 13, 8, 0.5, 0.1]}
               ]
         }
-    ]
+    ],
+    "text": "The following forumula sheets are available to you on this exam:<ul><li><a href=\"<%= clientFilesAssessment %>/formulas.pdf\">PDF version</a></li>"
 }


### PR DESCRIPTION
https://prairielearn.readthedocs.io/en/latest/assessment/ links to the exampleCourse exam1 as an example of how to add a formula sheet to an assessment, but it was missing. This adds it back.