### PR TITLE
Fix workspace host container checking for Jupyter Lab

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -185,7 +185,9 @@ function _checkServer(workspace_id, container, callback) {
     function checkWorkspace() {
         request(`http://${config.workspaceNativeLocalhost}:${id_workspace_mapper[workspace_id].port}/`, function(err, res, _body) {
             if (err) { /* do nothing, because errors are expected while the container is launching */ }
-            if (res && res.statusCode == 200) {
+            if (res && (res.statusCode == 200 || res.statusCode == 404)) {
+                /* We might get a 404 because the URL is not being rewritten and the application doesn't
+                   have a page at root.  This is okay since it still means the server is running. */
                 callback(null, workspace_id, container);
             } else {
                 const endTime = (new Date()).getTime();

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -185,9 +185,8 @@ function _checkServer(workspace_id, container, callback) {
     function checkWorkspace() {
         request(`http://${config.workspaceNativeLocalhost}:${id_workspace_mapper[workspace_id].port}/`, function(err, res, _body) {
             if (err) { /* do nothing, because errors are expected while the container is launching */ }
-            if (res && (res.statusCode == 200 || res.statusCode == 404)) {
-                /* We might get a 404 because the URL is not being rewritten and the application doesn't
-                   have a page at root.  This is okay since it still means the server is running. */
+            if (res && res.statusCode) {
+                /* We might get all sorts of strange status codes from the server, this is okay since it still means the server is running and we're getting responses. */
                 callback(null, workspace_id, container);
             } else {
                 const endTime = (new Date()).getTime();


### PR DESCRIPTION
When we get Jupyter Lab at / it returns a 404 (because it's actually mounted at `workspaces/:workspace_id/container`).  We should just consider 404 to be a successful container start, since there is a server listening.