### PR TITLE
npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3431,14 +3431,22 @@
             }
         },
         "handlebars": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
-            "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+            "version": "4.7.6",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+            "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
             "requires": {
+                "minimist": "^1.2.5",
                 "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
                 "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+                }
             }
         },
         "har-schema": {
@@ -4951,11 +4959,6 @@
                 "brace-expansion": "^1.1.7"
             }
         },
-        "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
         "minipass": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
@@ -4993,11 +4996,18 @@
             "integrity": "sha512-SyV9uPETRig5ZmYev0ANfiGeB+g6N2EnqqEfBbCGmmJ6MgZ3E4qv5aPbnHVdZ60KAHHXV+T3sXopdrnIXQdmjQ=="
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+                }
             }
         },
         "mkdirp-classic": {
@@ -5813,15 +5823,6 @@
                     "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
                     "dev": true
                 }
-            }
-        },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
             }
         },
         "optionator": {
@@ -7720,13 +7721,12 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-            "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.1.tgz",
+            "integrity": "sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==",
             "optional": true,
             "requires": {
-                "commander": "~2.20.3",
-                "source-map": "~0.6.1"
+                "commander": "~2.20.3"
             }
         },
         "uid2": {
@@ -8133,9 +8133,9 @@
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
         },
         "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "wrap-ansi": {
             "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "filesize": "^6.1.0",
         "fs-extra": "^9.0.0",
         "googleapis": "^48.0.0",
-        "handlebars": "^4.7.3",
+        "handlebars": "^4.7.6",
         "highlight.js": "^9.18.1",
         "http-status": "^1.4.2",
         "isbinaryfile": "^4.0.5",


### PR DESCRIPTION
I'm not sure why dependabot didn't catch and process this, but we've had a GitHub security warning for `minimist` for almost a month. This branch tries to resolve this.

It's a checkout and `npm audit fix` which updates handlebars to get rid of the warned dependency.