### PR TITLE
New options on pl-python-variable to hide DataFrame labels

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -906,6 +906,9 @@ Attribute | Type | Default | Description
 `prefix` | string | (empty) | Any prefix to append to the output in `text` mode.
 `suffix` | string | (empty) | Any suffix to append to the output in `text` mode.
 `no-highlight` | string | False | Disable syntax highlighting in `text` mode.
+`show-header` | string | True | Show the header row of a DataFrame in default mode. (No effect in `text` mode.)
+`show-index` | string | True | Show the index column of a DataFrame in default mode. (No effect in `text` mode.)
+`show-dimensions` | string | True | Show a footer with the dimensions of a DataFrame in default mode. (No effect in `text` mode.)
 
 #### Details
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -829,7 +829,7 @@ Attribute | Type | Default | Description
 `language` | string | — | The programming language syntax highlighting to use. See below for options.
 `no-highlight` | boolean | false | Disable highlighting.
 `source-file-name` | text | - | Name of the source file with existing code to be displayed as a code block (instead of writing the existing code between the element tags as illustrated in the above code snippet).
-`prevent-select` | booelan | false | Applies methods to make the source code more difficult to copy, like preventing selection or right-clicking. Note that the source code is still accessible in the page source, which will always be visible to students.
+`prevent-select` | boolean | false | Applies methods to make the source code more difficult to copy, like preventing selection or right-clicking. Note that the source code is still accessible in the page source, which will always be visible to students.
 `highlight-lines` | text | - | Apply a distinctive background highlight the specified lines of code. Accepts input like `4`, `1-3,5-10`, and `1,2-5,20`.
 `highlight-lines-color` | text | `#b3d7ff` | Specifies the color of highlighted lines of code.
 
@@ -902,13 +902,13 @@ def generate(data):
 Attribute | Type | Default | Description
 --- | --- | --- | ---
 `params-name` | string | — | The name of the key in `data['params']` to get a value from
-`text` | string | False | Force the variable to be displayed in a textual format, as given by `repr(var)`.  By default, special types like DataFrames will be rendered as HTML tables.
+`text` | boolean | false | Force the variable to be displayed in a textual format, as given by `repr(var)`.  By default, special types like DataFrames will be rendered as HTML tables.
 `prefix` | string | (empty) | Any prefix to append to the output in `text` mode.
 `suffix` | string | (empty) | Any suffix to append to the output in `text` mode.
-`no-highlight` | string | False | Disable syntax highlighting in `text` mode.
-`show-header` | string | True | Show the header row of a DataFrame in default mode. (No effect in `text` mode.)
-`show-index` | string | True | Show the index column of a DataFrame in default mode. (No effect in `text` mode.)
-`show-dimensions` | string | True | Show a footer with the dimensions of a DataFrame in default mode. (No effect in `text` mode.)
+`no-highlight` | boolean | false | Disable syntax highlighting in `text` mode.
+`show-header` | boolean | true | Show the header row of a DataFrame in default mode. (No effect in `text` mode.)
+`show-index` | boolean | true | Show the index column of a DataFrame in default mode. (No effect in `text` mode.)
+`show-dimensions` | boolean | true | Show a footer with the dimensions of a DataFrame in default mode. (No effect in `text` mode.)
 
 #### Details
 
@@ -1358,7 +1358,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `width` | float | - | The width of the overlay canvas in pixels.  Required only if no background is specified.
 `height` | float | - | The height of the overlay canvas in pixels.  Required only if no background is specified.
-`clip` | boolean | True | If true, children will be cut off when exceeding overlay boundaries.
+`clip` | boolean | true | If true, children will be cut off when exceeding overlay boundaries.
 
 #### `pl-location` Customizations
 

--- a/elements/pl-python-variable/pl-python-variable.css
+++ b/elements/pl-python-variable/pl-python-variable.css
@@ -8,6 +8,7 @@
     border-collapse: collapse;
     border: none;
     border-spacing: 0;
+    margin-bottom: 1rem;
 }
 
 .pl-python-variable-table thead {
@@ -52,9 +53,9 @@
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 14px;
     line-height: 20px;
-    margin-bottom: 0px;
+    margin-bottom: 1rem;
     margin-left: 0px;
     margin-right: 0px;
-    margin-top: 14px;
+    margin-top: 1rem;
     text-align: left;
 }

--- a/elements/pl-python-variable/pl-python-variable.py
+++ b/elements/pl-python-variable/pl-python-variable.py
@@ -5,17 +5,22 @@ NO_HIGHLIGHT_DEFAULT = False
 PREFIX_DEFAULT = ''
 SUFFIX_DEFAULT = ''
 TEXT_DEFAULT = False
-
+SHOW_HEADER_DEFAULT = True
+SHOW_INDEX_DEFAULT = True
+SHOW_DIMENSIONS_DEFAULT = True
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
-    pl.check_attribs(element, required_attribs=['params-name'], optional_attribs=['text', 'no-highlight', 'prefix', 'suffix'])
+    pl.check_attribs(element, required_attribs=['params-name'], optional_attribs=['text', 'no-highlight', 'prefix', 'suffix', 'show-header', 'show-index', 'show-dimensions'])
 
 
 def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     force_text = pl.get_boolean_attrib(element, 'text', TEXT_DEFAULT)
     varname = pl.get_string_attrib(element, 'params-name')
+    show_header = pl.get_boolean_attrib(element, 'show-header', SHOW_HEADER_DEFAULT)
+    show_index = pl.get_boolean_attrib(element, 'show-index', SHOW_INDEX_DEFAULT)
+    show_dimensions = pl.get_boolean_attrib(element, 'show-dimensions', SHOW_DIMENSIONS_DEFAULT)
 
     if varname not in data['params']:
         raise Exception('Could not find {} in params!'.format(varname))
@@ -32,7 +37,9 @@ def render(element_html, data):
 
     # render the output variable
     if var_type == 'dataframe':
-        html += var_out.to_html(classes=['pl-python-variable-table']) + '<p class="pl-python-variable-table-dimensions">{} rows x {} columns</p><br>'.format(str(var_out.shape[0]), str(var_out.shape[1]))
+        html += var_out.to_html(header=show_header, index=show_index, classes=['pl-python-variable-table'])
+        if show_dimensions:
+            html += '<p class="pl-python-variable-table-dimensions">{} rows x {} columns</p>'.format(str(var_out.shape[0]), str(var_out.shape[1]))
     else:
         no_highlight = pl.get_boolean_attrib(element, 'no-highlight', NO_HIGHLIGHT_DEFAULT)
         prefix = pl.get_string_attrib(element, 'prefix', PREFIX_DEFAULT)

--- a/elements/pl-python-variable/pl-python-variable.py
+++ b/elements/pl-python-variable/pl-python-variable.py
@@ -9,6 +9,7 @@ SHOW_HEADER_DEFAULT = True
 SHOW_INDEX_DEFAULT = True
 SHOW_DIMENSIONS_DEFAULT = True
 
+
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     pl.check_attribs(element, required_attribs=['params-name'], optional_attribs=['text', 'no-highlight', 'prefix', 'suffix', 'show-header', 'show-index', 'show-dimensions'])
@@ -49,3 +50,4 @@ def render(element_html, data):
         html += '<pl-code language="python" no-highlight="{}">{}</pl-code>'.format(no_highlight, text)
 
     return html
+

--- a/elements/pl-python-variable/pl-python-variable.py
+++ b/elements/pl-python-variable/pl-python-variable.py
@@ -50,4 +50,3 @@ def render(element_html, data):
         html += '<pl-code language="python" no-highlight="{}">{}</pl-code>'.format(no_highlight, text)
 
     return html
-

--- a/exampleCourse/questions/element/pythonVariable/question.html
+++ b/exampleCourse/questions/element/pythonVariable/question.html
@@ -12,7 +12,7 @@
   <pl-code source-file-name="test.py"></pl-code>
   <pl-python-variable params-name="df"></pl-python-variable>
   <p>
-    By default, a Pandas DataFrame will have show its index column and header row, as well as a postscript label with the table dimensions. You can toggle these with attributes on the <code>pl-python-variable</code> tag. Here, we've added <code>show-header="false" show-index="false" show-dimensions="false"</code>:
+    By default, a Pandas DataFrame will display its index column and header row, as well as a postscript label with the table dimensions. You can toggle these with attributes on the <code>pl-python-variable</code> tag. Here, we've added <code>show-header="false" show-index="false" show-dimensions="false"</code>:
   </p>
   <pl-python-variable params-name="df" show-header="false" show-index="false" show-dimensions="false"></pl-python-variable>
   <p>

--- a/exampleCourse/questions/element/pythonVariable/question.html
+++ b/exampleCourse/questions/element/pythonVariable/question.html
@@ -12,7 +12,11 @@
   <pl-code source-file-name="test.py"></pl-code>
   <pl-python-variable params-name="df"></pl-python-variable>
   <p>
-    Here is the same example with <code>text="true"</code>, forcing the variable to be rendered in its textual representation:
+    By default, a Pandas DataFrame will have show its index column and header row, as well as a postscript label with the table dimensions. You can toggle these with attributes on the <code>pl-python-variable</code> tag. Here, we've added <code>show-header=False show-index=False show-dimensions=False</code>:
+  </p>
+  <pl-python-variable params-name="df" show-header=False show-index=False show-dimensions=False></pl-python-variable>
+  <p>
+    Here is the same example with <code>text="true"</code>, forcing the variable to be rendered in its textual representation. (The <code>show-header</code>, <code>show-index</code>, and <code>show-dimensions</code> attributes don't affect this.)
   </p>
   <pl-python-variable params-name="df" text="true"></pl-python-variable>
   </div>

--- a/exampleCourse/questions/element/pythonVariable/question.html
+++ b/exampleCourse/questions/element/pythonVariable/question.html
@@ -12,9 +12,9 @@
   <pl-code source-file-name="test.py"></pl-code>
   <pl-python-variable params-name="df"></pl-python-variable>
   <p>
-    By default, a Pandas DataFrame will have show its index column and header row, as well as a postscript label with the table dimensions. You can toggle these with attributes on the <code>pl-python-variable</code> tag. Here, we've added <code>show-header=False show-index=False show-dimensions=False</code>:
+    By default, a Pandas DataFrame will have show its index column and header row, as well as a postscript label with the table dimensions. You can toggle these with attributes on the <code>pl-python-variable</code> tag. Here, we've added <code>show-header="false" show-index="false" show-dimensions="false"</code>:
   </p>
-  <pl-python-variable params-name="df" show-header=False show-index=False show-dimensions=False></pl-python-variable>
+  <pl-python-variable params-name="df" show-header="false" show-index="false" show-dimensions="false"></pl-python-variable>
   <p>
     Here is the same example with <code>text="true"</code>, forcing the variable to be rendered in its textual representation. (The <code>show-header</code>, <code>show-index</code>, and <code>show-dimensions</code> attributes don't affect this.)
   </p>

--- a/exampleCourse/questions/element/pythonVariable/question.html
+++ b/exampleCourse/questions/element/pythonVariable/question.html
@@ -16,7 +16,7 @@
   </p>
   <pl-python-variable params-name="df" show-header="false" show-index="false" show-dimensions="false"></pl-python-variable>
   <p>
-    Here is the same example with <code>text="true"</code>, forcing the variable to be rendered in its textual representation. (The <code>show-header</code>, <code>show-index</code>, and <code>show-dimensions</code> attributes don't affect this.)
+    Here is the same example with <code>text="true"</code>, forcing the variable to be rendered in its textual representation. The <code>show-header</code>, <code>show-index</code>, and <code>show-dimensions</code> attributes don't affect this.
   </p>
   <pl-python-variable params-name="df" text="true"></pl-python-variable>
   </div>

--- a/exampleCourse/questions/element/pythonVariable/server.py
+++ b/exampleCourse/questions/element/pythonVariable/server.py
@@ -11,5 +11,5 @@ def generate(data):
     data['params']['df'] = pl.to_json(df.head(15))
     data['params']['matrix'] = pl.to_json(np.random.random((3, 3)))
     data['params']['my_dictionary'] = {'a': 1, 'b': 2, 'c': 3}
-    
+
     return data


### PR DESCRIPTION
New options for the `pl-python-variable` element to let you hide header labels of various kinds on a Pandas DataFrame. Includes example and doc edits.

It seemed like there should also be an option to hide the overflow horizontal scrollbar if the dataframe is very small, just for aesthetics, but decided to leave that out. People can do that with a CSS hack in their question HTML if they want it.