### PR TITLE
Fix "Edit on GitHub" links in mkdocs.yml

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 
 * __next version__ - XXXX-XX-XX
 
+  * Fixing GitHub links in mkdocs.yml (Eric Huber).
+
   * Fix typo in documentation (Eric Huber).
 
   * Add Learning Tools Interoperability LTI 1.1.1 tool provider functionality (Dave Mussulman).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,8 @@ site_url: https://github.com/PrairieLearn/PrairieLearn
 repo_url: https://github.com/PrairieLearn/PrairieLearn
 theme: readthedocs
 docs_dir: doc
+# Fix "Edit on GitHub" link: (defaults to edit/master/docs/, note the s)
+edit_uri: blob/master/doc/
 
 pages:
 - Main: 'index.md'


### PR DESCRIPTION
Have to add a line to mkdocs.yml to make the "Edit on GitHub" links point to real pages.