### PR TITLE
Fix workspace reboot

### DIFF
--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -206,14 +206,16 @@ module.exports = {
 
     async startup(workspace_id, state) {
         if (state == 'uninitialized' || state == 'stopped') {
+            let useInitialZip = false;
             if (state == 'uninitialized') {
+                useInitialZip = true;
                 await module.exports.initialize(workspace_id);
                 await module.exports.updateState(workspace_id, 'stopped', 'Initialization complete');
             }
             await module.exports.updateState(workspace_id, 'launching', 'Assigning workspace host');
             await module.exports.assignHost(workspace_id);
             await module.exports.updateMessage(workspace_id, 'Sending launch command to host');
-            await module.exports.controlContainer(workspace_id, 'init', {useInitialZip: true});
+            await module.exports.controlContainer(workspace_id, 'init', {useInitialZip});
         }
     },
 


### PR DESCRIPTION
PR #2937 fixed the use of `initial.zip`, but this had the unfortunate
side-effect of breaking reboots. The problem is that we were _always_
setting `useInitialZip: true` when starting a stopped or uninitialized
workspace. In fact we only want to use the initial zip when the
workspace is uninitialized. When it's stopped, we just want to start it
again without overwriting the home directory.