### PR TITLE
Fix assessment syncing with deleted assessments having the same TID

### DIFF
--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -159,6 +159,7 @@ BEGIN
             ) AS aggregates
         WHERE
             a.tid = valid_assessment.tid
+            AND a.deleted_at IS NULL
             AND a.tid = aggregates.tid
             AND a.course_instance_id = syncing_course_instance_id
         RETURNING id INTO new_assessment_id;

--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -361,7 +361,10 @@ BEGIN
                     'SQL_ASCII'),'\x00')
                 FROM regexp_matches(number, '0*([0-9]+)|([^0-9]+)', 'g') r 
             ) ASC) AS order_by
-        FROM assessments WHERE course_instance_id = syncing_course_instance_id
+        FROM assessments
+        WHERE
+            course_instance_id = syncing_course_instance_id
+            AND deleted_at IS NULL
     ) AS assessments_with_ordinality
     WHERE
         a.tid = assessments_with_ordinality.tid

--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -380,6 +380,7 @@ BEGIN
     FROM disk_assessments AS da
     WHERE
         a.tid = da.tid
+        AND a.deleted_at IS NULL
         AND a.course_instance_id = syncing_course_instance_id
         AND (da.errors IS NOT NULL AND da.errors != '');
 


### PR DESCRIPTION
We forgot some `WHERE deleted_at IS NULL` checks, so we were picking up deleted rows and updating more than assessments row in this UPDATE: https://github.com/PrairieLearn/PrairieLearn/blob/eac3eb5ba50654be86e274119be499b7c3d01948/sprocs/sync_assessments.sql#L134

This would then fail with `query returned more than one row` because it was RETURNING into a scalar value here: https://github.com/PrairieLearn/PrairieLearn/blob/eac3eb5ba50654be86e274119be499b7c3d01948/sprocs/sync_assessments.sql#L164

The actual fix is just the one for this query (plus a test case that used to fail and now doesn't). I also added `WHERE deleted_at IS NULL` to a few other places where it seemed necessary (anywhere we are looking up an assessment by its `tid`), but I didn't write tests beforehand to see whether those were actually causing bugs.

I haven't checked the sync sprocs for course_instances, courses, and questions to see whether they have similar issues.