### PR TITLE
Escape special HTML characters in code snippets

### DIFF
--- a/exampleCourse/questions/elementCode/question.html
+++ b/exampleCourse/questions/elementCode/question.html
@@ -1,12 +1,11 @@
 <pl-question-panel>
-<markdown>Questions below were designed to showcase the different features of 
+<markdown>Questions below were designed to showcase the different features of
 [`pl-code`](http://prairielearn.readthedocs.io/en/latest/elements/#pl-code-element). 
  The goal of [`pl-code`](http://prairielearn.readthedocs.io/en/latest/elements/#pl-code-element)
 is to display different programming languages with appropriate syntax highlighting and code line emphasis.
 </markdown>
 </pl-question-panel>
 
-      
 <div class="card my-2">
 <div class="card-body">
 <pl-question-panel>
@@ -19,7 +18,22 @@ python with `language="python"`.
 def square(x):
     return x * x
 </pl-code>
-</pl-question-panel>                
+</pl-question-panel>
+</div>
+</div>
+
+<div class="card my-2">
+<div class="card-body">
+<pl-question-panel>
+<p> Any special HTML characters (&lt;, &gt;, etc.) will be automatically escaped for you when using inline code. </p>
+<pl-code language="cpp">
+void loop() {
+    for (int i = 0; i < 10; i++) {
+        std::cout << i << std::endl;
+    }
+}
+</pl-code>
+</pl-question-panel>
 </div>
 </div>
 
@@ -42,7 +56,7 @@ def square(x):
 def bar(x):
     return 'bar'
 </pl-code>
-</pl-question-panel>                
+</pl-question-panel>
 </div>
 </div>
 

--- a/exampleCourse/questions/elementMarkdown/question.html
+++ b/exampleCourse/questions/elementMarkdown/question.html
@@ -50,7 +50,7 @@ class Example {
     }
 
     Example(std::string name) {
-        stc::cout << "Hello, " << name << std::endl;
+        std::cout << "Hello, " << name << std::endl;
     }
 };
 ```


### PR DESCRIPTION
Special characters (<, >, etc.) will be automatically escaped when enclosed in `<pl-code>` or `<code>` tags.  Fixes #1098.


The following

```
<p> Any special HTML characters (&lt;, &gt;, etc.) will be automatically escaped for you when using inline code. </p>
<pl-code language="cpp">
void loop() {
    for (int i = 0; i < 10; i++) {
        std::cout << i << std::endl;
    }
}
</pl-code>
```

will get rendered as:

![image](https://user-images.githubusercontent.com/1790491/78394781-e3d0e200-75b1-11ea-83cc-3a2551a24731.png)
