### PR TITLE
Add option to hide score badge for partial-credit="false" to pl-checkbox

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -173,7 +173,7 @@ Attribute | Type | Default | Description
 `detailed-help-text` | boolean | false | Display detailed information in help text about the number of options to choose.
 `hide-answer-panel` | boolean | false | Option to not display the correct answer in the correct panel.
 `hide-letter-keys` | boolean | false | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.
-`hide-partial-score-badge` | boolean | false | Hide badges next to selected answers unless all answers are correctly selected.
+`hide-score-badge` | boolean | false | Hide badges next to selected answers.
 
 Inside the `pl-checkbox` element, each choice must be specified with
 a `pl-answer` that has attributes:

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -173,6 +173,7 @@ Attribute | Type | Default | Description
 `detailed-help-text` | boolean | false | Display detailed information in help text about the number of options to choose.
 `hide-answer-panel` | boolean | false | Option to not display the correct answer in the correct panel.
 `hide-letter-keys` | boolean | false | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.
+`hide-partial-score-badge` | boolean | false | Hide badges next to selected answers unless all answers are correctly selected.
 
 Inside the `pl-checkbox` element, each choice must be specified with
 a `pl-answer` that has attributes:

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -14,14 +14,14 @@ HIDE_ANSWER_PANEL_DEFAULT = False
 HIDE_HELP_TEXT_DEFAULT = False
 DETAILED_HELP_TEXT_DEFAULT = False
 HIDE_LETTER_KEYS_DEFAULT = False
-HIDE_PARTIAL_SCORE_BADGE_DEFAULT = False
+HIDE_SCORE_BADGE_DEFAULT = False
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method', 'hide-letter-keys', 'hide-partial-score-badge']
+    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method', 'hide-letter-keys', 'hide-score-badge']
 
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
@@ -109,13 +109,13 @@ def render(element_html, data):
     name = pl.get_string_attrib(element, 'answers-name')
     partial_credit = pl.get_boolean_attrib(element, 'partial-credit', PARTIAL_CREDIT_DEFAULT)
     partial_credit_method = pl.get_string_attrib(element, 'partial-credit-method', PARTIAL_CREDIT_METHOD_DEFAULT)
-    hide_partial_score_badge = pl.get_boolean_attrib(element, 'hide-partial-score-badge', HIDE_PARTIAL_SCORE_BADGE_DEFAULT)
+    hide_score_badge = pl.get_boolean_attrib(element, 'hide-score-badge', HIDE_SCORE_BADGE_DEFAULT)
 
     editable = data['editable']
     # answer feedback is not displayed when partial credit is True
     # (unless the question is disabled)
     show_answer_feedback = True
-    if (partial_credit and editable) or hide_partial_score_badge:
+    if (partial_credit and editable) or hide_score_badge:
         show_answer_feedback = False
 
     display_answers = data['params'].get(name, [])

--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -14,13 +14,14 @@ HIDE_ANSWER_PANEL_DEFAULT = False
 HIDE_HELP_TEXT_DEFAULT = False
 DETAILED_HELP_TEXT_DEFAULT = False
 HIDE_LETTER_KEYS_DEFAULT = False
+HIDE_PARTIAL_SCORE_BADGE_DEFAULT = False
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     required_attribs = ['answers-name']
-    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method', 'hide-letter-keys']
+    optional_attribs = ['weight', 'number-answers', 'min-correct', 'max-correct', 'fixed-order', 'inline', 'hide-answer-panel', 'hide-help-text', 'detailed-help-text', 'partial-credit', 'partial-credit-method', 'hide-letter-keys', 'hide-partial-score-badge']
 
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
@@ -108,12 +109,13 @@ def render(element_html, data):
     name = pl.get_string_attrib(element, 'answers-name')
     partial_credit = pl.get_boolean_attrib(element, 'partial-credit', PARTIAL_CREDIT_DEFAULT)
     partial_credit_method = pl.get_string_attrib(element, 'partial-credit-method', PARTIAL_CREDIT_METHOD_DEFAULT)
+    hide_partial_score_badge = pl.get_boolean_attrib(element, 'hide-partial-score-badge', HIDE_PARTIAL_SCORE_BADGE_DEFAULT)
 
     editable = data['editable']
     # answer feedback is not displayed when partial credit is True
     # (unless the question is disabled)
     show_answer_feedback = True
-    if partial_credit and editable:
+    if (partial_credit and editable) or hide_partial_score_badge:
         show_answer_feedback = False
 
     display_answers = data['params'].get(name, [])


### PR DESCRIPTION
Resolves https://github.com/ace-lab/pl-ucb-cs10/issues/82

In `<pl-checkbox>`, unless `partial-credit="true"`, each submission will display a correct/incorrect badge next to the selected answers. This makes questions intended for students to try until they get all correct trivial to defeat (since the question tells them the correctness of their choice).

For example:
<img width="600" alt="Screen Shot 2020-08-18 at 12 29 46 AM" src="https://user-images.githubusercontent.com/29329194/90484612-4652f680-e0eb-11ea-9074-bcde799d2c27.png">

If this question is set to All or Nothing with multiple attempts, student can easily figure out the correct answer. The intended effect of a submission like this one looks like the below picture, where the correctness of each choice is hidden from student.


<img width="600" alt="Screen Shot 2020-08-18 at 12 29 24 AM" src="https://user-images.githubusercontent.com/29329194/90484644-5074f500-e0eb-11ea-868b-64a37cc36a08.png">

The new attribute: `hide-score-badge` will hide the badges even for none partial-credit questions.

