### PR TITLE
Displaying issue status to student open/closed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4920,8 +4920,8 @@
             "from": "git://github.com/mathjax/MathJax-src.git",
             "requires": {
                 "esm": "^3.2.25",
-                "mj-context-menu": "^0.2.0",
-                "speech-rule-engine": "^3.0.0-beta.6"
+                "mj-context-menu": "^0.2.2",
+                "speech-rule-engine": "^3.0.0-beta.8"
             }
         },
         "mdast-util-definitions": {

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -27,9 +27,9 @@
       </tbody>
     </table>
 
-    <% if (devMode || authz_data.has_instructor_view || is_administrator) { %>
+    
     <div class="card-body border border-bottom-0 border-left-0 border-right-0">
-      <% if (is_administrator && issue.system_data.courseErrData ) { %>
+      <% if ((devMode || authz_data.has_instructor_view || is_administrator) && (is_administrator && issue.system_data.courseErrData) ) { %>
       <p><strong>Console log:</strong>
         <pre class="bg-dark text-white rounded p-3"><%= issue.system_data.courseErrData.outputBoth %></pre>
         <% } %>
@@ -41,19 +41,33 @@
       <div class="collapse" id="issue-course-data-<%= iIssue %>">
         <pre class="bg-dark text-white rounded p-3"><%= JSON.stringify(issue.course_data, null, '    ') %></pre>
       </div>
-      <% if (is_administrator) { %>
+      <% if ((devMode || authz_data.has_instructor_view || is_administrator) && (is_administrator)) { %>
       <p><strong>System data:</strong>
         <button type="button" class="btn btn-xs btn-secondary" data-toggle="collapse" href="#issue-system-data-<%= iIssue %>" aria-expanded="false" aria-controls="#issue-system-data-<%= iIssue %>">
           Show/hide
         </button>
       </p>
+      <% } %>
+      <p><strong>Issue status:</strong>
+        <% if (issue.open) { %>
+          <span type="button" class="badge badge-danger" data-toggle="collapse" href="#">
+            Open
+          </span>
+          <% } else { %>
+            <span type="button" class="badge badge-success" data-toggle="collapse" href="#">
+              Closed
+            </span>
+          <% } %>
+      </p>
       <div class="collapse" id="issue-system-data-<%= iIssue %>">
         <pre class="bg-dark text-white rounded p-3"><%= JSON.stringify(issue.system_data, null, '    ') %></pre>
       </div>
-      <% } %>
+     
     </div>
-    <% } %>
+
   </div>
+
+  
   <% }); %>
 
 


### PR DESCRIPTION
Displayed whether the issue is open/closed to the student. 
Below, issue status is "open". 

![image](https://user-images.githubusercontent.com/51917387/75615884-41839180-5b0f-11ea-99f0-0ae758dd94ed.png)
