### PR TITLE
Add `questions.workspace_graded_image` column

### DIFF
--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -22,6 +22,7 @@ columns
     topic_id: bigint
     type: enum_question_type
     uuid: uuid not null
+    workspace_graded_files: text[] default ARRAY[]::text[]
     workspace_image: text
 
 indexes

--- a/migrations/178_questions__workspace_graded_files__add.sql
+++ b/migrations/178_questions__workspace_graded_files__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN IF NOT EXISTS workspace_graded_files text[] DEFAULT ARRAY[]::text[];


### PR DESCRIPTION
Looks like we also need a `questions.workspace_graded_image` column based on #2504's proposed json:
```json
{
    "workspace": {
        "image": "some-docker-image-name",
        "gradedFiles": [
            "animal.h",
            "animal.cpp"
        ]
    }
}
```