### PR TITLE
Show connecting IP

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@
 
   * Add docs for `singleVariant` question option (Matt West).
 
+  * Add connecting IP address report in instructor effective user page (Dave Mussulman).
+
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Change `centos7-python` to `grader-python` and place it under `graders/`  (James Balamuta).

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.ejs
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.ejs
@@ -17,13 +17,14 @@
           <p><strong>Authenticated name:</strong> <%= authz_data.authn_user.name %></p>
           <p><strong>Authenticated role:</strong> <%= authz_data.authn_role %></p>
           <p><strong>Authenticated mode:</strong> <%= authz_data.authn_mode %></p>
-          <p>Connecting from IP: <%= ipaddress %></p>
 
-          <form id="resetForm" method="POST">
+          <p><form id="resetForm" method="POST">
             <input type="hidden" name="__action" value="reset">
             <button type="submit" class="btn btn-info">Reset to these values</button>
             <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
-          </form>
+        </form></p>
+
+          <p><strong>Connecting from IP:</strong> <%= ipaddress %></p>
         </div>
 
         <div class="card-footer">

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.ejs
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.ejs
@@ -17,6 +17,7 @@
           <p><strong>Authenticated name:</strong> <%= authz_data.authn_user.name %></p>
           <p><strong>Authenticated role:</strong> <%= authz_data.authn_role %></p>
           <p><strong>Authenticated mode:</strong> <%= authz_data.authn_mode %></p>
+          <p>Connecting from IP: <%= ipaddress %></p>
 
           <form id="resetForm" method="POST">
             <input type="hidden" name="__action" value="reset">

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -19,6 +19,7 @@ router.get('/', function(req, res, next) {
     sqldb.queryOneRow(sql.select, params, function(err, result) {
         if (ERR(err, next)) return;
         _.assign(res.locals, result.rows[0]);
+        
         res.locals.ipaddress = req.headers['x-forwarded-for'] || req.ip;
         // Trim out IPv6 wrapper on IPv4 addresses
         if (res.locals.ipaddress.substr(0, 7) == '::ffff:') {

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -19,7 +19,7 @@ router.get('/', function(req, res, next) {
     sqldb.queryOneRow(sql.select, params, function(err, result) {
         if (ERR(err, next)) return;
         _.assign(res.locals, result.rows[0]);
-        res.locals.ipaddress = req.ip;
+        res.locals.ipaddress = req.headers['x-forwarded-for'] || req.ip
         // Trim out IPv6 wrapper on IPv4 addresses
         if (res.locals.ipaddress.substr(0, 7) == '::ffff:') {
               res.locals.ipaddress = res.locals.ipaddress.substr(7);

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -19,6 +19,11 @@ router.get('/', function(req, res, next) {
     sqldb.queryOneRow(sql.select, params, function(err, result) {
         if (ERR(err, next)) return;
         _.assign(res.locals, result.rows[0]);
+        res.locals.ipaddress = req.ip;
+        // Trim out IPv6 wrapper on IPv4 addresses
+        if (res.locals.ipaddress.substr(0, 7) == '::ffff:') {
+              res.locals.ipaddress = res.locals.ipaddress.substr(7);
+        }
 
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -19,7 +19,7 @@ router.get('/', function(req, res, next) {
     sqldb.queryOneRow(sql.select, params, function(err, result) {
         if (ERR(err, next)) return;
         _.assign(res.locals, result.rows[0]);
-        res.locals.ipaddress = req.headers['x-forwarded-for'] || req.ip
+        res.locals.ipaddress = req.headers['x-forwarded-for'] || req.ip;
         // Trim out IPv6 wrapper on IPv4 addresses
         if (res.locals.ipaddress.substr(0, 7) == '::ffff:') {
               res.locals.ipaddress = res.locals.ipaddress.substr(7);

--- a/server.js
+++ b/server.js
@@ -88,7 +88,7 @@ if (config.blockedAtWarnEnable) {
 const app = express();
 app.set('views', path.join(__dirname, 'pages'));
 app.set('view engine', 'ejs');
-app.set('trust proxy', true);
+app.set('trust proxy', 'loopback');
 
 config.devMode = (app.get('env') == 'development');
 

--- a/server.js
+++ b/server.js
@@ -88,6 +88,7 @@ if (config.blockedAtWarnEnable) {
 const app = express();
 app.set('views', path.join(__dirname, 'pages'));
 app.set('view engine', 'ejs');
+app.set('trust proxy', true);
 
 config.devMode = (app.get('env') == 'development');
 

--- a/server.js
+++ b/server.js
@@ -88,7 +88,6 @@ if (config.blockedAtWarnEnable) {
 const app = express();
 app.set('views', path.join(__dirname, 'pages'));
 app.set('view engine', 'ejs');
-app.set('trust proxy', 'loopback');
 
 config.devMode = (app.get('env') == 'development');
 


### PR DESCRIPTION
Adds the Express connecting IP address to the authenticated user information shown in the instructor "Change effective user page"

There hasn't been a way for the user (Instructor) to see which IP address they are connecting from. Making that more visible than grepping through server logs will make troubleshooting exam mode network configurations easier.