### PR TITLE
Fix documentation formatting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,8 @@
 
   * Fix the syncing of missing tags and topics (Nathan Walters).
 
+  * Fix documentation formatting (Dave Mussulman).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/doc/question.md
+++ b/doc/question.md
@@ -128,7 +128,7 @@ A few special behaviors have been added to enable Markdown to work better within
 
 ### Code blocks
 
-Fenced code blocks (those using triple-backticks <code>```</code>) are rendered as `<pl-code>` elements, which will then be rendered as usual by PrairieLearn. These blocks support specifying language and highlighted lines, which are then passed to the resulting `<pl-code>` element. Consider the following markdown:
+Fenced code blocks (those using triple-backticks <code>\`\`\`</code>) are rendered as `<pl-code>` elements, which will then be rendered as usual by PrairieLearn. These blocks support specifying language and highlighted lines, which are then passed to the resulting `<pl-code>` element. Consider the following markdown:
 
 `````html
 <markdown>


### PR DESCRIPTION
The https://prairielearn.readthedocs.io/en/latest/question/ page has a runaway backtick. Hopefully this fixes it.