### PR TITLE
Fix hljs syntax highlighting compatibility issue in pl-code.py

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -204,6 +204,8 @@
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).
 
   * Remove `string_from_2darray_sf()` from `freeformPythonLib/prairielearn.py` (Liz Livingston)
+  
+  * Fix hljs syntax highlighting compatibility issue in `pl-code.py` (Eric Huber)
 
 * __3.1.0__ - 2018-10-08
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -198,14 +198,14 @@
   * Fix (or at least attempt to) S3 file uploads for external grading (Nathan Walters).
 
   * Fix handling of binary files during external grading (Nathan Walters).
+  
+  * Fix hljs syntax highlighting compatibility issue in `pl-code.py` (Eric Huber).
 
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).
 
   * Remove `string_from_2darray_sf()` from `freeformPythonLib/prairielearn.py` (Liz Livingston)
-  
-  * Fix hljs syntax highlighting compatibility issue in `pl-code.py` (Eric Huber)
 
 * __3.1.0__ - 2018-10-08
 

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -89,7 +89,7 @@ def highlight_lines_in_code(code, highlight_lines, color):
             if len(line.strip()) == 0:
                 # insert line break to prevent collapsing the line
                 line = '<br>'
-            result_lines += '<span class="pl-code-highlighted-line" style="background-color: ' + color + ';">' + line + '</span>'
+            result_lines += '<span class="pl-code-highlighted-line" style="background-color: ' + color + ';">' + line + '\n</span>'
         else:
             result_lines += line + '\n'
         line_number += 1


### PR DESCRIPTION
hljs has a compatibility issue with pl-code, where a single-line C++ comment can't be parsed correctly if the line is "highlighted" by pl-code and it is not terminated with a newline; the result is that the line following the single-line comment is also marked as a comment by hljs. Inserting a terminating \n on the highlighted line, inside the span, seems to fix this.

GitHub isn't letting me attach an image here but I'll try in a followup.