### PR TITLE
Fix extra columns in the gradebook

### DIFF
--- a/pages/instructorGradebook/instructorGradebook.sql
+++ b/pages/instructorGradebook/instructorGradebook.sql
@@ -18,16 +18,28 @@ course_assessments AS (
     WHERE a.deleted_at IS NULL
     AND a.course_instance_id = $course_instance_id
 ),
-course_scores AS (
-    SELECT DISTINCT ON (ai.user_id, ai.group_id, a.id)
-        ai.user_id, a.id AS assessment_id, ai.score_perc, ai.id AS assessment_instance_id, ai.group_id
+course_assessment_instances AS (
+    SELECT ai.id, COALESCE(ai.user_id, gu.user_id) AS user_id
     FROM
         assessment_instances AS ai
+        JOIN assessments AS a ON (a.id = ai.assessment_id)
+        LEFT JOIN groups AS g ON (g.id = ai.group_id)
+        LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
+    WHERE
+        a.course_instance_id = $course_instance_id
+        AND g.deleted_at IS NULL
+),
+course_scores AS (
+    SELECT DISTINCT ON (cai.user_id, a.id)
+        cai.user_id, a.id AS assessment_id, ai.score_perc, ai.id AS assessment_instance_id
+    FROM
+        course_assessment_instances AS cai
+        JOIN assessment_instances AS ai ON (ai.id = cai.id)
         JOIN assessments AS a ON (a.id = ai.assessment_id)
     WHERE
         a.course_instance_id = $course_instance_id
     ORDER BY
-        ai.user_id, ai.group_id, a.id, ai.score_perc DESC, ai.id
+        cai.user_id, a.id, ai.score_perc DESC, ai.id
 ),
 user_ids AS (
     (SELECT DISTINCT user_id FROM course_scores)
@@ -48,8 +60,7 @@ scores AS (
     FROM
         course_users AS u
         CROSS JOIN course_assessments AS a
-        LEFT JOIN group_users AS gu ON (u.user_id = gu.user_id)
-        LEFT JOIN course_scores AS s ON (((s.user_id = u.user_id)OR(s.group_id = gu.group_id)) AND s.assessment_id = a.id)
+        LEFT JOIN course_scores AS s ON (s.user_id = u.user_id AND s.assessment_id = a.id)
 )
 SELECT user_id,uid,uin,user_name,role,
     ARRAY_AGG(


### PR DESCRIPTION
Fixes #2927. The problem was that we were unconditionally JOINing over
group_users, even for groups that were not part of the current course
instance.