### PR TITLE
Fix extraneous line breaks added to element html

### DIFF
--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -134,7 +134,7 @@ def inner_html(element):
         inner = ''
     inner = html.escape(str(inner))
     for child in element:
-        inner += lxml.html.tostring(child, method='html', pretty_print=True).decode('utf-8')
+        inner += lxml.html.tostring(child, method='html').decode('utf-8')
     return inner
 
 


### PR DESCRIPTION
Fixes #2848 by removing `pretty_print` formatting from `inner_html()`, as debugged by @nicknytko and @mwest1066 earlier. I'm not seeing any side effects in `exampleCourse` questions.