### PR TITLE
Fix to remove test-once button on external questions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -112,6 +112,7 @@
   * Fix `assessments.assessment_set_id` to cascade on deletes (Matt West).
 
   * Fix git merge during CI (Matt West).
+  * Fix to prevent instructor testing of externally-graded questions (Matt West).
 
 * __3.2.0__ - 2019-08-05
 

--- a/pages/instructorQuestion/instructorQuestion.ejs
+++ b/pages/instructorQuestion/instructorQuestion.ejs
@@ -80,11 +80,10 @@
                 <th>Assessments</th>
                 <td><%- include('../partials/assessments', {assessments: assessments}); %></td>
               </tr>
-              <% if (question.type == 'Freeform') { %>
+              <% if (question.type == 'Freeform' && question.grading_method != 'External') { %>
               <tr>
                 <th class="align-middle">Tests</th>
                 <td>
-                  <% if (question.grading_method !== 'External') { %>
                   <form method="POST">
                     <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
                     <button class="btn btn-sm btn-outline-primary" name="__action" value="test_once">
@@ -94,7 +93,6 @@
                       Test 100 times with only results
                     </button>
                   </form>
-                  <% } %>
                 </td>
               </tr>
               <% } %>

--- a/pages/instructorQuestion/instructorQuestion.ejs
+++ b/pages/instructorQuestion/instructorQuestion.ejs
@@ -84,17 +84,17 @@
               <tr>
                 <th class="align-middle">Tests</th>
                 <td>
+                  <% if (question.grading_method !== 'External') { %>
                   <form method="POST">
                     <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
                     <button class="btn btn-sm btn-outline-primary" name="__action" value="test_once">
                       Test once with full details
                     </button>
-                    <% if (question.grading_method !== 'External') { %>
                     <button class="btn btn-sm btn-outline-primary" name="__action" value="test_100">
                       Test 100 times with only results
                     </button>
-                    <% } %>
                   </form>
+                  <% } %>
                 </td>
               </tr>
               <% } %>


### PR DESCRIPTION
We don't support testing of externally-graded questions because we don't
submit the grading jobs for them. We were correctly removing the "Test
100 times" button, but we weren't removing "Test once" for
externally-graded questions. This patch fixes this.

Closes #1748