### PR TITLE
Demonstrate proxying for workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -453,6 +453,19 @@
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
             "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
         },
+        "@types/http-proxy": {
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
+            "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/node": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.1.tgz",
+            "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA=="
+        },
         "@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -2832,6 +2845,11 @@
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
         },
+        "eventemitter3": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+            "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        },
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -3172,6 +3190,24 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
             "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
             "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
+            "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
+            "requires": {
+                "debug": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
         },
         "foreground-child": {
             "version": "2.0.0",
@@ -3957,6 +3993,28 @@
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
                     "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
                 }
+            }
+        },
+        "http-proxy": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+            "requires": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.3.tgz",
+            "integrity": "sha512-GHvPeBD+A357zS5tHjzj6ISrVOjjCiy0I92bdyTJz0pNmIjFxO0NX/bX+xkGgnclKQE/5hHAB9JEQ7u9Pw4olg==",
+            "requires": {
+                "@types/http-proxy": "^1.17.3",
+                "http-proxy": "^1.18.0",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "micromatch": "^4.0.2"
             }
         },
         "http-signature": {
@@ -5221,6 +5279,15 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "micromatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+            "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+            }
         },
         "mime": {
             "version": "1.6.0",
@@ -6901,6 +6968,11 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
             "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "requizzle": {
             "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "googleapis": "^49.0.0",
         "handlebars": "^4.7.6",
         "highlight.js": "^10.0.1",
+        "http-proxy-middleware": "^1.0.3",
         "http-status": "^1.4.2",
         "isbinaryfile": "^4.0.6",
         "javascript-natural-sort": "^0.7.1",

--- a/server.js
+++ b/server.js
@@ -228,7 +228,7 @@ const workspaceProxyOptions = {
     pathRewrite: {
         '^/workspace/[0-9]/': '/',
     },
-    logProvider: provider => logger,
+    logProvider: _provider => logger,
     router: async (req) => {
         let url = 'not-matched';
         if (/^\/workspace\/0/.test(req.url)) {
@@ -237,7 +237,7 @@ const workspaceProxyOptions = {
             url = 'http://localhost:8081';
         }
         return url;
-    }
+    },
 };
 const workspaceProxy = createProxyMiddleware(workspaceProxyOptions);
 app.use('/workspace', workspaceProxy);


### PR DESCRIPTION
This is a test of proxying workspace paths to different VS Code instances. To test:
```
cd /some/directory
docker run -it -p 127.0.0.1:8080:8080 -v "$PWD:/home/coder/project" -u "$(id -u):$(id -g)" codercom/code-server:latest

cd /different/directory
docker run -it -p 127.0.0.1:8081:8080 -v "$PWD:/home/coder/project" -u "$(id -u):$(id -g)" codercom/code-server:latest
```

Then run `npm start` to run PL. There should be three different available URL schemes:

* `/pl/` - normal PL pages
* `/workspace/0/` - the first copy of VS Code in `/some/directory`
* `/workspace/1/` - the second copy of VS Code in `/different/directory`