### PR TITLE
String element update

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -127,6 +127,9 @@
 
   * Remove `element_index` from list of arguments passed to elements (Tim Bretl).
 
+  * Change `pl-string-input` to include an attribute for the placeholder (Mariana Silva).
+
+
 * __3.0.0__ - 2018-05-23
 
   * Add improved support for very large file downloads (Nathan Walters).

--- a/elements/pl-string-input/pl-string-input.mustache
+++ b/elements/pl-string-input/pl-string-input.mustache
@@ -68,7 +68,3 @@
 Your answer must be a string. Any symbolic expressions or numbers will be intepreted as a string.
 </p>
 {{/format}}
-
-{{#shortformat}}
-string
-{{/shortformat}}

--- a/elements/pl-string-input/pl-string-input.mustache
+++ b/elements/pl-string-input/pl-string-input.mustache
@@ -15,7 +15,7 @@
             <span class="input-group-text">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
+        <input name="{{name}}" type="text" class="form-control" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{placeholder}}" />
         <span class="input-group-append">
             {{#suffix}}<span class="input-group-text">{{suffix}}</span>{{/suffix}}
             <a class="btn btn-light border" role="button" data-toggle="popover" data-html="true" title="String" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -9,11 +9,12 @@ import random
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank']
+    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank', 'placeholder-text']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
     name = pl.get_string_attrib(element, 'answers-name')
     correct_answer = pl.get_string_attrib(element, 'correct-answer', None)
+    placeholder = pl.get_string_attrib(element, 'placeholder-text', None)
 
     if correct_answer is not None:
         if name in data['correct_answers']:
@@ -29,6 +30,7 @@ def render(element_html, data):
     display = pl.get_string_attrib(element, 'display', 'inline')
     remove_leading_trailing = pl.get_string_attrib(element, 'remove-leading-trailing', False)
     remove_spaces = pl.get_string_attrib(element, 'remove-spaces', False)
+    placeholder = pl.get_string_attrib(element, 'placeholder-text', None)
 
     if data['panel'] == 'question':
         editable = data['editable']
@@ -40,8 +42,6 @@ def render(element_html, data):
             template = f.read()
             info = chevron.render(template, info_params).strip()
             info_params.pop('format', None)
-            info_params['shortformat'] = True
-            shortinfo = chevron.render(template, info_params).strip()
 
         html_params = {
             'question': True,
@@ -52,7 +52,7 @@ def render(element_html, data):
             'remove-spaces': remove_spaces,
             'editable': editable,
             'info': info,
-            'shortinfo': shortinfo,
+            'shortinfo': placeholder,
             'uuid': pl.get_uuid()
         }
 

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -14,7 +14,6 @@ def prepare(element_html, data):
 
     name = pl.get_string_attrib(element, 'answers-name')
     correct_answer = pl.get_string_attrib(element, 'correct-answer', None)
-    placeholder = pl.get_string_attrib(element, 'placeholder-text', None)
 
     if correct_answer is not None:
         if name in data['correct_answers']:

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -9,7 +9,7 @@ import random
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank', 'placeholder-text']
+    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank', 'placeholder']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
     name = pl.get_string_attrib(element, 'answers-name')
@@ -29,7 +29,7 @@ def render(element_html, data):
     display = pl.get_string_attrib(element, 'display', 'inline')
     remove_leading_trailing = pl.get_string_attrib(element, 'remove-leading-trailing', False)
     remove_spaces = pl.get_string_attrib(element, 'remove-spaces', False)
-    placeholder = pl.get_string_attrib(element, 'placeholder-text', None)
+    placeholder = pl.get_string_attrib(element, 'placeholder', None)
 
     if data['panel'] == 'question':
         editable = data['editable']
@@ -51,7 +51,7 @@ def render(element_html, data):
             'remove-spaces': remove_spaces,
             'editable': editable,
             'info': info,
-            'shortinfo': placeholder,
+            'placeholder': placeholder,
             'uuid': pl.get_uuid()
         }
 

--- a/exampleCourse/questions/examplesStringInput/question.html
+++ b/exampleCourse/questions/examplesStringInput/question.html
@@ -43,7 +43,7 @@ a = "{{params.stringname}}"*{{params.a}}
 <p> 4) Enter the string below, however include blank spaces between some of the numbers.
 When using the attribute <code>remove-spaces="true"</code>, the answer will
 still be evaluated as correct. This example also uses the attribute
-<code>placeholder-text = "string"</code>,
+<code>placeholder="string"</code>,
 to add a placeholder indicating the expected input is of type "string".</p>
 <pl-code language="python">
 "{{params.d}}"
@@ -51,7 +51,7 @@ to add a placeholder indicating the expected input is of type "string".</p>
 </pl-question-panel>
 
 <p>
-<pl-string-input answers-name="ans4" remove-spaces="true" placeholder-text="string">
+<pl-string-input answers-name="ans4" remove-spaces="true" placeholder="string">
 </pl-string-input>
 </p>
 

--- a/exampleCourse/questions/examplesStringInput/question.html
+++ b/exampleCourse/questions/examplesStringInput/question.html
@@ -42,14 +42,16 @@ a = "{{params.stringname}}"*{{params.a}}
 <pl-question-panel>
 <p> 4) Enter the string below, however include blank spaces between some of the numbers.
 When using the attribute <code>remove-spaces="true"</code>, the answer will
-still be evaluated as correct. </p>
+still be evaluated as correct. This example also uses the attribute
+<code>placeholder-text = "string"</code>,
+to add a placeholder indicating the expected input is of type "string".</p>
 <pl-code language="python">
 "{{params.d}}"
 </pl-code>
 </pl-question-panel>
 
 <p>
-<pl-string-input answers-name="ans4" remove-spaces="true">
+<pl-string-input answers-name="ans4" remove-spaces="true" placeholder-text="string">
 </pl-string-input>
 </p>
 


### PR DESCRIPTION
Removes the word "string" as a default placeholder. Creates an attribute `placeholder-text` allowing users to choose their own text. By default, it displays an empty input box.

This PR addresses issue #1276 