### PR TITLE
Fix MaxListenersExceededWarning

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -95,6 +95,8 @@
 
   * Fix external grading results containing NULL bytes (Matt West).
 
+  * Fix `MaxListenersExceededWarning` (Dave Mussulman).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/middlewares/logResponse.js
+++ b/middlewares/logResponse.js
@@ -33,7 +33,7 @@ module.exports = function(req, res, next) {
 
         // install a handler that will always be called, so we can
         // check whether we correctly logged the response
-        res.socket.on('close', () => {
+        res.on('close', () => {
             if (!res.locals.response_logged) logger.error('response was not logged', {response_id: res.locals.response_id});
         });
     }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
         "exclude": [
             "node_modules",
             "public",
-            "tests"
+            "tests",
+            "ChangeLog.md"
         ]
     }
 }


### PR DESCRIPTION
If you loaded up the docker container and clicked a lot of links in a short amount of time, you probably got a 

```(node:1260) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. Use emitter.setMaxListeners() to increase limit```

warning. I traced that back to `middlewares/logResponse` that was adding a `close` event to the response object's underlying socket (`res.socket`) instead of the response itself. HTTP/1.1 will (apparently) share the same socket with multiple requests. At least that's the best of my figuring on why it would trigger so often.

`res.on('close')` should do the same thing (only fire when something happened to the response's underlying connection). I'm not sure if different logging with the `res.locals.response_logged` is even necessary, as I think close will only trigger when finish doesn't.

I'm not sure what problem this code was added to originally solve, but I tested that repeatedly hammering the server when it's set to `res.on('close')` doesn't generate the MaxListenersExceededWarning anymore.
