### PR TITLE
Fix external grading results containing NULL bytes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,6 +83,8 @@
 
   * Fix legacy Ace editor assets (Nathan Walters).
 
+  * Fix external grading results containing NULL bytes (Matt West).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/lib/externalGraderCommon.js
+++ b/lib/externalGraderCommon.js
@@ -175,10 +175,25 @@ module.exports.makeGradingResult = function(jobId, rawData) {
     }
 
     try {
-        data = JSON.parse(data.replace(/\0/g, ''));
+        // replace NULL with unicode replacement character
+        data = JSON.parse(data.replace(/\0/g, '\ufffd'));
     } catch (e) {
         return makeGradingFailureWithMessage(jobId, data, 'Could not parse the grading results.');
     }
+
+    function replaceNull(d) {
+        if (_.isString(d)) {
+            // replace NULL with unicode replacement character
+            return d.replace(/\0/g, '\ufffd');
+        } else if (_.isArray(d)) {
+            return _.map(d, x => replaceNull(x));
+        } else if (_.isObject(d)) {
+            return _.mapValues(d, x => replaceNull(x));
+        } else {
+            return d;
+        }
+    }
+    data = replaceNull(data);
 
     if (!data.succeeded) {
         return {


### PR DESCRIPTION
This is an update to #935. That PR failed to fix all cases of NULL
bytes, because NULL bytes might be encoded as "\u0000" in JSON. To fix
this, we process the parsed JSON as a JavaScript object, recursively
searching for strings and replacing NULL bytes in them. We also change
from #935 in that we don't just remove NULL bytes, but rather replace
them with the Unicode replacement character "\uFFFD".

Closes #1270