### PR TITLE
Fix disabled server load reporting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -71,6 +71,8 @@
 
   * Fix KeyboardInterrupt errors when Ctrl-C'ing out of docker (Dave Mussulman).
 
+  * Fix disabled server load reporting to CloudWatch (Matt West).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/cron/index.js
+++ b/cron/index.js
@@ -60,12 +60,12 @@ module.exports = {
                 module: require('./externalGraderLoad'),
                 intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalExternalGraderLoadSec,
             },
-/*            {
+            {
                 name: 'serverLoad',
                 module: require('./serverLoad'),
                 intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalServerLoadSec,
             },
-*/            {
+            {
                 name: 'serverUsage',
                 module: require('./serverUsage'),
                 intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalServerUsageSec,


### PR DESCRIPTION
Turns out I accidentally turned off server load reporting to CloudWatch a month ago.