### PR TITLE
Display workspace logs on container launch timeout

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -558,7 +558,13 @@ function _checkServer(workspace, callback) {
             } else {
                 const endTime = (new Date()).getTime();
                 if (endTime - startTime > maxMilliseconds) {
-                    callback(new Error(`Max startup time exceeded for workspace_id=${workspace.id}`));
+                    workspace.container.logs({
+                        stdout: true,
+                        stderr: true,
+                    }, (err, logs) => {
+                        if (ERR(err, callback)) return;
+                        callback(new Error(`Max startup time exceeded for workspace_id=${workspace.id} (launch uuid ${workspace.launch_uuid})\n${logs}`));
+                    });
                 } else {
                     setTimeout(checkWorkspace, checkMilliseconds);
                 }


### PR DESCRIPTION
Adds some more debug information when a container launch times out, could be helpful for debugging on prod:

![image](https://user-images.githubusercontent.com/1790491/91520276-8324a780-e8ba-11ea-8176-e8139f4b8c2b.png)

Incidentally, I'm not sure what the garbage characters are on the left hand side.  Maybe a dockerode issue?