### PR TITLE
Fix downloads page by removing group_info() sproc

### DIFF
--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -18,7 +18,7 @@ SELECT
     (row_number() OVER (PARTITION BY u.user_id ORDER BY score_perc DESC, ai.number DESC, ai.id DESC)) = 1 AS highest_score,
     (row_number() OVER (PARTITION BY g.id)) = 1 AS unique_group,
     g.name AS groupname,
-    (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list
+    (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id ORDER BY u.uid) AS uid_list
 FROM
     assessments AS a
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
@@ -56,7 +56,7 @@ WITH instance_questions AS (
         extract(epoch FROM iq.duration) AS duration_seconds,
         (row_number() OVER (PARTITION BY g.id, q.id)) = 1 AS unique_group,
         g.name AS groupname,
-        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list
+        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id ORDER BY u.uid) AS uid_list
     FROM
         instance_questions AS iq
         JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
@@ -158,7 +158,7 @@ WITH all_submissions AS (
         (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC NULLS LAST, s.date DESC, s.id DESC)) = 1 AS best_submission_per_variant,
         (row_number() OVER (PARTITION BY g.id, v.id, s.id)) = 1 AS unique_group,
         g.name AS groupname,
-        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list,
+        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id ORDER BY u.uid) AS uid_list,
         su.uid AS submission_user
     FROM
         assessments AS a

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -85,19 +85,19 @@ WHERE
 
 -- BLOCK submissions_for_manual_grading
 WITH final_assessment_instances AS (
-    SELECT DISTINCT ON (gr.id, u.user_id)
+    SELECT DISTINCT ON (g.id, u.user_id)
         u.user_id,
-        gr.id AS group_id,
+        g.id AS group_id,
         ai.id,
         assessment_id,
-        gr.name AS groupname,
-        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = gr.id) AS uid_list
+        g.name AS groupname,
+        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list
     FROM
         assessment_instances AS ai
-        LEFT JOIN groups AS gr ON (gr.id = ai.group_id)
+        LEFT JOIN groups AS g ON (g.id = ai.group_id)
         LEFT JOIN users AS u ON (u.user_id = ai.user_id)
     WHERE ai.assessment_id = $assessment_id
-    ORDER BY gr.id, u.user_id, ai.number DESC
+    ORDER BY g.id, u.user_id, ai.number DESC
 )
 SELECT DISTINCT ON (ai.id, q.qid)
     u.uid,
@@ -195,17 +195,17 @@ ORDER BY
 -- BLOCK files_for_manual_grading
 WITH
 final_assessment_instances AS (
-    SELECT DISTINCT ON (gr.id, u.user_id)
+    SELECT DISTINCT ON (g.id, u.user_id)
         u.user_id,
-        gr.id AS group_id,
+        g.id AS group_id,
         ai.id,
-        gr.name AS groupname
+        g.name AS groupname
     FROM
         assessment_instances AS ai
-        LEFT JOIN groups AS gr ON (gr.id = ai.group_id)
+        LEFT JOIN groups AS g ON (g.id = ai.group_id)
         LEFT JOIN users AS u ON (u.user_id = ai.user_id)
     WHERE ai.assessment_id = $assessment_id
-    ORDER BY gr.id, u.user_id, ai.number DESC
+    ORDER BY g.id, u.user_id, ai.number DESC
 ),
 submissions_with_files AS (
     SELECT DISTINCT ON (ai.id, q.qid)
@@ -387,15 +387,15 @@ OFFSET
 
 -- BLOCK group_configs
 SELECT 
-    gr.name, u.uid
+    g.name, u.uid
 FROM 
     group_configs AS gc
-    JOIN groups AS gr ON gc.id = gr.group_config_id
-    JOIN group_users AS gu ON gr.id = gu.group_id
+    JOIN groups AS g ON gc.id = g.group_config_id
+    JOIN group_users AS gu ON g.id = gu.group_id
     JOIN users AS u ON gu.user_id = u.user_id
 WHERE
     gc.assessment_id = $assessment_id 
     AND gc.deleted_at IS NULL 
-    AND gr.deleted_at IS NULL
+    AND g.deleted_at IS NULL
 ORDER BY 
-    gr.name, u.uid;
+    g.name, u.uid;

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -18,7 +18,7 @@ SELECT
     (row_number() OVER (PARTITION BY u.user_id ORDER BY score_perc DESC, ai.number DESC, ai.id DESC)) = 1 AS highest_score,
     (row_number() OVER (PARTITION BY g.id)) = 1 AS unique_group,
     g.name AS groupname,
-    (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id ORDER BY u.uid) AS uid_list
+    groups_uid_list(g.id) AS uid_list
 FROM
     assessments AS a
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
@@ -56,7 +56,7 @@ WITH instance_questions AS (
         extract(epoch FROM iq.duration) AS duration_seconds,
         (row_number() OVER (PARTITION BY g.id, q.id)) = 1 AS unique_group,
         g.name AS groupname,
-        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id ORDER BY u.uid) AS uid_list
+        groups_uid_list(g.id) AS uid_list
     FROM
         instance_questions AS iq
         JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
@@ -91,7 +91,7 @@ WITH final_assessment_instances AS (
         ai.id,
         assessment_id,
         g.name AS groupname,
-        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list
+        groups_uid_list(g.id) AS uid_list
     FROM
         assessment_instances AS ai
         LEFT JOIN groups AS g ON (g.id = ai.group_id)
@@ -158,7 +158,7 @@ WITH all_submissions AS (
         (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC NULLS LAST, s.date DESC, s.id DESC)) = 1 AS best_submission_per_variant,
         (row_number() OVER (PARTITION BY g.id, v.id, s.id)) = 1 AS unique_group,
         g.name AS groupname,
-        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id ORDER BY u.uid) AS uid_list,
+        groups_uid_list(g.id) AS uid_list,
         su.uid AS submission_user
     FROM
         assessments AS a

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -16,16 +16,17 @@ SELECT
     EXTRACT(EPOCH FROM ai.duration) AS duration_secs,
     EXTRACT(EPOCH FROM ai.duration) / 60 AS duration_mins,
     (row_number() OVER (PARTITION BY u.user_id ORDER BY score_perc DESC, ai.number DESC, ai.id DESC)) = 1 AS highest_score,
-    (row_number() OVER (PARTITION BY gi.id)) = 1 AS unique_group,
-    gi.name AS groupname,
-    gi.uid_list
+    (row_number() OVER (PARTITION BY g.id)) = 1 AS unique_group,
+    g.name AS groupname,
+    (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list
 FROM
     assessments AS a
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
     JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
     JOIN assessment_instances AS ai ON (ai.assessment_id = a.id)
-    LEFT JOIN group_info($assessment_id) AS gi ON (gi.id = ai.group_id)
-    LEFT JOIN group_users AS gu ON (gu.group_id = gi.id)
+    LEFT JOIN group_configs AS gc ON (gc.assessment_id = a.id)
+    LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.group_config_id = gc.id)
+    LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
     JOIN users AS u ON (u.user_id = ai.user_id OR u.user_id = gu.user_id)
     LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = a.course_instance_id)
 WHERE
@@ -53,9 +54,9 @@ WITH instance_questions AS (
         iq.last_submission_score,
         iq.number_attempts,
         extract(epoch FROM iq.duration) AS duration_seconds,
-        (row_number() OVER (PARTITION BY gi.id, q.id)) = 1 AS unique_group,
-        gi.name AS groupname,
-        gi.uid_list
+        (row_number() OVER (PARTITION BY g.id, q.id)) = 1 AS unique_group,
+        g.name AS groupname,
+        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list
     FROM
         instance_questions AS iq
         JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
@@ -64,8 +65,9 @@ WITH instance_questions AS (
         JOIN assessments AS a ON (a.id = ai.assessment_id)
         JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
         JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-        LEFT JOIN group_info($assessment_id) AS gi ON (gi.id = ai.group_id)
-        LEFT JOIN group_users AS gu ON (gu.group_id = gi.id)
+        LEFT JOIN group_configs AS gc ON (gc.assessment_id = a.id)
+        LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.group_config_id = gc.id)
+        LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
         JOIN users AS u ON (u.user_id = ai.user_id OR u.user_id = gu.user_id)
         LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
     WHERE
@@ -83,22 +85,19 @@ WHERE
 
 -- BLOCK submissions_for_manual_grading
 WITH final_assessment_instances AS (
-    SELECT DISTINCT ON (CASE 
-                            WHEN $group_work THEN gr.id
-                            ELSE u.user_id
-                        END)
+    SELECT DISTINCT ON (gr.id, u.user_id)
         u.user_id,
         gr.id AS group_id,
-        ai.id
+        ai.id,
+        assessment_id,
+        gr.name AS groupname,
+        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = gr.id) AS uid_list
     FROM
         assessment_instances AS ai
         LEFT JOIN groups AS gr ON (gr.id = ai.group_id)
         LEFT JOIN users AS u ON (u.user_id = ai.user_id)
     WHERE ai.assessment_id = $assessment_id
-    ORDER BY (CASE 
-                WHEN $group_work THEN gr.id
-                ELSE u.user_id
-              END), ai.number DESC
+    ORDER BY gr.id, u.user_id, ai.number DESC
 )
 SELECT DISTINCT ON (ai.id, q.qid)
     u.uid,
@@ -110,16 +109,14 @@ SELECT DISTINCT ON (ai.id, q.qid)
     v.true_answer,
     (s.submitted_answer - '_files') AS submitted_answer,
     s.partial_scores,
-    gi.name AS groupname,
-    gi.uid_list
+    ai.groupname,
+    ai.uid_list
 FROM
     submissions AS s
     JOIN variants AS v ON (v.id = s.variant_id)
     JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
     JOIN final_assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
-    LEFT JOIN group_info($assessment_id) AS gi ON (gi.id = ai.group_id)
-    LEFT JOIN group_users AS gu ON (gu.group_id = gi.id)
-    JOIN users AS u ON (u.user_id = ai.user_id OR u.user_id = gu.user_id)
+    LEFT JOIN users AS u ON (u.user_id = ai.user_id)
     JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
     JOIN questions AS q ON (q.id = aq.question_id)
 ORDER BY ai.id, q.qid, s.date DESC;
@@ -159,17 +156,18 @@ WITH all_submissions AS (
         s.feedback,
         (row_number() OVER (PARTITION BY v.id ORDER BY s.date DESC, s.id DESC)) = 1 AS final_submission_per_variant,
         (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC NULLS LAST, s.date DESC, s.id DESC)) = 1 AS best_submission_per_variant,
-        (row_number() OVER (PARTITION BY gi.id, v.id, s.id)) = 1 AS unique_group,
-        gi.name AS groupname,
-        gi.uid_list,
+        (row_number() OVER (PARTITION BY g.id, v.id, s.id)) = 1 AS unique_group,
+        g.name AS groupname,
+        (SELECT array_agg(u.uid) FROM users AS u JOIN group_users AS gu ON (u.user_id = gu.user_id) WHERE gu.group_id = g.id) AS uid_list,
         su.uid AS submission_user
     FROM
         assessments AS a
         JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
         JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
         JOIN assessment_instances AS ai ON (ai.assessment_id = a.id)
-        LEFT JOIN group_info($assessment_id) AS gi ON (gi.id = ai.group_id)
-        LEFT JOIN group_users AS gu ON (gu.group_id = gi.id)
+        LEFT JOIN group_configs AS gc ON (gc.assessment_id = a.id)
+        LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.group_config_id = gc.id)
+        LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
         JOIN users AS u ON (u.user_id = ai.user_id OR u.user_id = gu.user_id)
         LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
         JOIN instance_questions AS iq ON (iq.assessment_instance_id = ai.id)
@@ -197,22 +195,17 @@ ORDER BY
 -- BLOCK files_for_manual_grading
 WITH
 final_assessment_instances AS (
-    SELECT DISTINCT ON (CASE 
-                            WHEN $group_work THEN gr.id
-                            ELSE u.user_id
-                        END)
+    SELECT DISTINCT ON (gr.id, u.user_id)
         u.user_id,
         gr.id AS group_id,
-        ai.id
+        ai.id,
+        gr.name AS groupname
     FROM
         assessment_instances AS ai
         LEFT JOIN groups AS gr ON (gr.id = ai.group_id)
         LEFT JOIN users AS u ON (u.user_id = ai.user_id)
     WHERE ai.assessment_id = $assessment_id
-    ORDER BY (CASE 
-                WHEN $group_work THEN gr.id
-                ELSE u.user_id
-              END), ai.number DESC
+    ORDER BY gr.id, u.user_id, ai.number DESC
 ),
 submissions_with_files AS (
     SELECT DISTINCT ON (ai.id, q.qid)
@@ -222,15 +215,13 @@ submissions_with_files AS (
         s.id AS submission_id,
         s.submitted_answer,
         v.params,
-        gi.name AS groupname
+        ai.groupname
     FROM
         submissions AS s
         JOIN variants AS v ON (v.id = s.variant_id)
         JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
         JOIN final_assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
-        LEFT JOIN group_info($assessment_id) AS gi ON (gi.id = ai.group_id)
-        LEFT JOIN group_users AS gu ON (gu.group_id = gi.id)
-        JOIN users AS u ON (u.user_id = ai.user_id OR u.user_id = gu.user_id)
+        LEFT JOIN users AS u ON (u.user_id = ai.user_id)
         JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
         JOIN questions AS q ON (q.id = aq.question_id)
     WHERE
@@ -309,13 +300,14 @@ WITH all_submissions_with_files AS (
         row_number() OVER (PARTITION BY v.id ORDER BY s.date) AS submission_number,
         (row_number() OVER (PARTITION BY v.id ORDER BY s.date DESC, s.id DESC)) = 1 AS final_submission_per_variant,
         (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC NULLS LAST, s.date DESC, s.id DESC)) = 1 AS best_submission_per_variant,
-        (row_number() OVER (PARTITION BY gi.id, v.id, s.id)) = 1 AS unique_group,
-        gi.name AS groupname
+        (row_number() OVER (PARTITION BY g.id, v.id, s.id)) = 1 AS unique_group,
+        g.name AS groupname
     FROM
         assessments AS a
         JOIN assessment_instances AS ai ON (ai.assessment_id = a.id)
-        LEFT JOIN group_info($assessment_id) AS gi ON (gi.id = ai.group_id)
-        LEFT JOIN group_users AS gu ON (gu.group_id = gi.id)
+        LEFT JOIN group_configs AS gc ON (gc.assessment_id = a.id)
+        LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.group_config_id = gc.id)
+        LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
         JOIN users AS u ON (u.user_id = ai.user_id OR u.user_id = gu.user_id)
         JOIN instance_questions AS iq ON (iq.assessment_instance_id = ai.id)
         JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)

--- a/sprocs/groups_uid_list.sql
+++ b/sprocs/groups_uid_list.sql
@@ -1,0 +1,18 @@
+DROP FUNCTION IF EXISTS group_uid_list(bigint);
+
+CREATE OR REPLACE FUNCTION
+    group_uid_list (
+        IN group_id bigint
+    ) RETURNS text[]
+    )
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT array_agg(u.uid)
+    FROM
+        users AS u
+        JOIN group_users AS gu ON (u.user_id = gu.user_id)
+    WHERE gu.group_id = g.id
+    ORDER BY u.uid;
+END
+$$ LANGUAGE plpgsql STABLE;

--- a/sprocs/groups_uid_list.sql
+++ b/sprocs/groups_uid_list.sql
@@ -7,12 +7,11 @@ CREATE OR REPLACE FUNCTION
     )
 AS $$
 BEGIN
-    SELECT array_agg(u.uid)
+    SELECT array_agg(u.uid) OVER (ORDER BY u.uid)
     INTO uid_list
     FROM
         group_users AS gu
         JOIN users AS u ON (u.user_id = gu.user_id)
-    WHERE gu.group_id = groups_uid_list.group_id
-    ORDER BY u.uid;
+    WHERE gu.group_id = groups_uid_list.group_id;
 END
 $$ LANGUAGE plpgsql STABLE;

--- a/sprocs/groups_uid_list.sql
+++ b/sprocs/groups_uid_list.sql
@@ -2,7 +2,7 @@ DROP FUNCTION IF EXISTS groups_uid_list(bigint);
 
 CREATE OR REPLACE FUNCTION
     groups_uid_list (
-        IN group_id bigint
+        IN group_id bigint,
         OUT uid_list text[]
     )
 AS $$

--- a/sprocs/groups_uid_list.sql
+++ b/sprocs/groups_uid_list.sql
@@ -1,18 +1,18 @@
-DROP FUNCTION IF EXISTS group_uid_list(bigint);
+DROP FUNCTION IF EXISTS groups_uid_list(bigint);
 
 CREATE OR REPLACE FUNCTION
-    group_uid_list (
+    groups_uid_list (
         IN group_id bigint
-    ) RETURNS text[]
+        OUT uid_list text[]
     )
 AS $$
 BEGIN
-    RETURN QUERY
     SELECT array_agg(u.uid)
+    INTO uid_list
     FROM
-        users AS u
-        JOIN group_users AS gu ON (u.user_id = gu.user_id)
-    WHERE gu.group_id = g.id
+        group_users AS gu
+        JOIN users AS u ON (u.user_id = gu.user_id)
+    WHERE gu.group_id = groups_uid_list.group_id
     ORDER BY u.uid;
 END
 $$ LANGUAGE plpgsql STABLE;

--- a/sprocs/index.js
+++ b/sprocs/index.js
@@ -166,6 +166,7 @@ module.exports = {
             'assessment_groups_delete_member.sql',
             'assessment_groups_delete_group.sql',
             'group_info.sql',
+            'groups_uid_list.sql',
             'workspaces_message_update.sql',
             'workspaces_state_update.sql',
         ], function(filename, callback) {


### PR DESCRIPTION
The use of `group_info()` was preventing the query planner from selecting an appropriate plan, leading to it using seq scans and the queries timing out. This PR removes the use of `group_info()` and codes the group JOINs inline. It's actually not too bad, so I'm tentatively in favor of removing `group_info()` everywhere.

Fixes #2930
