### PR TITLE
Fix server crash on undefined file data

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1098,10 +1098,7 @@ module.exports = {
                             workers.returnPythonCaller(pc, (pcErr) => {
                                 if (ERR(pcErr, callback)) return;
                                 if (ERR(err, callback)) return;
-                                let fileDataBase64 = '';
-                                if (typeof fileData !== 'undefined' && fileData !== null) {
-                                    fileDataBase64 = fileData.toString('base64');
-                                }
+                                const fileDataBase64 = (fileData || '').toString('base64');
                                 const cachedData = {courseIssues, fileDataBase64};
                                 callback(null, cachedData);
                             });

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1098,7 +1098,10 @@ module.exports = {
                             workers.returnPythonCaller(pc, (pcErr) => {
                                 if (ERR(pcErr, callback)) return;
                                 if (ERR(err, callback)) return;
-                                const fileDataBase64 = fileData.toString('base64');
+                                let fileDataBase64 = '';
+                                if (typeof fileData !== 'undefined' && fileData !== null) {
+                                    fileDataBase64 = fileData.toString('base64');
+                                }
                                 const cachedData = {courseIssues, fileDataBase64};
                                 callback(null, cachedData);
                             });


### PR DESCRIPTION
fixes #2693 by checking if `fileData` is undefined/null before converting it to base64