### PR TITLE
Fix escaping of contents of pl-code block

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -85,6 +85,8 @@
 
   * Fix Python linter errors in (Matt West).
 
+  * Fix `pl-code` HTML escaping (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/elements/pl-code/pl-code.mustache
+++ b/elements/pl-code/pl-code.mustache
@@ -9,4 +9,4 @@ onselectstart="return false;"
 onmousedown="return false;"
 oncontextmenu="return false;"
 {{/prevent_select}}
->{{code}}</code></pre>
+>{{{code}}}</code></pre>


### PR DESCRIPTION
#1382 accidentally introduced a regression in `pl-code` where HTML entities were being escaped twice. This PR changes the `pl-code` template to use the triple-mustache so that the code is not re-escaped.