### PR TITLE
Improve Docker ag error message

### DIFF
--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -97,10 +97,8 @@ class Grader {
                     },
                     Entrypoint: question.external_grading_entrypoint.split(' '),
                 }, (err, container) => {
-                    if (ERR(err, () => {})) {
-                        err.message = `Unable to launch Docker container for grading: ${err.message}`;
-                        return callback(err);
-                    }
+                    if (err) err.message = `Unable to launch Docker container for grading: ${err.message}`;
+                    if (ERR(err, callback)) return;
                     callback(null, container);
                 });
             },

--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -97,7 +97,10 @@ class Grader {
                     },
                     Entrypoint: question.external_grading_entrypoint.split(' '),
                 }, (err, container) => {
-                    if (ERR(err, callback)) return;
+                    if (ERR(err, () => {})) {
+                        err.message = `Unable to launch Docker container for grading: ${err.message}`;
+                        callback(err);
+                    }
                     callback(null, container);
                 });
             },

--- a/lib/externalGraderLocal.js
+++ b/lib/externalGraderLocal.js
@@ -99,7 +99,7 @@ class Grader {
                 }, (err, container) => {
                     if (ERR(err, () => {})) {
                         err.message = `Unable to launch Docker container for grading: ${err.message}`;
-                        callback(err);
+                        return callback(err);
                     }
                     callback(null, container);
                 });


### PR DESCRIPTION
Tried this patch based on suggestions in Slack, but looks like I'm not getting the custom error message. Not sure if it's the wrong location or just implemented incorrectly.

```
$ docker run -it --rm -p 3000:3000 -v C:\Users\Tim\PL\pl_ag_jobs:/jobs -e HOST_JOBS_DIR=C:\Users\Tim\PL\pl_ag_jobs -v /var/run/docker.sock:/var/run/docker.sock -v C:\Users\Tim\PL\PrairieLearn:/PrairieLearn prairielearn/prairielearn

...

info: docker pull output:  {"status":"Pulling from prairielearn/grader-python","id":"latest"}
info: docker pull output:  {"status":"Digest: sha256:cd80c016363207c7c956effbe35080ae0779e0fc13e961fd4b35fce8545f5c8f"}
info: docker pull output:  {"status":"Status: Image is up to date for prairielearn/grader-python:latest"}
error: Error processing external grading job 1
error: handleGraderErrorUnable to launch Docker container for grading: (HTTP code 500) server error - invalid mode: /grade  {"reason":"server error","statusCode":500,"json":{"message":"invalid mode: /grade"},"stack":"Async Stacktrace:\n    at /PrairieLearn/lib/externalGraderLocal.js:100:25\n\nError: (HTTP code 500) server error - invalid mode: /grade \n    at /PrairieLearn/node_modules/docker-modem/lib/modem.js:295:17\n    at getCause (/PrairieLearn/node_modules/docker-modem/lib/modem.js:325:7)\n    at Modem.buildPayload (/PrairieLearn/node_modul
es/docker-modem/lib/modem.js:294:5)\n    at IncomingMessage.<anonymous> (/PrairieLearn/node_modules/docker-modem/lib/modem.js:269:14)\n
 at IncomingMessage.emit (events.js:323:22)\n    at IncomingMessage.EventEmitter.emit (domain.js:482:12)\n    at endReadableNT (_stream_re
adable.js:1204:12)\n    at processTicksAndRejections (internal/process/task_queues.js:84:21)"}
/PrairieLearn/node_modules/async/dist/async.js:318
            if (fn === null) throw new Error("Callback was already called.");
                             ^

Error: Callback was already called.
    at /PrairieLearn/node_modules/async/dist/async.js:318:36
    at /PrairieLearn/lib/externalGraderLocal.js:104:21
    at /PrairieLearn/node_modules/dockerode/lib/docker.js:73:23
    at /PrairieLearn/node_modules/docker-modem/lib/modem.js:303:7
    at getCause (/PrairieLearn/node_modules/docker-modem/lib/modem.js:325:7)
    at Modem.buildPayload (/PrairieLearn/node_modules/docker-modem/lib/modem.js:294:5)
    at IncomingMessage.<anonymous> (/PrairieLearn/node_modules/docker-modem/lib/modem.js:269:14)
    at IncomingMessage.emit (events.js:323:22)
    at IncomingMessage.EventEmitter.emit (domain.js:482:12)
    at endReadableNT (_stream_readable.js:1204:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```