### PR TITLE
Fix group work flag bug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -261,6 +261,8 @@
 
   * Fix default institution in course instance access rules (Tim Bretl).
 
+  * Fix `group_work` flag when calling `authz_assessment_instance` (Tim Bretl).
+
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 
   * Remove introduction alert at the top of `homework` assessments (Tim Yang).

--- a/middlewares/selectAndAuthzAssessmentInstance.sql
+++ b/middlewares/selectAndAuthzAssessmentInstance.sql
@@ -50,7 +50,7 @@ FROM
     LEFT JOIN groups AS gr ON (gr.id = gu.group_id AND gr.deleted_at IS NULL)
     JOIN users AS u ON (u.user_id = gu.user_id OR u.user_id = ai.user_id)
     LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
-    JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, TRUE) AS aai ON TRUE
+    JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, a.group_work) AS aai ON TRUE
     CROSS JOIN file_list AS fl
 WHERE
     ai.id = $assessment_instance_id

--- a/middlewares/selectAndAuthzAssessmentInstance.sql
+++ b/middlewares/selectAndAuthzAssessmentInstance.sql
@@ -1,17 +1,3 @@
--- BLOCK get_group_work
-SELECT *
-FROM
-    assessment_instances AS ai
-    JOIN assessments AS a ON (a.id = ai.assessment_id)
-    JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-    JOIN pl_courses AS c ON (c.id = ci.course_id)
-    JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-    JOIN group_users AS gu ON (ai.group_id = gu.group_id)
-    JOIN groups AS gr ON (gr.id = gu.group_id)
-WHERE
-     ai.id = $assessment_instance_id
-     AND gr.deleted_at IS NULL;
-
 -- BLOCK select_and_auth
 WITH file_list AS (
     SELECT coalesce(jsonb_agg(f ORDER BY f.created_at), '[]'::jsonb) AS list

--- a/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -1,7 +1,7 @@
 -- BLOCK get_group_work
 SELECT *
 FROM
-    
+
     assessment_instances AS ai
     LEFT JOIN instance_questions AS iq ON (iq.assessment_instance_id = ai.id)
     JOIN group_users AS gu ON (ai.group_id = gu.group_id)
@@ -81,7 +81,7 @@ FROM
     LEFT JOIN groups AS gr ON (gr.id = gu.group_id AND gr.deleted_at IS NULL)
     JOIN users AS u ON (u.user_id = gu.user_id OR u.user_id = ai.user_id)
     LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
-    JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, TRUE) AS aai ON TRUE
+    JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, a.group_work) AS aai ON TRUE
     CROSS JOIN file_list AS fl
 WHERE
     iq.id = $instance_question_id

--- a/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -1,15 +1,3 @@
--- BLOCK get_group_work
-SELECT *
-FROM
-
-    assessment_instances AS ai
-    LEFT JOIN instance_questions AS iq ON (iq.assessment_instance_id = ai.id)
-    JOIN group_users AS gu ON (ai.group_id = gu.group_id)
-    JOIN groups AS gr ON (gr.id = gu.group_id)
-WHERE
-    iq.id = $instance_question_id
-    AND gr.deleted_at IS NULL;
-
 -- BLOCK select_and_auth
 WITH instance_questions_info AS (
     SELECT


### PR DESCRIPTION
The last input argument of the function `authz_assessment_instance` is the boolean `group_work`, which is meant to indicate whether or not the corresponding assessment is for group work. This argument was hard-coded as `TRUE` in the two places where `authz_assessment_instance` was being called, when it should have been `a.group_work`.

This mistake does not seem to have any negative consequences right now, but that is just a lucky chance.