### PR TITLE
Fix logger.error() calls without a string argument

### DIFF
--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -648,6 +648,17 @@ function foo(p, callback) {
 
 * Note that the [async-stacktrace library](https://github.com/Pita/async-stacktrace) `ERR` function will throw an exception if not provided with a callback, so in cases where there is no callback (e.g., in `cron/index.js`) we should call it with `ERR(err, function() {})`.
 
+* If we are in a function that does not have an active callback (perhaps we already called it) then we should log errors with the following pattern. Note that the first string argument to `logger.error()` is mandatory.
+
+```javascript
+function foo(p) {
+    bar(p, function(err, result) {
+        if (ERR(err, e => logger.error('Error in bar()', e);
+        ...
+    });
+}
+```
+
 * Don't call a `callback` function inside a try block, especially if there is also a `callback` call in the catch handler. Otherwise exceptions thrown much later will show up incorrectly as a double-callback or just in the wrong place. For example:
 
 ```javascript
@@ -736,6 +747,17 @@ router.post('/', function(req, res, next) {
 ```
 
 * The `res.locals.__csrf_token` variable is set and checked by early-stage middleware, so no explicit action is needed on each page.
+
+
+## Logging errors
+
+* We use [Winston](https://github.com/winstonjs/winston) for logging to the console and to files. To use this, require `lib/logger` and call `logger.info()`, `logger.error()`, etc.
+
+* To show a message on the console, use `logger.info()`.
+
+* To log just to the log files, but not to the console, use `logger.verbose()`.
+
+* All `logger` functions have a mandatory first argument that is a string, and an optional second argument that is an object containing useful information. It is important to always provide a string as the first argument.
 
 
 ## Coding style

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -648,7 +648,7 @@ function foo(p, callback) {
 
 * Note that the [async-stacktrace library](https://github.com/Pita/async-stacktrace) `ERR` function will throw an exception if not provided with a callback, so in cases where there is no callback (e.g., in `cron/index.js`) we should call it with `ERR(err, function() {})`.
 
-* If we are in a function that does not have an active callback (perhaps we already called it) then we should log errors with the following pattern. Note that the first string argument to `logger.error()` is mandatory.
+* If we are in a function that does not have an active callback (perhaps we already called it) then we should log errors with the following pattern. Note that the first string argument to `logger.error()` is mandatory. Failure to provide a string argument will result in `error: undefined` being logged to the console.
 
 ```javascript
 function foo(p) {

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -85,7 +85,7 @@ class Editor {
                     no_job_sequence_update: true,
                 };
                 serverJobs.createJob(jobOptions, (err, job) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in createJob()', e))) {
                         _finishWithFailure();
                         return;
                     }
@@ -93,7 +93,7 @@ class Editor {
                     const lockName = 'coursedir:' + options.courseDir;
                     job.verbose(`Trying lock ${lockName}`);
                     namedLocks.waitLock(lockName, {timeout: 5000}, (err, lock) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in waitLock()', e))) {
                             job.fail(err);
                         } else if (lock == null) {
                             job.verbose(`Did not acquire lock ${lockName}`);
@@ -162,13 +162,13 @@ class Editor {
                     no_job_sequence_update: true,
                 };
                 serverJobs.createJob(jobOptions, (err, job) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in createJob()', e))) {
                         _finishWithFailure();
                         return;
                     }
 
                     this.write((err) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in write()', e))) {
                             job.fail(err);
                         } else {
                             job.succeed();
@@ -244,7 +244,7 @@ class Editor {
             const _updateCommitHash = () => {
                 debug(`${job_sequence_id}: _updateCommitHash`);
                 courseUtil.updateCourseCommitHash(this.course, (err) => {
-                    ERR(err, (e) => logger.error(e));
+                    ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
                     _syncFromDisk();
                 });
             };
@@ -263,12 +263,12 @@ class Editor {
                     no_job_sequence_update: true,
                 };
                 serverJobs.createJob(jobOptions, (err, job) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in createJob()', e))) {
                         _finishWithFailure();
                         return;
                     }
                     syncFromDisk._syncDiskToSqlWithLock(this.course.path, this.course.id, job, (err) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in _syncDiskToSqlWithLock()', e))) {
                             debug('_syncDiskToSqlWithLock(): failure');
                             job.fail(err);
                         } else {
@@ -293,13 +293,13 @@ class Editor {
                     no_job_sequence_update: true,
                 };
                 serverJobs.createJob(jobOptions, (err, job) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in createJob()', e))) {
                         _finishWithFailure();
                         return;
                     }
                     const coursePath = this.course.path;
                     requireFrontend.undefQuestionServers(coursePath, job, (err) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in undefQuestionServers()', e))) {
                             job.fail(err);
                         } else {
                             job.succeed();
@@ -340,13 +340,13 @@ class Editor {
                     no_job_sequence_update: true,
                 };
                 serverJobs.createJob(jobOptions, (err, job) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in createJob()', e))) {
                         _finishWithFailure();
                         return;
                     }
 
                     namedLocks.releaseLock(courseLock, (err) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in releaseLock()', e))) {
                             job.fail(err);
                         } else {
                             job.verbose(`Released lock`);
@@ -368,7 +368,7 @@ class Editor {
                     last_in_sequence: true,
                 };
                 serverJobs.createJob(jobOptions, (err, job) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in createJob()', e))) {
                         _finishWithFailure();
                         return;
                     }

--- a/middlewares/authnToken.js
+++ b/middlewares/authnToken.js
@@ -46,7 +46,7 @@ module.exports = (req, res, next) => {
                 token_id: result.rows[0].token_id,
             };
             sqldb.query(sql.update_token_last_used, lastUsedParams, (err) => {
-                if (ERR(err, (e) => logger.error('Error in update_token_last_used', e)));
+                if (ERR(err, (e) => logger.error('Error in sql.update_token_last_used', e)));
             });
         }
     });

--- a/middlewares/authnToken.js
+++ b/middlewares/authnToken.js
@@ -46,7 +46,7 @@ module.exports = (req, res, next) => {
                 token_id: result.rows[0].token_id,
             };
             sqldb.query(sql.update_token_last_used, lastUsedParams, (err) => {
-                if (ERR(err, (e) => logger.error(e)));
+                if (ERR(err, (e) => logger.error('Error in update_token_last_used', e)));
             });
         }
     });

--- a/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
+++ b/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
@@ -44,7 +44,7 @@ router.post('/', function(req, res, next) {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     debug(`Get assessment_id from uuid=${editor.uuid} with course_instance_id=${res.locals.course_instance.id}`);
@@ -63,7 +63,7 @@ router.post('/', function(req, res, next) {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     res.redirect(res.locals.urlPrefix + '/instance_admin/assessments');
@@ -92,7 +92,7 @@ router.post('/', function(req, res, next) {
             editor.canEdit((err) => {
                 if (ERR(err, next)) return;
                 editor.doEdit((err, job_sequence_id) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                         res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                     } else {
                         res.redirect(req.originalUrl);

--- a/pages/instructorAssessments/instructorAssessments.js
+++ b/pages/instructorAssessments/instructorAssessments.js
@@ -125,7 +125,7 @@ router.post('/', (req, res, next) => {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     debug(`Get assessment_id from uuid=${editor.uuid} with course_instance_id=${res.locals.course_instance.id}`);

--- a/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
+++ b/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
@@ -57,7 +57,7 @@ router.post('/', (req, res, next) => {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     debug(`Get course_instance_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`);

--- a/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
+++ b/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
@@ -51,7 +51,7 @@ router.post('/', (req, res, next) => {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     res.redirect(req.originalUrl);

--- a/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -355,7 +355,7 @@ router.post('/*', function(req, res, next) {
             editor.canEdit((err) => {
                 if (ERR(err, next)) return;
                 editor.doEdit((err, job_sequence_id) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                         res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                     } else {
                         res.redirect(req.originalUrl);
@@ -391,7 +391,7 @@ router.post('/*', function(req, res, next) {
                 editor.canEdit((err) => {
                     if (ERR(err, next)) return;
                     editor.doEdit((err, job_sequence_id) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                             res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                         } else {
                             if (req.body.was_viewing_file) {
@@ -433,7 +433,7 @@ router.post('/*', function(req, res, next) {
                 editor.canEdit((err) => {
                     if (ERR(err, next)) return;
                     editor.doEdit((err, job_sequence_id) => {
-                        if (ERR(err, (e) => logger.error(e))) {
+                        if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                             res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                         } else {
                             res.redirect(req.originalUrl);

--- a/pages/instructorFileEditor/instructorFileEditor.js
+++ b/pages/instructorFileEditor/instructorFileEditor.js
@@ -663,7 +663,7 @@ function saveAndSync(fileEdit, locals, callback) {
         const _pullFromRemoteHash = () => {
             debug(`${job_sequence_id}: _pullFromRemoteHash`);
             courseUtil.updateCourseCommitHash(locals.course, (err) => {
-                ERR(err, (e) => logger.error(e));
+                ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
                 _checkHash();
             });
         };
@@ -885,7 +885,7 @@ function saveAndSync(fileEdit, locals, callback) {
         const _updateCommitHash = () => {
             debug(`${job_sequence_id}: _updateCommitHash`);
             courseUtil.updateCourseCommitHash(locals.course, (err) => {
-                ERR(err, (e) => logger.error(e));
+                ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
                 if (fileEdit.needToSync) {
                     _syncFromDisk();
                 } else {

--- a/pages/instructorFileTransfer/instructorFileTransfer.js
+++ b/pages/instructorFileTransfer/instructorFileTransfer.js
@@ -55,7 +55,7 @@ router.get('/:file_transfer_id', function(req, res, next) {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     debug(`Soft-delete file transfer`);

--- a/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
+++ b/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
@@ -44,7 +44,7 @@ router.post('/', function(req, res, next) {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     debug(`Get course_instance_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`);
@@ -63,7 +63,7 @@ router.post('/', function(req, res, next) {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     res.redirect(`${res.locals.plainUrlPrefix}/course/${res.locals.course.id}/course_admin`);
@@ -91,7 +91,7 @@ router.post('/', function(req, res, next) {
             editor.canEdit((err) => {
                 if (ERR(err, next)) return;
                 editor.doEdit((err, job_sequence_id) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                         res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                     } else {
                         res.redirect(req.originalUrl);

--- a/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -57,7 +57,7 @@ router.post('/', function(req, res, next) {
             editor.canEdit((err) => {
                 if (ERR(err, next)) return;
                 editor.doEdit((err, job_sequence_id) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                         res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                     } else {
                         res.redirect(req.originalUrl);
@@ -75,7 +75,7 @@ router.post('/', function(req, res, next) {
             editor.canEdit((err) => {
                 if (ERR(err, next)) return;
                 editor.doEdit((err, job_sequence_id) => {
-                    if (ERR(err, (e) => logger.error(e))) {
+                    if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                         res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                     } else {
                         debug(`Get question_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`);
@@ -126,7 +126,7 @@ router.post('/', function(req, res, next) {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     res.redirect(res.locals.urlPrefix + '/course_admin/questions');

--- a/pages/instructorQuestions/instructorQuestions.js
+++ b/pages/instructorQuestions/instructorQuestions.js
@@ -72,7 +72,7 @@ router.post('/', (req, res, next) => {
         editor.canEdit((err) => {
             if (ERR(err, next)) return;
             editor.doEdit((err, job_sequence_id) => {
-                if (ERR(err, (e) => logger.error(e))) {
+                if (ERR(err, (e) => logger.error('Error in doEdit()', e))) {
                     res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
                 } else {
                     debug(`Get question_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`);

--- a/pages/shared/syncHelpers.js
+++ b/pages/shared/syncHelpers.js
@@ -104,7 +104,7 @@ module.exports.pullAndUpdate = function(locals, callback) {
         // to load and store the current commit hash in the database
         const syncStage2 = () => {
             courseUtil.updateCourseCommitHash(locals.course, (err) => {
-                ERR(err, (e) => logger.error(e));
+                ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
                 syncStage3();
             });
         };

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -845,7 +845,7 @@ module.exports = {
                 cache.get(cacheKey, (err, cachedData) => {
                     // We don't actually want to fail if the cache has an error; we'll
                     // just render the panel as normal
-                    ERR(err, (e) => logger.error(e));
+                    ERR(err, (e) => logger.error('Error in cache.get()', e));
                     if (!err && cachedData !== null) {
                         const {
                             courseIssues,
@@ -870,7 +870,7 @@ module.exports = {
                     // If for some reason we failed to get a cache key, don't
                     // actually fail the request, just skip the cache entirely
                     // and render as usual
-                    ERR(err, e => logger.error(e));
+                    ERR(err, e => logger.error('Error in _getCacheKey()', e));
                     if (err || !cacheKey) {
                         doRender(null);
                     } else {

--- a/tools/external-grading-load-test/main.js
+++ b/tools/external-grading-load-test/main.js
@@ -96,8 +96,7 @@ async.series([
                 return next(null);
             });
             request.on('error', (err) => {
-                logger.error(`Error submitting job ${n}!`);
-                logger.error(err);
+                logger.error(`Error submitting job ${n}!`, err);
                 return next(err);
             });
         }, (err) => {
@@ -157,7 +156,7 @@ async.series([
     },
 
 ], (err) => {
-    ERR(err, (err) => logger.error(err));
+    ERR(err, (err) => logger.error('Error', err));
 
     async.series([
         // Tear down all the buckets we created so as not to leave extra files

--- a/tools/external-grading-load-test/main.js
+++ b/tools/external-grading-load-test/main.js
@@ -96,7 +96,7 @@ async.series([
                 return next(null);
             });
             request.on('error', (err) => {
-                logger.error(`Error submitting job ${n}!`, err);
+                logger.error(`Error submitting job ${n}`, err);
                 return next(err);
             });
         }, (err) => {

--- a/webhooks/grading/grading.js
+++ b/webhooks/grading/grading.js
@@ -36,7 +36,7 @@ router.post('/', function(req, res, next) {
         };
 
         sqldb.queryOneRow(sql.update_grading_received_time, params, (err, _result) => {
-            if (ERR(err, (err) => logger.error(err))) return;
+            if (ERR(err, (err) => logger.error('Error in update_grading_received_time', err))) return;
             externalGradingSocket.gradingJobStatusUpdated(jobId);
         });
 
@@ -94,18 +94,17 @@ router.post('/', function(req, res, next) {
                         ResponseContentType: 'application/json',
                     };
                     new AWS.S3().getObject(params, (err, s3Data) => {
-                        if (ERR(err, (err) => logger.error(err))) return;
+                        if (ERR(err, (err) => logger.error('Error in AWS.S3().getObject()', err))) return;
                         processResults(jobId, s3Data.Body);
                         callback(null);
                     });
                 }
             },
         ], (err) => {
-            if (ERR(err, (err) => logger.error(err))) return;
+            if (ERR(err, (err) => logger.error('Error in processing grading result', err))) return;
         });
     } else {
-        logger.error('Invalid grading event received:');
-        logger.error(data);
+        logger.error('Invalid grading event received:', data);
         return next(new Error(`Unknown grading event: ${data.event}`));
     }
 });

--- a/webhooks/grading/grading.js
+++ b/webhooks/grading/grading.js
@@ -36,7 +36,7 @@ router.post('/', function(req, res, next) {
         };
 
         sqldb.queryOneRow(sql.update_grading_received_time, params, (err, _result) => {
-            if (ERR(err, (err) => logger.error('Error in update_grading_received_time', err))) return;
+            if (ERR(err, (err) => logger.error('Error in sql.update_grading_received_time', err))) return;
             externalGradingSocket.gradingJobStatusUpdated(jobId);
         });
 


### PR DESCRIPTION
Calls to `logger.error()` must have a string as the first argument to log correctly. This PR fixes all the calls that were missing this.