### PR TITLE
Add `questions.workspace_args` column

### DIFF
--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -22,10 +22,10 @@ columns
     topic_id: bigint
     type: enum_question_type
     uuid: uuid not null
+    workspace_args: text
     workspace_graded_files: text[] default ARRAY[]::text[]
     workspace_image: text
     workspace_port: integer
-    workspace_args: text
 
 indexes
     questions_pkey: PRIMARY KEY (id) USING btree (id)

--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -25,6 +25,7 @@ columns
     workspace_graded_files: text[] default ARRAY[]::text[]
     workspace_image: text
     workspace_port: integer
+    workspace_args: text
 
 indexes
     questions_pkey: PRIMARY KEY (id) USING btree (id)

--- a/docs/workspace/index.md
+++ b/docs/workspace/index.md
@@ -6,11 +6,12 @@ Workspaces allow students to work in persistent remote containers via in-browser
 
 ### `info.json`
 
-The question's `info.json` should contain a `workspaceOptions` dictionary with three keys:
+The question's `info.json` should contain a `workspaceOptions` dictionary:
 
 * `image`: Dockerhub image that will be used to serve this question
 * `port`: port number used in the Docker image
 * `gradedFiles`: list of files or directories that will be copied for grading
+* `args`: command line arguments to pass to the Docker
 
 A full `info.json` file should look something like:
 

--- a/docs/workspace/index.md
+++ b/docs/workspace/index.md
@@ -27,8 +27,8 @@ A full `info.json` file should look something like:
         "port": 15000,
         "args": "--auth none",
         "gradedFiles": [
-            "animal.h",
-            "animal.cpp"
+            "starter_code.h",
+            "starter_code.c"
         ]
     }
 }

--- a/docs/workspace/index.md
+++ b/docs/workspace/index.md
@@ -25,6 +25,7 @@ A full `info.json` file should look something like:
     "workspaceOptions": {
         "image": "prairielearn/workspace-vscode",
         "port": 15000,
+        "args": "--auth none",
         "gradedFiles": [
             "animal.h",
             "animal.cpp"

--- a/exampleCourse/questions/demo/workspace/info.json
+++ b/exampleCourse/questions/demo/workspace/info.json
@@ -10,9 +10,10 @@
     "workspaceOptions": {
         "image": "prairielearn/vscode-workspace",
         "port": 15000,
+        "args": "--auth none",
         "gradedFiles": [
-            "animal.h",
-            "animal.cpp"
+            "starter_code.h",
+            "starter_code.c"
         ]
     }
 }

--- a/migrations/181_questions__workspace_args__add.sql
+++ b/migrations/181_questions__workspace_args__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN workspace_args text;

--- a/schemas/schemas/infoQuestion.json
+++ b/schemas/schemas/infoQuestion.json
@@ -220,7 +220,11 @@
                     "description": "The port number used in the Docker image.",
                     "type": "integer"
                 },
-                "gradedFiles": {
+                "args": {
+                    "description": "Command line arguments to pass to the Docker.",
+                    "type": "string"
+                },
+                 "gradedFiles": {
                     "description": "The list of files or directories that will be copied for grading.",
                     "type": "array",
                     "items": {

--- a/sprocs/sync_questions.sql
+++ b/sprocs/sync_questions.sql
@@ -39,6 +39,7 @@ BEGIN
             dependencies,
             workspace_image,
             workspace_port,
+            workspace_args,
             workspace_graded_files
         ) SELECT
             (question->>'uuid')::uuid,
@@ -64,6 +65,7 @@ BEGIN
             (question->>'dependencies')::jsonb,
             question->>'workspace_image',
             (question->>'workspace_port')::integer,
+            question->>'workspace_args',
             jsonb_array_to_text_array(question->'workspace_graded_files')
         FROM JSONB_ARRAY_ELEMENTS(sync_questions.new_questions) AS question
         ON CONFLICT (course_id, uuid) DO UPDATE
@@ -89,6 +91,7 @@ BEGIN
             dependencies = EXCLUDED.dependencies,
             workspace_image = EXCLUDED.workspace_image,
             workspace_port = EXCLUDED.workspace_port,
+            workspace_args = EXCLUDED.workspace_args,
             workspace_graded_files = EXCLUDED.workspace_graded_files
         WHERE
             questions.course_id = new_course_id

--- a/sync/fromDisk/questions.js
+++ b/sync/fromDisk/questions.js
@@ -55,6 +55,7 @@ module.exports.sync = function(courseInfo, questionDB, jobLogger, callback) {
                 dependencies: q.dependencies || {},
                 workspace_image: (q.workspaceOptions && q.workspaceOptions.image),
                 workspace_port: (q.workspaceOptions && q.workspaceOptions.port),
+                workspace_args: (q.workspaceOptions && q.workspaceOptions.args),
                 workspace_graded_files: (q.workspaceOptions && q.workspaceOptions.gradedFiles),
             };
         });

--- a/tests/sync/questionsSync.js
+++ b/tests/sync/questionsSync.js
@@ -104,11 +104,12 @@ describe('Question syncing', () => {
     await assert.isRejected(util.syncCourseData(courseDir));
   });
 
-  it('fails if workspaceOptions["image"] is not synced correctly', async () => {
+  it('fails if workspaceOptions are not synced correctly', async () => {
     const courseData = util.getCourseData();
     const question = courseData.questions[util.WORKSPACE_QUESTION_ID];
     const workspaceImage = question.workspaceOptions.image;
     const workspacePort = question.workspaceOptions.port;
+    const workspaceArgs = question.workspaceOptions.args;
     const quuid = question.uuid;
 
     const courseDir = await util.writeCourseToTempDirectory(courseData);
@@ -116,9 +117,11 @@ describe('Question syncing', () => {
     const result = await sqldb.queryOneRowAsync(sql.get_workspace_options, {quuid});
     const workspace_image = result.rows[0].workspace_image;
     const workspace_port = result.rows[0].workspace_port;
+    const workspace_args = result.rows[0].workspace_args;
 
     await assert.equal(workspaceImage, workspace_image);
     await assert.equal(workspacePort, workspace_port);
+    await assert.equal(workspaceArgs, workspace_args);
   });
 
   it('fails if a question directory is missing an info.json file', async () => {

--- a/tests/sync/questionsSync.sql
+++ b/tests/sync/questionsSync.sql
@@ -1,4 +1,4 @@
 -- BLOCK get_workspace_options
-SELECT workspace_image, workspace_port
+SELECT workspace_image, workspace_port, workspace_args
 FROM questions as q
 WHERE q.uuid = $quuid;

--- a/tests/sync/util.js
+++ b/tests/sync/util.js
@@ -151,6 +151,7 @@ const syncFromDisk = require('../../sync/syncFromDisk');
  * @typedef {Object} QuestionWorkspaceOptions
  * @property {string} image
  * @property {number} port
+ * @property {string} args
  * @property {string[]} gradedFiles
  */
 
@@ -318,6 +319,7 @@ const questions = {
     workspaceOptions: {
       image: 'prairielearn/workspace-vscode',
       port: 15000,
+      args: '--auth none',
       gradedFiles: [
         'animal.h',
         'animal.c',


### PR DESCRIPTION
The motivation is to allow users to pass Docker arguments (e.g., `"args": "--auth none --foo bar"`).