### PR TITLE
Fix grading of duplicate elements in `pl-drawing`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -212,6 +212,8 @@
   * Fix permissions on issues page (Tim Bretl).
   
   * Fix angle tolerance checks for vectors in `pl-drawing` element (Nicolas Nytko).
+  
+  * Fix unique element checking in default grader for `pl-drawing` element (Nicolas Nytko).
 
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -2060,7 +2060,7 @@ def grade(element_html, data):
             if 'optional_grading' in ref_element and ref_element['optional_grading']:
                 continue
             num_total_ref += 1
-
+            
     # Loop through and check everything
     for element in student['objects']:
         if 'gradingName' not in element or element['gradingName'] not in comp or not element['graded']:
@@ -2070,7 +2070,7 @@ def grade(element_html, data):
         num_total_st += 1
 
         for ref_element in reference['objects']:
-            if ref_element['gradingName'] not in comp or ref_element['id'] not in matches or not ref_element['graded'] or element['gradingName'] != ref_element['gradingName']:
+            if ref_element['gradingName'] not in comp or ref_element['id'] not in matches or matches[ref_element['id']] or not ref_element['graded'] or element['gradingName'] != ref_element['gradingName']:
                 continue
 
             if comp[element['gradingName']](ref_element, element):
@@ -2086,7 +2086,7 @@ def grade(element_html, data):
                 break
 
     extra_not_optional = num_total_st - (num_optional + num_correct)
-
+    
     if num_total_ref == 0:
         score = 1
     else:

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -2060,7 +2060,7 @@ def grade(element_html, data):
             if 'optional_grading' in ref_element and ref_element['optional_grading']:
                 continue
             num_total_ref += 1
-            
+
     # Loop through and check everything
     for element in student['objects']:
         if 'gradingName' not in element or element['gradingName'] not in comp or not element['graded']:
@@ -2086,7 +2086,7 @@ def grade(element_html, data):
                 break
 
     extra_not_optional = num_total_st - (num_optional + num_correct)
-    
+
     if num_total_ref == 0:
         score = 1
     else:


### PR DESCRIPTION
Turns out unique matches were being stored, but not actually being checked in grading.  This should fix that issue, before students were able to get scores >100% just by placing multiple objects in the same position.