### PR TITLE
Add support for Latex in <markdown> tags

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,6 +37,8 @@
 
   * Add python library `tzlocal` (James Balamuta).
 
+  * Add support for Latex in `<markdown>` tags (Nathan Walters).
+
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Change `centos7-python` to `grader-python` and place it under `graders/`  (James Balamuta).

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -2,6 +2,7 @@ const unified = require('unified');
 const markdown = require('remark-parse');
 const raw = require('rehype-raw');
 const remark2rehype = require('remark-rehype');
+const math = require('remark-math');
 const stringify = require('rehype-stringify');
 const visit = require('unist-util-visit');
 
@@ -45,21 +46,45 @@ const visitCodeBlock = (ast, _vFile) => {
     });
 };
 
-const handleCode = () => {
-    return function transformer(ast, vFile, next) {
-        visitCodeBlock(ast, vFile);
-    
+/**
+ * By default, `remark-math` installs compilers to transform the AST back into
+ * HTML, which ends up wrapping the math in unwanted spans and divs. Since all
+ * math will be rendered on the client, we have our own visitor that will replace
+ * any `math` or `inlineMath` nodes with raw text values wrapped in the appropriate
+ * fences.
+ */
+const visitMathBlock = (ast, _vFile) => {
+    return visit(ast, ['math', 'inlineMath'], (node, index, parent) => {
+        const startFence = node.type === 'math' ? '$$\n' : '$';
+        const endFence = node.type === 'math' ? '\n$$' : '$';
+        const text = {
+            type: 'text',
+            value: startFence + node.value + endFence,
+        };
+        parent.children.splice(index, 1, text);
+        return node;
+    });
+};
+
+const makeHandler = (visitor) => {
+    return () => (ast, vFile, next) => {
+        visitor(ast, vFile);
+
         if (typeof next === 'function') {
             return next(null, ast, vFile);
         }
-    
         return ast;
     };
 };
 
+const handleCode = makeHandler(visitCodeBlock);
+const handleMath = makeHandler(visitMathBlock);
+
 const processor = unified()
     .use(markdown)
+    .use(math)
     .use(handleCode)
+    .use(handleMath)
     .use(remark2rehype, { allowDangerousHTML: true })
     .use(raw)
     .use(stringify);

--- a/package-lock.json
+++ b/package-lock.json
@@ -627,7 +627,7 @@
             "dependencies": {
                 "buffer": {
                     "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+                    "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "requires": {
                         "base64-js": "^1.0.2",
@@ -1032,7 +1032,7 @@
                 },
                 "readable-stream": {
                     "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -1993,7 +1993,7 @@
                 },
                 "readable-stream": {
                     "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -2548,7 +2548,7 @@
         },
         "events": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "execa": {
@@ -5766,7 +5766,7 @@
         },
         "ncp": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
         },
         "negotiator": {
@@ -6030,13 +6030,13 @@
                 },
                 "resolve-from": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "resolved": "",
                     "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                     "dev": true
                 },
                 "rimraf": {
                     "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "resolved": "",
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "dev": true,
                     "requires": {
@@ -6608,7 +6608,7 @@
             "dependencies": {
                 "semver": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+                    "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
                     "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
                 }
             }
@@ -6864,7 +6864,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
                 "core-util-is": "~1.0.0",
@@ -6968,6 +6968,11 @@
             "requires": {
                 "es6-error": "^4.0.1"
             }
+        },
+        "remark-math": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-2.0.0.tgz",
+            "integrity": "sha512-eQ8LLVIKVJbvNj0HCuuYdaBpHEiv/AX+3nb1ErUSPMNFMzvjKXe+H450vr9bTii9Ih5lRX7Wx/7sDVLLCfXJpg=="
         },
         "remark-parse": {
             "version": "7.0.1",
@@ -7196,7 +7201,7 @@
         },
         "sax": {
             "version": "1.2.1",
-            "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "search-string": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "redis-lru": "^0.6.0",
         "rehype-raw": "^4.0.1",
         "rehype-stringify": "^6.0.0",
+        "remark-math": "^2.0.0",
         "remark-parse": "^7.0.1",
         "remark-rehype": "^5.0.0",
         "request-promise-native": "^1.0.7",

--- a/tests/index.js
+++ b/tests/index.js
@@ -32,4 +32,5 @@ require('./testSproc-check_assessment_access');
 require('./testSproc-users_select_or_insert');
 require('./testJsonLoad');
 require('./testSchemas');
+require('./testMarkdown');
 require('./sync');

--- a/tests/testMarkdown.js
+++ b/tests/testMarkdown.js
@@ -13,15 +13,9 @@ describe('Markdown processing', () => {
         testMarkdown(question, expected);
     });
 
-    it('strips <p> tags if necessary', () => {
-        const question = '<markdown>This is **inline**.</markdown>';
-        const expected = 'This is <strong>inline</strong>.';
-        testMarkdown(question, expected);
-    });
-
     it ('handles multiple <markdown> tags', () => {
         const question = '<markdown>`nice`</markdown><markdown>`also nice`</markdown>';
-        const expected = '<code>nice</code><code>also nice</code>';
+        const expected = '<p><code>nice</code></p><p><code>also nice</code></p>';
         testMarkdown(question, expected);
     });
 
@@ -58,6 +52,48 @@ describe('Markdown processing', () => {
     it('handles weird escaped <markdown> tags', () => {
         const question = '<markdown>```html\n<markdown###></markdown###>\n```</markdown>';
         const expected = '<pl-code language="html">&#x3C;markdown##>&#x3C;/markdown##></pl-code>';
+        testMarkdown(question, expected);
+    });
+
+    it('handles inline latex with underscores', () => {
+        const question = '<markdown>$a _{1_ 2}$</markdown>';
+        const expected = '<p>$a _{1_ 2}$</p>';
+        testMarkdown(question, expected);
+    });
+
+    it('handles inline latex', () => {
+        const question = '<markdown>$a_1 + a_2 = a_3$</markdown>';
+        const expected = '<p>$a_1 + a_2 = a_3$</p>';
+        testMarkdown(question, expected);
+    });
+
+    it('handles multiple lines of inline latex', () => {
+        const question = '<markdown>$a_{ 1 } = 3$ and\n$a_{ 2 } = 4$</markdown>';
+        const expected = '<p>$a_{ 1 } = 3$ and\n$a_{ 2 } = 4$</p>';
+        testMarkdown(question, expected);
+    });
+
+    it('handles block latex', () => {
+        const question = '<markdown>\n$$\na^2 + b^2 = c^2\n$$</markdown>';
+        const expected = '$$\na^2 + b^2 = c^2\n$$';
+        testMarkdown(question, expected);
+    });
+
+    it('handles block latex with asterisks', () => {
+        const question = '<markdown>$$\na **b** c\n$$</markdown>';
+        const expected = '$$\na **b** c\n$$';
+        testMarkdown(question, expected);
+    });
+
+    it('handles two consecutive latex blocks', () => {
+        const question = '<markdown>$$\na **b** c\n$$\n$$\na+b=c\n$$</markdown>';
+        const expected = '$$\na **b** c\n$$\n$$\na+b=c\n$$';
+        testMarkdown(question, expected);
+    });
+
+    it('handles block latex with asterisks and surrouding text', () => {
+        const question = '<markdown>testing\n$$\na **b** c\n$$\ntesting</markdown>';
+        const expected = '<p>testing</p>\n$$\na **b** c\n$$\n<p>testing</p>';
         testMarkdown(question, expected);
     });
 });


### PR DESCRIPTION
Allows Latex fenced by `$` or `$$` to appear in `<markdown>` tags by allowing it to pass through unmodified to the final HTML document. Adds a bunch of tests to ensure this works (and continues to work) correctly. @coatless let me know if you see any weird potential edge cases not captured in the current tests!

Closes #1742 