### PR TITLE
Fix render bug with real-time external grader results

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -97,6 +97,8 @@
 
   * Fix `pl-matrix-component-input` element to adjust height (Mariana Silva).
 
+  * Fix real-time external grading results in exam mode by disabling exam-specific message in the question score panel (Nathan Walters).
+
   * Change `pl-code` to display code from a source file OR inline text (Mariana Silva).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).

--- a/pages/partials/questionScorePanel.ejs
+++ b/pages/partials/questionScorePanel.ejs
@@ -44,7 +44,7 @@
           itself. Do not use this form if you just don't know how to
           answer the question.
         </p>
-        <% if (authz_data.mode == 'Exam') { %>
+        <% if (/*authz_data.mode == 'Exam'*/ false) { %>
         <p class="small">
           Ask a proctor if you think there is a problem with your computer.
         </p>


### PR DESCRIPTION
We don't have authz data when rendering the score panel async for real-time results. A temp fix is to just disable the exam-specific message.