### PR TITLE
Fix angle checks for vectors in `pl-drawing` element

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -210,6 +210,8 @@
   * Fix in-browser add/copy of course instances to ensure user has `Instructor` role (Tim Bretl).
 
   * Fix permissions on issues page (Tim Bretl).
+  
+  * Fix angle tolerance checks for vectors in `pl-drawing` element (Nicolas Nytko).
 
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -1925,15 +1925,15 @@ def grade(element_html, data):
         rang = ref['angle']
         rang_bwd = ref['angle'] + 180
         rang_rad = rang * (np.pi / 180.0)
-        
+
         # Defining the error box limit in the direction of the vector
         max_backward = ref['offset_backward'] + tol
         max_forward = ref['offset_forward'] + tol
-        
+
         # Check the angles
         error_fwd = abserr_ang(rang, eang)
         error_bwd = abserr_ang(rang_bwd, eang)
-        
+
         if ref['disregard_sense']:
             if error_fwd > angtol and error_bwd > angtol:
                 return False
@@ -1972,9 +1972,9 @@ def grade(element_html, data):
         max_forward = ref['offset_forward'] + tol
 
         # Check the angles
-        error_fwd = abserr_ang(rang, eang)
+        error_fwd = abserr_ang(rang_fwd, eang)
         error_bwd = abserr_ang(rang_bwd, eang)
-        
+
         if ref['disregard_sense']:
             if error_fwd > angtol and error_bwd > angtol:
                 return False

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -1961,7 +1961,7 @@ def grade(element_html, data):
         # Get the position of the anchor point for the correct answer
         rpos = np.array([ref['x1'], ref['y1']])
         # Get the angle for the correct answer
-        rang_fwd = ref['angle']
+        rang = ref['angle']
         rang_bwd = ref['angle'] + 180
         rang_rad = rang * (np.pi / 180.0)
         rlen = ref['range']
@@ -1972,7 +1972,7 @@ def grade(element_html, data):
         max_forward = ref['offset_forward'] + tol
 
         # Check the angles
-        error_fwd = abserr_ang(rang_fwd, eang)
+        error_fwd = abserr_ang(rang, eang)
         error_bwd = abserr_ang(rang_bwd, eang)
 
         if ref['disregard_sense']:

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -1880,8 +1880,6 @@ def grade(element_html, data):
         return np.abs(x - xapp)
 
     def abserr_ang(ref, x):
-        ref = ref % 360
-        x = x % 360
         return np.abs(((np.abs(ref - x) + 180) % 360) - 180)
 
     def comp_controlledLine(ref, st):

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -1017,6 +1017,7 @@ def render_drawing_items(elem, curid=1, defaults={}):
             'offset_forward': offset_forward,
             'offset_backward': offset_backward,
             'selectable': drawing_defaults['selectable'],
+            'evented': drawing_defaults['selectable'],
             'type': 'arrow',
             'gradingName': 'vector',
         }
@@ -1211,6 +1212,7 @@ def render_drawing_items(elem, curid=1, defaults={}):
             'originY': 'center',
             'fill': color,
             'selectable': drawing_defaults['selectable'],
+            'evented': drawing_defaults['selectable'],
             'type': 'circle',
             'gradingName': 'point',
         }
@@ -1860,6 +1862,7 @@ def grade(element_html, data):
 
     grid_size = pl.get_integer_attrib(element, 'grid-size', element_defaults['grid-size'])
     tol = pl.get_float_attrib(element, 'tol', grid_size / 2)
+    angtol = pl.get_float_attrib(element, 'angle-tol', element_defaults['angle-tol'])
 
     name = pl.get_string_attrib(element, 'answers-name', element_defaults['answers-name'])
     student = data['submitted_answers'][name]
@@ -1875,6 +1878,11 @@ def grade(element_html, data):
 
     def abserr(x, xapp):
         return np.abs(x - xapp)
+
+    def abserr_ang(ref, x):
+        ref = ref % 360
+        x = x % 360
+        return np.abs(((np.abs(ref - x) + 180) % 360) - 180)
 
     def comp_controlledLine(ref, st):
         ex1, ex2 = st['x1'], st['x2']
@@ -1912,26 +1920,25 @@ def grade(element_html, data):
 
         # Get the position of the anchor point for the correct answer
         rpos = np.array([ref['x1'], ref['y1']])
+
         # Get the angle for the correct answer
         rang = ref['angle']
-        rang2 = -1.0 * np.sign(rang) * (360 - np.abs(rang)) if np.sign(rang) != 0 else 360
-        rang3 = -1.0 * np.sign(rang) * (180 - np.abs(rang)) if np.sign(rang) != 0 else -180
-        rang4 = 1.0 * np.sign(rang) * (180 + np.abs(rang)) if np.sign(rang) != 0 else 180
+        rang_bwd = ref['angle'] + 180
         rang_rad = rang * (np.pi / 180.0)
+        
         # Defining the error box limit in the direction of the vector
         max_backward = ref['offset_backward'] + tol
         max_forward = ref['offset_forward'] + tol
-
+        
         # Check the angles
-        error1 = abserr(rang, eang)
-        error2 = abserr(rang2, eang)
-        error3 = abserr(rang3, eang)
-        error4 = abserr(rang4, eang)
+        error_fwd = abserr_ang(rang, eang)
+        error_bwd = abserr_ang(rang_bwd, eang)
+        
         if ref['disregard_sense']:
-            if error1 > tol and error2 > tol and error3 > tol and error4 > tol:
+            if error_fwd > angtol and error_bwd > angtol:
                 return False
         else:
-            if error1 > tol and error2 > tol:
+            if error_fwd > angtol:
                 return False
 
         # Get position of student answer relative to reference answer
@@ -1954,10 +1961,8 @@ def grade(element_html, data):
         # Get the position of the anchor point for the correct answer
         rpos = np.array([ref['x1'], ref['y1']])
         # Get the angle for the correct answer
-        rang = ref['angle']
-        rang2 = -1.0 * np.sign(rang) * (360 - np.abs(rang)) if np.sign(rang) != 0 else 360
-        rang3 = -1.0 * np.sign(rang) * (180 - np.abs(rang)) if np.sign(rang) != 0 else -180
-        rang4 = 1.0 * np.sign(rang) * (180 + np.abs(rang)) if np.sign(rang) != 0 else 180
+        rang_fwd = ref['angle']
+        rang_bwd = ref['angle'] + 180
         rang_rad = rang * (np.pi / 180.0)
         rlen = ref['range']
         rw1 = ref['w1']
@@ -1967,15 +1972,14 @@ def grade(element_html, data):
         max_forward = ref['offset_forward'] + tol
 
         # Check the angles
-        error1 = abserr(rang, eang)
-        error2 = abserr(rang2, eang)
-        error3 = abserr(rang3, eang)
-        error4 = abserr(rang4, eang)
+        error_fwd = abserr_ang(rang, eang)
+        error_bwd = abserr_ang(rang_bwd, eang)
+        
         if ref['disregard_sense']:
-            if error1 > tol and error2 > tol and error3 > tol and error4 > tol:
+            if error_fwd > angtol and error_bwd > angtol:
                 return False
         else:
-            if error1 > tol and error2 > tol:
+            if error_fwd > angtol:
                 return False
 
         # Check width


### PR DESCRIPTION
As pointed out by Vadim on Slack changing the `angle-tol` parameter previously did not change anything, this fix makes the grader use that parameter when checking tolerances.