### PR TITLE
Allow loading of dependencies per-question

### DIFF
--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -2,6 +2,7 @@ columns
     client_files: text[] default ARRAY[]::text[]
     course_id: bigint not null
     deleted_at: timestamp with time zone
+    dependencies: jsonb default '{}'::jsonb
     directory: text
     external_grading_enable_networking: boolean
     external_grading_enabled: boolean default false

--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -2,7 +2,7 @@ columns
     client_files: text[] default ARRAY[]::text[]
     course_id: bigint not null
     deleted_at: timestamp with time zone
-    dependencies: jsonb default '{}'::jsonb
+    dependencies: jsonb not null default '{}'::jsonb
     directory: text
     external_grading_enable_networking: boolean
     external_grading_enabled: boolean default false

--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -153,7 +153,7 @@ Property | Description
 `elementStyles` | The styles required by this element relative to the element's directory, which is either `[PrairieLearn directory]/elements/this-element-name` or `[course directory]/elements/this-element-name`.
 `elementScripts` | The scripts required by this element relative to the element's directory, which is either `[PrairieLearn directory]/elements/this-element-name` or `[course directory]/elements/this-element-name`.
 `clientFilesCourseStyles` | The styles required by this element relative to `[course directory]/clientFilesCourse`. *(Note: This property is only available for elements hosted in a specific course's directory, not system-wide PrairieLearn elements.)*
-`clientFilesCourseStyles` | The styles required by this element relative to `[course directory]/clientFilesCourse`. *(Note: This property is only available for elements hosted in a specific course's directory, not system-wide PrairieLearn elements.)*
+`clientFilesCourseScripts` | The scripts required by this element relative to `[course directory]/clientFilesCourse`. *(Note: This property is only available for elements hosted in a specific course's directory, not system-wide PrairieLearn elements.)*
 
 You can also find the types of dependencies defined in these schema files:
 

--- a/docs/question.md
+++ b/docs/question.md
@@ -62,8 +62,52 @@ Property | Type | Description
 `singleVariant` | boolean | Whether the question is not randomized and only generates a single variant. (Optional; default: `false`)
 `partialCredit` | boolean | Whether the question will give partial points for fractional scores. (Optional; default: `true`)
 `externalGradingOptions` | object | Options for externally graded questions. See the [external grading docs](externalGrading.md). (Optional; default: none)
+`dependencies` | object | External JavaScript or CSS dependencies to load.  See below.  (Optional; default: `{}`)
 
 For details see the [format specification for question `info.json`](https://github.com/PrairieLearn/PrairieLearn/blob/master/schemas/schemas/infoQuestion.json)
+
+### Question Dependencies
+
+Your quesition can load client-side assets such as scripts or stylesheets from different sources.  A full list of dependencies will be compiled based on the question's needs and any dependencies needed by page elements, then they will be de-duped and loaded onto the page.
+
+These dependencies are specified in the `info.json` file, and can be configured as follows:
+
+```json
+{
+    [ ... ]
+    "dependencies": {
+        "coreScripts": [
+            "d3.min.js"
+        ],
+        "nodeModulesScripts": [
+            "three/build/three.min.js"
+        ],
+        "clientFilesQuestionScripts": [
+            "my-question-script.js"
+        ],
+        "clientFilesQuestionStyles": [
+            "my-question-style.css"
+        ],
+        "clientFilesCourseStyles": [
+            "courseStylesheet1.css",
+            "courseStylesheet2.css"
+        ]
+    }
+}
+```
+
+The different types of dependency properties available are summarized in this table:
+
+Property | Description
+--- | ---
+`coreStyles` |  The styles required by this question, relative to `[PrairieLearn directory]/public/stylesheets`.
+`coreScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/public/javascripts`.
+`nodeModulesStyles` | The styles required by this question, relative to `[PrairieLearn directory]/node_modules`.
+`nodeModulesScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/node_modules`.
+`clientFilesQuestionStyles` | The scripts required by this question relative to the question's `clientFilesQuestion` directory.
+`clientFilesQuestionScripts` | The scripts required by this question relative to the question's `clientFilesQuestion` directory.
+`clientFilesCourseStyles` | The styles required by this question relative to `[course directory]/clientFilesCourse`.
+`clientFilesCourseScripts` | The scripts required by this question relative to `[course directory]/clientFilesCourse`. 
 
 ## Question `question.html`
 

--- a/docs/question.md
+++ b/docs/question.md
@@ -74,7 +74,6 @@ These dependencies are specified in the `info.json` file, and can be configured 
 
 ```json
 {
-    [ ... ]
     "dependencies": {
         "coreScripts": [
             "d3.min.js"

--- a/docs/question.md
+++ b/docs/question.md
@@ -68,7 +68,7 @@ For details see the [format specification for question `info.json`](https://gith
 
 ### Question Dependencies
 
-Your quesition can load client-side assets such as scripts or stylesheets from different sources.  A full list of dependencies will be compiled based on the question's needs and any dependencies needed by page elements, then they will be de-duped and loaded onto the page.
+Your question can load client-side assets such as scripts or stylesheets from different sources.  A full list of dependencies will be compiled based on the question's needs and any dependencies needed by page elements, then they will be de-duped and loaded onto the page.
 
 These dependencies are specified in the `info.json` file, and can be configured as follows:
 

--- a/exampleCourse/questions/demoCustomStylingScripts/clientFilesQuestion/script.js
+++ b/exampleCourse/questions/demoCustomStylingScripts/clientFilesQuestion/script.js
@@ -1,0 +1,4 @@
+$(document).ready(() => {
+    $("#demo-span").text("Hello, world! " +
+                         "The contents of this span are set using a JS script.");
+});

--- a/exampleCourse/questions/demoCustomStylingScripts/clientFilesQuestion/style.css
+++ b/exampleCourse/questions/demoCustomStylingScripts/clientFilesQuestion/style.css
@@ -1,0 +1,4 @@
+#demo-span {
+    text-shadow: 5px 5px 10px;
+    color: purple;
+}

--- a/exampleCourse/questions/demoCustomStylingScripts/info.json
+++ b/exampleCourse/questions/demoCustomStylingScripts/info.json
@@ -1,0 +1,11 @@
+{
+    "uuid": "41027D6D-016A-4202-9F09-3F7997391E8E",
+    "title": "Demo: Custom question styles and scripts",
+    "topic": "Test",
+    "type": "v3",
+    "tags": ["Sp20", "nnytko2", "v3"],
+    "dependencies": {
+        "clientFilesQuestionStyles": [ "style.css" ],
+        "clientFilesQuestionScripts": [ "script.js" ]
+    }
+}

--- a/exampleCourse/questions/demoCustomStylingScripts/question.html
+++ b/exampleCourse/questions/demoCustomStylingScripts/question.html
@@ -11,9 +11,9 @@ The dependencies for this example are given by:
 }
 ```
     </markdown>
-    CSS:
+    CSS (<code>style.css</code>):
     <pl-code source-file-name="clientFilesQuestion/style.css" language="css"></pl-code>
-    JavaScript:
+    JavaScript (<code>script.js</code>):
     <pl-code source-file-name="clientFilesQuestion/script.js" language="js"></pl-code
     <br><br>
     <p>

--- a/exampleCourse/questions/demoCustomStylingScripts/question.html
+++ b/exampleCourse/questions/demoCustomStylingScripts/question.html
@@ -1,0 +1,23 @@
+<div class="card my-2">
+  <div class="card-body">
+    <markdown>
+ Similarly to elements, questions can pull in external CSS and JavaScript dependencies by listing them in the `dependencies` table in the question's `info.json`.  Questions can pull an almost identical list of dependencies as elements can, except `elementStyles` and `elementScripts` are replaced with `clientFilesQuestionStyles` and `clientFilesQuestionScripts`, respectively.
+
+The dependencies for this example are given by:
+```js
+"dependencies": {
+    "clientFilesQuestionStyles": [ "style.css" ],
+    "clientFilesQuestionScripts": [ "script.js" ]
+}
+```
+    </markdown>
+    CSS:
+    <pl-code source-file-name="clientFilesQuestion/style.css" language="css"></pl-code>
+    JavaScript:
+    <pl-code source-file-name="clientFilesQuestion/script.js" language="js"></pl-code
+    <br><br>
+    <p>
+      <span id="demo-span"></span>
+    </p>
+  </div>
+</div>

--- a/migrations/170_questions__client_dependencies__add.sql
+++ b/migrations/170_questions__client_dependencies__add.sql
@@ -1,1 +1,1 @@
-ALTER TABLE questions ADD COLUMN dependencies jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE questions ADD COLUMN dependencies jsonb NOT NULL DEFAULT '{}'::jsonb;

--- a/migrations/170_questions__client_dependencies__add.sql
+++ b/migrations/170_questions__client_dependencies__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN dependencies jsonb DEFAULT '{}'::jsonb;

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -106,7 +106,7 @@ module.exports = {
                             // TODO remove once everyone is using the new version
                             if (elementType === 'core') {
                                 elements[elementName.replace(/-/g, '_')] = info;
-                                
+
                                 if ('additionalNames' in info) {
                                     info.additionalNames.forEach(name => {
                                         elements[name] = info;
@@ -961,7 +961,18 @@ module.exports = {
                             courseElementScripts: [],
                             clientFilesCourseStyles: [],
                             clientFilesCourseScripts: [],
+                            clientFilesQuestionStyles: [],
+                            clientFilesQuestionScripts: [],
                         };
+
+                        /* Question dependencies are checked via schema on sync-time, so there's no need for sanity checks here. */
+                        for (let type in question.dependencies) {
+                            for (let dep of question.dependencies[type]) {
+                                if (!_.includes(dependencies[type], dep)) {
+                                    dependencies[type].push(dep);
+                                }
+                            }
+                        }
 
                         // Gather dependencies for all rendered elements
                         allRenderedElementNames.forEach((elementName) => {
@@ -1039,6 +1050,8 @@ module.exports = {
                         dependencies.nodeModulesScripts.forEach((file) => coreScriptUrls.push(`/node_modules/${file}`));
                         dependencies.clientFilesCourseStyles.forEach((file) => styleUrls.push(`${locals.urlPrefix}/clientFilesCourse/${file}`));
                         dependencies.clientFilesCourseScripts.forEach((file) => scriptUrls.push(`${locals.urlPrefix}/clientFilesCourse/${file}`));
+                        dependencies.clientFilesQuestionStyles.forEach((file) => styleUrls.push(`${locals.clientFilesQuestionUrl}/${file}`));
+                        dependencies.clientFilesQuestionScripts.forEach((file) => scriptUrls.push(`${locals.clientFilesQuestionUrl}/${file}`));
                         dependencies.coreElementStyles.forEach((file) => styleUrls.push(`/pl/static/elements/${file}`));
                         dependencies.coreElementScripts.forEach((file) => scriptUrls.push(`/pl/static/elements/${file}`));
                         dependencies.courseElementStyles.forEach((file) => styleUrls.push(`${locals.urlPrefix}/elements/${file}`));

--- a/schemas/schemas/infoQuestion.json
+++ b/schemas/schemas/infoQuestion.json
@@ -130,6 +130,77 @@
                     "type": "boolean"
                 }
             }
+        },
+        "dependencies": {
+            "description": "The question's client-side dependencies.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coreStyles": {
+                    "description": "The styles required by this question from /public/stylesheets.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .css file located in /public/stylesheets.",
+                        "type": "string"
+                    }
+                },
+                "coreScripts": {
+                    "description": "The scripts required by this question from /public/javascripts.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .js file located in /public/javascripts.",
+                        "type": "string"
+                    }
+                },
+                "nodeModulesStyles": {
+                    "description": "The styles required by this question from /node_modules.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .css file located in /node_modules.",
+                        "type": "string"
+                    }
+                },
+                "nodeModulesScripts": {
+                    "description": "The scripts required by this question from /node_modules.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .js file located in /node_modules.",
+                        "type": "string"
+                    }
+                },
+                "clientFilesCourseStyles": {
+                    "description": "The styles required by this question from clientFilesCourse.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .css file located in clientFilesCourse.",
+                        "type": "string"
+                    }
+                },
+                "clientFilesCourseScripts": {
+                    "description": "The styles required by this question from clientFilesCourse.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .js file located in clientFilesCourse.",
+                        "type": "string"
+                    }
+                },
+                "clientFilesQuestionStyles": {
+                    "description": "The styles required by this question from clientFilesQuestion.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .css file located in the clientFilesQuestion.",
+                        "type": "string"
+                    }
+                },
+                "clientFilesQuestionScripts": {
+                    "description": "The scripts required by this question from clientFilesQuestion.",
+                    "type": "array",
+                    "items": {
+                        "description": "A .js file located in the clientFilesQuestion.",
+                        "type": "string"
+                    }
+                }
+            }
         }
     }
 }

--- a/sprocs/sync_questions.sql
+++ b/sprocs/sync_questions.sql
@@ -35,7 +35,8 @@ BEGIN
             external_grading_files,
             external_grading_entrypoint,
             external_grading_timeout,
-            external_grading_enable_networking
+            external_grading_enable_networking,
+            dependencies
         ) SELECT
             (question->>'uuid')::uuid,
             question->>'qid',
@@ -56,7 +57,8 @@ BEGIN
             jsonb_array_to_text_array(question->'external_grading_files'),
             question->>'external_grading_entrypoint',
             (question->>'external_grading_timeout')::integer,
-            (question->>'external_grading_enable_networking')::boolean
+            (question->>'external_grading_enable_networking')::boolean,
+            (question->>'dependencies')::jsonb
         FROM JSONB_ARRAY_ELEMENTS(sync_questions.new_questions) AS question
         ON CONFLICT (course_id, uuid) DO UPDATE
         SET
@@ -77,7 +79,8 @@ BEGIN
             external_grading_files = EXCLUDED.external_grading_files,
             external_grading_entrypoint = EXCLUDED.external_grading_entrypoint,
             external_grading_timeout = EXCLUDED.external_grading_timeout,
-            external_grading_enable_networking = EXCLUDED.external_grading_enable_networking
+            external_grading_enable_networking = EXCLUDED.external_grading_enable_networking,
+            dependencies = EXCLUDED.dependencies
         WHERE
             questions.course_id = new_course_id
         RETURNING id, qid

--- a/sync/fromDisk/questions.js
+++ b/sync/fromDisk/questions.js
@@ -52,6 +52,7 @@ module.exports.sync = function(courseInfo, questionDB, jobLogger, callback) {
                 external_grading_entrypoint: (q.externalGradingOptions && q.externalGradingOptions.entrypoint),
                 external_grading_timeout: (q.externalGradingOptions && q.externalGradingOptions.timeout),
                 external_grading_enable_networking: (q.externalGradingOptions && q.externalGradingOptions.enableNetworking),
+                dependencies: q.dependencies || {},
             };
         });
 


### PR DESCRIPTION
Resolves #2271 

Questions can now load dependencies from the following:
Property | Description
--- | ---
`coreStyles` |  The styles required by this question, relative to `[PrairieLearn directory]/public/stylesheets`.
`coreScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/public/javascripts`.
`nodeModulesStyles` | The styles required by this question, relative to `[PrairieLearn directory]/node_modules`.
`nodeModulesScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/node_modules`.
`clientFilesQuestionStyles` | The scripts required by this question relative to the question's `clientFilesQuestion` directory.
`clientFilesQuestionScripts` | The scripts required by this question relative to the question's `clientFilesQuestion` directory.
`clientFilesCourseStyles` | The styles required by this question relative to `[course directory]/clientFilesCourse`.
`clientFilesCourseScripts` | The scripts required by this question relative to `[course directory]/clientFilesCourse`. 

Also adds a _beautiful_ new demo question, `demoCustomStylingScripts`:

![image](https://user-images.githubusercontent.com/1790491/79601143-f5d07b80-80ad-11ea-85ce-cba9ad5cb705.png)

