### PR TITLE
Add the ucidata package to plbase.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,7 +59,7 @@
 
   * Add more detailed grader statistics (Matt West).
 
-  * Add the `ucidata` package to `centos-plbase` (James Balamuta, h/t David Dalpiaz).
+  * Add the `ucidata` package to `centos-plbase` (James Balamuta, h/t David Dalpiaz). 
 
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,6 +59,8 @@
 
   * Add more detailed grader statistics (Matt West).
 
+  * Add the `ucidata` package to `centos-plbase` (James Balamuta, h/t David Dalpiaz).
+
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Change `centos7-python` to `grader-python` and place it under `graders/`  (James Balamuta).

--- a/environments/centos7-plbase/r-requirements.R
+++ b/environments/centos7-plbase/r-requirements.R
@@ -22,6 +22,7 @@ update.packages(ask = FALSE, checkBuilt = TRUE)
 # The following are packages used in STAT 385 and STAT 432
 pkg_list = c(
   'tidyverse',
+  'remotes',
   'RcppArmadillo',
   'rmarkdown',
   'RSQLite',
@@ -61,3 +62,9 @@ to_install_pkgs = pkg_list[!(pkg_list %in% installed.packages()[,"Package"])]
 if(length(to_install_pkgs)) {
   install.packages(to_install_pkgs)
 }
+
+# List of packages only on GitHub
+gh_pkg_list = c('coatless/ucidata')
+
+# Install packages from GitHub
+remotes::install_github(gh_pkg_list)


### PR DESCRIPTION
Adds to `centos7-plbase` the `ucidata` package. This package features data sets from the [UC Irvine's ML repository](https://archive.ics.uci.edu/ml/index.php). 

/cc @daviddalpiaz 