### PR TITLE
Upgrade sympy to version 1.3

### DIFF
--- a/environments/centos7-python/requirements.txt
+++ b/environments/centos7-python/requirements.txt
@@ -3,5 +3,5 @@ networkx==2.1
 numpy==1.14.0
 pandas==0.22.0
 scipy==1.0.0
-sympy==1.1.1
+sympy==1.3
 Pillow==5.2.0


### PR DESCRIPTION
I'm writing some questions for a differential equations course that benefit from the ics functionality introduced in the dsolve() module.