### PR TITLE
Fix python autograder failing when grading plot labels

### DIFF
--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -51,7 +51,7 @@ class PLTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """ 
+        """
         Close all plots and increment the iteration number on test finish
         """
 
@@ -150,4 +150,4 @@ class PLTestCaseWithPlot(PLTestCase):
         else:
             Feedback.add_feedback('Plot is missing ylabel')
 
-        Feedback.set_percent(points / 3.0)
+        Feedback.set_score(points / 3.0)


### PR DESCRIPTION
Resolves #2580

Plot grading was using the old `set_percent()` instead of `set_score()`