### PR TITLE
Add more detailed tab titles to student homework pages

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -59,7 +59,9 @@
 
   * Add more detailed grader statistics (Matt West).
 
-  * Add the `ucidata` package to `centos-plbase` (James Balamuta, h/t David Dalpiaz). 
+  * Add the `ucidata` package to `centos-plbase` (James Balamuta, h/t David Dalpiaz).
+
+  * Add more detailed tab titles to student homework pages (David Mitchell)
 
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
@@ -150,9 +152,9 @@
   * Fix error reporting for v2 questions (Matt West).
 
   * Fix detection of different internals during R package installation (James Balamuta).
-  
+
   * Fix figures in `pl-drawing` documentation (Nicolas Nytko).
-  
+
   * Fix use of `data["correct_answers"]` in documentation (James Balamuta, h/t Eric Huber).
 
   * Fix authorization for users behind web proxies (Dave Mussulman).

--- a/pages/partials/head.ejs
+++ b/pages/partials/head.ejs
@@ -1,7 +1,8 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>PrairieLearn</title>
+<!-- <title>PrairieLearn</title> -->
+<title><%= htmlTitle %></title>
 <link href="/node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
 <link href="/stylesheets/colors.css" rel="stylesheet" />
 <link href="/stylesheets/local.css" rel="stylesheet" />

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
@@ -20,7 +20,7 @@ const ensureUpToDate = (locals, callback) => {
 
         debug('updated:', updated);
         if (!updated) return callback(null);
-        
+
         // we updated the assessment_instance, so reload it
 
         debug('selecting assessment instance');
@@ -53,6 +53,11 @@ router.get('/', function(req, res, next) {
             assessment.renderText(res.locals.assessment, res.locals.urlPrefix, function(err, assessment_text_templated) {
                 if (ERR(err, next)) return;
                 res.locals.assessment_text_templated = assessment_text_templated;
+
+                res.locals.htmlTitle = res.locals.assessment_set.abbreviation
+                  + res.locals.assessment.number
+                  + ": " + res.locals.assessment.title
+                  + " - " + res.locals.course.short_name;
 
                 debug('rendering EJS');
                 res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
@@ -56,8 +56,8 @@ router.get('/', function(req, res, next) {
 
                 res.locals.htmlTitle = res.locals.assessment_set.abbreviation
                   + res.locals.assessment.number
-                  + ": " + res.locals.assessment.title
-                  + " - " + res.locals.course.short_name;
+                  + ': ' + res.locals.assessment.title
+                  + ' - ' + res.locals.course.short_name;
 
                 debug('rendering EJS');
                 res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);

--- a/pages/studentAssessments/studentAssessments.js
+++ b/pages/studentAssessments/studentAssessments.js
@@ -17,6 +17,7 @@ router.get('/', function(req, res, next) {
     sqldb.query(sql.select_assessments, params, function(err, result) {
         if (ERR(err, next)) return;
         res.locals.rows = result.rows;
+        res.locals.htmlTitle = "Assessments - " + res.locals.course.short_name;
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });

--- a/pages/studentAssessments/studentAssessments.js
+++ b/pages/studentAssessments/studentAssessments.js
@@ -17,7 +17,7 @@ router.get('/', function(req, res, next) {
     sqldb.query(sql.select_assessments, params, function(err, result) {
         if (ERR(err, next)) return;
         res.locals.rows = result.rows;
-        res.locals.htmlTitle = "Assessments - " + res.locals.course.short_name;
+        res.locals.htmlTitle = 'Assessments - ' + res.locals.course.short_name;
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });

--- a/pages/studentGradebook/studentGradebook.js
+++ b/pages/studentGradebook/studentGradebook.js
@@ -15,7 +15,7 @@ router.get('/', function(req, res, next) {
     sqldb.query(sql.select_assessment_instances, params, function(err, result) {
         if (ERR(err, next)) return;
         res.locals.rows = result.rows;
-        res.locals.htmlTitle = "Gradebook - " + res.locals.course.short_name;
+        res.locals.htmlTitle = 'Gradebook - ' + res.locals.course.short_name;
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });

--- a/pages/studentGradebook/studentGradebook.js
+++ b/pages/studentGradebook/studentGradebook.js
@@ -15,6 +15,7 @@ router.get('/', function(req, res, next) {
     sqldb.query(sql.select_assessment_instances, params, function(err, result) {
         if (ERR(err, next)) return;
         res.locals.rows = result.rows;
+        res.locals.htmlTitle = "Gradebook - " + res.locals.course.short_name;
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });

--- a/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
+++ b/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
@@ -98,8 +98,8 @@ router.get('/', function(req, res, next) {
             if (ERR(err, next)) return;
 
             res.locals.htmlTitle = res.locals.instance_question_info.question_number
-              + ": " + res.locals.question.title
-              + " - " + res.locals.course.short_name;
+              + ': ' + res.locals.question.title
+              + ' - ' + res.locals.course.short_name;
 
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });

--- a/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
+++ b/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
@@ -96,6 +96,11 @@ router.get('/', function(req, res, next) {
         if (ERR(err, next)) return;
         logPageView(req, res, (err) => {
             if (ERR(err, next)) return;
+
+            res.locals.htmlTitle = res.locals.instance_question_info.question_number
+              + ": " + res.locals.question.title
+              + " - " + res.locals.course.short_name;
+
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });
     });

--- a/server.js
+++ b/server.js
@@ -100,6 +100,8 @@ app.use(function(req, res, next) {res.locals.urlPrefix = res.locals.plainUrlPref
 app.use(function(req, res, next) {res.locals.navbarType = 'plain'; next();});
 app.use(function(req, res, next) {res.locals.devMode = config.devMode; next();});
 app.use(function(req, res, next) {res.locals.is_administrator = false; next();});
+app.use(function(req, res, next) {res.locals.appName = 'PrairieLearn'; next();});
+app.use(function(req, res, next) {res.locals.htmlTitle = res.locals.appName; next();});
 
 if (config.hasAzure) {
     var OIDCStrategy = require('passport-azure-ad').OIDCStrategy;


### PR DESCRIPTION
In a page's `.js` file, overriding the value res.locals.htmlTitle now lets a page set a custom string that shows up in the browser's tab (the default is set to "Prairielearn" in `server.js`). 4b1ff82 provides a few examples where the student homework pages have richer tab titles, in order of (question number and name) (assessment) and (class). Closes #1863.