### PR TITLE
Add mkdocs-material to python requirements for new doc system

### DIFF
--- a/environments/centos7-plbase/python-requirements.txt
+++ b/environments/centos7-plbase/python-requirements.txt
@@ -21,3 +21,4 @@ Pygments==2.6.1
 sphinx==3.1.1
 sphinx-markdown-builder==0.5.4
 recommonmark==0.6.0
+mkdocs-material==5.4.0


### PR DESCRIPTION
Adds to the base image `mkdocs-material`, which includes Material for MkDocs theme, [MkDocs][2],
[Markdown][3], [Pygments][4] and [PyMdown Extensions][5]. 

**Note:** `mkdocs` was missing from the image before.


  [2]: https://www.mkdocs.org
  [3]: https://python-markdown.github.io/
  [4]: https://pygments.org/
  [5]: https://facelessuser.github.io/pymdown-extensions/
