### PR TITLE
Grade all button

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,10 @@
 
   * Add read-only API for instructors to access assessment data (Nathan Walters).
 
+  * Add ability to "Grade all saved answers" on exam assessment overview (Dave Mussulman).
+
+  * Change "Save & Grade" button text and alignment (Dave Mussulman).
+
   * Fix load-reporting close during unit tests (Matt West).
 
   * Fix responsiveness and centering of images displayed with `pl-figure` (James Balamuta, h/t Dave Mussulman).

--- a/pages/partials/questionFooter.ejs
+++ b/pages/partials/questionFooter.ejs
@@ -7,7 +7,7 @@
       <div class="col-sm-6">
           <% if (showGradeButton) { %>
               <% if (question_context == 'student_homework') { %>
-                  <button class="btn btn-primary question-grade disable-on-submit" name="__action" value="grade">Grade
+                  <button class="btn btn-primary question-grade disable-on-submit" name="__action" value="grade">Save & Grade
                       <% if ((assessment_question.tries_per_variant - variant.num_tries) > 1) { %>
                           <span class="badge">
                               <%= String(assessment_question.tries_per_variant - variant.num_tries) %>
@@ -16,16 +16,16 @@
                       <% } %>
                   </button>
               <% } else { %>
-                  <button class="btn btn-primary question-grade disable-on-submit" name="__action" value="grade">Grade</button>
+                  <button class="btn btn-primary question-grade disable-on-submit" name="__action" value="grade">Save & Grade</button>
               <% } %>
           <% } %>
           <% if (showManualGradingMsg) { %>
-          This question will be manually graded
+          This question will be manually graded.
           <% } %>
+          <% if (showSaveButton) { %><button class="btn btn-info question-save disable-on-submit" name="__action" value="save">Save only</button><% } %>
       </div>
       <div class="col-sm-6">
         <span class="float-right">
-          <% if (showSaveButton) { %><button class="btn btn-info question-save disable-on-submit" name="__action" value="save">Save</button><% } %>
           <input type="hidden" name="__variant_id" value="<%= variant.id %>">
           <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
           <% if (showNewVariantButton) { %><a href="<%= newVariantUrl %>" class="btn btn-primary disable-on-click">New variant</a><% } %>
@@ -45,7 +45,7 @@
           <div class="col-sm-6">
               <% if (showGradeButton) { %>
                   <% if (question_context == 'student_homework') { %>
-                      <button class="btn btn-primary question-grade disable-on-submit">Grade
+                      <button class="btn btn-primary question-grade disable-on-submit">Save & Grade
                           <% if ((assessment_question.tries_per_variant - variant.num_tries) > 1) { %>
                               <span class="badge">
                                   <%= String(assessment_question.tries_per_variant - variant.num_tries) %>
@@ -54,16 +54,16 @@
                           <% } %>
                       </button>
                   <% } else { %>
-                      <button class="btn btn-primary question-grade disable-on-submit">Grade</button>
+                      <button class="btn btn-primary question-grade disable-on-submit">Save & Grade</button>
                   <% } %>
               <% } %>
               <% if (showManualGradingMsg) { %>
-              This question will be manually graded
+              This question will be manually graded.
               <% } %>
+              <% if (showSaveButton) { %><button class="btn btn-info question-save disable-on-submit">Save only</button><% } %>
           </div>
         <div class="col-sm-6">
           <span class="float-right">
-            <% if (showSaveButton) { %><button class="btn btn-info question-save disable-on-submit">Save</button><% } %>
             <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
             <input type="hidden" name="postData" class="postData">
             <input type="hidden" name="__action" class="__action">

--- a/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs
+++ b/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs
@@ -74,11 +74,18 @@
           <div class="col-md-3 col-sm-6">
             <%- include('../partials/scorebar', {score: assessment_instance.score_perc}) %>
           </div>
-          <div class="col-md-6 col-sm-12 text-right">
+          <div class="col-md-6 col-sm-12">
               <% if (assessment_instance.open) { %>
-              Assessment is <strong>open</strong> and you can answer questions
+                  Assessment is <strong>open</strong> and you can answer questions.
+                  <p>
+                  Available credit: <%= authz_result.credit_date_string %>
+                  <%- include('../partials/studentAccessRulesPopover', {
+                    accessRules: authz_result.access_rules,
+                    assessmentSetName: assessment_set.name,
+                    assessmentNumber: assessment.number,
+                  }); %>
               <% } else { %>
-              Assessment is <strong>closed</strong> and you cannot answer questions
+                  Assessment is <strong>closed</strong> and you cannot answer questions.
               <% } %>
           </div>
         </div>
@@ -164,21 +171,26 @@
       </table>
 
       <div class="card-footer">
-        Submit your answer to each question with the <strong>Grade</strong> button on the question page.
-        Look at <strong>Best submission</strong> to confirm that each question has been graded.
-
+        <ul>
+        <li>Submit your answer to each question with the <strong>Grade</strong> or <strong>Save</strong> buttons on the question page.</li>
+        <li>
+          <form name="grade-form" method="POST" class="form-inline">
+              <input type="hidden" name="__action" value="grade">
+              <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+              If you saved answers, you can grade them all at once:&nbsp;
+              <button type="submit" class="btn btn-primary">Grade all saved answers</button>
+          </form>
+        </li>
+        <li>Look at <strong>Best submission</strong> to confirm that each question has been graded.</li>
         <% if (authz_result.mode == 'SEB' || authz_result.password != null) { %>
-        <hr>
-        <p class="text-right">
-          After you have answered all the questions completely, click here:
-        </p>
-        <p class="text-right">
-          <button class="btn btn-danger" data-toggle="modal" data-target="#confirmFinishModal">Finish assessment</button>
-        </p>
-        <% } else { %>
-            When you are done, please logout and close your browser; there is no need to do anything else.
-        <% } %>
 
+          <li>After you have answered all the questions completely, click here:
+              <button class="btn btn-danger" data-toggle="modal" data-target="#confirmFinishModal">Finish assessment</button>
+          </li>
+        <% } else { %>
+            <li>When you are done, please logout and close your browser; there is no need to do anything else.</li>
+        <% } %>
+        </ul>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Change question button text to "Save & Grade" and "Save only" to be clearer on what they do.
- Move buttons closer to each other so one or the other isn't ignored.

![screen shot 2018-10-16 at 9 15 29 am](https://user-images.githubusercontent.com/10765199/47022904-19ff7500-d124-11e8-8405-1340d4e8e18f.png)

- Adds "Grade all saved answers" button to exam assessment overview (closes #1087).

![screen shot 2018-10-16 at 9 16 15 am](https://user-images.githubusercontent.com/10765199/47022985-474c2300-d124-11e8-8b5b-fdb12b05ffbd.png)

Telling the student to save all answers and grade at the end addresses #1128.