### PR TITLE
Source Ace editor from npm

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@
 
   * Add read-only API for instructors to access assessment data (Nathan Walters).
 
+  * Change Ace editor to use source files from npm (Nathan Walters).
+
   * Fix load-reporting close during unit tests (Matt West).
 
   * Fix responsiveness and centering of images displayed with `pl-figure` (James Balamuta, h/t Dave Mussulman).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@
 
   * Add read-only API for instructors to access assessment data (Nathan Walters).
 
-  * Change Ace editor to use source files from npm (Nathan Walters).
+  * Change Ace editor to use source files from npm and upgrade to 1.4.1 from 1.2.8 (Nathan Walters).
 
   * Fix load-reporting close during unit tests (Matt West).
 

--- a/elements/pl-file-editor/info.json
+++ b/elements/pl-file-editor/info.json
@@ -1,8 +1,8 @@
 {
     "controller": "pl-file-editor.py",
     "dependencies": {
-        "coreScripts": [
-            "ace/ace.js"
+        "nodeModulesScripts": [
+            "ace-builds/src-min-noconflict/ace.js"
         ],
         "elementScripts": [
             "pl-file-editor.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "PrairieLearn",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -49,7 +49,7 @@
         },
         "acorn-jsx": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
@@ -58,7 +58,7 @@
             "dependencies": {
                 "acorn": {
                     "version": "3.3.0",
-                    "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
                     "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
                     "dev": true
                 }
@@ -351,7 +351,7 @@
         },
         "axios": {
             "version": "0.18.0",
-            "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
             "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
             "requires": {
                 "follow-redirects": "^1.3.0",
@@ -383,7 +383,7 @@
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -396,7 +396,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
@@ -787,7 +787,7 @@
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 },
                 "lru-cache": {
@@ -1575,7 +1575,7 @@
         },
         "duplexer": {
             "version": "0.1.1",
-            "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
         "duplexer3": {
@@ -1728,7 +1728,7 @@
         },
         "eslint": {
             "version": "4.19.1",
-            "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
@@ -1863,7 +1863,7 @@
         },
         "events": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "execa": {
@@ -1927,7 +1927,7 @@
         },
         "express": {
             "version": "4.16.3",
-            "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
             "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
             "requires": {
                 "accepts": "~1.3.5",
@@ -2074,7 +2074,7 @@
         },
         "external-editor": {
             "version": "2.2.0",
-            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
@@ -2210,7 +2210,7 @@
         },
         "finalhandler": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
             "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
             "requires": {
                 "debug": "2.6.9",
@@ -2841,7 +2841,7 @@
         },
         "gcp-metadata": {
             "version": "0.6.3",
-            "resolved": "http://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
             "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
             "requires": {
                 "axios": "^0.18.0",
@@ -2878,7 +2878,7 @@
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
@@ -3007,7 +3007,7 @@
         },
         "got": {
             "version": "6.7.1",
-            "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "requires": {
                 "create-error-class": "^3.0.0",
@@ -3189,7 +3189,7 @@
         },
         "http-errors": {
             "version": "1.6.3",
-            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "requires": {
                 "depd": "~1.1.2",
@@ -3451,7 +3451,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-path-cwd": {
@@ -4000,7 +4000,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
@@ -4048,7 +4048,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "requires": {
                 "minimist": "0.0.8"
@@ -4198,7 +4198,7 @@
         },
         "ncp": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "optional": true
         },
@@ -7174,12 +7174,12 @@
             "dependencies": {
                 "async": {
                     "version": "1.5.2",
-                    "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                 },
                 "passport": {
                     "version": "0.3.2",
-                    "resolved": "http://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+                    "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
                     "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
                     "requires": {
                         "passport-strategy": "1.x.x",
@@ -7236,7 +7236,7 @@
         },
         "pause-stream": {
             "version": "0.0.11",
-            "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
                 "through": "~2.3"
@@ -7695,7 +7695,7 @@
         },
         "rimraf": {
             "version": "2.4.5",
-            "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
             "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
             "requires": {
                 "glob": "^6.0.1"
@@ -7770,12 +7770,12 @@
         },
         "sax": {
             "version": "1.2.1",
-            "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "search-string": {
             "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/search-string/-/search-string-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/search-string/-/search-string-3.1.0.tgz",
             "integrity": "sha512-yY3b0VlaXfKi2B//34PN5AFF+GQvwme6Kj4FjggmoSBOa7B8AHfS1nYZbsrYu+IyGeYOAkF8ywL9LN9dkrOo6g=="
         },
         "select": {
@@ -8432,7 +8432,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "timed-out": {
@@ -8882,7 +8882,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "requires": {
                 "string-width": "^1.0.1",
@@ -8914,7 +8914,7 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
                         "ansi-regex": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,11 @@
                 "negotiator": "0.6.1"
             }
         },
+        "ace-builds": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.1.tgz",
+            "integrity": "sha512-ulsfTOi/oAXBIt9hYlK4asyFZYsFOOUAbwBZidbjWWJycRX4LtwIithMyndcnoQ4PavkZ0iGJ+c9nqHNiYbubA=="
+        },
         "acorn": {
             "version": "5.7.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -1186,7 +1191,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                     "dev": true
                 }
@@ -1478,7 +1483,7 @@
                 },
                 "readable-stream": {
                     "version": "1.0.34",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -7474,7 +7479,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
             }
@@ -8865,7 +8870,7 @@
             "dependencies": {
                 "async": {
                     "version": "1.0.0",
-                    "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
                     "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
                 },
                 "colors": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "private": true,
     "dependencies": {
         "@prairielearn/prairielib": "^1.5.1",
+        "ace-builds": "^1.4.1",
         "adm-zip": "^0.4.11",
         "archiver": "^2.1.1",
         "async": "^2.6.1",


### PR DESCRIPTION
This PR changes `<pl-file-editor>` to use a version of the Ace editor from npm. This allows us to keep the source up to date. Using the latest source also fixes some bugs that Ace had in mobile browsers, such as shift and backspace behaving weirdly.

I'm leaving the ace editor in `public/javascripts/ace` for now, as I'm not sure if any courses still rely on it. We can probably check request logs a few months after this is deployed to check if anyone is still accessing them and strip them out of that directory if so.