### PR TITLE
Fix course instance syncing with deleted course instances

### DIFF
--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -142,6 +142,7 @@ BEGIN
         FROM course_instances AS ci
         WHERE
             ci.short_name = valid_course_instance.short_name
+            AND ci.deleted_at IS NULL
             AND ci.course_id = syncing_course_id;
 
         INSERT INTO course_instance_access_rules (

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -229,6 +229,7 @@ BEGIN
     FROM disk_course_instances AS src
     WHERE
         dest.short_name = src.short_name
+        AND dest.deleted_at IS NULL
         AND dest.course_id = syncing_course_id
         AND (src.errors IS NOT NULL AND src.errors != '');
 END;

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -128,6 +128,7 @@ BEGIN
     FROM disk_course_instances AS src
     WHERE
         dest.short_name = src.short_name
+        AND dest.deleted_at IS NULL
         AND dest.course_id = syncing_course_id
         AND (src.errors IS NULL OR src.errors = '');
 

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -138,7 +138,7 @@ BEGIN
         FROM disk_course_instances AS src
         WHERE (src.errors IS NULL OR src.errors = '')
     ) LOOP
-        SELECT ci.id INTO syncing_course_instance_id
+        SELECT ci.id INTO STRICT syncing_course_instance_id
         FROM course_instances AS ci
         WHERE
             ci.short_name = valid_course_instance.short_name

--- a/tests/sync/courseInstancesSync.js
+++ b/tests/sync/courseInstancesSync.js
@@ -182,7 +182,7 @@ describe('Course instance syncing', () => {
 
   it('correctly handles a new course instance with the same short name as a deleted course instance', async () => {
     const courseData = util.getCourseData();
-    const courseInstance = makeCourseInstance(courseData);
+    const courseInstance = makeCourseInstance();
     courseData.courseInstances['repeatedCourseInstance'] = courseInstance;
     const courseDir = await util.writeAndSyncCourseData(courseData);
 
@@ -198,7 +198,7 @@ describe('Course instance syncing', () => {
 
   it('does not modify deleted course instance long names', async () => {
     const courseData = util.getCourseData();
-    const originalCourseInstance = makeCourseInstance(courseData);
+    const originalCourseInstance = makeCourseInstance();
     courseData.courseInstances['repeatedCourseInstance'] = originalCourseInstance;
     const courseDir = await util.writeAndSyncCourseData(courseData);
 
@@ -216,7 +216,7 @@ describe('Course instance syncing', () => {
 
   it('does not add errors to deleted course instances', async () => {
     const courseData = util.getCourseData();
-    const originalCourseInstance = makeCourseInstance(courseData);
+    const originalCourseInstance = makeCourseInstance();
     courseData.courseInstances['repeatedCourseInstance'] = originalCourseInstance;
     const courseDir = await util.writeAndSyncCourseData(courseData);
 

--- a/tests/sync/courseInstancesSync.js
+++ b/tests/sync/courseInstancesSync.js
@@ -179,4 +179,20 @@ describe('Course instance syncing', () => {
       assert.isUndefined(syncedCourseInstance);
     }
   });
+
+  it('correctly handles a new course instance with the same short name as a deleted course instance', async () => {
+    const courseData = util.getCourseData();
+    const courseInstance = makeCourseInstance(courseData);
+    courseData.courseInstances['repeatedCourseInstance'] = courseInstance;
+    const courseDir = await util.writeAndSyncCourseData(courseData);
+
+    // now change the UUID of the course instance and re-sync
+    courseInstance.courseInstance.uuid = '276eeddb-74e1-44e5-bfc5-3c39d79afa85';
+    courseInstance.courseInstance.longName = 'test new long name';
+    await util.overwriteAndSyncCourseData(courseData, courseDir);
+    const syncedCourseInstances = await util.dumpTable('course_instances');
+    const syncedCourseInstance = syncedCourseInstances.find(ci => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at == null);
+    assert.equal(syncedCourseInstance.uuid, courseInstance.courseInstance.uuid);
+    assert.equal(syncedCourseInstance.long_name, courseInstance.courseInstance.longName);
+  });
 });


### PR DESCRIPTION
This is more of the same bug class as #2917 and #2912 (not checking for `WHERE deleted_at IS NULL` during sync).

In this case two of the bugs were serious (would sync data to the deleted course instance rather than to the new non-deleted one) and one of the bugs was harmless for end users.