### PR TITLE
Add attribute to <pl-checkbox> to pull correct and/or incorrect answers from a json file

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -170,6 +170,9 @@ Attribute | Type | Default | Description
 `detailed-help-text` | boolean | false | Display detailed information in help text about the number of options to choose.
 `hide-answer-panel` | boolean | false | Option to not display the correct answer in the correct panel.
 `hide-letter-keys` | boolean | false | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.
+`external-json` | string | special | Optional path to a JSON file to load external answer choices from.  Answer choices are stored as lists under "correct" and "incorrect" key names.
+`external-json-correct-key` | string | special | Optionally override default json "correct" attribute name when using `external-json` file.
+`external-json-incorrect-key` | string | special | Optionally override default json "incorrect" attribute name when using `external-json` file.
 
 Inside the `pl-checkbox` element, each choice must be specified with
 a `pl-answer` that has attributes:

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -1,4 +1,6 @@
 import prairielearn as pl
+import pathlib
+import json
 import lxml.html
 import random
 import math
@@ -14,22 +16,13 @@ HIDE_ANSWER_PANEL_DEFAULT = False
 HIDE_HELP_TEXT_DEFAULT = False
 DETAILED_HELP_TEXT_DEFAULT = False
 HIDE_LETTER_KEYS_DEFAULT = False
+EXTERNAL_JSON_DEFAULT = None
+EXTERNAL_JSON_CORRECT_KEY_DEFAULT = 'correct'
+EXTERNAL_JSON_INCORRECT_KEY_DEFAULT = 'incorrect'
 
 
-def prepare(element_html, data):
-    element = lxml.html.fragment_fromstring(element_html)
-
-    required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method', 'hide-letter-keys']
-
-    pl.check_attribs(element, required_attribs, optional_attribs)
-    name = pl.get_string_attrib(element, 'answers-name')
-
-    partial_credit = pl.get_boolean_attrib(element, 'partial-credit', PARTIAL_CREDIT_DEFAULT)
-    partial_credit_method = pl.get_string_attrib(element, 'partial-credit-method', None)
-    if not partial_credit and partial_credit_method is not None:
-        raise Exception('Cannot specify partial-credit-method if partial-credit is not enabled')
-
+def categorize_options(element, data):
+    """Get provided correct and incorrect answers"""
     correct_answers = []
     incorrect_answers = []
     index = 0
@@ -44,6 +37,47 @@ def prepare(element_html, data):
             else:
                 incorrect_answers.append(answer_tuple)
             index += 1
+
+    file_path = pl.get_string_attrib(element, 'external-json', EXTERNAL_JSON_DEFAULT)
+    if file_path is not EXTERNAL_JSON_DEFAULT:
+        correct_attrib = pl.get_string_attrib(element, 'external-json-correct-key', EXTERNAL_JSON_CORRECT_KEY_DEFAULT)
+        incorrect_attrib = pl.get_string_attrib(element, 'external-json-incorrect-key', EXTERNAL_JSON_INCORRECT_KEY_DEFAULT)
+        if pathlib.PurePath(file_path).is_absolute():
+            json_file = file_path
+        else:
+            json_file = pathlib.PurePath(data['options']['question_path']).joinpath(file_path)
+        try:
+            with open(json_file, mode='r', encoding='utf-8') as f:
+                obj = json.load(f)
+                for text in obj.get(correct_attrib, []):
+                    correct_answers.append((index, True, text))
+                    index += 1
+                for text in obj.get(incorrect_attrib, []):
+                    incorrect_answers.append((index, False, text))
+                    index += 1
+        except FileNotFoundError:
+            raise Exception(f'JSON answer file: "{json_file}" could not be found')
+    return correct_answers, incorrect_answers
+
+
+def prepare(element_html, data):
+    element = lxml.html.fragment_fromstring(element_html)
+
+    required_attribs = ['answers-name']
+    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order',
+                        'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text',
+                        'partial-credit', 'partial-credit-method', 'hide-letter-keys',
+                        'external-json', 'external-json-correct-key', 'external-json-incorrect-key']
+
+    pl.check_attribs(element, required_attribs, optional_attribs)
+    name = pl.get_string_attrib(element, 'answers-name')
+
+    partial_credit = pl.get_boolean_attrib(element, 'partial-credit', PARTIAL_CREDIT_DEFAULT)
+    partial_credit_method = pl.get_string_attrib(element, 'partial-credit-method', None)
+    if not partial_credit and partial_credit_method is not None:
+        raise Exception('Cannot specify partial-credit-method if partial-credit is not enabled')
+
+    correct_answers, incorrect_answers = categorize_options(element, data)
 
     len_correct = len(correct_answers)
     len_incorrect = len(incorrect_answers)

--- a/exampleCourse/questions/element/checkbox/question.html
+++ b/exampleCourse/questions/element/checkbox/question.html
@@ -203,3 +203,25 @@
         </pl-checkbox>
     </div>
 </div>
+
+<div class="card my-2">
+    <div class="card-header">
+        Part 8
+    </div>
+
+    <div class="card-body">
+
+        <pl-question-panel>
+            <p>Here, the <code>pl-checkbox</code> element does not contain any <code>pl-answer</code> inner tag; instead, it pulls the correct and incorrect choices, if exist,
+                from <code>group-work.json</code> file inside <code>serverFilesQuestion/</code> directory. By default, the external json file should have <code>"correct"</code>
+                and <code>"incorrect"</code> attributes of type list to store choices, these attribute names can be overridden with <code>"external-json-correct-key"</code>
+                and <code>"external-json-incorrect-key"</code>.</p>
+
+            <p>Group work provides which of the following benefits:</p>
+        </pl-question-panel>
+
+        <pl-checkbox answers-name="group_ans_v7" external-json="serverFilesQuestion/group-work.json" external-json-incorrect-key="incorrect_choices">
+        </pl-checkbox>
+
+    </div>
+</div>

--- a/exampleCourse/questions/element/checkbox/serverFilesQuestion/group-work.json
+++ b/exampleCourse/questions/element/checkbox/serverFilesQuestion/group-work.json
@@ -1,0 +1,15 @@
+{
+    "correct": [
+        "Exposure to new viewpoints from different fields and life experiences.",
+        "Improved creativity and overall work quality.",
+        "Constructive dialog and increased internal group motivation.",
+        "Personal accountability to the team to work on a project.",
+        "Friendship.",
+        "Prepares you for a team-environment in the workplace or a research group."
+    ],
+    "incorrect_choices": [
+        "The ability to work on a project by yourself.",
+        "Having only one person make all of the decisions.",
+        "The resources to work on a small project instead of a large project."
+    ]
+}


### PR DESCRIPTION
Similar to #2733 

`external-json` is an *optional* attribute to `<pl-checkbox>`, type string, default to `None`

User can pass a json file path to this attribute, preferably a relatively path to *where question.html lives*; or an absolute path that might look like: `/PrairieLearn/course/etc/file.json`

Exceptions will be thrown when file is not found, and `json` library when the file is not correctly formatted.

By default, the target json file should have 2 attributes: "correct", and "incorrect", both of which are json lists containing text that will be added to poll of correct and incorrect answers already in question.html. Below is an example of what the json might look like:

```json
{
    "correct": [
        "A true statement"
    ],
    "incorrect": [
        "Incorrect statement 1",
        "Incorrect statement 2"
    ]
}
```

Alternatively, user can pass in the name of attributes representing "correct" or "incorrect" using `external-json-correct-key` and `external-json-incorrect-key` respectively to override the default attribute names.

Resolve https://github.com/ace-lab/pl-ucb-cs10/issues/47