### PR TITLE
Add support for server-side live-reloading

### DIFF
--- a/doc/installingLocal.md
+++ b/doc/installingLocal.md
@@ -27,6 +27,12 @@ By default, PrairieLearn will load `exampleCourse`, `testCourse`, and any course
 docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn
 ```
 
+By default, PrairieLearn does not monitor for server-side changes, so it will **not** automatically restart the node server when you change the node source. To enable automatic live-reloading of server-side changes, use the `-e` flag to set the `NODEMON=true` environment variable:
+
+```sh
+docker run -it --rm -p 3000:3000 -e NODEMON=true -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn
+```
+
 ### Running a Specific Branch
 
 By default, the above command will run PrairieLearn from the `master` branch on GitHub.  If you would like to run a different branch (to test it, for example), the branch name can be appended to the end of the image name as such:
@@ -53,13 +59,17 @@ docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairiel
 
 ### Server from shell
 
-When making local changes to server-side code, it is faster to restart only the node server instead of the whole docker container.  This can be done by starting the server manually from a shell instance, then restarting the server when changes are made.
+When making local changes to server-side code, it is faster to restart only the node server instead of the whole docker container. This can be done either
+
+* automatically by using the `-e NODEMON=true` setting as described earlier,
+
+* or manually by starting the server from a shell instance:
 
 ```sh
 /PrairieLearn/docker/init.sh
 ```
 
-Then when any modifications are made, you can close the server with `<ctrl-C>` and re-run the init script.
+and when any modifications are made, you can close the server with `<ctrl-C>` and re-run the init script.
 
 ### Tests from shell
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,7 +14,7 @@ else
     # Uncomment to start redis to test message passing
     # redis-server --daemonize yes
 
-    if [[ -n $NODEMON ]] && [[ $NODEMON == "true" ]]; then
+    if [[ $NODEMON == "true" ]]; then
         npm run start-nodemon
     else
         npm start

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     },
     "scripts": {
         "start": "node server.js",
-        "start-nodemon": "node_modules/nodemon/bin/nodemon.js -L server.js",
+        "start-nodemon": "npx nodemon -L server.js",
         "test": "nyc --reporter=lcov mocha tests/index.js",
         "test-nocoverage": "mocha tests/index.js",
         "lint-js": "eslint --ext js \"**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     },
     "scripts": {
         "start": "node server.js",
-        "start-nodemon": "nodemon server.js",
+        "start-nodemon": "node_modules/nodemon/bin/nodemon.js -L server.js",
         "test": "nyc --reporter=lcov mocha tests/index.js",
         "test-nocoverage": "mocha tests/index.js",
         "lint-js": "eslint --ext js \"**/*.js\"",


### PR DESCRIPTION
There were already fragments of `nodemon` lying around, but this PR makes it actually usable:

* [x] Add/fix `nodemon` support: `-e NODEMON=true`
* [x] Add docker command to docs
* [x] Clarify that live-reload is not default in PL (I guess I've been spoiled by React and assumed that live-reload was a given in node)

```
$ docker run -it --rm -p 3000:3000 -e NODEMON=true -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn
```
```
waiting for server to start.... done
server started

> PrairieLearn@3.2.0 start-nodemon /PrairieLearn
> node_modules/nodemon/bin/nodemon.js -L server.js

[nodemon] 2.0.2
[nodemon] to restart at any time, enter `rs`
[nodemon] watching dir(s): *.*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node server.js`
info: PrairieLearn server start
info: Running migration 167_assessments__require_honor_code__add.sql
info: Not using Redis for message passing
info: External grader running locally
info: PrairieLearn server ready, press Control-C to quit
info: Go to http://localhost:3000/pl
[nodemon] restarting due to changes...      <----- auto detect+restart when source changes
[nodemon] starting `node server.js`
info: PrairieLearn server start
info: Not using Redis for message passing
info: External grader running locally
info: PrairieLearn server ready, press Control-C to quit
info: Go to http://localhost:3000/pl
```