### PR TITLE
Fix latex glyphs being rendered over each other

### DIFF
--- a/elements/pl-drawing/mechanicsObjects.js
+++ b/elements/pl-drawing/mechanicsObjects.js
@@ -779,6 +779,15 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
                 let refLink = use.getAttribute("xlink:href");
                 let refElement = $(refLink)[0];
                 let replacement = $(refElement.outerHTML)[0];
+
+                /* Copy over any attributes on the link */
+                for (let i = 0; i < use.attributes.length; i++) {
+                    let attrib = use.attributes.item(i);
+                    if (attrib.name.toLowerCase() !== "xlink:href") {
+                        replacement.setAttribute(attrib.name, attrib.value);
+                    }
+                }
+
                 /* Replace the reference with the actual value */
                 use.parentNode.replaceChild(replacement, use);
             });


### PR DESCRIPTION
Fixes #2147 

Before:

>![image](https://user-images.githubusercontent.com/1790491/76172335-97d17f80-6162-11ea-84cf-d2a9c36e0827.png)
>
>MathJax stores a cache of pre-rendered SVG glyphs which are normally linked to when rendering static math on the page, but in the drawing element these references are replaced with their actual value so that they show up correctly in the canvas context.
>
>Some of these references have a transformation applied to them which isn't getting carried over.

Fix:

<img width="483" alt="image" src="https://user-images.githubusercontent.com/1790491/76172319-7d97a180-6162-11ea-8a91-fcc70825b79c.png">

Glyph transformations are now correctly copied over during rendering.