### PR TITLE
Fix highest-score statistic in Homework instance questions CSV.

### DIFF
--- a/sprocs/instance_questions_points_homework.sql
+++ b/sprocs/instance_questions_points_homework.sql
@@ -30,7 +30,7 @@ BEGIN
     SELECT * INTO aq FROM assessment_questions WHERE id = iq.assessment_question_id;
 
     max_points := aq.max_points;
-    highest_submission_score := greatest(submission_score, coalesce(highest_submission_score, 0));
+    highest_submission_score := greatest(submission_score, coalesce(iq.highest_submission_score, 0));
 
     open := TRUE;
     points_list := NULL;


### PR DESCRIPTION
Fixes #2424

We were incorrectly referncing the return value as the current value for `highest_submission_score`, so it was always `NULL` and we always set the new `highest_submission_score` to the latest score. This only affected Homeworks, not Exams.