### PR TITLE
Fix navbar display of mode in course context

### DIFF
--- a/pages/authLogin/authLogin.js
+++ b/pages/authLogin/authLogin.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var router = express.Router();
 
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res, _next) {
     // We could set res.locals.config.hasOauth = false (or
     // hasAzure) to not display those options inside the CBTF, but
     // this will also need to depend on which institution we have

--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -37,9 +37,9 @@ if (!locals.effective_user_has_no_access_to_course_instance) {
     }
     if (authz_data.authn_has_instructor_view) {
       showStatus.push(authz_data.role);
-    }
-    if (authz_data.mode != 'Public') {
-      showStatus.push(`${authz_data.mode} mode`);
+      if (authz_data.mode != 'Public') {
+        showStatus.push(`${authz_data.mode} mode`);
+      }
     }
     if (showStatus.length > 0) {
       displayedName += ' (' + showStatus.join(', ') + ')';


### PR DESCRIPTION
Fixes regression in the navbar logic to not display anything about mode outside of a course instance context.