### PR TITLE
Rebuild centos7-plbase image on CI if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
   slack:
     secure: DzxZ8DNGFANLnls0j0/hiKjwg6aO/gI3UO8SiRKjqCO/x27uvBCJiDkTqCx834XVzuDBp6LIdHbyUuwRFyaVHyFYTbA0pqE4fe4/DxkK5DuRDj89cw8JgoK7/g9m/J9Y6GvwaOaE4SW0tnHeTwNDVCt7/w8rn1kxDo/tWtS+3cg=
 before_install:
+  - sh ./tools/build-plbase-if-needed.sh
   - docker build -t pltest .
 script:
   - 'if [[ "$TRAVIS_PULL_REQUEST" != "false" && ! ( "$TRAVIS_BRANCH" =~ ^dependabot/ ) && ! ( "$TRAVIS_PULL_REQUEST_BRANCH" =~ ^dependabot/ ) ]]; then sh ./tools/verify-changelog.sh; fi'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,8 @@
 
   * Change `type: "Exam"` under `mode: "Public"` to not display "waiting for proctor..." message (James Balamuta).
 
+  * Change Travis script to rebuild `prairielearn/centos7-plbase` if any relevant files have changed (Nathan Walters).
+
   * Fix dead letter cron job for `async` v3 (Matt West).
 
   * Fix deadlock when syncing course staff (Nathan Walters).

--- a/environments/centos7-plbase/Dockerfile
+++ b/environments/centos7-plbase/Dockerfile
@@ -7,8 +7,6 @@ ENV PYTHONIOENCODING=UTF-8
 # r-requirements.R        - list of R packages that should be installed from the Rstudio CRAN mirror
 COPY python-requirements.txt r-requirements.R /
 
-# Dummy change to test rebuild
-
 RUN yum -y install \
         epel-release \
         https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \

--- a/environments/centos7-plbase/Dockerfile
+++ b/environments/centos7-plbase/Dockerfile
@@ -7,6 +7,8 @@ ENV PYTHONIOENCODING=UTF-8
 # r-requirements.R        - list of R packages that should be installed from the Rstudio CRAN mirror
 COPY python-requirements.txt r-requirements.R /
 
+# Dummy change to test rebuild
+
 RUN yum -y install \
         epel-release \
         https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \

--- a/tools/build-plbase-if-needed.sh
+++ b/tools/build-plbase-if-needed.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if git diff --exit-code master -- environments/centos7-plbase; then
+  echo "prairielearn/centos7-plbase files not modified; no rebuild required"
+else
+  echo "prairielearn/centos7-plbase requires a rebuild"
+  docker build ./environments/centos7-plbase -t prairielearn/centos7-plbase
+fi


### PR DESCRIPTION
Currently, the `prairielearn/centos7-plbase` image is never rebuilt by Travis because it takes a long time to build and is generally pretty static. However, PRs like #1669 will have failing tests because the new version of the image isn't being used. This PR adds a script run by Travis that will check if any relevant files were changed in the current branch and rebuild the aforementioned image if needed.