### PR TITLE
Switch Python autograder to use file preview element

### DIFF
--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -1,6 +1,6 @@
 # Python Autograder
 
-This file documents the default Python autograder included in the `prairielearn/grader-python` Docker image.  For general information on how to set up an external grader, visit the [external grading](../externalGrading.md) page. 
+This file documents the default Python autograder included in the `prairielearn/grader-python` Docker image.  For general information on how to set up an external grader, visit the [external grading](../externalGrading.md) page.
 
 ## Setting up
 
@@ -47,7 +47,7 @@ Each variable dictionary has entries `name` (the Python variable name in the cod
 
 ### `question.html`
 
-At a minimum, the question markup should contain a `pl-file-editor` element (or `pl-file-upload`) and a `pl-external-grading-results` to show the status of grading jobs.  These are placed in the question panel and submission panel, respectively, and thus the question markup should be structured as:
+At a minimum, the question markup should contain a `pl-file-editor` element (or `pl-file-upload`) and a `pl-external-grading-results` to show the status of grading jobs.  These are placed in the question panel and submission panel, respectively.  It is also recommended to place a `pl-file-preview` element in the submission panel so that students may see their previous code submissions.  An example question markup is given below:
 
 ```html
 <pl-question-panel>
@@ -56,6 +56,7 @@ At a minimum, the question markup should contain a `pl-file-editor` element (or 
 
 <pl-submission-panel>
   <pl-external-grading-results></pl-external-grading-results>
+  <pl-file-preview></pl-file-preview>
 </pl-submission-panel>
 ```
 

--- a/exampleCourse/questions/demoAutograderNumpy/question.html
+++ b/exampleCourse/questions/demoAutograderNumpy/question.html
@@ -4,14 +4,14 @@
             This question uses the built-in methods in <code>code_feedback.py</code> to check NumPy arrays. In addition, specific library functions can be disabled by hooking them in the setup autograder code.
         </i>
     </p>
-    
+
     <p>
         Given a full rank matrix ${\bf A} \in \mathbb{R}^{n \times n}$ and vector ${\bf b} \in \mathbb{R}^n$, compute ${\bf x}$ such that ${\bf x} = {\bf A}^{-1}{\bf b}$.  You may use any NumPy function except for <code>numpy.linalg.inv()</code> and <code>numpy.linalg.pinv()</code>.
     </p>
-    
+
     <p>The setup code gives the following variables:</p>
     <p><pl-external-grader-variables params-name="names_for_user"></pl-external-grader-variables></p>
-    
+
     <p>Your code snippet should define the following variables:</p>
     <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
     <pl-file-editor
@@ -22,4 +22,5 @@
 
 <pl-submission-panel>
     <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/exampleCourse/questions/demoAutograderPandas/question.html
+++ b/exampleCourse/questions/demoAutograderPandas/question.html
@@ -19,4 +19,5 @@
 
 <pl-submission-panel>
     <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/exampleCourse/questions/demoAutograderPlots/question.html
+++ b/exampleCourse/questions/demoAutograderPlots/question.html
@@ -9,10 +9,10 @@
         $$ f(x) = e^x $$
         on the integer values of $x \in \left[0, 10\right]$, with a linear scale for the x-axis and a logarithmic scale for the y-axis.  Save the plot in the variable <code>plot</code> using <code>plt.gca()</code>.
     </p>
-    
+
     <p>The setup code gives the following variables:</p>
     <p><pl-external-grader-variables params-name="names_for_user"></pl-external-grader-variables></p>
-    
+
     <p>Your code snippet should define the following variables:</p>
     <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
     <pl-file-editor
@@ -23,4 +23,5 @@
 
 <pl-submission-panel>
     <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/exampleCourse/questions/demoAutograderRandom/question.html
+++ b/exampleCourse/questions/demoAutograderRandom/question.html
@@ -8,7 +8,7 @@
     <p>
         Using Monte Carlo integration, approximate the area of a circle with radius of $1$.  Generate $N=100$ random points such that each point lies inside of a box centered at the origin with side length $2$, and use these points to estimate the area.
     </p>
-    
+
     <p>Your code snippet should define the following variables:</p>
     <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
     <pl-file-editor
@@ -19,4 +19,5 @@
 
 <pl-submission-panel>
     <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/exampleCourse/questions/demoAutograderSquare/question.html
+++ b/exampleCourse/questions/demoAutograderSquare/question.html
@@ -8,10 +8,10 @@
     <p>
         Find the square of <code>x</code> and save it as <code>x_sq</code>.
     </p>
-    
+
     <p>The setup code gives the following variables:</p>
     <p><pl-external-grader-variables params-name="names_for_user"></pl-external-grader-variables></p>
-    
+
     <p>Your code snippet should define the following variables:</p>
     <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
     <pl-file-editor
@@ -22,4 +22,5 @@
 
 <pl-submission-panel>
     <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/exampleCourse/questions/demoCodeEditorAutograded/question.html
+++ b/exampleCourse/questions/demoCodeEditorAutograded/question.html
@@ -13,7 +13,7 @@
 
   <p>Your code snippet should define the following variables:</p>
   <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
-  
+
   <pl-file-editor file-name="user_code.py" ace-mode="ace/mode/python" source-file-name="initial_code.py">
   </pl-file-editor>
 
@@ -29,4 +29,5 @@
 
 <pl-submission-panel>
   <pl-external-grader-results></pl-external-grader-results>
+  <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/exampleCourse/questions/demoCodeUploadAutograded/question.html
+++ b/exampleCourse/questions/demoCodeUploadAutograded/question.html
@@ -10,14 +10,14 @@
     Write a Python function <tt>fib</tt> that takes a number <tt>n</tt>
     and returns the n<sup>th</sup> Fibonacci number.
   </p>
-  
+
   <p>Your code snippet should define the following variables:</p>
   <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
-  
+
   <pl-file-upload file-names="fib.py"></pl-file-upload>
 </pl-question-panel>
 
 <pl-submission-panel>
-  <pl-file-preview></pl-file-preview>
   <pl-external-grader-results></pl-external-grader-results>
+  <pl-file-preview></pl-file-preview>
 </pl-submission-panel>

--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -4,8 +4,6 @@ FROM centos:7
 ENV PYTHONIOENCODING=UTF-8
 
 COPY requirements.txt /
-COPY python_autograder /python_autograder
-RUN chmod +x /python_autograder/run.sh
 
 RUN yum -y update \
     && yum install -y sudo gcc make \
@@ -15,3 +13,6 @@ RUN yum -y update \
     && python3 -m pip install --no-cache-dir -r /requirements.txt
 
 RUN useradd ag
+
+COPY python_autograder /python_autograder
+RUN chmod +x /python_autograder/run.sh

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -7,6 +7,7 @@ from pl_helpers import (points, name, save_plot, print_student_code, not_repeate
 from pl_execute import execute_code
 from code_feedback import Feedback
 
+
 # Needed to ensure matplotlib runs on Docker
 import matplotlib
 matplotlib.use('Agg')
@@ -21,7 +22,6 @@ class PLTestCase(unittest.TestCase):
     """
 
     include_plt = False
-    student_code_string = 'test_zzz_print_student_code'
     student_code_file = 'user_code.py'
     iter_num = 0
     total_iters = 1
@@ -51,7 +51,7 @@ class PLTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """ 
+        """
         Close all plots and increment the iteration number on test finish
         """
 
@@ -103,18 +103,8 @@ class PLTestCase(unittest.TestCase):
         """
 
         test_id = self.id().split('.')[-1]
-        if not result.done_grading or test_id == self.student_code_string:
+        if not result.done_grading:
             super(PLTestCase, self).run(result)
-
-
-    @not_repeated
-    @points(0)
-    @name('Student Code')
-    def test_zzz_print_student_code(self):
-        """
-        Test cases are alphabetically ordered, so add a buncha z's in the name to display student code last
-        """
-        print_student_code(self.student_code_abs_path)
 
 
 class PLTestCaseWithPlot(PLTestCase):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ pages:
   - 'PrairieDraw graphics': 'PrairieDraw.md'
   - 'Element for drawing': 'pl-drawing/index.md'
   - 'External grading': 'externalGrading.md'
+  - 'Python autograder': 'python-grader/index.md'
   - 'Manual grading': 'manualGrading.md'
   - 'What to tell students': 'whatToTellStudents.md'
   - 'How to use PL to learn student names': 'howToLearnNames.md'


### PR DESCRIPTION
Fixes #2577 

Student submissions are no longer displayed as a test case, but instead use the `pl-file-preview` element.  This has the benefit that submissions are now displayed if a student clicks "save" instead of "save and grade".

![Screenshot_2020-06-10 PrairieLearn](https://user-images.githubusercontent.com/1790491/84286892-e0ebf380-ab04-11ea-9c66-540cf26515d2.png)

![Screenshot_2020-06-10 PrairieLearn(1)](https://user-images.githubusercontent.com/1790491/84286897-e21d2080-ab04-11ea-8e38-758add8ff00e.png)
