### PR TITLE
Compile native R code in parallel in Docker image

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,8 @@
 
   * Change Travis script to rebuild `prairielearn/centos7-plbase` if any relevant files have changed (Nathan Walters).
 
+  * Change `prairielearn/centos7-plbase` image to compile native R code in parallel (Nathan Walters).
+
   * Fix dead letter cron job for `async` v3 (Matt West).
 
   * Fix deadlock when syncing course staff (Nathan Walters).

--- a/environments/centos7-plbase/Dockerfile
+++ b/environments/centos7-plbase/Dockerfile
@@ -50,6 +50,7 @@ RUN yum -y install \
         && ln -s /usr/bin/python3.6 /usr/bin/python3 \
         && python3 -m pip install --no-cache-dir -r /python-requirements.txt \
     && echo "installing R packages..." \
+        && echo "MAKE='make -j`nproc`'" >> /usr/lib64/R/Renviron `# Ensure native code is compiled in parallel` \
         && chmod +x /r-requirements.R `# Install a list of R packages to work with` \
         && mkdir -p /usr/share/doc/R-3.4.3/html/ \
         && touch /usr/share/doc/R-3.4.3/html/packages.html \


### PR DESCRIPTION
Experimental change based on https://www.r-bloggers.com/speeding-up-r-packages-installation-process/ - I saw much better build times locally, but I want to see how this performs on CI.