### PR TITLE
Ignore /public directory in Nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     },
     "scripts": {
         "start": "node server.js",
-        "start-nodemon": "npx nodemon -e js,json,sql -L server.js",
+        "start-nodemon": "npx nodemon -e js,json,sql -L server.js --ignore /public",
         "test": "nyc --reporter=lcov mocha tests/index.js",
         "test-nocoverage": "mocha tests/index.js",
         "lint-js": "eslint --ext js \"**/*.js\"",


### PR DESCRIPTION
Since files in /public contain frontend JS, it shouldn't require a server restart if we edit one of these files.