### PR TITLE
Add edit button for course institutions

### DIFF
--- a/pages/administratorOverview/administratorOverview.ejs
+++ b/pages/administratorOverview/administratorOverview.ejs
@@ -242,7 +242,7 @@
             <tbody>
               <% courses.forEach(function(course, i) { %>
               <tr>
-                <td><%= course.institution.short_name %></td>
+                <%- include('courseUpdateInstitutionColumn', {course: course, i: i}) %>
                 <%- include('courseUpdateColumn', {column_name: 'short_name',       label: 'short name', course: course, i: i}) %>
                 <%- include('courseUpdateColumn', {column_name: 'title',            label: 'title',      course: course, i: i}) %>
                 <%- include('courseUpdateColumn', {column_name: 'display_timezone', label: 'timezone',   course: course, i: i}) %>

--- a/pages/administratorOverview/courseUpdateInstitutionColumn.ejs
+++ b/pages/administratorOverview/courseUpdateInstitutionColumn.ejs
@@ -1,0 +1,12 @@
+<td class="align-middle">
+  <%= course.institution.short_name %>
+  <button type="button" class="btn btn-xs btn-secondary"
+     id="courseButtonInstitution<%= i %>" tabindex="0"
+     data-toggle="popover" data-container="body"
+     data-html="true" data-placement="auto" title="Change institution"
+     data-content="<%= include('courseUpdateInstitutionColumnForm',
+                   {id: 'courseButtonInstitution' + i}) %>"
+     data-trigger="manual" onclick="$(this).popover('show')">
+    <i class="fa fa-edit" aria-hidden="true"></i>
+  </button>
+</td>

--- a/pages/administratorOverview/courseUpdateInstitutionColumnForm.ejs
+++ b/pages/administratorOverview/courseUpdateInstitutionColumnForm.ejs
@@ -1,0 +1,17 @@
+<form name="edit-course-column-form" method="POST">
+  <input type="hidden" name="__action" value="courses_update_column">
+  <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+  <input type="hidden" name="course_id" value="<%= course.id %>">
+  <input type="hidden" name="column_name" value="institution_id">
+  <div class="form-group">
+    <select name="value" id="input<%= id %>" class="form-control">
+        <% institutions.forEach(function(inst, i) { %>
+            <option value="<%= inst.id %>" <%= (inst.id == course.institution.id) ? 'selected' : '' %>> <%= inst.short_name %> </option>
+        <% }); %>
+    </select>
+  </div>
+  <div class="text-right">
+    <button type="button" class="btn btn-secondary" onclick="$('#<%= id %>').popover('hide')">Cancel</button>
+    <button type="submit" class="btn btn-primary">Change</button>
+  </div>
+</form>

--- a/sprocs/courses_update_column.sql
+++ b/sprocs/courses_update_column.sql
@@ -42,6 +42,10 @@ BEGIN
             UPDATE pl_courses AS c SET repository = value
             WHERE c.id = course_id
             RETURNING c.* INTO new_row;
+        WHEN 'institution_id' THEN
+            UPDATE pl_courses AS c SET institution_id = CAST(value AS BIGINT)
+            WHERE c.id = course_id
+            RETURNING c.* INTO new_row;
         ELSE
             RAISE EXCEPTION 'unknown column_name: %', column_name;
     END CASE;


### PR DESCRIPTION
Resolves #2697 

Adds an edit button to the institution column in the courses table on the admin overview page.  Institutions are shown in a dropdown field.

![image](https://user-images.githubusercontent.com/1790491/87567936-7b9e9b80-c68a-11ea-933a-ce3f0a069f7e.png)
![image](https://user-images.githubusercontent.com/1790491/87567976-878a5d80-c68a-11ea-8bcb-8ffa904e55e9.png)
