### PR TITLE
Populate data['options'] for other Freeform stages

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -165,7 +165,7 @@ module.exports = {
     },
 
     /**
-     * Add clientFiles urls for elements and extensions.
+     * Add clientFiles urls for elements.
      * Returns a copy of data with the new urls inserted.
      */
     getElementClientFiles: function(data, elementName, context) {
@@ -176,14 +176,7 @@ module.exports = {
             /* Join the URL using Posix join to avoid generating a path with backslashes,
                as would be the case when running on Windows */
             dataCopy.options.client_files_element_url = path.posix.join(data.options.base_url, 'elements', elementName, 'clientFilesElement');
-            dataCopy.options.client_files_extensions_url = {};
-
-            if (_.has(context.course_element_extensions, elementName)) {
-                Object.keys(context.course_element_extensions[elementName]).forEach(extension => {
-                    const url = path.posix.join(data.options.base_url, 'elementExtensions', elementName, extension, 'clientFilesExtension');
-                    dataCopy.options.client_files_extensions_url[extension] = url;
-                });
-            }
+            /* This will add extension urls once those are added */
         }
         return dataCopy;
     },
@@ -734,7 +727,6 @@ module.exports = {
         let options = {};
         options.question_path = context.question_dir;
         options.client_files_question_path = path.join(context.question_dir, 'clientFilesQuestion');
-        options.course_extensions_path = path.join(context.course.path, 'elementExtensions');
         return options;
     },
 

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -168,7 +168,7 @@ module.exports = {
      * Add clientFiles urls for elements.
      * Returns a copy of data with the new urls inserted.
      */
-    getElementClientFiles: function(data, elementName, context) {
+    getElementClientFiles: function(data, elementName, _context) {
         let dataCopy = _.cloneDeep(data);
         /* The options field wont contain URLs unless in the 'render' stage, so check
            if it is populated before adding the element url */
@@ -176,7 +176,7 @@ module.exports = {
             /* Join the URL using Posix join to avoid generating a path with backslashes,
                as would be the case when running on Windows */
             dataCopy.options.client_files_element_url = path.posix.join(data.options.base_url, 'elements', elementName, 'clientFilesElement');
-            /* This will add extension urls once those are added */
+            /* This will add extension urls once that is merged (and will use the context, I promise!) */
         }
         return dataCopy;
     },


### PR DESCRIPTION
(Ported over from #2152 )

Stages `generate`, `prepare`, `parse`, `grade`, and `test` now have access to `data['options']['question_path']` and `data['options']['client_files_question_path']`