### PR TITLE
Fix htmlparser2 config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -101,6 +101,8 @@
 
   * Fix docs for `examUuid` usage (Matt West).
 
+  * Fix `htmlparser2` config by copying default options from Cheerio (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -287,7 +287,15 @@ module.exports = {
             if (ERR(err, callback)) return;
             let $;
             try {
-                const dom = htmlparser2.parseDOM(html, { recognizeSelfClosing: true });
+                const dom = htmlparser2.parseDOM(html, {
+                    // Default options from Cheerio
+                    withDomLvl1: true,
+                    normalizeWhitespace: false,
+                    xmlMode: false,
+                    decodeEntities: true,
+                    // Needed to handle self-closing PL elements
+                    recognizeSelfClosing: true,
+                });
                 $ = cheerio.load(dom);
             } catch (e) {
                 err = e;


### PR DESCRIPTION
In #1399, I changed to explicitly using `htmlparser2`, but didn't account for the fact that Cheerio was setting some default options for `htmlparser2` when it was used internally. This caused some problems, specifically because `decodeEntities` wasn't set. This PR copies those default options into our own config for `htmlparser2`.