### PR TITLE
Remove frequent debugging output for workspace sync

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -730,7 +730,6 @@ async function _getRunningWorkspaceByPath(path) {
 
 async function _autoUpdateJobManager() {
     lastAutoUpdateTime = Date.now();
-    logger.info(`_autoUpdateJobManager(): Pushing changed files to S3: ${JSON.stringify(update_queue)}`);
     var jobs = [];
     for (const key in update_queue) {
         logger.info(`_autoUpdateJobManager: key=${key}`);


### PR DESCRIPTION
This removes the every-five-second log of `_autoUpdateJobManager(): Pushing changed files to S3: {}` that is spamming everyone's local prairielearn terminal, even if they aren't using workspaces. I think we don't need this, because the timer canaries should pick up any failure of the cron job.