### PR TITLE
[WIP] Autosave + restore with localStorage

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,8 @@
   * Add documentation on common development errors to FAQ. (James Balamuta).
 
   * Add R Data Packages and SQLite connection to centos-plbase. (James Balamuta).
+
+  * Add `window.localStorage` autosave/restore to `pl-file-editor` (Nathan Walters).
   
   * Change "Save & Grade" button text and alignment (Dave Mussulman).
 

--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -34,14 +34,17 @@ window.PLFileEditor = function(uuid, options) {
     var currentContents = options.currentContents || '';
 
     // We may need to restore from local storage
+    // To avoid polluting local storage over long periods of time, we'll
+    // wipe storage on page load if the contents of local storage match
+    // the current contents on the page
+    var wipeLocalStorageAfterLoad = false;
     if (window.localStorage) {
         // We have local storage support!
         var savedData = window.localStorage.getItem(this.localStorageKey);
         if (savedData !== null) {
             // Check if the contents are actually different
             if (savedData === currentContents) {
-                // They're the same; wipe local storage for now
-                window.localStorage.removeItem(this.localStorageKey);
+                wipeLocalStorageAfterLoad = true;
             } else {
                 // Restore contents
                 currentContents = savedData;
@@ -50,6 +53,10 @@ window.PLFileEditor = function(uuid, options) {
     }
 
     this.setEditorContents(this.b64DecodeUnicode(currentContents));
+
+    if (wipeLocalStorageAfterLoad) {
+        window.localStorage.removeItem(this.localStorageKey);
+    }
 
     this.initRestoreOriginalButton();
 };

--- a/elements/pl-file-editor/pl-file-editor.mustache
+++ b/elements/pl-file-editor/pl-file-editor.mustache
@@ -6,6 +6,8 @@ $(function() {
     new window.PLFileEditor(UUID, {
         originalContents: "{{original_file_contents}}",
         currentContents: "{{current_file_contents}}",
+        questionId: "{{question_id}}",
+        fileName: "{{file_name}}",
         aceMode: {{#ace_mode}}"{{ace_mode}}"{{/ace_mode}}{{^ace_mode}}undefined{{/ace_mode}},
         aceTheme: {{#ace_theme}}"{{ace_theme}}"{{/ace_theme}}{{^ace_theme}}undefined{{/ace_theme}}
     });

--- a/elements/pl-file-editor/pl-file-editor.py
+++ b/elements/pl-file-editor/pl-file-editor.py
@@ -51,7 +51,9 @@ def render(element_html, data):
         'ace_mode': ace_mode,
         'ace_theme': ace_theme,
         'editor_config_function': editor_config_function,
-        'uuid': uuid
+        # TODO use something better. probably variant ID.
+        'question_id': data['options']['client_files_question_dynamic_url'],
+        'uuid': uuid,
     }
 
     if source_file_name is not None:


### PR DESCRIPTION
So far, just a proof of concept illustrating the use of `window.localStorage` to autosave + restore files. Some things to consider before actually merging:

* Should restore be automatic, or should it prompt first?
* We should probably use a better unique question identifier than `client_files_question_dynamic_url`. It is currently unique per variant, but we probably want the variant ID itself. This required modifying the element/question renderer.

cc @pranaygp

Fixes #1371