### PR TITLE
Bump rpy2 version from 2.9.5 to 3.2.0 (latest)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,8 @@
   * Change docker to use CentOS7 python3 instead of python36u (Dave Mussulman).
 
   * Change SSL file paths to be configurable (Dave Mussulman).
+  
+  * Change `rpy2` version from 2.9.5 to 3.2.0 (James Balamuta).
 
   * Fix dead letter cron job for `async` v3 (Matt West).
 
@@ -112,6 +114,7 @@
   * Fix `assessments.assessment_set_id` to cascade on deletes (Matt West).
 
   * Fix git merge during CI (Matt West).
+  
   * Fix to prevent instructor testing of externally-graded questions (Matt West).
 
 * __3.2.0__ - 2019-08-05

--- a/environments/centos7-plbase/python-requirements.txt
+++ b/environments/centos7-plbase/python-requirements.txt
@@ -10,7 +10,7 @@ pycryptodome==3.7.2
 pyquaternion==0.9.2
 scipy==1.2.0
 sympy==1.3
-rpy2==2.9.5
+rpy2==3.2.0
 pygraphviz==1.5
 ansi2html==1.5.2
 scikit-learn==0.21.3


### PR DESCRIPTION
Upgrades the present version of `rpy2` to the latest.

Please hold off on merging until Wednesday, October 16th. 