### PR TITLE
WIP: code coverage ignore for ERR()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -183,6 +183,8 @@
 
   * Fix redirects to question preview page by maintaining query parameters (Nathan Walters).
 
+  * Fix code coverage tool to ignore async-stacktrace error handler (Dave Mussulman).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
             "public",
             "tests",
             "ChangeLog.md"
-        ]
+        ],
+        "ignore-class-method": "ERR"
     }
 }


### PR DESCRIPTION
Checking to see if we can ignore code coverage for the async-stacktrace functions anytime they're called.

Not ready to merge, but PR will call the coveralls bit.