### PR TITLE
Fixing unclear navbar symbol, text baseline alignment, broken active elements

### DIFF
--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -7,7 +7,7 @@
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <div class="collapse navbar-collapse">
+  <div id="course-nav" class="collapse navbar-collapse">
     <ul class="nav navbar-nav mr-auto" id="main-nav">
         <% if (typeof navbarType == 'undefined' || navbarType == 'plain') { %>
         <%- include('navbarPlain'); %>

--- a/pages/partials/navbarInstructor.ejs
+++ b/pages/partials/navbarInstructor.ejs
@@ -30,8 +30,8 @@
         <!-------------------------------------------------------------------------------->
         <!-- Instance Admin -------------------------------------------------------------->
 
+        <span class="navbar-text mx-2 no-select">/</span>
         <li class="nav-item btn-group">
-            <span class="navbar-text mx-2 no-select">/</span>
             <a class="nav-link <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin" role="button">
                 <%= course_instance.short_name %>
             </a>
@@ -57,8 +57,8 @@
         <li class="nav-item <% if (navPage == "instance_admin" && typeof navSubPage !== 'undefined' && navSubPage == "gradebook") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/instance_admin/gradebook">Gradebook</a></li>
 
         <% if (typeof assessment_label != 'undefined' && typeof assessment != 'undefined') { %>
+            <span class="navbar-text mx-2 no-select">/</span>
             <li class="nav-item btn-group">
-                <span class="navbar-text mx-2 no-select">/</span>
                 <a class="nav-link <% if (navPage == "assessment") { %>active<% } %>" href="<%= urlPrefix %>/assessment/<%= assessment.id %>" role="button">
                     <%= assessment_label %>
                 </a>

--- a/pages/partials/navbarInstructor.ejs
+++ b/pages/partials/navbarInstructor.ejs
@@ -30,8 +30,8 @@
         <!-------------------------------------------------------------------------------->
         <!-- Instance Admin -------------------------------------------------------------->
 
-        <li class="nav-item btn-group <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>">
-            <a class="nav-link" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin" role="button">
+        <li class="nav-item btn-group">
+            <a class="nav-link <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin" role="button">
                 <span class="mr-1">
                     <i class="fas fa-circle"></i>
                 </span>
@@ -59,8 +59,8 @@
         <li class="nav-item <% if (navPage == "instance_admin" && typeof navSubPage !== 'undefined' && navSubPage == "gradebook") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/instance_admin/gradebook">Gradebook</a></li>
 
         <% if (typeof assessment_label != 'undefined' && typeof assessment != 'undefined') { %>
-            <li class="nav-item btn-group <% if (navPage == "assessment") { %>active<% } %>">
-                <a class="nav-link" href="<%= urlPrefix %>/assessment/<%= assessment.id %>" role="button">
+            <li class="nav-item btn-group">
+                <a class="nav-link <% if (navPage == "assessment") { %>active<% } %>" href="<%= urlPrefix %>/assessment/<%= assessment.id %>" role="button">
                     <span class="mr-1">
                         <i class="fas fa-circle"></i>
                     </span>

--- a/pages/partials/navbarInstructor.ejs
+++ b/pages/partials/navbarInstructor.ejs
@@ -30,12 +30,11 @@
         <!-------------------------------------------------------------------------------->
         <!-- Instance Admin -------------------------------------------------------------->
 
-        <span class="navbar-text mx-2">
-            <i class="fas fa-circle"></i>
-        </span>
-
         <li class="nav-item btn-group <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>">
             <a class="nav-link" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin" role="button">
+                <span class="mr-1">
+                    <i class="fas fa-circle"></i>
+                </span>
                 <%= course_instance.short_name %>
             </a>
             <a class="nav-link dropdown-toggle dropdown-toggle-split" href="#" id="navbarDropdownMenuInstanceAdminLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -60,12 +59,11 @@
         <li class="nav-item <% if (navPage == "instance_admin" && typeof navSubPage !== 'undefined' && navSubPage == "gradebook") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/instance_admin/gradebook">Gradebook</a></li>
 
         <% if (typeof assessment_label != 'undefined' && typeof assessment != 'undefined') { %>
-            <span class="navbar-text mx-2">
-                <i class="fas fa-circle"></i>
-            </span>
-
             <li class="nav-item btn-group <% if (navPage == "assessment") { %>active<% } %>">
                 <a class="nav-link" href="<%= urlPrefix %>/assessment/<%= assessment.id %>" role="button">
+                    <span class="mr-1">
+                        <i class="fas fa-circle"></i>
+                    </span>
                     <%= assessment_label %>
                 </a>
                 <a class="nav-link dropdown-toggle dropdown-toggle-split" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -81,12 +79,11 @@
         <% } %>
     <% } else { %>
         <% if (locals.course_instances && course_instances.length > 0) { %>
-            <span class="navbar-text mx-2">
-                <i class="fas fa-circle"></i>
-            </span>
-
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuInstanceChoose" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="mr-1">
+                        <i class="fas fa-circle"></i>
+                    </span>
                     Choose course instance...
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuInstanceChoose">

--- a/pages/partials/navbarInstructor.ejs
+++ b/pages/partials/navbarInstructor.ejs
@@ -2,8 +2,8 @@
     <!-------------------------------------------------------------------------------->
     <!-- Course Admin ---------------------------------------------------------------->
 
-    <li class="nav-item btn-group <% if (navPage == "course_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "issues" || navSubPage == "questions" || navSubPage == "syncs"))) { %>active<% } %>">
-        <a class="nav-link <% if (! authz_data.has_course_permission_view) { %> disabled <% } %>" href="<%= urlPrefix %>/course_admin" role="button">
+    <li class="nav-item btn-group">
+        <a class="nav-link <% if (navPage == "course_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "issues" || navSubPage == "questions" || navSubPage == "syncs"))) { %>active<% } %> <% if (! authz_data.has_course_permission_view) { %> disabled <% } %>" href="<%= urlPrefix %>/course_admin" role="button">
             <%= course.short_name %>
         </a>
         <% if (locals.courses && courses.length > 0) { %>
@@ -31,10 +31,8 @@
         <!-- Instance Admin -------------------------------------------------------------->
 
         <li class="nav-item btn-group">
+            <span class="navbar-text mx-2 no-select">/</span>
             <a class="nav-link <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin" role="button">
-                <span class="mr-1">
-                    <i class="fas fa-circle"></i>
-                </span>
                 <%= course_instance.short_name %>
             </a>
             <a class="nav-link dropdown-toggle dropdown-toggle-split" href="#" id="navbarDropdownMenuInstanceAdminLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -60,10 +58,8 @@
 
         <% if (typeof assessment_label != 'undefined' && typeof assessment != 'undefined') { %>
             <li class="nav-item btn-group">
+                <span class="navbar-text mx-2 no-select">/</span>
                 <a class="nav-link <% if (navPage == "assessment") { %>active<% } %>" href="<%= urlPrefix %>/assessment/<%= assessment.id %>" role="button">
-                    <span class="mr-1">
-                        <i class="fas fa-circle"></i>
-                    </span>
                     <%= assessment_label %>
                 </a>
                 <a class="nav-link dropdown-toggle dropdown-toggle-split" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -79,11 +75,9 @@
         <% } %>
     <% } else { %>
         <% if (locals.course_instances && course_instances.length > 0) { %>
+            <span class="navbar-text mx-2 no-select">/</span>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuInstanceChoose" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="mr-1">
-                        <i class="fas fa-circle"></i>
-                    </span>
                     Choose course instance...
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuInstanceChoose">

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -153,7 +153,7 @@ a.badge {
   text-decoration: none;
 }
 
-.navbar {
+.navbar, #course-nav {
     align-items: baseline;
 }
 

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -157,6 +157,10 @@ a.badge {
     align-items: baseline;
 }
 
+.no-select {
+    user-select: none;
+}
+
 /*****************
  * Brand label ("PrairieLearn" text)
  *****************/

--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -153,6 +153,13 @@ a.badge {
   text-decoration: none;
 }
 
+.navbar {
+    align-items: baseline;
+}
+
+/*****************
+ * Brand label ("PrairieLearn" text)
+ *****************/
 .navbar-brand {
   position: relative;
 }


### PR DESCRIPTION
[Updated 5/12] Fixes #2350 by replacing the circle separators in the instructor navbar with slashes `/` to more clearly communicate their purpose.

|Comparison|
|---|
|Before|
|![image](https://user-images.githubusercontent.com/32315760/81769571-934b7f00-94a3-11ea-9538-1c9c9b31a66a.png)|
|After| 
|![image](https://user-images.githubusercontent.com/32315760/81769543-7e6eeb80-94a3-11ea-92c1-bd24b86dca39.png)|

Some other minor cosmetic changes: 
- If an item in the navbar is active and has a dropdown arrow attached, the dropdown arrow will no longer show itself as active: 
![image](https://user-images.githubusercontent.com/32315760/81769656-c3931d80-94a3-11ea-9126-96dc25652680.png)
(Hard to see, but the arrow isn't white anymore)
- Items in the navbar are now aligned at their baselines, including the "PrairieLearn" brand text. 
![image](https://user-images.githubusercontent.com/32315760/81769685-e0c7ec00-94a3-11ea-81e4-f98213e143a0.png)