### PR TITLE
WIP: Add LTIOutcomeRequired access rule

### DIFF
--- a/pages/instructorAssessmentAccess/instructorAssessmentAccess.ejs
+++ b/pages/instructorAssessmentAccess/instructorAssessmentAccess.ejs
@@ -26,6 +26,7 @@
                 <th>Time limit</th>
                 <th>Password</th>
                 <th>CBTF exam</th>
+                <th>LTI Outcome Required</th>
               </tr>
             </thead>
             <tbody>
@@ -40,6 +41,7 @@
                 <td><%= access_rule.time_limit %></td>
                 <td><%= access_rule.password %></td>
                 <td><%- access_rule.exam %></td>
+                <td><%= access_rule.lti_outcome_required %></td>
               </tr>
               <% }); %>
             </tbody>

--- a/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
+++ b/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
@@ -33,6 +33,10 @@ SELECT
         ELSE aar.password
     END AS password,
     CASE
+        WHEN aar.lti_outcome_required IS NULL THEN '—'
+        ELSE aar.lti_outcome_required::TEXT
+    END AS lti_outcome_required,
+    CASE
         WHEN aar.exam_uuid IS NULL THEN '—'
         WHEN e.exam_id IS NULL THEN 'Exam not found: ' || aar.exam_uuid
         WHEN NOT $link_exam_id THEN ps_c.rubric || ': ' || e.exam_string

--- a/pages/studentAssessments/studentAssessments.ejs
+++ b/pages/studentAssessments/studentAssessments.ejs
@@ -13,7 +13,20 @@
     <div id="content" class="container">
 
       <%- include('../partials/advertisement'); %>
-      
+
+      <% if (authn_user.provider == 'lti') { %>
+          <div class="card bg-warning">
+              <div class="card-header bg-warning"><strong>Warning coming from other learning systems (Coursera, Compass2g, etc.)</strong></div>
+              <div class="card-body">
+                  <ul>
+                      <li class="card-text">In most cases, you should link into the PrairieLearn
+                          assessments directly from your origin learning system. This menu isn't needed.</li>
+                      <li class="card-text">This might not be your complete list of assessments.</li>
+                  </ul>
+              </div>
+          </div>
+      <% } %>
+
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">Assessments</div>
 

--- a/schemas/infoAssessment.json
+++ b/schemas/infoAssessment.json
@@ -119,6 +119,10 @@
                     "type": "integer",
                     "minimum": 0
                 },
+                "LTIOutcomeRequired": {
+                    "description": "Check to see if we have an LTI outcome recorded for this user and assessment to provide access",
+                    "type": "boolean"
+                },
                 "password": {
                     "description": "Password to begin the assessment (only for Exams).",
                     "type": "string"

--- a/sprocs/check_assessment_access.sql
+++ b/sprocs/check_assessment_access.sql
@@ -54,7 +54,8 @@ BEGIN
     FROM
         assessment_access_rules AS aar
         JOIN LATERAL check_assessment_access_rule(aar, check_assessment_access.authz_mode, check_assessment_access.role,
-            check_assessment_access.user_id, check_assessment_access.uid, check_assessment_access.date, TRUE) AS caar ON TRUE
+            check_assessment_access.user_id, check_assessment_access.uid, check_assessment_access.assessment_id,
+            check_assessment_access.date, TRUE) AS caar ON TRUE
     WHERE
         aar.assessment_id = check_assessment_access.assessment_id
         AND caar.authorized

--- a/sync/fromDisk/assessments.js
+++ b/sync/fromDisk/assessments.js
@@ -178,6 +178,7 @@ module.exports = {
                     password: _(dbRule).has('password') ? dbRule.password : null,
                     seb_config: _(dbRule).has('SEBConfig') ? dbRule.SEBConfig : null,
                     exam_uuid: _(dbRule).has('examUuid') ? dbRule.examUuid : null,
+                    lti_outcome_required: _(dbRule).has('LTIOutcomeRequired') ? dbRule.LTIOutcomeRequired : null,
                 };
                 sqldb.query(sql.insert_assessment_access_rule, params, function(err, _result) {
                     if (ERR(err, callback)) return;

--- a/sync/fromDisk/assessments.sql
+++ b/sync/fromDisk/assessments.sql
@@ -78,13 +78,13 @@ WHERE uuid = $exam_uuid;
 -- BLOCK insert_assessment_access_rule
 INSERT INTO assessment_access_rules
         (assessment_id,  number,  mode,  role,  credit,  uids,          time_limit_min,
-        password,   seb_config,  exam_uuid,
+        password,   seb_config,  exam_uuid, lti_outcome_required,
         start_date,
         end_date)
 (
     SELECT
         $assessment_id, $number, $mode, $role, $credit, $uids::TEXT[], $time_limit_min,
-        $password, $seb_config, $exam_uuid,
+        $password, $seb_config, $exam_uuid, $lti_outcome_required,
         input_date($start_date, ci.display_timezone),
         input_date($end_date, ci.display_timezone)
     FROM
@@ -101,6 +101,7 @@ SET
     time_limit_min = EXCLUDED.time_limit_min,
     password = EXCLUDED.password,
     exam_uuid = EXCLUDED.exam_uuid,
+    lti_outcome_required = EXCLUDED.lti_outcome_required,
     uids = EXCLUDED.uids,
     seb_config = EXCLUDED.seb_config,
     start_date = EXCLUDED.start_date,


### PR DESCRIPTION
- Stop users that come from LTI with outcomes enabled from browsing to assessments where outcomes are not already present (i.e. they must navigate to the assessments from their origin LMS instead of through PL)
