### PR TITLE
Ensure images are displayed in a responsive manner (close #1322)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 * __next version__ - XXXX-XX-XX
 
   * Fix load-reporting close during unit tests (Matt West).
+  
+  * Fix responsiveness and centering of images displayed with `pl-figure` (James Balamuta, h/t Dave Mussulman).
 
 * __3.1.0__ - 2018-10-08
 
@@ -119,7 +121,7 @@
 
   * Fix unexpected token error in administrator overview page (Tim Bretl).
 
-  * Fix `pl-matrix-component-input` rendering bug on Safari (Nicolas Nytko)
+  * Fix `pl-matrix-component-input` rendering bug on Safari (Nicolas Nytko).
 
   * Change `pl-code` to display code from a source file OR inline text (Mariana Silva).
 

--- a/elements/pl-figure/pl-figure.mustache
+++ b/elements/pl-figure/pl-figure.mustache
@@ -1,3 +1,3 @@
 <div class="container-fluid">
-    <img src="{{src}}" {{#width}}width="{{width}}"{{/width}} class="img-responsive center-block" />
+    <img src="{{src}}" {{#width}}width="{{width}}"{{/width}} class="img-fluid mx-auto d-block" />
 </div>


### PR DESCRIPTION
Updates the Bootstrap 3 classes on the `img` tag generated by `pl-figure` to Bootstrap 4 classes of `img-fluid` for responsiveness and `mx-auto d-block` for centering. 

c.f. 

- fluid images: https://getbootstrap.com/docs/4.1/content/images/ 
- centering approach (`text-center` vs. `mx-auto d-block`): https://stackoverflow.com/a/43227280/1345455

### Before:
<img width="791" alt="screen shot 2018-10-11 at 9 29 34 pm" src="https://user-images.githubusercontent.com/833642/46845116-a1a15880-cd9f-11e8-9f34-1e7648bd03eb.png">

### After:

<img width="791" alt="screen shot 2018-10-11 at 9 30 48 pm" src="https://user-images.githubusercontent.com/833642/46845115-a1a15880-cd9f-11e8-8617-ad9553a2a8c7.png">
