### PR TITLE
Add "partial_scores" column to manual grading submissions CSV

### DIFF
--- a/api/v1/endpoints/queries.sql
+++ b/api/v1/endpoints/queries.sql
@@ -173,6 +173,7 @@ WITH object_data AS (
         v.options,
         format_date_iso8601(s.date, ci.display_timezone) AS date,
         s.submitted_answer,
+        s.partial_scores,
         s.override_score,
         s.credit,
         s.mode,

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -185,6 +185,7 @@ router.get('/:filename', function(req, res, next) {
                 ['params', 'params'],
                 ['true_answer', 'true_answer'],
                 ['submitted_answer', 'submitted_answer'],
+                ['partial_scores', 'partial_scores'],
                 ['score_perc', null],
                 ['feedback', null],
             ];

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -226,7 +226,7 @@ router.get('/:filename', function(req, res, next) {
                 ['submission_id', 'submission_id'],
                 ['Submission date', 'submission_date_formatted'],
                 ['Submitted answer', 'submitted_answer'],
-		['Partial Scores', 'partial_scores'],
+                ['Partial Scores', 'partial_scores'],
                 ['Override score', 'override_score'],
                 ['Credit', 'credit'],
                 ['Mode', 'mode'],

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -226,6 +226,7 @@ router.get('/:filename', function(req, res, next) {
                 ['submission_id', 'submission_id'],
                 ['Submission date', 'submission_date_formatted'],
                 ['Submitted answer', 'submitted_answer'],
+		['Partial Scores', 'partial_scores'],
                 ['Override score', 'override_score'],
                 ['Credit', 'credit'],
                 ['Mode', 'mode'],

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -82,7 +82,8 @@ SELECT DISTINCT ON (ai.id, q.qid)
     s.id AS submission_id,
     v.params,
     v.true_answer,
-    (s.submitted_answer - '_files') AS submitted_answer
+    (s.submitted_answer - '_files') AS submitted_answer,
+    s.partial_scores
 FROM
     submissions AS s
     JOIN variants AS v ON (v.id = s.variant_id)

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -118,7 +118,7 @@ WITH all_submissions AS (
         s.id AS submission_id,
         format_date_iso8601(s.date, ci.display_timezone) AS submission_date_formatted,
         s.submitted_answer,
-	s.partial_scores,
+        s.partial_scores,
         s.override_score,
         s.credit,
         s.mode,

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -118,6 +118,7 @@ WITH all_submissions AS (
         s.id AS submission_id,
         format_date_iso8601(s.date, ci.display_timezone) AS submission_date_formatted,
         s.submitted_answer,
+	s.partial_scores,
         s.override_score,
         s.credit,
         s.mode,


### PR DESCRIPTION
Resolves #2565 

The `submissions_for_manual_grading.csv` file is now structured like:

![image](https://user-images.githubusercontent.com/1790491/83578248-e55c4f00-a4fb-11ea-80d5-f1f5c14d7982.png)
