### PR TITLE
Add explanation of `None` role in documentation and instructor gradebook view

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -75,6 +75,8 @@
 
   * Add file size limit to student-visible part of `pl-file-upload` (Nathan Bowman).
 
+  * Add explanation of `None` role in documentation and instructor gradebook view (James Balamuta).
+
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 
   * Change `centos7-python` to `grader-python` and place it under `graders/`  (James Balamuta).

--- a/doc/courseInstance.md
+++ b/doc/courseInstance.md
@@ -68,7 +68,7 @@ Each user has a single role assigned to them. These are:
 
 Role         | Description
 ---          | ---
-`None`       | A user who at one point was enrolled in the course and, then, unenrolled. They can no longer access the course, but the work done within the course has been retained.
+`None`       | A user who at one point added the course and later removed themselves. They can no longer access the course but their work done within the course has been retained.
 `Student`    | A student participating in the class. They can only see their own information, and can do assessments. Default permission.
 `TA`         | A teaching assisstant. They can see the data of all users, but can only edit their own information.
 `Instructor` | A person in charge of the course. They have full permission to see and edit the information of other users.

--- a/doc/courseInstance.md
+++ b/doc/courseInstance.md
@@ -68,9 +68,13 @@ Each user has a single role assigned to them. These are:
 
 Role         | Description
 ---          | ---
-`Student`    | A student participating in the class. They can only see their own information, and can do do assessments.
+`None`       | A user who at one point was enrolled in the course and, then, unenrolled. They can no longer access the course, but the work done within the course has been retained.
+`Student`    | A student participating in the class. They can only see their own information, and can do assessments. Default permission.
 `TA`         | A teaching assisstant. They can see the data of all users, but can only edit their own information.
-`Instructor` | A person in charge of the course. Has full permission to see and edit the information of other users.
+`Instructor` | A person in charge of the course. They have full permission to see and edit the information of other users.
+
+By default, any user not explicitly mentioned in the `userRoles` list will
+be considered as a `Student`.
 
 ## Course instance `allowAccess`
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -46,6 +46,14 @@ Second, edit the assessment `pl-exp101/courseInstance/Fa17/assessments/final/inf
 
 See [Access control](accessControl.md) for more details.
 
+## Why does a user have the role of None?
+
+Users with the role of `None` at one point have enrolled and, then, unenrolled
+in the course. All data for anyone who ever did anything in the course
+-- even if they drop the course -- will be retained but with this indication.
+Their information is also included within the aggregation of assessment
+statistics.
+
 ## Why is the exam closed if it is not past the end date?
 
 As a built-in security measure, assessments are automatically closed after 6 hours

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -49,7 +49,7 @@ See [Access control](accessControl.md) for more details.
 ## Why does a user have the role of None?
 
 Users with a role of `None` at one point added the course and later removed themselves.
-in the course. All data for anyone who ever did anything in the course
+All data for anyone who ever did anything in the course
 -- even if they drop the course -- will be retained but with this indication.
 Their information is also included within the aggregation of assessment
 statistics.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -48,7 +48,7 @@ See [Access control](accessControl.md) for more details.
 
 ## Why does a user have the role of None?
 
-Users with the role of `None` at one point have enrolled and, then, unenrolled
+Users with a role of `None` at one point added the course and later removed themselves.
 in the course. All data for anyone who ever did anything in the course
 -- even if they drop the course -- will be retained but with this indication.
 Their information is also included within the aggregation of assessment
@@ -282,4 +282,3 @@ To address this, there are a variety of different ways. In particular, we have:
 - Restart your computer.
 - Stop the process in terminal with <kbd>CNTRL</kbd> + <kbd>C</kbd> and, then, 
   close the terminal application.   
-

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -227,6 +227,18 @@
               <% }); %>
             </tbody>
           </table>
+          
+          <div class="card-footer">
+            <small>
+              <strong>Roles:</strong>
+              <ul>
+                 <li><strong>Instructor</strong> is a person in charge of the course. They have full permission to see and edit the information of other users.</li>
+                 <li><strong>TA</strong> is a teaching assisstant. They can see the data of all users, but can only edit their own information.</li>
+                 <li><strong>Student</strong> is a student participating in the class. They can only see their own information, and can do assessments.</li>
+                 <li><strong>None</strong> is a user who at one point added the course and later removed themselves. They can no longer access the course but their work done within the course has been retained.</li>
+              </ul>
+            </small>
+          </div>
         </div>
         <script>
           $(function(){

--- a/pages/instructorGradebook/instructorGradebook.ejs
+++ b/pages/instructorGradebook/instructorGradebook.ejs
@@ -102,7 +102,7 @@
                  <li><strong>Instructor</strong> is a person in charge of the course. They have full permission to see and edit the information of other users.</li>
                  <li><strong>TA</strong> is a teaching assisstant. They can see the data of all users, but can only edit their own information.</li>
                  <li><strong>Student</strong> is a student participating in the class. They can only see their own information, and can do assessments.</li>
-                 <li><strong>None</strong> is a user who at one point was enrolled in the course and, then, unenrolled. They can no longer access the course, but the work done within the course has been retained.</li>
+                 <li><strong>None</strong> is a user who at one point added the course and later removed themselves. They can no longer access the course but their work done within the course has been retained.</li>
             </ul>
           </small>
         </div>

--- a/pages/instructorGradebook/instructorGradebook.ejs
+++ b/pages/instructorGradebook/instructorGradebook.ejs
@@ -95,7 +95,16 @@
         </div>
 
         <div class="card-footer">
-          Download <a href="<%= urlPrefix %>/gradebook/<%= csvFilename %>"><%= csvFilename %></a>
+          <p>Download <a href="<%= urlPrefix %>/gradebook/<%= csvFilename %>"><%= csvFilename %></a></p>
+          <small>
+            <strong>Roles:</strong>
+             <ul>
+                 <li><strong>Instructor</strong> is a person in charge of the course. They have full permission to see and edit the information of other users.</li>
+                 <li><strong>TA</strong> is a teaching assisstant. They can see the data of all users, but can only edit their own information.</li>
+                 <li><strong>Student</strong> is a student participating in the class. They can only see their own information, and can do assessments.</li>
+                 <li><strong>None</strong> is a user who at one point was enrolled in the course and, then, unenrolled. They can no longer access the course, but the work done within the course has been retained.</li>
+            </ul>
+          </small>
         </div>
 
       </div>


### PR DESCRIPTION
Add explanation of `None` role in documentation and instructor gradebook view. Close #964

Modeled after footer in assessment statistics:

![Screen Shot 2020-01-28 at 1 01 37 PM](https://user-images.githubusercontent.com/833642/73296069-8fcf0900-41ce-11ea-9f6e-1e344b14a7df.png)
