### PR TITLE
Add overall timeout on workspace launching

### DIFF
--- a/cron/stopStaleWorkspaces.js
+++ b/cron/stopStaleWorkspaces.js
@@ -53,5 +53,5 @@ module.exports.run = function(callback) {
         await stopLaunchedTimeoutWorkspaces();
         await stopHeartbeatTimeoutWorkspaces();
         await stopInLaunchingTimeoutWorkspaces();
-})(callback);
+    })(callback);
 };

--- a/cron/stopStaleWorkspaces.js
+++ b/cron/stopStaleWorkspaces.js
@@ -10,17 +10,48 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 module.exports = {};
 
+async function stopLaunchedTimeoutWorkspaces() {
+    const params = {
+        launched_timeout_sec: config.workspaceLaunchedTimeoutSec,
+    };
+    const result = await sqldb.queryAsync(sql.select_launched_timeout_workspaces, params);
+    const workspaces = result.rows;
+    for (const workspace of workspaces) {
+        logger.verbose(`stopStaleWorkspaces: launched timeout for workspace_id = ${workspace.id}`);
+        await workspaceHelper.updateState(workspace.id, 'stopped', `Maximum run time of ${config.workspaceLaunchedTimeoutSec / 3600} hours exceeded`);
+    }
+}
+
+async function stopHeartbeatTimeoutWorkspaces() {
+    const params = {
+        heartbeat_timeout_sec: config.workspaceHeartbeatTimeoutSec,
+    };
+    const result = await sqldb.queryAsync(sql.select_heartbeat_timeout_workspaces, params);
+    const workspaces = result.rows;
+    for (const workspace of workspaces) {
+        logger.verbose(`stopStaleWorkspaces: heartbeat timeout for workspace_id = ${workspace.id}`);
+        await workspaceHelper.updateState(workspace.id, 'stopped', `Connection was lost for more than ${config.workspaceHeartbeatTimeoutSec / 60} minutes`);
+    }
+}
+
+async function stopInLaunchingTimeoutWorkspaces() {
+    const params = {
+        in_launching_timeout_sec: config.workspaceInLaunchingTimeoutSec,
+    };
+    const result = await sqldb.queryAsync(sql.select_in_launching_timeout_workspaces, params);
+    const workspaces = result.rows;
+    for (const workspace of workspaces) {
+        // these are errors because timeouts should have been enforced
+        // by the workspace hosts
+        logger.error(`stopStaleWorkspaces: in-launching timeout for workspace_id = ${workspace.id}`);
+        await workspaceHelper.updateState(workspace.id, 'stopped', `Maximum launching time of ${config.workspaceInLaunchingTimeoutSec / 60} minutes exceeded`);
+    }
+}
+
 module.exports.run = function(callback) {
     util.callbackify(async () => {
-        const params = {
-            launched_timeout_sec: config.workspaceLaunchedTimeoutSec,
-            heartbeat_timeout_sec: config.workspaceHeartbeatTimeoutSec,
-        };
-        const result = await sqldb.queryAsync(sql.select_stale_workspaces, params);
-        const staleWorkspaces = result.rows;
-        for (const staleWorkspace of staleWorkspaces) {
-            logger.verbose(`stopStaleWorkspaces: stopping workspace_id = ${staleWorkspace.id}`);
-            await workspaceHelper.updateState(staleWorkspace.id, 'stopped', 'Cron job');
-        }
-    })(callback);
+        await stopLaunchedTimeoutWorkspaces();
+        await stopHeartbeatTimeoutWorkspaces();
+        await stopInLaunchingTimeoutWorkspaces();
+})(callback);
 };

--- a/cron/stopStaleWorkspaces.sql
+++ b/cron/stopStaleWorkspaces.sql
@@ -1,11 +1,20 @@
--- BLOCK select_stale_workspaces
-SELECT
-    *
-FROM
-    workspaces AS w
+-- BLOCK select_launched_timeout_workspaces
+SELECT *
+FROM workspaces AS w
 WHERE
     w.state = 'running'::enum_workspace_state
-    AND (
-        w.launched_at < now() - make_interval(secs => $launched_timeout_sec)
-        OR w.heartbeat_at < now() - make_interval(secs => $heartbeat_timeout_sec)
-    );
+    AND w.launched_at < now() - make_interval(secs => $launched_timeout_sec);
+
+-- BLOCK select_heartbeat_timeout_workspaces
+SELECT *
+FROM workspaces AS w
+WHERE
+    w.state = 'running'::enum_workspace_state
+    AND w.heartbeat_at < now() - make_interval(secs => $heartbeat_timeout_sec);
+
+-- BLOCK select_in_launching_timeout_workspaces
+SELECT *
+FROM workspaces AS w
+WHERE
+    w.state = 'launching'::enum_workspace_state
+    AND w.launched_at < now() - make_interval(secs => $in_launching_timeout_sec);

--- a/lib/config.js
+++ b/lib/config.js
@@ -137,6 +137,7 @@ config.workspaceHostZipsDirectory = '/workspace_host_zips';
 config.workspaceHeartbeatIntervalSec = 60;
 config.workspaceHeartbeatTimeoutSec = 10 * 60;
 config.workspaceLaunchedTimeoutSec = 12 * 60 * 60;
+config.workspaceInLaunchingTimeoutSec = 30 * 60;
 config.workspaceHostFileWatchIntervalSec = 5;
 config.workspaceHostForceUploadIntervalSec = 10 * 60;
 config.workspaceHostPruneContainersSec = 60;


### PR DESCRIPTION
Also separate out launched-timeout and heartbeat-timeout so we can add better messages to the workspaces in these cases.