### PR TITLE
Fix python traceback

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -103,6 +103,8 @@
 
   * Fix `htmlparser2` config by copying default options from Cheerio (Nathan Walters).
 
+  * Fix traceback in console log for python errors (Tim Bretl).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/lib/python-caller-trampoline.py
+++ b/lib/python-caller-trampoline.py
@@ -83,12 +83,17 @@ def worker_loop():
             # change to the desired working directory
             os.chdir(cwd)
 
-            # load the "file" as a module
-            #mod = importlib.import_module('.' + file, os.path.basename(os.getcwd()));
+            # we used to load the "file" as a module:
+            #   mod = importlib.import_module('.' + file, os.path.basename(os.getcwd()));
+            # now, instead, we read the "file" as a string, then compile and exec it:
             mod = {}
-            with open(os.path.join(cwd, file + '.py')) as inf:
-                contents = inf.read()
-                exec(contents, mod)
+            file_path = os.path.join(cwd, file + '.py')
+            with open(file_path) as inf:
+                # use compile to associate filename with code object, so the
+                # filename appears in the traceback if there is an error
+                # (https://stackoverflow.com/a/437857)
+                code = compile(inf.read(), file_path, 'exec')
+                exec(code, mod)
 
             # check whether we have the desired fcn in the module
             if fcn in mod: #hasattr(mod, fcn):


### PR DESCRIPTION
The traceback in the console log generated by a python error (e.g., displayed on the question page or as an issue) had been incorrectly referring to `"<string>"` instead of to the name of the file in which the error was thrown. This has been fixed.

fixes #1408 