### PR TITLE
Fix assessments.assessment_set_id delete cascade rule

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -99,6 +99,8 @@
 
   * Fix jobsPerInstance grader statistic (Matt West).
 
+  * Fix `assessments.assessment_set_id` to cascade on deletes (Matt West).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/database/tables/assessment_sets.pg
+++ b/database/tables/assessment_sets.pg
@@ -15,4 +15,4 @@ foreign-key constraints
     assessment_sets_course_id_fkey: FOREIGN KEY (course_id) REFERENCES pl_courses(id) ON UPDATE CASCADE ON DELETE CASCADE
 
 referenced by
-    assessments: FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE SET NULL
+    assessments: FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/assessments.pg
+++ b/database/tables/assessments.pg
@@ -28,7 +28,7 @@ indexes
     assessments_course_instance_id_idx: USING btree (course_instance_id)
 
 foreign-key constraints
-    assessments_assessment_set_id_fkey: FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE SET NULL
+    assessments_assessment_set_id_fkey: FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE CASCADE
     assessments_course_instance_id_fkey: FOREIGN KEY (course_instance_id) REFERENCES course_instances(id) ON UPDATE CASCADE ON DELETE CASCADE
 
 referenced by

--- a/migrations/151_assessments__assessment_set_id_fkey__alter.sql
+++ b/migrations/151_assessments__assessment_set_id_fkey__alter.sql
@@ -1,2 +1,3 @@
-ALTER TABLE assessments DROP CONSTRAINT assessments_assessment_set_id_fkey;
-ALTER TABLE assessments ADD CONSTRAINT assessments_assessment_set_id_fkey FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE CASCADE;
+ALTER TABLE assessments
+    DROP CONSTRAINT assessments_assessment_set_id_fkey,
+    ADD CONSTRAINT assessments_assessment_set_id_fkey FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE CASCADE;

--- a/migrations/151_assessments__assessment_set_id_fkey__alter.sql
+++ b/migrations/151_assessments__assessment_set_id_fkey__alter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE assessments DROP CONSTRAINT assessments_assessment_set_id_fkey;
+ALTER TABLE assessments ADD CONSTRAINT assessments_assessment_set_id_fkey FOREIGN KEY (assessment_set_id) REFERENCES assessment_sets(id) ON UPDATE CASCADE ON DELETE CASCADE;


### PR DESCRIPTION
The assessments.assessment_set_id foreign key constraint had ON DELETE
SET NULL, but the assessment_set_id column had a NOT NULL constraint.
This makes no sense and gave an error when we deleted courses (and hence
assessment_sets) in the tools/dump_filter.sh script.