### PR TITLE
Change sync procedural steps to allow history rewrites (close #1258)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -81,6 +81,8 @@
 
   * Change `cheerio` back to `v0.22.0` (Nathan Walters).
 
+  * Change sync procedural steps to use fetch and reset to allow for history changes (James Balamuta).
+
   * Fix load-reporting close during unit tests (Matt West).
 
   * Fix PL / scheduler linking stored procedure to allow linked exams and fix bugs (Dave Mussulman).

--- a/pages/courseSyncs/courseSyncs.js
+++ b/pages/courseSyncs/courseSyncs.js
@@ -47,7 +47,8 @@ const pullAndUpdate = function(locals, callback) {
 
         // First define the jobs.
         //
-        // We will start with either 1A or 1B below.
+        // We will start with either 1A or 1B below to either clone or 
+        // update the content.
 
         const syncStage1A = function() {
             const jobOptions = {
@@ -81,8 +82,25 @@ const pullAndUpdate = function(locals, callback) {
             };
             serverJobs.spawnJob(jobOptions);
         };
-        
+
         const syncStage1B2 = function() {
+            const jobOptions = {
+                course_id: locals.course.id,
+                user_id: locals.user.user_id,
+                authn_user_id: locals.authz_data.authn_user.user_id,
+                job_sequence_id: job_sequence_id,
+                type: 'clean_git_repo',
+                description: 'Clean local files not in remote git repository',
+                command: 'git',
+                arguments: ['clean', '-fdx'],
+                working_directory: locals.course.path,
+                env: gitEnv,
+                on_success: syncStage1B3,
+            };
+            serverJobs.spawnJob(jobOptions);
+        };
+
+        const syncStage1B3 = function() {
             const jobOptions = {
                 course_id: locals.course.id,
                 user_id: locals.user.user_id,

--- a/pages/courseSyncs/courseSyncs.js
+++ b/pages/courseSyncs/courseSyncs.js
@@ -75,7 +75,7 @@ const pullAndUpdate = function(locals, callback) {
                 type: 'fetch_from_git',
                 description: 'Fetch from remote git repository',
                 command: 'git',
-                arguments: ['fetch', 'origin', 'master'],
+                arguments: ['fetch'],
                 working_directory: locals.course.path,
                 env: gitEnv,
                 on_success: syncStage1B2,


### PR DESCRIPTION
Changes the sync steps from:

```
git pull --force
```

to 

```
git fetch 
git reset --hard origin/master
```

This change allows for users to rewrite repository history and closes #1258.