### PR TITLE
Fix detection of different internals (close #1817)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,7 @@
   * Add `pl-hide-in-panel` element (Matt West).
 
   * Add `pl-drawing` element (Mariana Silva and Nicolas Nytko)
+  
   * Add `pl-python-variable` element for displaying Pandas dataframes and Python variables (Nicolas Nytko).
 
   * Add student Gradebook page (Matt West).
@@ -125,6 +126,8 @@
   * Fix LTI outcome reporting with Blackboard Learn (Dave Mussulman).
 
   * Fix error reporting for v2 questions (Matt West).
+  
+  * Fix detection of different internals during R package installation (James Balamuta).
 
 * __3.2.0__ - 2019-08-05
 

--- a/environments/centos7-plbase/r-requirements.R
+++ b/environments/centos7-plbase/r-requirements.R
@@ -5,7 +5,7 @@
 # Dynamical detect physical cores...
 Ncpus = parallel::detectCores(logical = FALSE)
 
-# Cap number of cores used in installation to less than 4
+# Cap number of cores used in installation to be 4 or less
 if(Ncpus > 4) {
   Ncpus = 4
 } else {
@@ -15,6 +15,9 @@ if(Ncpus > 4) {
 # Set the default number of cores to use for compiling code
 # during package installation/updation and set the default mirror
 options(Ncpus = Ncpus, repos = c("CRAN" = "https://cran.rstudio.com"))
+
+# Check if any updates exist, if so... Install!
+update.packages(ask = FALSE, checkBuilt = TRUE)
 
 # The following are packages used in STAT 385 and STAT 432
 pkg_list = c(
@@ -58,6 +61,3 @@ to_install_pkgs = pkg_list[!(pkg_list %in% installed.packages()[,"Package"])]
 if(length(to_install_pkgs)) {
   install.packages(to_install_pkgs)
 }
-
-# Check if any updates exist, if so... Install!
-update.packages(ask = FALSE, checkBuilt = TRUE)

--- a/environments/centos7-plbase/r-requirements.R
+++ b/environments/centos7-plbase/r-requirements.R
@@ -60,4 +60,4 @@ if(length(to_install_pkgs)) {
 }
 
 # Check if any updates exist, if so... Install!
-update.packages(ask = FALSE)
+update.packages(ask = FALSE, checkBuilt = TRUE)


### PR DESCRIPTION
- Added `checkBuilt = TRUE` to `upgrade.packages()` to enforce recompilation even on minor (x.*.z) versions.
- Moved `update.packages()` before official list

c.f. #1817 