### PR TITLE
Fix external grading vulnerability

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -65,6 +65,8 @@
 
   * Fix LTI callback URL (Matt West).
 
+  * Fix vulnerability in external grading that allows arbitrary files on the server to be overwritten (Nathan Walters).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/lib/externalGraderCommon.js
+++ b/lib/externalGraderCommon.js
@@ -111,6 +111,14 @@ module.exports.buildDirectory = function(dir, submission, variant, question, cou
 
                     // Files are expected to be base-64 encoded
                     let decodedContents = Buffer.from(file.contents, 'base64');
+                    // Check that the file name does not try to navigate up in
+                    // the directory hierarchy
+                    const fullPath = path.join(dir, 'student', file.name);
+                    const relPath = path.relative(path.join(dir, 'student'), fullPath);
+                    if (relPath.split(path.sep)[0] == '..' || path.isAbsolute(relPath)) {
+                        callback(new Error('Invalid filename'));
+                        return;
+                    }
                     fs.writeFile(path.join(dir, 'student', file.name), decodedContents, callback);
                 }, function(err) {
                     if (ERR(err, callback)) return;


### PR DESCRIPTION
This PR fixes a vulnerability that allows an attacker to overwrite arbitrary files on the PL host. Borrows code that @tbretl wrote for in-browser editing.