### PR TITLE
Fix default institution

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -70,7 +70,7 @@
   * Add support for Rust to `pl-code` element (Nathan Walters).
 
   * Add tests for LTI auth (Dave Mussulman).
-  
+
   * Add more robust Python autograder to `prairielearn/grader-python` (Nathan Bowman and Nicolas Nytko).
 
   * Add choose course instance dropdown to instructor nav-bar when viewing course only (Tim Bretl).
@@ -110,7 +110,7 @@
   * Change blocked-event-loop detection to be more lightweight in production (Matt West).
 
   * Change file editing access to `Editor`, down from `Owner` (Matt West).
-  
+
   * Change syncing to be more resilient and to record errors/warnings encountered during sync (Nathan Walters).
 
   * Change element default setup to be top-down instead of inline (James Balamuta).
@@ -258,6 +258,8 @@
   * Fix gradebook and question statistics download links (Tim Bretl).
 
   * Fix `demoRandomPlot` by updating the matlibplot subplot code (James Balamuta).
+
+  * Fix default institution in course instance access rules (Tim Bretl).
 
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 

--- a/sync/fromDisk/courseInstances.js
+++ b/sync/fromDisk/courseInstances.js
@@ -6,8 +6,8 @@ const infofile = require('../infofile');
 const perf = require('../performance')('question');
 
 /**
- * 
- * @param {import('../course-db').CourseInstance} courseInstance 
+ *
+ * @param {import('../course-db').CourseInstance} courseInstance
  * @param {string} courseTimezone
  */
 function getParamsForCourseInstance(courseInstance, courseTimezone) {
@@ -18,7 +18,7 @@ function getParamsForCourseInstance(courseInstance, courseTimezone) {
         uids: _(accessRule).has('uids') ? accessRule.uids : null,
         start_date: _(accessRule).has('startDate') ? accessRule.startDate : null,
         end_date: _(accessRule).has('endDate') ? accessRule.endDate : null,
-        institution: _(accessRule).has('institution') ? accessRule.institution : 'UIUC',
+        institution: _(accessRule).has('institution') ? accessRule.institution : null,
     }));
 
     const userRoles = Object.entries(courseInstance.userRoles || {})


### PR DESCRIPTION
If an institution is not specified by a course instance access rule, it should be set to `null` and not to `"UIUC"`.

This gets us the behavior that we want - when no institution is specified, we default to checking that the user's institution is the same as the course's institution to grant access.