### PR TITLE
Fixed typo in git clone command

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@
 Next, clone your forked repository to your local machine and set up the main repository as an "upstream" repository:
 
 ```sh
-git clone git@github.com/$user_name/PrairieLearn.git
+git clone git@github.com:$user_name/PrairieLearn.git
 git remote add upstream git@github.com/PrairieLearn/PrairieLearn.git
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,7 +11,7 @@ Next, clone your forked repository to your local machine and set up the main rep
 
 ```sh
 git clone git@github.com:$user_name/PrairieLearn.git
-git remote add upstream git@github.com/PrairieLearn/PrairieLearn.git
+git remote add upstream git@github.com:PrairieLearn/PrairieLearn.git
 ```
 
 This means that you now have three key repositories to keep track of:


### PR DESCRIPTION
Fixed a little typo in the git clone command on the Contributing page.

Not sure how this wasn't noticed earlier!  Guess others know their git stuff well enough to not have to refer to the docs :smile: .