### PR TITLE
Fix gradebook download link for special characters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -157,6 +157,8 @@
 
   * Fix `tools/generate_uuid.py` to not add UUID in element subdirectory (Pavitra Shadvani).
 
+  * Fix gradebook download link for courses with special characters in their names (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -43,28 +43,6 @@ module.exports = {
     },
 
     /**
-     * Construct a filename prefix that is unique for a given assessment.
-     *
-     * @param {Object} assessment - The assessment database object.
-     * @param {Object} assessment_set - The assessment_set database object.
-     * @param {Object} course_instance - The course_instance database object.
-     * @param {Object} course - The course database object.
-     */
-    filenamePrefix(assessment, assessment_set, course_instance, course) {
-        const sanitizeName = function(name) {
-            return name.replace(/[^a-zA-Z0-9]/g, '_');
-        };
-        const prefix = sanitizeName(course.short_name)
-              + '_'
-              + sanitizeName(course_instance.short_name)
-              + '_'
-              + sanitizeName(assessment_set.abbreviation)
-              + sanitizeName(assessment.number)
-              + '_';
-        return prefix;
-    },
-
-    /**
      * Render the "text" property of an assessment.
      *
      * @param {Object} assessment - The assessment to render the text for.

--- a/lib/sanitize-name.js
+++ b/lib/sanitize-name.js
@@ -1,0 +1,69 @@
+module.exports = {
+
+    /**
+     * Replace special characters in string with underscores.
+     *
+     * @param {String} s - The string to sanitize.
+     * @return {String} A sanitized version of s.
+     */
+    sanitizeString(s) {
+        return s.replace(/[^a-zA-Z0-9-]/g, '_');
+    },
+    
+    /**
+     * Construct a sanitized filename prefix for a course.
+     *
+     * @param {Object} course - The course database object.
+     * @return {String} The sanitized prefix string.
+     */
+    courseFilenamePrefix(course) {
+        const prefix = this.sanitizeString(course.short_name)
+              + '_';
+        return prefix;
+    },
+
+    /**
+     * Construct a sanitized filename prefix for a course instance.
+     *
+     * @param {Object} course_instance - The course_instance database object.
+     * @param {Object} course - The course database object.
+     * @return {String} The sanitized prefix string.
+     */
+    courseInstanceFilenamePrefix(course_instance, course) {
+        const prefix = this.courseFilenamePrefix(course)
+              + this.sanitizeString(course_instance.short_name)
+              + '_';
+        return prefix;
+    },
+
+    /**
+     * Construct a sanitized filename prefix for an assessment.
+     *
+     * @param {Object} assessment - The assessment database object.
+     * @param {Object} assessment_set - The assessment_set database object.
+     * @param {Object} course_instance - The course_instance database object.
+     * @param {Object} course - The course database object.
+     * @return {String} The sanitized prefix string.
+     */
+    assessmentFilenamePrefix(assessment, assessment_set, course_instance, course) {
+        const prefix = this.courseInstanceFilenamePrefix(course_instance, course)
+              + this.sanitizeString(assessment_set.abbreviation)
+              + this.sanitizeString(assessment.number)
+              + '_';
+        return prefix;
+    },
+
+    /**
+     * Construct a sanitized filename prefix for a question.
+     *
+     * @param {Object} question - The question database object.
+     * @param {Object} course - The course database object.
+     * @return {String} The sanitized prefix string.
+     */
+    questionFilenamePrefix(question, course) {
+        const prefix = this.courseFilenamePrefix(course)
+              + this.sanitizeString(question.qid)
+              + '_';
+        return prefix;
+    },
+};

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -8,14 +8,14 @@ const archiver = require('archiver');
 
 const csvMaker = require('../../lib/csv-maker');
 const { paginateQuery } = require('../../lib/paginate');
-const assessment = require('../../lib/assessment');
+const sanitizeName = require('../../lib/sanitize-name');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const setFilenames = function(locals) {
-    const prefix = assessment.filenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course);
+    const prefix = sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course);
     locals.scoresCsvFilename = prefix + 'scores.csv';
     locals.scoresAllCsvFilename = prefix + 'scores_all.csv';
     locals.scoresByUsernameCsvFilename = prefix + 'scores_by_username.csv';

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -5,18 +5,14 @@ const express = require('express');
 const router = express.Router();
 const { error, sqlDb, sqlLoader} = require('@prairielearn/prairielib');
 
-const sql = sqlLoader.loadSqlEquiv(__filename);
+const sanitizeName = require('../../lib/sanitize-name');
 const ltiOutcomes = require('../../lib/ltiOutcomes');
 
+const sql = sqlLoader.loadSqlEquiv(__filename);
+
 const logCsvFilename = (locals) => {
-    return locals.course.short_name.replace(/\s+/g, '')
-        + '_'
-        + locals.course_instance.short_name
-        + '_'
-        + locals.assessment_set.abbreviation
-        + locals.assessment.number
-        + '_'
-        + locals.instance_user.uid.replace(/[^a-z0-9]/g, '_')
+    return sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course)
+        + sanitizeName.sanitizeString(locals.instance_user.uid)
         + '_'
         + locals.assessment_instance.number
         + '_'

--- a/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
+++ b/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
@@ -8,14 +8,14 @@ const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
 const error = require('@prairielearn/prairielib/error');
-const assessment = require('../../lib/assessment');
+const sanitizeName = require('../../lib/sanitize-name');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const setFilenames = function(locals) {
-    const prefix = assessment.filenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course);
+    const prefix = sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course);
     locals.questionStatsCsvFilename = prefix + 'question_stats.csv';
 };
 

--- a/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
+++ b/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
@@ -7,14 +7,14 @@ const csvStringify = require('csv').stringify;
 const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
-const assessment = require('../../lib/assessment');
+const sanitizeName = require('../../lib/sanitize-name');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const setFilenames = function(locals) {
-    const prefix = assessment.filenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course);
+    const prefix = sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course);
     locals.scoreStatsCsvFilename = prefix + 'score_stats.csv';
     locals.durationStatsCsvFilename = prefix + 'duration_stats.csv';
     locals.statsByDateCsvFilename = prefix + 'scores_by_date.csv';

--- a/pages/instructorAssessments/instructorAssessments.js
+++ b/pages/instructorAssessments/instructorAssessments.js
@@ -6,24 +6,19 @@ const archiver = require('archiver');
 const router = express.Router();
 
 const { paginateQuery } = require('../../lib/paginate');
+const sanitizeName = require('../../lib/sanitize-name');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const csvFilename = (locals) => {
-    return locals.course.short_name.replace(/\s+/g, '')
-        + '_'
-        + locals.course_instance.short_name.replace(/\s+/g, '')
-        + '_'
+    return sanitizeName.courseInstanceFilenamePrefix(locals.course_instance, locals.course)
         + 'assessment_stats.csv';
 };
 
 const fileSubmissionsName = (locals) => {
-    return locals.course.short_name.replace(/\s+/g, '')
-        + '_'
-        + locals.course_instance.short_name.replace(/\s+/g, '')
-        + '_'
+    return sanitizeName.courseInstanceFilenamePrefix(locals.course_instance, locals.course)
         + 'file_submissions';
 };
 

--- a/pages/instructorGradebook/instructorGradebook.js
+++ b/pages/instructorGradebook/instructorGradebook.js
@@ -5,18 +5,14 @@ var express = require('express');
 var router = express.Router();
 
 var error = require('@prairielearn/prairielib/error');
+const sanitizeName = require('../../lib/sanitize-name');
 var sqldb = require('@prairielearn/prairielib/sql-db');
 var sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
 var sql = sqlLoader.loadSqlEquiv(__filename);
 
-const sanitizeStringForUrl = (str) => str.replace(/[^a-zA-Z0-9]/g, '_');
-
 var csvFilename = function(locals) {
-    return sanitizeStringForUrl(locals.course.short_name)
-        + '_'
-        + sanitizeStringForUrl(locals.course_instance.short_name)
-        + '_'
+    return sanitizeName.courseInstanceFilenamePrefix(locals.course_instance, locals.course)
         + 'gradebook.csv';
 };
 

--- a/pages/instructorGradebook/instructorGradebook.js
+++ b/pages/instructorGradebook/instructorGradebook.js
@@ -10,10 +10,12 @@ var sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
 var sql = sqlLoader.loadSqlEquiv(__filename);
 
+const sanitizeStringForUrl = (str) => str.replace(/[^a-zA-Z0-9]/g, '_');
+
 var csvFilename = function(locals) {
-    return locals.course.short_name.replace(/\s+/g, '')
+    return sanitizeStringForUrl(locals.course.short_name)
         + '_'
-        + locals.course_instance.short_name
+        + sanitizeStringForUrl(locals.course_instance.short_name)
         + '_'
         + 'gradebook.csv';
 };

--- a/pages/instructorQuestion/instructorQuestion.ejs
+++ b/pages/instructorQuestion/instructorQuestion.ejs
@@ -273,7 +273,7 @@
 
         <div class="card-footer">
           <p>
-            Download <a href="<%= urlPrefix %>/question/<%= question.id %>/<%= assessmentStatsCsvFilename %>"><%= assessmentStatsCsvFilename %></a>
+            Download <a href="<%= urlPrefix %>/question/<%= question.id %>/<%= questionStatsCsvFilename %>"><%= questionStatsCsvFilename %></a>
           </p>
           <small>
             <ul>


### PR DESCRIPTION
Course names like "STAT/CS/IS 107" and "TAM 210/211" would have gradebook download links with the `/` character in the link, which would confuse the Express router. This adopts a similar approach to that used in the assessment downloads page and replaces any character not in `[a-zA-Z0-9]` with an underscore.