### PR TITLE
Fix "teaching assisstant" typos

### DIFF
--- a/docs/courseInstance.md
+++ b/docs/courseInstance.md
@@ -70,7 +70,7 @@ Role         | Description
 ---          | ---
 `None`       | A user who at one point added the course and later removed themselves. They can no longer access the course but their work done within the course has been retained.
 `Student`    | A student participating in the class. They can only see their own information, and can do assessments. Default permission.
-`TA`         | A teaching assisstant. They can see the data of all users, but can only edit their own information.
+`TA`         | A teaching assistant. They can see the data of all users, but can only edit their own information.
 `Instructor` | A person in charge of the course. They have full permission to see and edit the information of other users.
 
 By default, any user not explicitly mentioned in the `userRoles` list will

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -239,7 +239,7 @@
               <strong>Roles:</strong>
               <ul>
                  <li><strong>Instructor</strong> is a person in charge of the course. They have full permission to see and edit the information of other users.</li>
-                 <li><strong>TA</strong> is a teaching assisstant. They can see the data of all users, but can only edit their own information.</li>
+                 <li><strong>TA</strong> is a teaching assistant. They can see the data of all users, but can only edit their own information.</li>
                  <li><strong>Student</strong> is a student participating in the class. They can only see their own information, and can do assessments.</li>
                  <li><strong>None</strong> is a user who at one point added the course and later removed themselves. They can no longer access the course but their work done within the course has been retained.</li>
               </ul>

--- a/pages/instructorGradebook/instructorGradebook.ejs
+++ b/pages/instructorGradebook/instructorGradebook.ejs
@@ -101,7 +101,7 @@
             <strong>Roles:</strong>
              <ul>
                  <li><strong>Instructor</strong> is a person in charge of the course. They have full permission to see and edit the information of other users.</li>
-                 <li><strong>TA</strong> is a teaching assisstant. They can see the data of all users, but can only edit their own information.</li>
+                 <li><strong>TA</strong> is a teaching assistant. They can see the data of all users, but can only edit their own information.</li>
                  <li><strong>Student</strong> is a student participating in the class. They can only see their own information, and can do assessments.</li>
                  <li><strong>None</strong> is a user who at one point added the course and later removed themselves. They can no longer access the course but their work done within the course has been retained.</li>
             </ul>


### PR DESCRIPTION
Assistant is misspelled as "assisstant" in some places in the interface and docs.