### PR TITLE
Change the cache error logging to exclude the large value.

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -53,9 +53,11 @@ module.exports.set = function(key, value, maxAgeMS=null) {
             // to reach the cache before continuing, and we don't *really*
             // care if it errors
             if (maxAgeMS) {
-                cache.set(key, value, 'PX', maxAgeMS).catch(err => logger.error('Cache set error', {err, key, value, maxAgeMS}));
+                // we don't log the error because it contains the cached value, which can be huge and which fills up the logs
+                cache.set(key, value, 'PX', maxAgeMS).catch(err => logger.error('Cache set error', {key, maxAgeMS}));
             } else {
-                cache.set(key, value).catch(err => logger.error('Cache set error', {err, key, value}));
+                // we don't log the error because it contains the cached value, which can be huge and which fills up the logs
+                cache.set(key, value).catch(err => logger.error('Cache set error', {key}));
             }
             break;
         default:

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -54,10 +54,10 @@ module.exports.set = function(key, value, maxAgeMS=null) {
             // care if it errors
             if (maxAgeMS) {
                 // we don't log the error because it contains the cached value, which can be huge and which fills up the logs
-                cache.set(key, value, 'PX', maxAgeMS).catch(err => logger.error('Cache set error', {key, maxAgeMS}));
+                cache.set(key, value, 'PX', maxAgeMS).catch(_err => logger.error('Cache set error', {key, maxAgeMS}));
             } else {
                 // we don't log the error because it contains the cached value, which can be huge and which fills up the logs
-                cache.set(key, value).catch(err => logger.error('Cache set error', {key}));
+                cache.set(key, value).catch(_err => logger.error('Cache set error', {key}));
             }
             break;
         default:


### PR DESCRIPTION
At the moment, on cache error we log the error (which contains the
value) as well as the value itself. When the cache fails, this fills up
the logs with the large values (often full HTML pages).