### PR TITLE
Fix use of `data["correct_answers"]` in docs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -148,6 +148,8 @@
   * Fix detection of different internals during R package installation (James Balamuta).
   
   * Fix figures in `pl-drawing` documentation (Nicolas Nytko).
+  
+  * Fix use of `data["correct_answers"]` in documentation (James Balamuta, h/t Eric Huber).
 
 * __3.2.0__ - 2019-08-05
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -411,7 +411,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answers-name` | string | — | Variable name to store data in.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answer` | string | special | Correct answer for grading. Defaults to `data["correct-answers"][answers-name]`.
+`correct-answer` | string | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$x =$"`).
 `suffix` | text | — | A suffix to display after the input box (e.g., `suffix="items"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.


### PR DESCRIPTION
Close #1865 thanks to @echuber2. 