### PR TITLE
Fix MathJax rendering bug

### DIFF
--- a/pages/partials/mathjax.ejs
+++ b/pages/partials/mathjax.ejs
@@ -14,6 +14,16 @@
      onReady: (cb) => { MathJax.config.readyQueue.push(cb); },
      startup: {
          ready: () => {
+             if (MathJax.version === '3.0.5') {
+                 /* Work-around for SVG output on MathJax 3.0.5, we can remove this after
+                    it's been fixed. */
+                 const SVGWrapper = MathJax._.output.svg.Wrapper.SVGWrapper;
+                 const CommonWrapper = SVGWrapper.prototype.__proto__;
+                 SVGWrapper.prototype.unicodeChars = function (text, variant) {
+                     if (!variant) variant = this.variant || 'normal';
+                     return CommonWrapper.unicodeChars.call(this, text, variant);
+                 }
+             }
              MathJax.startup.defaultReady();
              MathJax.Hub = {
                  Queue: function(){


### PR DESCRIPTION
MathJax 3.0.5 breaks on SVG output when representing double/triple/quad primes with `''`, `'''`, and `''''`.  Here is a fix by one of the MathJax developers to get around this.