### PR TITLE
Fix editor breaking on no preview

### DIFF
--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -56,7 +56,7 @@ window.PLFileEditor = function(uuid, options) {
             this.updatePreview(this.editor.getValue());
         });
         this.updatePreview(this.editor.getValue());
-    } else {
+    } else if (options.preview !== undefined) {
         let preview = this.element.find('.preview')[0];
         preview.innerHTML = '<p>Unknown preview type: <code>' + options.preview + '</code></p>';
     }


### PR DESCRIPTION
The markdown preview accidentally broke normal editors by assuming the 'preview' element exists.