### PR TITLE
Fix exam overview "Grade" button spacing

### DIFF
--- a/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs
+++ b/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs
@@ -229,12 +229,12 @@
               <input type="hidden" name="__action" value="grade">
               <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
               <% if (savedAnswers > 0) { %>
-                <button type="submit" class="btn btn-info">Grade <%= savedAnswers %> saved answer<% if (savedAnswers != 1) { %>s<% } %></button>
+                <button type="submit" class="btn btn-info my-2">Grade <%= savedAnswers %> saved answer<% if (savedAnswers != 1) { %>s<% } %></button>
               <% } else { %>
-                <button type="submit" class="btn btn-info disabled" disabled>No saved answers to grade</button>
+                <button type="submit" class="btn btn-info my-2 disabled" disabled>No saved answers to grade</button>
               <% } %>
             </form>
-            <ul>
+            <ul class="my-1">
               <li>Submit your answer to each question with the <strong>Save & Grade</strong> or <strong>Save only</strong> buttons on the question page.</li>
               <li>Look at <strong>Best submission</strong> to confirm that each question has been graded. Questions with <strong>Available points</strong> can be attempted again for more points. Attempting questions again will never reduce the points you already have.</li>
               <% if (authz_result.mode == 'SEB' || authz_result.password != null) { %>
@@ -247,7 +247,7 @@
               <% } %>
             </ul>
           <% } else { %>
-            <ul>
+            <ul class="my-1">
               <li>Submit your answer to each question with the <strong>Save</strong> button on the question page.</li>
               <% if (authz_result.mode == 'SEB' || authz_result.password != null) { %>
                 <li>


### PR DESCRIPTION
Fix #2207. Spaced according to personal preference. Can alter if requested.

(Also the default bullet padding seems a bit much here, but I didn't change it for now).

`if allow_real_time_grading:`

<img src="https://user-images.githubusercontent.com/2503508/77486039-b0959280-6dfc-11ea-911a-e7eae404e485.png" width="300"/>

`else:`

<img src="https://user-images.githubusercontent.com/2503508/77486134-e63a7b80-6dfc-11ea-8e0b-0974985de9da.png" width="300"/>