### PR TITLE
Fix workspace config variable caching for zip directory

### DIFF
--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -18,8 +18,6 @@ const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 const ERR = require('async-stacktrace');
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
-const zipPrefix = config.workspaceMainZipsDirectory;
-
 const zipDirectory = async function (source, zip) {
     const stream = fs.createWriteStream(zip);
     const archive = archiver('zip');
@@ -44,8 +42,8 @@ module.exports = {
         module.exports._namespace = socketServer.io.of('/workspace');
         module.exports._namespace.on('connection', module.exports.connection);
 
-        debug(`init: zipPrefix=${zipPrefix}`);
-        await fs.promises.mkdir(zipPrefix, { recursive: true, mode: 0o700 });
+        debug(`init: config.workspaceMainZipsDirectory=${config.workspaceMainZipsDirectory}`);
+        await fs.promises.mkdir(config.workspaceMainZipsDirectory, { recursive: true, mode: 0o700 });
 
         if (!config.runningInEc2) {
             const configFile = path.join(process.cwd(), 'aws-config.json');
@@ -183,7 +181,7 @@ module.exports = {
             const match = contentDisposition.match(/^attachment; filename="(.*)"$/);
             if (!match) throw new Error(`Content-Disposition format error: ${contentDisposition}`);
             const zipName = match[1];
-            const zipPath = path.join(zipPrefix, zipName);
+            const zipPath = path.join(config.workspaceMainZipsDirectory, zipName);
 
             debug(`controlContainer: saving ${zipPath}`);
             let stream = fs.createWriteStream(zipPath);
@@ -226,7 +224,7 @@ module.exports = {
         const s3Path = `${config.workspaceS3Bucket}/workspace-${workspace_id}`;
         const now = new Date().toISOString().replace(/[-T:.]/g, '-');
         const zipName = `workspace-${workspace_id}-${now}.zip`;
-        const zipPath = path.join(zipPrefix, zipName);
+        const zipPath = path.join(config.workspaceMainZipsDirectory, zipName);
 
         debug(`Zipping ${localPath} as ${zipPath}`);
         await zipDirectory(localPath, zipPath);
@@ -290,7 +288,7 @@ module.exports = {
     async getGradedFilesFromS3(workspace_id) {
         const timestamp = new Date().toISOString().replace(/[-T:.]/g, '-');
         const zipName = `workspace-${workspace_id}-${timestamp}.zip`;
-        const zipPath = path.join(zipPrefix, zipName);
+        const zipPath = path.join(config.workspaceMainZipsDirectory, zipName);
 
         // we should get the gradedFiles from S3 and zip them into zipPath
 

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -35,7 +35,6 @@ if ('config' in argv) {
     configFilename = argv['config'];
 }
 config.loadConfig(configFilename);
-const zipPrefix = config.workspaceHostZipsDirectory;
 
 logger.info(`Workspace S3 bucket: ${config.workspaceS3Bucket}`);
 
@@ -153,7 +152,7 @@ async.series([
         }
     },
     (callback) => {
-        fs.mkdir(zipPrefix, { recursive: true, mode: 0o700 }, (err) => {
+        fs.mkdir(config.workspaceHostZipsDirectory, { recursive: true, mode: 0o700 }, (err) => {
             if (ERR(err, callback)) return;
             callback(null);
         });
@@ -697,7 +696,7 @@ async function _getInitialZipAsync(workspace) {
     const localName = workspace.local_name;
     const s3Name = workspace.s3_name;
     const localPath = `${workspacePrefix}/${localName}`;
-    const zipPath = `${zipPrefix}/${localName}-initial.zip`;
+    const zipPath = `${config.workspaceHostZipsDirectory}/${localName}-initial.zip`;
     const s3Path = s3Name.replace('current', 'initial.zip');
 
     debug(`Downloading s3Path=${s3Path} to zipPath=${zipPath}`);
@@ -943,7 +942,7 @@ function gradeSequence(workspace_id, res) {
             const workspaceSettings = await _getWorkspaceSettingsAsync(workspace_id);
             const timestamp = new Date().toISOString().replace(/[-T:.]/g, '-');
             const zipName = `workspace-${workspace_id}-${timestamp}.zip`;
-            zipPath = path.join(zipPrefix, zipName);
+            zipPath = path.join(config.workspaceHostZipsDirectory, zipName);
 
             return {
                 workspace,


### PR DESCRIPTION
We should not store config variables in global variables (like `zipPrefix`), because these global variables are initialized when the code is loaded from disk, which is _before_ we've had a chance to load user-provided config files. This means that the global variable (`zipPrefix` in this case) will always have the default value of the config variable, even if it was later overridden.