### PR TITLE
Change to exit on idle-client-error from DB

### DIFF
--- a/server.js
+++ b/server.js
@@ -880,6 +880,8 @@ if (config.startServer) {
             logger.verbose('Connecting to database ' + pgConfig.user + '@' + pgConfig.host + ':' + pgConfig.database);
             var idleErrorHandler = function(err) {
                 logger.error('idle client error', err);
+                // https://github.com/PrairieLearn/PrairieLearn/issues/2396
+                process.exit(1);
             };
             sqldb.init(pgConfig, idleErrorHandler, function(err) {
                 if (ERR(err, callback)) return;


### PR DESCRIPTION
As a workaround for #2396, this PR makes the server exit with an error code on idle client errors, so that the process supervisor can restart the server.