### PR TITLE
Fix locals for externally-graded question panels

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -189,3 +189,12 @@ config.loadConfig = function(file) {
         logger.warn(file + ' not found, using default configuration');
     }
 };
+
+config.setLocals = (locals) => {
+    locals.homeUrl = config.homeUrl;
+    locals.urlPrefix = config.urlPrefix;
+    locals.plainUrlPrefix = config.urlPrefix;
+    locals.navbarType = 'plain';
+    locals.devMode = config.devMode;
+    locals.is_administrator = false;
+};

--- a/lib/question.js
+++ b/lib/question.js
@@ -1400,9 +1400,10 @@ module.exports = {
             };
 
             // Fake locals. Yay!
-            const locals = this._buildQuestionUrls(urlPrefix, variant, question, instance_question, assessment);
+            const locals = {};
+            config.setLocals(locals);
+            _.assign(locals, this._buildQuestionUrls(urlPrefix, variant, question, instance_question, assessment));
             _.assign(locals, this._buildLocals(variant, question, instance_question, assessment, assessment_instance));
-            locals.urlPrefix = urlPrefix;
 
             async.parallel([
                 (callback) => {

--- a/server.js
+++ b/server.js
@@ -97,11 +97,7 @@ app.set('trust proxy', 'loopback');
 
 config.devMode = (app.get('env') == 'development');
 
-app.use(function(req, res, next) {res.locals.homeUrl = config.homeUrl; next();});
-app.use(function(req, res, next) {res.locals.urlPrefix = res.locals.plainUrlPrefix = config.urlPrefix; next();});
-app.use(function(req, res, next) {res.locals.navbarType = 'plain'; next();});
-app.use(function(req, res, next) {res.locals.devMode = config.devMode; next();});
-app.use(function(req, res, next) {res.locals.is_administrator = false; next();});
+app.use(function(req, res, next) {config.setLocals(res.locals); next();});
 
 if (config.hasAzure) {
     var OIDCStrategy = require('passport-azure-ad').OIDCStrategy;


### PR DESCRIPTION
When we render the new question panels for externally graded results, we
have been triggered by the grading results queue and so we are not
inside a request. This means we don't have `res.locals`, but rendering
assumes we have it, so we construct a fake `locals` object that has all
the same info. We had missed `locals.devMode`, which was subtly changing
the caching behavior in dev. To fix this, and hopefully ensure we keep
the real locals and fake locals the same in the future, this PR adds a
helper function to create the base locals object, and makes both normal
requests and the fake locals creator use the helper.