### PR TITLE
Add more detailed JSON validation errors

### DIFF
--- a/lib/json-load.js
+++ b/lib/json-load.js
@@ -52,7 +52,7 @@ module.exports.validateJSON = function(json, schema, callback) {
         return;
     }
     if (!valid) {
-        callback(new Error(ajv.errorsText(validate.errors)));
+        callback(new Error(`${ajv.errorsText(validate.errors)}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`));
     } else {
         callback(null, json);
     }
@@ -95,7 +95,7 @@ module.exports.readJSONSyncOrDie = function(jsonFilename, schema) {
             const validate = ajv.compile(schema);
             const valid = validate(json);
             if (!valid) {
-                logger.error(`Error in JSON file: ${ajv.errorsText(validate.errors)}`);
+                logger.error(`Error in JSON file: ${ajv.errorsText(validate.errors)}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`);
                 process.exit(1);
                 return;
             } else {

--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -501,7 +501,7 @@ module.exports.loadInfoFile = async function({ coursePath, filePath, schema, tol
             const valid = validate(json);
             if (!valid) {
                 const result = { uuid: json.uuid };
-                infofile.addError(result, ajv.errorsText(validate.errors));
+                infofile.addError(result, `Error: ${ajv.errorsText(validate.errors)}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`);
                 return result;
             }
             return {


### PR DESCRIPTION
Rather than displaying only `data should NOT have additional properties`, which doesn't tell you which property is the problem, we will now display additional details:
```
Error: data should NOT have additional properties
Error details:
[
  {
    "keyword": "additionalProperties",
    "dataPath": "",
    "schemaPath": "#/additionalProperties",
    "params": {
      "additionalProperty": "badKey"
    },
    "message": "should NOT have additional properties"
  }
]
```

This extra detail is shown for all JSON validation errors, not just "additional properties".