### PR TITLE
Fix admin overview page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -109,6 +109,8 @@
 
   * Fix `triangularDistributedLoad` in `PrairieDraw.js` (Mariana Silva).
 
+  * Fix unexpected token error in administrator overview page (Tim Bretl).
+
   * Change `pl-code` to display code from a source file OR inline text (Mariana Silva).
 
   * Change element names to use dashes instead of underscores (Nathan Walters).

--- a/pages/administratorOverview/administratorOverview.ejs
+++ b/pages/administratorOverview/administratorOverview.ejs
@@ -284,12 +284,11 @@
               invalidateButton.show();
               confirmInvalidateContainer.hide();
             });
-            var questionCacheHitRate = <%= question_render_cache_stats.question_cache_hit_rate %>;
-            var panelCacheHitRate = <%= question_render_cache_stats.panel_cache_hit_rate %>;
+            var questionCacheHitRate = <%= question_render_cache_stats.question_cache_hit_rate ? question_render_cache_stats.question_cache_hit_rate : 0 %>;
+            var panelCacheHitRate = <%= question_render_cache_stats.panel_cache_hit_rate ? question_render_cache_stats.panel_cache_hit_rate : 0 %>;
             // This draws the percentage in the middle of the pie
             Chart.pluginService.register({
               beforeDraw: function(chart) {
-                console.log(chart);
                 var width = chart.chart.width,
                 height = chart.chart.height,
                 ctx = chart.chart.ctx;
@@ -297,7 +296,7 @@
                 var fontSize = (height / 160).toFixed(2);
                 ctx.font = fontSize + "em sans-serif";
                 ctx.textBaseline = "middle";
-                var text = Number(chart.config.data.datasets[0].data[0]).toFixed(2) + '%'
+                var text = Number(chart.config.data.datasets[0].data[0]).toFixed(2) + '%',
                 textX = Math.round((width - ctx.measureText(text).width) / 2),
                 textY = height / 2;
                 ctx.fillText(text, textX, textY);


### PR DESCRIPTION
The administrative overview page was throwing an `Unexpected token ;` error when run natively, because the variables `question_render_cache_stats.question_cache_hit_rate` and `question_render_cache_stats.panel_cache_hit_rate` (included by EJS templating) were undefined. The value `0` is now used when these variables are undefined.

Two small typos were also corrected (missing `;`, spurious `console.log`).