### PR TITLE
Add extra /course* mount points (#813)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -80,6 +80,8 @@
   * Add support for editing from bare git repo (Tim Bretl).
   
   * Add `disregard-extra-elements` attribute to `pl-drawing` element to ignore duplicate grading objects (Nicolas Nytko).
+  
+  * Add extra `/course*` mount points (Tim Yang).
 
   * Change v3 questions to disable autocomplete on the question form (Nathan Walters).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /PrairieLearn/
 # set up PrairieLearn and run migrations to initialize the DB
 RUN chmod +x /PrairieLearn/docker/init.sh \
     && mv /PrairieLearn/docker/config.json /PrairieLearn \
-    && mkdir /course \
+    && mkdir /course{,{2..9}} \
     && /PrairieLearn/docker/start_postgres.sh \
     && cd /PrairieLearn \
     && node server.js --migrate-and-exit \

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -27,7 +27,7 @@ docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course -v C:\GitHub\pl-
 On MacOS/Linux:
 
 ```sh
-docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course -v /Users/mwest/git/pl-xc101:/course prairielearn/prairielearn
+docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course -v /Users/mwest/git/pl-xc101:/course2 prairielearn/prairielearn
 ```
 
 If you are using Docker for Windows then you will need to first give Docker permission to access the C: drive (or whichever drive your course directory is on). This can be done by right-clicking on the Docker "whale" icon in the taskbar, choosing "Settings", and granting shared access to the C: drive.

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -16,16 +16,18 @@ docker run -it --rm -p 3000:3000 prairielearn/prairielearn
 
 * Step 4: When you are finished with PrairieLearn, type Control-C on the commandline where your ran the server to stop it.
 
-* Step 5: To use your own course, point Docker to the correct directory (replace the precise path with your own) on Windows:
+* Step 5: To use your own courses, use the `-v` flag to point your own course directories to the Docker `/course` directories. There are nine available mount points in the Docker: `/course`, `/course2`, `/course3`, ..., `/course9`.
+
+On Windows (replace the precise course paths with your own):
 
 ```sh
-docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course prairielearn/prairielearn
+docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course -v C:\GitHub\pl-xc101:/course2 prairielearn/prairielearn
 ```
 
-or on MacOS/Linux:
+On MacOS/Linux:
 
 ```sh
-docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course prairielearn/prairielearn
+docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course -v /Users/mwest/git/pl-xc101:/course prairielearn/prairielearn
 ```
 
 If you are using Docker for Windows then you will need to first give Docker permission to access the C: drive (or whichever drive your course directory is on). This can be done by right-clicking on the Docker "whale" icon in the taskbar, choosing "Settings", and granting shared access to the C: drive.

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -16,7 +16,7 @@ docker run -it --rm -p 3000:3000 prairielearn/prairielearn
 
 * Step 4: When you are finished with PrairieLearn, type Control-C on the commandline where your ran the server to stop it.
 
-* Step 5: To use your own course, use the `-v` flag to point your own course directory to the Docker `/course` directory on Windows (replace the precise course path with your own):
+* Step 5: To use your own course, use the `-v` flag to bind the Docker `/course` directory with your own course directory (replace the precise path with your own) on Windows:
 
 ```sh
 docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course prairielearn/prairielearn

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -16,19 +16,19 @@ docker run -it --rm -p 3000:3000 prairielearn/prairielearn
 
 * Step 4: When you are finished with PrairieLearn, type Control-C on the commandline where your ran the server to stop it.
 
-* Step 5: To use your own courses, use the `-v` flag to point your own course directories to the Docker `/course` directories. There are nine available mount points in the Docker: `/course`, `/course2`, `/course3`, ..., `/course9`.
-
-On Windows (replace the precise course paths with your own):
+* Step 5: To use your own course, use the `-v` flag to point your own course directory to the Docker `/course` directory on Windows (replace the precise course path with your own):
 
 ```sh
-docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course -v C:\GitHub\pl-xc101:/course2 prairielearn/prairielearn
+docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course prairielearn/prairielearn
 ```
 
-On MacOS/Linux:
+or on MacOS/Linux:
 
 ```sh
-docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course -v /Users/mwest/git/pl-xc101:/course2 prairielearn/prairielearn
+docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course prairielearn/prairielearn
 ```
+
+To use multiple courses, add additional `-v` flags (e.g., `-v /path/to/course:/course -v /path/to/course2:course2`). There are nine available mount points in the Docker: `/course`, `/course2`, `/course3`, ..., `/course9`.
 
 If you are using Docker for Windows then you will need to first give Docker permission to access the C: drive (or whichever drive your course directory is on). This can be done by right-clicking on the Docker "whale" icon in the taskbar, choosing "Settings", and granting shared access to the C: drive.
 

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -28,9 +28,9 @@ or on MacOS/Linux:
 docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course prairielearn/prairielearn
 ```
 
-To use multiple courses, add additional `-v` flags (e.g., `-v /path/to/course:/course -v /path/to/course2:course2`). There are nine available mount points in the Docker: `/course`, `/course2`, `/course3`, ..., `/course9`.
-
 If you are using Docker for Windows then you will need to first give Docker permission to access the C: drive (or whichever drive your course directory is on). This can be done by right-clicking on the Docker "whale" icon in the taskbar, choosing "Settings", and granting shared access to the C: drive.
+
+To use multiple courses, add additional `-v` flags (e.g., `-v /path/to/course:/course -v /path/to/course2:course2`). There are nine available mount points in the Docker: `/course`, `/course2`, `/course3`, ..., `/course9`.
 
 If you're in the root of your course directory already, you can substitute `%cd%` (on Windows) or `$PWD` (Linux and MacOS) for `/path/to/course`.
 

--- a/docker/config.json
+++ b/docker/config.json
@@ -2,7 +2,15 @@
     "courseDirs": [
         "/PrairieLearn/exampleCourse",
         "/PrairieLearn/testCourse",
-        "/course"
+        "/course",
+        "/course2",
+        "/course3",
+        "/course4",
+        "/course5",
+        "/course6",
+        "/course7",
+        "/course8",
+        "/course9"
     ],
     "filesRoot": "/files"
 }


### PR DESCRIPTION
Fixes #813:
* Creates nine mount points: `/course`, `/course2`, `course3`, ... `course9`
* Updates `installing.md` doc for multiple `-v` flags

Checked docker build:
```
$ docker build -t prairielearn .
$ docker run -it --rm -p 3000:3000 prairielearn /bin/bash
# ls course*
course course2 course3 course4 course5 course6 course7 course8 course9
```

Checked multiple course loading:
```
$ docker run -it --rm -p 3000:3000 -v /path/to/course:/course -v /path/to/course2:/course2 prairielearn
```