### PR TITLE
Add ocaml/opam2:centos based image

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,8 @@
 
   * Add R package caching and parallel installation to centos-plbase. (James Balamuta).
 
+  * Add ocaml/opam2 based Docker image (John Lee & Dave Mussulman).
+
   * Change "Save & Grade" button text and alignment (Dave Mussulman).
 
   * Change Ace editor to use source files from npm and upgrade to 1.4.1 from 1.2.8 (Nathan Walters).

--- a/environments/ocaml-opam2-centos/Dockerfile
+++ b/environments/ocaml-opam2-centos/Dockerfile
@@ -1,0 +1,10 @@
+FROM ocaml/opam2:centos
+USER root
+
+ENV PYTHONIOENCODING=UTF-8
+
+RUN yum -y update \
+    && yum install -y https://centos7.iuscommunity.org/ius-release.rpm \
+    && yum install -y python36u python36u-pip \
+    && opam install aez \
+    && eval $(opam env)


### PR DESCRIPTION
An alternative to adding opam to our centos7-based image, base our grader modifications off the ocaml/opam2:centos image (that already has the ocaml needs installed)