### PR TITLE
Fix const redeclaration race condition in beforeunload script

### DIFF
--- a/pages/partials/questionFooter.ejs
+++ b/pages/partials/questionFooter.ejs
@@ -119,11 +119,11 @@
 <% } %>
 
 <script>
-    const form = $('form.question-form');
-    const getForm = () => form.serialize();
-
     // Wait for DOM (ace, file upload, etc.)
     $(document).ready(() => {
+        const form = $('form.question-form');
+        const getForm = () => form.serialize();
+
         // Set form state on load and submit
         var initialForm = getForm();
         form.submit(() => {


### PR DESCRIPTION
When I spam save/grade enough times on an autograded question, the console eventually spits out a const redeclaration error. I could only reproduce on autograded questions, so not sure if it's due to websockets or just coincidence. I was hoping this would also deal with #2234 but no dice (another fix incoming for that). Still, this issue should be addressed as well.

```
SyntaxError: redeclaration of const form [preview:1:1]
    <anonymous> (index):1
    jQuery 7
    fetchResults (index):1106
    onack (index):312
    onpacket (index):236
    exports index.js:21
    emit index.js:133
    ondecoded (index):332
    exports index.js:21
    emit index.js:134
    add index.js:246
    ondata (index):322
    exports index.js:21
    emit index.js:133
    onPacket socket.js:451
    setTransport socket.js:268
    emit index.js:133
    onPacket transport.js:145
    onData transport.js:137
    onmessage websocket.js:146
```