### PR TITLE
LTI outcomes fix for Blackboard

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,7 +42,7 @@
   * Add console stack traces on Node warnings (Matt West).
 
   * Add support for Latex in `<markdown>` tags (Nathan Walters).
-  
+
   * Add support for rendering graphs using adjacency matrices in `pl-graph` (Nicolas Nytko).
 
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
@@ -114,7 +114,9 @@
   * Fix `assessments.assessment_set_id` to cascade on deletes (Matt West).
 
   * Fix git merge during CI (Matt West).
+
   * Fix to prevent instructor testing of externally-graded questions (Matt West).
+  
   * Fix LTI outcome reporting with Blackboard Learn (Dave Mussulman).
 
 * __3.2.0__ - 2019-08-05

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -115,6 +115,7 @@
 
   * Fix git merge during CI (Matt West).
   * Fix to prevent instructor testing of externally-graded questions (Matt West).
+  * Fix LTI outcome reporting with Blackboard Learn (Dave Mussulman).
 
 * __3.2.0__ - 2019-08-05
 

--- a/lib/ltiOutcomes.js
+++ b/lib/ltiOutcomes.js
@@ -2,6 +2,8 @@ const ERR = require('async-stacktrace');
 const request = require('request');
 const xml2js = require('xml2js');
 const _ = require('lodash');
+const path = require('path');
+const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
 var sqldb = require('@prairielearn/prairielib').sqlDb;
 var sqlLoader = require('@prairielearn/prairielib').sqlLoader;
@@ -90,19 +92,26 @@ var _updateScoreWithClient = function(ai_id, client, callback) {
             body: xmlReplaceResult(info.lis_result_sourcedid, score, info.date),
         };
 
+        debug(post_params);
         request.post(post_params, function(err, httpResponse, body) {
             if (ERR(err, callback)) return;
 
+            debug(httpResponse);
+            debug(body);
             // Inspect the XML result, log the action
             parser.parseString(body, (err, result) => {
                 if (ERR(err, callback)) return;
                 const imsx_codeMajor = _.get(result, ['imsx_POXEnvelopeResponse', 'imsx_POXHeader', 'imsx_POXResponseHeaderInfo', 'imsx_statusInfo', 'imsx_codeMajor'], null);
                 if (imsx_codeMajor == 'success') {
                     logger.info(`ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} returned ${result.imsx_POXEnvelopeResponse.imsx_POXHeader.imsx_POXResponseHeaderInfo.imsx_statusInfo.imsx_codeMajor}`);
+                    debug(`ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} returned ${result.imsx_POXEnvelopeResponse.imsx_POXHeader.imsx_POXResponseHeaderInfo.imsx_statusInfo.imsx_codeMajor}`);
                 } else {
                     logger.info(`ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} did not return success, debugging follows:`);
                     logger.info(post_params);
                     logger.info(body);
+                    debug(`ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} did not return success, debugging follows:`);
+                    debug('post_params', post_params);
+                    debug('body', body);
                 }
                 callback(null);
             });

--- a/lib/ltiOutcomes.js
+++ b/lib/ltiOutcomes.js
@@ -89,7 +89,10 @@ var _updateScoreWithClient = function(ai_id, client, callback) {
                 consumer_secret: info.secret,
                 body_hash: true,
             },
-            body: xmlReplaceResult(info.lis_result_sourcedid, score, info.date),
+            headers: {
+                'Content-type': 'application/xml',
+            },
+            body: xmlReplaceResult(info.lis_result_sourcedid, score, info.date.toString()),
         };
 
         debug(post_params);


### PR DESCRIPTION
- Added debug to LTI code
- Found a bug where I was passing a Date object instead of String to the `imsx_messageIdentifier` so it wasn't getting populated. Blackboard was throwing HTTP 500 errors at that, even though the online test suites and Coursera didn't seem to care.