### PR TITLE
Remove prairieDrawFigure from example assessment

### DIFF
--- a/exampleCourse/courseInstances/Sp15/assessments/hw03-elementExamples/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/hw03-elementExamples/infoAssessment.json
@@ -43,7 +43,6 @@
                 {"id": "element/stringInput",              "points": 2, "maxPoints": 10},
                 {"id": "element/matrixComponentInput",     "points": 2, "maxPoints": 10},
                 {"id": "element/matrixLatex",              "points": 2, "maxPoints": 10},
-                {"id": "element/prairieDrawFigure",        "points": 2, "maxPoints": 10},
                 {"id": "element/variableOutput",           "points": 2, "maxPoints": 10},
                 {"id": "element/fileEditor",               "points": 2, "maxPoints": 10},
                 {"id": "element/pythonVariable",           "points": 2, "maxPoints": 10},


### PR DESCRIPTION
Looks like we forgot to move this when we moved the prairie draw question from exampleCourse to testCourse