### PR TITLE
Fix countdown timer bar colors

### DIFF
--- a/pages/partials/countdown.ejs
+++ b/pages/partials/countdown.ejs
@@ -68,13 +68,13 @@ process) in milliseconds as the variable "serverRemainingMS".
       countdownProgressBar.css('width', perc + '%');
       if (remainingSec >= 180) {
           countdownDisplay.text(remainingMin + ' min');
-          countdownProgressBar.attr('class', 'progress-bar progress-bar-primary');
+          countdownProgressBar.attr('class', 'progress-bar bg-primary');
       } else if (remainingSec >= 60) {
           countdownDisplay.text(remainingMin + ' min');
-          countdownProgressBar.attr('class', 'progress-bar progress-bar-warning');
+          countdownProgressBar.attr('class', 'progress-bar bg-warning');
       } else {
           countdownDisplay.text(remainingSec + ' sec');
-          countdownProgressBar.attr('class', 'progress-bar progress-bar-danger');
+          countdownProgressBar.attr('class', 'progress-bar bg-danger');
       }
 
       if (remainingMS > 500) {


### PR DESCRIPTION
Fixes #2246. Noticed the cause when I was digging around `countdown.ejs` for 2215.

<img src="https://user-images.githubusercontent.com/2503508/77610121-d6e82a80-6eef-11ea-9b8a-f15ee111ff22.png" width="240"/>
(yellow does work, no screenshot)