### PR TITLE
Downgrade jQuery to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4590,9 +4590,9 @@
             "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
         "jquery": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-            "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+            "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
         },
         "js-tokens": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "isbinaryfile": "^4.0.6",
         "javascript-natural-sort": "^0.7.1",
         "jju": "^1.3.0",
-        "jquery": "^3.5.0",
+        "jquery": "^3.4.1",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",


### PR DESCRIPTION
jQuery 3.5.0 breaks bootstrap collapse fields, downgrade to fix.

Have tested and can confirm this resolves #2483