### PR TITLE
Disable autocomplete on v3 questions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -163,6 +163,8 @@
 
   * Change file editor to simplify the use of drafts and to improve the user interface (Tim Bretl).
 
+  * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
+
   * Fix load-reporting close during unit tests (Matt West).
 
   * Fix PL / scheduler linking stored procedure to allow linked exams and fix bugs (Dave Mussulman).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 
 * __next version__ - XXXX-XX-XX
 
+  * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).
@@ -162,8 +164,6 @@
   * Change enroll page interface to allow Bootstrap modal dialogues instead of popover tooltips with buttons on them; add more verbose description of what it means to add/remove a course. (Eric Huber)
 
   * Change file editor to simplify the use of drafts and to improve the user interface (Tim Bretl).
-
-  * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Fix load-reporting close during unit tests (Matt West).
 

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -58,7 +58,7 @@
 
 
   <% if (question.type == 'Freeform') { %>
-  <form class="question-form" name="question-form" method="POST">
+  <form class="question-form" name="question-form" method="POST" autocomplete="off">
     <div class="card mb-4 question-block">
       <div class="card-header bg-primary text-white">
         <% if (question_context == 'student_homework') { %>


### PR DESCRIPTION
Adds `autocomplete="off"` to the v3 question for to disable autocomplete. Fixes #1624.