### PR TITLE
Change coveralls CI step to continue on error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,4 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.github_token }}
+      continue-on-error: true


### PR DESCRIPTION
#2710 changed `coveralls.sh`, but it seems that was only used by the old travis CI config. This PR changes the current CI workflow to `continue-on-error` for the coveralls step.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

Side note: should we delete the deprecated travis config/scripts?