### PR TITLE
Python autograder: change working directory before executing test code

### DIFF
--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -64,10 +64,6 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     # Seed student code and answer code with same seed
     seed = random.randint(0, (2 ** 32) - 1)
 
-    # Update the working directory so tests may access local files
-    prev_wd = os.getcwd()
-    os.chdir(base_dir)
-
     setup_code = {'test_iter_num': test_iter_num, 'data': data}
     # make all the variables in setup_code.py available to ans.py
     exec(str_setup, setup_code)
@@ -137,9 +133,6 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     # Redirect stdout back to normal
     sys.stdout.flush()
     sys.stdout = previous_stdout
-
-    # Change back to previous directory
-    os.chdir(prev_wd)
 
     ref_result = {}
     for i,j in ref_code.items():

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -31,10 +31,10 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     - fname_student: Filename for the submitted student answer code.
     - include_plt: If true, plots will be included in grading results.
     - console_output_fname: Filename to redirect console output to.
-    - test_iter_num: The iteration number of this test, when test cases are run multiple times. 
+    - test_iter_num: The iteration number of this test, when test cases are run multiple times.
 
     Returns:
-    - ref_result: A named tuple with reference variables 
+    - ref_result: A named tuple with reference variables
     - student_result: A named tuple with submitted student variables
     - plot_value: Any plots made by the student
     """
@@ -63,6 +63,10 @@ def execute_code(fname_ref, fname_student, include_plt=False,
 
     # Seed student code and answer code with same seed
     seed = random.randint(0, (2 ** 32) - 1)
+
+    # Update the working directory so tests may access local files
+    prev_wd = os.getcwd()
+    os.chdir(base_dir)
 
     setup_code = {'test_iter_num': test_iter_num, 'data': data}
     # make all the variables in setup_code.py available to ans.py
@@ -133,6 +137,9 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     # Redirect stdout back to normal
     sys.stdout.flush()
     sys.stdout = previous_stdout
+
+    # Change back to previous directory
+    os.chdir(prev_wd)
 
     ref_result = {}
     for i,j in ref_code.items():

--- a/graders/python/python_autograder/pl_main.py
+++ b/graders/python/python_autograder/pl_main.py
@@ -50,6 +50,10 @@ if __name__ == '__main__':
             output_fname = output_f.read()
         os.remove(join(filenames_dir, OUTPUT_FILE))
 
+        # Update the working directory so tests may access local files
+        prev_wd = os.getcwd()
+        os.chdir(base_dir)
+
         # Run the tests with our custom setup
         loader = TestLoader()
         all_results = []
@@ -64,6 +68,9 @@ if __name__ == '__main__':
                 gradable = False
                 format_errors = result.format_errors
                 break
+
+        # Change back to previous directory
+        os.chdir(prev_wd)
 
         if len(all_results) > 1:
             # Combine results into big dict and then back to list of dicts


### PR DESCRIPTION
Previously, the autograder would use only absolute paths for everything.  This gives problems when the test cases/setup code/user code want to access files in the same directory like images, for example. 

This PR updates the grader to CD into the base directory with all files before executing user code, test code, and setup code.