### PR TITLE
adding option to grade specific cells in jupyter notebook

### DIFF
--- a/exampleCourse/questions/demo/autograder/codeEditor/question.html
+++ b/exampleCourse/questions/demo/autograder/codeEditor/question.html
@@ -1,7 +1,7 @@
 <pl-question-panel>
   <p>
     The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each
-    number is the sum of the two before it.
+    number is the sum of the two before it. These are numbered $F_1, F_2, ...$, and
     \[
     F_n = F_{n-1} + F_{n-2}
     \]

--- a/exampleCourse/questions/demo/autograder/codeUpload/question.html
+++ b/exampleCourse/questions/demo/autograder/codeUpload/question.html
@@ -4,7 +4,10 @@
   </p>
   <p>
     The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each
-    number is the sum of the two before it.
+    number is the sum of the two before it. These are numbered $F_1, F_2, ...$, and
+    \[
+    F_n = F_{n-1} + F_{n-2}
+    \]
   </p>
   <p>
     Write a Python function <tt>fib</tt> that takes a number <tt>n</tt>

--- a/exampleCourse/questions/demo/manualGrade/codeUpload/question.html
+++ b/exampleCourse/questions/demo/manualGrade/codeUpload/question.html
@@ -1,7 +1,10 @@
 <pl-question-panel>
   <p>
     The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each
-    number is the sum of the two before it.
+    number is the sum of the two before it. These are numbered $F_1, F_2, ...$, and
+    \[
+    F_n = F_{n-1} + F_{n-2}
+    \]
   </p>
   <p>
     Write a Python function <tt>fib</tt> that takes a number <tt>n</tt>

--- a/exampleCourse/questions/demo/workspace/jupyterlab/info.json
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/info.json
@@ -1,19 +1,27 @@
 {
-    "uuid": "d9046679-ca5d-496d-8120-98aed21281ad",
+    "uuid": "F158CCF4-48F8-42F9-BBE6-C761210EA540",
     "title": "Workspace demo: JupyterLab",
     "topic": "Workspace",
     "tags": [
         "su20",
-        "nnytko2"
+        "tyang15", "mfsilva", "nntyko2"
     ],
     "type": "v3",
     "workspaceOptions": {
-        "image": "prairielearn/workspace-jupyterlab",
-        "port": 8080,
-        "home": "/home/jovyan",
-        "rewriteUrl": false,
-        "gradedFiles": [
-            "Workbook.ipynb"
-        ]
+      "image": "prairielearn/workspace-jupyterlab",
+      "port": 8080,
+      "home": "/home/jovyan",
+      "rewriteUrl": false,
+      "gradedFiles": [
+          "Workbook.ipynb"
+      ]
+    },
+    "singleVariant": true,
+    "gradingMethod": "External",
+    "externalGradingOptions": {
+        "enabled": true,
+        "image": "prairielearn/grader-python",
+        "entrypoint": "/python_autograder/run.sh",
+        "timeout": 20
     }
 }

--- a/exampleCourse/questions/demo/workspace/jupyterlab/info.json
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/info.json
@@ -4,7 +4,7 @@
     "topic": "Workspace",
     "tags": [
         "su20",
-        "tyang15", "mfsilva", "nntyko2"
+        "tyang15", "mfsilva", "nnytko2"
     ],
     "type": "v3",
     "workspaceOptions": {

--- a/exampleCourse/questions/demo/workspace/jupyterlab/question.html
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/question.html
@@ -4,7 +4,7 @@
 
   <p>
     The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each
-    number is the sum of the two before it.
+    number is the sum of the two before it. These are numbered $F_1, F_2, ...$, and
     \[
     F_n = F_{n-1} + F_{n-2}
     \]

--- a/exampleCourse/questions/demo/workspace/jupyterlab/question.html
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/question.html
@@ -1,4 +1,26 @@
 <pl-question-panel>
-  <p>This is a workspace question with an in-browser <a href="https://jupyter.org">JupyterLab</a>.</p>
+  <p>This is a workspace question with an in-browser <a href="https://jupyter.org">JupyterLab</a>.
+  </p>
+
+  <p>
+    The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each
+    number is the sum of the two before it.
+    \[
+    F_n = F_{n-1} + F_{n-2}
+    \]
+  </p>
+
+  <p>
+    In the notebook, you will be prompted to write a Python function <tt>fib</tt> that takes a number <tt>n</tt>
+    and returns the n<sup>th</sup> Fibonacci number.
+  </p>
+
+  <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
+
   <pl-workspace></pl-workspace>
 </pl-question-panel>
+
+<pl-submission-panel>
+  <pl-external-grader-results></pl-external-grader-results>
+  <pl-file-preview></pl-file-preview>
+</pl-submission-panel>

--- a/exampleCourse/questions/demo/workspace/jupyterlab/server.py
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/server.py
@@ -1,0 +1,5 @@
+def generate(data):
+    data['params']['names_for_user'] = []
+    data['params']['names_from_user'] = [
+        {'name': 'fib', 'description': 'Function to compute the $n^\\text{th}$ Fibonacci number', 'type': 'python function'},
+    ]

--- a/exampleCourse/questions/demo/workspace/jupyterlab/tests/ans.py
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/tests/ans.py
@@ -1,0 +1,5 @@
+def fib(n):
+    if n <= 1:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)

--- a/exampleCourse/questions/demo/workspace/jupyterlab/tests/test.py
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/tests/test.py
@@ -1,0 +1,51 @@
+from pl_helpers import name, points, not_repeated
+from pl_unit_test import PLTestCaseWithPlot, PLTestCase
+from code_feedback import Feedback
+from functools import wraps
+import numpy as np
+import numpy.random
+
+
+class Test(PLTestCase):
+
+    student_code_file = 'Workbook.ipynb'
+
+    @points(1)
+    @name('Check fib(0)')
+    def test_0(self):
+        user_val = Feedback.call_user(self.st.fib, 0)
+        if Feedback.check_scalar("fib(0)", self.ref.fib(0), user_val):
+            Feedback.set_score(1)
+        else:
+            Feedback.set_score(0)
+
+    @points(1)
+    @name('Check fib(1)')
+    def test_1(self):
+        user_val = Feedback.call_user(self.st.fib, 1)
+        if Feedback.check_scalar("fib(1)", self.ref.fib(1), user_val):
+            Feedback.set_score(1)
+        else:
+            Feedback.set_score(0)
+
+    @points(2)
+    @name('Check fib(7)')
+    def test_2(self):
+        user_val = Feedback.call_user(self.st.fib, 7)
+        if Feedback.check_scalar("fib(7)", self.ref.fib(7), user_val):
+            Feedback.set_score(1)
+        else:
+            Feedback.set_score(0)
+
+    @points(3)
+    @name('Check random values')
+    def test_3(self):
+        points = 0
+        num_tests = 10
+        test_values = np.random.choice(np.arange(2, 30), size=num_tests, replace=False)
+        for in_val in test_values:
+            correct_val = self.ref.fib(in_val)
+            user_val = Feedback.call_user(self.st.fib, in_val)
+            if Feedback.check_scalar(f"fib({in_val})", correct_val, user_val):
+                points += 1
+        Feedback.set_score(points / num_tests)

--- a/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The autograder will search for cells that start with a keyword (in this example `#grade`), and only use the contents from this cell for grading. \n",
+    "The autograder will search for cells that start with a configurable keyword (in this example `#grade`), and only use the contents from those cells for grading. This keyword is configured using the test suite's `ipynb_key` variable and has been defined in this demo question as `ipynb_key = '#grade'`.\n",
     "\n",
     "This will avoid the autograder trying to execute additional lines of code that include several print statements, plots, and use of libraries that are not installed in PL."
    ]

--- a/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "The autograder will search for cells that start with a keyword (in this example `#grade`), and only use the contents from this cell for grading. \n",
     "\n",
-    "This will avoid the autograder tring to execute additional lines of code that include several print statements, plots, and use of libraries that are not installed in PL"
+    "This will avoid the autograder trying to execute additional lines of code that include several print statements, plots, and use of libraries that are not installed in PL."
    ]
   },
   {

--- a/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each number is the sum of the two before it.\n",
+    "The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each number is the sum of the two before it. These are numbered $F_1, F_2, ...$, and\n",
     "\n",
     "$$F_n = F_{n-1} + F_{n-2}$$"
    ]
@@ -29,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#keep (write your code in this cell and DO NOT DELETE THIS LINE)\n",
+    "#grade (write your code in this cell and DO NOT DELETE THIS LINE)\n",
     "\n"
    ]
   },

--- a/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
@@ -1,14 +1,26 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "%matplotlib inline"
+    "# Fibonacci numbers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each number is the sum of the two before it.\n",
+    "\n",
+    "$$F_n = F_{n-1} + F_{n-2}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write a Python function `fib` that takes a number `n` and returns the $n^{th}$ Fibonacci number."
    ]
   },
   {
@@ -17,8 +29,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = np.linspace(0, 2*np.pi, 100)\n",
-    "y = np.sin(x)"
+    "#keep (write your code in this cell and DO NOT DELETE THIS LINE)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The autograder will search for cells that start with a keyword (in this example \"#keep\"), and only use the contents from this cell for grading. \n",
+    "\n",
+    "This will avoid the autograder tring to execute additional lines of code that include several print statements, plots, and use of libraries that are not installed in PL"
    ]
   },
   {
@@ -26,9 +47,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "plt.plot(x, y);"
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -47,7 +66,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The autograder will search for cells that start with a keyword (in this example \"#keep\"), and only use the contents from this cell for grading. \n",
+    "The autograder will search for cells that start with a keyword (in this example `#grade`), and only use the contents from this cell for grading. \n",
     "\n",
     "This will avoid the autograder tring to execute additional lines of code that include several print statements, plots, and use of libraries that are not installed in PL"
    ]

--- a/exampleCourse/questions/demo/workspace/vscode/question.html
+++ b/exampleCourse/questions/demo/workspace/vscode/question.html
@@ -3,7 +3,7 @@
 
   <p>
     The Fibonacci numbers are 1, 1, 2, 3, 5, 8, ..., where each
-    number is the sum of the two before it.
+    number is the sum of the two before it. These are numbered $F_1, F_2, ...$\n", and
     \[
     F_n = F_{n-1} + F_{n-2}
     \]

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.random
 import random
 from os.path import join
+from os.path import splitext
 from types import ModuleType, FunctionType
 from copy import deepcopy
 
@@ -36,7 +37,7 @@ def set_random_seed(seed=None):
 
 
 def execute_code(fname_ref, fname_student, include_plt=False,
-                 console_output_fname=None, test_iter_num=0, ipynb_key="keep"):
+                 console_output_fname=None, test_iter_num=0, ipynb_key="#grade"):
     """
     execute_code(fname_ref, fname_student)
 
@@ -65,7 +66,8 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     with open(fname_ref, 'r', encoding='utf-8') as f:
         str_ref = f.read()
     with open(fname_student, 'r', encoding='utf-8') as f:
-        if fname_student[-6:] == '.ipynb':
+        filename, extension = splitext(fname_student)
+        if extension == '.ipynb':
             str_student = extract_cell_content(f, ipynb_key)
         else:
             str_student = f.read()

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -21,8 +21,14 @@ def extract_cell_content(f, ipynb_key):
     for cell in nb.cells:
         if cell["cell_type"] == "code":
             code = shell.input_transformer_manager.transform_cell(cell.source)
-            if ipynb_key in code:
+            lines = code.splitlines(keepends=True)
+            first_line = lines[0] if len(lines) > 0 else ''
+            if ipynb_key in first_line:
                 content += code
+                continue
+            for line in lines:
+                if "import" in line:
+                    content += line
     return content
 
 class UserCodeFailed(Exception):

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -17,18 +17,12 @@ from IPython.core.interactiveshell import InteractiveShell
 def extract_cell_content(f, ipynb_key):
     nb = read(f, 4)
     shell = InteractiveShell.instance()
-    content = ""
+    content = ''
     for cell in nb.cells:
-        if cell["cell_type"] == "code":
+        if cell['cell_type'] == 'code':
             code = shell.input_transformer_manager.transform_cell(cell.source)
-            lines = code.splitlines(keepends=True)
-            first_line = lines[0] if len(lines) > 0 else ''
-            if ipynb_key in first_line:
+            if code.strip().startswith(ipynb_key):
                 content += code
-                continue
-            for line in lines:
-                if "import" in line:
-                    content += line
     return content
 
 class UserCodeFailed(Exception):
@@ -71,10 +65,15 @@ def execute_code(fname_ref, fname_student, include_plt=False,
         str_setup = f.read()
     with open(fname_ref, 'r', encoding='utf-8') as f:
         str_ref = f.read()
+    try:
+        with open(join(filenames_dir, 'leading_code.py'), 'r', encoding='utf-8') as f:
+            str_leading = f.read()
+    except:
+        str_leading = ''
     with open(fname_student, 'r', encoding='utf-8') as f:
         filename, extension = splitext(fname_student)
         if extension == '.ipynb':
-            str_student = extract_cell_content(f, ipynb_key)
+            str_student = str_leading + extract_cell_content(f, ipynb_key)
         else:
             str_student = f.read()
     with open(join(filenames_dir, 'test.py'), encoding='utf-8') as f:

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -26,6 +26,7 @@ class PLTestCase(unittest.TestCase):
     student_code_file = 'user_code.py'
     iter_num = 0
     total_iters = 1
+    ipynb_key = '#keep'
 
     @classmethod
     def setUpClass(self):
@@ -47,7 +48,8 @@ class PLTestCase(unittest.TestCase):
                                                               join(base_dir, self.student_code_file),
                                                               self.include_plt,
                                                               join(base_dir, 'output.txt'),
-                                                              self.iter_num)
+                                                              self.iter_num,
+                                                              self.ipynb_key)
         answerTuple = namedtuple('answerTuple', ref_result.keys())
         self.ref = answerTuple(**ref_result)
         studentTuple = namedtuple('studentTuple', student_result.keys())

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -26,7 +26,7 @@ class PLTestCase(unittest.TestCase):
     student_code_file = 'user_code.py'
     iter_num = 0
     total_iters = 1
-    ipynb_key = '#keep'
+    ipynb_key = '#grade'
 
     @classmethod
     def setUpClass(self):

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -44,7 +44,7 @@ chmod 1777 "$MERGE_DIR"
 export FILENAMES_DIR=$MERGE_DIR'/filenames'
 mkdir $FILENAMES_DIR
 chmod 777 $FILENAMES_DIR
-mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $JOB_DIR/data/data.json $FILENAMES_DIR
+mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $MERGE_DIR/leading_code.py $JOB_DIR/data/data.json $FILENAMES_DIR
 
 ##########################
 # RUN


### PR DESCRIPTION
When using JupyterLab as workspace, we can use the python autograder to grade parts of the notebook. Instead of converting the entire notebook to .py as student code, this PR adds the option to search for specific cells based on a keyword (default is #keep), and grade the content of these cells only. This will be helpful when the notebook contains lots of code with intermediate steps, plots, print statements, additional libraries, etc, that we don't want to send to the autograder. 

