### PR TITLE
Fix namedLocks.tryLock() to return null if lock was not acquired

### DIFF
--- a/lib/named-locks.js
+++ b/lib/named-locks.js
@@ -96,8 +96,8 @@ module.exports._getLock = function(name, options, callback) {
                     (callback) => {
                         sqldb.queryWithClient(client, lock_sql, {name}, (err, result) => {
                             if (ERR(err, callback)) return;
-                            // could not get the lock
-                            if (result.rowCount == 0) return callback(new Error('could not get the lock'));
+                            // could not get the lock, return success with a null lock
+                            if (result.rowCount == 0) return callback(null, null);
                             // got the lock, make a lock object and return it
                             const lock = {client, done};
                             callback(null, lock);


### PR DESCRIPTION
It looks like b190cdc207e248cb6229d32fde5836d3374cac66 broke `tryLock()` by changing the `_getLock()` helper function so that it would return an error when it couldn't get the lock, rather than returning a `null` lock: 

This change did not affect `waitLock()`, because it was checking for a `null` lock and returning an error anyway, so after the change it would still return an error.

However, `tryLock()` was returning the `null` lock rather than raising an error, and the callers of `tryLock()` (especially `cron`, which is what I noticed) were relying on this behavior to tell whether the lock could not be acquired.

This PR restores the earlier behavior of returning `null` when the lock could not be acquired, and only returning actual errors as errors.