### PR TITLE
Fix label keys for pl-checkbox and pl-multiple-choice

### DIFF
--- a/elements/pl-checkbox/pl-checkbox.css
+++ b/elements/pl-checkbox/pl-checkbox.css
@@ -5,4 +5,5 @@
 
 :not(.form-check-inline) > .pl-checkbox-key-label {
     min-width: 1.25em;
+    overflow-wrap: normal;
 }

--- a/elements/pl-multiple-choice/pl-multiple-choice.css
+++ b/elements/pl-multiple-choice/pl-multiple-choice.css
@@ -5,4 +5,5 @@
 
 :not(.form-check-inline) > .pl-multiple-choice-key-label {
     min-width: 1.25em;
+    overflow-wrap: normal;
 }


### PR DESCRIPTION
Fixes #2582 

Strangely enough, this bug only occurs on macOS.

Before:
![image](https://user-images.githubusercontent.com/1790491/84518600-8e424100-ac96-11ea-817a-f041c6285a31.png)

After:
![image](https://user-images.githubusercontent.com/1790491/84518614-9601e580-ac96-11ea-8630-3a61c0009ab9.png)