### PR TITLE
Allow use of the `data` parameter in python autograder test cases

### DIFF
--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -92,6 +92,8 @@ Note that the `<pl-external-grader-variables>` element is for purely decorative 
 
 This file is executed before any reference or student code is run.  Any variables defined in `names_for_user` can be accessed from here in student code, while the reference answer may freely access variables without restriction.  The code in this file is run only _once_ total for both student and reference code.  If you need to run some code before each of student and reference code (for example, to set a random seed), you may define the function `def repeated_setup()`, which will be executed before each of them.  `repeated_setup()` will always be run after the setup code itself is run.
 
+The server parameters in `data` can be accessed with `data` in this file.
+
 ### `tests/test.py`
 
 The test cases for each coding problem are defined as methods of a `test` class contained in the aptly named `test.py` file.  The class will have one of the following signatures, depending if you require plots from the student:
@@ -136,6 +138,8 @@ def test_0(self):
 ```
 
 Note that `Feedback.set_score()` is used to set the correctness of the test case between `0` and `1`, this is then multiplied by the number of points awarded by the test case.  For example, if a test case is worth 10 points and `Feedback.set_score(0.5)` is run, the student will be awarded 5 points.
+
+The server parameters in `data` can be accessed from within the test cases using `self.data`.
 
 #### Multiple Iterations
 

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -43,7 +43,7 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     job_dir = os.environ.get("JOB_DIR")
     filenames_dir = os.environ.get("FILENAMES_DIR")
 
-    with open(join(job_dir, 'data', 'data.json')) as f:
+    with open(join(filenames_dir, 'data.json')) as f:
         data = json.load(f)
     with open(join(filenames_dir, 'setup_code.py'), 'r') as f:
         str_setup = f.read()
@@ -53,6 +53,8 @@ def execute_code(fname_ref, fname_student, include_plt=False,
         str_student = f.read()
     with open(join(filenames_dir, 'test.py')) as f:
         str_test = f.read()
+
+    os.remove(join(filenames_dir, 'data.json'))
     os.remove(fname_ref)
     os.remove(join(filenames_dir, 'setup_code.py'))
     os.remove(join(filenames_dir, 'test.py'))
@@ -121,6 +123,8 @@ def execute_code(fname_ref, fname_student, include_plt=False,
         err = None
     except Exception:
         err = sys.exc_info()
+    with open(join(filenames_dir, 'data.json'), 'w') as f:
+        json.dump(data, f)
     with open(fname_ref, 'w') as f:
         f.write(str_ref)
     with open(join(filenames_dir, 'setup_code.py'), 'w') as f:

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import json
 from os.path import join
 from types import FunctionType
 from collections import namedtuple
@@ -27,63 +28,70 @@ class PLTestCase(unittest.TestCase):
     total_iters = 1
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(self):
         """
         On start, run the user code and generate answer tuples.
         """
-        Feedback.set_test(cls)
-        filenames_dir = os.environ.get("FILENAMES_DIR")
+        Feedback.set_test(self)
         base_dir = os.environ.get("MERGE_DIR")
-        cls.student_code_abs_path = join(base_dir, cls.student_code_file)
+        job_dir = os.environ.get("JOB_DIR")
+        filenames_dir = os.environ.get("FILENAMES_DIR")
+        self.student_code_abs_path = join(base_dir, self.student_code_file)
+
+        # Load data so that we can use it in the test cases
+        filenames_dir = os.environ.get("FILENAMES_DIR")
+        with open(join(filenames_dir, 'data.json')) as f:
+            self.data = json.load(f)
+
         ref_result, student_result, plot_value = execute_code(join(filenames_dir, 'ans.py'),
-                                                              join(base_dir, cls.student_code_file),
-                                                              cls.include_plt,
+                                                              join(base_dir, self.student_code_file),
+                                                              self.include_plt,
                                                               join(base_dir, 'output.txt'),
-                                                              cls.iter_num)
+                                                              self.iter_num)
         answerTuple = namedtuple('answerTuple', ref_result.keys())
-        cls.ref = answerTuple(**ref_result)
+        self.ref = answerTuple(**ref_result)
         studentTuple = namedtuple('studentTuple', student_result.keys())
-        cls.st = studentTuple(**student_result)
-        cls.plt = plot_value
-        if cls.include_plt:
-            cls.display_plot()
+        self.st = studentTuple(**student_result)
+        self.plt = plot_value
+        if self.include_plt:
+            self.display_plot()
 
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(self):
         """
         Close all plots and increment the iteration number on test finish
         """
 
-        if cls.include_plt:
-            cls.plt.close('all')
-        cls.iter_num += 1
+        if self.include_plt:
+            self.plt.close('all')
+        self.iter_num += 1
 
 
     @classmethod
-    def display_plot(cls):
-        axes = cls.plt.gca()
+    def display_plot(self):
+        axes = self.plt.gca()
         if axes.get_lines() or axes.collections or axes.patches or axes.images:
-            save_plot(cls.plt, cls.iter_num)
+            save_plot(self.plt, self.iter_num)
 
 
     @classmethod
-    def get_total_points(cls):
+    def get_total_points(self):
         """
         Get the total number of points awarded by this test suite, including
         cases where the test suite is run multiple times.
         """
 
-        methods = [y for x, y in cls.__dict__.items()
+        methods = [y for x, y in self.__dict__.items()
                    if callable(y) and hasattr(y, '__dict__') and x.startswith('test_') and 'points' in y.__dict__]
-        if cls.total_iters == 1:
+        if self.total_iters == 1:
             total = sum([m.__dict__['points'] for m in methods])
         else:
             once = sum([m.__dict__['points'] for m in methods
                        if not m.__dict__.get('__repeated__', True)])
             several = sum([m.__dict__['points'] for m in methods
                           if m.__dict__.get('__repeated__', True)])
-            total = cls.total_iters*several + once
+            total = self.total_iters*several + once
         return total
 
 
@@ -92,7 +100,6 @@ class PLTestCase(unittest.TestCase):
         On test start, initialise the points and set up the code feedback library
         to provide feedback for this test.
         """
-
         self.points = 0
         Feedback.set_test(self)
 

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -44,7 +44,7 @@ chmod 1777 "$MERGE_DIR"
 export FILENAMES_DIR=$MERGE_DIR'/filenames'
 mkdir $FILENAMES_DIR
 chmod 777 $FILENAMES_DIR
-mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $FILENAMES_DIR
+mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $JOB_DIR/data/data.json $FILENAMES_DIR
 
 ##########################
 # RUN


### PR DESCRIPTION
Resolves #2667 

`data` can be accessed from the test cases using `self.data`.

Also, the `data.json` file is deleted before user code is run so that students do not have access.