### PR TITLE
Fix question syncing with deleted questions

### DIFF
--- a/sprocs/sync_questions.sql
+++ b/sprocs/sync_questions.sql
@@ -153,6 +153,7 @@ BEGIN
         ) AS aggregates
     WHERE
         dest.qid = src.qid
+        AND dest.deleted_at IS NULL
         AND dest.qid = aggregates.qid
         AND dest.course_id = syncing_course_id
         AND (src.errors IS NULL OR src.errors = '');

--- a/sprocs/sync_questions.sql
+++ b/sprocs/sync_questions.sql
@@ -168,6 +168,7 @@ BEGIN
     FROM disk_questions AS src
     WHERE
         dest.qid = src.qid
+        AND dest.deleted_at IS NULL
         AND dest.course_id = syncing_course_id
         AND (src.errors IS NOT NULL AND src.errors != '');
 

--- a/tests/sync/questionsSync.js
+++ b/tests/sync/questionsSync.js
@@ -278,7 +278,7 @@ describe('Question syncing', () => {
     }
   });
 
-  it('correctly handles a new assessment with the same QID as a deleted question', async () => {
+  it('correctly handles a new question with the same QID as a deleted question', async () => {
     const courseData = util.getCourseData();
     const question = makeQuestion(courseData);
     courseData.questions['repeatedQuestion'] = question;


### PR DESCRIPTION
This is the same category of bug as in #2912, except for questions rather than assessments. In this case the impact was much lower (invisible to end users), but still worth fixing.