### PR TITLE
Change element ordering of Access Rules on instructorAssessment page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -133,6 +133,7 @@
 
   * Change element documentation to add placeholder attribute to `pl-string-input` (Mariana Silva).
 
+  * Change display location of access rules to be at the top of the `instructorAssessment` page (James Balamuta).
 
 * __3.0.0__ - 2018-05-23
 

--- a/pages/instructorAssessment/instructorAssessment.ejs
+++ b/pages/instructorAssessment/instructorAssessment.ejs
@@ -26,6 +26,48 @@
 
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">
+          <%= assessment_set.name %> <%= assessment.number %>: Access rules
+        </div>
+
+        <div class="table-responsive">
+          <table class="table table-sm table-hover">
+            <thead>
+              <tr>
+                <th>Mode</th>
+                <th>Role</th>
+                <th>UIDs</th>
+                <th>Start date</th>
+                <th>End date</th>
+                <th>Credit</th>
+                <th>Time limit</th>
+                <th>Password</th>
+                <th>CBTF exam</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% access_rules.forEach(function(access_rule) { %>
+              <tr>
+                <td><%= access_rule.mode %></td>
+                <td><%= access_rule.role %></td>
+                <td><%= access_rule.uids %></td>
+                <td><%= access_rule.start_date %></td>
+                <td><%= access_rule.end_date %></td>
+                <td><%= access_rule.credit %></td>
+                <td><%= access_rule.time_limit %></td>
+                <td><%= access_rule.password %></td>
+                <td><%- access_rule.exam %></td>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ###################################################################### -->
+      <!-- ###################################################################### -->
+
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
           <%= assessment_set.name %> <%= assessment.number %>: Questions
         </div>
 
@@ -134,48 +176,6 @@
                   <% }); %>
                   <% } %>
                 </td>
-              </tr>
-              <% }); %>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <!-- ###################################################################### -->
-      <!-- ###################################################################### -->
-
-      <div class="card mb-4">
-        <div class="card-header bg-primary text-white">
-          <%= assessment_set.name %> <%= assessment.number %>: Access rules
-        </div>
-
-        <div class="table-responsive">
-          <table class="table table-sm table-hover">
-            <thead>
-              <tr>
-                <th>Mode</th>
-                <th>Role</th>
-                <th>UIDs</th>
-                <th>Start date</th>
-                <th>End date</th>
-                <th>Credit</th>
-                <th>Time limit</th>
-                <th>Password</th>
-                <th>CBTF exam</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% access_rules.forEach(function(access_rule) { %>
-              <tr>
-                <td><%= access_rule.mode %></td>
-                <td><%= access_rule.role %></td>
-                <td><%= access_rule.uids %></td>
-                <td><%= access_rule.start_date %></td>
-                <td><%= access_rule.end_date %></td>
-                <td><%= access_rule.credit %></td>
-                <td><%= access_rule.time_limit %></td>
-                <td><%= access_rule.password %></td>
-                <td><%- access_rule.exam %></td>
               </tr>
               <% }); %>
             </tbody>


### PR DESCRIPTION
This PR reorders how the instructorAssessment page displays an assessment's access rules.  In particular, it places the access rule portion at the top of the page before listing out the questions. The hope here is to emphasize when the assessment is open and when it is closed.

c.f.

### New

![pl-ac-above](https://user-images.githubusercontent.com/833642/46022834-fad37180-c0a8-11e8-8c25-cc7a2e7ebb7d.png)

### Old 

![pl-ac-underneath](https://user-images.githubusercontent.com/833642/46022835-fad37180-c0a8-11e8-8d2c-d3ffd3116b44.png)

