### PR TITLE
Add MathJax support to docs

### DIFF
--- a/docs/mathjax-config.js
+++ b/docs/mathjax-config.js
@@ -1,0 +1,11 @@
+var MathJax = {
+    tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+    },
+    svg: {
+        fontCache: 'global'
+    },
+    loader: {
+        load: ['input/tex', 'output/svg']
+    }
+};

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,10 @@ docs_dir: docs
 # Fix "Edit on GitHub" link: (defaults to edit/master/docs/, note the s)
 edit_uri: blob/master/docs/
 
+extra_javascript:
+  - mathjax-config.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js
+
 pages:
 - Main: 'index.md'
 - Getting Started:


### PR DESCRIPTION
Adds a small MathJax config script and loads MathJax proper from cdn.jsdelivr.net