### PR TITLE
Add *.ejs to NodeMon

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     },
     "scripts": {
         "start": "node server.js",
-        "start-nodemon": "npx nodemon -L server.js",
+        "start-nodemon": "npx nodemon -e ejs,js,json -L server.js",
         "test": "nyc --reporter=lcov mocha tests/index.js",
         "test-nocoverage": "mocha tests/index.js",
         "lint-js": "eslint --ext js \"**/*.js\"",


### PR DESCRIPTION
PR adds `ejs` monitoring (default = `js`, `mjs`, `json`).