### PR TITLE
Add showClosedAssessment access rule restriction

### DIFF
--- a/database/tables/assessment_access_rules.pg
+++ b/database/tables/assessment_access_rules.pg
@@ -9,6 +9,7 @@ columns
     password: text
     role: enum_role
     seb_config: jsonb
+    show_closed_assessment: boolean default true
     start_date: timestamp with time zone
     time_limit_min: integer
     uids: text[]

--- a/database/tables/assessment_access_rules.pg
+++ b/database/tables/assessment_access_rules.pg
@@ -9,7 +9,7 @@ columns
     password: text
     role: enum_role
     seb_config: jsonb
-    show_closed_assessment: boolean default true
+    show_closed_assessment: boolean not null default true
     start_date: timestamp with time zone
     time_limit_min: integer
     uids: text[]

--- a/doc/accessControl.md
+++ b/doc/accessControl.md
@@ -29,18 +29,19 @@ The general format of `allowAccess` is:
 
 Each `accessRule` is an object that specifies a set of circumstances under which the assessment is accessible. If any of the access rules gives access, then the assessment is accessible. Each access rule can have one or more restrictions as follows. The "courseInstance" and "assessment" columns indicate whether the restiction is available for the respective objects.
 
-Access restriction | courseInstance | assessment | Meaning | Example
----                | ---            | ---        | ---     | ---
-`role`             | ✓ | ✓ | Require at least this role to access.                               | `"role": "TA"`
-`uids`             | ✓ | ✓ | Require one of the UIDs in the array to access.                     | `"uids": ["mwest@illinois.edu", "zilles@illinois.edu"]`
-`startDate`        | ✓ | ✓ | Only allow access after this date.                                  | `"startDate": "2015-01-19T00:00:01"`
-`endDate`          | ✓ | ✓ | Only access access before this date.                                | `"endDate": "2015-05-13T23:59:59"`
-`institution`      | ✓ |   | Only people from this institution (or "Any" or "LTI").              | `"institution": "UIUC"`
-`mode`             |   | ✓ | Only allow access from this server mode.                            | `"mode": "Exam"`
-`credit`           |   | ✓ | Maximum credit as percentage of full credit (can be more than 100). | `"credit": 100`
-`timeLimitMin`     |   | ✓ | Time limit in minutes to complete an assessment (only for Exams).   | `"timeLimitMin": 60`
-`password`         |   | ✓ | Password required to start an assessment (only for Exams).          | `"password": "mysecret"`
-`examUuid`         |   | ✓ | Exam scheduler UUID that students must register for.                | `"examUuid": "5719ebfe-ad20-42b1-b0dc-c47f0f714871"`
+Access restriction                                          | courseInstance | assessment | Meaning | Example
+---                                                         | --- | --- | --- | ---
+[`role`](#roles)                                            | ✓ | ✓ | Require at least this role to access. | `"role": "TA"`
+`uids`                                                      | ✓ | ✓ | Require one of the UIDs in the array to access. | `"uids": ["mwest@illinois.edu", "zilles@illinois.edu"]`
+[`startDate`](#dates)                                       | ✓ | ✓ | Only allow access after this date. | `"startDate": "2015-01-19T00:00:01"`
+[`endDate`](#dates)                                         | ✓ | ✓ | Only access access before this date. | `"endDate": "2015-05-13T23:59:59"`
+[`institution`](#institutions)                              | ✓ |   | Only people from this institution (or "Any" or "LTI"). | `"institution": "UIUC"`
+[`mode`](#server-modes)                                     |   | ✓ | Only allow access from this server mode. | `"mode": "Exam"`
+[`credit`](#credit)                                         |   | ✓ | Maximum credit as percentage of full credit (can be more than 100). | `"credit": 100`
+[`timeLimitMin`](#time-limits)                              |   | ✓ | Time limit in minutes to complete an assessment (only for Exams). | `"timeLimitMin": 60`
+[`password`](#passwords)                                    |   | ✓ | Password required to start an assessment (only for Exams). | `"password": "mysecret"`
+[`examUuid`](#exam-uuids)                                   |   | ✓ | Exam scheduler UUID that students must register for. | `"examUuid": "5719ebfe-ad20-42b1-b0dc-c47f0f714871"`
+[`showClosedAssessment`](#showinghiding-closed-assessments) |   | ✓ | Whether to allow viewing of assessment contents when closed (default `true`). | `"showClosedAssessment": false`
 
 Each access rule will only grant access if all of the restrictions are satisfied.
 
@@ -134,6 +135,26 @@ To require that students are taking a particular exam in the Computer-Based Test
 ```
 
 Note that in this case the `startDate` and `endDate` should *NOT* be specified. These will be automatically determined by the scheduler app and should not be set in PrairieLearn.
+
+## Showing/hiding closed assessments
+
+When using [time limits](#time-limits), an assessment will "close" when the time limit runs out. When an assesment closes it automatially grades all saved answers and compute the new total score. By default, at this point students can still view the entire exam, see which questions they got correct/incorrect, and look at the questions themselves.
+
+To block students from viewing closed assessment details, set `"showClosedAssessment": false` in the `allowAccess` rule, like this:
+
+```json
+"allowAccess": [
+    {
+        "startDate": "2015-01-19T00:00:01",
+        "endDate": "2015-05-13T23:59:59",
+        "timeLimitMin": 50,
+        "showClosedAssessment": false,
+        "credit": 100
+    }
+]
+```
+
+The `showClosedAssessment` access rule restriction is only really useful in conjuction with [time limits](#time-limits). It is common to pair `showClosedAssessment` with [disabled real-time grading](assessment.md#disabling-real-time-grading).
 
 ## Course instance example
 

--- a/doc/assessment.md
+++ b/doc/assessment.md
@@ -143,7 +143,7 @@ PrairieLearn is designed to give students immediate feedback on their work. Howe
 
 To disable real-time grading for an assessment, add `"allowRealTimeGrading": false` to the assessment's `infoAssessment.json` file. This will hide the "Save & Grade" button on student question pages; only the "Save" button will be available. The "Grade saved answers" button on the assessment overview will also be hidden. Note that real-time grading can only be disabled for `Exam` assessments, as immediate feedback is a core part of the `Homework` experience.
 
-An assessment without real-time grading will not show any score information during the exam, but after a [time limit](accessControl.md#time-limits) runs out the assessment with auto-grade and show students exactly which questions they got correct/incorrect. To prevent this, set the [`showClosedAssessment` access rule restriction](accessControl.md#showinghiding-closed-assessments).
+An assessment without real-time grading will not show any score information during the exam, but after the [time limit](accessControl.md#time-limits) runs out the assessment will auto-grade and show students exactly which questions they got correct/incorrect. To prevent this, set the [`showClosedAssessment` access rule restriction](accessControl.md#showinghiding-closed-assessments).
 
 Disabling real-time grading changes a lot of fundamental details of how PrairieLearn is used. To account for that, the student assessment overview page displays less information about points and grading than for usual exams.
 

--- a/doc/assessment.md
+++ b/doc/assessment.md
@@ -143,6 +143,8 @@ PrairieLearn is designed to give students immediate feedback on their work. Howe
 
 To disable real-time grading for an assessment, add `"allowRealTimeGrading": false` to the assessment's `infoAssessment.json` file. This will hide the "Save & Grade" button on student question pages; only the "Save" button will be available. The "Grade saved answers" button on the assessment overview will also be hidden. Note that real-time grading can only be disabled for `Exam` assessments, as immediate feedback is a core part of the `Homework` experience.
 
+An assessment without real-time grading will not show any score information during the exam, but after a [time limit](accessControl.md#time-limits) runs out the assessment with auto-grade and show students exactly which questions they got correct/incorrect. To prevent this, set the [`showClosedAssessment` access rule restriction](accessControl.md#showinghiding-closed-assessments).
+
 Disabling real-time grading changes a lot of fundamental details of how PrairieLearn is used. To account for that, the student assessment overview page displays less information about points and grading than for usual exams.
 
 Here is the assessment page for a normal exam with real-time grading enabled:

--- a/doc/assessment.md
+++ b/doc/assessment.md
@@ -143,7 +143,7 @@ PrairieLearn is designed to give students immediate feedback on their work. Howe
 
 To disable real-time grading for an assessment, add `"allowRealTimeGrading": false` to the assessment's `infoAssessment.json` file. This will hide the "Save & Grade" button on student question pages; only the "Save" button will be available. The "Grade saved answers" button on the assessment overview will also be hidden. Note that real-time grading can only be disabled for `Exam` assessments, as immediate feedback is a core part of the `Homework` experience.
 
-An assessment without real-time grading will not show any score information during the exam, but after the [time limit](accessControl.md#time-limits) runs out the assessment will auto-grade and show students exactly which questions they got correct/incorrect. To prevent this, set the [`showClosedAssessment` access rule restriction](accessControl.md#showinghiding-closed-assessments).
+An assessment without real-time grading will not show any score information during the exam. However, if a [time limit](accessControl.md#time-limits) is used then when it runs out the assessment will auto-grade and show students exactly which questions they got correct/incorrect. The same revealing behavior will happen if an instructor manually closes and grades the student assessment. To prevent this, set the [`showClosedAssessment` access rule restriction](accessControl.md#showinghiding-closed-assessments).
 
 Disabling real-time grading changes a lot of fundamental details of how PrairieLearn is used. To account for that, the student assessment overview page displays less information about points and grading than for usual exams.
 

--- a/exampleCourse/courseInstances/Sp15/assessments/exam02-realTimeGradingDisabled/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam02-realTimeGradingDisabled/infoAssessment.json
@@ -11,9 +11,9 @@
             "credit": 100
         },
         {
-            "mode": "Exam",
+            "mode": "Public",
             "credit": 100,
-            "examUuid": "edd569e8-5075-4c35-88f9-28c5feaad0cb"
+            "showClosedAssessment": false
        }
     ],
     "zones": [

--- a/exampleCourse/courseInstances/Sp15/assessments/exam02-realTimeGradingDisabled/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam02-realTimeGradingDisabled/infoAssessment.json
@@ -13,6 +13,7 @@
         {
             "mode": "Public",
             "credit": 100,
+            "timeLimitMin": 5,
             "showClosedAssessment": false
        }
     ],

--- a/middlewares/studentAssessmentAccess.ejs
+++ b/middlewares/studentAssessmentAccess.ejs
@@ -32,7 +32,7 @@
                       <div class="col-md-3 col-sm-6">
                         <%- include('../pages/partials/scorebar', {score: assessment_instance.score_perc}) %>
                       </div>
-                      <div class="col-md-6 col-sm-12 text-right">
+                      <div class="col-md-6 col-sm-12 text-right assessment-closed-message">
                           Assessment is <strong>closed</strong> and is no longer available.
                       </div>
                     </div>
@@ -54,7 +54,9 @@
                     </a>
 
                 <% } else { %>
-                    Assessment is <strong>closed</strong> and is no longer available.
+                    <div class="assessment-closed-message">
+                        Assessment is <strong>closed</strong> and is no longer available.
+                    </div>
                 <% } %>
             </div> <!-- panel-body -->
         </div>

--- a/middlewares/studentAssessmentAccess.ejs
+++ b/middlewares/studentAssessmentAccess.ejs
@@ -22,9 +22,7 @@
 
             <div class="card-body">
 
-                <% if (prompt == 'closedAssessmentNotViewable') { %>
-                    Assessment is <strong>closed</strong> and is no longer available.
-                <% } else if (typeof assessment_instance !== 'undefined' && assessment_instance.open === false) { %>
+                <% if (typeof assessment_instance !== 'undefined' && assessment_instance.open === false) { %>
 
                     <div class="row align-items-center">
                       <div class="col-md-3 col-sm-6">
@@ -55,6 +53,8 @@
                         Launch into the Safe Exam Browser
                     </a>
 
+                <% } else { %>
+                    Assessment is <strong>closed</strong> and is no longer available.
                 <% } %>
             </div> <!-- panel-body -->
         </div>

--- a/middlewares/studentAssessmentAccess.ejs
+++ b/middlewares/studentAssessmentAccess.ejs
@@ -16,7 +16,7 @@
     <%- include('../pages/partials/navbar', {navPage: ''}); %>
     <div id="content" class="container">
         <div class="card mb-4">
-            <div class="card-header bg-danger text-white">
+            <div class="card-header bg-primary text-white">
                 <%= assessment_set.abbreviation %><%= assessment.number %>: <%= assessment.title %>
             </div>
 

--- a/middlewares/studentAssessmentAccess.ejs
+++ b/middlewares/studentAssessmentAccess.ejs
@@ -32,7 +32,7 @@
                       <div class="col-md-3 col-sm-6">
                         <%- include('../pages/partials/scorebar', {score: assessment_instance.score_perc}) %>
                       </div>
-                      <div class="col-md-6 col-sm-12 text-right assessment-closed-message">
+                      <div class="col-md-6 col-sm-12 text-right test-suite-assessment-closed-message">
                           Assessment is <strong>closed</strong> and is no longer available.
                       </div>
                     </div>
@@ -54,7 +54,7 @@
                     </a>
 
                 <% } else { %>
-                    <div class="assessment-closed-message">
+                    <div class="test-suite-assessment-closed-message">
                         Assessment is <strong>closed</strong> and is no longer available.
                     </div>
                 <% } %>

--- a/middlewares/studentAssessmentAccess.ejs
+++ b/middlewares/studentAssessmentAccess.ejs
@@ -22,7 +22,9 @@
 
             <div class="card-body">
 
-                <% if (typeof assessment_instance !== 'undefined' && assessment_instance.open === false) { %>
+                <% if (prompt == 'closedAssessmentNotViewable') { %>
+                    Assessment is <strong>closed</strong> and is no longer available.
+                <% } else if (typeof assessment_instance !== 'undefined' && assessment_instance.open === false) { %>
 
                     <div class="row align-items-center">
                       <div class="col-md-3 col-sm-6">
@@ -33,12 +35,12 @@
                         <%- include('../pages/partials/scorebar', {score: assessment_instance.score_perc}) %>
                       </div>
                       <div class="col-md-6 col-sm-12 text-right">
-                          Assessment is <strong>closed</strong> and is no longer available
+                          Assessment is <strong>closed</strong> and is no longer available.
                       </div>
                     </div>
 
                     <% if (authz_data.mode == 'SEB') { %>
-                        <p><a href="/pl/SEBquit">Click here to quit the Safe Exam Browser</a>
+                        <p><a href="/pl/SEBquit">Click here to quit the Safe Exam Browser</a></p>
                     <% } %>
 
                 <% } else if (prompt == 'SEB') { %>

--- a/middlewares/studentAssessmentAccess.js
+++ b/middlewares/studentAssessmentAccess.js
@@ -92,7 +92,7 @@ function badSEB(req, res) {
     //res.locals.SEBUrl = proto + req.get('host') + '/pl/downloadSEBConfig/';
     res.locals.SEBUrl = config.SEBDownloadUrl;
     res.locals.prompt = 'SEB';
-    return res.status(401).render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+    return res.status(403).render(__filename.replace(/\.js$/, '.ejs'), res.locals);
 }
 
 function checkUserAgent(res, userAgent) {

--- a/middlewares/studentAssessmentAccess.js
+++ b/middlewares/studentAssessmentAccess.js
@@ -121,6 +121,5 @@ function checkUserAgent(res, userAgent) {
 }
 
 function closedAssessmentNotViewable(res) {
-    res.locals.prompt = 'closedAssessmentNotViewable';
     res.status(403).render(__filename.replace(/\.js$/, '.ejs'), res.locals);
 }

--- a/middlewares/studentAssessmentAccess.js
+++ b/middlewares/studentAssessmentAccess.js
@@ -121,5 +121,6 @@ function checkUserAgent(res, userAgent) {
 }
 
 function closedAssessmentNotViewable(res) {
+    res.locals.prompt = 'closedAssessmentNotViewable';
     res.status(403).render(__filename.replace(/\.js$/, '.ejs'), res.locals);
 }

--- a/middlewares/studentAssessmentAccess.js
+++ b/middlewares/studentAssessmentAccess.js
@@ -1,8 +1,6 @@
-//var ERR = require('async-stacktrace');
-//var _ = require('lodash');
-//var sha256 = require('crypto-js/sha256');
 const express = require('express');
-var router = express.Router();
+const router = express.Router();
+const _ = require('lodash');
 
 var logger = require('../lib/logger');
 var csrf = require('../lib/csrf');
@@ -37,26 +35,35 @@ router.all('/', function(req, res, next) {
         'password' in res.locals.authz_result &&
         res.locals.authz_result.password) {
 
-            // If the assessment is complete, use this middleware to show the logout page
-            if ('assessment_instance' in res.locals && res.locals.assessment_instance.open == false) {
-                return badSEB(req, res);
-            }
-
-            // No password yet case
-            if (req.cookies.pl_assessmentpw == null) {
-                return badPassword(res, req);
-            }
-
-            // Invalid or expired password case
-            var pwData = csrf.getCheckedData(req.cookies.pl_assessmentpw, config.secretKey,
-                                             {maxAge: timeout * 60 * 60 * 1000});
-            if (pwData == null
-                || pwData.password !== res.locals.authz_result.password) {
-                    return badPassword(res, req);
-            }
-
-            // Successful password case: falls though
+        // If the assessment is complete, use this middleware to show the logout page
+        if ('assessment_instance' in res.locals && res.locals.assessment_instance.open == false) {
+            return badSEB(req, res);
         }
+
+        // No password yet case
+        if (req.cookies.pl_assessmentpw == null) {
+            return badPassword(res, req);
+        }
+
+        // Invalid or expired password case
+        var pwData = csrf.getCheckedData(req.cookies.pl_assessmentpw, config.secretKey,
+                                            {maxAge: timeout * 60 * 60 * 1000});
+        if (pwData == null
+            || pwData.password !== res.locals.authz_result.password) {
+                return badPassword(res, req);
+        }
+
+        // Successful password case: falls though
+    }
+
+    if (
+        !_.get(res.locals, 'authz_result.show_closed_assessment', true) &&
+        !_.get(res.locals, 'assessment_instance.open', true)
+    ) {
+        // This assessment instance is closed and can no longer be viewed
+        closedAssessmentNotViewable(res);
+        return;
+    }
 
     // Pass-through for everything else
     next();
@@ -111,4 +118,9 @@ function checkUserAgent(res, userAgent) {
         // Assessment list view, enable the mode
         res.locals.authz_data.mode = 'SEB';
     }
+}
+
+function closedAssessmentNotViewable(res) {
+    res.locals.prompt = 'closedAssessmentNotViewable';
+    res.status(403).render(__filename.replace(/\.js$/, '.ejs'), res.locals);
 }

--- a/migrations/166_assessment_access_rules__show_closed_assessment__add.sql
+++ b/migrations/166_assessment_access_rules__show_closed_assessment__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessment_access_rules ADD COLUMN show_closed_assessment boolean DEFAULT true;

--- a/migrations/166_assessment_access_rules__show_closed_assessment__add.sql
+++ b/migrations/166_assessment_access_rules__show_closed_assessment__add.sql
@@ -1,1 +1,1 @@
-ALTER TABLE assessment_access_rules ADD COLUMN show_closed_assessment boolean DEFAULT true;
+ALTER TABLE assessment_access_rules ADD COLUMN show_closed_assessment boolean NOT NULL DEFAULT true;

--- a/schemas/schemas/infoAssessment.json
+++ b/schemas/schemas/infoAssessment.json
@@ -168,7 +168,7 @@
                     }
                 },
                 "showClosedAssessment": {
-                    "description": "If true, prevents the assessment from being viewed once it has been closed",
+                    "description": "Whether the student can view the assessment after it has been closed",
                     "type": "boolean",
                     "default": true
                 }

--- a/schemas/schemas/infoAssessment.json
+++ b/schemas/schemas/infoAssessment.json
@@ -168,7 +168,7 @@
                     }
                 },
                 "showClosedAssessment": {
-                    "description": "If set, prevents the assessment from being viewed once it has been closed",
+                    "description": "If true, prevents the assessment from being viewed once it has been closed",
                     "type": "boolean",
                     "default": true
                 }

--- a/schemas/schemas/infoAssessment.json
+++ b/schemas/schemas/infoAssessment.json
@@ -166,6 +166,11 @@
                             }
                         }
                     }
+                },
+                "showClosedAssessment": {
+                    "description": "If set, prevents the assessment from being viewed once it has been closed",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/sprocs/authz_assessment.sql
+++ b/sprocs/authz_assessment.sql
@@ -16,6 +16,7 @@ CREATE OR REPLACE FUNCTION
         OUT password text,           -- The password (if any) for this assessment.
         OUT mode enum_mode,          -- The mode for this assessment.
         OUT seb_config JSONB,        -- The SEB config (if any) for this assessment.
+        OUT show_closed_assessment boolean, -- If students can view the assessment after it is closed.
         OUT access_rules JSONB       -- For display to the user. The currently active rule is marked by 'active' = TRUE.
     )
 AS $$
@@ -76,5 +77,6 @@ BEGIN
     access_rules := user_result.access_rules;
     mode := user_result.mode;
     seb_config := user_result.seb_config;
+    show_closed_assessment := user_result.show_closed_assessment;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/authz_assessment_instance.sql
+++ b/sprocs/authz_assessment_instance.sql
@@ -17,6 +17,7 @@ CREATE OR REPLACE FUNCTION
         OUT password text,           -- Password (if any) for this assessment.
         OUT mode enum_mode,
         OUT seb_config JSONB,
+        OUT show_closed_assessment boolean, -- If students can view the assessment after it is closed.
         OUT access_rules JSONB       -- For display to the user. The currently active rule is marked by 'active' = TRUE.
     )
 AS $$
@@ -41,6 +42,7 @@ BEGIN
     access_rules := assessment_result.access_rules;
     mode := assessment_result.mode;
     seb_config := assessment_result.seb_config;
+    show_closed_assessment := assessment_result.show_closed_assessment;
 
     time_limit_expired := FALSE;
     IF assessment_instance.date_limit IS NOT NULL AND assessment_instance.date_limit < req_date THEN

--- a/sprocs/check_assessment_access.sql
+++ b/sprocs/check_assessment_access.sql
@@ -18,6 +18,7 @@ CREATE OR REPLACE FUNCTION
         OUT password text,           -- What is the password (if any) for this assessment.
         OUT mode enum_mode,          -- Mode of the assessment.
         OUT seb_config JSONB,         -- SEBKeys (if any) for this assessment.
+        OUT show_closed_assessment boolean, -- If students can view the assessment after it is closed.
         OUT access_rules JSONB       -- For display to the user. The currently active rule is marked by 'active' = TRUE.
     ) AS $$
 DECLARE
@@ -41,6 +42,7 @@ BEGIN
         aar.password,
         aar.mode,
         aar.seb_config,
+        aar.show_closed_assessment,
         aar.id
     INTO
         authorized,
@@ -50,6 +52,7 @@ BEGIN
         password,
         mode,
         seb_config,
+        show_closed_assessment,
         active_access_rule_id
     FROM
         assessment_access_rules AS aar
@@ -72,6 +75,7 @@ BEGIN
         password = NULL;
         mode = NULL;
         seb_config = NULL;
+        show_closed_assessment = TRUE;
     END IF;
 
     -- Override if we are an Instructor
@@ -84,6 +88,7 @@ BEGIN
         password = NULL;
         mode = NULL;
         seb_config = NULL;
+        show_closed_assessment = TRUE;
     END IF;
 
     -- List of all access rules that will grant access to this user/mode/role at some date (past or future),

--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -109,7 +109,8 @@ BEGIN
                 seb_config,
                 exam_uuid,
                 start_date,
-                end_date)
+                end_date,
+                show_closed_assessment)
             (
                 SELECT
                     new_assessment_id,
@@ -123,7 +124,8 @@ BEGIN
                     access_rule->'seb_config',
                     (access_rule->>'exam_uuid')::uuid,
                     input_date(access_rule->>'start_date', ci.display_timezone),
-                    input_date(access_rule->>'end_date', ci.display_timezone)
+                    input_date(access_rule->>'end_date', ci.display_timezone),
+                    (access_rule->>'show_closed_assessment')::boolean
                 FROM
                     assessments AS a
                     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
@@ -141,7 +143,8 @@ BEGIN
                 uids = EXCLUDED.uids,
                 seb_config = EXCLUDED.seb_config,
                 start_date = EXCLUDED.start_date,
-                end_date = EXCLUDED.end_date;
+                end_date = EXCLUDED.end_date,
+                show_closed_assessment = EXCLUDED.show_closed_assessment;
         END LOOP;
 
         -- Delete excess access rules

--- a/sync/fromDisk/assessments.js
+++ b/sync/fromDisk/assessments.js
@@ -82,6 +82,7 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
                 password: _(accessRule).has('password') ? accessRule.password : null,
                 seb_config: _(accessRule).has('SEBConfig') ? accessRule.SEBConfig : null,
                 exam_uuid: _(accessRule).has('examUuid') ? accessRule.examUuid : null,
+                show_closed_assessment: !!_(accessRule).get('showClosedAssessment', true),
             };
         });
 

--- a/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
@@ -8,7 +8,8 @@
     "allowAccess": [
         {
             "mode": "Public",
-            "credit": 100
+            "credit": 100,
+            "timeLimitMin": 50
         }
     ],
     "zones": [

--- a/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
@@ -9,7 +9,8 @@
         {
             "mode": "Public",
             "credit": 100,
-            "timeLimitMin": 50
+            "timeLimitMin": 50,
+            "showClosedAssessment": false
         }
     ],
     "zones": [

--- a/tests/helperClient.js
+++ b/tests/helperClient.js
@@ -1,0 +1,43 @@
+const fetch = require('node-fetch');
+const assert = require('chai').assert;
+const cheerio = require('cheerio');
+
+module.exports = {}
+
+/**
+ * A wrapper around node-fetch that provides a few features:
+ * * Automatic parsing with cheerio
+ * * A `form` option akin to that from the `request` library
+ */
+module.exports.fetchCheerio = async (url, options = {}) => {
+    if (options.form) {
+        options.body = JSON.stringify(options.form);
+        options.headers = {
+            'Content-Type': 'application/json',
+            ...options.headers,
+        };
+        delete options.form;
+    }
+    const response = await fetch(url, options);
+    const text = await response.text();
+    response.$ = cheerio.load(text);
+    // response.text() can only be called once, which we already did.
+    // patch this so consumers can use it as normal.
+    response.text = () => text;
+    return response;
+};
+
+/**
+ * Utility function that extracts a CSRF token from a `__csrf_token` input
+ * that is a descendent of the `parentSelector`, if one is specified.
+ * The token will also be persisted to `context.__csrf_token`.
+ */
+module.exports.extractAndSaveCSRFToken = (context, $, parentSelector = '') => {
+    const csrfTokenInput = $(`${parentSelector} input[name="__csrf_token"]`);
+    assert.lengthOf(csrfTokenInput, 1);
+    const csrfToken = csrfTokenInput.val();
+    assert.isString(csrfToken);
+    context.__csrf_token = csrfToken;
+    return csrfToken;
+};
+

--- a/tests/helperClient.js
+++ b/tests/helperClient.js
@@ -2,7 +2,7 @@ const fetch = require('node-fetch');
 const assert = require('chai').assert;
 const cheerio = require('cheerio');
 
-module.exports = {}
+module.exports = {};
 
 /**
  * A wrapper around node-fetch that provides a few features:

--- a/tests/testShowClosedAssessment.js
+++ b/tests/testShowClosedAssessment.js
@@ -1,0 +1,97 @@
+const util = require('util');
+const assert = require('chai').assert;
+const { step } = require('mocha-steps');
+
+const config = require('../lib/config');
+const sqldb = require('@prairielearn/prairielib/sql-db');
+const sqlLoader = require('@prairielearn/prairielib/sql-loader');
+const sql = sqlLoader.loadSqlEquiv(__filename);
+
+const helperServer = require('./helperServer');
+const helperClient = require('./helperClient');
+
+/**
+ * This test validates the behavior of exams with real-time grading disabled.
+ * It was deliberately written separately from `testExam.js` as a start to
+ * breaking tests out of that monolith. It does not reuse existing conventions
+ * from `testExam.js` in favor of experimenting with a different way of writing
+ * PrairieLearn tests.
+ */
+describe('Exam assessment with real-time grading disabled', function() {
+    this.timeout(60000);
+
+    const context = {};
+    context.siteUrl = `http://localhost:${config.serverPort}`;
+    context.baseUrl = `${context.siteUrl}/pl`;
+    context.courseInstanceBaseUrl= `${context.baseUrl}/course_instance/1`;
+
+    before('set up testing server', async function() {
+        await util.promisify(helperServer.before().bind(this))();
+        const results = await sqldb.queryOneRowAsync(sql.select_exam8, []);
+        context.assessmentId = results.rows[0].id;
+        context.assessmentUrl = `${context.courseInstanceBaseUrl}/assessment/${context.assessmentId}/`;
+    });
+    after('shut down testing server', helperServer.after);
+
+    step('visit start exam page', async () => {
+        const response = await helperClient.fetchCheerio(context.assessmentUrl);
+        assert.isTrue(response.ok);
+
+        assert.equal(response.$('#start-assessment').text(), 'Start assessment');
+
+        helperClient.extractAndSaveCSRFToken(context, response.$, 'form');
+    });
+
+    step('start the exam', async () => {
+        const form = {
+            __action: 'newInstance',
+            __csrf_token: context.__csrf_token,
+        };
+        const response = await helperClient.fetchCheerio(context.assessmentUrl, { method: 'POST', form });
+        assert.isTrue(response.ok);
+
+        // We should have been redirected to the assessment instance
+        const assessmentInstanceUrl = response.url;
+        assert.include(assessmentInstanceUrl, '/assessment_instance/');
+        context.assessmentInstanceUrl = assessmentInstanceUrl;
+
+        // save the questionUrl for later
+        const questionUrl = response.$('a:contains("Question 1")').attr('href');
+        context.questionUrl = `${context.siteUrl}${questionUrl}`;
+        
+        helperClient.extractAndSaveCSRFToken(context, response.$, 'form[name="time-limit-finish-form"]');
+    });
+
+    step('simulate a time limit expiration', async () => {
+        const form = {
+            __action: 'timeLimitFinish',
+            __csrf_token: context.__csrf_token,
+        };
+        const response = await helperClient.fetchCheerio(context.assessmentInstanceUrl, { method: 'POST', form });
+        assert.isTrue(response.ok);
+
+        // We should have been redirected back to the same assessment instance
+        assert.equal(response.url, context.assessmentInstanceUrl);
+
+        // we should not have any questions
+        assert.lengthOf(response.$('a:contains("Question 1")'), 0);
+
+        // we should have the "assessment closed" message
+        const msg = response.$('div.assessment-closed-message');
+        assert.lengthOf(msg, 1);
+        assert.match(msg[0].text(), /Assessment .* is no longer available/);
+    });
+
+    step('check the assessment instance is closed', async () {
+        const results = await sqldb.queryAsync(sql.select_assessment_instances, []);
+        assert.equal(results.rowCount, 1);
+        assert.equal(results.rows[0].open, false);
+    });
+
+    step('check that accessing a question gives the "assessment closed" message', async () => {
+        const response = await helperClient.fetchCheerio(context.questionUrl);
+        assert.isTrue(response.ok);
+
+        assert.lengthOf(response.$('div.assessment-closed-message'), 1);
+    });
+});

--- a/tests/testShowClosedAssessment.js
+++ b/tests/testShowClosedAssessment.js
@@ -91,7 +91,7 @@ describe('Exam assessment with showCloseAssessment access rule', function() {
         assert.lengthOf(response.$('a:contains("Question 1")'), 0);
 
         // we should have the "assessment closed" message
-        const msg = response.$('div.assessment-closed-message');
+        const msg = response.$('div.test-suite-assessment-closed-message');
         assert.lengthOf(msg, 1);
         assert.match(msg.text(), /Assessment .* is no longer available/);
     });
@@ -106,6 +106,6 @@ describe('Exam assessment with showCloseAssessment access rule', function() {
         const response = await helperClient.fetchCheerio(context.questionUrl, { headers });
         assert.equal(response.status, 403);
 
-        assert.lengthOf(response.$('div.assessment-closed-message'), 1);
+        assert.lengthOf(response.$('div.test-suite-assessment-closed-message'), 1);
     });
 });

--- a/tests/testShowClosedAssessment.js
+++ b/tests/testShowClosedAssessment.js
@@ -17,7 +17,7 @@ const helperClient = require('./helperClient');
  * from `testExam.js` in favor of experimenting with a different way of writing
  * PrairieLearn tests.
  */
-describe('Exam assessment with real-time grading disabled', function() {
+describe('Exam assessment with showCloseAssessment access rule', function() {
     this.timeout(60000);
 
     const context = {};
@@ -58,7 +58,8 @@ describe('Exam assessment with real-time grading disabled', function() {
         // save the questionUrl for later
         const questionUrl = response.$('a:contains("Question 1")').attr('href');
         context.questionUrl = `${context.siteUrl}${questionUrl}`;
-        
+
+        console.log(response.text());
         helperClient.extractAndSaveCSRFToken(context, response.$, 'form[name="time-limit-finish-form"]');
     });
 
@@ -82,7 +83,7 @@ describe('Exam assessment with real-time grading disabled', function() {
         assert.match(msg[0].text(), /Assessment .* is no longer available/);
     });
 
-    step('check the assessment instance is closed', async () {
+    step('check the assessment instance is closed', async () => {
         const results = await sqldb.queryAsync(sql.select_assessment_instances, []);
         assert.equal(results.rowCount, 1);
         assert.equal(results.rows[0].open, false);

--- a/tests/testShowClosedAssessment.sql
+++ b/tests/testShowClosedAssessment.sql
@@ -1,0 +1,3 @@
+-- BLOCK select_assessment_instances
+SELECT *
+FROM assessment_instances;

--- a/tests/testShowClosedAssessment.sql
+++ b/tests/testShowClosedAssessment.sql
@@ -1,3 +1,14 @@
+-- BLOCK select_exam8
+SELECT
+    a.id
+FROM
+    assessments AS a
+    JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
+WHERE
+    a.course_instance_id = 1
+    AND aset.abbreviation = 'E'
+    AND a.number = '8';
+
 -- BLOCK select_assessment_instances
 SELECT *
 FROM assessment_instances;

--- a/tests/testShowClosedAssessment.sql
+++ b/tests/testShowClosedAssessment.sql
@@ -1,3 +1,12 @@
+-- BLOCK enroll_student_in_course
+INSERT INTO enrollments (course_instance_id, role, user_id)
+SELECT ci.id, 'Student', u.user_id
+FROM
+    course_instances AS ci,
+    users AS u
+WHERE
+    u.uid ~ 'student';
+
 -- BLOCK select_exam8
 SELECT
     a.id


### PR DESCRIPTION
This PR adds a new `showClosedAssessment` flag to assessment access rules that controls whether closed assessments can be opened if their access rules would otherwise permit them to be opened.

Resolves #560

I unfortunately have a day job to go do this week, so I'm passing this off to @mwest1066 to see through.

**TODO**
- [x] Before merging, consider renaming in light of the `completelyHideAllTraceOfClosedAssessment` option
  - Consider `accessWhenClosed` instead of `showClosedAssessment`, and `displayWhenClosed` for `completelyHideAllTraceOfClosedAssessment`
- [x] Add documentation for this option, what it does, when to use it
- [x] Tests, ideally