### PR TITLE
Add display of R vector/matrix object in pl-variable-output

### DIFF
--- a/doc/elements.md
+++ b/doc/elements.md
@@ -991,7 +991,7 @@ If `file()` does not return anything, it will be treated as if `file()` returned
 ## `pl-variable-output` element
 
 Displays a list of variables that are formatted for import into the
-supported programming languages (e.g. MATLAB, Mathematica, or Python).
+supported programming languages (e.g. MATLAB, Mathematica, Python, or R).
 
 #### Sample Element
 
@@ -1034,6 +1034,7 @@ Attribute | Type | Default | Description
 `show-matlab` | boolean | true | Toggles the display of the Matlab tab.
 `show-mathematica` | boolean | true | Toggles the display of the Mathematica tab.
 `show-python` | boolean | true | Toggles the display of the Python tab.
+`show-r` | boolean | true | Toggles the display of the R tab.
 
 Attributes for `<variable>` (one of these for each variable to display):
 
@@ -1047,7 +1048,7 @@ Attribute | Type | Default | Description
 #### Details
 
 This element displays a list of variables inside `<pre>` tags that are formatted for import into
-either MATLAB, Mathematica, or Python (the user can switch between them). Each variable must be
+either MATLAB, Mathematica, Python, or R (the user can switch between them). Each variable must be
 either a scalar or a 2D numpy array (expressed as a list). Each variable will be prefixed by the
 text that appears between the `<variable>` and `</variable>` tags, followed by ` = `. Below
 are samples of the format displayed under each language tab.
@@ -1070,6 +1071,13 @@ A = [1.23; 4.56]; (* matrix *)
 import numpy as np
 
 A = np.array([[1.23], [4.56]]) # matrix
+```
+
+**R format:**
+
+```
+A = c(1.23, 4.56) # vector
+A = matrix(c(1.23, 4.56, 8.90, 1.23), nrow = 2, ncol = 2, byrow = TRUE) # matrix
 ```
 
 If a variable `v` is a complex object, you should use `import prairielearn as pl` and `data['params'][params-name] = pl.to_json(v)`.

--- a/elements/pl-variable-output/pl-variable-output.mustache
+++ b/elements/pl-variable-output/pl-variable-output.mustache
@@ -12,6 +12,8 @@
             {{#show_mathematica}}<li class="nav-item" role="presentation"><a class="nav-link{{#active_tab_mathematica}} active{{/active_tab_mathematica}}" href="#mathematica-{{uuid}}" aria-controls="mathematica-{{uuid}}" role="tab" data-toggle="pill">Mathematica</a></li>{{/show_mathematica}}
 
             {{#show_python}}<li class="nav-item" role="presentation"><a class="nav-link{{#active_tab_python}} active{{/active_tab_python}}" href="#python-{{uuid}}" aria-controls="python-{{uuid}}" role="tab" data-toggle="pill">Python</a></li>{{/show_python}}
+
+            {{#show_r}}<li class="nav-item" role="presentation"><a class="nav-link{{#active_tab_r}} active{{/active_tab_r}}" href="#r-{{uuid}}" aria-controls="r-{{uuid}}" role="tab" data-toggle="pill">R</a></li>{{/show_r}}
         </ul>
     </div>
     <div class="card-body">
@@ -31,6 +33,12 @@
             <div role="tabpanel" class="tab-pane {{#active_tab_python}}active{{/active_tab_python}}" id="python-{{uuid}}">
                 <pre class="bg-dark text-white rounded p-2" id="python-data-{{uuid}}">{{python_data}}</pre>
                 <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{uuid}}">
+                    copy this text
+                </button>
+            </div>
+            <div role="tabpanel" class="tab-pane {{#active_tab_r}}active{{/active_tab_r}}" id="r-{{uuid}}">
+                <pre class="bg-dark text-white rounded p-2" id="r-data-{{uuid}}">{{r_data}}</pre>
+                <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#r-data-{{uuid}}">
                     copy this text
                 </button>
             </div>

--- a/exampleCourse/questions/elementVariableOutput/question.html
+++ b/exampleCourse/questions/elementVariableOutput/question.html
@@ -77,7 +77,7 @@
         <variable params-name="x1">x1</variable>
       </pl-variable-output>
 
-      <p>All computational languages are displayed by default. These can be turned off using the element attributes <code>show-matlab</code>, <code>show-mathematica</code>, and <code>show-python</code>. In this example, we remove the the Matlab tab. The default active tab will be the first one in the list, in this case: Mathematica.</p>
+      <p>All computational languages are displayed by default. These can be turned off using the element attributes <code>show-matlab</code>, <code>show-mathematica</code>, <code>show-python</code>, and <code>show-r</code>. In this example, we remove the the Matlab tab. The default active tab will be the first one in the list, in this case: Mathematica.</p>
 
       <pl-variable-output digits="0" show-matlab="false">
         <variable params-name="x1">x1</variable>
@@ -89,9 +89,9 @@
         <variable params-name="d">d</variable>
       </pl-variable-output>
 
-      <p>Any tab can be displayed alone. In this case, the Matlab and Mathematica tabs are hidden and the Python tab is displayed alone.</p>
+      <p>Any tab can be displayed alone. In this case, the Matlab, Mathematica, and R tabs are hidden and the Python tab is displayed alone.</p>
 
-      <pl-variable-output digits="0" show-matlab="false" show-mathematica="false">
+      <pl-variable-output digits="0" show-matlab="false" show-mathematica="false" show-r="false">
         <variable params-name="x1">x1</variable>
       </pl-variable-output>
     </div>

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -462,11 +462,11 @@ def string_from_numpy(A, language='python', presentation_type='f', digits=2):
         result = result.replace('[', '')
         result = result.replace(']', '')
         # Cast to a vector: c(1, 2, 3, 4, 5, 6)
-        result = f"c({result})"
+        result = f'c({result})'
         if A.ndim == 2:
             nrow = A.shape[0]
             ncol = A.shape[1]
-            result = f"matrix({result}, nrow = {nrow}, ncol = {ncol}, byrow = TRUE)"
+            result = f'matrix({result}, nrow = {nrow}, ncol = {ncol}, byrow = TRUE)'
         return result
     else:
         raise Exception('language "{:s}" must be either "python", "matlab", "mathematica", or "r"'.format(language))

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -389,6 +389,14 @@ def string_from_numpy(A, language='python', presentation_type='f', digits=2):
 
         { ..., ..., ... }
 
+    If language is 'r' and A is a 2D ndarray, the string looks like this:
+
+        matrix(c(., ., .), nrow=NUM_ROWS, ncol=NUM_COLS, byrow = TRUE)
+
+    If A is a 1D ndarray, the string looks like this:
+
+        c(., ., .)
+
     In either case, if A is not a 1D or 2D ndarray, the string is a single number,
     not wrapped in brackets.
 
@@ -438,8 +446,30 @@ def string_from_numpy(A, language='python', presentation_type='f', digits=2):
         result = result.replace('[', '{')
         result = result.replace(']', '}')
         return result
+    elif language == 'r':
+        if presentation_type == 'sigfig':
+            formatter = {
+                'float_kind': lambda x: to_precision.to_precision(x, digits),
+                'complex_kind': lambda x: _string_from_complex_sigfig(x, digits)
+            }
+        else:
+            formatter = {
+                'float_kind': lambda x: '{:.{digits}{presentation_type}}'.format(x, digits=digits, presentation_type=presentation_type),
+                'complex_kind': lambda x: '{:.{digits}{presentation_type}}'.format(x, digits=digits, presentation_type=presentation_type)
+            }
+        result = np.array2string(A, formatter=formatter, separator=', ').replace('\n', '')
+        # Given as: [[1, 2, 3], [4, 5, 6]]
+        result = result.replace('[', '')
+        result = result.replace(']', '')
+        # Cast to a vector: c(1, 2, 3, 4, 5, 6)
+        result = f"c({result})"
+        if A.ndim == 2:
+            nrow = A.shape[0]
+            ncol = A.shape[1]
+            result = f"matrix({result}, nrow = {nrow}, ncol = {ncol}, byrow = TRUE)"
+        return result
     else:
-        raise Exception('language "{:s}" must be either "python", "matlab", or "mathematica"'.format(language))
+        raise Exception('language "{:s}" must be either "python", "matlab", "mathematica", or "r"'.format(language))
 
 
 # Deprecated version, keeping for backwards compatibility


### PR DESCRIPTION
Adds a tab to the `pl-variable-output` element that shows pre-formatted _R_ code in scalar/vector/matrix form. Close #1460

<img width="746" alt="Screen Shot 2020-03-20 at 2 04 20 PM" src="https://user-images.githubusercontent.com/833642/77198291-b580dc00-6ab4-11ea-9084-2f9b5d4b192e.png">

Note: `byrow = TRUE` is required because _R_ stores data in column-format whereas _NumPy_ stores it in row-format.