### PR TITLE
Add padding to table rows to match bootstrap card headers

### DIFF
--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -186,10 +186,10 @@ table td > .badge {
 }
 
 /* Used to give table rows the same padding as Bootstrap card headers */
-.card table tr td:first-child, .card table tr th {
+.card table tr td:first-child, .card table tr th:first-child {
     padding-left: 1.25rem;
 }
-.card table tr td:last-child, .card table tr th {
+.card table tr td:last-child, .card table tr th:last-child {
     padding-right: 1.25rem;
 }
 

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -185,6 +185,14 @@ table td > .badge {
   transform: translate(0, -12.5%);
 }
 
+/* Used to give table rows the same padding as Bootstrap card headers */
+.card table tr td:first-child, .card table tr th {
+    padding-left: 1.25rem;
+}
+.card table tr td:last-child, .card table tr th {
+    padding-right: 1.25rem;
+}
+
 /* Custom button styles that look better in input groups */
 .btn.btn-med-light {
   color: #212529;


### PR DESCRIPTION
Fixes #2090. I just copied the values that Bootstrap uses to set horizontal padding in card headers so that the sides of tables are aligned. 

| Before | After |
| ---- | ---- |
| ![pl-tables-before](https://user-images.githubusercontent.com/32315760/77986600-260dd100-72dd-11ea-8eb0-20eaa2f0a831.png) | ![pl-tables-after](https://user-images.githubusercontent.com/32315760/77986609-2b6b1b80-72dd-11ea-9bec-777a601cc4a0.png) |

