### PR TITLE
Add option to not focus the file editor

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -672,14 +672,14 @@ Attribute | Type | Default | description
 `max-lines` | integer | None | Maximum number of lines the editor should display at once. Must be greater than `min-lines`.
 `auto-resize` | boolean | true | Automatically expand the editor panel to ensure all lines are present. Overrides any value set by `max-lines` and establishes a default of 18 lines for `min-lines` if not supplied. See Details below for notes.
 `preview` | string | None | If set, provides a live preview mode for editing markup languages.  Currently supports `html` or `markdown`.
-`focus` | boolean | true | Specifies that the editor should begin with the cursor captured and focused. See Details below for notes.
+`focus` | boolean | false | Specifies that the editor should begin with the cursor captured and the editing pane focused. See Details below for notes.
 
 #### Details
 
 When using `auto-resize`, consider specifying a custom `min-lines` or pre-populating the code editor window with a code sample.
 This will initialize the editor area with a sufficient number of lines to display all of the code simultaneously without the need for scrolling.
 
-If there are multiple file editor elements on the page that have `focus="true"` (or not specified), then they will capture the focus sequentially when the page is loaded, typically causing the last editor to be focused. To focus only the first editor, set all but the first to `focus="false"`. To focus none of the editors, set all to false. Note that focusing any editor may cause the question page to scroll down to the editor's position immediately when the page is loaded.
+The `focus` attribute defaults to `"false"`. Setting this to true will cause the file editor element to automatically capture the cursor focus when the question page is loaded, which may also cause the page to scroll down so that the file editor is in view, bypassing any written introduction. This may have negative implications for accessibility with screen readers. In any case, only one editor element should ever have `focus` set to true, or else the behavior may be unpredictable.
 
 #### Example implementations
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -679,7 +679,7 @@ Attribute | Type | Default | description
 When using `auto-resize`, consider specifying a custom `min-lines` or pre-populating the code editor window with a code sample.
 This will initialize the editor area with a sufficient number of lines to display all of the code simultaneously without the need for scrolling.
 
-The `focus` attribute defaults to `"false"`. Setting this to true will cause the file editor element to automatically capture the cursor focus when the question page is loaded, which may also cause the page to scroll down so that the file editor is in view, bypassing any written introduction. This may have negative implications for accessibility with screen readers. In any case, only one editor element should ever have `focus` set to true, or else the behavior may be unpredictable.
+The `focus` attribute defaults to `"false"`. Setting this to true will cause the file editor element to automatically capture the cursor focus when the question page is loaded, which may also cause the page to scroll down so that the file editor is in view, bypassing any written introduction. This may have negative implications for accessibility with screen readers, so use caution. If you have multiple file editors on the same question page, only one element should have `focus` set to true, or else the behavior may be unpredictable.
 
 #### Example implementations
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -670,13 +670,16 @@ Attribute | Type | Default | description
 `source-file-name` | string | None | Name of the source file with existing code to be displayed in the browser text editor (instead of writing the existing code between the element tags as illustrated in the above code snippet).
 `min-lines` | integer | None | Minimum number of lines the editor should show initially.
 `max-lines` | integer | None | Maximum number of lines the editor should display at once. Must be greater than `min-lines`.
-`auto-resize` | boolean | true | Automatically expand the editor panel to ensure all lines are present. Overrides any value set by `max-lines` and establishes a default of 18 lines for `min-lines` if not supplied.
+`auto-resize` | boolean | true | Automatically expand the editor panel to ensure all lines are present. Overrides any value set by `max-lines` and establishes a default of 18 lines for `min-lines` if not supplied. See Details below for notes.
 `preview` | string | None | If set, provides a live preview mode for editing markup languages.  Currently supports `html` or `markdown`.
+`focus` | boolean | true | Specifies that the editor should begin with the cursor captured and focused. See Details below for notes.
 
 #### Details
 
 When using `auto-resize`, consider specifying a custom `min-lines` or pre-populating the code editor window with a code sample.
 This will initialize the editor area with a sufficient number of lines to display all of the code simultaneously without the need for scrolling.
+
+If there are multiple file editor elements on the page that have `focus="true"` (or not specified), then they will capture the focus sequentially when the page is loaded, typically causing the last editor to be focused. To focus only the first editor, set all but the first to `focus="false"`. To focus none of the editors, set all to false. Note that focusing any editor may cause the question page to scroll down to the editor's position immediately when the page is loaded.
 
 #### Example implementations
 

--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -44,6 +44,12 @@ window.PLFileEditor = function(uuid, options) {
         this.editor.setOption('maxLines', Infinity);
     }
 
+    if (options.plOptionFocus) {
+        this.plOptionFocus = true;
+    } else {
+        this.plOptionFocus = false;
+    }
+
     if (options.preview == 'markdown') {
         let renderer = new showdown.Converter();
 
@@ -108,10 +114,9 @@ window.PLFileEditor.prototype.initRestoreOriginalButton = function() {
 window.PLFileEditor.prototype.setEditorContents = function(contents) {
     this.editor.setValue(contents);
     this.editor.gotoLine(1, 0);
-    // Let's NOT set the focus here, because it can drag the window scroll
-    // down the page. Also, if there are multiple editors in one question,
-    // it's confusing to focus the last one.
-    // this.editor.focus();
+    if (this.plOptionFocus) {
+        this.editor.focus();
+    }
     this.syncFileToHiddenInput();
 };
 

--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -44,11 +44,7 @@ window.PLFileEditor = function(uuid, options) {
         this.editor.setOption('maxLines', Infinity);
     }
 
-    if (options.plOptionFocus) {
-        this.plOptionFocus = true;
-    } else {
-        this.plOptionFocus = false;
-    }
+    this.plOptionFocus = !!options.plOptionFocus;
 
     if (options.preview == 'markdown') {
         let renderer = new showdown.Converter();

--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -44,7 +44,7 @@ window.PLFileEditor = function(uuid, options) {
         this.editor.setOption('maxLines', Infinity);
     }
 
-    this.plOptionFocus = !!options.plOptionFocus;
+    this.plOptionFocus = options.plOptionFocus;
 
     if (options.preview == 'markdown') {
         let renderer = new showdown.Converter();

--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -108,7 +108,10 @@ window.PLFileEditor.prototype.initRestoreOriginalButton = function() {
 window.PLFileEditor.prototype.setEditorContents = function(contents) {
     this.editor.setValue(contents);
     this.editor.gotoLine(1, 0);
-    this.editor.focus();
+    // Let's NOT set the focus here, because it can drag the window scroll
+    // down the page. Also, if there are multiple editors in one question,
+    // it's confusing to focus the last one.
+    // this.editor.focus();
     this.syncFileToHiddenInput();
 };
 

--- a/elements/pl-file-editor/pl-file-editor.mustache
+++ b/elements/pl-file-editor/pl-file-editor.mustache
@@ -11,7 +11,8 @@ $(function() {
         minLines: {{#min_lines}}{{min_lines}}{{/min_lines}}{{^min_lines}}undefined{{/min_lines}},
         maxLines: {{#max_lines}}{{max_lines}}{{/max_lines}}{{^max_lines}}undefined{{/max_lines}},
         autoResize: {{#auto_resize}}{{auto_resize}}{{/auto_resize}}{{^auto_resize}}undefined{{/auto_resize}},
-        preview: {{#preview}}"{{preview}}"{{/preview}}{{^preview}}undefined{{/preview}}
+        preview: {{#preview}}"{{preview}}"{{/preview}}{{^preview}}undefined{{/preview}},
+        plOptionFocus: {{#focus}}{{focus}}{{/focus}}{{^focus}}undefined{{/focus}}
     });
 });
 </script>

--- a/elements/pl-file-editor/pl-file-editor.mustache
+++ b/elements/pl-file-editor/pl-file-editor.mustache
@@ -10,9 +10,9 @@ $(function() {
         aceTheme: {{#ace_theme}}"{{ace_theme}}"{{/ace_theme}}{{^ace_theme}}undefined{{/ace_theme}},
         minLines: {{#min_lines}}{{min_lines}}{{/min_lines}}{{^min_lines}}undefined{{/min_lines}},
         maxLines: {{#max_lines}}{{max_lines}}{{/max_lines}}{{^max_lines}}undefined{{/max_lines}},
-        autoResize: {{#auto_resize}}{{auto_resize}}{{/auto_resize}}{{^auto_resize}}undefined{{/auto_resize}},
+        autoResize: {{auto_resize}},
         preview: {{#preview}}"{{preview}}"{{/preview}}{{^preview}}undefined{{/preview}},
-        plOptionFocus: {{#focus}}{{focus}}{{/focus}}{{^focus}}undefined{{/focus}}
+        plOptionFocus: {{focus}}
     });
 });
 </script>

--- a/elements/pl-file-editor/pl-file-editor.py
+++ b/elements/pl-file-editor/pl-file-editor.py
@@ -12,8 +12,9 @@ ACE_THEME_DEFAULT = None
 SOURCE_FILE_NAME_DEFAULT = None
 MIN_LINES_DEFAULT = None
 MAX_LINES_DEFAULT = None
-AUTO_RESIZE_DEFAULT = 'true'
+AUTO_RESIZE_DEFAULT = True
 PREVIEW_DEFAULT = None
+FOCUS_DEFAULT = True
 
 
 def get_answer_name(file_name):
@@ -29,7 +30,7 @@ def add_format_error(data, error_string):
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = ['file-name']
-    optional_attribs = ['ace-mode', 'ace-theme', 'editor-config-function', 'source-file-name', 'min-lines', 'max-lines', 'auto-resize', 'preview']
+    optional_attribs = ['ace-mode', 'ace-theme', 'editor-config-function', 'source-file-name', 'min-lines', 'max-lines', 'auto-resize', 'preview', 'focus']
     pl.check_attribs(element, required_attribs, optional_attribs)
     source_file_name = pl.get_string_attrib(element, 'source-file-name', SOURCE_FILE_NAME_DEFAULT)
 
@@ -56,8 +57,13 @@ def render(element_html, data):
     source_file_name = pl.get_string_attrib(element, 'source-file-name', SOURCE_FILE_NAME_DEFAULT)
     min_lines = pl.get_integer_attrib(element, 'min-lines', MIN_LINES_DEFAULT)
     max_lines = pl.get_integer_attrib(element, 'max-lines', MAX_LINES_DEFAULT)
-    auto_resize = pl.get_string_attrib(element, 'auto-resize', AUTO_RESIZE_DEFAULT)
+    auto_resize = pl.get_boolean_attrib(element, 'auto-resize', AUTO_RESIZE_DEFAULT)
     preview = pl.get_string_attrib(element, 'preview', PREVIEW_DEFAULT)
+    focus = pl.get_boolean_attrib(element, 'focus', FOCUS_DEFAULT)
+
+    # stringify boolean attributes (needed when written to html_params)
+    auto_resize = 'true' if auto_resize else 'false'
+    focus = 'true' if focus else 'false'
 
     # If auto_resize is set but min_lines isn't, the height of the
     # file editor area will be set to 1 line. Thus, we need to set
@@ -76,7 +82,8 @@ def render(element_html, data):
         'max_lines': max_lines,
         'auto_resize': auto_resize,
         'preview': preview,
-        'uuid': uuid
+        'uuid': uuid,
+        'focus': focus
     }
 
     if source_file_name is not None:

--- a/elements/pl-file-editor/pl-file-editor.py
+++ b/elements/pl-file-editor/pl-file-editor.py
@@ -14,7 +14,7 @@ MIN_LINES_DEFAULT = None
 MAX_LINES_DEFAULT = None
 AUTO_RESIZE_DEFAULT = True
 PREVIEW_DEFAULT = None
-FOCUS_DEFAULT = True
+FOCUS_DEFAULT = False
 
 
 def get_answer_name(file_name):


### PR DESCRIPTION
I'm making a question with multiple embedded file editors that are halfway down the page. The 2nd editor was stealing focus and dragging the page scroll way down. I think it's very disorienting to the student. Also, if there are multiple editors in one question, it's confusing to focus the last one.

The culprit was:

```
    // this.editor.focus();
```

I left the line commented out with an explanatory comment to discourage someone from adding it back again. Things seem to work fine without the focus grab.