### PR TITLE
Change coveralls script to not block CI

### DIFF
--- a/docker/coveralls.sh
+++ b/docker/coveralls.sh
@@ -2,3 +2,6 @@
 
 cd /PrairieLearn
 cat coverage/lcov.info | ./node_modules/.bin/coveralls -v
+
+# do not block CI even if coveralls fails
+exit 0

--- a/docker/coveralls.sh
+++ b/docker/coveralls.sh
@@ -1,7 +1,4 @@
 #! /bin/bash
 
 cd /PrairieLearn
-cat coverage/lcov.info | ./node_modules/.bin/coveralls -v
-
-# do not block CI even if coveralls fails
-exit 0
+cat coverage/lcov.info | ./node_modules/.bin/coveralls -v || true


### PR DESCRIPTION
Based on the dev meeting convo -- prevent coveralls from blocking CI.

Travis does have an [**allow_failures**](https://docs.travis-ci.com/user/customizing-the-build#jobs-that-are-allowed-to-fail) option, but I couldn't tell exactly how to use it in our config.