### PR TITLE
Add course-level Questions page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -72,6 +72,8 @@
   * Add example questions for `pl-multiple-choice` and `pl-integer-input` customizations (James Balamuta).
 
   * Add `clientFilesElement` folder for loading element-specific client files (Nicolas Nytko).
+  
+  * Add course-level pages for viewing all questions, individual questions, and issues (Ray Essick).
 
   * Change "Save & Grade" button text and alignment (Dave Mussulman).
 

--- a/middlewares/selectAndAuthzCourseQuestion.js
+++ b/middlewares/selectAndAuthzCourseQuestion.js
@@ -1,0 +1,21 @@
+var ERR = require('async-stacktrace');
+var _ = require('lodash');
+
+var sqldb = require('@prairielearn/prairielib/sql-db');
+var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+var error = require('@prairielearn/prairielib/error');
+
+var sql = sqlLoader.loadSqlEquiv(__filename);
+
+module.exports = function(req, res, next) {
+    var params = {
+        question_id: req.params.question_id,
+        course_id: res.locals.course.id,
+    };
+    sqldb.queryZeroOrOneRow(sql.select_and_auth, params, function(err, result) {
+        if (ERR(err, next)) return;
+        if (result.rowCount == 0) return next(error.make(403, 'Access denied'));
+        _.assign(res.locals, result.rows[0]);
+        next();
+    });
+};

--- a/middlewares/selectAndAuthzCourseQuestion.sql
+++ b/middlewares/selectAndAuthzCourseQuestion.sql
@@ -1,0 +1,22 @@
+-- BLOCK select_and_auth
+WITH issue_count AS (
+    SELECT count(*) AS open_issue_count
+    FROM issues AS i
+    WHERE
+        i.question_id = $question_id
+        AND i.course_caused
+        AND i.open
+)
+SELECT
+    to_json(q) AS question,
+    to_json(top) AS topic,
+    tags_for_question(q.id) AS tags,
+    issue_count.open_issue_count
+FROM
+    questions as q
+    JOIN topics as top ON (top.id = q.topic_id),
+    issue_count
+WHERE
+    q.id = $question_id
+    AND q.course_id = $course_id
+    AND q.deleted_at IS NULL;

--- a/pages/courseGeneratedFilesQuestion/courseGeneratedFilesQuestion.js
+++ b/pages/courseGeneratedFilesQuestion/courseGeneratedFilesQuestion.js
@@ -1,0 +1,30 @@
+var ERR = require('async-stacktrace');
+var express = require('express');
+var router = express.Router();
+
+var question = require('../../lib/question');
+var sqldb = require('@prairielearn/prairielib/sql-db');
+var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+
+var sql = sqlLoader.loadSqlEquiv(__filename);
+
+router.get('/variant/:variant_id/*', function(req, res, next) {
+    var variant_id = req.params.variant_id;
+    var filename = req.params[0];
+    var params = {
+        question_id: res.locals.question.id,
+        variant_id: variant_id,
+    };
+    sqldb.queryOneRow(sql.select_variant, params, function(err, result) {
+        if (ERR(err, next)) return;
+        var variant = result.rows[0];
+
+        question.getFile(filename, variant, res.locals.question, res.locals.course, res.locals.authn_user.user_id, function(err, fileData) {
+            if (ERR(err, next)) return;
+            res.attachment(filename);
+            res.send(fileData);
+        });
+    });
+});
+
+module.exports = router;

--- a/pages/courseGeneratedFilesQuestion/courseGeneratedFilesQuestion.sql
+++ b/pages/courseGeneratedFilesQuestion/courseGeneratedFilesQuestion.sql
@@ -1,0 +1,8 @@
+-- BLOCK select_variant
+SELECT
+    v.*
+FROM
+    variants AS v
+WHERE
+    v.id = $variant_id
+    AND v.question_id = $question_id; -- check for security

--- a/pages/courseIssues/courseIssues.ejs
+++ b/pages/courseIssues/courseIssues.ejs
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head'); %>
+    <link href="/stylesheets/issues.css" rel="stylesheet" />
+  </head>
+  <body>
+    <%- include('../partials/navbar', {navPage: 'courseIssues'}); %>
+    <div id="content" class="container">
+
+      <div class="modal fade" id="closeAllIssuesModal" tabindex="-1" role="dialog" aria-labelledby="closeAllIssuesModalLabel">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title" id="closeAllIssuesModalLabel">Close all issues</h4>
+            </div>
+            <div class="modal-body">
+              Are you sure you want to close all issues? This cannot
+              be undone.
+            </div>
+            <div class="modal-footer">
+              <form name="close-all-form" method="POST">
+                <input type="hidden" name="__action" value="close_all">
+                <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-danger">Close all</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal fade" id="filterHelpModal" tabindex="-1" role="dialog" aria-labelledby="filterHelpModalLabel">
+        <div class="modal-dialog modal-lg" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title" id="filterHelpModalLabel">Filter help</h4>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <p>Issues can be filtered and searched in a variety of ways. Filtering
+                is done with the following set of qualifiers.</p>
+              <table class="table table-bordered">
+                <thead>
+                  <th>Qualifier</th>
+                  <th>Explanation</th>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>is:open</code></td>
+                    <td>Shows all issues that are open</td>
+                  </tr>
+                  <tr>
+                    <td><code>is:closed</code></td>
+                    <td>Shows all issues that are closed</td>
+                  </tr>
+                  <tr>
+                    <td><code>is:manually-reported</code></td>
+                    <td>Shows all issues that were manually reported by a student</td>
+                  </tr>
+                  <tr>
+                    <td><code>is:automatically-reported</code></td>
+                    <td>Shows all issues that were automatically reported by PrairieLearn</td>
+                  </tr>
+                  <tr>
+                    <td><code>qid:<em>QID</em></code></td>
+                    <td>
+                      Shows all issues with a question ID like <code>QID</code>.
+                      <br>
+                      <strong>Example:</strong> <code>qid:graph</code> shows all issues associated with questions such as <code>graphConnectivity</code> and <code>speedTimeGraph</code>.</td>
+                  </tr>
+                  <tr>
+                    <td><code>user:<em>USER</em></code></td>
+                    <td>
+                      Shows all issues that were reported by a user ID like <code>USER</code>.
+                      <br>
+                      <strong>Example:</strong> <code>user:nwalter2@illinois.edu</code> shows all issues that were reported by <code>nwalter2@illinois.edu</code>.</td>
+                  </tr>
+                </tbody>
+              </table>
+              <h4>Full-text search</h4>
+              <p>You can also search the issue message by simply entering text. For example, <code>no picture</code> would return any issues that contain text like "no picture".</p>
+
+              <h4>Qualifier negation</h4>
+              <p>Any qualifier can be negagted with the a hyphen (<code>-</code>). For example, <code>-is:manually-reported</code> would return all issues that were <strong>not</strong> manually reported.</p>
+
+              <h4>Combining qualifiers</h4>
+              <p>These can be combined to form complex searches. An example:</p>
+              <code><pre>is:open qid:vector answer is wrong</pre></code>
+              <p>This would return any open issues with a QID like <code>vector</code> whose message contains text like "answer is wrong".</p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <%- include('../partials/issueResponseModal'); %>
+
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white">
+          <div class="d-flex flex-row align-items-center mb-2">
+            <div class="d-flex flex-column">
+              Issues
+              <small>
+                <a href="<%= commonQueries.allOpenQuery %>" class="mr-3 text-white">
+                  <i class="fa fa-exclamation-circle"></i> <%= openCount %> open
+                </a>
+                <a href="<%= commonQueries.allClosedQuery %>" class="text-white">
+                  <i class="fa fa-check-circle"></i> <%= closedCount %> closed
+                </a>
+              </small>
+            </div>
+            <button class="btn btn-sm btn-danger ml-auto" data-toggle="modal" data-target="#closeAllIssuesModal">
+              <i class="fa fa-times" aria-hidden="true"></i> Close all issues
+            </button>
+          </div>
+          <form name="query-form" method="GET">
+            <div class="input-group">
+              <div class="input-group-prepend">
+                <button class="btn btn-med-light dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Filters</button>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="<%= commonQueries.allOpenQuery %>">Open issues</a>
+                  <a class="dropdown-item" href="<%= commonQueries.allClosedQuery %>">Closed issues</a>
+                  <a class="dropdown-item" href="<%= commonQueries.allManuallyReportedQuery %>">Manually-reported issues</a>
+                  <a class="dropdown-item" href="<%= commonQueries.allAutomaticallyReportedQuery %>">Automatically-reported issues</a>
+                </div>
+              </div>
+              <input type="text" class="form-control" name="q" value="<%= filterQuery %>">
+              <div class="input-group-append">
+                <a class="btn btn-med-light" href="<%= urlPrefix %>/issues?q=" title="Clear filters">
+                  <i class="fa fa-times" aria-hidden="true"></i>
+                </a>
+                <button class="btn btn-med-light" type="button" title="Show filter help" data-toggle="modal" data-target="#filterHelpModal">
+                  <i class="fa fa-question-circle" aria-hidden="true"></i>
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <%
+        var getFormattedMessage = function(row) {
+          if (row.student_message == null || row.student_message.length == 0) {
+            return '—';
+          }
+
+          var msg = row.student_message;
+          if (row.manually_reported) {
+            msg = '"' + msg + '"';
+          }
+          return msg;
+        };
+        %>
+
+        <% if (rows.length == 0) { %>
+          <div class="card-body">
+            <div class="text-center text-muted">No matching issues found</div>
+          </div>
+        <% } else { %>
+        <div class="list-group list-group-flush">
+          <% rows.forEach(row => { %>
+          <div class="list-group-item issue-list-item d-flex flex-row align-items-center">
+            <div style="min-width: 0;">
+              <% if (row.open) { %>
+              <i class="fa fa-exclamation-circle text-danger issue-status-icon"></i>
+              <% } else { %>
+              <i class="fa fa-check-circle text-success issue-status-icon"></i>
+              <% } %>
+              <a class="d-block" href="<%= urlPrefix %>/question/<%= row.question_id %>/?variant_id=<%= row.variant_id %>">
+                <%= row.question_qid %>
+              </a>
+              <p class="mb-0">
+                <%= getFormattedMessage(row) %>
+              </p>
+              <% if (row.manually_reported) { %>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> by <%= row.user_name || '-' %> (<a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a>)</small>
+              <% } else { %>
+              <small class="text-muted mr-2">#<%= row.issue_id %> reported <span title="<%= row.formatted_date %>"><%= row.relative_date %></span> for <%= row.user_name || '-' %> (<a href="mailto:<%= row.user_uid || '-' %>?subject=Reported%20PrairieLearn%20Issue&body=Hello%20<%= row.user_name %>,%0ARegarding%20the%20issue%20of:%0A%0A%22<%= row.student_message || '-' %>%22%0A%0AWe've..."><%= row.user_uid || '-' %></a>)</small>
+              <% } %>
+              <% if (row.manually_reported) { %>
+              <span class="badge badge-info">Manually reported</span>
+              <% } else { %>
+              <span class="badge badge-warning">Automatically reported</span>
+              <% } %>
+              <% if (row.assessment) { %>
+              <%- include('../partials/assessment', {assessment: row.assessment}) %>
+              <% } %>
+              <% if (row.course_instance_short_name) { %>
+              <span class="badge badge-dark"><%= row.course_instance_short_name || '—' %></span>
+              <% } %>
+            </div>
+            <div class="ml-auto pl-4">
+              <%- include('../partials/issueActionButtons', {issue: row}) %>
+            </div>
+          </div>
+          <% }); %>
+        </div>
+        <% } %>
+
+        <% if (shouldPaginate) { %>
+        <div class="card-body">
+          <%- include('../partials/pager', {params: 'q=' + encodedFilterQuery}) %>
+        </div>
+        <% } %>
+
+      </div>
+    </div>
+  </body>
+</html>

--- a/pages/courseIssues/courseIssues.js
+++ b/pages/courseIssues/courseIssues.js
@@ -143,7 +143,10 @@ router.get('/', function(req, res, next) {
 });
 
 router.post('/', function(req, res, next) {
-    if (!res.locals.authz_data.has_instructor_edit) return next();
+    if (!res.locals.authz_data.has_instructor_edit && 
+        !res.locals.authz_data.has_course_permission_edit) {
+        return next( error.make(403, 'Action requires instructor or course admin permissions', {locals: res.locals, body: req.body}) );
+    }
     if (req.body.__action == 'open') {
         let params = [
             req.body.issue_id,

--- a/pages/courseIssues/courseIssues.js
+++ b/pages/courseIssues/courseIssues.js
@@ -1,0 +1,184 @@
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
+const moment = require('moment');
+const express = require('express');
+const router = express.Router();
+const SearchString = require('search-string');
+
+const error = require('@prairielearn/prairielib/error');
+const paginate = require('../../lib/paginate');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
+
+const sql = sqlLoader.loadSqlEquiv(__filename);
+
+const PAGE_SIZE = 100;
+
+const commonQueries = {
+    allOpenQuery: 'is:open',
+    allClosedQuery: 'is:closed',
+    allManuallyReportedQuery: 'is:manually-reported',
+    allAutomaticallyReportedQuery: 'is:automatically-reported',
+};
+
+const formattedCommonQueries = {};
+
+Object.keys(commonQueries).forEach((key) => {
+    formattedCommonQueries[key] = `?q=${encodeURIComponent(commonQueries[key])}`;
+});
+
+function formatForLikeClause(str) {
+    return `%${str}%`;
+}
+
+function parseRawQuery(str) {
+    const parsedQuery = SearchString.parse(str);
+    const filters = {
+        filter_is_open: null,
+        filter_is_closed: null,
+        filter_manually_reported: null,
+        filter_automatically_reported: null,
+        filter_qids: null,
+        filter_not_qids: null,
+        filter_query_text: null,
+        filter_users: null,
+        filter_not_users: null,
+    };
+
+    const queryText = parsedQuery.getAllText();
+    if (queryText) {
+        filters.filter_query_text = queryText;
+    }
+
+    for (const option of parsedQuery.getConditionArray()) {
+        switch (option.keyword) {
+            case 'is': // boolean option
+                switch (option.value) {
+                    case 'open':
+                        filters.filter_is_open = !option.negated;
+                        break;
+                    case 'closed':
+                        filters.filter_is_closed = !option.negated;
+                        break;
+                    case 'manually-reported':
+                        filters.filter_manually_reported = !option.negated;
+                        break;
+                    case 'automatically-reported':
+                        filters.filter_automatically_reported = !option.negated;
+                        break;
+                }
+                break;
+            case 'qid':
+                if (!option.negated) {
+                    filters.filter_qids = filters.filter_qids || [];
+                    filters.filter_qids.push(formatForLikeClause(option.value));
+                } else {
+                    filters.filter_not_qids = filters.filter_not_qids || [];
+                    filters.filter_not_qids.push(formatForLikeClause(option.value));
+                }
+                break;
+            case 'user':
+                if (!option.negated) {
+                    filters.filter_users = filters.filter_users || [];
+                    filters.filter_users.push(formatForLikeClause(option.value));
+                } else {
+                    filters.filter_not_users = filters.filter_not_users || [];
+                    filters.filter_not_users.push(formatForLikeClause(option.value));
+                }
+                break;
+        }
+    }
+
+    return filters;
+}
+
+router.get('/', function(req, res, next) {
+    if (!('q' in req.query)) {
+        req.query.q = 'is:open';
+    }
+    const filters = parseRawQuery(req.query.q);
+
+    var params = {
+        course_id: res.locals.course.id,
+    };
+    _.assign(params, filters);
+
+    sqldb.query(sql.issues_count, params, function(err, result) {
+        if (ERR(err, next)) return;
+        if (result.rowCount != 2) return next(new Error('unable to obtain issue count, rowCount = ' + result.rowCount));
+        res.locals.closedCount = result.rows[0].count;
+        res.locals.openCount = result.rows[1].count;
+        res.locals.issueCount = res.locals.closedCount + res.locals.openCount;
+
+        _.assign(res.locals, paginate.pages(req.query.page, res.locals.issueCount, PAGE_SIZE));
+        res.locals.shouldPaginate = res.locals.issueCount > PAGE_SIZE;
+
+        var params = {
+            course_id: res.locals.course.id,
+            offset: (res.locals.currPage - 1) * PAGE_SIZE,
+            limit: PAGE_SIZE,
+        };
+        _.assign(params, filters);
+
+        sqldb.query(sql.select_issues, params, function(err, result) {
+            if (ERR(err, next)) return;
+
+            // Add human-readable relative dates to each row
+            result.rows.forEach((row) => {
+                row.relative_date = moment(row.formatted_date).from(row.now_date);
+            });
+
+            res.locals.rows = result.rows;
+
+            res.locals.filterQuery = req.query.q;
+            res.locals.encodedFilterQuery = encodeURIComponent(req.query.q);
+            res.locals.filters = filters;
+
+            res.locals.commonQueries = {};
+            _.assign(res.locals.commonQueries, formattedCommonQueries);
+
+            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+        });
+    });
+});
+
+router.post('/', function(req, res, next) {
+    if (!res.locals.authz_data.has_instructor_edit) return next();
+    if (req.body.__action == 'open') {
+        let params = [
+            req.body.issue_id,
+            true, // open status
+            res.locals.course.id,
+            res.locals.authn_user.user_id,
+        ];
+        sqldb.call('issues_update_open', params, function(err, _result) {
+            if (ERR(err, next)) return;
+            res.redirect(req.originalUrl);
+        });
+    } else if (req.body.__action == 'close') {
+        let params = [
+            req.body.issue_id,
+            false, // open status
+            res.locals.course.id,
+            res.locals.authn_user.user_id,
+        ];
+        sqldb.call('issues_update_open', params, function(err, _result) {
+            if (ERR(err, next)) return;
+            res.redirect(req.originalUrl);
+        });
+    } else if (req.body.__action == 'close_all') {
+        let params = [
+            false, // open status
+            res.locals.course.id,
+            res.locals.authn_user.user_id,
+        ];
+        sqldb.call('issues_update_open_all', params, function(err, _result) {
+            if (ERR(err, next)) return;
+            res.redirect(req.originalUrl);
+        });
+    } else {
+        return next(error.make(400, 'unknown __action', {locals: res.locals, body: req.body}));
+    }
+});
+
+module.exports = router;

--- a/pages/courseIssues/courseIssues.sql
+++ b/pages/courseIssues/courseIssues.sql
@@ -1,0 +1,62 @@
+-- BLOCK issues_count
+WITH counts AS (
+    SELECT
+        i.open,
+        count(*)::int
+    FROM
+        issues AS i
+    WHERE
+        i.course_id = $course_id
+        AND i.course_caused
+    GROUP BY i.open
+)
+SELECT
+    open,
+    coalesce(count, 0) AS count
+FROM
+    (VALUES (true), (false)) AS tmp(open)
+    LEFT JOIN counts USING (open)
+ORDER BY open;
+
+-- BLOCK select_issues
+SELECT
+    i.id AS issue_id,
+    format_date_iso8601(now(), coalesce(ci.display_timezone, c.display_timezone)) AS now_date,
+    format_date_iso8601(i.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
+    ci.short_name AS course_instance_short_name,
+    CASE WHEN i.assessment_id IS NOT NULL THEN assessments_format(i.assessment_id) ELSE NULL END AS assessment,
+    i.question_id,
+    q.directory AS question_qid,
+    u.uid AS user_uid,
+    u.name AS user_name,
+    i.student_message,
+    i.variant_id,
+    i.open,
+    i.manually_reported
+FROM
+    issues_select_with_filter (
+        $filter_is_open,
+        $filter_is_closed,
+        $filter_manually_reported,
+        $filter_automatically_reported,
+        $filter_qids,
+        $filter_not_qids,
+        $filter_users,
+        $filter_not_users,
+        $filter_query_text
+    ) AS selected_issues
+    JOIN issues AS i ON (i.id = selected_issues.issue_id)
+    JOIN pl_courses AS c ON (c.id = i.course_id)
+    LEFT JOIN course_instances AS ci ON (ci.id = i.course_instance_id)
+    LEFT JOIN assessments AS a ON (a.id = i.assessment_id)
+    LEFT JOIN questions AS q ON (q.id = i.question_id)
+    LEFT JOIN users AS u ON (u.user_id = i.user_id)
+WHERE
+    i.course_id = $course_id
+    AND i.course_caused
+ORDER BY
+    i.date DESC, i.id
+LIMIT
+    $limit
+OFFSET
+    $offset;

--- a/pages/courseQuestion/courseQuestion.ejs
+++ b/pages/courseQuestion/courseQuestion.ejs
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head'); %>
+    <script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});</script>
+    <script src="/MathJax/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    <script src="/javascripts/socket.io.js"></script>
+    <script src="/javascripts/d3.min.js"></script>
+    <script src="/javascripts/lodash.min.js"></script>
+    <script src="/localscripts/stacked_histogram.js"></script>
+    <script src="/localscripts/histmini.js"></script>
+    <script>
+      document.urlPrefix = '<%= urlPrefix %>';
+    </script>
+    <% if (question.type != 'Freeform') { %>
+    <script src="/javascripts/lodash.min.js"></script>
+    <script src="/javascripts/require.js"></script>
+    <script src="/localscripts/question.js"></script>
+    <script src="/localscripts/question<%= effectiveQuestionType %>.js"></script>
+    <% } %>
+    <%- extraHeadersHtml %>
+  </head>
+  <body>
+    <%- include('../partials/navbar', {navPage: ''}); %>
+    <div id="content" class="container">
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white">Question <%= question.qid %></div>
+
+        <div class="table-responsive">
+          <table class="table table-sm table-hover two-column-description">
+            <tbody>
+              <tr>
+                <th>Title</th>
+                <td><%= question.title %></td>
+              </tr>
+              <tr>
+                <th>QID</th>
+                <td><%= question.qid %>
+                    <% if (questionGHLink) { %>(<a target="_blank" href="<%= questionGHLink %>">view on GitHub</a>)<% } %>
+                </td>
+              </tr>
+              <tr>
+                <th>Type</th>
+                <td><%= question.type %></td>
+              </tr>
+              <tr>
+                <th>Topic</th>
+                <td><%- include('../partials/topic', {topic: topic}); %></td>
+              </tr>
+              <tr>
+                <th>Tags</th>
+                <td><%- include('../partials/tags', {tags: tags}); %></td>
+              </tr>
+              <tr>
+                <th>Issues</th>
+                <td><%- include('../partials/issueBadge', {count: open_issue_count, issueQid: question.qid}); %></td>
+              </tr>
+              <% if ( typeof assessments !== 'undefined' ) { %>
+              <tr>
+                <th>Assessments</th>
+                <td><%- include('../partials/assessments', {assessments: assessments}); %></td>
+              </tr>
+              <% } %>
+              <% if (question.type == 'Freeform' && 
+                     typeof course_instance !== 'undefined' ) { %>
+              <tr>
+                <th class="align-middle">Tests</th>
+                <td>
+                  <form method="POST">
+                    <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+                    <button class="btn btn-sm btn-outline-primary" name="__action" value="test_once">
+                      Test once with full details
+                    </button>
+                    <% if (question.grading_method !== 'External') { %>
+                    <button class="btn btn-sm btn-outline-primary" name="__action" value="test_100">
+                      Test 100 times with only results
+                    </button>
+                    <% } %>
+                  </form>
+                </td>
+              </tr>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+        <div class="card-footer">
+          <button class="btn btn-sm btn-primary" type="button" data-toggle="collapse" data-target="#issueCollapse" aria-expanded="false" aria-controls="issueCollapse">
+            Report an issue with this question
+          </button>
+          <div class="collapse" id="issueCollapse">
+            <hr />
+            <form method="POST">
+              <div class="form-group">
+                <textarea class="form-control" rows="5" name="description" placeholder="Describe the issue"></textarea>
+              </div>
+              <input type="hidden" name="__variant_id" value="<%= variant.id %>">
+              <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+              <div class="form-group text-right">
+                <button class="btn btn-small btn-warning" name="__action" value="report_issue">Report issue</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <%- include('../partials/question', {question_context: 'instructor'}); %>
+
+      <!-- ###################################################################### -->
+      <!-- ###################################################################### -->
+
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white">Detailed assessment statistics</div>
+
+        <div class="table-responsive">
+          <table id="questionsTable" class="table table-sm table-hover tablesorter table-bordered">
+            <thead>
+            <tr>
+              <th class="text-center">Course Instance</th>
+              <th class="text-center">Assessment</th>
+                <% Object.keys(stat_descriptions).forEach(function(stat) {%>
+              <th
+                      class="text-center"
+                      title="<%- stat_descriptions[stat].description %>">
+                  <%- stat_descriptions[stat].title %>
+              </th>
+                <% }); %>
+
+            </tr>
+            </thead>
+            <tbody>
+            <% assessment_stats.forEach(function(row, i) { %>
+            <tr>
+              <td>
+                  <%= row.course_title %>
+              </td>
+              <td style="width: 1%">
+                <a href="/pl/course_instance/<%= row.course_instance_id %>/instructor/assessment/<%= row.assessment_id %>/" class="badge color-<%=
+                  row.color %> color-hover" role="button"><%= row.label %></a>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.mean_question_score, 1) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.question_score_variance, 1) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.discrimination, 1) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.some_submission_perc, 1) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.some_perfect_submission_perc, 1) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.some_nonzero_submission_perc, 1) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.average_first_submission_score, 2) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.first_submission_score_variance, 2) %>
+              </td>
+              <td class="text-center">
+                  <% if (row.first_submission_score_hist !== null) { %>
+                <div id="firstSubmissionScoreHist<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.average_last_submission_score, 2) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.last_submission_score_variance, 2) %>
+              </td>
+              <td class="text-center">
+                  <% if (row.last_submission_score_hist !== null) { %>
+                <div id="lastSubmissionScoreHist<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.average_max_submission_score, 2) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.max_submission_score_variance, 2) %>
+              </td>
+              <td class="text-center">
+                  <% if (row.max_submission_score_hist !== null) { %>
+                <div id="maxSubmissionScoreHist<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.average_average_submission_score, 2) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.average_submission_score_variance, 2) %>
+              </td>
+              <td class="text-center">
+                  <% if (row.average_submission_score_hist !== null) { %>
+                <div id="averageSubmissionScoreHist<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                  <% if (row.submission_score_array_averages !== null) { %>
+                <div id="submissionScoreArray<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                  <% if (row.incremental_submission_score_array_averages !== null) { %>
+                <div id="incrementalSubmissionScoreArray<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                <% if (row.type !== 'Homework') { %>
+                  <% if (row.incremental_submission_points_array_averages !== null) { %>
+                    <div id="incrementalSubmissionPointsArray<%= i %>" class="miniHist"></div>
+                  <% } %>
+                <% } else { %>
+                  N/A
+                <% } %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.average_number_submissions, 2) %>
+              </td>
+              <td class="text-center">
+                  <%= formatFloat(row.number_submissions_variance, 2) %>
+              </td>
+              <td class="text-center">
+                  <% if (row.number_submissions_hist !== null) { %>
+                <div id="numberSubmissionsHist<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <td class="text-center">
+                  <% if (row.quintile_question_scores !== null) { %>
+                <div id="quintileQuestionScoresHist<%= i %>" class="miniHist"></div>
+                  <% } %>
+              </td>
+              <script>
+                $(function() {
+                    const options = {
+                        width: 60,
+                        height: 20,
+                        ymax: 1
+                    };
+                    histmini("#firstSubmissionScoreHist<%= i %>",
+                             [<%= row.first_submission_score_hist %>],
+                             _.defaults({normalize: true}, options));
+                    histmini("#lastSubmissionScoreHist<%= i %>",
+                             [<%= row.last_submission_score_hist %>],
+                             _.defaults({normalize: true}, options));
+                    histmini("#maxSubmissionScoreHist<%= i %>",
+                             [<%= row.max_submission_score_hist %>],
+                             _.defaults({normalize: true}, options));
+                    histmini("#averageSubmissionScoreHist<%= i %>",
+                             [<%= row.average_submission_score_hist %>],
+                             _.defaults({normalize: true}, options));
+                    histmini("#submissionScoreArray<%= i %>",
+                             [<%= row.submission_score_array_averages %>],
+                             options);
+                    histmini("#incrementalSubmissionScoreArray<%= i %>",
+                             [<%= row.incremental_submission_score_array_averages %>],
+                             options);
+                    histmini("#incrementalSubmissionPointsArray<%= i %>",
+                             [<%= row.incremental_submission_points_array_averages %>],
+                             _.defaults({ymax: <%= row.max_points %>}, options));
+                    histmini("#numberSubmissionsHist<%= i %>",
+                             [<%= row.number_submissions_hist %>],
+                             _.defaults({normalize: true}, options));
+                    histmini("#quintileQuestionScoresHist<%= i %>",
+                             [<%= row.quintile_question_scores %>],
+                             _.defaults({ymax: 100}, options));
+                });
+              </script>
+            </tr>
+            <% }); %>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card-footer">
+          <p>
+            Download <a href="<%= urlPrefix %>/question/<%= question.id %>/<%= questionStatsCsvFilename %>"><%= questionStatsCsvFilename %></a>
+          </p>
+          <small>
+            <ul>
+                <% Object.keys(stat_descriptions).forEach(function(stat) {%>
+              <li>
+                <strong>
+                    <%- stat_descriptions[stat].title %>:
+                </strong>
+                  <%- stat_descriptions[stat].description %>
+              </li>
+                <% }); %>
+            </ul>
+            <p class="mb-0">
+              In the case that a student takes this assessment multiple
+              times (e.g., if this assessment is a practice exam), we
+              are calculating the above statistics by first averaging
+              over all assessment instances for each student, then
+              averaging over students.
+            </p>
+          </small>
+        </div>
+      </div>
+
+    </div>
+  </body>
+</html>

--- a/pages/courseQuestion/courseQuestion.js
+++ b/pages/courseQuestion/courseQuestion.js
@@ -1,0 +1,248 @@
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
+const express = require('express');
+const router = express.Router();
+const csvStringify = require('csv').stringify;
+
+const async = require('async');
+const error = require('@prairielearn/prairielib/error');
+const sanitizeName = require('../../lib/sanitize-name');
+const question = require('../../lib/question');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const debug = require('debug')('prairielearn:instructorQuestion');
+
+const logPageView = require('../../middlewares/logPageView')('instructorQuestion');
+
+const sql = sqlLoader.loadSqlEquiv(__filename);
+
+const filenames = function(locals) {
+    const prefix = sanitizeName.questionFilenamePrefix(locals.question, locals.course);
+    return {
+        questionStatsCsvFilename: prefix + 'stats.csv',
+    };
+};
+
+function processSubmission(req, res, callback) {
+    let variant_id, submitted_answer;
+    if (res.locals.question.type == 'Freeform') {
+        variant_id = req.body.__variant_id;
+        submitted_answer = _.omit(req.body, ['__action', '__csrf_token', '__variant_id']);
+    } else {
+        if (!req.body.postData) return callback(error.make(400, 'No postData', {locals: res.locals, body: req.body}));
+        let postData;
+        try {
+            postData = JSON.parse(req.body.postData);
+        } catch (e) {
+            return callback(error.make(400, 'JSON parse failed on body.postData', {locals: res.locals, body: req.body}));
+        }
+        variant_id = postData.variant ? postData.variant.id : null;
+        submitted_answer = postData.submittedAnswer;
+    }
+    const submission = {
+        variant_id: variant_id,
+        auth_user_id: res.locals.authn_user.user_id,
+        submitted_answer: submitted_answer,
+    };
+    sqldb.callOneRow('variants_ensure_question', [submission.variant_id, res.locals.question.id], (err, result) => {
+        if (ERR(err, callback)) return;
+        const variant = result.rows[0];
+        if (req.body.__action == 'grade') {
+            question.saveAndGradeSubmission(submission, variant, res.locals.question, res.locals.course, (err) => {
+                if (ERR(err, callback)) return;
+                callback(null, submission.variant_id);
+            });
+        } else if (req.body.__action == 'save') {
+            question.saveSubmission(submission, variant, res.locals.question, res.locals.course, (err) => {
+                if (ERR(err, callback)) return;
+                callback(null, submission.variant_id);
+            });
+        } else {
+            callback(error.make(400, 'unknown __action', {locals: res.locals, body: req.body}));
+        }
+    });
+}
+
+function processIssue(req, res, callback) {
+    const description = req.body.description;
+    if (!_.isString(description) || description.length == 0) {
+        return callback(new Error('A description of the issue must be provided'));
+    }
+
+    const variant_id = req.body.__variant_id;
+    sqldb.callOneRow('variants_ensure_question', [variant_id, res.locals.question.id], (err, _result) => {
+        if (ERR(err, callback)) return;
+
+        const course_data = _.pick(res.locals, ['variant', 'question', 'course_instance', 'course']);
+        const params = [
+            variant_id,
+            description, // student message
+            'instructor-reported issue', // instructor message
+            true, // manually_reported
+            true, // course_caused
+            course_data,
+            {}, // system_data
+            res.locals.authn_user.user_id,
+        ];
+        sqldb.call('issues_insert_for_variant', params, (err) => {
+            if (ERR(err, callback)) return;
+            callback(null, variant_id);
+        });
+    });
+}
+
+router.post('/', function(req, res, next) {
+    if (req.body.__action == 'grade' || req.body.__action == 'save') {
+        processSubmission(req, res, function(err, variant_id) {
+            if (ERR(err, next)) return;
+            res.redirect(res.locals.urlPrefix + '/question/' + res.locals.question.id
+                         + '/?variant_id=' + variant_id);
+        });
+    } else if (req.body.__action == 'test_once') {
+        const count = 1;
+        const showDetails = true;
+        question.startTestQuestion(count, showDetails, res.locals.question, res.locals.course_instance, res.locals.course, res.locals.authn_user.user_id, (err, job_sequence_id) => {
+            if (ERR(err, next)) return;
+            res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
+        });
+    } else if (req.body.__action == 'test_100') {
+        if (res.locals.question.grading_method !== 'External') {
+            const count = 100;
+            const showDetails = false;
+            question.startTestQuestion(count, showDetails, res.locals.question, res.locals.course_instance, res.locals.course, res.locals.authn_user.user_id, (err, job_sequence_id) => {
+                if (ERR(err, next)) return;
+                res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
+            });
+        } else {
+            next(new Error('Not supported for externally-graded questions'));
+        }
+    } else if (req.body.__action == 'report_issue') {
+        processIssue(req, res, function(err, variant_id) {
+            if (ERR(err, next)) return;
+            res.redirect(res.locals.urlPrefix + '/question/' + res.locals.question.id
+                         + '/?variant_id=' + variant_id);
+        });
+    } else {
+        return next(new Error('unknown __action: ' + req.body.__action));
+    }
+});
+
+router.get('/', function(req, res, next) {
+    async.series([
+        (callback) => {
+            debug('set filenames');
+            _.assign(res.locals, filenames(res.locals));
+            callback(null);
+        },
+        (callback) => {
+            sqldb.query(sql.assessment_question_stats, {question_id: res.locals.question.id}, function(err, result) {
+                if (ERR(err, callback)) return;
+                res.locals.assessment_stats = result.rows;
+                callback(null);
+            });
+        },
+        (callback) => {
+            res.locals.question_attempts_histogram = null;
+            res.locals.question_attempts_before_giving_up_histogram = null;
+            res.locals.question_attempts_histogram_hw = null;
+            res.locals.question_attempts_before_giving_up_histogram_hw = null;
+            // res.locals.question_attempts_histogram = res.locals.result.question_attempts_histogram;
+            // res.locals.question_attempts_before_giving_up_histogram = res.locals.result.question_attempts_before_giving_up_histogram;
+            // res.locals.question_attempts_histogram_hw = res.locals.result.question_attempts_histogram_hw;
+            // res.locals.question_attempts_before_giving_up_histogram_hw = res.locals.result.question_attempts_before_giving_up_histogram_hw;
+            callback(null);
+        },
+        (callback) => {
+            // req.query.variant_id might be undefined, which will generate a new variant
+            question.getAndRenderVariant(req.query.variant_id, res.locals, function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        (callback) => {
+            logPageView(req, res, (err) => {
+                if (ERR(err, next)) return;
+                callback(null);
+            });
+        },
+        (callback) => {
+            res.locals.questionGHLink = null;
+            if (res.locals.course.repository) {
+                const GHfound = res.locals.course.repository.match(/^git@github.com:\/?(.+?)(\.git)?\/?$/);
+                if (GHfound) {
+                    res.locals.questionGHLink = 'https://github.com/' + GHfound[1] + '/tree/master/questions/' + res.locals.question.qid;
+                }
+            } else if (res.locals.course.options.isExampleCourse) {
+                res.locals.questionGHLink = `https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/${res.locals.question.qid}`;
+            }
+            callback(null);
+        },
+    ], (err) => {
+        if (ERR(err, next)) return;
+        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+    });
+});
+
+router.get('/:filename', function(req, res, next) {
+    _.assign(res.locals, filenames(res.locals));
+
+    if (req.params.filename === res.locals.questionStatsCsvFilename) {
+        sqldb.query(sql.assessment_question_stats, {question_id: res.locals.question.id}, function(err, result) {
+            if (ERR(err, next)) return;
+            var questionStatsList = result.rows;
+            var csvData = [];
+            var csvHeaders = ['Course instance', 'Assessment'];
+            Object.keys(res.locals.stat_descriptions).forEach(key => {
+                csvHeaders.push(res.locals.stat_descriptions[key].non_html_title);
+            });
+
+            csvData.push(csvHeaders);
+
+            _(questionStatsList).each(function(questionStats) {
+                var questionStatsData = [];
+                questionStatsData.push(questionStats.course_title);
+                questionStatsData.push(questionStats.label);
+                questionStatsData.push(questionStats.mean_question_score);
+                questionStatsData.push(questionStats.question_score_variance);
+                questionStatsData.push(questionStats.discrimination);
+                questionStatsData.push(questionStats.some_submission_perc);
+                questionStatsData.push(questionStats.some_perfect_submission_perc);
+                questionStatsData.push(questionStats.some_nonzero_submission_perc);
+                questionStatsData.push(questionStats.average_first_submission_score);
+                questionStatsData.push(questionStats.first_submission_score_variance);
+                questionStatsData.push(questionStats.first_submission_score_hist);
+                questionStatsData.push(questionStats.average_last_submission_score);
+                questionStatsData.push(questionStats.last_submission_score_variance);
+                questionStatsData.push(questionStats.last_submission_score_hist);
+                questionStatsData.push(questionStats.average_max_submission_score);
+                questionStatsData.push(questionStats.max_submission_score_variance);
+                questionStatsData.push(questionStats.max_submission_score_hist);
+                questionStatsData.push(questionStats.average_average_submission_score);
+                questionStatsData.push(questionStats.average_submission_score_variance);
+                questionStatsData.push(questionStats.average_submission_score_hist);
+                questionStatsData.push(questionStats.submission_score_array_averages);
+                questionStatsData.push(questionStats.incremental_submission_score_array_averages);
+                questionStatsData.push(questionStats.incremental_submission_points_array_averages);
+                questionStatsData.push(questionStats.average_number_submissions);
+                questionStatsData.push(questionStats.number_submissions_variance);
+                questionStatsData.push(questionStats.number_submissions_hist);
+                questionStatsData.push(questionStats.quintile_question_scores);
+
+                _(questionStats.quintile_scores).each(function(perc) {
+                    questionStatsData.push(perc);
+                });
+
+                csvData.push(questionStatsData);
+            });
+
+            csvStringify(csvData, function(err, csv) {
+                if (ERR(err, next)) return;
+                res.attachment(req.params.filename);
+                res.send(csv);
+            });
+        });
+    } else {
+        next(new Error('Unknown filename: ' + req.params.filename));
+    }
+});
+module.exports = router;

--- a/pages/courseQuestion/courseQuestion.sql
+++ b/pages/courseQuestion/courseQuestion.sql
@@ -1,0 +1,26 @@
+-- BLOCK assessment_question_stats
+SELECT
+    aset.name || ' ' || a.number || ': ' || title AS title,
+    ci.short_name AS course_title,
+    a.id AS assessment_id,
+    a.type AS type,
+    a.course_instance_id,
+    aset.color,
+    (aset.abbreviation || a.number) as label,
+    admin_assessment_question_number(aq.id) as number,
+    aq.*
+FROM
+    assessment_questions AS aq
+    JOIN assessments AS a ON (a.id = aq.assessment_id)
+    JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
+    JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+    aq.question_id=$question_id
+    AND aq.deleted_at IS NULL
+GROUP BY
+    a.id,
+    aq.id,
+    aset.id,
+    ci.id
+ORDER BY
+    admin_assessment_question_number(aq.id);

--- a/pages/courseQuestions/courseQuestions.ejs
+++ b/pages/courseQuestions/courseQuestions.ejs
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head'); %>
+    <link href="/stylesheets/theme.bootstrap.css" rel="stylesheet" />
+    <script src="/javascripts/jquery.tablesorter.min.js"></script>
+    <script src="/javascripts/jquery.tablesorter.widgets.js"></script>
+  </head>
+  <body>
+    <%- include('../partials/navbar', {navPage: 'courseQuestions'}); %>
+    <div id="content" class="container-fluid">
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white d-flex align-items-center">
+          Questions
+          <button class="btn btn-sm btn-light ml-auto" id="resetFilter">Clear all filters</button>
+        </div>
+
+        <div class="table-responsive">
+          <table id="questionsTable" class="table table-sm table-hover tablesorter">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>QID</th>
+                <th class="filter-select filter-exact" data-placeholder="Choose topic">Topic</th>
+                <th data-placeholder="Choose tag">Tags</th>
+                <!-- One column per course instance -->
+                <% course_instance_list.forEach( function(ci) { %>
+                <th data-placeholder="Choose <%= ci.course_instance_short_name %> assessment"><%= ci.course_instance_short_name %></th>
+                <% }); %>
+              </tr>
+            </thead>
+            <tbody>
+              <% questions.forEach(function(question) { %>
+              <tr>
+                <td class="align-middle">
+                  <a href="<%= urlPrefix %>/question/<%= question.id %>/"><%= question.title %></a>
+                  <%- include('../partials/issueBadge', {count: question.open_issue_count, issueQid: question.qid}); %>
+                </td>
+                <td class="align-middle"><%= question.qid %></td>
+                <td class="align-middle"><%- include('../partials/topic', {topic: question.topic}); %></td>
+                <td class="align-middle"><%- include('../partials/tags', {tags: question.tags}); %></td>
+                <!-- Render each course instance assessment list -->
+                <% question.course_instances.forEach(function(course_instance) { %>
+                <td class="align-middle"><%- include('../partials/assessments', {course_instance_id: course_instance.course_instance_id, assessments: course_instance.assessments}); %></td>
+                <% }); %>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+        <script>
+          $(function(){
+              $("#questionsTable").tablesorter({
+                  theme: "bootstrap",
+                  widthFixed: true,
+                  headerTemplate: '{content} {icon}',
+                  widgets: ["uitheme", "filter", "zebra"],
+                  widgetOptions: {
+                      zebra: ["even", "odd"],
+                      filter_reset : "#resetFilter",
+                      filter_cssFilter: "form-control",
+                      filter_functions: {
+                          3: {
+                              <% all_tags.forEach(function(tag) { %>
+                                  "<%= tag.name %>": function(e, n, f, i, $r, c, data) { return /\b<%= tag.name %>\b/.test(e); },
+                              <% }); %>
+                          },
+                          <% course_instance_list.forEach(function(course_instance, ci_index) { %>
+                          <%= 4+ci_index %>: {
+                              <% course_instance.assessments.forEach(function(assessment) { %>
+                                  "<%= assessment.label %>": function(e, n, f, i, $r, c, data) { return /\b<%= assessment.label %>\b/.test(e); },
+                              <% }); %>
+                          },
+                          <% }); %>
+                      },
+                  },
+              });
+          });
+        </script>
+      </div>
+    </div>
+  </body>
+</html>

--- a/pages/courseQuestions/courseQuestions.ejs
+++ b/pages/courseQuestions/courseQuestions.ejs
@@ -41,7 +41,7 @@
                 <td class="align-middle"><%- include('../partials/tags', {tags: question.tags}); %></td>
                 <!-- Render each course instance assessment list -->
                 <% question.course_instances.forEach(function(course_instance) { %>
-                <td class="align-middle"><%- include('../partials/assessments', {course_instance_id: course_instance.course_instance_id, assessments: course_instance.assessments}); %></td>
+                <td class="align-middle"><%- include('../partials/courseAssessments', {course_instance_id: course_instance.course_instance_id, assessments: course_instance.assessments}); %></td>
                 <% }); %>
               </tr>
               <% }); %>

--- a/pages/courseQuestions/courseQuestions.js
+++ b/pages/courseQuestions/courseQuestions.js
@@ -1,0 +1,38 @@
+var ERR = require('async-stacktrace');
+var express = require('express');
+var router = express.Router();
+
+var sqldb = require('@prairielearn/prairielib/sql-db');
+var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+
+var sql = sqlLoader.loadSqlEquiv(__filename);
+
+router.get('/', function(req, res, next) {
+    var params = {
+        course_id: res.locals.course.id,
+    };
+    sqldb.query(sql.course_instance_list, params, function(err, result) {
+        if (ERR(err, next)) return;
+        res.locals.course_instance_list = result.rows;
+
+        var params = {
+            course_id: res.locals.course.id,
+        };
+        sqldb.query(sql.questions, params, function(err, result) {
+            if (ERR(err, next)) return;
+            res.locals.questions = result.rows;
+
+            var params = {
+                course_id: res.locals.course.id,
+            };
+            sqldb.query(sql.tags, params, function(err, result) {
+                if (ERR(err, next)) return;
+                res.locals.all_tags = result.rows;
+
+                res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+            });
+        });
+    });
+});
+
+module.exports = router;

--- a/pages/courseQuestions/courseQuestions.sql
+++ b/pages/courseQuestions/courseQuestions.sql
@@ -1,0 +1,100 @@
+-- BLOCK course_instance_list
+WITH assessment_list AS (
+    SELECT
+        aset.abbreviation || a.number AS label,
+        a.id AS assessment_id,
+        aset.color AS color,
+        ci.id AS course_instance_id,
+        aset.number AS assessment_set_number,
+        a.number AS assessment_number
+    FROM
+        assessments AS a
+        JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
+        JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+    WHERE
+        ci.deleted_at IS NULL
+        AND a.deleted_at IS NULL
+        AND ci.course_id = $course_id
+    ORDER BY aset.number, a.number
+)
+SELECT
+    ci.id AS course_instance_id,
+    ci.number AS course_instance_number,
+    ci.short_name AS course_instance_short_name,
+    ARRAY_AGG(
+        json_build_object(
+            'label', al.label,
+            'assessment_id', al.assessment_id,
+            'color', al.color
+        ) ORDER BY al.assessment_set_number, al.assessment_number
+    ) as assessments
+FROM
+    course_instances AS ci
+    JOIN assessment_list AS al ON (al.course_instance_id = ci.id)
+WHERE
+    ci.deleted_at IS NULL
+    AND ci.course_id = $course_id
+GROUP BY ci.id, ci.number, ci.short_name
+ORDER BY
+    ci.number DESC;
+    
+-- BLOCK questions
+WITH issue_count AS (
+    SELECT
+        i.question_id,
+        count(*) AS open_issue_count
+    FROM issues AS i
+    WHERE
+        i.course_id = $course_id
+        AND i.course_caused
+        AND i.open
+    GROUP BY i.question_id
+),
+course_instance_list AS (
+    SELECT
+        ci.id AS course_instance_id,
+        ci.number AS course_instance_number,
+        ci.short_name AS course_instance_short_name
+    FROM course_instances AS ci
+    WHERE ci.deleted_at IS NULL
+          AND ci.course_id = $course_id
+    ORDER BY course_instance_number DESC
+),
+question_list AS (
+    SELECT
+        q.id,
+        ARRAY_AGG(
+            json_build_object(
+                'course_instance_id', cil.course_instance_id,
+                'course_instance_number', cil.course_instance_number,
+                'course_instance_short_name', cil.course_instance_short_name,
+                'assessments', assessments_format_for_question(q.id, cil.course_instance_id)
+            ) ORDER BY cil.course_instance_number DESC
+        ) AS course_instances
+    FROM questions AS q
+         CROSS JOIN course_instance_list AS cil
+    WHERE q.deleted_at IS NULL
+          AND q.course_id = $course_id
+    GROUP BY q.id
+)
+SELECT
+    q.*,
+    ql.course_instances,
+    coalesce(issue_count.open_issue_count, 0) AS open_issue_count,
+    row_to_json(top) AS topic,
+    tags_for_question(q.id) AS tags
+FROM
+    questions AS q
+    JOIN question_list AS ql ON (q.id = ql.id)
+    JOIN topics AS top ON (top.id = q.topic_id)
+    LEFT JOIN issue_count ON (issue_count.question_id = q.id)
+WHERE
+    q.course_id = $course_id
+    AND q.deleted_at IS NULL
+ORDER BY top.number, q.title;
+
+-- BLOCK tags
+SELECT tag.name AS name
+FROM tags AS tag
+WHERE tag.course_id = $course_id
+ORDER BY tag.number;

--- a/pages/partials/courseAssessment.ejs
+++ b/pages/partials/courseAssessment.ejs
@@ -1,0 +1,3 @@
+<a href="/pl/course_instance/<%= course_instance_id %>/instructor/assessment/<%= assessment.assessment_id %>" class="badge color-<%= assessment.color %> color-hover">
+  <%= assessment.label %>
+</a>

--- a/pages/partials/courseAssessments.ejs
+++ b/pages/partials/courseAssessments.ejs
@@ -1,0 +1,5 @@
+<% if (assessments) { %>
+<% assessments.forEach(function(assessment) { %>
+<%- include('./courseAssessment', {course_instance_id: course_instance_id, assessment: assessment}); %>
+<% }); %>
+<% } %>

--- a/pages/partials/navbarCourse.ejs
+++ b/pages/partials/navbarCourse.ejs
@@ -12,6 +12,7 @@
       <!-- Main pages ------------------------------------------------------------------>
 
       <li class="nav-item <% if (navPage == "courseOverview") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/overview">Course</a></li>
+      <li class="nav-item <% if (navPage == "courseQuestions") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/questions">Questions</a></li>
       <% if (!devMode && authz_data.has_course_permission_edit) { %>
       <li class="nav-item <% if (navPage == "sync")           { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/syncs">Sync</a></li>
       <% } %>

--- a/pages/partials/navbarCourse.ejs
+++ b/pages/partials/navbarCourse.ejs
@@ -13,6 +13,7 @@
 
       <li class="nav-item <% if (navPage == "courseOverview") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/overview">Course</a></li>
       <li class="nav-item <% if (navPage == "courseQuestions") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/questions">Questions</a></li>
+      <li class="nav-item <% if (navPage == "courseIssues")      { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/issues">Issues <%- include('issueBadge', {count: navbarOpenIssueCount, suppressLink: true}) %></a></li>
       <% if (!devMode && authz_data.has_course_permission_edit) { %>
       <li class="nav-item <% if (navPage == "sync")           { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/syncs">Sync</a></li>
       <% } %>

--- a/server.js
+++ b/server.js
@@ -461,10 +461,41 @@ app.use('/pl/course/:course_id', require('./middlewares/selectOpenIssueCount'));
 app.use(/^\/pl\/course\/[0-9]+\/?$/, function(req, res, _next) {res.redirect(res.locals.urlPrefix + '/overview');}); // redirect plain course URL to overview page
 app.use('/pl/course/:course_id/overview', require('./pages/courseOverview/courseOverview'));
 app.use('/pl/course/:course_id/questions', require('./pages/courseQuestions/courseQuestions'));
+app.use('/pl/course/:course_id/question/:question_id', [
+    require('./middlewares/selectAndAuthzCourseQuestion'),
+    require('./pages/shared/assessmentStatDescriptions'),
+    require('./pages/shared/floatFormatters'),
+    require('./pages/courseQuestion/courseQuestion'),
+]);
 app.use('/pl/course/:course_id/issues', require('./pages/courseIssues/courseIssues'));
 app.use('/pl/course/:course_id/loadFromDisk', require('./pages/instructorLoadFromDisk/instructorLoadFromDisk'));
 app.use('/pl/course/:course_id/syncs', require('./pages/courseSyncs/courseSyncs'));
 app.use('/pl/course/:course_id/jobSequence', require('./pages/instructorJobSequence/instructorJobSequence'));
+
+// clientFiles
+// Omitting clientFilesCourseInstance and clientFilesAssessment, as these are only
+// sensible in the context of a course instance
+app.use('/pl/course/:course_id/clientFilesCourse', require('./pages/clientFilesCourse/clientFilesCourse'));
+app.use('/pl/course/:course_id/question/:question_id/clientFilesQuestion', [
+   require('./middlewares/selectAndAuthzCourseQuestion'),
+   require('./pages/clientFilesQuestion/clientFilesQuestion'),
+   ] );
+
+// generatedFiles
+app.use('/pl/course/:course_id/question/:question_id/generatedFilesQuestion', [
+   require('./middlewares/selectAndAuthzCourseQuestion'),
+   require('./pages/courseGeneratedFilesQuestion/courseGeneratedFilesQuestion'),
+   ] );
+
+// legacy client file paths
+app.use('/pl/course/:course_id/question/:question_id/file', [
+   require('./middlewares/selectAndAuthzCourseQuestion'),
+   require('./pages/legacyQuestionFile/legacyQuestionFile'),
+   ] );
+app.use('/pl/course/:course_id/question/:question_id/text', [
+   require('./middlewares/selectAndAuthzCourseQuestion'),
+   require('./pages/legacyQuestionText/legacyQuestionText'),
+   ] );
 
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////

--- a/server.js
+++ b/server.js
@@ -457,9 +457,11 @@ app.use('/pl/course_instance/:course_instance_id/instance_question/:instance_que
 app.use('/pl/course/:course_id', require('./middlewares/authzCourse')); // set res.locals.course
 app.use('/pl/course/:course_id', function(req, res, next) {res.locals.urlPrefix = '/pl/course/' + req.params.course_id; next();});
 app.use('/pl/course/:course_id', function(req, res, next) {res.locals.navbarType = 'course'; next();});
+app.use('/pl/course/:course_id', require('./middlewares/selectOpenIssueCount'));
 app.use(/^\/pl\/course\/[0-9]+\/?$/, function(req, res, _next) {res.redirect(res.locals.urlPrefix + '/overview');}); // redirect plain course URL to overview page
 app.use('/pl/course/:course_id/overview', require('./pages/courseOverview/courseOverview'));
 app.use('/pl/course/:course_id/questions', require('./pages/courseQuestions/courseQuestions'));
+app.use('/pl/course/:course_id/issues', require('./pages/courseIssues/courseIssues'));
 app.use('/pl/course/:course_id/loadFromDisk', require('./pages/instructorLoadFromDisk/instructorLoadFromDisk'));
 app.use('/pl/course/:course_id/syncs', require('./pages/courseSyncs/courseSyncs'));
 app.use('/pl/course/:course_id/jobSequence', require('./pages/instructorJobSequence/instructorJobSequence'));

--- a/server.js
+++ b/server.js
@@ -459,6 +459,7 @@ app.use('/pl/course/:course_id', function(req, res, next) {res.locals.urlPrefix 
 app.use('/pl/course/:course_id', function(req, res, next) {res.locals.navbarType = 'course'; next();});
 app.use(/^\/pl\/course\/[0-9]+\/?$/, function(req, res, _next) {res.redirect(res.locals.urlPrefix + '/overview');}); // redirect plain course URL to overview page
 app.use('/pl/course/:course_id/overview', require('./pages/courseOverview/courseOverview'));
+app.use('/pl/course/:course_id/questions', require('./pages/courseQuestions/courseQuestions'));
 app.use('/pl/course/:course_id/loadFromDisk', require('./pages/instructorLoadFromDisk/instructorLoadFromDisk'));
 app.use('/pl/course/:course_id/syncs', require('./pages/courseSyncs/courseSyncs'));
 app.use('/pl/course/:course_id/jobSequence', require('./pages/instructorJobSequence/instructorJobSequence'));


### PR DESCRIPTION
This PR creates a "Questions" page for the course view, along with some supporting pages:
- A courseQuestions page to view all questions, including one column per course instance showing the assessments which use the question.
- A courseQuestion page to view individual question details outside of a course instance
- A courseIssues page to view issues outside a course instance

This replaces PR #1018 (which got broken during a rebase); that PR should go away.

This does everything in #988 except a view/hide toggle on individual course instances (so you can compare a subset of course instances like "last two years" or "times I taught"). I'd suggest that get spun out into a new Enhancement issue.

Closes #988, closes #912, fixes #1019
