### PR TITLE
Fix in-browser add and copy of course instance

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -199,10 +199,13 @@
 
   * Fix in-browser course edit handler to keep one course lock throughout entire process (Tim Bretl).
 
-  * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
   * Fix button alignment in popovers (Tim Bretl).
 
   * Fix authorization of effective user (Tim Bretl).
+
+  * Fix in-browser add/copy of course instances to ensure user has `Instructor` role (Tim Bretl).
+
+  * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 
 * __3.2.0__ - 2019-08-05
 

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -743,6 +743,18 @@ class CourseInstanceCopyEditor extends Editor {
                 });
             },
             (infoJson, callback) => {
+                if (! config.devMode) {
+                    debug(`Ensure ${this.user.uid} has role Instructor in new course instance`);
+                    if (infoJson.hasOwnProperty('userRoles')) {
+                        // this will either create or modify the role associated with this.user.uid
+                        // (if the role was already 'Instructor', this will do nothing)
+                        infoJson.userRoles[this.user.uid] = 'Instructor'
+                    } else {
+                        infoJson.userRoles = {
+                            [this.user.uid]: 'Instructor',
+                        };
+                    }
+                }
                 debug(`Write infoCourseInstance.json with new longName and uuid`);
                 infoJson.longName = this.long_name;
                 this.uuid = uuidv4();       // <-- store uuid so we can find the new course instance in the DB

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -882,6 +882,11 @@ class CourseInstanceAddEditor extends Editor {
                     allowAccess: [],
                 };
 
+                if (! config.devMode) {
+                    debug(`Ensure ${this.user.uid} has role Instructor in new course instance`);
+                    infoJson.userRoles[this.user.uid] = 'Instructor';
+                }
+
                 // We use outputJson to create the directory this.courseInstancePath if it
                 // does not exist (which it shouldn't). We use the file system flag 'wx' to
                 // throw an error if this.courseInstancePath already exists.

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -745,10 +745,10 @@ class CourseInstanceCopyEditor extends Editor {
             (infoJson, callback) => {
                 if (! config.devMode) {
                     debug(`Ensure ${this.user.uid} has role Instructor in new course instance`);
-                    if (infoJson.hasOwnProperty('userRoles')) {
+                    if (typeof infoJson['userRoles'] !== 'undefined') {
                         // this will either create or modify the role associated with this.user.uid
                         // (if the role was already 'Instructor', this will do nothing)
-                        infoJson.userRoles[this.user.uid] = 'Instructor'
+                        infoJson.userRoles[this.user.uid] = 'Instructor';
                     } else {
                         infoJson.userRoles = {
                             [this.user.uid]: 'Instructor',

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -745,15 +745,10 @@ class CourseInstanceCopyEditor extends Editor {
             (infoJson, callback) => {
                 if (! config.devMode) {
                     debug(`Ensure ${this.user.uid} has role Instructor in new course instance`);
-                    if (typeof infoJson['userRoles'] !== 'undefined') {
-                        // this will either create or modify the role associated with this.user.uid
-                        // (if the role was already 'Instructor', this will do nothing)
-                        infoJson.userRoles[this.user.uid] = 'Instructor';
-                    } else {
-                        infoJson.userRoles = {
-                            [this.user.uid]: 'Instructor',
-                        };
-                    }
+                    // this will either create or modify the role associated with this.user.uid
+                    // (if the role was already 'Instructor', this will do nothing)
+                    infoJson['userRoles'] = infoJson['userRoles'] || {};
+                    infoJson.userRoles[this.user.uid] = 'Instructor';
                 }
                 debug(`Write infoCourseInstance.json with new longName and uuid`);
                 infoJson.longName = this.long_name;


### PR DESCRIPTION
When a user adds or copies a course instance in the browser, a `userRole` will be created (if one does not exist already) that makes the user an `Instructor` for the new course instance. Without this change, the user would have been able to create new course instances but would not have had access to these new instances.

Fixes #2000