### PR TITLE
Highlight specific lines of code in pl-code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,8 @@
 
   * Add a second example of reading XML code in from a file with `pl-code` (James Balamuta).
 
+  * Add ability to highlight the background of specific lines of text in `pl-code` (Nathan Walters).
+
   * Change "Save & Grade" button text and alignment (Dave Mussulman).
 
   * Change Ace editor to use source files from npm and upgrade to 1.4.1 from 1.2.8 (Nathan Walters).

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -516,6 +516,8 @@ Attribute | Type | Default | Description
 `no-highlight` | boolean | false | Disable highlighting.
 `source-file-name` | text | - | Name of the source file with existing code to be displayed as a code block (instead of writing the existing code between the element tags as illustrated in the above code snippet).
 `prevent-select` | booelan | false | Applies methods to make the source code more difficult to copy, like preventing selection or right-clicking. Note that the source code is still accessible in the page source, which will always be visible to students.
+`highlight-lines` | text | - | Apply a distinctive background highlight the specified lines of code. Accepts input like `4`, `1-3,5-10`, and `1,2-5,20`.
+`highlight-lines-color` | text | `#b3d7ff` | Specifies the color of highlighted lines of code.
 
 The `language` can be one of the following values.
 

--- a/elements/pl-checkbox/info.json
+++ b/elements/pl-checkbox/info.json
@@ -5,5 +5,4 @@
             "pl-checkbox.css"
         ]
     }
-
 }

--- a/elements/pl-code/info.json
+++ b/elements/pl-code/info.json
@@ -9,6 +9,9 @@
         ],
         "elementScripts": [
             "pl-code.js"
+        ],
+        "elementStyles": [
+            "pl-code.css"
         ]
     }
 }

--- a/elements/pl-code/pl-code.css
+++ b/elements/pl-code/pl-code.css
@@ -1,0 +1,7 @@
+.pl-code-highlighted-line {
+    margin-left: -0.5em;
+    margin-right: -0.5em;
+    padding-right: 0.5em;
+    padding-left: 0.5em;
+    display: block;
+}

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -86,6 +86,9 @@ def highlight_lines_in_code(code, highlight_lines, color):
     result_lines = ''
     for line in code_lines:
         if line_should_be_highlighted(line_number, lines_to_highlight):
+            if len(line.strip()) == 0:
+                # insert line break to prevent collapsing the line
+                line = '<br>'
             result_lines += '<span class="pl-code-highlighted-line" style="background-color: ' + color + ';">' + line + '</span>'
         else:
             result_lines += line + '\n'

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -159,10 +159,6 @@ def render(element_html, data):
         elif len(code) > 0 and (code[0] == '\n' or code[0] == '\r'):
             code = code[1:]
 
-    # code_lines = code.splitlines()
-    # code_lines[0] = '<span style="background-color: #b3d7ff; margin-left: -0.5em; margin-right: -0.5em; padding-right: 0.5em; padding-left: 0.5em; display: block;">' + code_lines[0] + '</span>'
-    # code_lines[1] = '<span style="background-color: #b3d7ff; margin-left: -0.5em; margin-right: -0.5em; padding-right: 0.5em; padding-left: 0.5em; display: block;">' + code_lines[1] + '</span>'
-    # code = '\n'.join(code_lines)
     if highlight_lines is not None:
         code = highlight_lines_in_code(code, highlight_lines, highlight_lines_color)
 

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -49,7 +49,7 @@ def parse_highlight_lines(highlight_lines):
     lines = []
     components = highlight_lines.split(',')
     for component in components:
-        compoenent = component.strip()
+        component = component.strip()
         try:
             line = int(component)
             lines.append((line, line))
@@ -117,7 +117,6 @@ def prepare(element_html, data):
         print(parse_highlight_lines(highlight_lines))
         if parse_highlight_lines(highlight_lines) is None:
             raise Exception('Could not parse highlight-lines attribute; check your syntax')
-
 
 
 def render(element_html, data):

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -114,7 +114,6 @@ def prepare(element_html, data):
 
     highlight_lines = pl.get_string_attrib(element, 'highlight-lines', None)
     if highlight_lines is not None:
-        print(parse_highlight_lines(highlight_lines))
         if parse_highlight_lines(highlight_lines) is None:
             raise Exception('Could not parse highlight-lines attribute; check your syntax')
 

--- a/exampleCourse/questions/codeHighlight/question.html
+++ b/exampleCourse/questions/codeHighlight/question.html
@@ -10,7 +10,7 @@ def square(x):
     return x * x
 </pl-code>
 
-<pl-code language="python" highlight-lines="4-5" highlight-lines-color="red">
+<pl-code language="python" highlight-lines="5-6">
 # Here's a version that highlights specific lines of code
 def foo():
     return 'foo'

--- a/exampleCourse/questions/codeHighlight/question.html
+++ b/exampleCourse/questions/codeHighlight/question.html
@@ -10,6 +10,18 @@ def square(x):
     return x * x
 </pl-code>
 
+<pl-code language="python" highlight-lines="4-5" highlight-lines-color="red">
+# Here's a version that highlights specific lines of code
+def foo():
+    return 'foo'
+
+def square(x):
+    return x * x
+
+def bar(x):
+    return 'bar'
+</pl-code>
+
 <p>How many arguments does the function <code>square()</code> take?</p>
 </pl-question-panel>
 


### PR DESCRIPTION
Lets users specify specific lines of code to apply a background highlight to. Users can also specify the color of the background highlight. Here's what that looks like in the example question:

![image](https://user-images.githubusercontent.com/1476544/53462419-4d72da00-3a09-11e9-8897-82fee1b6fc82.png)
