### PR TITLE
Add default course dirs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -12,6 +12,7 @@ config.postgresqlUser = 'postgres';
 config.postgresqlPassword = null;
 config.postgresqlDatabase = 'postgres';
 config.postgresqlHost = 'localhost';
+config.courseDirs = ['exampleCourse'];
 config.urlPrefix = '/pl';
 config.homeUrl = '/';
 config.redisUrl = null; // redis://localhost:6379/ for dev


### PR DESCRIPTION
I temporarily confused myself by trying to run without `config.courseDirs` set in local dev. This PR sets the default value `config.courseDirs = ['exampleCourse']` to avoid this.