### PR TITLE
Fix server crash when testing without courseInstance

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -510,7 +510,7 @@ module.exports = {
                        be marked ungradable and we should bail here to prevent LTI updates. */
                     grading_job = result.rows[0];
                     if (!grading_job.gradable) return callback(new NoSubmissionError());
-                    
+
                     debug('_gradeVariantWithClient()', 'inserted', 'grading_job.id:', grading_job.id);
                     callback(null);
                 });
@@ -876,9 +876,10 @@ module.exports = {
             async.series([
                 (callback) => {
                     const instance_question_id = null;
+                    const course_instance_id = (course_instance && course_instance.id) || null;
                     const options = {};
                     const require_open = true;
-                    this._ensureVariantWithClient(client, question.id, instance_question_id, authn_user_id, authn_user_id, course_instance.id, course, options, require_open, (err, ret_variant) => {
+                    this._ensureVariantWithClient(client, question.id, instance_question_id, authn_user_id, authn_user_id, course_instance_id, course, options, require_open, (err, ret_variant) => {
                         if (ERR(err, callback)) return;
                         variant = ret_variant;
                         debug('_testQuestion()', 'created variant_id: :', variant.id);


### PR DESCRIPTION
Resolves #2692 

Checks if courseInstance exists before grabbing id, otherwise passes along null to `ensureVariantWithClient()`.
Turns out this was a simple fix since the `variants_insert` sproc (what ultimately ends up getting called) is okay with a null courseInstance.