### PR TITLE
Fix group users comma joins

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -261,6 +261,8 @@
 
   * Fix default institution in course instance access rules (Tim Bretl).
 
+  * Fix bad comma joins in select_single_assessment_instance block queries (Tim Bretl).
+
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).
 
   * Remove introduction alert at the top of `homework` assessments (Tim Yang).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -261,7 +261,6 @@
 
   * Fix default institution in course instance access rules (Tim Bretl).
 
-  * Fix bad comma joins in select_single_assessment_instance block queries (Tim Bretl).
   * Fix `group_work` flag when calling `authz_assessment_instance` (Tim Bretl).
 
   * Remove `number` column from `course_instances` table and `number` property from `infoCourseInstance.json` schema (Tim Bretl).

--- a/pages/studentAssessmentExam/studentAssessmentExam.sql
+++ b/pages/studentAssessmentExam/studentAssessmentExam.sql
@@ -3,10 +3,9 @@ SELECT
     ai.*
 FROM
     assessment_instances AS ai
-    LEFT JOIN (SELECT *
-     FROM group_users AS gi
-     WHERE $user_id = gi.user_id) AS gid ON TRUE
+    LEFT JOIN groups AS g ON (g.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = ai.group_id AND gu.group_id = g.id)
 WHERE
     ai.assessment_id = $assessment_id
     AND ai.number = 1
-    AND ((ai.group_id = gid.group_id) OR (ai.user_id = $user_id));
+    AND ((gu.user_id = $user_id) OR (ai.user_id = $user_id));

--- a/pages/studentAssessmentExam/studentAssessmentExam.sql
+++ b/pages/studentAssessmentExam/studentAssessmentExam.sql
@@ -3,8 +3,8 @@ SELECT
     ai.*
 FROM
     assessment_instances AS ai
-    LEFT JOIN groups AS g ON (g.deleted_at IS NULL)
-    LEFT JOIN group_users AS gu ON (gu.group_id = ai.group_id AND gu.group_id = g.id)
+    LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
 WHERE
     ai.assessment_id = $assessment_id
     AND ai.number = 1

--- a/pages/studentAssessmentExam/studentAssessmentExam.sql
+++ b/pages/studentAssessmentExam/studentAssessmentExam.sql
@@ -2,10 +2,10 @@
 SELECT
     ai.*
 FROM
-    assessment_instances AS ai,
-    (SELECT *
-     FROM group_users AS gi 
-     WHERE $user_id = gi.user_id) AS gid
+    assessment_instances AS ai
+    LEFT JOIN (SELECT *
+     FROM group_users AS gi
+     WHERE $user_id = gi.user_id) AS gid ON TRUE
 WHERE
     ai.assessment_id = $assessment_id
     AND ai.number = 1

--- a/pages/studentAssessmentHomework/studentAssessmentHomework.sql
+++ b/pages/studentAssessmentHomework/studentAssessmentHomework.sql
@@ -2,51 +2,51 @@
 SELECT
     ai.*
 FROM
-    assessment_instances AS ai,
-    (SELECT *
+    assessment_instances AS ai
+    LEFT JOIN (SELECT *
      FROM group_users AS gi
      JOIN groups AS gr ON gi.group_id = gr.id
-     WHERE $user_id = gi.user_id AND gr.deleted_at IS NULL) AS gid
+     WHERE $user_id = gi.user_id AND gr.deleted_at IS NULL) AS gid ON TRUE
 WHERE
     ai.assessment_id = $assessment_id
     AND ai.number = 1
     AND ((ai.group_id = gid.group_id) OR (ai.user_id = $user_id));
 
 -- BLOCK get_config_info
-SELECT 
+SELECT
     gc.student_authz_join, gc.student_authz_create, gc.student_authz_leave, gc.maximum, gc.minimum
-FROM 
+FROM
     group_configs gc
-WHERE 
+WHERE
     gc.assessment_id = $assessment_id AND gc.deleted_at IS NULL;
 
 -- BLOCK check_group_size
-SELECT 
+SELECT
     COUNT(gu) AS cur_size, AVG(gc.maximum) AS maximum
-FROM 
+FROM
     groups gr
     JOIN group_configs gc ON gr.group_config_id = gc.id
     LEFT JOIN group_users gu ON gu.group_id = gr.id
-WHERE 
+WHERE
     gr.name = $group_name
-    AND gr.join_code = $join_code 
-    AND gc.assessment_id = $assessment_id 
-    AND gr.deleted_at IS NULL 
+    AND gr.join_code = $join_code
+    AND gc.assessment_id = $assessment_id
+    AND gr.deleted_at IS NULL
     AND gc.deleted_at IS NULL
 GROUP BY
     gr.id;
 
 -- BLOCK join_group
 WITH log AS (
-    INSERT INTO 
+    INSERT INTO
         group_users (user_id, group_id)
-    VALUES 
+    VALUES
         ($user_id, (SELECT id
                     FROM groups
                     WHERE name = $group_name AND join_code = $join_code AND deleted_at IS NULL))
     RETURNING group_id
 )
-INSERT INTO group_logs 
+INSERT INTO group_logs
     (authn_user_id, user_id, group_id, action)
 SELECT $user_id, $user_id, group_id, 'join'
 FROM log;
@@ -54,59 +54,59 @@ FROM log;
 
 -- BLOCK create_group
 WITH log AS (
-    INSERT INTO groups 
+    INSERT INTO groups
         (name, group_config_id, course_instance_id)
-    VALUES 
+    VALUES
         (
-            $group_name, 
+            $group_name,
             (SELECT id FROM group_configs WHERE assessment_id = $assessment_id AND deleted_at IS NULL),
             (SELECT course_instance_id FROM group_configs WHERE assessment_id = $assessment_id AND deleted_at IS NULL)
         )
     RETURNING id
 )
-INSERT INTO group_logs 
+INSERT INTO group_logs
     (authn_user_id, user_id, group_id, action)
 SELECT $user_id, $user_id, id, 'create'
 FROM log;
 
 -- BLOCK join_justcreated_group
 WITH log AS (
-    INSERT INTO group_users 
+    INSERT INTO group_users
         (group_id, user_id)
-    VALUES 
+    VALUES
         (
             (SELECT id FROM groups WHERE name = $group_name AND deleted_at IS NULL),
             $user_id
         )
     RETURNING group_id
 )
-INSERT INTO group_logs 
+INSERT INTO group_logs
     (authn_user_id, user_id, group_id, action)
 SELECT $user_id, $user_id, group_id, 'join'
 FROM log;
 
 -- BLOCK get_group_info
-SELECT 
+SELECT
     gu.group_id, gr.name, gr.join_code, us.uid, gc.minimum, gc.maximum
-FROM 
+FROM
     assessments ass
     JOIN group_configs gc ON gc.assessment_id = ass.id
     JOIN groups gr ON gr.group_config_id = gc.id
     JOIN group_users gu ON gu.group_id = gr.id
     JOIN group_users gu2 ON gu2.group_id = gu.group_id
     JOIN users us ON us.user_id = gu2.user_id
-WHERE 
-    ass.id = $assessment_id 
-    AND gu.user_id = $user_id 
-    AND gr.deleted_at IS NULL 
+WHERE
+    ass.id = $assessment_id
+    AND gu.user_id = $user_id
+    AND gr.deleted_at IS NULL
     AND gc.deleted_at IS NULL;
 
 -- BLOCK leave_group
 WITH log AS (
-    DELETE FROM 
+    DELETE FROM
         group_users
-    WHERE 
-        user_id = $user_id 
+    WHERE
+        user_id = $user_id
         AND group_id IN (SELECT gr.id
                         FROM assessments ass
                         JOIN group_configs gc ON gc.assessment_id = ass.id
@@ -115,8 +115,8 @@ WITH log AS (
                         AND gr.deleted_at IS NULL
                         AND gc.deleted_at IS NULL)
     RETURNING group_id
-) 
-INSERT INTO group_logs 
+)
+INSERT INTO group_logs
     (authn_user_id, user_id, group_id, action)
 SELECT $user_id, $user_id, group_id, 'leave'
 FROM log;

--- a/pages/studentAssessmentHomework/studentAssessmentHomework.sql
+++ b/pages/studentAssessmentHomework/studentAssessmentHomework.sql
@@ -3,14 +3,12 @@ SELECT
     ai.*
 FROM
     assessment_instances AS ai
-    LEFT JOIN (SELECT *
-     FROM group_users AS gi
-     JOIN groups AS gr ON gi.group_id = gr.id
-     WHERE $user_id = gi.user_id AND gr.deleted_at IS NULL) AS gid ON TRUE
+    LEFT JOIN groups AS g ON (g.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = ai.group_id AND gu.group_id = g.id)
 WHERE
     ai.assessment_id = $assessment_id
     AND ai.number = 1
-    AND ((ai.group_id = gid.group_id) OR (ai.user_id = $user_id));
+    AND ((gu.user_id = $user_id) OR (ai.user_id = $user_id));
 
 -- BLOCK get_config_info
 SELECT

--- a/pages/studentAssessmentHomework/studentAssessmentHomework.sql
+++ b/pages/studentAssessmentHomework/studentAssessmentHomework.sql
@@ -3,8 +3,8 @@ SELECT
     ai.*
 FROM
     assessment_instances AS ai
-    LEFT JOIN groups AS g ON (g.deleted_at IS NULL)
-    LEFT JOIN group_users AS gu ON (gu.group_id = ai.group_id AND gu.group_id = g.id)
+    LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
 WHERE
     ai.assessment_id = $assessment_id
     AND ai.number = 1


### PR DESCRIPTION
The block `find_single_assessment_instance` appears in both of these SQL files:
* `pages/studentAssessmentHomework/studentAssessmentHomework.sql`
* `pages/studentAssessmentExam/studentAssessmentExam.sql`

As its name indicates, this block returns an assessment instance, if one exists. Both blocks used comma-joins like this:
```
SELECT
    ai.*
FROM
    assessment_instances AS ai,
    (SELECT *
     FROM group_users AS gi
     JOIN groups AS gr ON gi.group_id = gr.id
     WHERE $user_id = gi.user_id AND gr.deleted_at IS NULL) AS gid
WHERE
    ai.assessment_id = $assessment_id
    AND ai.number = 1
    AND ((ai.group_id = gid.group_id) OR (ai.user_id = $user_id));
```

Unfortunately, these comma-joins cause the block to return nothing (always) if the assessment instance is not associated with group work. So, `studentAssessment*.js` will try to create a new assessment instance, which will fail.

The ultimate consequence of this mistake is that no student will be able to access any assessment instance after the very first time it is created.

This PR eliminates the comma-joins and fixes the bug, restoring access to assessment instances.