### PR TITLE
Fix null filenames from missing files in downloads

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -99,6 +99,8 @@
 
   * Fix jobsPerInstance grader statistic (Matt West).
 
+  * Fix null filenames from missing files in downloads (Matt West).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -194,6 +194,9 @@ SELECT
     decode(contents, 'base64') AS contents
 FROM
     all_files
+WHERE
+    filename IS NOT NULL
+    AND contents IS NOT NULL
 ORDER BY
     uid, assessment_instance_number, qid, variant_number, date
 LIMIT


### PR DESCRIPTION
In the `_all_files.zip` download, we were incorrectly including rows for
student submissions that had missing files. That is, the question
requires a file upload, but the student made an invalid submission
without a file. We were including this submission row in the SELECT,
resulting in a row with `filename = NULL` and hence a `null` file in the
zip file. To avoid this, we only include submission rows for which the
file is present (`filename IS NOT NULL AND contents IS NOT NULL`).

Closes #1744