### PR TITLE
Fix `pl-string-input` not rendering verbatim answer/input

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -221,6 +221,8 @@
 
   * Fix course instance access check (Tim Bretl).
 
+  * Fix `pl-string-input` incorrectly displaying whitespace and special characters (Nicolas Nytko).
+
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 
 * __3.2.0__ - 2019-08-05

--- a/elements/pl-string-input/pl-string-input.css
+++ b/elements/pl-string-input/pl-string-input.css
@@ -2,3 +2,10 @@
     width: 400px;
     max-width: 100%;
 }
+
+.pl-string-input-value {
+    display: inline;
+    font-size: 16px;
+    color: unset;
+    white-space: pre;
+}

--- a/elements/pl-string-input/pl-string-input.mustache
+++ b/elements/pl-string-input/pl-string-input.mustache
@@ -49,7 +49,7 @@
 {{/parse_error}}
 {{^parse_error}}
 {{#label}}<span>{{label}}</span>{{/label}}
-<code class="pl-string-input-value submission">{{a_sub}}</code>
+<code class="pl-string-input-value">{{a_sub}}</code>
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{#correct}}<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
 {{#partial}}<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
@@ -60,7 +60,7 @@
 
 {{#answer}}
 {{#label}}<span>{{label}}</span>{{/label}}
-<code class="pl-string-input-value answer">{{a_tru}}</code>
+<code class="pl-string-input-value">{{a_tru}}</code>
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{/answer}}
 

--- a/elements/pl-string-input/pl-string-input.mustache
+++ b/elements/pl-string-input/pl-string-input.mustache
@@ -30,7 +30,6 @@
 {{#inline}}</span>{{/inline}}
 {{/question}}
 
-
 {{#submission}}
 {{#inline}}<span class="d-inline-block">{{/inline}}
 {{#parse_error}}
@@ -50,7 +49,7 @@
 {{/parse_error}}
 {{^parse_error}}
 {{#label}}<span>{{label}}</span>{{/label}}
-<samp>{{a_sub}}</samp>
+<code class="pl-string-input-value submission">{{a_sub}}</code>
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{#correct}}<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
 {{#partial}}<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
@@ -61,7 +60,7 @@
 
 {{#answer}}
 {{#label}}<span>{{label}}</span>{{/label}}
-<samp>{{a_tru}}</samp>
+<code class="pl-string-input-value answer">{{a_tru}}</code>
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{/answer}}
 


### PR DESCRIPTION
Fixes #2055 

Switches the `<samp>` tag to an inline `<code>` and adds some custom styling.

Tagging @zillesc to make sure it is working for his use case.