### PR TITLE
Config toggles for localstack usage

### DIFF
--- a/cron/externalGraderLoad.js
+++ b/cron/externalGraderLoad.js
@@ -9,7 +9,7 @@ const sqldb = require('@prairielearn/prairielib/sql-db');
 module.exports = {};
 
 module.exports.run = function(callback) {
-    if (!config.externalGradingUseAws) return callback(null);
+    if (!config.runningInEc2) return callback(null);
     getLoadStats((err, stats) => {
         if (ERR(err, callback)) return;
         sendStatsToCloudWatch(stats, (err) => {

--- a/cron/externalGraderLoad.js
+++ b/cron/externalGraderLoad.js
@@ -38,7 +38,7 @@ function getLoadStats(callback) {
 }
 
 function sendStatsToCloudWatch(stats, callback) {
-    const cloudwatch = new AWS.CloudWatch();
+    const cloudwatch = new AWS.CloudWatch(config.awsServiceGlobalOptions);
     const dimensions = [{Name: 'By Queue', Value: config.externalGradingJobsQueueName}];
     const params = {
         // AWS limits to 20 items within each MetricData list
@@ -340,7 +340,7 @@ function setAutoScalingGroupCapacity(stats, callback) {
     if (stats.desired_instances < 1 || stats.desired_instances > 1e6) return callback(null);
     if (stats.desired_instances == stats.instance_count) return callback(null);
 
-    const autoscaling = new AWS.AutoScaling();
+    const autoscaling = new AWS.AutoScaling(config.awsServiceGlobalOptions);
     const params = {
         AutoScalingGroupName: config.externalGradingAutoScalingGroupName,
         DesiredCapacity: stats.desired_instances,

--- a/cron/sendExternalGraderDeadLetters.js
+++ b/cron/sendExternalGraderDeadLetters.js
@@ -15,7 +15,7 @@ module.exports.run = (callback) => {
     if (!opsbot.canSendMessages()) return callback(null);
     if (!config.externalGradingUseAws) return callback(null);
 
-    const sqs = new AWS.SQS();
+    const sqs = new AWS.SQS(config.awsServiceGlobalOptions);
     let msg;
     async.series([
         (callback) => {
@@ -85,7 +85,7 @@ function getDeadLetterMsg(sqs, queueName, callback) {
         }
         logger.verbose('cron:sendExternalGraderDeadLetters', {queue: queueName, count: messages.length, messages});
         callback(null, msgDL);
-    });        
+    });
 }
 
 function drainQueue(sqs, queueName, callback) {

--- a/cron/serverLoad.js
+++ b/cron/serverLoad.js
@@ -8,7 +8,7 @@ const sqldb = require('@prairielearn/prairielib/sql-db');
 module.exports = {};
 
 module.exports.run = function(callback) {
-    if (!config.externalGradingUseAws) return callback(null); // FIXME: replace with config.runningInEc2
+    if (!config.runningInEc2) return callback(null);
     const params = [
         config.groupName,
         config.serverLoadAverageIntervalSec,
@@ -16,7 +16,7 @@ module.exports.run = function(callback) {
     sqldb.call('server_loads_current', params, (err, result) => {
         if (ERR(err, callback)) return;
         if (result.rowCount == 0) return callback(null); // nothing to report
-        const cloudwatch = new AWS.CloudWatch();
+        const cloudwatch = new AWS.CloudWatch(config.awsServiceGlobalOptions);
         async.each(result.rows, (row, callback) => {
             const params = {
                 Namespace: 'PrairieLearn',

--- a/cron/serverUsage.js
+++ b/cron/serverUsage.js
@@ -7,14 +7,14 @@ const sqldb = require('@prairielearn/prairielib/sql-db');
 module.exports = {};
 
 module.exports.run = function(callback) {
-    if (!config.externalGradingUseAws) return callback(null); // FIXME: replace with config.runningInEc2
+    if (!config.runningInEc2) return callback(null);
     const params = [
         config.serverUsageIntervalSec,
     ];
     sqldb.callOneRow('server_usage_current', params, (err, result) => {
         if (ERR(err, callback)) return;
         const stats = result.rows[0];
-        const cloudwatch = new AWS.CloudWatch();
+        const cloudwatch = new AWS.CloudWatch(config.awsServiceGlobalOptions);
         const dimensions = [
             {Name: 'Server Group', Value: config.groupName},
         ];

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ -n $DELAYED_START ]]; then
+    echo "Waiting $DELAYED_START seconds to start"
+    sleep $DELAYED_START
+fi
 cd /PrairieLearn
 
 

--- a/docker/start_postgres.sh
+++ b/docker/start_postgres.sh
@@ -6,9 +6,12 @@ else
     ACTION=$1
 fi
 
-su postgres -c "/usr/pgsql-11/bin/pg_ctl -D /var/postgres -l /var/postgres/pg_log/logfile $ACTION"
+# Only locally start postgres if we weren't given a PG_HOST environment variable
+if [[ -z "$PG_HOST" ]]; then
+  su postgres -c "/usr/pgsql-11/bin/pg_ctl -D /var/postgres -l /var/postgres/pg_log/logfile $ACTION"
+fi
 
 if [[ "$ACTION" == "start" ]]; then
-    # wait for postgres to start
+    # wait for postgres to start (local or PG_HOST)
     until /usr/pgsql-11/bin/pg_isready -q ; do sleep 1 ; done
 fi

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -19,5 +19,10 @@ module.exports.init = function(callback) {
     // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html
     AWS.config.update({region: config.awsRegion});
 
+    config.awsServiceGlobalOptions = {};
+    if (process.env.AWS_ENDPOINT) {
+        config.awsServiceGlobalOptions.endpoint = new AWS.Endpoint(process.env.AWS_ENDPOINT);
+    }
+
     callback(null);
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -68,6 +68,7 @@ config.externalGradingLoadAverageIntervalSec = 30;
 config.externalGradingHistoryLoadIntervalSec = 5400;
 config.externalGradingCurrentCapacityFactor = 1;
 config.externalGradingHistoryCapacityFactor = 1;
+config.runningInEc2 = false;
 config.fileEditorUseGit = false;
 config.useWorkers = true;
 config.workersCount = null; // if null, use workersPerCpu instead

--- a/lib/externalGraderResults.js
+++ b/lib/externalGraderResults.js
@@ -20,7 +20,7 @@ module.exports.init = function(callback) {
         return callback(null);
     }
 
-    const sqs = new AWS.SQS();
+    const sqs = new AWS.SQS(config.awsServiceGlobalOptions);
     loadQueueUrl(sqs, (err) => {
         if (ERR(err, callback)) return;
         callback(null);
@@ -178,7 +178,7 @@ function processMessage(data, callback) {
                         ResponseContentType: 'application/json',
                     };
                     logBundle.push({ timestamp: Date.now(), msg: 'fetching from s3'});
-                    new AWS.S3().getObject(params, (err, s3Data) => {
+                    new AWS.S3(config.awsServiceGlobalOptions).getObject(params, (err, s3Data) => {
                         if (ERR(err, callback)) return;
                         logBundle.push({ timestamp: Date.now(), msg: 'finished with s3 fetch'});
                         processResults(jobId, s3Data.Body);

--- a/lib/externalGraderSqs.js
+++ b/lib/externalGraderSqs.js
@@ -49,7 +49,7 @@ class Grader {
                     Body: passthrough,
                 };
 
-                const s3 = new AWS.S3();
+                const s3 = new AWS.S3(config.awsServiceGlobalOptions);
                 s3.upload(params, (err) => {
                     if (ERR(err, callback)) return;
                     callback(null);
@@ -91,7 +91,7 @@ function getS3RootKey(jobId) {
 }
 
 function sendJobToQueue(jobId, question, config, callback) {
-    const sqs = new AWS.SQS();
+    const sqs = new AWS.SQS(config.awsServiceGlobalOptions);
     async.series([
         (callback) => {
             if (QUEUE_URL) {

--- a/pages/instructorGradingJob/instructorGradingJob.js
+++ b/pages/instructorGradingJob/instructorGradingJob.js
@@ -4,6 +4,7 @@ const express = require('express');
 const router = express.Router();
 const AWS = require('aws-sdk');
 
+const config = require('../../lib/config');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 
@@ -52,7 +53,7 @@ router.get('/:job_id/file/:file', (req, res, next) => {
             Key: `${grading_job.s3_root_key}/${file}`,
         };
         res.attachment(file);
-        new AWS.S3().getObject(params).createReadStream()
+        new AWS.S3(config.awsServiceGlobalOptions).getObject(params).createReadStream()
         .on('error', (err) => {
             return ERR(err, next);
         }).pipe(res);

--- a/schemas/schemas/serverConfig.json
+++ b/schemas/schemas/serverConfig.json
@@ -96,6 +96,10 @@
             "description": "Time after last activity when exams are auto-closed (minutes).",
             "type": "integer"
         },
+        "runningInEc2": {
+            "description": "Toggle if PL is running as an AWS EC2 instance",
+            "type": "boolean"
+        },
         "externalGradingUseAws": {
             "description": "If the external grader should use AWS (production) or not (local dev).",
             "type": "boolean"

--- a/schemas/schemas/serverConfig.json
+++ b/schemas/schemas/serverConfig.json
@@ -97,7 +97,7 @@
             "type": "integer"
         },
         "runningInEc2": {
-            "description": "Toggle if PL is running as an AWS EC2 instance",
+            "description": "Whether PL is running as an AWS EC2 instance",
             "type": "boolean"
         },
         "externalGradingUseAws": {


### PR DESCRIPTION
Adds the ability to specify AWS endpoints to use PrairieLearn under different frameworks, like https://github.com/localstack/localstack

Adds `config.runningInEc2` to mimic PrairieGrader for some load reporting toggling (that localstack doesn't support).