### PR TITLE
Change warning -> info in config for docker startup (Close #2525)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -192,7 +192,7 @@ config.loadConfig = function(file) {
         const fileConfig = jsonLoad.readJSONSyncOrDie(file, schemas.serverConfig);
         _.assign(config, fileConfig);
     } else {
-        logger.warn(file + ' not found, using default configuration');
+        logger.info(file + ' not found, using default single-course configuration');
     }
 };
 


### PR DESCRIPTION
Deactivates a warning in favor of emphasizing a single-course setup is being used.

Closes #2525 