### PR TITLE
Disable 'Test 100 times' button for externally graded questions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -103,6 +103,8 @@
 
   * Change element documentation to have a separation between submission and format elements (James Balamuta).
 
+  * Change instructor question page to hide "Test 100 times" for externally graded questions (Nathan Walters).
+
   * Fix load-reporting close during unit tests (Matt West).
 
   * Fix PL / scheduler linking stored procedure to allow linked exams and fix bugs (Dave Mussulman).

--- a/pages/instructorQuestion/instructorQuestion.ejs
+++ b/pages/instructorQuestion/instructorQuestion.ejs
@@ -68,9 +68,11 @@
                     <button class="btn btn-sm btn-outline-primary" name="__action" value="test_once">
                       Test once with full details
                     </button>
+                    <% if (question.grading_method !== 'External') { %>
                     <button class="btn btn-sm btn-outline-primary" name="__action" value="test_100">
                       Test 100 times with only results
                     </button>
+                    <% } %>
                   </form>
                 </td>
               </tr>

--- a/pages/instructorQuestion/instructorQuestion.js
+++ b/pages/instructorQuestion/instructorQuestion.js
@@ -106,12 +106,16 @@ router.post('/', function(req, res, next) {
             res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
         });
     } else if (req.body.__action == 'test_100') {
-        const count = 100;
-        const showDetails = false;
-        question.startTestQuestion(count, showDetails, res.locals.question, res.locals.course_instance, res.locals.course, res.locals.authn_user.user_id, (err, job_sequence_id) => {
-            if (ERR(err, next)) return;
-            res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-        });
+        if (res.locals.question.grading_method !== 'External') {
+            const count = 100;
+            const showDetails = false;
+            question.startTestQuestion(count, showDetails, res.locals.question, res.locals.course_instance, res.locals.course, res.locals.authn_user.user_id, (err, job_sequence_id) => {
+                if (ERR(err, next)) return;
+                res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
+            });
+        } else {
+            next(new Error('Not supported for externally-graded questions'));
+        }
     } else if (req.body.__action == 'report_issue') {
         processIssue(req, res, function(err, variant_id) {
             if (ERR(err, next)) return;


### PR DESCRIPTION
Because any button that allows a single person to slow our grading throughput to a crawl is Bad.