### PR TITLE
Remove ChangeLog check on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sh ./tools/build-plbase-if-needed.sh
   - docker build -t pltest .
 script:
-  - 'if [[ "$TRAVIS_PULL_REQUEST" != "false" && ! ( "$TRAVIS_BRANCH" =~ ^dependabot/ ) && ! ( "$TRAVIS_PULL_REQUEST_BRANCH" =~ ^dependabot/ ) ]]; then sh ./tools/verify-changelog.sh; fi'
+  #- 'if [[ "$TRAVIS_PULL_REQUEST" != "false" && ! ( "$TRAVIS_BRANCH" =~ ^dependabot/ ) && ! ( "$TRAVIS_PULL_REQUEST_BRANCH" =~ ^dependabot/ ) ]]; then sh ./tools/verify-changelog.sh; fi'
   - docker run -itd --name=test_container pltest /bin/bash
   - docker exec -it test_container /PrairieLearn/docker/lint_js.sh
   - docker exec -it test_container /PrairieLearn/docker/lint_python.sh


### PR DESCRIPTION
We are now using the git log as our ChangeLog and we haven't been enforcing ChangeLog entries for PRs, so we might as well remove this. In fact we should maybe just turn off Travis, but it doesn't hurt to leave it running for now.

It would be good to explore solutions for auto-generating a ChangeLog file from commits.