### PR TITLE
Fix file downloads for assessments

### DIFF
--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -304,7 +304,6 @@ all_files AS (
 SELECT
     (
         uid
-        || '_' || uin
         || '_' || assessment_instance_number
         || '_' || qid
         || '_' || variant_number
@@ -319,7 +318,7 @@ WHERE
     filename IS NOT NULL
     AND contents IS NOT NULL
 ORDER BY
-    uid, uin, assessment_instance_number, qid, variant_number, date
+    uid, assessment_instance_number, qid, variant_number, date
 LIMIT
     $limit
 OFFSET

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -240,7 +240,6 @@ WITH all_submissions_with_files AS (
     SELECT
         s.id AS submission_id,
         u.uid,
-        u.uin,
         ai.number AS assessment_instance_number,
         q.qid,
         v.number AS variant_number,


### PR DESCRIPTION
Resolves #2613 

Student file submissions were trying to be named with the their UIN in the filename, but there was a bug in the query.  I took the UIN out of the filename because it looked cluttered IMO, but I can add this if wanted.