### PR TITLE
Fix the syncing of missing tags and topics

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@
 
   * Fix assessment password clearing cookie situations, issue #1579 (Dave Mussulman).
 
+  * Fix the syncing of missing tags and topics (Nathan Walters).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/sync/fromDisk/tags.js
+++ b/sync/fromDisk/tags.js
@@ -30,10 +30,15 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
         // We'll create placeholder tags for tags that aren't specified in
         // infoCourse.json.
         const knownTagNames = new Set(tags.map(tag => tag.name));
-        const questionTagNames = [];
-        Object.values(questionDB).forEach(q => questionTagNames.push(...(q.tags || [])))
-        const missingTagNames = questionTagNames.filter(name => !knownTagNames.has(name));
-        tags.push(...missingTagNames.map(name => ({
+        const missingTagNames = new Set();
+        Object.values(questionDB).forEach(q => {
+            (q.tags || []).forEach(tag => {
+                if (!knownTagNames.has(tag)) {
+                    missingTagNames.add(tag);
+                }
+            });
+        });
+        tags.push(...[...missingTagNames].map(name => ({
             name,
             color: 'gray1',
             description: 'Auto-generated from use in a question; add this tag to your courseInfo.json file to customize',

--- a/sync/fromDisk/topics.js
+++ b/sync/fromDisk/topics.js
@@ -8,13 +8,13 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
         // We'll create placeholder topics for tags that aren't specified in
         // infoCourse.json.
         const knownTopicNames = new Set(topics.map(topic => topic.name));
-        const questionTopicNames = [];
+        const missingTopicNames = new Set();
         Object.values(questionDB).forEach(q => {
-            questionTopicNames.push(q.topic);
-            questionTopicNames.push(...(q.secondaryTopics || []));
-        })
-        const missingTopicNames = questionTopicNames.filter(name => !knownTopicNames.has(name));
-        topics.push(...missingTopicNames.map(name => ({
+            if (!knownTopicNames.has(q.topic)) {
+                missingTopicNames.add(q.topic);
+            }
+        });
+        topics.push(...[...missingTopicNames].map(name => ({
             name,
             color: 'gray1',
             description: 'Auto-generated from use in a question; add this topic to your courseInfo.json file to customize',

--- a/tests/sync/questionsSync.js
+++ b/tests/sync/questionsSync.js
@@ -56,29 +56,21 @@ describe('Question syncing', () => {
     // Missing topics should be created
     const courseData = util.getCourseData();
     const missingTopicName = 'missing topic name';
-    const missingSecondaryTopicName = 'missing secondary topic name';
     const originalTopicName = courseData.questions[util.QUESTION_ID].topic;
     courseData.questions[util.QUESTION_ID].topic = missingTopicName;
-    courseData.questions[util.QUESTION_ID].secondaryTopics.push(missingSecondaryTopicName);
     const courseDir = await util.writeAndSyncCourseData(courseData);
     let syncedTopics = await util.dumpTable('topics');
     let syncedTopic = syncedTopics.find(topic => topic.name === missingTopicName);
     assert.isOk(syncedTopic);
     assert(syncedTopic.description && syncedTopic.description.length > 0, 'tag should not have empty description');
-    let syncedSecondaryTopic = syncedTopics.find(topic => topic.name === missingSecondaryTopicName);
-    assert.isOk(syncedSecondaryTopic);
-    assert(syncedSecondaryTopic.description && syncedSecondaryTopic.description.length > 0, 'tag should not have empty description');
 
     // When missing topics are no longer used in any questions, they should
     // be removed from the DB
     courseData.questions[util.QUESTION_ID].topic = originalTopicName;
-    courseData.questions[util.QUESTION_ID].secondaryTopics.pop();
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     syncedTopics = await util.dumpTable('topics');
     syncedTopic = syncedTopics.find(tag => tag.name === missingTopicName);
     assert.isUndefined(syncedTopic);
-    syncedSecondaryTopic = syncedTopics.find(tag => tag.name === missingSecondaryTopicName);
-    assert.isUndefined(syncedSecondaryTopic);
   });
 
   it('allows the same UUID to be used in different courses', async () => {


### PR DESCRIPTION
Previously, we weren't handling duplicates of missing tags/topics appropriately. Now, we dedupe before trying to sync.

This also removes what little support we had for `secondaryTopics` in questions, which was already going to be ripped out in #1640 anyways.