### PR TITLE
Fix tryLock() to end the transaction if the lock was not acquired

### DIFF
--- a/lib/named-locks.js
+++ b/lib/named-locks.js
@@ -8,15 +8,43 @@ const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
 /*
+ * The functions here all identify locks by "name", which is a plain
+ * string. The locks use the named_locks DB table. Each lock name
+ * corresponds to a unique table row. To take a lock, we:
+ *     1. make sure a row exists for the lock name
+ *     2. start a transaction
+ *     3. acquire a "FOR UPDATE" row lock on the DB row for the named
+ *        lock (this blocks all other locks on the same row). See
+ *        https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS
+ *     4. return to the caller with the transaction held open
+ *
+ * The caller then does some work and finally calls releaseLock(),
+ * which ends the transaction, thereby releasing the row lock.
+ *
+ * The flow above will wait indefinitely for the lock to become
+ * available. To implement optional timeouts, we set the DB variable
+ * `lock_timeout`:
+ * https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT
+ * If we timeout then we will return an error to the caller.
+ *
+ * To implement a no-waiting tryLock() we use the PostgreSQL "SKIP
+ * LOCKED" feature:
+ * https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE
+ * If we fail to acquire the lock then we immediately release the
+ * transaction and return to the caller with `lock = null`. In this
+ * case the caller should not call releaseLock().
+ *
  * The lock object returned by functions in this module are of the
  * form `{client, done}`, where `client` and `done` are sqldb
- * transaction objects.
+ * transaction objects. These are simply the objects we need to end
+ * the transaction, which will release the lock.
  */
 
 /**
  * Try to acquire a lock and either succeed if it's available or
- * return immediately if not. If a lock is acquired then it must
- * later be released by releaseLock().
+ * return immediately if not. If a lock is acquired (not null) then it
+ * must later be released by releaseLock(). If a lock is not acquired
+ * (it is null) then releaseLock() should not be called.
  *
  * @param {string} name - The name of the lock to acquire.
  * @param {function} callback - A callback(err, lock) function. If lock is null then it was not acquired.
@@ -104,13 +132,31 @@ module.exports._getLock = function(name, options, callback) {
                         });
                     },
                 ], (err, lock) => {
+                    // We need to make sure the transaction is going
+                    // to be ended on any code path.
                     if (err) {
+                        // Something went wrong, so we end the
+                        // transaction and return the error.
                         sqldb.endTransaction(client, done, err, (endErr) => {
                             if (ERR(endErr, callback)) return;
                             callback(err);
                         });
                     } else {
-                        callback(null, lock);
+                        if (lock == null) {
+                            // We didn't acquire the lock so our
+                            // parent caller will never release it, so
+                            // we have to end the transaction now.
+                            sqldb.endTransaction(client, done, err, (endErr) => {
+                                if (ERR(endErr, callback)) return;
+                                callback(null, null);
+                            });
+                        } else {
+                            // We successfully acquired the lock, so
+                            // we return with the transaction held
+                            // open. The caller will later call
+                            // releaseLock() to end the transaction.
+                            callback(null, lock);
+                        }
                     }
                 });
             });


### PR DESCRIPTION
It turns out that #2395 did not completely fix the tryLock() handling. If we fail to acquire the lock, we need to both return null _and_ end the transaction. The change in #2395 fixed the "return null" part, but it turns out that b190cdc207e248cb6229d32fde5836d3374cac66 had also eliminated the code that ended the transaction if the lock was null. This PR adds this back.

I also added more comments to explain how the locking logic works.