### PR TITLE
Lint the syncing code

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@
 /public/
 /exampleCourse/
 /testCourse/
-/sync/
 /question-servers/default-calculation/
 /coverage/
 /out/

--- a/sync/fromDisk/assessmentSets.js
+++ b/sync/fromDisk/assessmentSets.js
@@ -4,7 +4,7 @@ const sqldb = require('@prairielearn/prairielib/sql-db');
 module.exports.sync = function(courseInfo, callback) {
     callbackify(async () => {
         const assessmentSets = courseInfo.assessmentSets || [];
-        const assessmentSetsParams = assessmentSets.map((assessmentSet, index) => ({
+        const assessmentSetsParams = assessmentSets.map((assessmentSet) => ({
             abbreviation: assessmentSet.abbreviation,
             name: assessmentSet.name,
             heading: assessmentSet.heading,

--- a/sync/fromDisk/assessmentSets.js
+++ b/sync/fromDisk/assessmentSets.js
@@ -17,4 +17,4 @@ module.exports.sync = function(courseInfo, callback) {
         ];
         await sqldb.callAsync('sync_assessment_sets', params);
     })(callback);
-}
+};

--- a/sync/fromDisk/assessments.js
+++ b/sync/fromDisk/assessments.js
@@ -75,7 +75,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
                 password: _(accessRule).has('password') ? accessRule.password : null,
                 seb_config: _(accessRule).has('SEBConfig') ? accessRule.SEBConfig : null,
                 exam_uuid: _(accessRule).has('examUuid') ? accessRule.examUuid : null,
-            }
+            };
         });
 
         const zones = assessment.zones || [];
@@ -125,7 +125,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
                             points: question.points,
                             forceMaxPoints: _.has(question, 'forceMaxPoints') ? question.forceMaxPoints : false,
                             triesPerVariant: _.has(question, 'triesPerVariant') ? question.triesPerVariant : 1,
-                        }
+                        },
                     ];
                 } else {
                     throw error.make(400, 'Must specify either "id" or "alternatives" in question', {question});
@@ -172,7 +172,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
                 alternativeGroupParams.questions = alternatives.map((alternative, alternativeIndex) => {
                     assessmentQuestionNumber++;
                     // Loop up the ID of this question based on its QID
-                    const question = questionDB[alternative.qid]
+                    const question = questionDB[alternative.qid];
                     if (!question) {
                         throw new Error(`Invalid QID in assessment ${assessment.tid}: ${alternative.qid}`);
                     }
@@ -186,7 +186,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
                         tries_per_variant: alternative.triesPerVariant,
                         question_id: questionId,
                         number_in_alternative_group: alternativeIndex + 1,
-                    }
+                    };
 
                 });
 
@@ -205,7 +205,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
         course_instance_id: courseInstance.courseInstanceId,
         course_id: courseInfo.courseId,
         check_access_rules_exam_uuid: config.checkAccessRulesExamUuid,
-    }
+    };
 }
 
 module.exports.sync = function(courseInfo, courseInstance, questionDB, callback) {
@@ -222,7 +222,7 @@ module.exports.sync = function(courseInfo, courseInstance, questionDB, callback)
             .each(function(assessments, uuid) {
                 if (assessments.length > 1) {
                     const directories = assessments.map(a => a.directory).join(', ');
-                    throw new Error(`UUID ${uuid} is used in multiple assessments: ${directories}`)
+                    throw new Error(`UUID ${uuid} is used in multiple assessments: ${directories}`);
                 }
             });
 
@@ -237,4 +237,4 @@ module.exports.sync = function(courseInfo, courseInstance, questionDB, callback)
         await sqldb.callOneRowAsync('sync_assessments', syncParams);
         perf.end(`syncAssessments${courseInstance.courseInstanceId}Sproc`);
     })(callback);
-}
+};

--- a/sync/fromDisk/assessments.js
+++ b/sync/fromDisk/assessments.js
@@ -104,7 +104,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
             return zone.questions.map((question) => {
                 let alternatives;
                 if (_(question).has('alternatives')) {
-                    if (_(question).has('id')) return callback(error.make(400, 'Cannot have both "id" and "alternatives" in one question', {question}));
+                    if (_(question).has('id')) throw error.make(400, 'Cannot have both "id" and "alternatives" in one question', {question});
                     question.alternatives.forEach(a => checkAndRecordQID(a.id));
                     alternatives = _.map(question.alternatives, function(alternative) {
                         return {

--- a/sync/fromDisk/assessments.js
+++ b/sync/fromDisk/assessments.js
@@ -100,8 +100,8 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
 
         let alternativeGroupNumber = 0;
         let assessmentQuestionNumber = 0;
-        assessmentParams.alternativeGroups = zones.map((zone, zoneIndex) => {
-            return zone.questions.map((question, questionIndex) => {
+        assessmentParams.alternativeGroups = zones.map((zone) => {
+            return zone.questions.map((question) => {
                 let alternatives;
                 if (_(question).has('alternatives')) {
                     if (_(question).has('id')) return callback(error.make(400, 'Cannot have both "id" and "alternatives" in one question', {question}));

--- a/sync/fromDisk/courseInfo.js
+++ b/sync/fromDisk/courseInfo.js
@@ -1,5 +1,4 @@
 const ERR = require('async-stacktrace');
-const _ = require('lodash');
 
 const error = require('@prairielearn/prairielib/error');
 const sqldb = require('@prairielearn/prairielib/sql-db');

--- a/sync/fromDisk/courseInfo.js
+++ b/sync/fromDisk/courseInfo.js
@@ -23,4 +23,4 @@ module.exports.sync = (courseInfo, course_id, callback) => {
         courseInfo.timezone = result.rows[0].display_timezone;
         callback(null);
     });
-}
+};

--- a/sync/fromDisk/courseInstances.js
+++ b/sync/fromDisk/courseInstances.js
@@ -8,7 +8,7 @@ module.exports.sync = function(courseInfo, courseInstanceDB, callback) {
             .groupBy('uuid')
             .each(function(courseInstances, uuid) {
                 if (courseInstances.length > 1) {
-                    const directories = courseInstances.map(ci => ci.directory).join(', ')
+                    const directories = courseInstances.map(ci => ci.directory).join(', ');
                     throw new Error(`UUID ${uuid} is used in multiple course instances: ${directories}`);
                 }
             });
@@ -43,4 +43,4 @@ module.exports.sync = function(courseInfo, courseInstanceDB, callback) {
             courseInstanceDB[courseInstanceParam.short_name].courseInstanceId = newCourseInstanceIds[index];
         });
     })(callback);
-}
+};

--- a/sync/fromDisk/courseStaff.js
+++ b/sync/fromDisk/courseStaff.js
@@ -35,4 +35,4 @@ module.exports.sync = function(courseInstance, callback) {
         ];
         await sqldb.callAsync('sync_course_staff', params);
     })(callback);
-}
+};

--- a/sync/fromDisk/questions.js
+++ b/sync/fromDisk/questions.js
@@ -71,4 +71,4 @@ module.exports.sync = function(courseInfo, questionDB, jobLogger, callback) {
             questionDB[idMapping.qid].id = idMapping.id;
         });
     })(callback);
-}
+};

--- a/sync/fromDisk/tags.js
+++ b/sync/fromDisk/tags.js
@@ -23,7 +23,7 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
         // duplicates are present.
         const duplicateNames = getDuplicatesByKey(tags, 'name');
         if (duplicateNames.length > 0) {
-            const duplicateNamesJoined = duplicateNames.join(', ')
+            const duplicateNamesJoined = duplicateNames.join(', ');
             throw new Error(`Duplicate tag names found: ${duplicateNamesJoined}. Tag names must be unique within the course.`);
         }
 
@@ -95,4 +95,4 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
 
         await sqldb.callAsync('sync_question_tags', [JSON.stringify(paramQuestionTags)]);
     })(callback);
-}
+};

--- a/sync/fromDisk/topics.js
+++ b/sync/fromDisk/topics.js
@@ -42,7 +42,7 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
             description: 'Auto-generated from use in a question; add this topic to your courseInfo.json file to customize',
         })));
 
-        const topicsParams = topics.map((topic, index) => ({
+        const topicsParams = topics.map((topic) => ({
             name: topic.name,
             color: topic.color,
             description: topic.description,

--- a/sync/fromDisk/topics.js
+++ b/sync/fromDisk/topics.js
@@ -23,7 +23,7 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
         // duplicates are present.
         const duplicateNames = getDuplicatesByKey(topics, 'name');
         if (duplicateNames.length > 0) {
-            const duplicateNamesJoined = duplicateNames.join(', ')
+            const duplicateNamesJoined = duplicateNames.join(', ');
             throw new Error(`Duplicate topic names found: ${duplicateNamesJoined}. Topic names must be unique within the course.`);
         }
 
@@ -54,4 +54,4 @@ module.exports.sync = function(courseInfo, questionDB, callback) {
         ];
         await sqldb.callAsync('sync_topics', params);
     })(callback);
-}
+};

--- a/sync/performance.js
+++ b/sync/performance.js
@@ -32,5 +32,5 @@ module.exports = function(scopeName) {
         start,
         end,
         timedFunc,
-    }
-}
+    };
+};

--- a/sync/syncFromDisk.js
+++ b/sync/syncFromDisk.js
@@ -1,5 +1,4 @@
 const ERR = require('async-stacktrace');
-const _ = require('lodash');
 const async = require('async');
 
 const namedLocks = require('../lib/named-locks');

--- a/sync/syncFromDisk.js
+++ b/sync/syncFromDisk.js
@@ -20,38 +20,38 @@ const perf = require('./performance')('sync');
 // Performance data can be logged by setting the `PROFILE_SYNC` environment variable
 
 module.exports._syncDiskToSqlWithLock = function(courseDir, course_id, logger, callback) {
-    logger.info("Starting sync of git repository to database for " + courseDir);
-    logger.info("Loading info.json files from git repository...");
-    perf.start("sync");
-    perf.start("loadFullCourse");
+    logger.info('Starting sync of git repository to database for ' + courseDir);
+    logger.info('Loading info.json files from git repository...');
+    perf.start('sync');
+    perf.start('loadFullCourse');
     courseDB.loadFullCourse(courseDir, logger, function(err, course) {
-        perf.end("loadFullCourse");
+        perf.end('loadFullCourse');
         if (ERR(err, callback)) return;
-        logger.info("Successfully loaded all info.json files");
+        logger.info('Successfully loaded all info.json files');
         async.series([
-            function(callback) {logger.info("Syncing courseInfo from git repository to database..."); callback(null);},
-            perf.timedFunc.bind(null, "syncCourseInfo", syncCourseInfo.sync.bind(null, course.courseInfo, course_id)),
-            function(callback) {logger.info("Syncing courseInstances from git repository to database..."); callback(null);},
-            perf.timedFunc.bind(null, "syncCourseInstances", syncCourseInstances.sync.bind(null, course.courseInfo, course.courseInstanceDB)),
-            function(callback) {logger.info("Syncing topics from git repository to database..."); callback(null);},
-            perf.timedFunc.bind(null, "syncTopics", syncTopics.sync.bind(null, course.courseInfo, course.questionDB)),
-            function(callback) {logger.info("Syncing questions from git repository to database..."); callback(null);},
-            perf.timedFunc.bind(null, "syncQuestions", syncQuestions.sync.bind(null, course.courseInfo, course.questionDB, logger)),
-            function(callback) {logger.info("Syncing tags from git repository to database..."); callback(null);},
-            perf.timedFunc.bind(null, "syncTags", syncTags.sync.bind(null, course.courseInfo, course.questionDB)),
-            function(callback) {logger.info("Syncing assessment sets from git repository to database..."); callback(null);},
-            perf.timedFunc.bind(null, "syncAssessmentSets", syncAssessmentSets.sync.bind(null, course.courseInfo)),
+            function(callback) {logger.info('Syncing courseInfo from git repository to database...'); callback(null);},
+            perf.timedFunc.bind(null, 'syncCourseInfo', syncCourseInfo.sync.bind(null, course.courseInfo, course_id)),
+            function(callback) {logger.info('Syncing courseInstances from git repository to database...'); callback(null);},
+            perf.timedFunc.bind(null, 'syncCourseInstances', syncCourseInstances.sync.bind(null, course.courseInfo, course.courseInstanceDB)),
+            function(callback) {logger.info('Syncing topics from git repository to database...'); callback(null);},
+            perf.timedFunc.bind(null, 'syncTopics', syncTopics.sync.bind(null, course.courseInfo, course.questionDB)),
+            function(callback) {logger.info('Syncing questions from git repository to database...'); callback(null);},
+            perf.timedFunc.bind(null, 'syncQuestions', syncQuestions.sync.bind(null, course.courseInfo, course.questionDB, logger)),
+            function(callback) {logger.info('Syncing tags from git repository to database...'); callback(null);},
+            perf.timedFunc.bind(null, 'syncTags', syncTags.sync.bind(null, course.courseInfo, course.questionDB)),
+            function(callback) {logger.info('Syncing assessment sets from git repository to database...'); callback(null);},
+            perf.timedFunc.bind(null, 'syncAssessmentSets', syncAssessmentSets.sync.bind(null, course.courseInfo)),
             (callback) => {
-                perf.start("syncCourseInstaces");
+                perf.start('syncCourseInstaces');
                 // TODO: is running these in parallel safe? Everything should be isolated by course instance.
                 async.forEachOf(course.courseInstanceDB, function(courseInstance, courseInstanceShortName, callback) {
                     perf.start(`syncCourseInstance${courseInstanceShortName}`);
                     async.series([
-                        function(callback) {logger.info("Syncing " + courseInstanceShortName
-                                                        + " courseInstance from git repository to database..."); callback(null);},
+                        function(callback) {logger.info('Syncing ' + courseInstanceShortName
+                                                        + ' courseInstance from git repository to database...'); callback(null);},
                         perf.timedFunc.bind(null, `syncCourseInstance${courseInstanceShortName}Staff`, syncCourseStaff.sync.bind(null, courseInstance)),
-                        function(callback) {logger.info("Syncing " + courseInstanceShortName
-                                                        + " assessments from git repository to database..."); callback(null);},
+                        function(callback) {logger.info('Syncing ' + courseInstanceShortName
+                                                        + ' assessments from git repository to database...'); callback(null);},
                         perf.timedFunc.bind(null, `syncCourseInstance${courseInstanceShortName}Assessments`, syncAssessments.sync.bind(null, course.courseInfo, courseInstance, course.questionDB)),
                     ], function(err) {
                     perf.end(`syncCourseInstance${courseInstanceShortName}`);
@@ -59,18 +59,18 @@ module.exports._syncDiskToSqlWithLock = function(courseDir, course_id, logger, c
                         callback(null);
                     });
                 }, function(err) {
-                    perf.end("syncCourseInstances");
+                    perf.end('syncCourseInstances');
                     if (ERR(err, callback)) return;
-                    logger.info("Completed sync of git repository to database");
+                    logger.info('Completed sync of git repository to database');
                     callback(null);
                 });
             },
-            function(callback) {logger.info("Reloading course elements..."); callback(null);},
+            function(callback) {logger.info('Reloading course elements...'); callback(null);},
             freeformServer.reloadElementsForCourse.bind(null, course.courseInfo),
         ], function(err) {
-            perf.end("sync");
+            perf.end('sync');
             if (ERR(err, callback)) return;
-            logger.info("Completed sync of git repository to database");
+            logger.info('Completed sync of git repository to database');
             callback(null);
         });
     });


### PR DESCRIPTION
This PR removes `/sync/` from our `.eslintignore` file so that syncing code can be properly linted. This actually caught a bug - see [#fdd03fe](https://github.com/PrairieLearn/PrairieLearn/commit/fdd03feca978bd6320f0f48483298931f91d650a)!