### PR TITLE
Adding modal dialogue support to enroll.ejs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -204,6 +204,8 @@
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).
 
   * Remove `string_from_2darray_sf()` from `freeformPythonLib/prairielearn.py` (Liz Livingston)
+  
+  * Change enroll page interface to allow Bootstrap modal dialogues instead of popover tooltips with buttons on them; add more verbose description of what it means to add/remove a course. (Eric Huber)
 
 * __3.1.0__ - 2018-10-08
 

--- a/pages/enroll/enroll.ejs
+++ b/pages/enroll/enroll.ejs
@@ -2,6 +2,12 @@
 <html>
   <head>
     <%- include('../partials/head'); %>
+
+    <style>
+      .modal-course-title-style {
+        font-size: 125%;
+      }
+    </style>
   </head>
   <body>
     <script>
@@ -15,6 +21,17 @@
         <div class="card-header bg-primary text-white">Courses</div>
         <table class="table table-sm table-hover table-striped">
           <tbody>
+            <%# If useModals=true, then the UI will use modal confirmation
+                dialogs. If false, then the old popover tooltips with buttons
+                will be generated instead. %>
+            <% var useModals=true; %>
+            <%# Modal configuration preamble. This has to come before the
+                following forEach: %>
+            <%
+              var modalIdx=0;
+              var dataToggleVal="popover";
+              if (useModals) {dataToggleVal="modal";}
+            %>
             <% course_instances.forEach(function(course_instance) { %>
             <tr>
               <td class="align-middle">
@@ -23,8 +40,10 @@
               <td>
                 <% if (!course_instance.enrolled) { %>
                 <a tabindex="0" class="btn btn-sm btn-info" role="button"
-                   data-toggle="popover" data-trigger="focus" data-container="body"
+                   data-toggle="<%= dataToggleVal %>"
+                   data-trigger="focus" data-container="body"
                    data-html="true" data-placement="auto" title="Confirm add"
+                   data-target="#addModal<%= modalIdx %>"
                    data-content="
                                  <form name=&quot;enroll-form&quot; method=&quot;POST&quot;>
                                    <input type=&quot;hidden&quot; name=&quot;__action&quot; value=&quot;enroll&quot;>
@@ -38,13 +57,47 @@
                                  ">
                   Add course
                 </a>
+                <div class="modal fade" id="addModal<%= modalIdx %>" tabindex="-1" role="dialog" aria-labelledby="addModal<%= modalIdx %>Title" aria-hidden="true">
+                  <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title" id="addModal<%= modalIdx %>Title">Confirm add course</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span aria-hidden="true">&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        <p>Are you sure you want to add this course content to your PrairieLearn account?</p>
+                        <p class="modal-course-title-style"><%= course_instance.label %></p>
+                        <p>This does not register you in the actual course.
+                         You need to formally register for courses with the University separately.</p>
+                      </div>
+                      <div class="modal-footer">
+                         <form name="enroll-form" method="POST">
+                           <input type="hidden" name="__action" value="enroll">
+                           <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+                           <input type="hidden" name="course_instance_id"
+                                  value="<%= course_instance.course_instance_id %>">
+                           <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                           Cancel
+                           </button>
+                           <button type="submit" class="btn btn-info">
+                             Add <%= course_instance.short_label %>
+                           </button>
+                         </form>
+                      </div>
+                    </div>
+                  </div>
+                </div>
                 <% } %>
               </td>
               <td>
                 <% if (course_instance.enrolled) { %>
                 <a tabindex="0" class="btn btn-sm btn-danger" role="button"
-                   data-toggle="popover" data-trigger="focus" data-container="body"
+                   data-toggle="<%= dataToggleVal %>"
+                   data-trigger="focus" data-container="body"
                    data-html="true" data-placement="auto" title="Confirm remove"
+                   data-target="#removeModal<%= modalIdx %>"
                    data-content="
                                  <form name=&quot;unenroll-form&quot; method=&quot;POST&quot;>
                                    <input type=&quot;hidden&quot; name=&quot;__action&quot; value=&quot;unenroll&quot;>
@@ -58,9 +111,50 @@
                                  ">
                   Remove course
                 </a>
+                <div class="modal fade" id="removeModal<%= modalIdx %>" tabindex="-1" role="dialog" aria-labelledby="removeModal<%= modalIdx %>Title" aria-hidden="true">
+                  <div class="modal-dialog modal-dialog-centered" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title" id="removeModal<%= modalIdx %>Title">Confirm remove course</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span aria-hidden="true">&times;</span>
+                        </button>
+                      </div>
+                      <div class="modal-body">
+                        <p>Are you sure you want to remove this course content from your
+                          PrairieLearn account?
+                        </p>
+                        <p class="modal-course-title-style"><%= course_instance.label %></p>
+                        <p>This does not drop you from the actual course.
+                         You need to formally drop classes through the University registration system.</p>
+                        <%# Perhaps the following notice isn't necessary if students removing themselves
+                            from courses doesn't affect our records of results. (?) %>
+                        <p>
+                          If you have recently used this PrairieLearn course to take an exam for
+                          proficiency, placement, or entrance qualification, please do not remove yourself from the course.
+                        </p>
+                      </div>
+                      <div class="modal-footer">
+                         <form name="unenroll-form" method="POST">
+                           <input type="hidden" name="__action" value="unenroll">
+                           <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+                           <input type="hidden" name="course_instance_id"
+                                  value="<%= course_instance.course_instance_id %>">
+                           <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                           Cancel
+                           </button>
+                           <button type="submit" class="btn btn-danger">
+                             Remove <%= course_instance.short_label %>
+                           </button>
+                         </form>
+                      </div>
+                    </div>
+                  </div>
+                </div>
                 <% } %>
               </td>
             </tr>
+            <% ; modalIdx++; %>
             <% }); %>
           </tbody>
         </table>

--- a/pages/enroll/enroll.ejs
+++ b/pages/enroll/enroll.ejs
@@ -21,18 +21,8 @@
         <div class="card-header bg-primary text-white">Courses</div>
         <table class="table table-sm table-hover table-striped">
           <tbody>
-            <%# If useModals=true, then the UI will use modal confirmation
-                dialogs. If false, then the old popover tooltips with buttons
-                will be generated instead. %>
-            <% var useModals=true; %>
-            <%# Modal configuration preamble. This has to come before the
-                following forEach: %>
-            <%
-              var modalIdx=0;
-              var dataToggleVal="popover";
-              if (useModals) {dataToggleVal="modal";}
-            %>
-            <% course_instances.forEach(function(course_instance) { %>
+            <%# var modalIdx=0; must come before the forEach: %>
+            <% var modalIdx=0; course_instances.forEach(function(course_instance) { %>
             <tr>
               <td class="align-middle">
                 <%= course_instance.label %>
@@ -40,21 +30,7 @@
               <td>
                 <% if (!course_instance.enrolled) { %>
                 <a tabindex="0" class="btn btn-sm btn-info" role="button"
-                   data-toggle="<%= dataToggleVal %>"
-                   data-trigger="focus" data-container="body"
-                   data-html="true" data-placement="auto" title="Confirm add"
-                   data-target="#addModal<%= modalIdx %>"
-                   data-content="
-                                 <form name=&quot;enroll-form&quot; method=&quot;POST&quot;>
-                                   <input type=&quot;hidden&quot; name=&quot;__action&quot; value=&quot;enroll&quot;>
-                                   <input type=&quot;hidden&quot; name=&quot;__csrf_token&quot; value=&quot;<%= __csrf_token %>&quot;>
-                                   <input type=&quot;hidden&quot; name=&quot;course_instance_id&quot;
-                                          value=&quot;<%= course_instance.course_instance_id %>&quot;>
-                                   <button type=&quot;submit&quot; class=&quot;btn btn-info&quot;>
-                                     Add <%= course_instance.short_label %>
-                                   </button>
-                                 </form>
-                                 ">
+                   data-toggle="modal" data-target="#addModal<%= modalIdx %>" >
                   Add course
                 </a>
                 <div class="modal fade" id="addModal<%= modalIdx %>" tabindex="-1" role="dialog" aria-labelledby="addModal<%= modalIdx %>Title" aria-hidden="true">
@@ -69,8 +45,7 @@
                       <div class="modal-body">
                         <p>Are you sure you want to add this course content to your PrairieLearn account?</p>
                         <p class="modal-course-title-style"><%= course_instance.label %></p>
-                        <p>This does not register you in the actual course.
-                         You need to formally register for courses with the University separately.</p>
+                        <p>Adding or removing courses here only affects what is visible to you on PrairieLearn. This does not change your university course registration.</p>
                       </div>
                       <div class="modal-footer">
                          <form name="enroll-form" method="POST">
@@ -94,21 +69,7 @@
               <td>
                 <% if (course_instance.enrolled) { %>
                 <a tabindex="0" class="btn btn-sm btn-danger" role="button"
-                   data-toggle="<%= dataToggleVal %>"
-                   data-trigger="focus" data-container="body"
-                   data-html="true" data-placement="auto" title="Confirm remove"
-                   data-target="#removeModal<%= modalIdx %>"
-                   data-content="
-                                 <form name=&quot;unenroll-form&quot; method=&quot;POST&quot;>
-                                   <input type=&quot;hidden&quot; name=&quot;__action&quot; value=&quot;unenroll&quot;>
-                                   <input type=&quot;hidden&quot; name=&quot;__csrf_token&quot; value=&quot;<%= __csrf_token %>&quot;>
-                                   <input type=&quot;hidden&quot; name=&quot;course_instance_id&quot;
-                                          value=&quot;<%= course_instance.course_instance_id %>&quot;>
-                                   <button type=&quot;submit&quot; class=&quot;btn btn-danger&quot;>
-                                     Remove <%= course_instance.short_label %>
-                                   </button>
-                                 </form>
-                                 ">
+                   data-toggle="modal" data-target="#removeModal<%= modalIdx %>" >
                   Remove course
                 </a>
                 <div class="modal fade" id="removeModal<%= modalIdx %>" tabindex="-1" role="dialog" aria-labelledby="removeModal<%= modalIdx %>Title" aria-hidden="true">
@@ -121,18 +82,9 @@
                         </button>
                       </div>
                       <div class="modal-body">
-                        <p>Are you sure you want to remove this course content from your
-                          PrairieLearn account?
-                        </p>
+                        <p>Are you sure you want to remove this course content from your PrairieLearn account?</p>
                         <p class="modal-course-title-style"><%= course_instance.label %></p>
-                        <p>This does not drop you from the actual course.
-                         You need to formally drop classes through the University registration system.</p>
-                        <%# Perhaps the following notice isn't necessary if students removing themselves
-                            from courses doesn't affect our records of results. (?) %>
-                        <p>
-                          If you have recently used this PrairieLearn course to take an exam for
-                          proficiency, placement, or entrance qualification, please do not remove yourself from the course.
-                        </p>
+                        <p>Adding or removing courses here only affects what is visible to you on PrairieLearn. This does not change your university course registration.</p>
                       </div>
                       <div class="modal-footer">
                          <form name="unenroll-form" method="POST">
@@ -154,8 +106,8 @@
                 <% } %>
               </td>
             </tr>
-            <% ; modalIdx++; %>
-            <% }); %>
+            <%# incrementing modalIdx must be done before closing the forEach function block: %>
+            <% ; modalIdx++; }); %>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Add/remove modal popup will replace the old popover, if enabled. This should have better behavior on some touchscreen devices, as well as offering more verbose warnings about what it means to add/remove a course on PL.

~(There is a toggle in the EJS code, `var useModals=true`, so it's easy to undo this if it seems to cause some unforeseen problems, or if A/B testing is necessary.)~ (Removed popover cruft as per Dave Mussulman's suggestion on Slack.)

The more verbose messages clearly state that add/remove on PL does not register for or drop courses with the University:

> ~Are you sure you want to add this course content to your PrairieLearn account? This does not register you in the actual course. You need to formally register for courses with the University separately.~

> ~Are you sure you want to remove this course content from your PrairieLearn account? This does not drop you from the actual course. You need to formally drop classes through the University registration system.~

(revised:)

> Are you sure you want to add this course content to your PrairieLearn account? Adding or removing courses here only affects what is visible to you on PrairieLearn. This does not change your university course registration.

> Are you sure you want to remove this course content from your PrairieLearn account? Adding or removing courses here only affects what is visible to you on PrairieLearn. This does not change your university course registration.

~I'm not sure if this part of the "remove" warning message is necessary:~ (removed this as per suggestion)
> ~If you have recently used this PrairieLearn course to take an exam for proficiency, placement, or entrance qualification, please do not remove yourself from the course.~

I imagine some students removing themselves from a course after taking a one-time exam like a placement exam. I don't think this affects our records of their results, right? However, we may need to make new instances on a monthly basis to control how often students can re-take certain exams. In that case, maybe it's more clear from a UX perspective if the students can see which instances are the ones they _haven't_ previously taken, at a glance. So, they should just leave themselves added to past courses.