### PR TITLE
Remove homework intro text (#1989)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -234,6 +234,8 @@
   * Fix gradebook and question statistics download links (Tim Bretl).
 
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
+  
+  * Remove introduction alert at the top of `homework` assessments (Tim Yang).
 
 * __3.2.0__ - 2019-08-05
 

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
@@ -48,9 +48,7 @@
 
           <% if (assessment_text_templated) { %>
           <div class="alert alert-secondary mb-0">
-            <div class="well well-sm">
               <%- assessment_text_templated %>
-            </div>
           </div>
           <% } %>
         </div>

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
@@ -46,23 +46,13 @@
             </div>
           </div>
 
+          <% if (assessment_text_templated) { %>
           <div class="alert alert-secondary mb-0">
-            <p class="mb-0"><small>
-              Answer questions in any order. Questions can be repeated and not all
-              questions must be completed. Answering a question
-              correctly will increase its score by its current
-              value<%= (assessment.constant_question_value ? '.' : ', and will also increase its value.') %> Answering
-              a question incorrectly will reset its value. Total
-              points is the sum of all question
-              points.
-            </small></p>
-            <% if (assessment_text_templated) { %>
-            <hr>
             <div class="well well-sm">
               <%- assessment_text_templated %>
             </div>
-            <% } %>
           </div>
+          <% } %>
         </div>
 
         <table class="table table-sm table-hover">


### PR DESCRIPTION
Fix #1989 by removing the intro blurb on homeworks. And since the alert now contains nothing but `assessment_text_templated`, move the `if` logic to wrap the whole alert.

## Old
![image](https://user-images.githubusercontent.com/2503508/77178675-68d9d880-6a95-11ea-99b8-845f7b90fb01.png)

## New
`if assessment_text_templated`:
![image](https://user-images.githubusercontent.com/2503508/77178740-84dd7a00-6a95-11ea-82d7-381d6991a8f6.png)

`else`:
![image](https://user-images.githubusercontent.com/2503508/77178783-93c42c80-6a95-11ea-9270-5c78058ce993.png)
