### PR TITLE
added css overflow-wrap: normal for pre tag Issue #1661

### DIFF
--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -109,6 +109,10 @@ table.two-column-description-no-header-with-help tr td:last-of-type {
     white-space: nowrap;
 }
 
+pre {
+    overflow-wrap: normal;
+}
+
 /**************
  * Submissions
  **************/
@@ -202,12 +206,12 @@ table td > .badge {
     white-space: pre;
     color: #444;
     background: #F0F0F0;
-    
+
     padding-top: 4px;
     padding-bottom: 4px;
     padding-left: 2px;
     padding-right: 2px;
-    
+
     border-radius: 2px;
     border-color: #ccc;
     border-width: 1px;
@@ -239,4 +243,4 @@ table td > .badge {
     border-color: #6c757d;
     margin-left: 5px;
     background: #fff;
-} 
+}


### PR DESCRIPTION
Before:
<img width="465" alt="Screen Shot 2020-03-21 at 10 22 58 PM" src="https://user-images.githubusercontent.com/38590381/77241645-1bf42000-6bc3-11ea-87d9-67079612ef07.png">
After:
<img width="435" alt="Screen Shot 2020-03-21 at 10 23 12 PM" src="https://user-images.githubusercontent.com/38590381/77241648-20b8d400-6bc3-11ea-8a76-47767c2c5fbe.png">
Note: in the pl-code element, the code is not written in the \<pre> tag but in \<span> tags, and when I tested the code would still wrap in Safari but would not in chrome. Should I add the span class to the css?

Resolves #1661 