### PR TITLE
Vertically align inputs in checkbox and multiple choice elements 

### DIFF
--- a/elements/pl-checkbox/pl-checkbox.css
+++ b/elements/pl-checkbox/pl-checkbox.css
@@ -2,3 +2,7 @@
     width: 340px;
     max-width: 100%;
 }
+
+:not(.form-check-inline) > .pl-checkbox-key-label {
+    min-width: 20px;
+}

--- a/elements/pl-checkbox/pl-checkbox.css
+++ b/elements/pl-checkbox/pl-checkbox.css
@@ -4,5 +4,5 @@
 }
 
 :not(.form-check-inline) > .pl-checkbox-key-label {
-    min-width: 20px;
+    min-width: 1.25em;
 }

--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -72,7 +72,7 @@
 {{^inline}}<div class="d-block">{{/inline}}
     <span id="pl-checkbox-submission-{{uuid}}">
         <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-        <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+        <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
     </span>
 </div>
 {{#inline}}</span>{{/inline}}

--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -13,7 +13,7 @@
 {{^inline}}<div class="d-block">{{/inline}}
 
 {{#answers}}
-    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center">
+    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1">
         <input class="form-check-input" type="checkbox"
                name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">

--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -14,7 +14,7 @@
 
 {{#answers}}
     <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1">
-        <input class="form-check-input" type="checkbox"
+        <input class="form-check-input mt-0" type="checkbox"
                name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
 

--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -12,8 +12,28 @@
 {{#inline}}<span class="d-inline-block">{{/inline}}
 {{^inline}}<div class="d-block">{{/inline}}
 
-{{{answerset}}}
+{{#answers}}
+    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center">
+        <input class="form-check-input" type="checkbox"
+               name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
+               {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
 
+        <label class="form-check-label d-flex align-items-center" for="{{name}}-{{key}}">
+            <div class="pl-checkbox-key-label">({{key}})</div>
+            <div class="ml-1 mr-1">{{{html}}}</div>
+        </label>
+            
+        {{#display_score_badge}}
+            {{#correct}}
+                <span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i></span>
+            {{/correct}}
+            {{#incorrect}}
+                <span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i></span>
+            {{/incorrect}}
+        {{/display_score_badge}}
+    </div>
+{{/answers}}
+    
 {{#helptext}}
 <span class="form-inline">
     <span id="pl-checkbox-{{uuid}}" class="input-group pl-checkbox">
@@ -38,6 +58,7 @@
 {{/format}}
 
 {{#submission}}
+{{#parse_error}}
 <script>
     $(function(){
         $('#pl-checkbox-submission-{{uuid}} [data-toggle="popover"]').popover({
@@ -47,14 +68,65 @@
         });
     });
 </script>
-{{#parse_error}}
 {{#inline}}<span class="d-inline-block">{{/inline}}
 {{^inline}}<div class="d-block">{{/inline}}
     <span id="pl-checkbox-submission-{{uuid}}">
-        <a role="button" class="btn btn-light btn-sm" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Error" tabindex="0" data-content="{{parse_error}}">INVALID <span><i class="fa fa-question-circle" aria-hidden="true"></i></span></a>
+        <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
+        <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
     </span>
 </div>
 {{#inline}}</span>{{/inline}}
 {{^inline}}</div>{{/inline}}
 {{/parse_error}}
+{{^parse_error}}
+
+{{#inline}}<span class="d-inline-block"><ul class="list-inline mb-0">{{/inline}}
+{{^inline}}<div class="d-block"><ul class="list-unstyled mb-0">{{/inline}}
+    
+{{#answers}}
+    <li {{#inline}}class="list-inline-item"{{/inline}}>
+    ({{key}}) {{{html}}}
+
+    {{#display_score_badge}}
+        {{#correct}}
+            <span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i></span>
+        {{/correct}}
+        {{#incorrect}}
+            <span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i></span>
+        {{/incorrect}}
+    {{/display_score_badge}}
+    </li>
+{{/answers}}
+
+</ul>
+
+{{#display_score_badge}}
+    &nbsp;
+    {{#correct}}
+        <span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>
+    {{/correct}}
+    {{#incorrect}}
+        <span class="badge badge-danger"><i class="fa fa-check" aria-hidden="true"></i> 0%</span>
+    {{/incorrect}}
+    {{#partial}}
+        <span class="badge badge-danger"><i class="fa fa-check" aria-hidden="true"></i> {{partial}}%</span>
+    {{/partial}}
+{{/display_score_badge}}
+
+{{#inline}}</span>{{/inline}}
+{{^inline}}</div>{{/inline}}
+
+{{/parse_error}}
 {{/submission}}
+
+{{#answer}}
+    {{#inline}}<span class="d-inline-block"><ul class="list-inline mb-0">{{/inline}}
+    {{^inline}}<div class="d-block"><ul class="list-unstyled mb-0">{{/inline}}
+    {{#answers}}
+        <li {{#inline}}class="list-inline-item"{{/inline}}>
+            ({{key}}) {{{html}}}
+        </li>
+    {{/answers}}
+    {{#inline}}</ul></span>{{/inline}}
+    {{^inline}}</ul></div>{{/inline}}
+{{/answer}}

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -131,27 +131,18 @@ def render(element_html, data):
         partial_score = data['partial_scores'].get(name, {'score': None})
         score = partial_score.get('score', None)
 
-        answerset = ''
+        answerset = []
         for answer in display_answers:
-            item = '<input type="checkbox" class="form-check-input"' \
-                + ' name="' + name + '" value="' + answer['key'] + '"' \
-                + ('' if editable else ' disabled') \
-                + (' checked ' if (answer['key'] in submitted_keys) else '') \
-                + f' id="{name}-{answer["key"]}"' \
-                + ' />\n' \
-                + f'<label class="form-check-label" for="{name}-{answer["key"]}">\n' \
-                + '(' + answer['key'] + ') ' + answer['html'].strip() + '\n'
-            if score is not None and show_answer_feedback:
-                if answer['key'] in submitted_keys:
-                    if answer['key'] in correct_keys:
-                        item = item + '<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i></span>'
-                    else:
-                        item = item + '<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i></span>'
-            item += '  </label>\n'
-            item = f'<div class="form-check {"form-check-inline" if inline else ""}">\n' + item + '</div>\n'
-            answerset += item
-        if inline:
-            answerset = '<span>\n' + answerset + '</span>\n'
+            answer_html = {
+                'key': answer['key'],
+                'checked': (answer['key'] in submitted_keys),
+                'html': answer['html'].strip(),
+                'display_score_badge': score is not None and show_answer_feedback and answer['key'] in submitted_keys
+            }
+            if answer_html['display_score_badge']:
+                answer_html['correct'] = (answer['key'] in correct_keys)
+                answer_html['incorrect'] = (answer['key'] not in correct_keys)
+            answerset.append(answer_html)
 
         info_params = {'format': True}
         # Adds decorative help text per bootstrap formatting guidelines:
@@ -200,7 +191,8 @@ def render(element_html, data):
             'editable': editable,
             'uuid': pl.get_uuid(),
             'info': info,
-            'answerset': answerset,
+            'answers': answerset,
+            'inline': inline
         }
 
         if not hide_help_text:
@@ -226,44 +218,41 @@ def render(element_html, data):
         if parse_error is None:
             partial_score = data['partial_scores'].get(name, {'score': None})
             score = partial_score.get('score', None)
-            html_list = []
+
+            answers = []
             for submitted_key in submitted_keys:
-                item = ''
-                submitted_html = next((a['html'] for a in display_answers if a['key'] == submitted_key), None)
-                if submitted_html is None:
-                    # FIXME: escape submitted_key
-                    raise ValueError('invalid submitted_key: {:s}'.format(str(submitted_key)))
-                else:
-                    item = '(%s) %s' % (submitted_key, submitted_html)
-                    if score is not None and show_answer_feedback:
-                        if submitted_key in correct_keys:
-                            item = item + '&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i></span>'
-                        else:
-                            item = item + '&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i></span>'
-                if inline:
-                    item = '<li class="list-inline-item">' + item + '</li>'
-                else:
-                    item = '<li>' + item + '</li>'
-                html_list.append(item)
-            if inline:
-                html = '<ul class="list-inline mb-0">\n' + '\n'.join(html_list) + '</ul>'
-            else:
-                html = '<ul class="list-unstyled mb-0">\n' + '\n'.join(html_list) + '</ul>'
-            if score is not None:
+                submitted_answer = next(filter(lambda a: a['key'] == submitted_key, display_answers), None)
+                answer_item = {
+                    'key': submitted_key,
+                    'html': submitted_answer['html'],
+                    'display_score_badge': score is not None and show_answer_feedback
+                }
+                if answer_item['display_score_badge']:
+                    answer_item['correct'] = (submitted_key in correct_keys)
+                    answer_item['incorrect'] = (submitted_key not in correct_keys)
+                answers.append(answer_item)
+
+            html_params = {
+                'submission': True,
+                'display_score_badge': (score is not None),
+                'answers': answers,
+                'inline': inline
+            }
+
+            if html_params['display_score_badge']:
                 try:
                     score = float(score)
                     if score >= 1:
-                        html = html + '&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>'
+                        html_params['correct'] = True
                     elif score > 0:
-                        html = html + '&nbsp;<span class="badge badge-warning"><i class="far fa-circle" aria-hidden="true"></i> {:d}%</span>'.format(math.floor(score * 100))
+                        html_params['partial'] = math.floor(score * 100)
                     else:
-                        html = html + '&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>'
+                        html_params['incorrect'] = True
                 except Exception:
                     raise ValueError('invalid score' + score)
-            if inline:
-                html = '<span class="d-inline-block">' + html + '</span>'
-            else:
-                html = '<div class="d-block">' + html + '</div>'
+
+            with open('pl-checkbox.mustache', 'r', encoding='utf-8') as f:
+                html = chevron.render(f, html_params).strip()
         else:
             html_params = {
                 'submission': True,
@@ -281,22 +270,13 @@ def render(element_html, data):
             if len(correct_answer_list) == 0:
                 raise ValueError('At least one option must be true.')
             else:
-                html_list = []
-                for answer in correct_answer_list:
-                    item = '(%s) %s' % (answer['key'], answer['html'])
-                    if inline:
-                        item = '<li class="list-inline-item">' + item + '</li>'
-                    else:
-                        item = '<li>' + item + '</li>'
-                    html_list.append(item)
-                if inline:
-                    html = '<ul class="list-inline mb-0">\n' + '\n'.join(html_list) + '</ul>'
-                else:
-                    html = '<ul class="list-unstyled mb-0">\n' + '\n'.join(html_list) + '</ul>'
-            if inline:
-                html = '<span class="d-inline-block">' + html + '</span>'
-            else:
-                html = '<div class="d-block">' + html + '</div>'
+                html_params = {
+                    'answer': True,
+                    'inline': inline,
+                    'answers': correct_answer_list
+                }
+                with open('pl-checkbox.mustache', 'r', encoding='utf-8') as f:
+                    html = chevron.render(f, html_params).strip()
         else:
             html = ''
 

--- a/elements/pl-multiple-choice/info.json
+++ b/elements/pl-multiple-choice/info.json
@@ -1,3 +1,8 @@
 {
-    "controller": "pl-multiple-choice.py"
+    "controller": "pl-multiple-choice.py",
+    "dependencies": {
+        "elementStyles": [
+            "pl-multiple-choice.css"
+        ]
+    }
 }

--- a/elements/pl-multiple-choice/pl-multiple-choice.css
+++ b/elements/pl-multiple-choice/pl-multiple-choice.css
@@ -1,0 +1,8 @@
+.pl-multiple-choice-popover {
+    width: 340px;
+    max-width: 100%;
+}
+
+:not(.form-check-inline) > .pl-multiple-choice-key-label {
+    min-width: 20px;
+}

--- a/elements/pl-multiple-choice/pl-multiple-choice.css
+++ b/elements/pl-multiple-choice/pl-multiple-choice.css
@@ -4,5 +4,5 @@
 }
 
 :not(.form-check-inline) > .pl-multiple-choice-key-label {
-    min-width: 20px;
+    min-width: 1.25em;
 }

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -58,7 +58,7 @@
         
 <span id="pl-multiple-choice-submission-{{uuid}}">
     <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
 </span>
 {{/parse_error}}
 {{^parse_error}}

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -1,0 +1,82 @@
+{{#question}}
+
+{{#inline}}
+<span>
+{{/inline}}
+    
+{{#answers}}
+    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center">
+        <input class="form-check-input" type="radio"
+               name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
+               {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
+
+        <label class="form-check-label d-flex align-items-center" for="{{name}}-{{key}}">
+            <div class="pl-multiple-choice-key-label">({{key}})</div>
+            <div class="ml-1 mr-1">{{{html}}}</div>
+        </label>
+            
+        {{#display_score_badge}}
+            {{#correct}}
+                <span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i></span>
+            {{/correct}}
+            {{#incorrect}}
+                <span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i></span>
+            {{/incorrect}}
+        {{/display_score_badge}}
+    </div>
+{{/answers}}
+
+{{#display_score_badge}}
+    &nbsp;
+    {{#correct}}
+        <span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>
+    {{/correct}}
+    {{#incorrect}}
+        <span class="badge badge-danger"><i class="fa fa-check" aria-hidden="true"></i> 0%</span>
+    {{/incorrect}}
+    {{#partial}}
+        <span class="badge badge-danger"><i class="fa fa-check" aria-hidden="true"></i> {{partial}}%</span>
+    {{/partial}}
+{{/display_score_badge}}
+
+{{#inline}}
+</span>
+{{/inline}}
+
+{{/question}}
+{{#submission}}
+{{#parse_error}}
+<script>
+    $(function(){
+        $('#pl-multiple-choice-submission-{{uuid}} [data-toggle="popover"]').popover({
+            sanitize: false,
+            container: 'body',
+            template: '<div class="popover pl-checkbox-popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
+        });
+    });
+</script>
+        
+<span id="pl-multiple-choice-submission-{{uuid}}">
+    <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
+    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+</span>
+{{/parse_error}}
+{{^parse_error}}
+
+({{key}}) {{{answer.html}}}
+
+{{#display_score_badge}}
+    &nbsp;
+    {{#correct}}
+        <span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>
+    {{/correct}}
+    {{#incorrect}}
+        <span class="badge badge-danger"><i class="fa fa-check" aria-hidden="true"></i> 0%</span>
+    {{/incorrect}}
+    {{#partial}}
+        <span class="badge badge-danger"><i class="fa fa-check" aria-hidden="true"></i> {{partial}}%</span>
+    {{/partial}}
+{{/display_score_badge}}
+    
+{{/parse_error}}
+{{/submission}}

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -5,7 +5,7 @@
 {{/inline}}
     
 {{#answers}}
-    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center">
+    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1">
         <input class="form-check-input" type="radio"
                name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -6,7 +6,7 @@
     
 {{#answers}}
     <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1">
-        <input class="form-check-input" type="radio"
+        <input class="form-check-input mt-0" type="radio"
                name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
 


### PR DESCRIPTION
Fixes #1215 by sticking labels in a vertically aligned flexbox div/span

Also cleans up some of the code in the checkbox and multiple choice elements by moving markup out of the python files into their respective mustache templates

Before:
![image](https://user-images.githubusercontent.com/1790491/80840880-e419c880-8bc3-11ea-8011-2da14e355a19.png)
![image](https://user-images.githubusercontent.com/1790491/80840912-f5fb6b80-8bc3-11ea-9897-d92605d65e33.png)

After:
![image](https://user-images.githubusercontent.com/1790491/80920525-0e8b9300-8d36-11ea-9cce-1b0c76adc30a.png)
![image](https://user-images.githubusercontent.com/1790491/80920502-ed2aa700-8d35-11ea-9610-da818eaff136.png)

Small tweak, but labels are now horizontally aligned such that their left border will line up.

Checkbox/mc items now have more padding between them:

![image](https://user-images.githubusercontent.com/1790491/80920542-2f53e880-8d36-11ea-8ddd-710bbe6748b6.png)
