### PR TITLE
Remove the deprecated "files" option for external grading

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -278,6 +278,8 @@
   * Remove `string_from_2darray_sf()` from `freeformPythonLib/prairielearn.py` (Liz Livingston)
 
   * Remove `number` column from `question_tags` table; question tags are now sorted by `tags.number` (Nathan Walters).
+
+  * Remove support for `externalGradingOptions.files` in question `info.json` files (Nathan Walters).
   
   * Change enroll page interface to allow Bootstrap modal dialogues instead of popover tooltips with buttons on them; add more verbose description of what it means to add/remove a course. (Eric Huber)
 

--- a/schemas/schemas/infoQuestion.json
+++ b/schemas/schemas/infoQuestion.json
@@ -113,14 +113,6 @@
                     "description": "Program to run as the entrypoint to your grader. Must be runnable as 'chmod +x script && ./script'.",
                     "type": "string"
                 },
-                "files": {
-                    "description": "The list of files or directories that will be copied from course/externalGradingFiles/ to /grade/shared/",
-                    "type": "array",
-                    "items": {
-                        "description": "A single file or directory that will be copied to the external grader.",
-                        "type": "string"
-                    }
-                },
                 "serverFilesCourse": {
                     "description": "The list of files or directories that will be copied from course/externalGradingFiles/ to /grade/shared/",
                     "type": "array",

--- a/sync/fromDisk/questions.js
+++ b/sync/fromDisk/questions.js
@@ -24,19 +24,6 @@ module.exports.sync = function(courseInfo, questionDB, jobLogger, callback) {
         const questionsParam = Object.keys(questionDB).map(qid => {
             const q = questionDB[qid];
 
-            let external_grading_files = null;
-            if (q.externalGradingOptions) {
-                const opts = q.externalGradingOptions;
-                if (opts.files && opts.serverFilesCourse) {
-                    throw new Error(`Question ${qid} cannot use both externalGradingOptions.files and externalGradingOptions.serverFilesCourse`);
-                } else if (opts.files) {
-                    jobLogger.warn(`WARNING: Question ${qid} uses externalGradingOptions.files, which will be deprecated in favor of externalGradingOptions.serverFilesCourse`);
-                    external_grading_files = opts.files;
-                } else if (opts.serverFilesCourse) {
-                    external_grading_files = opts.serverFilesCourse;
-                }
-            }
-
             let partialCredit;
             if (q.partialCredit != null) {
                 partialCredit = q.partialCredit;
@@ -61,7 +48,7 @@ module.exports.sync = function(courseInfo, questionDB, jobLogger, callback) {
                 single_variant: !!q.singleVariant,
                 external_grading_enabled: (q.externalGradingOptions && q.externalGradingOptions.enabled),
                 external_grading_image: (q.externalGradingOptions && q.externalGradingOptions.image),
-                external_grading_files: external_grading_files,
+                external_grading_files: (q.externalGradingOptions && q.externalGradingOptions.serverFilesCourse),
                 external_grading_entrypoint: (q.externalGradingOptions && q.externalGradingOptions.entrypoint),
                 external_grading_timeout: (q.externalGradingOptions && q.externalGradingOptions.timeout),
                 external_grading_enable_networking: (q.externalGradingOptions && q.externalGradingOptions.enableNetworking),

--- a/tests/sync/util.js
+++ b/tests/sync/util.js
@@ -141,7 +141,6 @@ const syncFromDisk = require('../../sync/syncFromDisk');
  * @property {boolean} enabled
  * @property {string} image
  * @property {string} entrypoint
- * @property {string[]} files
  * @property {string[]} serverFilesCourse
  * @property {number} timeout
  * @property {boolean} enableNetworking


### PR DESCRIPTION
Removes remaining references to `externalGradingOptions.files` from question `info.json` files.

Closes #1588