### PR TITLE
Adding check for /grade to avoid problems

### DIFF
--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -11,8 +11,7 @@ RUN yum -y update \
 
 COPY requirements.txt /
 
-RUN yum -y update \
-    && python3 -m pip install --no-cache-dir -r /requirements.txt
+RUN python3 -m pip install --no-cache-dir -r /requirements.txt
     
 COPY python_autograder /python_autograder
 RUN chmod +x /python_autograder/run.sh  

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y update \
     && yum install -y python3 python3-devel python3-pip dos2unix \
     && yum install -y graphviz graphviz-devel \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
-    
-COPY python_autograder /python_autograder
-RUN chmod +x /python_autograder/run.sh  
 
 RUN useradd ag
+
+COPY python_autograder /python_autograder
+RUN chmod +x /python_autograder/run.sh

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -9,7 +9,7 @@ RUN yum -y update \
     && yum install -y sudo gcc make \
     && yum install -y https://repo.ius.io/ius-release-el7.rpm \
     && yum install -y python3 python3-devel python3-pip dos2unix \
-    && yum install -y graphviz graphviz-devel \
+    && yum install -y graphviz graphviz-devel
     && python3 -m pip install --no-cache-dir -r /requirements.txt
     
 COPY python_autograder /python_autograder

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -3,15 +3,14 @@ FROM centos:7
 # Needed to properly handle UTF-8
 ENV PYTHONIOENCODING=UTF-8
 
+COPY requirements.txt /
+
 RUN yum -y update \
     && yum install -y sudo gcc make \
     && yum install -y https://repo.ius.io/ius-release-el7.rpm \
     && yum install -y python3 python3-devel python3-pip dos2unix \
     && yum install -y graphviz graphviz-devel
-
-COPY requirements.txt /
-
-RUN python3 -m pip install --no-cache-dir -r /requirements.txt
+    && python3 -m pip install --no-cache-dir -r /requirements.txt
     
 COPY python_autograder /python_autograder
 RUN chmod +x /python_autograder/run.sh  

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -3,15 +3,18 @@ FROM centos:7
 # Needed to properly handle UTF-8
 ENV PYTHONIOENCODING=UTF-8
 
-COPY requirements.txt /
-COPY python_autograder /python_autograder
-RUN chmod +x /python_autograder/run.sh
-
 RUN yum -y update \
     && yum install -y sudo gcc make \
     && yum install -y https://repo.ius.io/ius-release-el7.rpm \
     && yum install -y python3 python3-devel python3-pip dos2unix \
-    && yum install -y graphviz graphviz-devel \
+    && yum install -y graphviz graphviz-devel
+
+COPY requirements.txt /
+
+RUN yum -y update \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
+    
+COPY python_autograder /python_autograder
+RUN chmod +x /python_autograder/run.sh  
 
 RUN useradd ag

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -9,7 +9,7 @@ RUN yum -y update \
     && yum install -y sudo gcc make \
     && yum install -y https://repo.ius.io/ius-release-el7.rpm \
     && yum install -y python3 python3-devel python3-pip dos2unix \
-    && yum install -y graphviz graphviz-devel
+    && yum install -y graphviz graphviz-devel \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
     
 COPY python_autograder /python_autograder

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -3,18 +3,15 @@ FROM centos:7
 # Needed to properly handle UTF-8
 ENV PYTHONIOENCODING=UTF-8
 
+COPY requirements.txt /
+COPY python_autograder /python_autograder
+RUN chmod +x /python_autograder/run.sh
+
 RUN yum -y update \
     && yum install -y sudo gcc make \
     && yum install -y https://repo.ius.io/ius-release-el7.rpm \
     && yum install -y python3 python3-devel python3-pip dos2unix \
-    && yum install -y graphviz graphviz-devel
-
-COPY requirements.txt /
-
-RUN yum -y update \
+    && yum install -y graphviz graphviz-devel \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
-    
-COPY python_autograder /python_autograder
-RUN chmod +x /python_autograder/run.sh  
 
 RUN useradd ag

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -3,14 +3,15 @@ FROM centos:7
 # Needed to properly handle UTF-8
 ENV PYTHONIOENCODING=UTF-8
 
-COPY requirements.txt /
-
 RUN yum -y update \
     && yum install -y sudo gcc make \
     && yum install -y https://repo.ius.io/ius-release-el7.rpm \
     && yum install -y python3 python3-devel python3-pip dos2unix \
     && yum install -y graphviz graphviz-devel
-    && python3 -m pip install --no-cache-dir -r /requirements.txt
+
+COPY requirements.txt /
+
+RUN python3 -m pip install --no-cache-dir -r /requirements.txt
     
 COPY python_autograder /python_autograder
 RUN chmod +x /python_autograder/run.sh  

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y update \
     && yum install -y python3 python3-devel python3-pip dos2unix \
     && yum install -y graphviz graphviz-devel \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
+    
+COPY python_autograder /python_autograder
+RUN chmod +x /python_autograder/run.sh  
 
 RUN useradd ag
-
-COPY python_autograder /python_autograder
-RUN chmod +x /python_autograder/run.sh

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -11,7 +11,8 @@ RUN yum -y update \
 
 COPY requirements.txt /
 
-RUN python3 -m pip install --no-cache-dir -r /requirements.txt
+RUN yum -y update \
+    && python3 -m pip install --no-cache-dir -r /requirements.txt
     
 COPY python_autograder /python_autograder
 RUN chmod +x /python_autograder/run.sh  

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -7,9 +7,7 @@
 # the autograder directory
 AG_DIR='/python_autograder'
 
-if [ -d /grade ] ; then
-        echo "Found /grade"
-else
+if [ ! -d /grade ] ; then
         echo "ERROR: /grade not found! Mounting may have failed."
         exit 1
 fi

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -7,9 +7,9 @@
 # the autograder directory
 AG_DIR='/python_autograder'
 
-if [ ! -d /grade ] ; then
-        echo "ERROR: /grade not found! Mounting may have failed."
-        exit 1
+if [[ ! -d /grade ]]; then
+  echo "ERROR: /grade not found! Mounting may have failed."
+  exit 1
 fi
 
 # the parent directory containing everything about this grading job

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -18,8 +18,8 @@ OUT_DIR=$JOB_DIR'/results'
 export MERGE_DIR=$JOB_DIR'/run'
 
 # now set up the stuff so that our run.sh can work
-mkdir $MERGE_DIR
-mkdir $OUT_DIR
+mkdir -p $MERGE_DIR
+mkdir -p $OUT_DIR
 
 mv $STUDENT_DIR/* $MERGE_DIR
 mv $AG_DIR/* $MERGE_DIR
@@ -37,7 +37,7 @@ chmod 1777 "$MERGE_DIR"
 
 # Create directory without sticky bit for deletable files
 export FILENAMES_DIR=$MERGE_DIR'/filenames'
-mkdir $FILENAMES_DIR
+mkdir -p $FILENAMES_DIR
 chmod 777 $FILENAMES_DIR
 mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $FILENAMES_DIR
 

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -7,6 +7,13 @@
 # the autograder directory
 AG_DIR='/python_autograder'
 
+if [ -d /grade ] ; then
+        echo "Found /grade"
+else
+        echo "ERROR: /grade not found! Mounting may have failed."
+        exit 1
+fi
+
 # the parent directory containing everything about this grading job
 export JOB_DIR='/grade'
 # the job subdirectories

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -25,8 +25,8 @@ OUT_DIR=$JOB_DIR'/results'
 export MERGE_DIR=$JOB_DIR'/run'
 
 # now set up the stuff so that our run.sh can work
-mkdir -p $MERGE_DIR
-mkdir -p $OUT_DIR
+mkdir $MERGE_DIR
+mkdir $OUT_DIR
 
 mv $STUDENT_DIR/* $MERGE_DIR
 mv $AG_DIR/* $MERGE_DIR
@@ -44,7 +44,7 @@ chmod 1777 "$MERGE_DIR"
 
 # Create directory without sticky bit for deletable files
 export FILENAMES_DIR=$MERGE_DIR'/filenames'
-mkdir -p $FILENAMES_DIR
+mkdir $FILENAMES_DIR
 chmod 777 $FILENAMES_DIR
 mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $FILENAMES_DIR
 


### PR DESCRIPTION
~-p creates intermediate subdirectories if they are missing and also suppresses errors if existing. This may or may not help with the Windows deployment issue~