### PR TITLE
Allow course "viewers" to copy questions

### DIFF
--- a/middlewares/authzCourse.js
+++ b/middlewares/authzCourse.js
@@ -19,7 +19,8 @@ module.exports = function(req, res, next) {
 
         var permissions_course = result.rows[0].permissions_course;
         res.locals.course = result.rows[0].course;
-        res.locals.courses = result.rows[0].courses;
+        res.locals.editable_courses = result.rows[0].editable_courses;
+        res.locals.viewable_courses = result.rows[0].viewable_courses;
         res.locals.course_instances = result.rows[0].course_instances;
 
         if (permissions_course.course_role == 'None') {

--- a/middlewares/authzCourse.sql
+++ b/middlewares/authzCourse.sql
@@ -2,7 +2,8 @@
 SELECT
     authz_course($authn_user_id, $course_id, $is_administrator) AS permissions_course,
     to_jsonb(c.*) AS course,
-    courses_user_can_edit($authn_user_id, $is_administrator) AS courses,
+    courses_user_can_edit($authn_user_id, $is_administrator) AS editable_courses,
+    courses_user_can_view($authn_user_id, $is_administrator) AS viewable_courses,
     course_instances_instructor_can_view($authn_user_id, $is_administrator, $req_date, c.id) AS course_instances
 FROM
     pl_courses AS c

--- a/middlewares/authzCourseInstance.js
+++ b/middlewares/authzCourseInstance.js
@@ -24,7 +24,8 @@ module.exports = function(req, res, next) {
         var authn_mode = result.rows[0].mode;
         res.locals.course = result.rows[0].course;
         res.locals.course_instance = result.rows[0].course_instance;
-        res.locals.courses = result.rows[0].courses;
+        res.locals.editable_courses = result.rows[0].editable_courses;
+        res.locals.viewable_courses = result.rows[0].viewable_courses;
         res.locals.course_instances = result.rows[0].course_instances;
 
         var permissions_course_instance = result.rows[0].permissions_course_instance;

--- a/middlewares/authzCourseInstance.sql
+++ b/middlewares/authzCourseInstance.sql
@@ -5,7 +5,8 @@ SELECT
     authz_course($authn_user_id, c.id, $is_administrator) AS permissions_course,
     to_jsonb(c.*) AS course,
     to_jsonb(ci.*) AS course_instance,
-    courses_user_can_edit($authn_user_id, $is_administrator) AS courses,
+    courses_user_can_edit($authn_user_id, $is_administrator) AS editable_courses,
+    courses_user_can_view($authn_user_id, $is_administrator) AS viewable_courses,
     course_instances_instructor_can_view($authn_user_id, $is_administrator, $req_date, c.id) AS course_instances
 FROM
     course_instances AS ci

--- a/pages/instructorQuestionSettings/copyForm.ejs
+++ b/pages/instructorQuestionSettings/copyForm.ejs
@@ -7,10 +7,8 @@
       <% if (course.options.isExampleCourse) { %>
       <option hidden disabled selected value> -- select a course -- </option>
       <% } %>
-      <% courses.forEach((c) => { %>
-        <% if (! c.options.isExampleCourse) { // cannot copy to example course %>
+      <% editable_courses.forEach((c) => { %>
         <option value="<%= c.id %>" <% if (c.id == course.id) { %>selected<% } %>><%= c.short_name %></option>
-        <% } %>
       <% }); %>
     </select>
     <div class="invalid-feedback" id="invalidIdMessage">

--- a/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -102,11 +102,12 @@
           We only want to show the card footer if it will have something inside. Since it is easy
           to make a mistake when merging logical conditions, we will simply "or" them all.
         -->
-        <% if ((authz_data.has_course_permission_edit && ((! course.options.isExampleCourse) || (courses && (courses.length > 1)))) ||
+        <% if (((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (course && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) ||
                ((authz_data.has_course_permission_edit) && (! course.options.isExampleCourse))) { %>
         <div class="card-footer">
           <div class="row">
-            <% if (authz_data.has_course_permission_edit && ((! course.options.isExampleCourse) || (courses && (courses.length > 1)))) { %>
+            <% if ((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (course && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) { %>
+            <!-- If we can edit this course, can we copy this question to this course or another course?  If we cannot edit this course, can we copy this question to another course? -->
             <div class="col-auto">
               <button type="button" class="btn btn-sm btn-primary" id="copyQuestionButton" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Copy this question" data-content="<%= include('copyForm', {buttonID: 'copyQuestionButton'}) %>" data-trigger="manual" onclick="$(this).popover('show')">
                   <i class="fa fa-clone"></i>

--- a/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -106,8 +106,11 @@
                ((authz_data.has_course_permission_edit) && (! course.options.isExampleCourse))) { %>
         <div class="card-footer">
           <div class="row">
-            <% if ((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (courses && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) { %>
-            <!-- If we can edit this course, can we copy this question to this course or another course?  If we cannot edit this course, can we copy this question to another course? -->
+            <% if (/* If we can edit this course, can we copy this question to this course or another course? */
+                   (authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (courses && courses.length > 1))) 
+                   ||
+                   /* If we cannot edit this course, can we copy this question to another course? */
+                   (!authz_data.has_course_permission_edit && courses && courses.length > 0)) { %>
             <div class="col-auto">
               <button type="button" class="btn btn-sm btn-primary" id="copyQuestionButton" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Copy this question" data-content="<%= include('copyForm', {buttonID: 'copyQuestionButton'}) %>" data-trigger="manual" onclick="$(this).popover('show')">
                   <i class="fa fa-clone"></i>

--- a/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -102,11 +102,11 @@
           We only want to show the card footer if it will have something inside. Since it is easy
           to make a mistake when merging logical conditions, we will simply "or" them all.
         -->
-        <% if (((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (course && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) ||
+        <% if (((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (courses && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) ||
                ((authz_data.has_course_permission_edit) && (! course.options.isExampleCourse))) { %>
         <div class="card-footer">
           <div class="row">
-            <% if ((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (course && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) { %>
+            <% if ((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (courses && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) { %>
             <!-- If we can edit this course, can we copy this question to this course or another course?  If we cannot edit this course, can we copy this question to another course? -->
             <div class="col-auto">
               <button type="button" class="btn btn-sm btn-primary" id="copyQuestionButton" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Copy this question" data-content="<%= include('copyForm', {buttonID: 'copyQuestionButton'}) %>" data-trigger="manual" onclick="$(this).popover('show')">

--- a/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -102,15 +102,11 @@
           We only want to show the card footer if it will have something inside. Since it is easy
           to make a mistake when merging logical conditions, we will simply "or" them all.
         -->
-        <% if (((authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (courses && courses.length > 1))) || (!authz_data.has_course_permission_edit && courses && courses.length > 0)) ||
+        <% if ((editable_courses && editable_courses.length > 0) ||
                ((authz_data.has_course_permission_edit) && (! course.options.isExampleCourse))) { %>
         <div class="card-footer">
           <div class="row">
-            <% if (/* If we can edit this course, can we copy this question to this course or another course? */
-                   (authz_data.has_course_permission_edit && (!course.options.isExampleCourse || (courses && courses.length > 1))) 
-                   ||
-                   /* If we cannot edit this course, can we copy this question to another course? */
-                   (!authz_data.has_course_permission_edit && courses && courses.length > 0)) { %>
+            <% if (editable_courses && editable_courses.length > 0) { %>
             <div class="col-auto">
               <button type="button" class="btn btn-sm btn-primary" id="copyQuestionButton" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Copy this question" data-content="<%= include('copyForm', {buttonID: 'copyQuestionButton'}) %>" data-trigger="manual" onclick="$(this).popover('show')">
                   <i class="fa fa-clone"></i>

--- a/pages/partials/navbarInstructor.ejs
+++ b/pages/partials/navbarInstructor.ejs
@@ -6,11 +6,11 @@
         <a class="nav-link <% if (navPage == "course_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "issues" || navSubPage == "questions" || navSubPage == "syncs"))) { %>active<% } %> <% if (! authz_data.has_course_permission_view) { %> disabled <% } %>" href="<%= urlPrefix %>/course_admin" role="button">
             <%= course.short_name %>
         </a>
-        <% if (locals.courses && courses.length > 0) { %>
+        <% if (locals.viewable_courses && viewable_courses.length > 0) { %>
         <a class="nav-link dropdown-toggle dropdown-toggle-split" href="#" id="navbarDropdownMenuCourseAdminLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuCourseAdminLink" id="navbarDropdownMenuCourseAdmin">
-            <% courses.forEach(function(c) { %>
+            <% viewable_courses.forEach(function(c) { %>
                 <a class="dropdown-item <% if (course.id == c.id) { %>active<% } %>" href="<%= plainUrlPrefix %>/course/<%= c.id %>/course_admin<% if (navPage == "course_admin" && typeof navSubPage !== 'undefined' && navSubPage != "file_edit") { %>/<%= navSubPage %><% } %>"><%= c.short_name %></a>
             <% }); %>
         </div>

--- a/sprocs/courses_user_can_view.sql
+++ b/sprocs/courses_user_can_view.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION
-    courses_user_can_edit (
+    courses_user_can_view (
         IN user_id bigint,
         IN is_administrator boolean,
         OUT courses jsonb
@@ -15,7 +15,6 @@ BEGIN
         JOIN authz_course(user_id, c.id, is_administrator) AS permissions_course ON TRUE
     WHERE
         c.deleted_at IS NULL
-        AND (c.options->>'isExampleCourse')::boolean IS FALSE
-        AND (permissions_course->>'has_course_permission_edit')::BOOLEAN IS TRUE;
+        AND (permissions_course->>'has_course_permission_view')::BOOLEAN IS TRUE;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/index.js
+++ b/sprocs/index.js
@@ -84,6 +84,7 @@ module.exports = {
             'courses_update_column.sql',
             'courses_delete.sql',
             'courses_user_can_edit.sql',
+            'courses_user_can_view.sql',
             'course_instances_instructor_can_view.sql',
             'select_or_insert_course_by_path.sql',
             'assessment_instances_delete.sql',


### PR DESCRIPTION
Resolves #2685 

Turns out this was as simple as updating the interface, the server code already was allowing users to copy questions as long as they has edit permission in the destination.

I was able to test this locally by adding course permissions to the dev user, then dropping dev user from the admin table.