### PR TITLE
Fix question variant redirects

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -179,6 +179,8 @@
 
   * Fix bug in element popovers (Tim Bretl).
 
+  * Fix redirects to question preview page by maintaining query parameters (Nathan Walters).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const uuidv4 = require('uuid/v4');
 const argv = require('yargs-parser') (process.argv.slice(2));
 const multer = require('multer');
 const filesize = require('filesize');
+const url = require('url');
 
 const logger = require('./lib/logger');
 const config = require('./lib/config');
@@ -368,7 +369,13 @@ app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_i
     require('./middlewares/selectAndAuthzInstructorQuestion'),
 ]);
 app.use(/^(\/pl\/course_instance\/[0-9]+\/instructor\/question\/[0-9]+)\/?$/, (req, res, _next) => {
-    res.redirect(`${req.params[0]}/preview`);
+    // Redirect legacy question URLs to their preview page.
+    // We need to maintain query parameters like `variant_id` so that the
+    // preview page can render the correct variant.
+    const newUrl = `${req.params[0]}/preview`;
+    const newUrlParts = url.parse(newUrl);
+    newUrlParts.query = req.query;
+    res.redirect(url.format(newUrlParts));
 });
 app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id', function(req, res, next) {res.locals.navPage = 'question'; next();});
 app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id/settings', [
@@ -634,7 +641,13 @@ app.use('/pl/course/:course_id/question/:question_id', [
     require('./middlewares/selectAndAuthzInstructorQuestion'),
 ]);
 app.use(/^(\/pl\/course\/[0-9]+\/question\/[0-9]+)\/?$/, (req, res, _next) => {
-    res.redirect(`${req.params[0]}/preview`);
+    // Redirect legacy question URLs to their preview page.
+    // We need to maintain query parameters like `variant_id` so that the
+    // preview page can render the correct variant.
+    const newUrl = `${req.params[0]}/preview`;
+    const newUrlParts = url.parse(newUrl);
+    newUrlParts.query = req.query;
+    res.redirect(url.format(newUrlParts));
 });
 app.use('/pl/course/:course_id/question/:question_id', function(req, res, next) {res.locals.navPage = 'question'; next();});
 app.use('/pl/course/:course_id/question/:question_id/settings', [

--- a/tests/index.js
+++ b/tests/index.js
@@ -37,4 +37,5 @@ require('./testSproc-users_select_or_insert');
 require('./testJsonLoad');
 require('./testSchemas');
 require('./testMarkdown');
+require('./testRedirects');
 require('./sync');

--- a/tests/testRedirects.js
+++ b/tests/testRedirects.js
@@ -8,11 +8,19 @@ const siteUrl = 'http://localhost:' + config.serverPort;
 
 const redirects = [
     {
-        original: '/pl/course/1/question/4/?variant_id=99',
+        original: '/pl/course/1/question/4',
+        redirect: '/pl/course/1/question/4/preview',
+    },
+    {
+        original: '/pl/course_instance/1/instructor/question/4',
+        redirect: '/pl/course_instance/1/instructor/question/4/preview',
+    },
+    {
+        original: '/pl/course/1/question/4?variant_id=99',
         redirect: '/pl/course/1/question/4/preview?variant_id=99',
     },
     {
-        original: '/pl/course_instance/1/instructor/question/4/?variant_id=99',
+        original: '/pl/course_instance/1/instructor/question/4?variant_id=99',
         redirect: '/pl/course_instance/1/instructor/question/4/preview?variant_id=99',
     },
 ];

--- a/tests/testRedirects.js
+++ b/tests/testRedirects.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const request = require('request');
+
+const config = require('../lib/config');
+const helperServer = require('./helperServer');
+
+const siteUrl = 'http://localhost:' + config.serverPort;
+
+const redirects = [
+    {
+        original: '/pl/course/1/question/4/?variant_id=99',
+        redirect: '/pl/course/1/question/4/preview?variant_id=99',
+    },
+    {
+        original: '/pl/course_instance/1/instructor/question/4/?variant_id=99',
+        redirect: '/pl/course_instance/1/instructor/question/4/preview?variant_id=99',
+    },
+];
+
+describe('Redirects', function() {
+    this.timeout(20000);
+
+    before('set up testing server', helperServer.before());
+    after('shut down testing server', helperServer.after);
+
+    redirects.forEach(redirect => {
+        it(`redirects ${redirect.original}`, function(done) {
+            request({
+                url: `${siteUrl}${redirect.original}`,
+                // No need to actually request the redirected page; we just
+                // want to assert that the response is a redirect and that
+                // it will redirect to the right place.
+                followRedirect: false,
+            }, (err, response) => {
+                assert.ifError(err);
+                assert.equal(response.statusCode, 302);
+                assert.equal(response.headers.location, redirect.redirect);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1968 by copying the original query params to the new URL. Adds tests to avoid future regressions.

I opted to duplicate the redirect code in `server.js` to avoid premature abstraction. If anyone feels strongly about it, I can move it into a helper.