### PR TITLE
Fix nightly calculation of question statistics

### DIFF
--- a/cron/calculateAssessmentQuestionStats.js
+++ b/cron/calculateAssessmentQuestionStats.js
@@ -1,15 +1,18 @@
-var ERR = require('async-stacktrace');
+const util = require('util');
 
-var sqldb = require('@prairielearn/prairielib/sql-db');
-var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
-var sql = sqlLoader.loadSqlEquiv(__filename);
+const sql = sqlLoader.loadSqlEquiv(__filename);
 
 module.exports = {};
 
 module.exports.run = function(callback) {
-    sqldb.query(sql.all, [], function(err) {
-        if (ERR(err, callback)) return;
-        callback(null);
-    });
+    util.callbackify(async () => {
+        const result = await sqldb.queryAsync(sql.select_assessments, {});
+        const assessments = result.rows;
+        for (const assessment of assessments) {
+            await sqldb.callAsync('assessment_questions_calculate_stats_for_assessment', [assessment.id]);
+        }
+    })(callback);
 };

--- a/cron/calculateAssessmentQuestionStats.sql
+++ b/cron/calculateAssessmentQuestionStats.sql
@@ -1,4 +1,3 @@
-SELECT
-    assessment_questions_calculate_stats_for_assessment(a.id)
-FROM
-    assessments AS a;
+-- BLOCK select_assessments
+SELECT *
+FROM assessments;

--- a/cron/calculateAssessmentQuestionStats.sql
+++ b/cron/calculateAssessmentQuestionStats.sql
@@ -1,3 +1,8 @@
 -- BLOCK select_assessments
 SELECT *
-FROM assessments;
+FROM assessments AS a
+WHERE EXISTS (
+    SELECT *
+    FROM assessment_instances AS ai
+    WHERE ai.modified_at > a.stats_last_updated
+);

--- a/cron/index.js
+++ b/cron/index.js
@@ -73,7 +73,7 @@ module.exports = {
             {
                 name: 'calculateAssessmentQuestionStats',
                 module: require('./calculateAssessmentQuestionStats'),
-                intervalSec: 'daily',
+                intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalCalculateAssessmentQuestionStatsSec,
             },
             {
                 name: 'calculateAssessmentMode',

--- a/database/tables/assessment_instances.pg
+++ b/database/tables/assessment_instances.pg
@@ -9,6 +9,7 @@ columns
     id: bigint not null default nextval('assessment_instances_id_seq'::regclass)
     max_points: double precision
     mode: enum_mode
+    modified_at: timestamp with time zone not null default CURRENT_TIMESTAMP
     number: integer
     obj: jsonb
     open: boolean default true
@@ -23,6 +24,7 @@ columns
 indexes
     assessment_instances_pkey: PRIMARY KEY (id) USING btree (id)
     assessment_instances_assessment_id_user_id_number_key: UNIQUE (assessment_id, user_id, number) USING btree (assessment_id, user_id, number)
+    assessment_instances_modified_at_key: USING btree (modified_at)
     assessment_instances_tiid_key: UNIQUE (tiid) USING btree (tiid)
     assessment_instances_user_id_idx: USING btree (user_id)
 

--- a/database/tables/assessment_instances.pg
+++ b/database/tables/assessment_instances.pg
@@ -24,8 +24,8 @@ columns
 indexes
     assessment_instances_pkey: PRIMARY KEY (id) USING btree (id)
     assessment_instances_assessment_id_user_id_number_key: UNIQUE (assessment_id, user_id, number) USING btree (assessment_id, user_id, number)
-    assessment_instances_modified_at_key: USING btree (modified_at)
     assessment_instances_tiid_key: UNIQUE (tiid) USING btree (tiid)
+    assessment_instances_modified_at_key: USING btree (modified_at)
     assessment_instances_user_id_idx: USING btree (user_id)
 
 foreign-key constraints

--- a/database/tables/instance_questions.pg
+++ b/database/tables/instance_questions.pg
@@ -14,6 +14,7 @@ columns
     incremental_submission_score_array: double precision[]
     last_submission_score: double precision
     max_submission_score: double precision
+    modified_at: timestamp with time zone not null default CURRENT_TIMESTAMP
     number: integer
     number_attempts: integer not null default 0
     open: boolean default true
@@ -36,6 +37,7 @@ indexes
     instance_questions_pkey: PRIMARY KEY (id) USING btree (id)
     instance_questions_assessment_question_id_assessment_instan_key: UNIQUE (assessment_question_id, assessment_instance_id) USING btree (assessment_question_id, assessment_instance_id)
     instance_questions_assessment_instance_id_idx: USING btree (assessment_instance_id)
+    instance_questions_modified_at_key: USING btree (modified_at)
 
 foreign-key constraints
     instance_questions_assessment_instance_id_fkey: FOREIGN KEY (assessment_instance_id) REFERENCES assessment_instances(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -503,9 +503,9 @@ FROM
 * To write a callback-style function that internally uses async/await code, use this pattern:
 
 ```javascript
-util = require('util');
+const util = require('util');
 function oldFunction(x1, x2, callback) {
-    util.callbackify(() => {
+    util.callbackify(async () => {
         # here we can use async/await code
         y1 = await f(x1);
         y2 = await f(x2);

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,6 +34,7 @@ config.cronIntervalErrorAbandonedJobsSec = 10 * 60;
 config.cronIntervalExternalGraderLoadSec = 8;
 config.cronIntervalServerLoadSec = 8;
 config.cronIntervalServerUsageSec = 8;
+config.cronIntervalCalculateAssessmentQuestionStatsSec = 10 * 60;
 config.cronDailySec = 8 * 60 * 60;
 config.autoFinishAgeMins = 6 * 60;
 config.questionDefaultsDir = 'question-servers/default-calculation';

--- a/migrations/164_instance_questions__modified_at__add.sql
+++ b/migrations/164_instance_questions__modified_at__add.sql
@@ -1,0 +1,11 @@
+ALTER TABLE instance_questions ADD COLUMN modified_at timestamp with time zone default CURRENT_TIMESTAMP;
+ALTER TABLE assessment_instances ADD COLUMN modified_at timestamp with time zone default CURRENT_TIMESTAMP;
+
+CREATE INDEX instance_questions_modified_at_key ON instance_questions (modified_at);
+CREATE INDEX assessment_instances_modified_at_key ON assessment_instances (modified_at);
+
+UPDATE instance_questions SET modified_at = created_at;
+UPDATE assessment_instances SET modified_at = date;
+
+ALTER TABLE instance_questions ALTER COLUMN modified_at SET NOT NULL;
+ALTER TABLE assessment_instances ALTER COLUMN modified_at SET NOT NULL;

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql
@@ -34,7 +34,8 @@ WITH results AS (
     SET
         open = true,
         date_limit = NULL,
-        auto_close = FALSE
+        auto_close = FALSE,
+        modified_at = now()
     WHERE
         ai.id = $assessment_instance_id
     RETURNING

--- a/sprocs/assessment_instances_close.sql
+++ b/sprocs/assessment_instances_close.sql
@@ -25,7 +25,8 @@ BEGIN
     SET
         open = FALSE,
         closed_at = CURRENT_TIMESTAMP,
-        duration = main.duration
+        duration = main.duration,
+        modified_at = now()
     WHERE ai.id = assessment_instance_id;
 
     INSERT INTO assessment_state_logs

--- a/sprocs/assessment_instances_grade.sql
+++ b/sprocs/assessment_instances_grade.sql
@@ -150,7 +150,8 @@ BEGIN
         points = new_values.points,
         points_in_grading = new_values.points_in_grading,
         score_perc = new_values.score_perc,
-        score_perc_in_grading = new_values.score_perc_in_grading
+        score_perc_in_grading = new_values.score_perc_in_grading,
+        modified_at = now()
     WHERE ai.id = assessment_instance_id
     RETURNING ai.*
     INTO new_assessment_instance;

--- a/sprocs/assessment_instances_regrade.sql
+++ b/sprocs/assessment_instances_regrade.sql
@@ -55,7 +55,8 @@ BEGIN
             points = aq.max_points,
             score_perc = 100,
             points_in_grading = 0,
-            score_perc_in_grading = 0
+            score_perc_in_grading = 0,
+            modified_at = now()
         FROM
             assessment_questions AS aq
             JOIN questions AS q ON (q.id = aq.question_id)

--- a/sprocs/assessment_instances_update.sql
+++ b/sprocs/assessment_instances_update.sql
@@ -105,7 +105,8 @@ BEGIN
 
         UPDATE assessment_instances AS ai
         SET
-            max_points = new_assessment_instance_max_points
+            max_points = new_assessment_instance_max_points,
+            modified_at = now()
         WHERE
             ai.id = assessment_instance_id;
 

--- a/sprocs/assessment_instances_update_points.sql
+++ b/sprocs/assessment_instances_update_points.sql
@@ -23,7 +23,8 @@ BEGIN
             points = new_points,
             points_in_grading = 0,
             score_perc = new_score_perc,
-            score_perc_in_grading = 0
+            score_perc_in_grading = 0,
+            modified_at = now()
         WHERE ai.id = assessment_instance_id
         RETURNING ai.*
     )

--- a/sprocs/assessment_instances_update_score_perc.sql
+++ b/sprocs/assessment_instances_update_score_perc.sql
@@ -23,7 +23,8 @@ BEGIN
             points = new_points,
             points_in_grading = 0,
             score_perc = new_score_perc,
-            score_perc_in_grading = 0
+            score_perc_in_grading = 0,
+            modified_at = now()
         WHERE ai.id = assessment_instance_id
         RETURNING ai.*
     )

--- a/sprocs/instance_questions_update_in_grading.sql
+++ b/sprocs/instance_questions_update_in_grading.sql
@@ -17,7 +17,8 @@ BEGIN
     SET
         status = 'grading',
         points_in_grading = new_values.points,
-        score_perc_in_grading = new_values.score_perc
+        score_perc_in_grading = new_values.score_perc,
+        modified_at = now()
     WHERE
         iq.id = instance_question_id;
 END;

--- a/sprocs/instance_questions_update_score.sql
+++ b/sprocs/instance_questions_update_score.sql
@@ -124,7 +124,8 @@ BEGIN
             points = new_points,
             points_in_grading = 0,
             score_perc = new_score_perc,
-            score_perc_in_grading = 0
+            score_perc_in_grading = 0,
+            modified_at = now()
         WHERE iq.id = instance_question_id;
 
         INSERT INTO question_score_logs

--- a/sprocs/submissions_insert.sql
+++ b/sprocs/submissions_insert.sql
@@ -99,11 +99,14 @@ BEGIN
         SET
             status = 'saved',
             duration = duration + delta,
-            first_duration = coalesce(first_duration, delta)
+            first_duration = coalesce(first_duration, delta),
+            modified_at = now()
         WHERE id = instance_question_id;
 
         UPDATE assessment_instances AS ai
-        SET duration = ai.duration + delta
+        SET
+            duration = ai.duration + delta,
+            modified_at = now()
         FROM instance_questions AS iq
         WHERE
             iq.id = instance_question_id


### PR DESCRIPTION
The nightly cron job to update question statistics used to iterate over assessments inside the SQL. However, this now takes more than 10 minutes so we timeout the query. This PR changes it to iterate over assessments in JS, so each individual SQL query should be below 10 minutes.

Fixes #1635
Fixes #1323