### PR TITLE
Add student gradebook page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,8 @@
 
   * Add `pl-hide-in-panel` element (Matt West).
 
+  * Add student Gradebook page (Matt West).
+
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Change `centos7-python` to `grader-python` and place it under `graders/`  (James Balamuta).

--- a/pages/partials/navbarStudent.ejs
+++ b/pages/partials/navbarStudent.ejs
@@ -11,6 +11,7 @@
       <!-- Main pages ------------------------------------------------------------------>
 
       <li class="nav item <% if (navPage == "assessments") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/assessments">Assessments</a></li>
+      <li class="nav item <% if (navPage == "gradebook") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/gradebook">Gradebook</a></li>
 
       <% if (typeof assessment_instance_label != 'undefined' && typeof assessment_instance != 'undefined') { %>
       <li class="nav item <% if (navPage == "assessment_instance") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>"><%= assessment_instance_label %></a></li>

--- a/pages/studentGradebook/studentGradebook.ejs
+++ b/pages/studentGradebook/studentGradebook.ejs
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <%- include('../partials/head'); %>
+  </head>
+  <body>
+    <script>
+      $(function () {
+          $('[data-toggle="popover"]').popover({sanitize: false})
+      });
+    </script>
+    <%- include('../partials/navbar', {navPage: 'gradebook'}); %>
+    <div id="content" class="container">
+
+      <%- include('../partials/advertisement'); %>
+      
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white">Gradebook</div>
+
+        <table class="table table-sm table-hover">
+          <thead>
+            <tr>
+              <th style="width: 1%"></th>
+              <th></th>
+              <th class="text-center">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% rows.forEach(function(row) { %>
+            <% if (row.start_new_set) { %>
+            <tr>
+              <th colspan="3"><%= row.assessment_set_heading %></th>
+            </tr>
+            <% } %>
+            <tr>
+              <td class="align-middle" style="width: 1%">
+                <% if (row.multiple_instance_header) { %>
+                <span class="badge color-<%= row.assessment_set_color %>"><%= row.label %></span>
+                <% } else { %>
+                <span class="badge color-<%= row.assessment_set_color %> color-hover">
+                  <%= row.label %>
+                </span>
+                <% } %>
+              </td>
+              <td class="align-middle">
+                <%= row.title %>
+              </td>
+              <td class="text-center align-middle">
+                <% if (!row.multiple_instance_header) { %>
+                <%- include('../partials/scorebar', {score: row.assessment_instance_score_perc}) %>
+                <% } %>
+              </td>
+            </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </body>
+</html>

--- a/pages/studentGradebook/studentGradebook.js
+++ b/pages/studentGradebook/studentGradebook.js
@@ -1,0 +1,22 @@
+var ERR = require('async-stacktrace');
+var express = require('express');
+var router = express.Router();
+
+var sqldb = require('@prairielearn/prairielib/sql-db');
+var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+
+var sql = sqlLoader.loadSqlEquiv(__filename);
+
+router.get('/', function(req, res, next) {
+    var params = {
+        course_instance_id: res.locals.course_instance.id,
+        user_id: res.locals.user.user_id,
+    };
+    sqldb.query(sql.select_assessment_instances, params, function(err, result) {
+        if (ERR(err, next)) return;
+        res.locals.rows = result.rows;
+        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+    });
+});
+
+module.exports = router;

--- a/pages/studentGradebook/studentGradebook.sql
+++ b/pages/studentGradebook/studentGradebook.sql
@@ -1,0 +1,35 @@
+-- BLOCK select_assessment_instances
+SELECT
+    a.id AS assessment_id,
+    a.number AS assessment_number,
+    a.order_by AS assessment_order_by,
+    CASE
+        WHEN a.multiple_instance THEN a.title || ' instance #' || ai.number
+        ELSE a.title
+    END AS title,
+    aset.id AS assessment_set_id,
+    aset.abbreviation AS assessment_set_abbreviation,
+    aset.name AS assessment_set_name,
+    aset.heading AS assessment_set_heading,
+    aset.color AS assessment_set_color,
+    aset.number AS assessment_set_number,
+    CASE
+        WHEN a.multiple_instance THEN aset.abbreviation || a.number || '#' || ai.number
+        ELSE aset.abbreviation || a.number
+    END AS label,
+    ai.id AS assessment_instance_id,
+    ai.number AS assessment_instance_number,
+    ai.score_perc AS assessment_instance_score_perc,
+    ai.open AS assessment_instance_open,
+    (lag(assessment_set_id) OVER (PARTITION BY aset.id ORDER BY a.order_by, a.id, ai.number) IS NULL) AS start_new_set
+FROM
+    assessment_instances AS ai
+    JOIN assessments AS a ON (a.id = ai.assessment_id)
+    JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+    JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
+WHERE
+    ci.id = $course_instance_id
+    AND ai.user_id = $user_id
+    AND a.deleted_at IS NULL
+ORDER BY
+    aset.number, a.order_by, a.id, ai.number;

--- a/server.js
+++ b/server.js
@@ -444,6 +444,11 @@ app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_i
 
 // Exam/Homeworks student routes are polymorphic - they have multiple handlers, each of
 // which checks the assessment type and calls next() if it's not the right type
+app.use('/pl/course_instance/:course_instance_id/gradebook', [
+    require('./middlewares/logPageView')('studentGradebook'),
+    require('./middlewares/studentAssessmentAccess'),
+    require('./pages/studentGradebook/studentGradebook'),
+]);
 app.use('/pl/course_instance/:course_instance_id/assessments', [
     require('./middlewares/logPageView')('studentAssessments'),
     require('./middlewares/studentAssessmentAccess'),

--- a/tests/testHomework.js
+++ b/tests/testHomework.js
@@ -1175,6 +1175,30 @@ describe('Homework assessment', function() {
         });
     });
 
+    describe('36. student gradebook page', function() {
+        it('should load successfully', function(callback) {
+            const gradebookUrl = locals.courseInstanceBaseUrl + '/gradebook';
+            request(gradebookUrl, function (error, response, body) {
+                if (error) {
+                    return callback(error);
+                }
+                if (response.statusCode != 200) {
+                    return callback(new Error('bad status: ' + response.statusCode));
+                }
+                res = response;
+                page = body;
+                callback(null);
+            });
+        });
+        it('should parse', function() {
+            locals.$ = cheerio.load(page);
+        });
+        it('should contain HW1', function() {
+            elemList = locals.$('td:contains("Homework for automatic test suite")');
+            assert.lengthOf(elemList, 1);
+        });
+    });
+
     partialCreditTests.forEach(function(partialCreditTest, iPartialCreditTest) {
 
         describe(`partial credit test #${iPartialCreditTest+1}`, function() {


### PR DESCRIPTION
Adds a student gradebook page that shows all the assessment instances for the student along with the scores. This ignores access permissions, so it shows the scores for every assessment instance, whether the student has access to see the assessment or not. The main use-case for this is to let students see the scores for their exams, after the exam is over. For this reason, the assessment instances on the gradebook page are not links.

Closes #1452 

![977A65F0-1D82-42E9-812A-AAC2B476DFD3](https://user-images.githubusercontent.com/875833/65642583-45861300-dfb5-11e9-9d55-cebd724ca391.jpeg)
