### PR TITLE
Fix authorization of effective user

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -199,6 +199,8 @@
 
   * Fix button alignment in popovers (Tim Bretl).
 
+  * Fix authorization of effective user (Tim Bretl).
+
 * __3.2.0__ - 2019-08-05
 
   * Add openpyxl to the centos7-python for Excel .xlsx autograding (Craig Zilles).

--- a/middlewares/authzCourseInstance.js
+++ b/middlewares/authzCourseInstance.js
@@ -120,11 +120,11 @@ module.exports = function(req, res, next) {
                 res.locals.req_date = result.rows[0].req_date;
 
                 // Make sure that we never grant extra permissions
-                if (res.locals.authz_data.has_instructor_view) res.locals.authz_data.has_instructor_view = result.rows[0].has_instructor_view;
-                if (res.locals.authz_data.has_instructor_edit) res.locals.authz_data.has_instructor_edit = result.rows[0].has_instructor_edit;
-                if (res.locals.authz_data.has_course_permission_view) res.locals.authz_data.has_course_permission_view = result.rows[0].permissions_course.has_course_permission_view;
-                if (res.locals.authz_data.has_course_permission_edit) res.locals.authz_data.has_course_permission_edit = result.rows[0].permissions_course.has_course_permission_edit;
-                if (res.locals.authz_data.has_course_permission_own) res.locals.authz_data.has_course_permission_own = result.rows[0].permissions_course.has_course_permission_own;
+                res.locals.authz_data.has_instructor_view = res.locals.authz_data.has_instructor_view && result.rows[0].has_instructor_view;
+                res.locals.authz_data.has_instructor_edit = res.locals.authz_data.has_instructor_edit && result.rows[0].has_instructor_edit;
+                res.locals.authz_data.has_course_permission_view = res.locals.authz_data.has_course_permission_view && result.rows[0].permissions_course.has_course_permission_view;
+                res.locals.authz_data.has_course_permission_edit = res.locals.authz_data.has_course_permission_edit && result.rows[0].permissions_course.has_course_permission_edit;
+                res.locals.authz_data.has_course_permission_own = res.locals.authz_data.has_course_permission_own && result.rows[0].permissions_course.has_course_permission_own;
 
                 // NOTE: When this code is all rewritten, you may want to throw an error if
                 // the user tries to emulate another user with greater permissions, so that

--- a/middlewares/authzCourseInstance.js
+++ b/middlewares/authzCourseInstance.js
@@ -53,8 +53,6 @@ module.exports = function(req, res, next) {
             has_course_permission_own: permissions_course.has_course_permission_own,
         };
         res.locals.user = res.locals.authz_data.user;
-        // FIXME: debugging for #422
-        logger.debug('Preliminary authz_data', res.locals.authz_data);
 
         // check whether we are requesting user data override
         if (!req.cookies.pl_requested_uid && !req.cookies.pl_requested_role && !req.cookies.pl_requested_mode && !req.cookies.pl_requested_date) {
@@ -132,8 +130,6 @@ module.exports = function(req, res, next) {
                 // the user tries to emulate another user with greater permissions, so that
                 // it is clear why these permissions aren't granted.
 
-                // FIXME: debugging for #422
-                logger.debug('Overridden authz_data', res.locals.authz_data);
                 res.locals.user = res.locals.authz_data.user;
                 next();
             });

--- a/middlewares/authzCourseInstance.js
+++ b/middlewares/authzCourseInstance.js
@@ -1,7 +1,6 @@
 var ERR = require('async-stacktrace');
 var _ = require('lodash');
 
-var logger = require('../lib/logger');
 var config = require('../lib/config');
 var error = require('@prairielearn/prairielib/error');
 var sqldb = require('@prairielearn/prairielib/sql-db');

--- a/middlewares/authzCourseInstance.js
+++ b/middlewares/authzCourseInstance.js
@@ -86,7 +86,35 @@ module.exports = function(req, res, next) {
             };
             sqldb.queryZeroOrOneRow(sql.select_effective_authz_data, params, function(err, result) {
                 if (ERR(err, next)) return;
-                if (result.rowCount == 0) return next(error.make(403, 'Access denied'));
+                if (result.rowCount == 0) {
+                    // The effective user has been denied access. For a real user, two things would be true:
+                    //
+                    //  1) authn_user would exist
+                    //  2) authz_data would not exist
+                    //
+                    // Unfortunately, for the effective user, both authn_user and authz_data exist but are
+                    // "wrong" in the sense that they are consistent with the real user and not the effective
+                    // user. This screws up various things on the error page.
+                    //
+                    // As a fix for now, we will remove authz_data and will set a flag saying that the
+                    // effective user has been denied access to the course instance - this will allow, for
+                    // example, the user dropdown in the navbar to be hidden. It is likely that a better
+                    // solution can be found when this code is all rewritten.
+                    delete res.locals.authz_data;
+                    res.locals.effective_user_has_no_access_to_course_instance = true;
+
+                    // Tell the real user what happened and how to reset the effective user.
+                    let err = error.make(403, 'Access denied');
+                    err.info =  `<p>You have changed the effective user to one with these properties:</p>` +
+                                `<div class="container"><pre class="bg-dark text-white rounded p-2">` +
+                                `uid = ${params.requested_uid}\n` +
+                                `role = ${params.requested_role}\n` +
+                                `mode = ${params.requested_mode}\n` +
+                                `</pre></div>` +
+                                `<p>This user does not have access to the course instance <code>${res.locals.course_instance.short_name}</code> (with long name "${res.locals.course_instance.long_name}").` +
+                                `<p>To reset the effective user, return to the <a href="${res.locals.homeUrl}">PrairieLearn home page</a>.</p>`;
+                    return next(err);
+                }
 
                 res.locals.authz_data.user = result.rows[0].user;
                 res.locals.authz_data.role = result.rows[0].role;

--- a/middlewares/authzCourseInstance.sql
+++ b/middlewares/authzCourseInstance.sql
@@ -50,10 +50,13 @@ WITH effective_data AS (
 )
 SELECT
     ed.*,
+    authz_course((ed.user->>'user_id')::bigint, c.id, FALSE) AS permissions_course,
     (ed.role >= 'TA') AS has_instructor_view,
     (ed.role >= 'Instructor') AS has_instructor_edit
 FROM
     effective_data AS ed
+    JOIN course_instances AS ci ON (ci.id = $course_instance_id AND ci.deleted_at IS NULL)
+    JOIN pl_courses AS c ON (c.id = ci.course_id AND c.deleted_at IS NULL)
 WHERE
     ed.role IS NOT NULL
     AND check_course_instance_access($course_instance_id, ed.role, ed.user->>'uid', (ed.user->>'institution_id')::bigint, ed.req_date);

--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -25,29 +25,34 @@
     <!-- User and logout ------------------------------------------------------------->
 
 <%
-var displayedName = '';
-if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) {
-    if (authz_data.user.name) {
-        displayedName = authz_data.user.name;
-    } else {
-        displayedName = authz_data.user.uid;
-    }
-    displayedName += ' (' + authz_data.role;
-    if (authz_data.mode != 'Public') {
-        displayedName += ', ' + authz_data.mode;
-    }
-    displayedName += ')';
-} else {
-    if (typeof authn_user == 'undefined') {
-        displayedName = '(No user)';
-    } else if (is_administrator) {
-        displayedName = authn_user.name + ' (Administrator)';
-    } else {
-        displayedName = authn_user.name;
-    }
+if (!locals.effective_user_has_no_access_to_course_instance) {
+  var displayedName = '';
+  if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) {
+      if (authz_data.user.name) {
+          displayedName = authz_data.user.name;
+      } else {
+          displayedName = authz_data.user.uid;
+      }
+      displayedName += ' (' + authz_data.role;
+      if (authz_data.mode != 'Public') {
+          displayedName += ', ' + authz_data.mode;
+      }
+      displayedName += ')';
+  } else {
+      if (typeof authn_user == 'undefined') {
+          displayedName = '(No user)';
+      } else if (is_administrator) {
+          displayedName = authn_user.name + ' (Administrator)';
+      } else {
+          displayedName = authn_user.name;
+      }
+  }
 }
 %>
+
 <ul class="nav navbar-nav" id="username-nav">
+
+    <% if (!locals.effective_user_has_no_access_to_course_instance) { %>
     <li class="nav-item dropdown mb-2 mb-md-0 mr-2 <% if (navPage == "effective") { %>active<% } %>">
         <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <%= displayedName %>
@@ -68,6 +73,7 @@ if (typeof authz_data !== 'undefined' && authz_data.authn_has_instructor_view) {
             </a>
         </div>
     </li>
+    <% } %>
 
 <%
 if (typeof authz_data !== 'undefined' && authz_data.has_instructor_view) {

--- a/server.js
+++ b/server.js
@@ -230,7 +230,7 @@ if (config.devMode) {
 }
 
 // clear cookies on the homepage to reset any stale session state
-app.use(/^(?:\/?)$|^(?:\/pl\/?)$/, require('./middlewares/clearCookies'));
+app.use(/^(\/?)$|^(\/pl\/?)$/, require('./middlewares/clearCookies'));
 
 // some pages don't need authorization
 app.use('/', require('./pages/home/home'));

--- a/server.js
+++ b/server.js
@@ -230,7 +230,7 @@ if (config.devMode) {
 }
 
 // clear cookies on the homepage to reset any stale session state
-app.use(/^\/pl\/?/, require('./middlewares/clearCookies'));
+app.use(/^(?:\/?)$|^(?:\/pl\/?)$/, require('./middlewares/clearCookies'));
 
 // some pages don't need authorization
 app.use('/', require('./pages/home/home'));


### PR DESCRIPTION
This PR sets the course permissions `has_course_permission_view`, `has_course_permission_edit`, and `has_course_permission_own` correctly when emulating another user (formerly these were always set to `false`), and leaves the `course_role` alone (formerly, this was set to `None`).

This PR also:
- adds helpful information to the the "Access denied" error page if the effective user does not have access to the current course instance;
- fixes the navbar appearance on this same error page.

**NOTE**

If a different `uid` has been requested, then course permissions are generated for the user with that `uid`. Otherwise, course permissions are generated for the original authenticated user. This means that, in development mode (i.e., in docker on a local machine), switching the `role` or the `mode` without switching the `uid` will result in losing course permissions, because the original authenticated user will be `dev@illinois.edu`, who typically will not have been granted any course permissions. This behavior is not necessarily "wrong," but it may be unexpected - it would probably be best to revisit this whole thing if improvements are made to how permissions are handled in PL.

Fixes #1990 
Fixes #1984
Fixes #1991

