### PR TITLE
Fixing asymptomatic syntax mistake

### DIFF
--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -58,7 +58,7 @@ def render(element_html, data):
         raw_submitted_answer = data['raw_submitted_answers'].get(name, None)
 
         operators = ', '.join(['cos', 'sin', 'tan', 'exp', 'log', 'sqrt', '( )', '+', '-', '*', '/', '^', '**'])
-        constants = ', '.join(['pi, e'])
+        constants = ', '.join(['pi', 'e'])
 
         info_params = {
             'format': True,


### PR DESCRIPTION
The original syntax achieved the same thing, but only by accident. (Maybe this is too minor to consider, unless it could lead to confusion for someone later.)