### PR TITLE
Fix file upload when editing a course question

### DIFF
--- a/server.js
+++ b/server.js
@@ -143,6 +143,8 @@ app.post('/pl/course_instance/:course_instance_id/instance_question/:instance_qu
 app.post('/pl/course_instance/:course_instance_id/assessment_instance/:assessment_instance_id', upload.single('file'));
 app.post('/pl/course_instance/:course_instance_id/instructor/question/:question_id', upload.single('file'));
 app.post('/pl/course/:course_id/question/:question_id', upload.single('file'));
+app.post('/pl/course/:course_id/question/:question_id/file_view', upload.single('file'));
+app.post('/pl/course/:course_id/question/:question_id/file_view/*', upload.single('file'));
 app.post('/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/settings', upload.single('file'));
 app.post('/pl/course_instance/:course_instance_id/instructor/instance_admin/settings', upload.single('file'));
 app.post('/pl/course_instance/:course_instance_id/instructor/course_admin/settings', upload.single('file'));


### PR DESCRIPTION
At the moment we can't upload files in questions when they are viewed in the context of a course. It works fine when viewing in a course instance. This is a problem for users who have course-level Editor access but not access to any course instance.