### PR TITLE
Restrict proctor message to access modes in CBTF/Secured Environments (close #1649)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,8 @@
 
   * Change file editing access to `Editor`, down from `Owner` (Matt West).
 
+  * Change `type: "Exam"` under `mode: "Public"` to not display "waiting for proctor..." message (James Balamuta).
+
   * Fix dead letter cron job for `async` v3 (Matt West).
 
   * Fix deadlock when syncing course staff (Nathan Walters).

--- a/exampleCourse/courseInstances/Sp15/assessments/exam5-public/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam5-public/infoAssessment.json
@@ -24,5 +24,5 @@
               ]
         }
     ],
-    "text": "The following forumula sheets are available to you on this exam:<ul><li><a href=\"<%= clientFilesAssessment %>/formulas.pdf\">PDF version</a></li>"
+    "text": "This exam should not display the 'Waiting for a Proctor' message if accessed through a public mode."
 }

--- a/exampleCourse/courseInstances/Sp15/assessments/exam5-public/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam5-public/infoAssessment.json
@@ -1,0 +1,28 @@
+{
+    "uuid": "ccdcc95b-76b5-4d08-b1d9-f87948f916ba",
+    "type": "Exam",
+    "title": "Verify Exam Mode Lacks 'Waiting for a Proctor'",
+    "set": "Exam",
+    "number": "5",
+    "allowAccess": [
+        {
+            "mode": "Public",
+            "credit": 100
+        }
+    ],
+    "zones": [
+        {
+            "title": "Hard questions",
+            "questions": [
+                {"id": "addNumbers",              "points": [5, 3, 1]},
+                {"id": "addVectors",              "points": [11, 9]},
+                {"id": "fossilFuelsRadio",        "points": [17, 13, 7, 2]},
+                {"id": "partialCredit1",          "points": [19]},
+                {"id": "partialCredit2",          "points": [9, 7, 5, 3]},
+                {"id": "partialCredit3",          "points": [13, 13, 8, 0.5, 0.1]},
+                {"id": "brokenGeneration",        "points": [10]}
+              ]
+        }
+    ],
+    "text": "The following forumula sheets are available to you on this exam:<ul><li><a href=\"<%= clientFilesAssessment %>/formulas.pdf\">PDF version</a></li>"
+}

--- a/exampleCourse/courseInstances/Sp15/assessments/exam8-public/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam8-public/infoAssessment.json
@@ -3,7 +3,7 @@
     "type": "Exam",
     "title": "Verify Exam Mode Lacks 'Waiting for a Proctor'",
     "set": "Exam",
-    "number": "5",
+    "number": "8",
     "allowAccess": [
         {
             "mode": "Public",

--- a/pages/studentAssessmentExam/studentAssessmentExam.ejs
+++ b/pages/studentAssessmentExam/studentAssessmentExam.ejs
@@ -13,9 +13,12 @@
 
         <div class="card-body">
 
-          <p class="lead text-center">
-            Please wait until instructed to start by a proctor
-          </p>
+          <% if (authz_result.mode == 'Exam' || authz_result.mode == 'SEB' || authz_result.password != null ) { %>
+            <p class="lead text-center">
+              Please wait until instructed to start by a proctor
+            </p>
+          <% } %>
+          
           <p class="lead text-center">
             This is <strong><%= assessment_set.name %> <%= assessment.number %>: <%= assessment.title %></strong> for <strong><%= course.short_name %></strong>
           </p>

--- a/tests/helperExam.js
+++ b/tests/helperExam.js
@@ -119,10 +119,6 @@ module.exports = {
             it('should parse', function() {
                 locals.$ = cheerio.load(page);
             });
-            it('should contain "Please wait"', function() {
-                elemList = locals.$('p.lead:contains("Please wait")');
-                assert.lengthOf(elemList, 1);
-            });
             it('should contain "Exam 1"', function() {
                 elemList = locals.$('p.lead strong:contains("Exam 1")');
                 assert.lengthOf(elemList, 1);

--- a/tests/testZoneGradingExam.js
+++ b/tests/testZoneGradingExam.js
@@ -140,10 +140,6 @@ describe('Zone grading exam assessment', function() {
             it('should parse', function() {
                 locals.$ = cheerio.load(page);
             });
-            it('should contain "Please wait"', function() {
-                elemList = locals.$('p.lead:contains("Please wait")');
-                assert.lengthOf(elemList, 1);
-            });
             it('should contain "Exam 5"', function() {
                 elemList = locals.$('p.lead strong:contains("Exam 5")');
                 assert.lengthOf(elemList, 1);


### PR DESCRIPTION
Removes the proctor message from appearing when student is under `mode: "Public"` on `type: "Exam"`. 

Note: This leaves the text present when the following access modes are used in an assessment of `type: "Exam"`: 

- `SEB`
- `Exam` (`Exam` with password)


`type: "Exam"` with `mode: "Public"`

![Screen Shot 2019-08-26 at 12 03 35 PM](https://user-images.githubusercontent.com/833642/63708730-dde47880-c7fa-11e9-9d9a-d8e85f12b14f.png)

`type: "Exam"` with `mode: "Exam"`

![Screen Shot 2019-08-26 at 12 17 29 PM](https://user-images.githubusercontent.com/833642/63709035-96aab780-c7fb-11e9-8645-5d0b522a549f.png)
