### PR TITLE
Get course_instance_id from res.locals instead of req.params

### DIFF
--- a/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
+++ b/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.load(path.join(__dirname, '..', 'queries.sql'));
 
 router.get('/:assessment_instance_id', (req, res, next) => {
     const params = {
-        course_instance_id: req.params.course_instance_id,
+        course_instance_id: res.locals.course_instance.id,
         assessment_id: null,
         assessment_instance_id: req.params.assessment_instance_id,
     };
@@ -31,7 +31,7 @@ router.get('/:assessment_instance_id', (req, res, next) => {
 
 router.get('/:assessment_instance_id/instance_questions', (req, res, next) => {
     const params = {
-        course_instance_id: req.params.course_instance_id,
+        course_instance_id: res.locals.course_instance.id,
         assessment_instance_id: req.params.assessment_instance_id,
         instance_question_id: null,
     };
@@ -43,7 +43,7 @@ router.get('/:assessment_instance_id/instance_questions', (req, res, next) => {
 
 router.get('/:assessment_instance_id/submissions', (req, res, next) => {
     const params = {
-        course_instance_id: req.params.course_instance_id,
+        course_instance_id: res.locals.course_instance.id,
         assessment_instance_id: req.params.assessment_instance_id,
         submission_id: null,
     };

--- a/api/v1/endpoints/courseInstanceAssessments/index.js
+++ b/api/v1/endpoints/courseInstanceAssessments/index.js
@@ -41,7 +41,7 @@ router.get('/:assessment_id', (req, res, next) => {
 
 router.get('/:assessment_id/assessment_instances', (req, res, next) => {
     const params = {
-        course_instance_id: req.params.course_instance_id,
+        course_instance_id: res.locals.course_instance.id,
         assessment_id: req.params.assessment_id,
         assessment_instance_id: null,
     };

--- a/api/v1/endpoints/courseInstanceGradebook/index.js
+++ b/api/v1/endpoints/courseInstanceGradebook/index.js
@@ -11,7 +11,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 router.get('/', (req, res, next) => {
     const params = {
-        course_instance_id: req.params.course_instance_id,
+        course_instance_id: res.locals.course_instance.id,
     };
     sqldb.queryOneRow(sql.select_user_scores, params, (err, result) => {
         if (ERR(err, next)) return;

--- a/api/v1/endpoints/courseInstanceSubmissions/index.js
+++ b/api/v1/endpoints/courseInstanceSubmissions/index.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.load(path.join(__dirname, '..', 'queries.sql'));
 
 router.get('/:submission_id', (req, res, next) => {
     const params = {
-        course_instance_id: req.params.course_instance_id,
+        course_instance_id: res.locals.course_instance.id,
         assessment_instance_id: null,
         submission_id: req.params.submission_id,
     };


### PR DESCRIPTION
Here's that PR for changing the setting of course_instance_id to come from res.locals.course_instance.id rather than req.params.course_instance_id in the code that implements the API.  I changed index.js in the all the directories under endpoints:
courseInstanceAssessmentInstances
courseInstanceAssessments
courseInstanceGradebook
courseInstanceSubmissions
