### PR TITLE
Fix legacy renderer self closing tags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -87,6 +87,8 @@
 
   * Fix `pl-code` HTML escaping (Nathan Walters).
 
+  * Fix legacy question renderer by explicitly using `htmlparser2` for cheerio (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,7 +1154,7 @@
         },
         "color-convert": {
             "version": "0.5.3",
-            "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
             "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
         },
         "color-name": {
@@ -2010,7 +2010,7 @@
         },
         "events": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "execa": {
@@ -3113,7 +3113,7 @@
         },
         "got": {
             "version": "6.7.1",
-            "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "requires": {
                 "create-error-class": "^3.0.0",
@@ -3477,7 +3477,7 @@
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
-            "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "requires": {
                 "kind-of": "^3.0.2"
@@ -3521,7 +3521,7 @@
         },
         "is-data-descriptor": {
             "version": "0.1.4",
-            "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "requires": {
                 "kind-of": "^3.0.2"
@@ -3628,7 +3628,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-path-inside": {
@@ -6209,7 +6209,7 @@
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 }
             }
@@ -6504,7 +6504,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "requires": {
                 "ret": "~0.1.10"
@@ -6517,7 +6517,7 @@
         },
         "sax": {
             "version": "1.2.1",
-            "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "search-string": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "fs-extra": "^7.0.1",
         "googleapis": "^36.0.0",
         "handlebars": "^4.0.11",
+        "htmlparser2": "^3.10.0",
         "http-status": "^1.3.1",
         "is-my-json-valid": "^2.17.2",
         "javascript-natural-sort": "^0.7.1",

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -5,6 +5,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const mustache = require('mustache');
 const cheerio = require('cheerio');
+const htmlparser2 = require('htmlparser2');
 const hash = require('crypto').createHash;
 const parse5 = require('parse5');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
@@ -286,9 +287,8 @@ module.exports = {
             if (ERR(err, callback)) return;
             let $;
             try {
-                $ = cheerio.load(html, {
-                    recognizeSelfClosing: true,
-                });
+                const dom = htmlparser2.parseDOM(html, { recognizeSelfClosing: true });
+                $ = cheerio.load(dom);
             } catch (e) {
                 err = e;
             }


### PR DESCRIPTION
The RC version of `cheerio` that we updated to uses `parse5` by defualt, which breaks our handling of self-closing tags. This PR follows the advice in https://github.com/cheeriojs/cheerio/issues/1261#issuecomment-450125112 and explicitly uses `htmlparser2` (like we did before) to parse questions.