### PR TITLE
Let generate_uuids.py find uppercase UUIDs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -191,9 +191,9 @@
 
   * Fix editing popovers to work with the new sanitization defaults (Matt West).
 
-  * Fix `tools/generate_uuid.py` to not add UUID in element subdirectory (Pavitra Shadvani).
+  * Fix `tools/generate_uuids.py` to not add UUID in element subdirectory (Pavitra Shadvani).
   
-  * Fix `tools/generate_uuid.py` to be able to find uppercase UUIDs (Eric Huber).
+  * Fix `tools/generate_uuids.py` to be able to find uppercase UUIDs (Eric Huber).
 
   * Fix gradebook download link for courses with special characters in their names (Nathan Walters).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -192,6 +192,8 @@
   * Fix editing popovers to work with the new sanitization defaults (Matt West).
 
   * Fix `tools/generate_uuid.py` to not add UUID in element subdirectory (Pavitra Shadvani).
+  
+  * Fix `tools/generate_uuid.py` to be able to find uppercase UUIDs (Eric Huber).
 
   * Fix gradebook download link for courses with special characters in their names (Nathan Walters).
 

--- a/tools/generate_uuids.py
+++ b/tools/generate_uuids.py
@@ -24,7 +24,7 @@ def add_uuid_to_file(filename):
                 return 0 # we don't want new UUIDs, so just skip this file
 
             # replace the exising UUID
-            (new_contents, n_sub) = re.subn(r'"uuid":(\s*)"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"',
+            (new_contents, n_sub) = re.subn(r'"uuid":(\s*)"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"',
                                             r'"uuid":\1"%s"' % uuid.uuid4(),
                                             contents)
             if n_sub == 0:


### PR DESCRIPTION
I encountered this issue recently. The script wasn't matching UUIDs with uppercase letters although it could see the `uuid` property was there, failing with an error message.