### PR TITLE
Remove disabling of the honor code from exam02

### DIFF
--- a/exampleCourse/courseInstances/Sp15/assessments/exam02-realTimeGradingDisabled/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/exam02-realTimeGradingDisabled/infoAssessment.json
@@ -5,7 +5,6 @@
     "set": "Exam",
     "number": "2",
     "allowRealTimeGrading": false,
-    "requireHonorCode": false,
     "allowAccess": [
         {
             "role": "TA",


### PR DESCRIPTION
I will properly convert exam02 later when I have time (#2286), but it's probably best to remove `"requireHonorCode": false` first.