### PR TITLE
Fix legacy Ace editor assets

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -79,6 +79,8 @@
 
   * Fix disabled server load reporting to CloudWatch (Matt West).
 
+  * Fix legacy Ace editor assets (Nathan Walters).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/server.js
+++ b/server.js
@@ -156,6 +156,7 @@ app.use('/node_modules', express.static(path.join(__dirname, 'node_modules')));
 
 // Support legacy use of ace by v2 questions
 app.use('/localscripts/calculationQuestion/ace', express.static(path.join(__dirname, 'node_modules/ace-builds/src-min-noconflict')));
+app.use('/javascripts/ace', express.static(path.join(__dirname, 'node_modules/ace-builds/src-min-noconflict')));
 
 
 // Middleware for all requests

--- a/server.js
+++ b/server.js
@@ -155,7 +155,7 @@ app.use('/MathJax', express.static(path.join(__dirname, 'node_modules', 'mathjax
 app.use('/node_modules', express.static(path.join(__dirname, 'node_modules')));
 
 // Support legacy use of ace by v2 questions
-app.use('/public/localscripts/calculationQuestion/ace', express.static(path.join(__dirname, 'node_modules/ace-builds/src-min-noconflict')));
+app.use('/localscripts/calculationQuestion/ace', express.static(path.join(__dirname, 'node_modules/ace-builds/src-min-noconflict')));
 
 
 // Middleware for all requests


### PR DESCRIPTION
#1609 removed Ace assets from `localscripts/calculationQuestion`, but some v2 questions still use them. That PR tried to serve the assets from the legacy URL, but used the wrong path. This PR corrects it to serve them from the right path.