### PR TITLE
Fix the file editor when there are soft-deleted rows

### DIFF
--- a/lib/editorUtil.sql
+++ b/lib/editorUtil.sql
@@ -8,14 +8,16 @@ SELECT sync_errors, sync_warnings
 FROM questions
 WHERE
     course_id = $course_id
-    AND qid = $qid;
+    AND qid = $qid
+    AND deleted_at IS NULL;
 
 -- BLOCK select_errors_and_warnings_for_course_instance
 SELECT sync_errors, sync_warnings
 FROM course_instances
 WHERE
     course_id = $course_id
-    AND short_name = $ciid;
+    AND short_name = $ciid
+    AND deleted_at IS NULL;
 
 -- BLOCK select_errors_and_warnings_for_assessment
 SELECT a.sync_errors, a.sync_warnings
@@ -23,5 +25,7 @@ FROM assessments AS a, course_instances AS ci
 WHERE
     ci.course_id = $course_id
     AND ci.short_name = $ciid
+    AND ci.deleted_at IS NULL
     AND a.course_instance_id = ci.id
-    AND a.tid = $aid;
+    AND a.tid = $aid
+    AND a.deleted_at IS NULL;


### PR DESCRIPTION
Another case of missing `WHERE deleted_at IS NULL` (see #2912, #2917, #2918). I didn't write any tests for this because that's going to take me too long to figure out how to test the file editor and a fix is urgently needed in production.