### PR TITLE
Fix how binary files are handled during external grading

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -195,6 +195,8 @@
 
   * Fix (or at least attempt to) S3 file uploads for external grading (Nathan Walters).
 
+  * Fix handling of binary files during external grading (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/lib/externalGraderCommon.js
+++ b/lib/externalGraderCommon.js
@@ -110,7 +110,7 @@ module.exports.buildDirectory = function(dir, submission, variant, question, cou
                     }
 
                     // Files are expected to be base-64 encoded
-                    let decodedContents = Buffer.from(file.contents, 'base64').toString();
+                    let decodedContents = Buffer.from(file.contents, 'base64');
                     fs.writeFile(path.join(dir, 'student', file.name), decodedContents, callback);
                 }, function(err) {
                     if (ERR(err, callback)) return;


### PR DESCRIPTION
For text files, eagerly decoding the base64 contents to a string was fine. For binary files (tar archives, specifically) that breaks things. We now decode the files into a `Buffer` and write that directly to disk.