### PR TITLE
Fix permissions on issues page

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -203,10 +203,13 @@
 
   * Fix in-browser course edit handler to keep one course lock throughout entire process (Tim Bretl).
 
-  * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
   * Fix button alignment in popovers (Tim Bretl).
 
   * Fix authorization of effective user (Tim Bretl).
+
+  * Fix permissions on issues page (Tim Bretl).
+
+  * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 
 * __3.2.0__ - 2019-08-05
 

--- a/pages/instructorIssues/instructorIssues.js
+++ b/pages/instructorIssues/instructorIssues.js
@@ -143,7 +143,7 @@ router.get('/', function(req, res, next) {
 });
 
 router.post('/', function(req, res, next) {
-    if (!res.locals.authz_data.has_instructor_edit) return next();
+    if (!res.locals.authz_data.has_course_permission_edit) return next();
     if (req.body.__action == 'open') {
         let params = [
             req.body.issue_id,

--- a/pages/instructorIssues/instructorIssues.js
+++ b/pages/instructorIssues/instructorIssues.js
@@ -143,7 +143,7 @@ router.get('/', function(req, res, next) {
 });
 
 router.post('/', function(req, res, next) {
-    if (!res.locals.authz_data.has_course_permission_edit) return next();
+    if (!(res.locals.authz_data.has_course_permission_edit || res.locals.authz_data.has_instructor_edit)) return next();
     if (req.body.__action == 'open') {
         let params = [
             req.body.issue_id,

--- a/tests/index.js
+++ b/tests/index.js
@@ -40,4 +40,5 @@ require('./testJsonLoad');
 require('./testSchemas');
 require('./testMarkdown');
 require('./testRedirects');
+require('./testIssues');
 require('./sync');

--- a/tests/testIssues.js
+++ b/tests/testIssues.js
@@ -1,0 +1,125 @@
+const ERR = require('async-stacktrace');
+const assert = require('chai').assert;
+const requestp = require('request-promise-native');
+const cheerio = require('cheerio');
+
+const config = require('../lib/config');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const sql = sqlLoader.loadSqlEquiv(__filename);
+
+const helperServer = require('./helperServer');
+
+const siteUrl = 'http://localhost:' + config.serverPort;
+const baseUrl = siteUrl + '/pl';
+const questionUrl = baseUrl + '/course_instance/1/instructor/question/1/preview';
+const courseInstanceIssuesUrl = baseUrl + '/course_instance/1/instructor/course_admin/issues';
+const courseIssuesUrl = baseUrl + '/course/1/course_admin/issues';
+
+const locals = {};
+
+describe('Issues', function() {
+    this.timeout(10000);
+
+    before('set up testing server', helperServer.before());
+    after('shut down testing server', helperServer.after);
+
+    doTest(questionUrl, courseInstanceIssuesUrl, 'course');
+    doTest(questionUrl, courseIssuesUrl, 'course instance');
+
+});
+
+function doTest(questionUrl, issuesUrl, label) {
+    let page, elemList;
+
+    describe(`Report issue with question and close all issues in ${label}`, () => {
+
+        it('should get question preview page', async () => {
+            page = await requestp(questionUrl);
+            locals.$ = cheerio.load(page); // eslint-disable-line require-atomic-updates
+        });
+
+        it('should have a __csrf_token and a __variant_id', () => {
+            elemList = locals.$('div[id="issueCollapse"] input[name="__csrf_token"]');
+            assert.lengthOf(elemList, 1);
+            assert.nestedProperty(elemList[0], 'attribs.value');
+            locals.__csrf_token = elemList[0].attribs.value;
+            assert.isString(locals.__csrf_token);
+            elemList = locals.$('div[id="issueCollapse"] input[name="__variant_id"]');
+            assert.lengthOf(elemList, 1);
+            assert.nestedProperty(elemList[0], 'attribs.value');
+            locals.__variant_id = elemList[0].attribs.value;
+            assert.isString(locals.__variant_id);
+        });
+
+        it('should post report_issue', async () => {
+            const options = {
+                url: questionUrl,
+                followAllRedirects: true,
+                resolveWithFullResponse: true,
+            };
+            options.form = {
+                __action: 'report_issue',
+                __csrf_token: locals.__csrf_token,
+                description: 'Something bad happened',
+                __variant_id: locals.__variant_id,
+            };
+            page = await requestp.post(options);
+            locals.url = page.request.href;     // eslint-disable-line require-atomic-updates
+            locals.$ = cheerio.load(page.body); // eslint-disable-line require-atomic-updates
+        });
+
+        it('should have one open issue', (callback) => {
+            sqldb.query(sql.select_open_issues, [], (err, result) => {
+                if (ERR(err, callback)) return;
+                if (result.rowCount != 1) {
+                    callback(new Error(`found ${result.rowCount} issues (expected one issue):\n`
+                                       + JSON.stringify(result.rows, null, '    ')));
+                    return;
+                }
+                callback(null);
+            });
+        });
+
+        it('should get issues page successfully', async () => {
+            page = await requestp(issuesUrl);
+            locals.$ = cheerio.load(page); // eslint-disable-line require-atomic-updates
+        });
+
+        it('should have a __csrf_token', () => {
+            elemList = locals.$('div[id="closeAllIssuesModal"] input[name="__csrf_token"]');
+            assert.lengthOf(elemList, 1);
+            assert.nestedProperty(elemList[0], 'attribs.value');
+            locals.__csrf_token = elemList[0].attribs.value;
+            assert.isString(locals.__csrf_token);
+        });
+
+        it('should post close_all', async () => {
+            const options = {
+                url: issuesUrl,
+                followAllRedirects: true,
+                resolveWithFullResponse: true,
+            };
+            options.form = {
+                __action: 'close_all',
+                __csrf_token: locals.__csrf_token,
+            };
+            page = await requestp.post(options);
+            locals.url = page.request.href;     // eslint-disable-line require-atomic-updates
+            locals.$ = cheerio.load(page.body); // eslint-disable-line require-atomic-updates
+        });
+
+        it('should have zero open issues', (callback) => {
+            sqldb.query(sql.select_open_issues, [], (err, result) => {
+                if (ERR(err, callback)) return;
+                if (result.rowCount > 0) {
+                    callback(new Error(`found ${result.rowCount} issues (expected zero issues):\n`
+                                       + JSON.stringify(result.rows, null, '    ')));
+                    return;
+                }
+                callback(null);
+            });
+        });
+
+    });
+}

--- a/tests/testIssues.sql
+++ b/tests/testIssues.sql
@@ -1,0 +1,4 @@
+-- BLOCK select_open_issues
+SELECT *
+FROM issues
+WHERE issues.open = TRUE;


### PR DESCRIPTION
This PR allows course owners and editors to open and close issues, and nobody else (except administrators).

Formerly, access was being granted only to instructors - this broke the ability to open and close issues through the `pl/course` route, where we don't check whether or not users are instructors.

This PR also adds a test that you can report an issue and close it either at the course level or the course instance level.

Fixes #1995