### PR TITLE
Fix course instance access LTI check

### DIFF
--- a/sprocs/check_course_instance_access_rule.sql
+++ b/sprocs/check_course_instance_access_rule.sql
@@ -43,14 +43,16 @@ BEGIN
         -- we have an explicit institution restriction
 
         IF course_instance_access_rule.institution = 'LTI' THEN
+            available := FALSE;
+
             -- get the uid row from users
             SELECT *
             INTO user_result
             FROM users
             WHERE users.uid = check_course_instance_access_rule.uid;
 
-            IF user_result.lti_course_instance_id != course_instance_access_rule.course_instance_id THEN
-                available := FALSE;
+            IF user_result.lti_course_instance_id = course_instance_access_rule.course_instance_id THEN
+                available := TRUE;
             END IF;
         ELSIF course_instance_access_rule.institution != 'Any' THEN
             -- check the institutions table

--- a/sprocs/check_course_instance_access_rule.sql
+++ b/sprocs/check_course_instance_access_rule.sql
@@ -43,16 +43,14 @@ BEGIN
         -- we have an explicit institution restriction
 
         IF course_instance_access_rule.institution = 'LTI' THEN
-            available := FALSE;
-
             -- get the uid row from users
             SELECT *
             INTO user_result
             FROM users
             WHERE users.uid = check_course_instance_access_rule.uid;
 
-            IF user_result.lti_course_instance_id = course_instance_access_rule.course_instance_id THEN
-                available := TRUE;
+            IF user_result.lti_course_instance_id IS DISTINCT FROM course_instance_access_rule.course_instance_id THEN
+                available := FALSE;
             END IF;
         ELSIF course_instance_access_rule.institution != 'Any' THEN
             -- check the institutions table

--- a/tests/testSproc-check_course_instance_access.js
+++ b/tests/testSproc-check_course_instance_access.js
@@ -191,4 +191,49 @@ describe('sproc check_course_instance_access* tests', function() {
             callback(null);
         });
     });
+    it('fail if institution=LTI and user is not created with a course instance', function(callback) {
+        var params = {
+            role: 'Student',
+            uid: 'person1@school.edu',
+            date: '2013-07-07 06:06:06-00',
+            ciar_id: 5,
+            short_name: 'school',
+        };
+
+        sqldb.query(sql.ciar_test, params, (err, result) => {
+            if (ERR(err, callback)) return;
+            assert.strictEqual(result.rows[0].authorized, false);
+            callback(null);
+        });
+    });
+    it('pass if institution=LTI and user is created with correct course instance', function(callback) {
+        var params = {
+            role: 'Student',
+            uid: 'ltiuserci1@host.com',
+            date: '2013-07-07 06:06:06-00',
+            ciar_id: 5,
+            short_name: 'host',
+        };
+
+        sqldb.query(sql.ciar_test, params, (err, result) => {
+            if (ERR(err, callback)) return;
+            assert.strictEqual(result.rows[0].authorized, true);
+            callback(null);
+        });
+    });
+    it('fail if institution=LTI and user is created with a different course instance', function(callback) {
+        var params = {
+            role: 'Student',
+            uid: 'ltiuserci2@host.com',
+            date: '2013-07-07 06:06:06-00',
+            ciar_id: 5,
+            short_name: 'school',
+        };
+
+        sqldb.query(sql.ciar_test, params, (err, result) => {
+            if (ERR(err, callback)) return;
+            assert.strictEqual(result.rows[0].authorized, false);
+            callback(null);
+        });
+    });
 });

--- a/tests/testSproc-check_course_instance_access.js
+++ b/tests/testSproc-check_course_instance_access.js
@@ -236,4 +236,21 @@ describe('sproc check_course_instance_access* tests', function() {
             callback(null);
         });
     });
+
+    it('fail if date is after end_date and LTI matches', function(callback) {
+        var params = {
+            role: 'Student',
+            uid: 'ltiuserci1@host.com',
+            date: '2017-07-07 06:06:06-00',
+            ciar_id: 5,
+            short_name: 'host',
+        };
+
+        sqldb.query(sql.ciar_test, params, (err, result) => {
+            if (ERR(err, callback)) return;
+            assert.strictEqual(result.rows[0].authorized, false);
+            callback(null);
+        });
+    });
+
 });

--- a/tests/testSproc-check_course_instance_access.js
+++ b/tests/testSproc-check_course_instance_access.js
@@ -194,10 +194,10 @@ describe('sproc check_course_instance_access* tests', function() {
     it('fail if institution=LTI and user is not created with a course instance', function(callback) {
         var params = {
             role: 'Student',
-            uid: 'person1@school.edu',
+            uid: 'normaluser@host.com',
             date: '2013-07-07 06:06:06-00',
             ciar_id: 5,
-            short_name: 'school',
+            short_name: 'host',
         };
 
         sqldb.query(sql.ciar_test, params, (err, result) => {
@@ -227,7 +227,7 @@ describe('sproc check_course_instance_access* tests', function() {
             uid: 'ltiuserci2@host.com',
             date: '2013-07-07 06:06:06-00',
             ciar_id: 5,
-            short_name: 'school',
+            short_name: 'host',
         };
 
         sqldb.query(sql.ciar_test, params, (err, result) => {

--- a/tests/testSproc-check_course_instance_access.sql
+++ b/tests/testSproc-check_course_instance_access.sql
@@ -1,11 +1,18 @@
 -- BLOCK setup_cia_generic_tests
 WITH
+setup_user AS (
+    INSERT INTO users (user_id, uid, lti_course_instance_id, institution_id) VALUES
+        (100, 'normaluser@host.com', null, 1),
+        (101, 'ltiuserci1@host.com', 1, 2),
+        (102, 'ltiuserci2@host.com', 2, 2)
+),
 setup_course AS (
     INSERT INTO pl_courses (id) VALUES (1)
 ),
 setup_ci AS (
     INSERT INTO course_instances (id, uuid, course_id) VALUES
-        (1, '5159a291-566f-4463-8f11-b07c931ad72a', 1)
+        (1, '5159a291-566f-4463-8f11-b07c931ad72a', 1),
+        (2, '5159a291-566f-4463-8f11-b07c931ad72b', 1)
 ),
 setup_ciars AS (
     INSERT INTO course_instance_access_rules
@@ -13,7 +20,8 @@ setup_ciars AS (
         (1, 1, 1, 'TA', '{"person1@host.com", "person2@host.com"}', '2010-01-01 00:00:00-00', '2010-12-31 23:59:59-00', 'Any'),
         (2, 1, 2, null, null, '2011-01-01 00:00:00-00', '2011-12-31 23:59:59-00', 'school'),
         (3, 1, 3, null, null, '2012-01-01 00:00:00-00', '2012-12-31 23:59:59-00', 'notInDb'),
-        (4, 1, 4, null, null, '2013-01-01 00:00:00-00', '2013-12-31 23:59:59-00', null)
+        (4, 1, 4, null, null, '2013-01-01 00:00:00-00', '2013-12-31 23:59:59-00', null),
+        (5, 1, 5, null, null, null, null, 'LTI')
 ),
 setup_institutions AS (
     INSERT INTO institutions (id, short_name, long_name, uid_regexp) VALUES

--- a/tests/testSproc-check_course_instance_access.sql
+++ b/tests/testSproc-check_course_instance_access.sql
@@ -21,7 +21,7 @@ setup_ciars AS (
         (2, 1, 2, null, null, '2011-01-01 00:00:00-00', '2011-12-31 23:59:59-00', 'school'),
         (3, 1, 3, null, null, '2012-01-01 00:00:00-00', '2012-12-31 23:59:59-00', 'notInDb'),
         (4, 1, 4, null, null, '2013-01-01 00:00:00-00', '2013-12-31 23:59:59-00', null),
-        (5, 1, 5, null, null, null, null, 'LTI')
+        (5, 1, 5, null, null, '2013-01-01 00:00:00-00', '2013-12-31 23:59:59-00', 'LTI')
 ),
 setup_institutions AS (
     INSERT INTO institutions (id, short_name, long_name, uid_regexp) VALUES


### PR DESCRIPTION
Updates the logic for course instances protected with `"institution": "LTI"` to force unauthorized unless the LTI course instance matches. Prior to this we weren't restricting access when comparing a NULL value, so users not associated with an LTI course instance could still access the course when protected with `"institution": "LTI"`.