### PR TITLE
Fix CSRF checking for external grading live updates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -253,6 +253,8 @@
 
   * Fix help text CSV upload example with `points` (Matt West, h/t Mariana Silva and James Balamuta).
 
+  * Fix CSRF checking for external grading live updates (Nathan Walters).
+
   * Remove `allowIssueReporting` option in `infoCourseInstance.json` (Matt West).
 
   * Remove old temporary upgrade flag `tmp_upgraded_iq_status` (Matt West).

--- a/lib/question.js
+++ b/lib/question.js
@@ -1161,7 +1161,8 @@ module.exports = {
         }
 
         // Used for "auth" for external grading realtime results
-        locals.variantToken = csrf.generateToken({variantId: variant.id}, config.secretKey);
+        // ID is coerced to a string so that it matches what we get back from the client
+        locals.variantToken = csrf.generateToken({variantId: '' + variant.id}, config.secretKey);
 
         if (variant.broken) {
             locals.showGradeButton = false;


### PR DESCRIPTION
Fixes an issue introduced by #1342 where the variant ID was a `Number` on the server but a `String` on the client. This coerces the ID to a `String` when generating a CSRF token for a variant so that it matches what the client sends.