### PR TITLE
Change sync procedural steps to allow history rewrites (close #1258)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -81,6 +81,8 @@
 
   * Change `cheerio` back to `v0.22.0` (Nathan Walters).
 
+  * Change sync procedural steps to use fetch and reset to allow for history changes (James Balamuta).
+
   * Fix load-reporting close during unit tests (Matt West).
 
   * Fix PL / scheduler linking stored procedure to allow linked exams and fix bugs (Dave Mussulman).


### PR DESCRIPTION
Changes the sync steps from:

```
git pull --force
```

to 

```
git fetch 
git reset --hard origin/master
```

This change allows for users to rewrite repository history and closes #1258.