### PR TITLE
scroll bar as auto

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,6 +45,8 @@
 
   * Add Pillow to the `centos7-python` container (Dave Mussulman).
 
+  * Add scroll bar in `pl-matrix-component-input` (Mariana Silva)
+
   * Fix `pl-file-editor` to allow display empty text editor and add option to include text from source file (Mariana Silva).
 
   * Fix HTML rendering by reverting `cheerio.js` to `0.22.0` (Matt West).

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.css
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.css
@@ -3,6 +3,10 @@
     max-width: 100%;
 }
 
+.pl-matrix-component-span-fullwidth {
+    max-width: calc(100% - 15px)
+}
+
 [id^=pl-matrix-component-input] .close-left {
   border-left: 3px solid black;
   border-top: 3px solid black;
@@ -26,8 +30,6 @@
 
 [id^=pl-matrix-component-input] .form-control {
   height: auto;
-}
-
-[id^=pl-matrix-component-input] .scrollbar {
-  overflow-x:auto;
+  overflow-x: auto;
+  overflow-y: auto;
 }

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.css
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.css
@@ -27,3 +27,7 @@
 [id^=pl-matrix-component-input] .form-control {
   height: auto;
 }
+
+[id^=pl-matrix-component-input] .scrollbar {
+  overflow-x:auto;
+}

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
@@ -8,13 +8,12 @@
         });
     });
 </script>
-<span class="form-inline d-inline-block ml-2">
+<span class="form-inline d-inline-block ml-2 pl-matrix-component-span-fullwidth">
     <div id="pl-matrix-component-input-{{uuid}}" class="input-group">
         <span class="input-group-prepend">
             {{#label}}<label class="input-group-text" id="basic-addon2">{{label}}</label>{{/label}}
         </span>
-        <!--<div class="d-inline-flex form-control" >-->
-        <div class="scrollbar form-control" >
+        <div class="form-control" >
             {{{input_array}}}
         </div>
         <div class="input-group-append">

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
@@ -13,7 +13,8 @@
         <span class="input-group-prepend">
             {{#label}}<label class="input-group-text" id="basic-addon2">{{label}}</label>{{/label}}
         </span>
-        <div class="d-inline-flex form-control">
+        <!--<div class="d-inline-flex form-control" >-->
+        <div class="scrollbar form-control" >
             {{{input_array}}}
         </div>
         <div class="input-group-append">

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -228,7 +228,7 @@ def parse(element_html, data):
                 data['format_errors'][each_entry_name] = '(Invalid blank entry)'
                 invalid_format = True
             else:
-                a_sub_parsed = pl.string_to_number(a_sub)
+                a_sub_parsed = pl.string_to_number(a_sub, allow_complex=False)
                 if a_sub_parsed is None:
                     data['submitted_answers'][each_entry_name] = None
                     data['format_errors'][each_entry_name] = '(Invalid format)'

--- a/exampleCourse/questions/examplesMatrixInput/question.html
+++ b/exampleCourse/questions/examplesMatrixInput/question.html
@@ -48,7 +48,7 @@
     </pl-matrix-component-input>
 </div>
 
-<div>
+<div class="mb-2">
     <h5>
     3.
     </h5>
@@ -61,5 +61,18 @@
     </pl-question-panel>
 
     <pl-matrix-component-input answers-name="out2" label="${\bf A} = $" comparison="sigfig" digits="{{params.sf}}" allow-partial-credit="true" allow-feedback="false">
+    </pl-matrix-component-input>
+</div>
+
+<div class="mb-2">
+    <h5>
+        4.
+    </h5>
+    <pl-question-panel>
+        <p>
+            This is a very long vector, it should be able to scroll.
+        </p>
+    </pl-question-panel>
+     <pl-matrix-component-input answers-name="out4" label="${\bf x} = $" comparison="relabs" atol="0" rtol="1e-6" allow-partial-credit="true">
     </pl-matrix-component-input>
 </div>

--- a/exampleCourse/questions/examplesMatrixInput/server.py
+++ b/exampleCourse/questions/examplesMatrixInput/server.py
@@ -11,6 +11,7 @@ def generate(data):
     sf = 2
     B = np.round(A,sf)
     x =  np.array([[1,2,3,4]])
+    long_matrix = np.array([[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]])
 
     data["params"]["sf"] = sf
     data["params"]["in"] = pl.to_json(B)
@@ -19,5 +20,6 @@ def generate(data):
     data["correct_answers"]["out1"] = pl.to_json(B)
     data["correct_answers"]["out2"] = pl.to_json(B)
     data["correct_answers"]["out3"] = pl.to_json(x)
+    data["correct_answers"]["out4"] = pl.to_json(long_matrix)
 
     return data


### PR DESCRIPTION
This adds a scroll bar to the matrix part of the element (not including the label and hint box), and adjusts the size of the entire element.

Added one question to `examplesMatrixInput` that shows a very long row-vector.

This PR also fixes a previous bug (this element does not considering complex numbers, based on the initial implementation, but entering `i` or `j` would break the question, instead of throwing an invalid message.

