### PR TITLE
Add `size` and `show-help-text` attributes to elements

### DIFF
--- a/doc/elements.md
+++ b/doc/elements.md
@@ -366,6 +366,8 @@ Attribute | Type | Default | Description
 `variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
 `allow-complex` | boolean | false | Whether complex numbers (expressions with `i` or `j` as the imaginary unit) are allowed.
 `imaginary-unit-for-display` | string | `i` | The imaginary unit that is used for display. It must be either `i` or `j`. Again, this is *only* for display. Both `i` and `j` can be used by the student in their submitted answer, when `allow-complex="true"`.
+`size` | integer | 35 | Size of the input box.
+`show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
 
 #### Details
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -421,6 +421,8 @@ Attribute | Type | Default | Description
 `allow-blank` | boolean | false | Whether or not an empty input box is allowed. By default, empty input boxes will not be graded (invalid format).
 `ignore-case` | boolean | false | Whether or not to enforce case sensitivity (e.g. "hello" != "HELLO").
 `placeholder` | text | None | Hint displayed inside the input box describing the expected type of input.
+`size` | integer | 35 | Size of the input box.
+`show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
 
 #### Example implementations
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -309,6 +309,8 @@ Attribute | Type | Default | Description
 `label` | text | — | A prefix to display before the input box (e.g., `label="$x =$"`).
 `suffix` | text | — | A suffix to display after the input box (e.g., `suffix="items"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
+`size` | integer | 35 | Size of the input box.
+`show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
 
 #### Example implementations
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -540,6 +540,8 @@ Attribute | Type | Default | Description
 `atol` | number | 1e-8 | Absolute tolerance for `comparison="relabs"`.
 `digits` | integer | 2 | number of digits that must be correct for `comparison="sigfig"` or `comparison="decdig"`.
 `allow-complex` | boolean | false | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answer'][answers-name] = pl.to_json(ans)`.
+`size` | integer | 35 | Size of the input box.
+`show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
 
 #### Details
 

--- a/doc/elements.md
+++ b/doc/elements.md
@@ -540,7 +540,6 @@ Attribute | Type | Default | Description
 `atol` | number | 1e-8 | Absolute tolerance for `comparison="relabs"`.
 `digits` | integer | 2 | number of digits that must be correct for `comparison="sigfig"` or `comparison="decdig"`.
 `allow-complex` | boolean | false | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answer'][answers-name] = pl.to_json(ans)`.
-`size` | integer | 35 | Size of the input box.
 `show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
 
 #### Details

--- a/elements/pl-integer-input/pl-integer-input.mustache
+++ b/elements/pl-integer-input/pl-integer-input.mustache
@@ -16,7 +16,7 @@
             <span class="input-group-text" id="pl-integer-input-{{uuid}}-label">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control pl-integer-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-integer-input-{{uuid}}-label pl-integer-input-{{uuid}}-suffix" placeholder="{{shortinfo}}" />
+        <input name="{{name}}" type="text" class="form-control pl-integer-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-integer-input-{{uuid}}-label pl-integer-input-{{uuid}}-suffix" {{#show_placeholder}}placeholder="{{shortinfo}}"{{/show_placeholder}} />
         <span class="input-group-append">
             {{#suffix}}
             <span class="input-group-text {{^show_info}}rounded-right{{/show_info}}" id="pl-integer-input-{{uuid}}-suffix">{{suffix}}</span>

--- a/elements/pl-integer-input/pl-integer-input.mustache
+++ b/elements/pl-integer-input/pl-integer-input.mustache
@@ -27,7 +27,7 @@
             <i class="fa fa-question-circle" aria-hidden="true"></i>
             {{/show_info}}
             {{^show_info}}
-            <span style="display:flex; align-items: center;">
+            <span class="d-flex align-items-center">
             {{/show_info}}
             
             {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}

--- a/elements/pl-integer-input/pl-integer-input.mustache
+++ b/elements/pl-integer-input/pl-integer-input.mustache
@@ -16,17 +16,30 @@
             <span class="input-group-text" id="pl-integer-input-{{uuid}}-label">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control pl-integer-input-input" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-integer-input-{{uuid}}-label pl-integer-input-{{uuid}}-suffix" placeholder="{{shortinfo}}" />
+        <input name="{{name}}" type="text" class="form-control pl-integer-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-integer-input-{{uuid}}-label pl-integer-input-{{uuid}}-suffix" placeholder="{{shortinfo}}" />
         <span class="input-group-append">
             {{#suffix}}
-            <span class="input-group-text" id="pl-integer-input-{{uuid}}-suffix">{{suffix}}</span>
+            <span class="input-group-text {{^show_info}}rounded-right{{/show_info}}" id="pl-integer-input-{{uuid}}-suffix">{{suffix}}</span>
             {{/suffix}}
+
+            {{#show_info}}
             <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Number" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
-                <i class="fa fa-question-circle" aria-hidden="true"></i>
-                {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
-                {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
-                {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+            <i class="fa fa-question-circle" aria-hidden="true"></i>
+            {{/show_info}}
+            {{^show_info}}
+            <span style="display:flex; align-items: center;">
+            {{/show_info}}
+            
+            {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
+            {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
+            {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+
+            {{#show_info}}
             </a>
+            {{/show_info}}
+            {{^show_info}}
+            </span>
+            {{/show_info}}
         </span>
     </span>
 {{#inline}}</span>{{/inline}}

--- a/elements/pl-integer-input/pl-integer-input.py
+++ b/elements/pl-integer-input/pl-integer-input.py
@@ -13,6 +13,7 @@ SUFFIX_DEFAULT = None
 DISPLAY_DEFAULT = 'inline'
 SIZE_DEFAULT = 35
 SHOW_HELP_TEXT_DEFAULT = True
+PLACEHOLDER_TEXT_THRESHOLD = 4 # Minimum size to show the placeholder text
 
 
 def prepare(element_html, data):
@@ -35,7 +36,8 @@ def render(element_html, data):
     label = pl.get_string_attrib(element, 'label', LABEL_DEFAULT)
     suffix = pl.get_string_attrib(element, 'suffix', SUFFIX_DEFAULT)
     display = pl.get_string_attrib(element, 'display', DISPLAY_DEFAULT)
-
+    size = pl.get_integer_attrib(element, 'size', SIZE_DEFAULT)
+    
     if data['panel'] == 'question':
         editable = data['editable']
         raw_submitted_answer = data['raw_submitted_answers'].get(name, None)
@@ -57,8 +59,9 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'shortinfo': shortinfo,
-            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
+            'size': size,
             'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
+            'show_placeholder': size >= PLACEHOLDER_TEXT_THRESHOLD,
             'uuid': pl.get_uuid()
         }
 

--- a/elements/pl-integer-input/pl-integer-input.py
+++ b/elements/pl-integer-input/pl-integer-input.py
@@ -11,12 +11,14 @@ CORRECT_ANSWER_DEFAULT = None
 LABEL_DEFAULT = None
 SUFFIX_DEFAULT = None
 DISPLAY_DEFAULT = 'inline'
+SIZE_DEFAULT = 35
+SHOW_HELP_TEXT_DEFAULT = True
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display']
+    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'size', 'show-help-text']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -55,6 +57,8 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'shortinfo': shortinfo,
+            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
+            'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
             'uuid': pl.get_uuid()
         }
 
@@ -71,6 +75,8 @@ def render(element_html, data):
                     html_params['incorrect'] = True
             except Exception:
                 raise ValueError('invalid score' + score)
+
+        html_params['display_append_span'] = html_params['show_info'] or suffix
 
         if display == 'inline':
             html_params['inline'] = True

--- a/elements/pl-integer-input/pl-integer-input.py
+++ b/elements/pl-integer-input/pl-integer-input.py
@@ -13,7 +13,7 @@ SUFFIX_DEFAULT = None
 DISPLAY_DEFAULT = 'inline'
 SIZE_DEFAULT = 35
 SHOW_HELP_TEXT_DEFAULT = True
-PLACEHOLDER_TEXT_THRESHOLD = 4 # Minimum size to show the placeholder text
+PLACEHOLDER_TEXT_THRESHOLD = 4  # Minimum size to show the placeholder text
 
 
 def prepare(element_html, data):
@@ -37,7 +37,7 @@ def render(element_html, data):
     suffix = pl.get_string_attrib(element, 'suffix', SUFFIX_DEFAULT)
     display = pl.get_string_attrib(element, 'display', DISPLAY_DEFAULT)
     size = pl.get_integer_attrib(element, 'size', SIZE_DEFAULT)
-    
+
     if data['panel'] == 'question':
         editable = data['editable']
         raw_submitted_answer = data['raw_submitted_answers'].get(name, None)

--- a/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -14,14 +14,26 @@
         <label class="input-group-text" id="pl-matrix-input-{{uuid}}-label">{{label}}</label>
     </span>
     {{/label}}
-    <input name="{{name}}" type="text" class="form-control pl-matrix-input-input" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-matrix-input-{{uuid}}-label" placeholder="{{shortinfo}}" />
+    <input name="{{name}}" type="text" class="form-control pl-matrix-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-matrix-input-{{uuid}}-label" placeholder="{{shortinfo}}" />
     <div class="input-group-append">
+        {{#show_info}}
         <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
-            <i class="fa fa-question-circle" aria-hidden="true"></i>
-            {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
-            {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
-            {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+        <i class="fa fa-question-circle" aria-hidden="true"></i>
+        {{/show_info}}
+        {{^show_info}}
+        <span style="display: flex; align-items: center;">
+        {{/show_info}}
+
+        {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
+        {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
+        {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+
+        {{#show_info}}
         </a>
+        {{/show_info}}
+        {{#show_info}}
+        </span>
+        {{/show_info}}
     </div>
 </div>
 {{/question}}

--- a/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -14,7 +14,7 @@
         <label class="input-group-text" id="pl-matrix-input-{{uuid}}-label">{{label}}</label>
     </span>
     {{/label}}
-    <input name="{{name}}" type="text" class="form-control pl-matrix-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-matrix-input-{{uuid}}-label" placeholder="{{shortinfo}}" />
+    <input name="{{name}}" type="text" class="form-control pl-matrix-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="pl-matrix-input-{{uuid}}-label" placeholder="{{shortinfo}}" />
     <div class="input-group-append">
         {{#show_info}}
         <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">

--- a/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -21,7 +21,7 @@
         <i class="fa fa-question-circle" aria-hidden="true"></i>
         {{/show_info}}
         {{^show_info}}
-        <span style="display: flex; align-items: center;">
+        <span class="d-flex align-items-center">
         {{/show_info}}
 
         {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}

--- a/elements/pl-matrix-input/pl-matrix-input.py
+++ b/elements/pl-matrix-input/pl-matrix-input.py
@@ -13,12 +13,14 @@ RTOL_DEFAULT = 1e-2
 ATOL_DEFAULT = 1e-8
 DIGITS_DEFAULT = 2
 ALLOW_COMPLEX_DEFAULT = False
+SIZE_DEFAULT = 35
+SHOW_HELP_TEXT_DEFAULT = True
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex']
+    optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex', 'size', 'show-help-text']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
@@ -73,6 +75,8 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'shortinfo': shortinfo,
+            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
+            'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
             'uuid': pl.get_uuid()
         }
 

--- a/elements/pl-matrix-input/pl-matrix-input.py
+++ b/elements/pl-matrix-input/pl-matrix-input.py
@@ -13,14 +13,13 @@ RTOL_DEFAULT = 1e-2
 ATOL_DEFAULT = 1e-8
 DIGITS_DEFAULT = 2
 ALLOW_COMPLEX_DEFAULT = False
-SIZE_DEFAULT = 35
 SHOW_HELP_TEXT_DEFAULT = True
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex', 'size', 'show-help-text']
+    optional_attribs = ['weight', 'label', 'comparison', 'rtol', 'atol', 'digits', 'allow-complex', 'show-help-text']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
 
@@ -75,7 +74,6 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'shortinfo': shortinfo,
-            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
             'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
             'uuid': pl.get_uuid()
         }

--- a/elements/pl-number-input/pl-number-input.mustache
+++ b/elements/pl-number-input/pl-number-input.mustache
@@ -25,7 +25,7 @@
               <i class="fa fa-question-circle" aria-hidden="true"></i>
             {{/show_info}}
             {{^show_info}}
-              <span style="display: flex; align-items: center;">
+              <span class="d-flex align-items-center">
             {{/show_info}}
 
             {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}

--- a/elements/pl-string-input/pl-string-input.mustache
+++ b/elements/pl-string-input/pl-string-input.mustache
@@ -16,15 +16,28 @@
             <span class="input-group-text">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control pl-string-input-input" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{{raw_submitted_answer}}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{placeholder}}" />
+        <input name="{{name}}" type="text" class="form-control pl-string-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{{raw_submitted_answer}}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{placeholder}}" />
         <span class="input-group-append">
-            {{#suffix}}<span class="input-group-text">{{suffix}}</span>{{/suffix}}
-            <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="String" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+            {{#suffix}}<span class="input-group-text {{^show_info}}rounded-right{{/show_info}}">{{suffix}}</span>{{/suffix}}
+
+            {{#show_info}}
+                <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="String" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
-                {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
-                {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
-                {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
-            </a>
+            {{/show_info}}
+            {{^show_info}}
+                <span style="display: flex; align-items: center;">
+            {{/show_info}}
+            
+            {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
+            {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
+            {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+
+            {{#show_info}}
+                </a>
+            {{/show_info}}
+            {{^show_info}}
+                </span>
+            {{/show_info}}
         </span>
     </span>
 {{#inline}}</span>{{/inline}}

--- a/elements/pl-string-input/pl-string-input.mustache
+++ b/elements/pl-string-input/pl-string-input.mustache
@@ -25,7 +25,7 @@
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
             {{/show_info}}
             {{^show_info}}
-                <span style="display: flex; align-items: center;">
+                <span class="d-flex align-items-center">
             {{/show_info}}
             
             {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -16,12 +16,14 @@ REMOVE_SPACES_DEFAULT = False
 PLACEHOLDER_DEFAULT = None
 ALLOW_BLANK_DEFAULT = False
 IGNORE_CASE_DEFAULT = False
+SIZE_DEFAULT = 35
+SHOW_HELP_TEXT_DEFAULT = True
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank', 'ignore-case', 'placeholder']
+    optional_attribs = ['weight', 'correct-answer', 'label', 'suffix', 'display', 'remove-leading-trailing', 'remove-spaces', 'allow-blank', 'ignore-case', 'placeholder', 'size', 'show-help-text']
     pl.check_attribs(element, required_attribs, optional_attribs)
 
     name = pl.get_string_attrib(element, 'answers-name')
@@ -75,6 +77,8 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'placeholder': placeholder,
+            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
+            'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
             'uuid': pl.get_uuid()
         }
 
@@ -92,6 +96,8 @@ def render(element_html, data):
             except Exception:
                 raise ValueError('invalid score' + score)
 
+        html_params['display_append_span'] = html_params['show_info'] or suffix
+            
         if display == 'inline':
             html_params['inline'] = True
         elif display == 'block':

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -97,7 +97,7 @@ def render(element_html, data):
                 raise ValueError('invalid score' + score)
 
         html_params['display_append_span'] = html_params['show_info'] or suffix
-            
+
         if display == 'inline':
             html_params['inline'] = True
         elif display == 'block':

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -16,7 +16,7 @@
             <span class="input-group-text">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" />
+        <input name="{{name}}" type="text" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{shortinfo}}"{{/show_placeholder}} />
         <span class="input-group-append">
 
             {{#show_info}}

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -16,14 +16,27 @@
             <span class="input-group-text">{{label}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control pl-symbolic-input-input" size="35" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" />
+        <input name="{{name}}" type="text" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" />
         <span class="input-group-append">
+
+            {{#show_info}}
             <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
-                <i class="fa fa-question-circle" aria-hidden="true"></i>
-                {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
-                {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
-                {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+            <i class="fa fa-question-circle" aria-hidden="true"></i>
+            {{/show_info}}
+            {{^show_info}}
+            <span style="display: flex; align-items: center;">
+            {{/show_info}}
+            
+            {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
+            {{#partial}}&nbsp;<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
+            {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+
+            {{#show_info}}
             </a>
+            {{/show_info}}
+            {{^show_info}}
+            </span>
+            {{/show_info}}
         </span>
     </span>
 {{#inline}}</span>{{/inline}}

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -15,6 +15,8 @@ LABEL_DEFAULT = None
 DISPLAY_DEFAULT = 'inline'
 ALLOW_COMPLEX_DEFAULT = False
 IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT = 'i'
+SIZE_DEFAULT = 35
+SHOW_HELP_TEXT_DEFAULT = True
 
 
 def get_variables_list(variables_string):
@@ -28,7 +30,7 @@ def get_variables_list(variables_string):
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'correct-answer', 'variables', 'label', 'display', 'allow-complex', 'imaginary-unit-for-display']
+    optional_attribs = ['weight', 'correct-answer', 'variables', 'label', 'display', 'allow-complex', 'imaginary-unit-for-display', 'size', 'show-help-text']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -81,6 +83,8 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'shortinfo': shortinfo,
+            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
+            'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
             'uuid': pl.get_uuid(),
             'allow_complex': allow_complex,
         }

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -17,7 +17,7 @@ ALLOW_COMPLEX_DEFAULT = False
 IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT = 'i'
 SIZE_DEFAULT = 35
 SHOW_HELP_TEXT_DEFAULT = True
-PLACEHOLDER_TEXT_THRESHOLD = 15 # Minimum size to show the placeholder text
+PLACEHOLDER_TEXT_THRESHOLD = 15  # Minimum size to show the placeholder text
 
 
 def get_variables_list(variables_string):
@@ -56,7 +56,7 @@ def render(element_html, data):
     allow_complex = pl.get_boolean_attrib(element, 'allow-complex', ALLOW_COMPLEX_DEFAULT)
     imaginary_unit = pl.get_string_attrib(element, 'imaginary-unit-for-display', IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT)
     size = pl.get_integer_attrib(element, 'size', SIZE_DEFAULT)
-    
+
     operators = ['cos', 'sin', 'tan', 'exp', 'log', 'sqrt', '( )', '+', '-', '*', '/', '^', '**']
     constants = ['pi', 'e']
 

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -17,6 +17,7 @@ ALLOW_COMPLEX_DEFAULT = False
 IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT = 'i'
 SIZE_DEFAULT = 35
 SHOW_HELP_TEXT_DEFAULT = True
+PLACEHOLDER_TEXT_THRESHOLD = 15 # Minimum size to show the placeholder text
 
 
 def get_variables_list(variables_string):
@@ -54,7 +55,8 @@ def render(element_html, data):
     display = pl.get_string_attrib(element, 'display', DISPLAY_DEFAULT)
     allow_complex = pl.get_boolean_attrib(element, 'allow-complex', ALLOW_COMPLEX_DEFAULT)
     imaginary_unit = pl.get_string_attrib(element, 'imaginary-unit-for-display', IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT)
-
+    size = pl.get_integer_attrib(element, 'size', SIZE_DEFAULT)
+    
     operators = ['cos', 'sin', 'tan', 'exp', 'log', 'sqrt', '( )', '+', '-', '*', '/', '^', '**']
     constants = ['pi', 'e']
 
@@ -83,10 +85,11 @@ def render(element_html, data):
             'editable': editable,
             'info': info,
             'shortinfo': shortinfo,
-            'size': pl.get_integer_attrib(element, 'size', SIZE_DEFAULT),
+            'size': size,
             'show_info': pl.get_boolean_attrib(element, 'show-help-text', SHOW_HELP_TEXT_DEFAULT),
             'uuid': pl.get_uuid(),
             'allow_complex': allow_complex,
+            'show_placeholder': size >= PLACEHOLDER_TEXT_THRESHOLD
         }
 
         partial_score = data['partial_scores'].get(name, {'score': None})

--- a/exampleCourse/questions/elementIntegerInput/question.html
+++ b/exampleCourse/questions/elementIntegerInput/question.html
@@ -36,3 +36,23 @@
     <pl-integer-input answers-name="c_3" display="block" weight = "4"></pl-integer-input>
   </div>
 </div>
+
+<div class="card my-2">
+  <div class="card-body">
+    <pl-question-panel>
+      <p> Within this variant, the different display options for <a href="http://prairielearn.readthedocs.io/en/latest/elements/#pl-integer-input-element"><code>pl-integer-input</code></a>  on the page are displayed. Specifically, this question uses the block option (<code>display="block"</code>) to display the input field on its own line instead of being inline with the question. Moreover, the weight for answering this question is higher than its predecessors.</p>
+      <p> Solve for the value of $c$ given $c = {{params.a}} + {{params.b}}$ </p>
+    </pl-question-panel>
+    <pl-integer-input answers-name="c_4" display="block" weight = "4"></pl-integer-input>
+  </div>
+</div>
+
+<div class="card my-2">
+  <div class="card-body">
+      <pl-question-panel>
+          <p> The size of the input box can be set with the attribute <code>size</code>, and the attribute <code>show-help-text="false"</code> removes the button for the help popup.  This box below has <code>size=5</code> instead of the default <code>size=35</code>. </p>
+      <p> Solve for the value of $c$ given $c = {{params.a}} + {{params.b}}$ </p>
+    </pl-question-panel>
+    <pl-integer-input answers-name="c_5" size="5" show-help-text="false"></pl-integer-input>
+  </div>
+</div>

--- a/exampleCourse/questions/elementIntegerInput/server.py
+++ b/exampleCourse/questions/elementIntegerInput/server.py
@@ -17,3 +17,5 @@ def generate(data):
     data["correct_answers"]["c_1"] = c
     data["correct_answers"]["c_2"] = c
     data["correct_answers"]["c_3"] = c
+    data["correct_answers"]["c_4"] = c
+    data["correct_answers"]["c_5"] = c

--- a/exampleCourse/questions/elementStringInput/question.html
+++ b/exampleCourse/questions/elementStringInput/question.html
@@ -72,11 +72,25 @@ that you will not receive the <code>Invalid</code> feedback (and hence the quest
 This will autoconvert both the student answer and the correct answer to lower case.  Entering the string below with any choice of uppercase and lowercase letters will yield the correct answer as a result. </p>
 
 <pl-code language="python">
-  "{{params.e}}"
+"{{params.e}}"
 </pl-code>
 </pl-question-panel>
   
 <p>
 <pl-string-input answers-name="ans6" label="Input box is case insensitive = " ignore-case="true">
 </pl-string-input>
+</p>
+
+<pl-question-panel>
+    <p>
+        7) The size of the input box can be set with the attribute <code>size</code>, and the attribute <code>show-help-text="false"</code> removes the button for the help popup.  This box below has <code>size=5</code> instead of the default <code>size=35</code>.
+    </p>
+
+<pl-code language="python">
+"{{params.f}}"
+</pl-code>
+</pl-question-panel>
+
+<p>
+    <pl-string-input answers-name="ans7" label="Small box = " show-help-text="false" size="5"></pl-string-input>
 </p>

--- a/exampleCourse/questions/elementStringInput/server.py
+++ b/exampleCourse/questions/elementStringInput/server.py
@@ -15,11 +15,14 @@ def generate(data):
     d = ''.join(str(e) for e in list1)
     e = 'cAsE iNsEnSiTiVe'
 
+    f = 'small'
+
     data["params"]["a"] = a
     data["params"]["b"] = b
     data["params"]["c"] = c
     data["params"]["d"] = d
     data["params"]["e"] = e
+    data["params"]["f"] = f
     data["params"]["stringname"] = stringname
 
     data["correct_answers"]["ans1"] = a*stringname
@@ -28,3 +31,4 @@ def generate(data):
     data["correct_answers"]["ans4"] = d
     data["correct_answers"]["ans5"] = "blank"
     data["correct_answers"]["ans6"] = e
+    data["correct_answers"]["ans7"] = f

--- a/exampleCourse/questions/elementStringInput/server.py
+++ b/exampleCourse/questions/elementStringInput/server.py
@@ -14,7 +14,6 @@ def generate(data):
 
     d = ''.join(str(e) for e in list1)
     e = 'cAsE iNsEnSiTiVe'
-
     f = 'small'
 
     data["params"]["a"] = a

--- a/exampleCourse/questions/elementSymbolicInput/question.html
+++ b/exampleCourse/questions/elementSymbolicInput/question.html
@@ -45,3 +45,16 @@
         <pl-symbolic-input answers-name="c" variables="a, b" allow-complex="true" imaginary-unit-for-display="j" label="$c=$"></pl-symbolic-input>
     </div>
 </div>
+
+<div class="card my-2">
+    <div class="card-header">
+        An example in which we change display attributes
+    </div>
+    <div class="card-body">
+        <pl-question-panel>
+            <p>The size of the input box can be set with the attribute <code>size</code>, and the attribute <code>show-help-text="false"</code> removes the button for the help popup.  This box below has <code>size=5</code> instead of the default <code>size=35</code>.</p>
+            <p>Write an expression for the first derivative of $\frac{1}{2} x^2$.</p>
+        </pl-question-panel>
+        <pl-symbolic-input answers-name="dx" variables="x" size="5" show-help-text="false" label="$\dfrac{d}{dx} \frac{1}{2}x^2 =$"></pl-symbolic-input>
+    </div>
+</div>

--- a/exampleCourse/questions/elementSymbolicInput/server.py
+++ b/exampleCourse/questions/elementSymbolicInput/server.py
@@ -10,3 +10,4 @@ def generate(data):
     data['correct_answers']['z'] = pl.to_json(z)
     data['correct_answers']['I'] = 'V / R'
     data['correct_answers']['c'] = pl.to_json(c)
+    data['correct_answers']['dx'] = 'x'


### PR DESCRIPTION
Adds `size` and `show-help-text` for:

- `pl-string-input`
- `pl-integer-input`
- `pl-symbolic-input`

Add `show-help-text` for:
- `pl-matrix-input` (this is a block element)

Fixes #2218 