### PR TITLE
Fix markdown syntax of "JSON syncing" docs

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -364,83 +364,83 @@ ALTER TABLE alternative_groups ADD UNIQUE (assessment_id, number);
 
 ## JSON syncing
 
-1. Edit the DB schema; e.g., to add a `require_honor_code` boolean for assessments, modify `database/tables/assessments.pg`:
+* Edit the DB schema; e.g., to add a `require_honor_code` boolean for assessments, modify `database/tables/assessments.pg`:
 
-    ```diff
-    @@ -16,2 +16,3 @@ columns
-         order_by: integer
-    +    require_honor_code: boolean default true
-         shuffle_questions: boolean default false
-    ```
+```diff
+@@ -16,2 +16,3 @@ columns
+     order_by: integer
++    require_honor_code: boolean default true
+     shuffle_questions: boolean default false
+```
 
-1. Add a DB migration; e.g., create `migrations/167_assessments__require_honor_code__add.sql`:
+* Add a DB migration; e.g., create `migrations/167_assessments__require_honor_code__add.sql`:
 
-    ```diff
-    @@ -0,0 +1 @@
-    +ALTER TABLE assessments ADD COLUMN require_honor_code boolean DEFAULT true;
-    ```
+```diff
+@@ -0,0 +1 @@
++ALTER TABLE assessments ADD COLUMN require_honor_code boolean DEFAULT true;
+```
 
-1. Edit the JSON schema; e.g., modify `schemas/schemas/infoAssessment.json`:
+* Edit the JSON schema; e.g., modify `schemas/schemas/infoAssessment.json`:
 
-    ```diff
-    @@ -89,2 +89,7 @@
-                 "default": true
-    +        },
-    +        "requireHonorCode": {
-    +            "description": "Requires the student to accept an honor code before starting exam assessments.",
-    +            "type": "boolean",
-    +            "default": true
-             }
-    ```
+```diff
+@@ -89,2 +89,7 @@
+             "default": true
++        },
++        "requireHonorCode": {
++            "description": "Requires the student to accept an honor code before starting exam assessments.",
++            "type": "boolean",
++            "default": true
+         }
+```
 
-1. Edit the sync parser; e.g., modify `sync/fromDisk/assessments.js`:
+* Edit the sync parser; e.g., modify `sync/fromDisk/assessments.js`:
 
-    ```diff
-    @@ -44,2 +44,3 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
-             const allowRealTimeGrading = !!_.get(assessment, 'allowRealTimeGrading', true);
-    +        const requireHonorCode = !!_.get(assessment, 'requireHonorCode', true);
+```diff
+@@ -44,2 +44,3 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
+         const allowRealTimeGrading = !!_.get(assessment, 'allowRealTimeGrading', true);
++        const requireHonorCode = !!_.get(assessment, 'requireHonorCode', true);
 
-    @@ -63,2 +64,3 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
-                 allow_real_time_grading: allowRealTimeGrading,
-    +            require_honor_code: requireHonorCode,
-                 auto_close: !!_.get(assessment, 'autoClose', true),
-    ```
+@@ -63,2 +64,3 @@ function buildSyncData(courseInfo, courseInstance, questionDB) {
+             allow_real_time_grading: allowRealTimeGrading,
++            require_honor_code: requireHonorCode,
+             auto_close: !!_.get(assessment, 'autoClose', true),
+```
 
-1. Edit the sync query; e.g., modify `sprocs/sync_assessments.sql`:
+* Edit the sync query; e.g., modify `sprocs/sync_assessments.sql`:
 
-    ```diff
-    @@ -44,3 +44,4 @@ BEGIN
-                 allow_issue_reporting,
-    -            allow_real_time_grading)
-    +            allow_real_time_grading,
-    +            require_honor_code)
-                 (
-    @@ -64,3 +65,4 @@ BEGIN
-                     (assessment->>'allow_issue_reporting')::boolean,
-    -                (assessment->>'allow_real_time_grading')::boolean
-    +                (assessment->>'allow_real_time_grading')::boolean,
-    +                (assessment->>'require_honor_code')::boolean
-             )
-    @@ -83,3 +85,4 @@ BEGIN
-                 allow_issue_reporting = EXCLUDED.allow_issue_reporting,
-    -            allow_real_time_grading = EXCLUDED.allow_real_time_grading
-    +            allow_real_time_grading = EXCLUDED.allow_real_time_grading,
-    +            require_honor_code = EXCLUDED.require_honor_code
-             WHERE
-    ```
+```diff
+@@ -44,3 +44,4 @@ BEGIN
+             allow_issue_reporting,
+-            allow_real_time_grading)
++            allow_real_time_grading,
++            require_honor_code)
+             (
+@@ -64,3 +65,4 @@ BEGIN
+                 (assessment->>'allow_issue_reporting')::boolean,
+-                (assessment->>'allow_real_time_grading')::boolean
++                (assessment->>'allow_real_time_grading')::boolean,
++                (assessment->>'require_honor_code')::boolean
+         )
+@@ -83,3 +85,4 @@ BEGIN
+             allow_issue_reporting = EXCLUDED.allow_issue_reporting,
+-            allow_real_time_grading = EXCLUDED.allow_real_time_grading
++            allow_real_time_grading = EXCLUDED.allow_real_time_grading,
++            require_honor_code = EXCLUDED.require_honor_code
+         WHERE
+```
 
-1. Edit the sync tests; e.g., modify `tests/sync/util.js`:
+* Edit the sync tests; e.g., modify `tests/sync/util.js`:
 
-    ```diff
-    @@ -128,2 +128,3 @@ const syncFromDisk = require('../../sync/syncFromDisk');
-      * @property {boolean} allowRealTimeGrading
-    + * @property {boolean} requireHonorCode
-      * @property {boolean} multipleInstance
-    ```
+```diff
+@@ -128,2 +128,3 @@ const syncFromDisk = require('../../sync/syncFromDisk');
+  * @property {boolean} allowRealTimeGrading
++ * @property {boolean} requireHonorCode
+  * @property {boolean} multipleInstance
+```
 
-1. Add documentation; e.g., the honor code option is described at [Assessments -- Honor code](assessment.md#honor-code).
+* Add documentation; e.g., the honor code option is described at [Assessments -- Honor code](assessment.md#honor-code).
 
-1. Add [tests](#unit-tests-and-integration-tests).
+* Add [tests](#unit-tests-and-integration-tests).
 
 
 ## Database access


### PR DESCRIPTION
Check with mkdocs `site/` preview. Fixed to actually show diff syntax now, but had to remove numbering/indentation.