### PR TITLE
Always display the correct answer for a question in dev, instructor, and admin modes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -129,6 +129,7 @@
 
   * Change `pl-string-input` to include an attribute for the placeholder (Mariana Silva).
 
+  * Change question pages to always include the answer if in instructor, dev, or administrator mode (James Balamuta).
 
 * __3.0.0__ - 2018-05-23
 

--- a/lib/question.js
+++ b/lib/question.js
@@ -1104,6 +1104,9 @@ module.exports = {
             locals.showSaveButton = true;
             locals.allowAnswerEditing = true;
             locals.showNewVariantButton = true;
+
+            // Always display the answer to the instructor
+            locals.showTrueAnswer = true;
         } else {
             // student question pages
             if (assessment.type == 'Homework') {


### PR DESCRIPTION

Related to #1114. 

This PR changes when the "correct answer" is displayed from being on input to always being active regardless of whether a user has answered the question in dev / instructor / or admin mode. The hope here is to easy debugging. The next stage is freeing question data from the "issue" ticket generation (c.f. "Script Vars") 

![always-enabled](https://user-images.githubusercontent.com/833642/45933083-08bfb000-bf4c-11e8-8820-3f26b5447304.png)
