### PR TITLE
Remove docker volumes when removing local grader containers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -113,6 +113,8 @@
 
   * Fix escape sequence of code specified in the `source-file-name` options of `pl-code` (James Balamuta).
 
+  * Fix local grader not removing volumes associated with containers (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -147,7 +147,10 @@ class Grader {
                 });
             },
             (container, callback) => {
-                container.remove((err) => {
+                container.remove({
+                    // Remove any volumes associated with this container
+                    v: true,
+                }, (err) => {
                     if (ERR(err, callback)) return;
                     callback(null);
                 });


### PR DESCRIPTION
By default, Docker doesn't remove any volumes created by a given container. Given that we want our containers to be 100% ephemeral, this changes the local grader to remove volumes when it removes containers after grading is complete. We'll need a corresponding PR for PrairieGrader as well.