### PR TITLE
Fix unaligned matrix input

### DIFF
--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -389,7 +389,7 @@ def createTableForHTMLDisplay(m, n, name, label, data, format):
 
     if format == 'output-invalid':
 
-        display_array = '<table class="table-no-row-padding">'
+        display_array = '<table>'
         display_array += '<tr>'
         display_array += '<td class="close-left" rowspan="' + str(m) + '"></td>'
         display_array += '<td style="width:4px" rowspan="' + str(m) + '"></td>'
@@ -439,7 +439,7 @@ def createTableForHTMLDisplay(m, n, name, label, data, format):
         else:
             score_message = ''
 
-        display_array = '<table class="table-no-row-padding">'
+        display_array = '<table>'
         display_array += '<tr>'
         # Add the prefix
         if label is not None:
@@ -484,7 +484,7 @@ def createTableForHTMLDisplay(m, n, name, label, data, format):
         display_array += '</table>'
 
     elif format == 'input':
-        display_array = '<table class="table-no-row-padding">'
+        display_array = '<table>'
         display_array += '<tr>'
         # Add first row
         display_array += '<td class="close-left" rowspan="' + str(m) + '"></td>'

--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -389,7 +389,7 @@ def createTableForHTMLDisplay(m, n, name, label, data, format):
 
     if format == 'output-invalid':
 
-        display_array = '<table>'
+        display_array = '<table class="table-no-row-padding">'
         display_array += '<tr>'
         display_array += '<td class="close-left" rowspan="' + str(m) + '"></td>'
         display_array += '<td style="width:4px" rowspan="' + str(m) + '"></td>'
@@ -439,7 +439,7 @@ def createTableForHTMLDisplay(m, n, name, label, data, format):
         else:
             score_message = ''
 
-        display_array = '<table>'
+        display_array = '<table class="table-no-row-padding">'
         display_array += '<tr>'
         # Add the prefix
         if label is not None:
@@ -484,7 +484,7 @@ def createTableForHTMLDisplay(m, n, name, label, data, format):
         display_array += '</table>'
 
     elif format == 'input':
-        display_array = '<table>'
+        display_array = '<table class="table-no-row-padding">'
         display_array += '<tr>'
         # Add first row
         display_array += '<td class="close-left" rowspan="' + str(m) + '"></td>'

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -186,10 +186,16 @@ table td > .badge {
 }
 
 /* Used to give table rows the same padding as Bootstrap card headers */
-.card table:not(.table-no-row-padding) tr td:first-child, .card table:not(.table-no-row-padding) tr th:first-child {
+.card > table tr td:first-child,
+.card > table tr th:first-child,
+.card .table-responsive > table tr td:first-child,
+.card .table-responsive > table tr th:first-child {
     padding-left: 1.25rem;
 }
-.card table:not(.table-no-row-padding) tr td:last-child, .card table:not(.table-no-row-padding) tr th:last-child {
+.card > table tr td:last-child,
+.card > table tr th:last-child,
+.card .table-responsive > table tr td:last-child,
+.card .table-responsive > table tr th:last-child {
     padding-right: 1.25rem;
 }
 

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -186,16 +186,12 @@ table td > .badge {
 }
 
 /* Used to give table rows the same padding as Bootstrap card headers */
-.card > table tr td:first-child,
-.card > table tr th:first-child,
-.card .table-responsive > table tr td:first-child,
-.card .table-responsive > table tr th:first-child {
+.card > table tr td:first-child, .card > table tr th:first-child,
+.card .table-responsive > table tr td:first-child, .card .table-responsive > table tr th:first-child {
     padding-left: 1.25rem;
 }
-.card > table tr td:last-child,
-.card > table tr th:last-child,
-.card .table-responsive > table tr td:last-child,
-.card .table-responsive > table tr th:last-child {
+.card > table tr td:last-child, .card > table tr th:last-child,
+.card .table-responsive > table tr td:last-child, .card .table-responsive > table tr th:last-child {
     padding-right: 1.25rem;
 }
 

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -187,11 +187,11 @@ table td > .badge {
 
 /* Used to give table rows the same padding as Bootstrap card headers */
 .card > table tr td:first-child, .card > table tr th:first-child,
-.card .table-responsive > table tr td:first-child, .card .table-responsive > table tr th:first-child {
+.card > .table-responsive > table tr td:first-child, .card > .table-responsive > table tr th:first-child {
     padding-left: 1.25rem;
 }
 .card > table tr td:last-child, .card > table tr th:last-child,
-.card .table-responsive > table tr td:last-child, .card .table-responsive > table tr th:last-child {
+.card > .table-responsive > table tr td:last-child, .card > .table-responsive > table tr th:last-child {
     padding-right: 1.25rem;
 }
 

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -186,10 +186,10 @@ table td > .badge {
 }
 
 /* Used to give table rows the same padding as Bootstrap card headers */
-.card table tr td:first-child, .card table tr th:first-child {
+.card table:not(.table-no-row-padding) tr td:first-child, .card table:not(.table-no-row-padding) tr th:first-child {
     padding-left: 1.25rem;
 }
-.card table tr td:last-child, .card table tr th:last-child {
+.card table:not(.table-no-row-padding) tr td:last-child, .card table:not(.table-no-row-padding) tr th:last-child {
     padding-right: 1.25rem;
 }
 

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -186,12 +186,16 @@ table td > .badge {
 }
 
 /* Used to give table rows the same padding as Bootstrap card headers */
-.card > table tr td:first-child, .card > table tr th:first-child,
-.card > .table-responsive > table tr td:first-child, .card > .table-responsive > table tr th:first-child {
+.card > table tr td:first-child,
+.card > table tr th:first-child,
+.card > .table-responsive > table tr td:first-child,
+.card > .table-responsive > table tr th:first-child {
     padding-left: 1.25rem;
 }
-.card > table tr td:last-child, .card > table tr th:last-child,
-.card > .table-responsive > table tr td:last-child, .card > .table-responsive > table tr th:last-child {
+.card > table tr td:last-child,
+.card > table tr th:last-child,
+.card > .table-responsive > table tr td:last-child,
+.card > .table-responsive > table tr th:last-child {
     padding-right: 1.25rem;
 }
 


### PR DESCRIPTION
Closes #2352.

Before:
<img width="419" alt="Screen Shot 2020-04-06 at 11 00 03 AM" src="https://user-images.githubusercontent.com/1790491/78581323-5da6dc80-77f9-11ea-950e-cc50c52b3cbf.png">

After:
<img width="350" alt="Screen Shot 2020-04-06 at 11 23 56 AM" src="https://user-images.githubusercontent.com/1790491/78581330-60a1cd00-77f9-11ea-83ef-f997af84e08e.png">

Recent changes to table padding are shifting entries in the matrix input, so created a `.table-no-row-padding` class and applied it to the component input to turn off the padding.