### PR TITLE
Change manual grading CSV to not include uploaded files

### DIFF
--- a/elements/pl-file-upload/pl-file-upload.py
+++ b/elements/pl-file-upload/pl-file-upload.py
@@ -79,6 +79,11 @@ def parse(element_html, data):
         add_format_error(data, 'No submitted answer for file upload.')
         return
 
+    # We will store the files in the submitted_answer["_files"] key,
+    # so delete the original submitted answer format to avoid
+    # duplication
+    del data['submitted_answers'][answer_name]
+
     try:
         parsed_files = json.loads(files)
     except ValueError:

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ejs
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ejs
@@ -160,7 +160,9 @@
                   re-upload (see the "Upload" tab). For each student
                   and each question, only the most recent submission
                   from the most recent assessment instance is
-                  included.
+                  included. Files are stripped from the submitted
+                  answer in the CSV and are available
+                  as <tt><%= filesForManualGradingZipFilename %></tt>.
                 </td>
               </tr>
               <tr>

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -80,7 +80,7 @@ SELECT DISTINCT ON (ai.id, q.qid)
     s.id AS submission_id,
     v.params,
     v.true_answer,
-    s.submitted_answer
+    (s.submitted_answer - '_files') AS submitted_answer
 FROM
     submissions AS s
     JOIN variants AS v ON (v.id = s.variant_id)


### PR DESCRIPTION
Fixes #2409

As well as stripping `_files` from `submitted_answers` for the CSV download, this PR also deletes the temporary answer name that `pl-file-upload` uses to store the files before it moves them into `_files`.