### PR TITLE
Add xtermjs workspace enhancements

### DIFF
--- a/workspaces/xtermjs/src/index.html
+++ b/workspaces/xtermjs/src/index.html
@@ -27,8 +27,8 @@
 
          let socket = new WebSocket('ws://' + window.location.host + window.location.pathname);
          socket.onopen = () => {
-             term.onKey((ev) => {
-                 socket.send(JSON.stringify({ 'event': 'keypress', 'value': ev }));
+             term.onData((ev) => {
+                 socket.send(JSON.stringify({ 'event': 'data', 'value': ev }));
              });
              window.onresize = () => {
                  fit.fit();

--- a/workspaces/xtermjs/src/server.js
+++ b/workspaces/xtermjs/src/server.js
@@ -21,36 +21,51 @@ if (options.help) {
     return;
 }
 
+const default_env = {
+    'LC_CTYPE': 'C.UTF-8',
+};
+
 /* Static files */
 app.get('/', (req, res) => res.sendFile(path.join(__dirname, 'index.html')));
 app.use('/xterm', express.static('node_modules/xterm'));
 app.use('/xterm-fit', express.static('node_modules/xterm-addon-fit'));
 
-/* Create a new pseudoterminal on each websocket connection */
-app.ws('/', (ws, req) => {
-    let term = pty.spawn(options.command, [], {
-        name: 'xterm-color',
-        cols: 80,
-        rows: 24,
-        cwd: options['working-dir'],
-        env: process.env
+/* Create one pseudoterminal that all connections share */
+let websockets = {};
+let ws_id = 0;
+let term_output = '';
+let term = pty.spawn(options.command, [], {
+    name: 'xterm-color',
+    cols: 80,
+    rows: 24,
+    cwd: options['working-dir'],
+    env: Object.assign({}, default_env, process.env),
+});
+term.on('data', function(data) {
+    term_output += data;
+    Object.values(websockets).forEach(ws => {
+        if (ws.readyState === 1) {
+            ws.send(data);
+        }
     });
+});
 
-    term.on('data', function(data) {
-        ws.send(data);
-    });
+/* Listen for any incoming websocket connections */
+app.ws('/', (ws, req) => {
+    const id = ws_id++;
+    websockets[id] = ws;
+    ws.send(term_output);
 
     ws.on('message', (msg) => {
         const val = JSON.parse(msg);
-        if (val.event === 'keypress') {
-            term.write(val.value.key);
+        if (val.event === 'data') {
+            term.write(val.value);
         } else if (val.event === 'resize') {
             term.resize(val.value.cols, val.value.rows);
         }
     });
-
     ws.on('close', (msg) => {
-        term.destroy();
+        delete websockets[id];
     });
 });
 


### PR DESCRIPTION
Adds:
- The host now only forks one pseudoterminal and each connection shares the same terminal.
- `LC_CTYPE` is set by default so `tmux` will work out of the box
- Copy + paste works correctly
- The terminal process will automatically restart when the running process dies