### PR TITLE
Assessment password cookie clearing fix

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,8 +12,10 @@
   * Fix deadlock when syncing course staff (Nathan Walters).
 
   * Fix name of `migrations/145_file_edits__job_sequence_id__add.sql` (Matt West).
-  
+
   * Fix `<pl-string-input>` handling of HTML entities in input (Nathan Walters).
+
+  * Fix assessment password clearing cookie situations, issue #1579 (Dave Mussulman).
 
 * __3.2.0__ - 2019-08-05
 

--- a/middlewares/clearCookies.js
+++ b/middlewares/clearCookies.js
@@ -1,8 +1,13 @@
-var _ = require('lodash');
+const _ = require('lodash');
+
+var cookies_to_ignore = ['pl_authn', 'pl_assessmentpw'];
 
 module.exports = function(req, res, next) {
     _(req.cookies).each(function(value, key) {
-        if (/^pl_/.test(key) && key != 'pl_authn') {
+        if (/^pl_/.test(key)) {
+            if (cookies_to_ignore.includes(key)) {
+                return;
+            }
             res.clearCookie(key);
         }
     });

--- a/middlewares/clearCookies.js
+++ b/middlewares/clearCookies.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-var cookies_to_ignore = ['pl_authn', 'pl_assessmentpw'];
+const cookies_to_ignore = ['pl_authn', 'pl_assessmentpw'];
 
 module.exports = function(req, res, next) {
     _(req.cookies).each(function(value, key) {

--- a/pages/authLogout/authLogout.js
+++ b/pages/authLogout/authLogout.js
@@ -3,6 +3,7 @@ var router = express.Router();
 
 router.get('/', function(req, res, _next) {
     res.clearCookie('pl_authn');
+    res.clearCookie('pl_assessmentpw');
     if (res.locals.authn_user.provider == 'shibboleth') {
         res.redirect('/Shibboleth.sso/Logout');
     } else {


### PR DESCRIPTION
Do not clear the assessment password cookie when visiting the `/pl` homepage, but do clear it when logging out.

Closes #1579 