### PR TITLE
Fix errors in element documentation question

### DIFF
--- a/doc/elements.md
+++ b/doc/elements.md
@@ -343,7 +343,7 @@ import sympy
 def generate(data):
   
   # Declare math symbols
-  sympy.var('x y')
+  x, y = sympy.symbols('x y')
 
   # Describe the equation
   z = x + y + 1

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -332,7 +332,7 @@ Fill in the blank field that allows for mathematical symbol input.
 
 **question.html**
 ```html
-<pl-symbolic-input answers-name="symbolic_math" label="$z =$"></pl-symbolic-input>
+<pl-symbolic-input answers-name="symbolic_math" variables="x, y" label="$z =$"></pl-symbolic-input>
 ```
 
 **server.py**

--- a/exampleCourse/questions/elementElementCodeDocumentation/question.html
+++ b/exampleCourse/questions/elementElementCodeDocumentation/question.html
@@ -110,7 +110,7 @@
          <p> Correct Input: <code>x + y + 1</code> </p>
         </pl-question-panel>
         
-        <pl-symbolic-input answers-name="symbolic_math" label="$z =$"></pl-symbolic-input>
+        <pl-symbolic-input answers-name="symbolic_math" variables="x, y" label="$z =$"></pl-symbolic-input>
 
     </div>
 </div>

--- a/exampleCourse/questions/elementElementCodeDocumentation/server.py
+++ b/exampleCourse/questions/elementElementCodeDocumentation/server.py
@@ -27,7 +27,7 @@ def generate(data):
     # Symbolic
     x, y = sympy.symbols('x y')
     data['correct_answers']['symbolic_math'] = pl.to_json(x + y + 1)
-    
+
     # Matrix Fill in the Blank
     data['correct_answers']['matrixA'] = pl.to_json(np.matrix('1 2; 3 4'))
     

--- a/exampleCourse/questions/elementElementCodeDocumentation/server.py
+++ b/exampleCourse/questions/elementElementCodeDocumentation/server.py
@@ -25,9 +25,9 @@ def generate(data):
     data["correct_answers"]["string_value"] = "Learn"
     
     # Symbolic
-    sympy.var('x y')
+    x, y = sympy.symbols('x y')
     data['correct_answers']['symbolic_math'] = pl.to_json(x + y + 1)
-
+    
     # Matrix Fill in the Blank
     data['correct_answers']['matrixA'] = pl.to_json(np.matrix('1 2; 3 4'))
     


### PR DESCRIPTION
Fixes #2210

The correct answer for the _symbolic input_ field was using a floating point variable `x` instead of symbolic `x`, which breaks the sympy parser because it doesn't like floats.