### PR TITLE
Add https infrastructure support inside Docker

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,8 @@
 
   * Add connecting IP address report in instructor effective user page (Dave Mussulman).
 
+  * Add SSL https support inside the Docker container (Dave Mussulman).
+
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Change `centos7-python` to `grader-python` and place it under `graders/`  (James Balamuta).

--- a/docker/gen_ssl.sh
+++ b/docker/gen_ssl.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+KEY=/etc/pki/tls/private/localhost.key
+CERT=/etc/pki/tls/certs/localhost.crt
+CA_CHAIN=/etc/pki/tls/certs/server-chain.crt
+
+if [ -e $KEY ]; then
+    exit 0
+fi
+
+openssl req -x509 -out $CERT -keyout $KEY \
+    -newkey rsa:2048 -nodes -sha256 \
+    -subj '/CN=localhost' -extensions EXT -config <( \
+    printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
+
+# Make sure the file exists but can be empty
+touch $CA_CHAIN

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -9,6 +9,7 @@ if [[ -f /efs/container/config.json ]] ; then
 else
     # we are running in local development mode
     docker/start_postgres.sh
+    docker/gen_ssl.sh
 
     # Uncomment to start redis to test message passing
     # redis-server --daemonize yes

--- a/environments/centos7-plbase/Dockerfile
+++ b/environments/centos7-plbase/Dockerfile
@@ -21,6 +21,7 @@ RUN yum -y install \
         python36u-devel \
         gcc \
         make \
+        openssl \
         readline-devel        `# needed for rpy2` \
         libcurl-devel         `# needed for rvest (for R)` \
         openssl-devel         `# needed for rvest (for R)` \


### PR DESCRIPTION
In case we needed `https://localhost:3000` support working with the Docker development containers, this PR adds the package and script support to setup the keys PrairieLearn is expecting. It generates a self-signed localhost key where PrairieLearn is expecting it.

This purposefully doesn't configure PL to use https. That needs a `config.json` `"serverType": "https"` config. But if that config exists, this should take care of everything needed in the container to support that.

My primary use for this is testing LTI endpoints which might balk at insecure connections.
