### PR TITLE
Fix escape of code under pl-code's file input (close #1420)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,8 @@
 
   * Add Graphviz Yum package and Python library to centos7-plbase and centos7-python (Nicolas Nytko).
 
+  * Add a second example of reading XML code in from a file with `pl-code` (James Balamuta).
+
   * Change "Save & Grade" button text and alignment (Dave Mussulman).
 
   * Change Ace editor to use source files from npm and upgrade to 1.4.1 from 1.2.8 (Nathan Walters).
@@ -108,6 +110,8 @@
   * Fix traceback in console log for python errors (Tim Bretl).
 
   * Fix render cache stats to limit to last day (Matt West).
+
+  * Fix escape sequence of code specified in the `source-file-name` options of `pl-code` (James Balamuta).
 
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -1,5 +1,6 @@
 import prairielearn as pl
 import lxml.html
+from html import escape
 import chevron
 import os
 
@@ -76,6 +77,8 @@ def render(element_html, data):
             code += line
         code = code[:-1]
         f.close()
+        # Automatically escape code in file source (important for: html/xml).
+        code = escape(code)
     else:
         # Strip a single leading newline from the code, if present. This
         # avoids having spurious newlines because of HTML like:

--- a/exampleCourse/questions/examplesAddCodeFromFile/question.html
+++ b/exampleCourse/questions/examplesAddCodeFromFile/question.html
@@ -1,7 +1,7 @@
 
 <pl-question-panel>
 <p>
-    Consider the following code snippet:
+   1. Consider the following code snippet:
 </p>
 
 <pl-code language="python" source-file-name="myCode.py"></pl-code>
@@ -12,8 +12,29 @@
 </pl-question-panel>
 
 <pl-multiple-choice answers-name="D">
-<pl-answer correct=true>float</pl-answer>
-<pl-answer correct=false>int</pl-answer>
+<pl-answer correct="true">float</pl-answer>
+<pl-answer correct="false">int</pl-answer>
 <pl-answer correct="false">boolean</pl-answer>
 <pl-answer correct="false">str</pl-answer>
+</pl-multiple-choice>
+
+<pl-question-panel> <hr /> </pl-question-panel>
+
+<pl-question-panel>
+<p>
+   2. Consider the following data file:
+</p>
+
+<pl-code language="html" source-file-name="sample-cd-data.xml"></pl-code>
+
+<p>
+    What kind of language was the data stored in?
+</p>
+</pl-question-panel>
+
+<pl-multiple-choice answers-name="A">
+<pl-answer correct="true">XML</pl-answer>
+<pl-answer correct="false">HTML</pl-answer>
+<pl-answer correct="false">JSON</pl-answer>
+<pl-answer correct="false">Text</pl-answer>
 </pl-multiple-choice>

--- a/exampleCourse/questions/examplesAddCodeFromFile/sample-cd-data.xml
+++ b/exampleCourse/questions/examplesAddCodeFromFile/sample-cd-data.xml
@@ -1,0 +1,10 @@
+<CATALOG>
+<CD>
+<TITLE>The Dark Side of the Moon</TITLE>
+<ARTIST>Pink Floyd</ARTIST>
+<COUNTRY>USA</COUNTRY>
+<COMPANY>Abbey Road Studios</COMPANY>
+<PRICE>7.50</PRICE>
+<YEAR>1973</YEAR>
+</CD>
+</CATALOG>


### PR DESCRIPTION
Within this PR, we:

- Ensured that code read in via `source-file-name` in `pl-code` was escaped.
- Added an example of reading in an XML data file (note, `xml` is not a language supported.)

Details in #1420. 