### PR TITLE
Fix issues link on instructor question page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,6 +44,8 @@
   * Fix exclude file list for code coverage (Matt West).
 
   * Fix `dump_filter.sh` to keep `authn_users` in all tables (Matt West).
+  
+  * Fix issues link on instructor question page (Nathan Walters).
 
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 

--- a/pages/instructorQuestion/instructorQuestion.ejs
+++ b/pages/instructorQuestion/instructorQuestion.ejs
@@ -53,7 +53,7 @@
               </tr>
               <tr>
                 <th>Issues</th>
-                <td><%- include('../partials/issueBadge', {count: open_issue_count}); %></td>
+                <td><%- include('../partials/issueBadge', {count: open_issue_count, issueQid: question.qid}); %></td>
               </tr>
               <tr>
                 <th>Assessments</th>


### PR DESCRIPTION
The issue link didn't include the QID; now it does 🎉 