### PR TITLE
Fix LTI callback URL.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -63,6 +63,8 @@
 
   * Fix description of the points download description for assessments (James Balamuta, h/t Mariana Silva).
 
+  * Fix LTI callback URL (Matt West).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/pages/authCallbackLti/authCallbackLti.js
+++ b/pages/authCallbackLti/authCallbackLti.js
@@ -159,7 +159,7 @@ router.post('/', function(req, res, next) {
                         // No linked assessment
 
                         if (role != 'Student') {
-                            redirUrl = `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/instructor/admin/lti`;
+                            redirUrl = `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/instructor/instance_admin/lti`;
                         } else {
                             // Show an error that the assignment is unavailable
                             return next(error.make(400, 'Assignment not available yet'));


### PR DESCRIPTION
This fixes a bug introduced in PR #1344 (commit 3cebe3d009), which
changed the admin URL routes but did not update the LTI callback URL to
match.