### PR TITLE
Change workspace logger.info() to debug()

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -58,7 +58,7 @@ module.exports.uploadToS3Async = async function (filePath, isDirectory, s3Path, 
         Body: body,
     };
     await s3.upload(params).promise();
-    logger.info(`Uploaded s3://${config.workspaceS3Bucket}/${s3Path} (${localPath})`);
+    debug(`Uploaded s3://${config.workspaceS3Bucket}/${s3Path} (${localPath})`);
 };
 module.exports.uploadToS3 = util.callbackify(this.uploadToS3Async);
 
@@ -74,6 +74,6 @@ module.exports.deleteFromS3Async = async function (_filePath, isDirectory, s3Pat
         Key: s3Path,
     };
     await s3.deleteObject(params).promise();
-    logger.info(`Deleted s3://${config.workspaceS3Bucket}/${s3Path} (${localPath})`);
+    debug(`Deleted s3://${config.workspaceS3Bucket}/${s3Path} (${localPath})`);
 };
 module.exports.deleteFromS3 = util.callbackify(this.deleteFromS3Async);

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -1,6 +1,9 @@
 const AWS = require('aws-sdk');
 const fs = require('fs-extra');
 const util = require('util');
+const path = require('path');
+const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
+
 const logger = require('./logger');
 const config = require('./config');
 

--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -33,7 +33,7 @@ const zipDirectory = async function (source, zip) {
         }).on('error', (err) => {
             reject(err);
         }).on('finish', () => {
-            logger.info(`Zipped ${source} as ${zip} (${archive.pointer()} total bytes)`);
+            debug(`Zipped ${source} as ${zip} (${archive.pointer()} total bytes)`);
             resolve(zip);
         });
     });
@@ -57,7 +57,7 @@ async function uploadDirectoryToS3Async(s3Path, bucketName) {
                 };
                 try {
                     await s3.putObject(params).promise();
-                    logger.info(`Synced ${bucketPath} to ${bucketName}`);
+                    debug(`Synced ${bucketPath} to ${bucketName}`);
                 } catch (err) {
                     logger.error(`Error syncing ${bucketPath}:\n ${err}`);
                 }
@@ -131,7 +131,7 @@ module.exports = {
     async updateState(workspace_id, state) {
         // TODO: add locking
         await sqldb.callAsync('workspaces_state_update', [workspace_id, state]);
-        logger.info(`Set workspaces.state to '${state}'`);
+        debug(`Set workspaces.state to '${state}'`);
         module.exports._namespace.to(workspace_id).emit('change:state', {workspace_id, state});
     },
 
@@ -201,20 +201,20 @@ module.exports = {
         const zipName = `workspace-${workspace_id}-${now}.zip`;
         const zipPath = path.join(zipPrefix, zipName);
 
-        logger.info(`Zipping ${localPath} as ${zipPath}`);
+        debug(`Zipping ${localPath} as ${zipPath}`);
         await zipDirectory(localPath, zipPath);
         const isDirectory = false;
         const s3ZipPath = `workspace-${workspace_id}/initial.zip`;
         await awsHelper.uploadToS3Async(zipPath, isDirectory, s3ZipPath, zipPath);
 
-        logger.info(`Syncing ${localPath} to ${s3Path}`);
+        debug(`Syncing ${localPath} to ${s3Path}`);
         await uploadDirectoryToS3Async(localPath, `${s3Path}/current`);
     },
 
     async assignHost(workspace_id) {
         // query available hosts
         const result = await sqldb.queryAsync(sql.select_workspace_hosts, {});
-        logger.info(`controlContainer workspace_hosts query: ${JSON.stringify(result.rows)}`);
+        debug(`controlContainer workspace_hosts query: ${JSON.stringify(result.rows)}`);
         const workspace_hosts = result.rows;
         if (workspace_hosts.length == 0) {
             throw new Error(`No workspace hosts found for workspace_id=${workspace_id}`);
@@ -223,7 +223,7 @@ module.exports = {
         // choose host
         const index = Math.floor(Math.random() * workspace_hosts.length);
         const workspace_host = workspace_hosts[index];
-        logger.info(`controlContainer workspace_host: ${JSON.stringify(workspace_host)}`);
+        debug(`controlContainer workspace_host: ${JSON.stringify(workspace_host)}`);
         const params = {
             workspace_id,
             workspace_host_id: workspace_host.id,


### PR DESCRIPTION
Left these as logger.infos. Can change more if needed.

lib/aws.js
```
        logger.info('Loading AWS credentials for external grading and workspace S3 resources');
```

lib/workspace.js
```
                logger.info('Loading configuration from "aws-config.json"');
                logger.info('Using local S3RVER configuration');
```

interface.js
```
logger.info(`Workspace S3 bucket: ${config.workspaceS3Bucket}`);
        logger.info(`Listening on port ${workspace_server_settings.port}`);
        logger.info('Successfully initialized workspace host');
        logger.info(`Pulling docker image: ${workspace_image}`);
        logger.info('Not pulling docker image');
    logger.info(`Creating docker container for image=${settings.workspace_image}`);
    logger.info(`Sending files for grading as ${zipPath}`);
```