### PR TITLE
Add parallel template rendering

### DIFF
--- a/lib/assessmentStatDescriptions.js
+++ b/lib/assessmentStatDescriptions.js
@@ -1,4 +1,4 @@
-var stat_descriptions = {
+module.exports = {
     MEAN_SCORE: {
         title: 'Mean (μ)',
         non_html_title: 'Mean',
@@ -125,9 +125,3 @@ var stat_descriptions = {
         description: 'Quintiles show the average scores on the question for students in the lowest 20% of the class, the next 20%, etc, where the quintiles are determined by total assessment score.',
     },
 };
-
-module.exports = function(req, res, next) {
-  res.locals.stat_descriptions = stat_descriptions;
-  next();
-};
-

--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const fs = require('fs');
+const logger = require('./logger');
+const jsonLoad = require('./json-load');
+const schemas = require('../schemas');
+
+module.exports = {};
+
+module.exports.load = function(config, file) {
+    if (fs.existsSync(file)) {
+        const fileConfig = jsonLoad.readJSONSyncOrDie(file, schemas.serverConfig);
+        _.assign(config, fileConfig);
+    } else {
+        logger.warn(file + ' not found, using default configuration');
+    }
+};
+
+module.exports.setLocals = (config, locals) => {
+    locals.homeUrl = config.homeUrl;
+    locals.urlPrefix = config.urlPrefix;
+    locals.plainUrlPrefix = config.urlPrefix;
+    locals.navbarType = 'plain';
+    locals.devMode = config.devMode;
+    locals.is_administrator = false;
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,4 @@
 const _ = require('lodash');
-const fs = require('fs');
-const logger = require('./logger');
-const jsonLoad = require('./json-load');
-const schemas = require('../schemas');
 
 const config = module.exports;
 
@@ -180,21 +176,3 @@ const azure = {
 };
 
 _.assign(config, azure);
-
-config.loadConfig = function(file) {
-    if (fs.existsSync(file)) {
-        const fileConfig = jsonLoad.readJSONSyncOrDie(file, schemas.serverConfig);
-        _.assign(config, fileConfig);
-    } else {
-        logger.warn(file + ' not found, using default configuration');
-    }
-};
-
-config.setLocals = (locals) => {
-    locals.homeUrl = config.homeUrl;
-    locals.urlPrefix = config.urlPrefix;
-    locals.plainUrlPrefix = config.urlPrefix;
-    locals.navbarType = 'plain';
-    locals.devMode = config.devMode;
-    locals.is_administrator = false;
-};

--- a/lib/question.js
+++ b/lib/question.js
@@ -9,6 +9,7 @@ const QR = require('qrcode-svg');
 const moment = require('moment');
 
 const config = require('./config');
+const configLoader = require('./config-loader');
 const csrf = require('./csrf');
 const externalGrader = require('./externalGrader');
 const logger = require('./logger');
@@ -1401,7 +1402,7 @@ module.exports = {
 
             // Fake locals. Yay!
             const locals = {};
-            config.setLocals(locals);
+            configLoader.setLocals(config, locals);
             _.assign(locals, this._buildQuestionUrls(urlPrefix, variant, question, instance_question, assessment));
             _.assign(locals, this._buildLocals(variant, question, instance_question, assessment, assessment_instance));
 

--- a/middlewares/renderAsync.js
+++ b/middlewares/renderAsync.js
@@ -1,9 +1,10 @@
 const { spawn, Pool, Worker } = require('threads');
 
-const pool = Pool(() => spawn(new Worker("./renderAsyncWorker")));
+const pool = Pool(() => spawn(new Worker('./renderAsyncWorker')));
 
-//await pool.completed()
-//await pool.terminate()
+// FIXME
+// await pool.completed()
+// await pool.terminate()
 
 module.exports = function(req, res, next) {
     res.renderAsync = function(filename, data) {

--- a/middlewares/renderAsync.js
+++ b/middlewares/renderAsync.js
@@ -1,0 +1,21 @@
+const { spawn, Pool, Worker } = require('threads');
+
+const pool = Pool(() => spawn(new Worker("./renderAsyncWorker")));
+
+//await pool.completed()
+//await pool.terminate()
+
+module.exports = function(req, res, next) {
+    res.renderAsync = function(filename, data) {
+        pool.queue(async render => {
+            let str;
+            try {
+                str = await render(filename, data);
+            } catch (err) {
+                return next(err);
+            }
+            res.send(str);
+        });
+    };
+    next();
+};

--- a/middlewares/renderAsyncWorker.js
+++ b/middlewares/renderAsyncWorker.js
@@ -1,0 +1,17 @@
+const ERR = require('async-stacktrace');
+const util = require('util');
+const ejs = require('ejs');
+const { expose } = require('threads/worker');
+
+const renderSync = (filename, locals, callback) => {
+    ejs.renderFile(filename, locals, null, (err, str) => {
+        if (ERR(err, callback)) return;
+        callback(null, str);
+    });
+};
+const renderAsync = util.promisify(renderSync);
+
+expose(async function render(filename, locals) {
+    const str = await renderAsync(filename, locals);
+    return str;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,8 +1252,7 @@
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
         "camelcase": {
             "version": "4.1.0",
@@ -2576,6 +2575,12 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
             "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
             "dev": true
+        },
+        "esm": {
+            "version": "3.2.25",
+            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+            "optional": true
         },
         "espree": {
             "version": "6.1.2",
@@ -4041,6 +4046,14 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+        },
+        "is-observable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+            "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+            "requires": {
+                "symbol-observable": "^1.1.0"
+            }
         },
         "is-path-inside": {
             "version": "1.0.1",
@@ -5777,6 +5790,11 @@
                 "es-abstract": "^1.17.0-next.1"
             }
         },
+        "observable-fns": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.5.1.tgz",
+            "integrity": "sha512-wf7g4Jpo1Wt2KIqZKLGeiuLOEMqpaOZ5gJn7DmSdqXgTdxRwSdBhWegQQpPteQ2gZvzCKqNNpwb853wcpA0j7A=="
+        },
         "on-finished": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -7329,6 +7347,11 @@
                 }
             }
         },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+        },
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7492,6 +7515,18 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "threads": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/threads/-/threads-1.4.0.tgz",
+            "integrity": "sha512-vaKhZODDnciJn4Bjmkd1GbJ2dlzFbzxwcQNM1IZV1bsCXmlJpirSAKsYG7MT7MHgO+qQxTaIn6CMstmlYnGNWw==",
+            "requires": {
+                "callsites": "^3.1.0",
+                "debug": "^4.1.1",
+                "is-observable": "^1.1.0",
+                "observable-fns": "^0.5.1",
+                "tiny-worker": ">= 2"
+            }
+        },
         "three": {
             "version": "0.115.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.115.0.tgz",
@@ -7511,6 +7546,15 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
             "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+        },
+        "tiny-worker": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+            "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+            "optional": true,
+            "requires": {
+                "esm": "^3.2.25"
+            }
         },
         "tmp": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "streamifier": "^0.1.1",
         "supports-color": "^7.1.0",
         "tar": "^6.0.1",
+        "threads": "^1.4.0",
         "three": "^0.115.0",
         "tmp-promise": "^2.0.2",
         "unified": "^9.0.0",

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<%- include('../partials/floatFormatter') %>
 <html>
   <head>
     <%- include('../partials/head'); %>

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -40,7 +40,7 @@ router.get('/', (req, res, next) => {
                     if (ERR(err, next)) return;
                     res.locals.log = result.rows;
 
-                    res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+                    res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
                 });
             });
         });

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
@@ -19,7 +19,7 @@ router.get('/', function(req, res, next) {
         if (ERR(err, next)) return;
         res.locals.user_scores = result.rows;
         debug('render page');
-        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+        res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });
 

--- a/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.ejs
+++ b/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.ejs
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<%- include('../partials/floatFormatter') %>
 <html>
   <head>
     <%- include('../partials/head'); %>

--- a/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
+++ b/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
@@ -9,6 +9,7 @@ const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'
 
 const error = require('@prairielearn/prairielib/error');
 const sanitizeName = require('../../lib/sanitize-name');
+const assessmentStatDescriptions = require('../../lib/assessmentStatDescriptions');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
@@ -22,6 +23,7 @@ const setFilenames = function(locals) {
 router.get('/', function(req, res, next) {
     debug('GET /');
     setFilenames(res.locals);
+    res.locals.stat_descriptions = assessmentStatDescriptions;
     async.series([
         function(callback) {
           var params = {assessment_id: res.locals.assessment.id};
@@ -71,8 +73,8 @@ router.get('/:filename', function(req, res, next) {
             var questionStatsList = result.rows;
             var csvData = [];
             var csvHeaders = ['Course', 'Instance', 'Assessment', 'Question number', 'QID', 'Question title'];
-            Object.keys(res.locals.stat_descriptions).forEach(key => {
-                csvHeaders.push(res.locals.stat_descriptions[key].non_html_title);
+            Object.keys(assessmentStatDescriptions).forEach(key => {
+                csvHeaders.push(assessmentStatDescriptions[key].non_html_title);
             });
 
             csvData.push(csvHeaders);

--- a/pages/instructorGradebook/instructorGradebook.js
+++ b/pages/instructorGradebook/instructorGradebook.js
@@ -28,7 +28,7 @@ router.get('/', function(req, res, next) {
             if (ERR(err, next)) return;
 
             res.locals.user_scores = result.rows;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+            res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });
     });
 });

--- a/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs
+++ b/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<%- include('../partials/floatFormatter') %>
 <html>
   <head>
     <%- include('../partials/head'); %>

--- a/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
+++ b/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
@@ -3,8 +3,6 @@ const _ = require('lodash');
 const express = require('express');
 const router = express.Router();
 const async = require('async');
-const path = require('path');
-const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
 const csvStringify = require('../../lib/nonblocking-csv-stringify');
 const sanitizeName = require('../../lib/sanitize-name');

--- a/pages/instructorQuestions/instructorQuestions.js
+++ b/pages/instructorQuestions/instructorQuestions.js
@@ -58,7 +58,7 @@ router.get('/', function(req, res, next) {
         },
     ], (err) => {
         if (ERR(err, next)) return;
-        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+        res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });
 

--- a/pages/partials/floatFormatter.ejs
+++ b/pages/partials/floatFormatter.ejs
@@ -1,13 +1,10 @@
-
-module.exports = function(req, res, next) {
-    res.locals.formatFloat = function(x, numDecDigits) {
+<%
+    formatFloat = function(x, numDecDigits) {
         if (numDecDigits == null) numDecDigits = 2;
         if (Number.isFinite(x)) {
             return x.toFixed(numDecDigits);
         } else {
             return '—';
         }
-    };
-    next();
-};
-
+    }
+%>

--- a/pages/studentAssessmentExam/studentAssessmentExam.js
+++ b/pages/studentAssessmentExam/studentAssessmentExam.js
@@ -21,7 +21,7 @@ router.get('/', function(req, res, next) {
         sqldb.query(sql.select_single_assessment_instance, params, function(err, result) {
             if (ERR(err, next)) return;
             if (result.rowCount == 0) {
-                res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+                res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
             } else {
                 res.redirect(res.locals.urlPrefix + '/assessment_instance/' + result.rows[0].id);
             }

--- a/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.js
+++ b/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.js
@@ -77,7 +77,7 @@ router.get('/', function(req, res, next) {
                 return sum;
             }, 0);
 
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+            res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });
     });
 });

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
@@ -55,7 +55,7 @@ router.get('/', function(req, res, next) {
                 res.locals.assessment_text_templated = assessment_text_templated;
 
                 debug('rendering EJS');
-                res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+                res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
             });
         });
     });

--- a/pages/studentAssessments/studentAssessments.js
+++ b/pages/studentAssessments/studentAssessments.js
@@ -17,7 +17,7 @@ router.get('/', function(req, res, next) {
     sqldb.query(sql.select_assessments, params, function(err, result) {
         if (ERR(err, next)) return;
         res.locals.rows = result.rows;
-        res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+        res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
     });
 });
 

--- a/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
+++ b/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
@@ -112,7 +112,7 @@ router.get('/', function(req, res, next) {
         if (ERR(err, next)) return;
         logPageView(req, res, (err) => {
             if (ERR(err, next)) return;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+            res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });
     });
 });

--- a/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
+++ b/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
@@ -96,7 +96,7 @@ router.get('/', function(req, res, next) {
         if (ERR(err, next)) return;
         logPageView(req, res, (err) => {
             if (ERR(err, next)) return;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+            res.renderAsync(__filename.replace(/\.js$/, '.ejs'), res.locals);
         });
     });
 });

--- a/tools/load-test.js
+++ b/tools/load-test.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const yargs = require('yargs');
 
 const config = require('../lib/config');
+const configLoader = require('../lib/config-loader');
 const csrf = require('../lib/csrf');
 
 
@@ -56,7 +57,7 @@ const argv = yargs
       .strict()
       .argv;
 
-config.loadConfig(argv.config);
+configLoader.load(config, argv.config);
 
 const exampleCourseName = 'XC 101: Example Course, Spring 2015';
 let questionTitle;

--- a/tools/paths-lookup.js
+++ b/tools/paths-lookup.js
@@ -9,12 +9,13 @@
 const ERR = require('async-stacktrace');
 const { sqldb, sqlLoader } = require('@prairielearn/prairielib');
 const config = require('../lib/config');
+const configLoader = require('../lib/config-loader');
 const logger = require('../lib/logger');
 const readline = require('readline');
 
 var sql = sqlLoader.loadSqlEquiv(__filename);
 
-config.loadConfig('config.json');
+configLoader.load(config, 'config.json');
 
 var pgConfig = {
     user: config.postgresqlUser,


### PR DESCRIPTION
This is a rebased version of #1143, also upgraded to the new version of `threads`.

It allows the use of multi-process EJS template rendering.

Still needs:
[ ] Should we terminate the pool at some point? See `middlewares/renderAsync.js`. This doesn't matter for the live server, but it probably does for tests.