### PR TITLE
Add workspace graded files to container settings query

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -219,6 +219,7 @@ function _queryContainerSettings(workspace_id, callback) {
             workspace_image: result.rows[0].workspace_image,
             workspace_port: result.rows[0].workspace_port,
             workspace_home: result.rows[0].workspace_home,
+            workspace_graded_files: result.rows[0].workspace_graded_files,
             workspace_args: result.rows[0].workspace_args || '',
             workspace_url_rewrite: url_rewrite,
         };

--- a/workspace_host/interface.sql
+++ b/workspace_host/interface.sql
@@ -4,6 +4,7 @@ SELECT
     workspace_port,
     workspace_args,
     workspace_home,
+    workspace_graded_files,
     workspace_url_rewrite
 FROM
     questions AS q


### PR DESCRIPTION
`settings.workspace_graded_files` can now be accessed in the `settings` object passed through the callbacks.