### PR TITLE
Added date to students assessment instances pages (including Details …

### DIFF
--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -75,6 +75,7 @@
                 <% } %>
               </td>
             </tr>
+            <tr><th>Date Started</th><td colspan="2"><%= assessment_instance_date_formatted %></td></tr>
             <tr><th>Duration</th><td colspan="2"><%= assessment_instance_duration %></td></tr>
           </tbody>
         </table>

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -75,7 +75,7 @@
                 <% } %>
               </td>
             </tr>
-            <tr><th>Date Started</th><td colspan="2"><%= assessment_instance_date_formatted %></td></tr>
+            <tr><th>Date started</th><td colspan="2"><%= assessment_instance_date_formatted %></td></tr>
             <tr><th>Duration</th><td colspan="2"><%= assessment_instance_duration %></td></tr>
           </tbody>
         </table>

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -26,8 +26,9 @@ router.get('/', (req, res, next) => {
         if (ERR(err, next)) return;
         res.locals.assessment_instance_stats = result.rows;
 
-        sqlDb.queryOneRow(sql.select_formatted_duration, params, (err, result) => {
+        sqlDb.queryOneRow(sql.select_date_formatted_duration, params, (err, result) => {
             if (ERR(err, next)) return;
+            res.locals.assessment_instance_date_formatted = result.rows[0].assessment_instance_date_formatted;
             res.locals.assessment_instance_duration = result.rows[0].assessment_instance_duration;
 
             const params = {assessment_instance_id: res.locals.assessment_instance.id};

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.sql
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.sql
@@ -35,11 +35,14 @@ GROUP BY
 ORDER BY
     aq.number;
 
--- BLOCK select_formatted_duration
+-- BLOCK select_date_formatted_duration
 SELECT
+    format_date_full_compact(ai.date, ci.display_timezone) AS assessment_instance_date_formatted,
     format_interval(ai.duration) AS assessment_instance_duration
 FROM
     assessment_instances AS ai
+    JOIN assessments AS a ON (a.id = ai.assessment_id)
+    JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
 WHERE
     ai.id = $assessment_instance_id;
 

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -108,7 +108,7 @@
                 <th class="text-center">Role</th>
                 <th class="text-center">Instance</th>
                 <th class="text-center">Score</th>
-                <th class="text-center">Date Started</th>
+                <th class="text-center">Date started</th>
                 <th class="text-center">Duration</th>
                 <th class="text-center">Remaining</th>
                 <th class="text-center"></th>

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -22,13 +22,15 @@
               <h4 class="modal-title" id="deleteAssessmentInstanceModalLabel">Delete assessment instance</h4>
             </div>
             <div class="modal-body">
-              Are you sure you want to delete assessment
-              instance <span class="modal-number"></span>
-              of <strong><%= assessment_set.name
-              %> <%= assessment.number %></strong>
-              for <strong><span class="modal-name"></span></strong>
-              (<span class="modal-uid"></span>) with a score
-              of <span class="modal-score-perc"></span>%?
+              Are you sure you want to delete assessment instance
+              <span class="modal-number"></span> of
+              <strong><%= assessment_set.name %>
+              <%= assessment.number %></strong> for
+              <strong><span class="modal-name"></span></strong>
+              (<span class="modal-uid"></span>) started at
+              <strong><span class="modal-date"></span></strong> with a
+              score of
+              <strong><span class="modal-score-perc"></span>%</strong>?
             </div>
             <div class="modal-footer">
               <form name="delete-form" method="POST">
@@ -49,12 +51,14 @@
             var uid = button.data('uid'); // Extract info from data-* attributes
             var name = button.data('name');
             var number = button.data('number');
+            var date_formatted = button.data('date-formatted');
             var score_perc = button.data('score-perc');
             var assessment_instance_id = button.data('assessment-instance-id');
             var modal = $(this);
             modal.find('.modal-uid').text(uid);
             modal.find('.modal-name').text(name);
             modal.find('.modal-number').text(number);
+            modal.find('.modal-date').text(date_formatted);
             modal.find('.modal-score-perc').text(score_perc);
             modal.find('.modal-assessment-instance-id').val(assessment_instance_id);
         });
@@ -104,6 +108,7 @@
                 <th class="text-center">Role</th>
                 <th class="text-center">Instance</th>
                 <th class="text-center">Score</th>
+                <th class="text-center">Date Started</th>
                 <th class="text-center">Duration</th>
                 <th class="text-center">Remaining</th>
                 <th class="text-center"></th>
@@ -118,6 +123,7 @@
                 <td class="text-center"><%= row.role %></td>
                 <td class="text-center"><%= row.number %></td>
                 <td class="text-center align-middle"><%- include('../partials/scorebar', {score: row.score_perc}); %></td>
+                <td class="text-center"><%= row.date_formatted %></td>
                 <td class="text-center" data-text="<%= row.duration_secs %>"><%= row.duration %></td>
                 <td class="text-center"><%= row.time_remaining %></td>
                 <td class="text-center">
@@ -185,6 +191,7 @@
                          data-toggle="modal" data-target="#deleteAssessmentInstanceModal"
                          data-uid="<%= row.uid %>" data-name="<%= row.name %>"
                          data-number="<%= row.number %>"
+                         data-date-formatted="<%= row.date_formatted %>"
                          data-score-perc="<%= Math.floor(row.score_perc) %>"
                          data-assessment-instance-id="<%= row.assessment_instance_id %>"
                          >

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql
@@ -11,7 +11,7 @@ SELECT
         WHEN ai.open THEN 'Open'
         ELSE 'Closed'
     END AS time_remaining,
-    format_date_iso8601(ai.date, ci.display_timezone) AS date_formatted,
+    format_date_full_compact(ai.date, ci.display_timezone) AS date_formatted,
     format_interval(ai.duration) AS duration,
     EXTRACT(EPOCH FROM ai.duration) AS duration_secs,
     EXTRACT(EPOCH FROM ai.duration) / 60 AS duration_mins,


### PR DESCRIPTION
I used "Date Started" as the name of the column on the students assessment instances page and the row on the Details page.  I used format_date_full_compact() rather than format_date_iso8601(), because it's more human readable.   I also expanded the text that's shown in the dialog box for the Delete action -- it now includes the date.