### PR TITLE
Fix button alignment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -197,6 +197,8 @@
 
   * Fix in-browser course edit handler to keep one course lock throughout entire process (Tim Bretl).
 
+  * Fix button alignment in popovers (Tim Bretl).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/pages/administratorOverview/administratorDeleteForm.ejs
+++ b/pages/administratorOverview/administratorDeleteForm.ejs
@@ -6,8 +6,8 @@
     <label>UID:</label>
     <p class="form-control-static"><%= uid %></p>
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Remove access</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Remove access</button>
+  </div>
 </form>

--- a/pages/administratorOverview/administratorInsertForm.ejs
+++ b/pages/administratorOverview/administratorInsertForm.ejs
@@ -5,8 +5,8 @@
     <label for="administratorInsertFormUid">UID:</label>
     <input type="text" class="form-control" id="administratorInsertFormUid" name="uid" placeholder="username@domain.org">
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Add administrator</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Add administrator</button>
+  </div>
 </form>

--- a/pages/administratorOverview/courseDeleteForm.ejs
+++ b/pages/administratorOverview/courseDeleteForm.ejs
@@ -6,8 +6,8 @@
     <label for="inputConfirm<%= id %>">Type “<%= course.short_name %>” to confirm:</label>
     <input type="text" class="form-control" id="inputConfirm<%= id %>" name="confirm_short_name" %>">
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-danger">Delete course</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-danger">Delete course</button>
+  </div>
 </form>

--- a/pages/administratorOverview/courseInsertForm.ejs
+++ b/pages/administratorOverview/courseInsertForm.ejs
@@ -29,8 +29,8 @@
     <label for="courseAddInputRepository">Repository:</label>
     <input type="text" class="form-control" id="courseAddInputRepository" name="repository" value="git@github.com:PrairieLearn/pl-XXX.git">
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Add course</button>
+  <div class="text-right">
+      <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+      <button type="submit" class="btn btn-primary">Add course</button>
+  </div>
 </form>

--- a/pages/administratorOverview/courseUpdateColumnForm.ejs
+++ b/pages/administratorOverview/courseUpdateColumnForm.ejs
@@ -6,8 +6,8 @@
   <div class="form-group">
     <input type="text" class="form-control" id="input<%= id %>" name="value" value="<%= course[column_name] %>">
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
 </form>

--- a/pages/instructorAssessmentInstance/editQuestionPointsForm.ejs
+++ b/pages/instructorAssessmentInstance/editQuestionPointsForm.ejs
@@ -9,8 +9,8 @@
     </div>
   </div>
   <p><small>This will also recalculate the total points and total score at 100% credit. This change will be overwritten if the question is answered again by the student.</small></p>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
 </form>

--- a/pages/instructorAssessmentInstance/editQuestionScorePercForm.ejs
+++ b/pages/instructorAssessmentInstance/editQuestionScorePercForm.ejs
@@ -9,8 +9,8 @@
     </div>
   </div>
   <p><small>This will also recalculate the total points and total score at 100% credit. This change will be overwritten if the question is answered again by the student.</small></p>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
 </form>

--- a/pages/instructorAssessmentInstance/editTotalPointsForm.ejs
+++ b/pages/instructorAssessmentInstance/editTotalPointsForm.ejs
@@ -9,8 +9,8 @@
     </div>
   </div>
   <p><small>This change will be overwritten if further questions are answered by the student.</small></p>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
 </form>

--- a/pages/instructorAssessmentInstance/editTotalScorePercForm.ejs
+++ b/pages/instructorAssessmentInstance/editTotalScorePercForm.ejs
@@ -9,8 +9,8 @@
     </div>
   </div>
   <p><small>This change will be overwritten if further questions are answered by the student.</small></p>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
 </form>

--- a/pages/instructorCourseAdminAccess/coursePermissionsDeleteForm.ejs
+++ b/pages/instructorCourseAdminAccess/coursePermissionsDeleteForm.ejs
@@ -6,8 +6,8 @@
     <label for="addUserInputUid">UID:</label>
     <p class="form-control-static"><%= uid %></p>
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Remove user access</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Remove user access</button>
+  </div>
 </form>

--- a/pages/instructorCourseAdminAccess/coursePermissionsInsertForm.ejs
+++ b/pages/instructorCourseAdminAccess/coursePermissionsInsertForm.ejs
@@ -13,8 +13,8 @@
       <option>Owner</option>
     </select>
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Add user</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Add user</button>
+  </div>
 </form>

--- a/pages/instructorCourseAdminAccess/coursePermissionsUpdateRoleForm.ejs
+++ b/pages/instructorCourseAdminAccess/coursePermissionsUpdateRoleForm.ejs
@@ -18,8 +18,8 @@
       <option>Owner</option>
     </select>
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change course role</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change course role</button>
+  </div>
 </form>

--- a/pages/instructorFileBrowser/instructorFileDeleteForm.ejs
+++ b/pages/instructorFileBrowser/instructorFileDeleteForm.ejs
@@ -5,8 +5,8 @@
   <input type="hidden" name="__action" value="delete_file">
   <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
   <input type="hidden" name="file_path" value="<%= file.path %>">
-  <button type="button" class="btn btn-secondary" onclick="$('#instructorFileDeleteForm-<%= file.id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Delete</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#instructorFileDeleteForm-<%= file.id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Delete</button>
+  </div>
 </form>

--- a/pages/instructorFileBrowser/instructorFileRenameForm.ejs
+++ b/pages/instructorFileBrowser/instructorFileRenameForm.ejs
@@ -15,10 +15,10 @@
       <div class="invalid-feedback" id="invalidMessage-<%= file.id %>">
       </div>
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#instructorFileRenameForm-<%= file.id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Change</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#instructorFileRenameForm-<%= file.id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
 </form>
 
 <script>

--- a/pages/instructorFileBrowser/instructorFileUploadForm.ejs
+++ b/pages/instructorFileBrowser/instructorFileUploadForm.ejs
@@ -23,10 +23,10 @@
     <% } else { %>
       <input type="hidden" name="working_path" value="<%= file.working_path %>">
     <% } %>
-    <button type="button" class="btn btn-secondary" onclick="$('#instructorFileUploadForm-<%= file.id %>').popover('hide')">
-      Cancel
-    </button>
-    <button type="submit" class="btn btn-primary">Upload file</button>
+    <div class="text-right">
+      <button type="button" class="btn btn-secondary" onclick="$('#instructorFileUploadForm-<%= file.id %>').popover('hide')">Cancel</button>
+      <button type="submit" class="btn btn-primary">Upload file</button>
+    </div>
   </div>
 </form>
 
@@ -37,7 +37,7 @@
           let fileName = $(this).val().replace(/\\/g, '/').replace(/.*\//, '');
           $(this).parent('.custom-file').find('.custom-file-label').text(fileName);
         });
-        
+
         $('form[name="instructor-file-upload-form-<%= file.id %>"]').submit(function(event) {
           if ($(this).get(0).checkValidity() === false) {
               event.preventDefault();

--- a/pages/instructorQuestionSettings/copyForm.ejs
+++ b/pages/instructorQuestionSettings/copyForm.ejs
@@ -16,10 +16,10 @@
     <div class="invalid-feedback" id="invalidIdMessage">
     </div>
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= buttonID %>').popover('hide')">
-      Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Submit</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= buttonID %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </div>
 </form>
 
 <script>

--- a/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -109,8 +109,8 @@
           <div class="row">
             <% if (authz_data.has_course_permission_edit && ((! course.options.isExampleCourse) || (courses && (courses.length > 1)))) { %>
             <div class="col-auto">
-              <button type="button" class="btn btn-sm btn-primary" id="copyQuestionButton" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Make a copy of this question" data-content="<%= include('copyForm', {buttonID: 'copyQuestionButton'}) %>" data-trigger="manual" onclick="$(this).popover('show')">
-                  <i class="fa fa-i-cursor"></i>
+              <button type="button" class="btn btn-sm btn-primary" id="copyQuestionButton" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Copy this question" data-content="<%= include('copyForm', {buttonID: 'copyQuestionButton'}) %>" data-trigger="manual" onclick="$(this).popover('show')">
+                  <i class="fa fa-clone"></i>
                   <span>Make a copy of this question</span>
               </button>
             </div>

--- a/pages/partials/attachFileDeleteForm.ejs
+++ b/pages/partials/attachFileDeleteForm.ejs
@@ -8,8 +8,8 @@
   <input type="hidden" name="__variant_id" value="<%= variant.id %>">
   <% } %>
   <input type="hidden" name="file_id" value="<%= file.id %>">
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Delete</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Delete</button>
+  </div>
 </form>

--- a/pages/partials/changeIdForm.ejs
+++ b/pages/partials/changeIdForm.ejs
@@ -10,10 +10,10 @@
         <div class="invalid-feedback" id="invalidIdMessage">
         </div>
     </div>
-    <button type="button" class="btn btn-secondary" onclick="$('#<%= buttonID %>').popover('hide')">
-        Cancel
-    </button>
-    <button type="submit" class="btn btn-primary">Change</button>
+    <div class="text-right">
+        <button type="button" class="btn btn-secondary" onclick="$('#<%= buttonID %>').popover('hide')">Cancel</button>
+        <button type="submit" class="btn btn-primary">Change</button>
+    </div>
 </form>
 
 <script>

--- a/pages/userSettings/tokenDeleteForm.ejs
+++ b/pages/userSettings/tokenDeleteForm.ejs
@@ -3,8 +3,8 @@
   <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
   <input type="hidden" name="token_id" value="<%= token_id %>">
   <p>Once you delete this token, any applications using it will no longer be able to access the API. You cannot undo this action.</p>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-danger">Delete token</button>
+  <div class="text-right">
+      <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+      <button type="submit" class="btn btn-danger">Delete token</button>
+  </div>
 </form>

--- a/pages/userSettings/tokenGenerateForm.ejs
+++ b/pages/userSettings/tokenGenerateForm.ejs
@@ -5,8 +5,8 @@
     <label for="token_name">Name:</label>
     <input type="text" class="form-control" id="token_name" name="token_name" placeholder="My token">
   </div>
-  <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">
-    Cancel
-  </button>
-  <button type="submit" class="btn btn-primary">Generate token</button>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Generate token</button>
+  </div>
 </form>


### PR DESCRIPTION
In addition to a couple minor style fixes, this PR right-aligns the "cancel" and "action" buttons that appear in forms that are in popovers (fixes #1978).