### PR TITLE
Load MathJax script synchronously

### DIFF
--- a/pages/partials/mathjax.ejs
+++ b/pages/partials/mathjax.ejs
@@ -40,4 +40,4 @@
      }
  };
 </script>
-<script type="text/javascript" id="MathJax-script" src="/MathJax/startup.js" async></script>
+<script type="text/javascript" id="MathJax-script" src="/MathJax/startup.js"></script>


### PR DESCRIPTION
Previously we were loading the MathJax script asynchronously (this is what was shown on the docs), but this leads to weird race conditions, especially with the `pl-drawing` element.  Now we will load the script synchronously, but the startup is still async.