### PR TITLE
Show "student" badge on student news

### DIFF
--- a/pages/news_item/news_item.ejs
+++ b/pages/news_item/news_item.ejs
@@ -15,7 +15,7 @@
       </a>
 
       <h1>
-         <%= news_item.title %>
+        <%= news_item.title %>
       </h1>
 
       <p class="text-muted">

--- a/pages/news_item/news_item.ejs
+++ b/pages/news_item/news_item.ejs
@@ -15,7 +15,7 @@
       </a>
 
       <h1>
-          <%= news_item.title %>
+         <%= news_item.title %>
       </h1>
 
       <p class="text-muted">

--- a/pages/news_item/news_item.ejs
+++ b/pages/news_item/news_item.ejs
@@ -26,7 +26,7 @@
           <% } %>
         </i>
         <% if (news_item.show_student_badge) { %>
-            <span class="badge badge-secondary ml-2">Student Visible</span>
+            <span class="badge badge-secondary ml-2">Visible to students</span>
         <% } %>
       </p>
 

--- a/pages/news_item/news_item.ejs
+++ b/pages/news_item/news_item.ejs
@@ -15,7 +15,10 @@
       </a>
 
       <h1>
-        <%= news_item.title %>
+          <%= news_item.title %>
+          <% if (news_item.show_student_badge) { %>
+              <span class="badge badge-secondary ml-4">Student</span>
+          <% } %>
       </h1>
 
       <p class="text-muted">

--- a/pages/news_item/news_item.ejs
+++ b/pages/news_item/news_item.ejs
@@ -16,9 +16,6 @@
 
       <h1>
           <%= news_item.title %>
-          <% if (news_item.show_student_badge) { %>
-              <span class="badge badge-secondary ml-4">Student</span>
-          <% } %>
       </h1>
 
       <p class="text-muted">
@@ -28,6 +25,9 @@
           by <%- news_item.author %>
           <% } %>
         </i>
+        <% if (news_item.show_student_badge) { %>
+            <span class="badge badge-secondary ml-2">Student Visible</span>
+        <% } %>
       </p>
 
       <%- news_item_html %>

--- a/pages/news_item/news_item.sql
+++ b/pages/news_item/news_item.sql
@@ -8,7 +8,7 @@ WITH mark_news_item_as_read AS (
 SELECT
     ni.*,
     format_date_only_no_tz(ni.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
-    (users_is_course_staff($user_id) and ni.visible_to_students) AS show_student_badge
+    (users_is_course_staff($user_id) AND ni.visible_to_students) AS show_student_badge
 FROM
     news_items AS ni
     LEFT JOIN course_instances AS ci ON (ci.id = $course_instance_id)

--- a/pages/news_item/news_item.sql
+++ b/pages/news_item/news_item.sql
@@ -7,7 +7,8 @@ WITH mark_news_item_as_read AS (
 )
 SELECT
     ni.*,
-    format_date_only_no_tz(ni.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date
+    format_date_only_no_tz(ni.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
+    (users_is_course_staff($user_id) and ni.visible_to_students) AS show_student_badge
 FROM
     news_items AS ni
     LEFT JOIN course_instances AS ci ON (ci.id = $course_instance_id)

--- a/pages/news_items/news_items.ejs
+++ b/pages/news_items/news_items.ejs
@@ -33,6 +33,9 @@
                     <% if (news_item.unread) { %>
                     <span class="badge badge-danger ml-2">Unread</span>
                     <% } %>
+                    <% if (news_item.visible_to_students == true) { %>
+                    <span class="badge badge-secondary ml-2">Student</span>
+                    <% } %>
                   </a>
                 </td>
               </tr>

--- a/pages/news_items/news_items.ejs
+++ b/pages/news_items/news_items.ejs
@@ -33,7 +33,7 @@
                     <% if (news_item.unread) { %>
                     <span class="badge badge-danger ml-2">Unread</span>
                     <% } %>
-                    <% if (news_item.visible_to_students == true) { %>
+                    <% if (news_item.show_student_badge) { %>
                     <span class="badge badge-secondary ml-2">Student</span>
                     <% } %>
                   </a>

--- a/pages/news_items/news_items.ejs
+++ b/pages/news_items/news_items.ejs
@@ -34,7 +34,7 @@
                     <span class="badge badge-danger ml-2">Unread</span>
                     <% } %>
                     <% if (news_item.show_student_badge) { %>
-                    <span class="badge badge-secondary ml-2">Student</span>
+                    <span class="badge badge-secondary ml-2">Visible to students</span>
                     <% } %>
                   </a>
                 </td>

--- a/pages/news_items/news_items.sql
+++ b/pages/news_items/news_items.sql
@@ -3,7 +3,7 @@ SELECT
     ni.*,
     format_date_only_no_tz(ni.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
     (an.id IS NOT NULL) AS unread,
-    (users_is_course_staff($user_id) and ni.visible_to_students) AS show_student_badge
+    (users_is_course_staff($user_id) AND ni.visible_to_students) AS show_student_badge
 FROM
     news_items AS ni
     LEFT JOIN news_item_notifications AS an ON (an.news_item_id = ni.id AND an.user_id = $user_id)

--- a/pages/news_items/news_items.sql
+++ b/pages/news_items/news_items.sql
@@ -2,7 +2,8 @@
 SELECT
     ni.*,
     format_date_only_no_tz(ni.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
-    (an.id IS NOT NULL) AS unread
+    (an.id IS NOT NULL) AS unread,
+    (users_is_course_staff($user_id) and ni.visible_to_students) AS show_student_badge
 FROM
     news_items AS ni
     LEFT JOIN news_item_notifications AS an ON (an.news_item_id = ni.id AND an.user_id = $user_id)

--- a/sprocs/users_is_course_staff.sql
+++ b/sprocs/users_is_course_staff.sql
@@ -25,4 +25,4 @@ BEGIN
 
     is_course_staff := FOUND;
 END;
-$$ LANGUAGE plpgsql VOLATILE;
+$$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
added a badge to news items that marks a news item to be for a "student" 
![image](https://user-images.githubusercontent.com/29923257/75616076-020a7480-5b12-11ea-9507-21cabf9741f7.png)
