### PR TITLE
Add help text for 1D arrays in matrix input element

### DIFF
--- a/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -122,12 +122,18 @@
 
 {{#format}}
 <p>
-Your answer must be a matrix (i.e., a 2D array). It can be expressed in one of two ways:
+    Your answer should be a matrix (i.e., a 2D array), or a vector (a 1D array).
+</p>
+<p>
+    A <strong>2D array</strong> can be expressed in one of two ways:
 </p>
 <ul>
     <li><strong>Matlab Format.</strong> Enclose it by a single pair of square brackets. Separate entries in each row with a space or comma. Indicate the end of each intermediate row with a semicolon. Examples: <code>[1 2 3; 4 5 6]</code> or <code>[1, 2, 3; 4, 5, 6]</code></li>
     <li><strong>Python Format.</strong> Enclose it by a single pair of square brackets. Enclose each row by a single pair of square brackets. Separate rows with a comma. Separate entries in each row with a comma. Example: <code>[[1, 2, 3], [4, 5, 6]]</code></li>
 </ul>
+<p>
+    A <strong>1D array</strong> can be expressed by enclosing the array with a single pair of square brackets.  Separate entries with a space or comma.  Note that this will generate a <i>row vector</i>, if you are trying to create a column vector use the above 2D array syntax.  Example: <code>[1,2,3]</code>
+</p>
 <p>
 {{#allow_complex}}
 Each entry must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number with both real and imaginary parts between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision real or complex number). Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
@@ -167,11 +173,19 @@ matrix {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}
     </p>
     <hr>
     <small>
-    <p>
-      Your answer must be a matrix (i.e., a 2D array). It can be expressed in one of two ways:
-    </p>
-    <p> <strong>Matlab Format:</strong> Enclose it by a single pair of square brackets. Separate entries in each row with a space or comma. Indicate the end of each intermediate row with a semicolon. <br> Examples: <code class="user-output small">[1 2 3; 4 5 6]</code> or <code class="user-output small">[1, 2, 3; 4, 5, 6]</code> </p>
-    <p> <strong>Python Format:</strong> Enclose it by a single pair of square brackets. Enclose each row by a single pair of square brackets. Separate rows with a comma. Separate entries in each row with a comma. <br> Example: <code class="user-output small">[[1, 2, 3], [4, 5, 6]]</code> </p>
-    <p> Each entry of the submitted answer must be formatted as a <i>double-precision floating-point</i> {{#complex}}or complex{{/complex}} number.  These numbers {{#complex}}(both real and complex parts){{/complex}} lie roughly in the range of -1.79 &times; 10<sup>308</sup> to 1.79 &times; 10<sup>308</sup>. </p>
+        <p>
+            Your answer should be a matrix (i.e., a 2D array), or a vector (a 1D array).
+        </p>
+        <p>
+            A <strong>2D array</strong> can be expressed in one of two ways:
+        </p>
+        <ul>
+            <li><strong>Matlab Format.</strong> Enclose it by a single pair of square brackets. Separate entries in each row with a space or comma. Indicate the end of each intermediate row with a semicolon. Examples: <code class="user-output small">[1 2 3; 4 5 6]</code> or <code class="user-output small">[1, 2, 3; 4, 5, 6]</code></li>
+            <li><strong>Python Format.</strong> Enclose it by a single pair of square brackets. Enclose each row by a single pair of square brackets. Separate rows with a comma. Separate entries in each row with a comma. Example: <code class="user-output small">[[1, 2, 3], [4, 5, 6]]</code></li>
+        </ul>
+        <p>
+            A <strong>1D array</strong> can be expressed by enclosing the array with a single pair of square brackets.  Separate entries with a space or comma.  Note that this will generate a <i>row vector</i>, if you are trying to create a column vector use the above 2D array syntax.  Example: <code class="user-output small">[1,2,3]</code>
+        </p>
+        <p> Each entry of the submitted answer must be formatted as a <i>double-precision floating-point</i> {{#complex}}or complex{{/complex}} number.  These numbers {{#complex}}(both real and complex parts){{/complex}} lie roughly in the range of -1.79 &times; 10<sup>308</sup> to 1.79 &times; 10<sup>308</sup>. </p>
     </small>
 {{/format_error}}

--- a/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -122,17 +122,14 @@
 
 {{#format}}
 <p>
-    Your answer should be a matrix (i.e., a 2D array), or a vector (a 1D array).
-</p>
-<p>
-    A <strong>2D array</strong> can be expressed in one of two ways:
+Your answer must be a matrix (i.e., a 2D array). It can be expressed in one of two ways:
 </p>
 <ul>
     <li><strong>Matlab Format.</strong> Enclose it by a single pair of square brackets. Separate entries in each row with a space or comma. Indicate the end of each intermediate row with a semicolon. Examples: <code>[1 2 3; 4 5 6]</code> or <code>[1, 2, 3; 4, 5, 6]</code></li>
     <li><strong>Python Format.</strong> Enclose it by a single pair of square brackets. Enclose each row by a single pair of square brackets. Separate rows with a comma. Separate entries in each row with a comma. Example: <code>[[1, 2, 3], [4, 5, 6]]</code></li>
 </ul>
 <p>
-    A <strong>1D array</strong> can be expressed by enclosing the array with a single pair of square brackets.  Separate entries with a space or comma.  Note that this will generate a <i>row vector</i>, if you are trying to create a column vector use the above 2D array syntax.  Example: <code>[1,2,3]</code>
+    Note that <code>[1, 2, 3]</code> is valid Matlab input for a 1&times;3 matrix (a row vector). If you want a column vector (a 3&times;1 matrix) then you should enter <code>[1; 2; 3]</code> or <code>[[1], [2], [3]]</code>.
 </p>
 <p>
 {{#allow_complex}}
@@ -173,19 +170,11 @@ matrix {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}
     </p>
     <hr>
     <small>
-        <p>
-            Your answer should be a matrix (i.e., a 2D array), or a vector (a 1D array).
-        </p>
-        <p>
-            A <strong>2D array</strong> can be expressed in one of two ways:
-        </p>
-        <ul>
-            <li><strong>Matlab Format.</strong> Enclose it by a single pair of square brackets. Separate entries in each row with a space or comma. Indicate the end of each intermediate row with a semicolon. Examples: <code class="user-output small">[1 2 3; 4 5 6]</code> or <code class="user-output small">[1, 2, 3; 4, 5, 6]</code></li>
-            <li><strong>Python Format.</strong> Enclose it by a single pair of square brackets. Enclose each row by a single pair of square brackets. Separate rows with a comma. Separate entries in each row with a comma. Example: <code class="user-output small">[[1, 2, 3], [4, 5, 6]]</code></li>
-        </ul>
-        <p>
-            A <strong>1D array</strong> can be expressed by enclosing the array with a single pair of square brackets.  Separate entries with a space or comma.  Note that this will generate a <i>row vector</i>, if you are trying to create a column vector use the above 2D array syntax.  Example: <code class="user-output small">[1,2,3]</code>
-        </p>
-        <p> Each entry of the submitted answer must be formatted as a <i>double-precision floating-point</i> {{#complex}}or complex{{/complex}} number.  These numbers {{#complex}}(both real and complex parts){{/complex}} lie roughly in the range of -1.79 &times; 10<sup>308</sup> to 1.79 &times; 10<sup>308</sup>. </p>
+    <p>
+      Your answer must be a matrix (i.e., a 2D array). It can be expressed in one of two ways:
+    </p>
+    <p> <strong>Matlab Format:</strong> Enclose it by a single pair of square brackets. Separate entries in each row with a space or comma. Indicate the end of each intermediate row with a semicolon. <br> Examples: <code class="user-output small">[1 2 3; 4 5 6]</code> or <code class="user-output small">[1, 2, 3; 4, 5, 6]</code> </p>
+    <p> <strong>Python Format:</strong> Enclose it by a single pair of square brackets. Enclose each row by a single pair of square brackets. Separate rows with a comma. Separate entries in each row with a comma. <br> Example: <code class="user-output small">[[1, 2, 3], [4, 5, 6]]</code> </p>
+    <p> Each entry of the submitted answer must be formatted as a <i>double-precision floating-point</i> {{#complex}}or complex{{/complex}} number.  These numbers {{#complex}}(both real and complex parts){{/complex}} lie roughly in the range of -1.79 &times; 10<sup>308</sup> to 1.79 &times; 10<sup>308</sup>. </p>
     </small>
 {{/format_error}}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1790491/81446019-ac6ccc80-913f-11ea-993a-e1827fb7a165.png)


Clarifies that 1D arrays can be created in the `pl-matrix-input` element, but they are row vectors by default.