### PR TITLE
Fix clipboardjs copy button

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -115,6 +115,8 @@
 
   * Fix local grader not removing volumes associated with containers (Nathan Walters).
 
+  * Fix copy button (Tim Bretl).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -115,8 +115,9 @@
 
   * Fix local grader not removing volumes associated with containers (Nathan Walters).
 
-  * Fix copy button (Tim Bretl).
   * Fix Python autograder container build (Matt West).
+
+  * Fix copy button (Tim Bretl).
 
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 

--- a/public/javascripts/PrairieUtil.js
+++ b/public/javascripts/PrairieUtil.js
@@ -8,11 +8,6 @@
      * @param  {[type]} options  Options for this button.
      */
     PrairieUtil.initCopyButton = function(selector, options) {
-        if (!window.Clipboard) {
-            console.warn('Clipboard.js isn\'t present on this page. Make sure to include it!');
-            return;
-        }
-
         options = options || {};
 
         var successMessage = options.success || 'copied to clipboard!';


### PR DESCRIPTION
This PR fixes the copy button that appears in `pl-matrix-input` and `pl-matrix-output` elements.

This button was broken on safari. The reason is that safari does not support the Clipboard API (https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). `PrairieUtil.js` was mistakenly checking for the existence of this Clipboard API when it was trying to check for the existence of `clipboard.js`. There was no consequence on chrome, which does support the Clipboard API.