### PR TITLE
Change "Generating questions" message to "Generating assessment"

### DIFF
--- a/pages/studentAssessmentExam/studentAssessmentExam.ejs
+++ b/pages/studentAssessmentExam/studentAssessmentExam.ejs
@@ -42,7 +42,7 @@
             $('#confirm-form').on('submit', function() {
                 $('#start-assessment')
                     .prop('disabled', true)
-                    .html('<i class="fa fa-sync fa-spin fa-fw"></i> Generating questions…');
+                    .html('<i class="fa fa-sync fa-spin fa-fw"></i> Generating assessment…');
             });
           </script>
 


### PR DESCRIPTION
We no longer generate questions at the start of the exam (we use "lazy" generation when we first access each question). This PR changes the message to reflect this.