### PR TITLE
Closes generate_uuid bug #1091 and added verbose flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -151,9 +151,9 @@
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).
 
-  * Fixed a bug in tools/generate_uuid.py that added a uuid for files in the element subdirectory (Pavitra Shadvani).
+  * Fix `tools/generate_uuid.py` to not add UUID in element subdirectory (Pavitra Shadvani).
 
-  * Added a verbose flag to tools/generate_uuid.py to show all the files changed.(Pavitra Shadvani).
+  * Add verbose flag to `tools/generate_uuid.py` to show all the files changed by script (Pavitra Shadvani).
 
 * __3.1.0__ - 2018-10-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,6 +45,8 @@
 
   * Add ability to highlight the background of specific lines of text in `pl-code` (Nathan Walters).
 
+  * Add verbose flag to `tools/generate_uuid.py` to show all the files changed by script (Pavitra Shadvani).
+  
   * Change "Save & Grade" button text and alignment (Dave Mussulman).
 
   * Change Ace editor to use source files from npm and upgrade to 1.4.1 from 1.2.8 (Nathan Walters).
@@ -147,13 +149,11 @@
 
   * Fix editing popovers to work with the new sanitization defaults (Matt West).
 
+  * Fix `tools/generate_uuid.py` to not add UUID in element subdirectory (Pavitra Shadvani).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).
-
-  * Fix `tools/generate_uuid.py` to not add UUID in element subdirectory (Pavitra Shadvani).
-
-  * Add verbose flag to `tools/generate_uuid.py` to show all the files changed by script (Pavitra Shadvani).
 
 * __3.1.0__ - 2018-10-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -151,6 +151,10 @@
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).
 
+  * Fixed a bug in tools/generate_uuid.py that added a uuid for files in the element subdirectory (Pavitra Shadvani).
+
+  * Also added a verbose flag that can be passed as a command line argument to print all the files that were changed by the script to help in debugging (Pavitra Shadvani).
+
 * __3.1.0__ - 2018-10-08
 
   * Add string input element (Mariana Silva).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -153,7 +153,7 @@
 
   * Fixed a bug in tools/generate_uuid.py that added a uuid for files in the element subdirectory (Pavitra Shadvani).
 
-  * Also added a verbose flag that can be passed as a command line argument to print all the files that were changed by the script to help in debugging (Pavitra Shadvani).
+  * Added a verbose flag to tools/generate_uuid.py to show all the files changed.(Pavitra Shadvani).
 
 * __3.1.0__ - 2018-10-08
 

--- a/tools/generate_uuids.py
+++ b/tools/generate_uuids.py
@@ -4,10 +4,12 @@ import sys, os, json, re, uuid, argparse
 
 parser = argparse.ArgumentParser(description="Generate UUIDs for info*.json files that don't already have them.")
 parser.add_argument("directory", help="the directory to search for info*.json files")
+parser.add_argument("-v", "--verbose", action="store_true", help="List all the files for which uuid's were generated")
 parser.add_argument("-n", "--new", action="store_true", help="generate new UUIDs for all files, even if they already have one")
 args = parser.parse_args()
 
-skip_dirs = [".git"]
+# Added elements in the skip directory because elements should not contain a uuid
+skip_dirs = [".git","elements"]
 
 error_list = []
 
@@ -47,6 +49,8 @@ def add_uuid_to_file(filename):
             out_f.write(new_contents)
         os.remove(filename) # needed on Windows
         os.rename(tmp_filename, filename)
+        if  args.verbose:
+            print("Created a UUID for ",filename)
         return 1
     except Exception as error:
         error_list.append(error)

--- a/tools/generate_uuids.py
+++ b/tools/generate_uuids.py
@@ -4,12 +4,12 @@ import sys, os, json, re, uuid, argparse
 
 parser = argparse.ArgumentParser(description="Generate UUIDs for info*.json files that don't already have them.")
 parser.add_argument("directory", help="the directory to search for info*.json files")
-parser.add_argument("-v", "--verbose", action="store_true", help="List all the files for which uuid's were generated")
+parser.add_argument("-v", "--verbose", action="store_true", help="list all the files for which UUIDs were generated")
 parser.add_argument("-n", "--new", action="store_true", help="generate new UUIDs for all files, even if they already have one")
 args = parser.parse_args()
 
-# Added elements in the skip directory because elements should not contain a uuid
-skip_dirs = [".git","elements"]
+
+skip_dirs = [".git", "elements"]
 
 error_list = []
 
@@ -50,7 +50,7 @@ def add_uuid_to_file(filename):
         os.remove(filename) # needed on Windows
         os.rename(tmp_filename, filename)
         if  args.verbose:
-            print("Created a UUID for ",filename)
+            print("Created a UUID for ", filename)
         return 1
     except Exception as error:
         error_list.append(error)


### PR DESCRIPTION
Fixed a bug in tools/generate_uuid.py that added a uuid for files in the element subdirectory. 

Also added a verbose flag that can be passed as a command line argument to print all the files that were changed by the script to help in debugging.