### PR TITLE
Fix tag/topic syncing with builtin JavaScript names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,7 +39,6 @@
 
   * Fix tags/topics duplicates checking when tag/topic is a builtin JS object property, like `toString` (Nathan Walters).
 
-  * .:w
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,9 @@
 
   * Fix handling of duplicate topics in `infoCourse.json` (Nathan Walters).
 
+  * Fix tags/topics duplicates checking when tag/topic is a builtin JS object property, like `toString` (Nathan Walters).
+
+  * .:w
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/sync/fromDisk/tags.js
+++ b/sync/fromDisk/tags.js
@@ -5,7 +5,7 @@ function getDuplicates(arr) {
     const seen = new Set();
     return arr.filter(v => {
         const present = seen.has(v);
-        seen.add(v)
+        seen.add(v);
         return present;
     });
 }

--- a/sync/fromDisk/tags.js
+++ b/sync/fromDisk/tags.js
@@ -2,10 +2,10 @@ const { callbackify } = require('util');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 
 function getDuplicates(arr) {
-    const seen = {};
+    const seen = new Set();
     return arr.filter(v => {
-        const present = seen[v];
-        seen[v] = true;
+        const present = seen.has(v);
+        seen.add(v)
         return present;
     });
 }

--- a/sync/fromDisk/topics.js
+++ b/sync/fromDisk/topics.js
@@ -2,10 +2,10 @@ const { callbackify } = require('util');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 
 function getDuplicates(arr) {
-    const seen = {};
+    const seen = new Set();
     return arr.filter(v => {
-        const present = seen[v];
-        seen[v] = true;
+        const present = seen.has(v);
+        seen.add(v);
         return present;
     });
 }


### PR DESCRIPTION
By using a `Set` instead of just an object, we can safely handle any property name.

This will also be fixed by #1640 once that's merged, but I want to get this fixed with the current code in the meantime.

Fixes #1651