### PR TITLE
Change to express 'trust proxy' for client IP parsing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -155,6 +155,8 @@
   
   * Fix use of `data["correct_answers"]` in documentation (James Balamuta, h/t Eric Huber).
 
+  * Fix authorization for users behind web proxies (Dave Mussulman).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/middlewares/authzCourseInstance.js
+++ b/middlewares/authzCourseInstance.js
@@ -15,7 +15,7 @@ module.exports = function(req, res, next) {
         course_instance_id: req.params.course_instance_id,
         is_administrator: res.locals.is_administrator,
         req_date: res.locals.req_date,
-        ip: req.headers['x-forwarded-for'] || req.ip,
+        ip: req.ip,
         force_mode: (config.authType == 'none' && req.cookies.pl_requested_mode) ? req.cookies.pl_requested_mode : null,
     };
     sqldb.queryZeroOrOneRow(sql.select_authz_data, params, function(err, result) {

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -20,7 +20,7 @@ router.get('/', function(req, res, next) {
         if (ERR(err, next)) return;
         _.assign(res.locals, result.rows[0]);
         
-        res.locals.ipaddress = req.headers['x-forwarded-for'] || req.ip;
+        res.locals.ipaddress = req.ip;
         // Trim out IPv6 wrapper on IPv4 addresses
         if (res.locals.ipaddress.substr(0, 7) == '::ffff:') {
               res.locals.ipaddress = res.locals.ipaddress.substr(7);

--- a/server.js
+++ b/server.js
@@ -91,6 +91,7 @@ if (config.blockedAtWarnEnable) {
 const app = express();
 app.set('views', path.join(__dirname, 'pages'));
 app.set('view engine', 'ejs');
+app.set('trust proxy', 'loopback');
 
 config.devMode = (app.get('env') == 'development');
 


### PR DESCRIPTION
Changes to use the built in Express logic to get the client IP `req.ip` when connecting through a proxy. Fixes #1911 where we weren't processing the raw headers properly.
