### PR TITLE
Change file edit access to "Editor", down from "Owner"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,8 @@
 
   * Change blocked-event-loop detection to be more lightweight in production (Matt West).
 
+  * Change file editing access to `Editor`, down from `Owner` (Matt West).
+
   * Fix dead letter cron job for `async` v3 (Matt West).
 
   * Fix deadlock when syncing course staff (Nathan Walters).

--- a/pages/instructorFileEditor/instructorFileEditor.js
+++ b/pages/instructorFileEditor/instructorFileEditor.js
@@ -29,7 +29,7 @@ router.get('/instructorFileEditorClient.js', (req, res) => {
 });
 
 router.get('/', (req, res, next) => {
-    if (!res.locals.authz_data.has_course_permission_own) return next(new Error('Insufficient permissions'));
+    if (!res.locals.authz_data.has_course_permission_edit) return next(new Error('Insufficient permissions'));
 
     if (_.isEmpty(req.query)) {
         return next(error.make(400, 'no query', {
@@ -155,7 +155,7 @@ router.get('/', (req, res, next) => {
 
 router.post('/', (req, res, next) => {
     debug(`Responding to post with action ${req.body.__action}`);
-    if (!res.locals.authz_data.has_course_permission_own) return next(new Error('Insufficient permissions'));
+    if (!res.locals.authz_data.has_course_permission_edit) return next(new Error('Insufficient permissions'));
 
     let fileEdit = {
         userID: res.locals.user.user_id,


### PR DESCRIPTION
We had the permissions required for file editing set to course “Owner”. I think that we actually want this to be “Editor”? Syncing currently requires “Editor”, which seems to be equivalent to file editing. The levels we have are:

* Viewer — only view, no edit.
* Editor — can edit the course.
* Owner — can edit the course, and can change access permissions of other users.
