### PR TITLE
Add option to hide letter keys in pl-multiple-choice and pl-checkbox

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -111,6 +111,7 @@ Attribute | Type | Default | Description
 `inline` | boolean | false | List answer choices on a single line instead of as separate paragraphs.
 `number-answers` | integer | special | The total number of answer choices to display. Defaults to displaying one correct answer and all incorrect answers.
 `fixed-order` | boolean | false | Disable the randomization of answer order.
+`hide-letter-keys` | boolean | false | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.
 
 Inside the `pl-multiple-choice` element, each choice must be specified with
 a `pl-answer` that has attributes:
@@ -164,6 +165,7 @@ Attribute | Type | Default | Description
 `hide-help-text` | boolean | false | Help text with hint regarding the selection of answers. Popover button describes the selected grading algorithm ('all-or-nothing', 'EDC' or 'PC')
 `detailed-help-text` | boolean | false | Display detailed information in help text about the number of options to choose.
 `hide-answer-panel` | boolean | false | Option to not display the correct answer in the correct panel.
+`hide-letter-keys` | boolean | false | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.
 
 Inside the `pl-checkbox` element, each choice must be specified with
 a `pl-answer` that has attributes:

--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -19,7 +19,7 @@
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
 
         <label class="form-check-label d-flex align-items-center" for="{{name}}-{{key}}">
-            <div class="pl-checkbox-key-label">({{key}})</div>
+            {{^hide_letter_keys}}<div class="pl-checkbox-key-label">({{key}})</div>{{/hide_letter_keys}}
             <div class="ml-1 mr-1">{{{html}}}</div>
         </label>
             
@@ -85,7 +85,7 @@
     
 {{#answers}}
     <li {{#inline}}class="list-inline-item"{{/inline}}>
-    ({{key}}) {{{html}}}
+    {{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{html}}}
 
     {{#display_score_badge}}
         {{#correct}}

--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -124,7 +124,7 @@
     {{^inline}}<div class="d-block"><ul class="list-unstyled mb-0">{{/inline}}
     {{#answers}}
         <li {{#inline}}class="list-inline-item"{{/inline}}>
-            ({{key}}) {{{html}}}
+            {{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{html}}}
         </li>
     {{/answers}}
     {{#inline}}</ul></span>{{/inline}}

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -13,6 +13,7 @@ PARTIAL_CREDIT_METHOD_DEFAULT = 'PC'
 HIDE_ANSWER_PANEL_DEFAULT = False
 HIDE_HELP_TEXT_DEFAULT = False
 DETAILED_HELP_TEXT_DEFAULT = False
+HIDE_LETTER_KEYS_DEFAULT = False
 
 
 def prepare(element_html, data):
@@ -193,7 +194,7 @@ def render(element_html, data):
             'info': info,
             'answers': answerset,
             'inline': inline,
-            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
+            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
         }
 
         if not hide_help_text:

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -137,8 +137,7 @@ def render(element_html, data):
                 'key': answer['key'],
                 'checked': (answer['key'] in submitted_keys),
                 'html': answer['html'].strip(),
-                'display_score_badge': score is not None and show_answer_feedback and answer['key'] in submitted_keys,
-                'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
+                'display_score_badge': score is not None and show_answer_feedback and answer['key'] in submitted_keys
             }
             if answer_html['display_score_badge']:
                 answer_html['correct'] = (answer['key'] in correct_keys)
@@ -193,7 +192,8 @@ def render(element_html, data):
             'uuid': pl.get_uuid(),
             'info': info,
             'answers': answerset,
-            'inline': inline
+            'inline': inline,
+            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
         }
 
         if not hide_help_text:

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -238,7 +238,8 @@ def render(element_html, data):
                 'submission': True,
                 'display_score_badge': (score is not None),
                 'answers': answers,
-                'inline': inline
+                'inline': inline,
+                'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
             }
 
             if html_params['display_score_badge']:
@@ -275,7 +276,8 @@ def render(element_html, data):
                 html_params = {
                     'answer': True,
                     'inline': inline,
-                    'answers': correct_answer_list
+                    'answers': correct_answer_list,
+                    'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
                 }
                 with open('pl-checkbox.mustache', 'r', encoding='utf-8') as f:
                     html = chevron.render(f, html_params).strip()

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -19,7 +19,7 @@ def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method']
+    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method', 'hide-letter-keys']
 
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
@@ -137,7 +137,8 @@ def render(element_html, data):
                 'key': answer['key'],
                 'checked': (answer['key'] in submitted_keys),
                 'html': answer['html'].strip(),
-                'display_score_badge': score is not None and show_answer_feedback and answer['key'] in submitted_keys
+                'display_score_badge': score is not None and show_answer_feedback and answer['key'] in submitted_keys,
+                'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
             }
             if answer_html['display_score_badge']:
                 answer_html['correct'] = (answer['key'] in correct_keys)

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -80,3 +80,15 @@
     
 {{/parse_error}}
 {{/submission}}
+
+{{#answer}}
+    {{#inline}}<span class="d-inline-block"><ul class="list-inline mb-0">{{/inline}}
+    {{^inline}}<div class="d-block"><ul class="list-unstyled mb-0">{{/inline}}
+    {{#answers}}
+        <li {{#inline}}class="list-inline-item"{{/inline}}>
+            {{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{html}}}
+        </li>
+    {{/answers}}
+    {{#inline}}</ul></span>{{/inline}}
+    {{^inline}}</ul></div>{{/inline}}
+{{/answer}}

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -11,7 +11,7 @@
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
 
         <label class="form-check-label d-flex align-items-center" for="{{name}}-{{key}}">
-            <div class="pl-multiple-choice-key-label">({{key}})</div>
+            {{^hide_letter_keys}}<div class="pl-multiple-choice-key-label">({{key}})</div>{{/hide_letter_keys}}
             <div class="ml-1 mr-1">{{{html}}}</div>
         </label>
             
@@ -63,7 +63,7 @@
 {{/parse_error}}
 {{^parse_error}}
 
-({{key}}) {{{answer.html}}}
+{{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{answer.html}}}
 
 {{#display_score_badge}}
     &nbsp;

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -6,7 +6,6 @@ import chevron
 
 WEIGHT_DEFAULT = 1
 INLINE_DEFAULT = False
-HIDE_ANSWER_PANEL_DEFAULT = False
 HIDE_LETTER_KEYS_DEFAULT = False
 
 
@@ -162,25 +161,22 @@ def render(element_html, data):
         with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:
             html = chevron.render(f, html_params).strip()
     elif data['panel'] == 'answer':
-        if not pl.get_boolean_attrib(element, 'hide-answer-panel', HIDE_ANSWER_PANEL_DEFAULT):
-            correct_answer = data['correct_answers'].get(name, None)
+        correct_answer = data['correct_answers'].get(name, None)
 
-            if correct_answer is None:
-                raise ValueError('No true answer.')
-            else:
-                html_params = {
-                    'answer': True,
-                    'answers': correct_answer,
-                    'key': correct_answer['key'],
-                    'html': correct_answer['html'],
-                    'inline': inline,
-                    'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
-                }
-                with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:
-                    html = chevron.render(f, html_params).strip()
-                    print(f'html: {html}')
+        if correct_answer is None:
+            raise ValueError('No true answer.')
         else:
-            html = ''
+            html_params = {
+                'answer': True,
+                'answers': correct_answer,
+                'key': correct_answer['key'],
+                'html': correct_answer['html'],
+                'inline': inline,
+                'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
+            }
+            with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:
+                html = chevron.render(f, html_params).strip()
+                print(f'html: {html}')
     else:
         raise Exception('Invalid panel type: %s' % data['panel'])
 

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -6,6 +6,7 @@ import chevron
 
 WEIGHT_DEFAULT = 1
 INLINE_DEFAULT = False
+HIDE_LETTER_KEYS_DEFAULT = False
 
 
 def prepare(element_html, data):
@@ -133,7 +134,7 @@ def render(element_html, data):
             'submission': True,
             'parse_error': parse_error,
             'uuid': pl.get_uuid(),
-            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
+            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
         }
 
         if parse_error is None:

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -96,8 +96,7 @@ def render(element_html, data):
                 'key': answer['key'],
                 'checked': (submitted_key == answer['key']),
                 'html': answer['html'],
-                'display_score_badge': display_score and submitted_key == answer['key'],
-                'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
+                'display_score_badge': display_score and submitted_key == answer['key']
             }
             if answer_html['display_score_badge']:
                 answer_html['correct'] = (correct_key == answer['key'])
@@ -133,7 +132,8 @@ def render(element_html, data):
         html_params = {
             'submission': True,
             'parse_error': parse_error,
-            'uuid': pl.get_uuid()
+            'uuid': pl.get_uuid(),
+            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
         }
 
         if parse_error is None:

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -11,7 +11,7 @@ INLINE_DEFAULT = False
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'number-answers', 'fixed-order', 'inline']
+    optional_attribs = ['weight', 'number-answers', 'fixed-order', 'inline', 'hide-letter-keys']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
 
@@ -96,7 +96,8 @@ def render(element_html, data):
                 'key': answer['key'],
                 'checked': (submitted_key == answer['key']),
                 'html': answer['html'],
-                'display_score_badge': display_score and submitted_key == answer['key']
+                'display_score_badge': display_score and submitted_key == answer['key'],
+                'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', False)
             }
             if answer_html['display_score_badge']:
                 answer_html['correct'] = (correct_key == answer['key'])

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -176,7 +176,6 @@ def render(element_html, data):
             }
             with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:
                 html = chevron.render(f, html_params).strip()
-                print(f'html: {html}')
     else:
         raise Exception('Invalid panel type: %s' % data['panel'])
 

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -6,6 +6,7 @@ import chevron
 
 WEIGHT_DEFAULT = 1
 INLINE_DEFAULT = False
+HIDE_ANSWER_PANEL_DEFAULT = False
 HIDE_LETTER_KEYS_DEFAULT = False
 
 
@@ -161,15 +162,25 @@ def render(element_html, data):
         with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:
             html = chevron.render(f, html_params).strip()
     elif data['panel'] == 'answer':
-        correct_answer = data['correct_answers'].get(name, None)
-        if correct_answer is None:
-            html = 'ERROR: No true answer'
-        else:
-            html = '(%s) %s' % (correct_answer['key'], correct_answer['html'])
+        if not pl.get_boolean_attrib(element, 'hide-answer-panel', HIDE_ANSWER_PANEL_DEFAULT):
+            correct_answer = data['correct_answers'].get(name, None)
 
-        html_params = {
-            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
-        }
+            if correct_answer is None:
+                raise ValueError('No true answer.')
+            else:
+                html_params = {
+                    'answer': True,
+                    'answers': correct_answer,
+                    'key': correct_answer['key'],
+                    'html': correct_answer['html'],
+                    'inline': inline,
+                    'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
+                }
+                with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:
+                    html = chevron.render(f, html_params).strip()
+                    print(f'html: {html}')
+        else:
+            html = ''
     else:
         raise Exception('Invalid panel type: %s' % data['panel'])
 

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -110,7 +110,8 @@ def render(element_html, data):
             'name': name,
             'editable': editable,
             'display_score_badge': display_score,
-            'answers': answerset
+            'answers': answerset,
+            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
         }
 
         # Display the score badge if necessary
@@ -165,6 +166,10 @@ def render(element_html, data):
             html = 'ERROR: No true answer'
         else:
             html = '(%s) %s' % (correct_answer['key'], correct_answer['html'])
+
+        html_params = {
+            'hide_letter_keys': pl.get_boolean_attrib(element, 'hide-letter-keys', HIDE_LETTER_KEYS_DEFAULT)
+        }
     else:
         raise Exception('Invalid panel type: %s' % data['panel'])
 

--- a/exampleCourse/questions/element/checkbox/question.html
+++ b/exampleCourse/questions/element/checkbox/question.html
@@ -190,7 +190,7 @@
             <p>Group work provides which of the following benefits:</p>
         </pl-question-panel>
 
-        <pl-checkbox answers-name="group_ans_hide_keys" partial-credit="true" partial-credit-method="EDC" hide-letter-keys="true">
+        <pl-checkbox answers-name="group_ans_v6" hide-letter-keys="true">
             <pl-answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl-answer>
             <pl-answer correct="true">Improved creativity and overall work quality.</pl-answer>
             <pl-answer>               The ability to work on a project by yourself.</pl-answer>
@@ -198,7 +198,7 @@
             <pl-answer correct="true">Constructive dialog and increased internal group motivation.</pl-answer>
             <pl-answer correct="true">Personal accountability to the team to work on a project.</pl-answer>
             <pl-answer correct="true">Friendship.</pl-answer>
-            <pl-answer>               The resources to work on a small project instead of a large project.</pl-answer>
+            <pl-answer>               The resources to work on a small project instead of a large project. </pl-answer>
             <pl-answer correct="true">Prepares you for a team-environment in the workplace or a research group.</pl-answer>
         </pl-checkbox>
     </div>

--- a/exampleCourse/questions/element/checkbox/question.html
+++ b/exampleCourse/questions/element/checkbox/question.html
@@ -190,7 +190,7 @@
             <p>Group work provides which of the following benefits:</p>
         </pl-question-panel>
 
-        <pl-checkbox answers-name="group_ans_hide_keys" partial-credit="true" partial-credit-method="EDC">
+        <pl-checkbox answers-name="group_ans_hide_keys" partial-credit="true" partial-credit-method="EDC" hide-letter-keys="true">
             <pl-answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl-answer>
             <pl-answer correct="true">Improved creativity and overall work quality.</pl-answer>
             <pl-answer>               The ability to work on a project by yourself.</pl-answer>

--- a/exampleCourse/questions/element/checkbox/question.html
+++ b/exampleCourse/questions/element/checkbox/question.html
@@ -177,3 +177,29 @@
 
     </div>
 </div>
+
+<div class="card my-2">
+    <div class="card-header">
+        Part 7
+    </div>
+
+    <div class="card-body">
+        <pl-question-panel>
+            <p>Here, letter keys are hidden with <code>hide-letter-keys="true"</code>. This option is especially useful when the answer options themselves are letters.</p>
+
+            <p>Group work provides which of the following benefits:</p>
+        </pl-question-panel>
+
+        <pl-checkbox answers-name="group_ans_hide_keys" partial-credit="true" partial-credit-method="EDC">
+            <pl-answer correct="true">Exposure to new viewpoints from different fields and life experiences.</pl-answer>
+            <pl-answer correct="true">Improved creativity and overall work quality.</pl-answer>
+            <pl-answer>               The ability to work on a project by yourself.</pl-answer>
+            <pl-answer>               Having only one person make all of the decisions.</pl-answer>
+            <pl-answer correct="true">Constructive dialog and increased internal group motivation.</pl-answer>
+            <pl-answer correct="true">Personal accountability to the team to work on a project.</pl-answer>
+            <pl-answer correct="true">Friendship.</pl-answer>
+            <pl-answer>               The resources to work on a small project instead of a large project.</pl-answer>
+            <pl-answer correct="true">Prepares you for a team-environment in the workplace or a research group.</pl-answer>
+        </pl-checkbox>
+    </div>
+</div>

--- a/exampleCourse/questions/element/multipleChoice/question.html
+++ b/exampleCourse/questions/element/multipleChoice/question.html
@@ -87,3 +87,33 @@
 
     </div>
 </div>
+
+<div class="card my-2">
+    <div class="card-header">
+        Part 4
+    </div>
+
+    <div class="card-body">
+
+        <pl-question-panel>
+            <p>
+              Here, letter keys are hidden with <code>hide-letter-keys="true"</code>.
+              This option is especially useful when the answer options themselves are letters.
+            </p>
+               
+            <p>What is the color of the sky?</p>
+        </pl-question-panel>
+
+        <pl-multiple-choice answers-name="sky-color4" hide-letter-keys="true">
+            <pl-answer correct="true">Blue</pl-answer>
+            <pl-answer>Pink</pl-answer>
+            <pl-answer>Purple</pl-answer>
+            <pl-answer>Orange</pl-answer>
+            <pl-answer>Yellow</pl-answer>
+            <pl-answer>Brown</pl-answer>
+            <pl-answer>Red</pl-answer>
+        </pl-multiple-choice>
+
+    </div>
+</div>
+


### PR DESCRIPTION
Adds a `hide-letter-keys` boolean for pl-multiple-choice and pl-checkbox tags. Useful when the answer options are letters themselves.

cc @glherman @echuber2 