### PR TITLE
Better client socket handling on externally graded questions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,8 @@
 
   * Add warm up for Python worker processes (Matt West).
 
+  * Add better handling of client sockets on externally graded questions (Nathan Walters).
+
   * Fix `pl-file-editor` to allow display empty text editor and add option to include text from source file (Mariana Silva).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).

--- a/exampleCourse/questions/fibonacciEditor/question.html
+++ b/exampleCourse/questions/fibonacciEditor/question.html
@@ -11,16 +11,16 @@
     and returns the n<sup>th</sup> Fibonacci number.
   </p>
 
-  <p>
   <pl-file-editor file-name="fib.py" ace-mode="ace/mode/python" source-file-name="initial_code.py">
   </pl-file-editor>
-  </p>
 
-  <p> <strong>Note:</strong> In the above example, the attribute
+  <p class="mt-2">
+    <strong>Note:</strong> In the above example, the attribute
     <code>source-file-name='initial_code.py'</code> was used to add existing code
     to the in-browser file editor from a source file. Another option is omit the <code>source-file-name</code>
     attribute and instead write the existing code directly inside the html element, between the
-  <code>pl-file-editor</code> tags.
+    <code>pl-file-editor</code> tags.
+  </p>
 
 </pl-question-panel>
 

--- a/pages/partials/externalGradingLiveUpdate.ejs
+++ b/pages/partials/externalGradingLiveUpdate.ejs
@@ -1,7 +1,6 @@
 <% if (question.grading_method == 'External') { %>
 <script>
   $(function() {
-    var socket = io('/external-grading');
     var variantId = '<%= variant.id %>';
     var variantToken = '<%= variantToken %>';
     var urlPrefix = '<%= urlPrefix %>';
@@ -9,11 +8,28 @@
     var csrfToken = '<%= __csrf_token %>';
 
     // Render initial grading states into the DOM
+    var gradingPending = false;
     $('[id^=submission-]').each(function(index, elem) {
+      // Ensure that this is a valid submission element
+      if (!/^submission-\d+$/.test($(elem).attr('id'))) {
+        return;
+      }
+
       var status = $(elem).data('grading-job-status');
       var submissionId = $(elem).attr('id').replace('submission-', '');
       updateStatus(submissionId, status);
+      if (status !== 'graded' && status !== 'canceled') {
+        gradingPending = true;
+      }
     });
+
+    // If everything has been graded or was canceled, don't even open a socket
+    if (!gradingPending) {
+      return;
+    }
+
+    // By this point, it's safe to open a socket
+    var socket = io('/external-grading');
 
     socket.emit('init', {variant_id: variantId, variant_token: variantToken}, function(msg) {
       handleStatusChange(msg);
@@ -56,6 +72,8 @@
         question_context: questionContext,
         csrf_token: csrfToken
       }, function(msg) {
+        // We're done with the socket for this incarnation of the page
+        socket.close();
         if (msg.submissionPanel) {
           $('#submission-' + submissionId).replaceWith(function() {
             return $(msg.submissionPanel).fadeIn('slow');

--- a/sprocs/grading_job_status.sql
+++ b/sprocs/grading_job_status.sql
@@ -15,6 +15,9 @@ BEGIN
     WHERE
         gj.id = grading_job_id;
 
+    IF job.grading_request_canceled_at IS NOT NULL THEN
+        RETURN 'canceled';
+    END IF;
     IF job.graded_at IS NOT NULL THEN
         RETURN 'graded';
     END IF;


### PR DESCRIPTION
This will close sockets after they're no longer needed, which for us is after the first set of results that we fetch from them. On any given page load, there will be at most one question that needs results fetched, given that we cancel pending jobs when a new one is submitted.

This also checks if any submissions on a page will actually need a socket and doesn't open one if everything is either graded or canceled.