### PR TITLE
Add jupyter environment variables to workspace image

### DIFF
--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -1,5 +1,5 @@
 FROM jupyter/datascience-notebook
 COPY jupyter_notebook_config.py /etc/jupyter/
-ENV JUPYTER_RUNTIME_DIR /tmp
+ENV JUPYTER_RUNTIME_DIR /tmp/runtime
 ENV JUPYTER_ALLOW_INSECURE_WRITES true
 CMD ["start.sh", "jupyter", "lab"]

--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -1,3 +1,5 @@
 FROM jupyter/datascience-notebook
 COPY jupyter_notebook_config.py /etc/jupyter/
+ENV JUPYTER_RUNTIME_DIR /tmp
+ENV JUPYTER_ALLOW_INSECURE_WRITES true
 CMD ["start.sh", "jupyter", "lab"]


### PR DESCRIPTION
Workaround for some permission errors in the jupyterlab workspace.

From @mwest1066 in slack: https://github.com/jupyter/notebook/issues/5058

![image](https://user-images.githubusercontent.com/2503508/91646192-4370d380-ea12-11ea-8275-412e2a126735.png)

```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/tornado/web.py", line 1703, in _execute
    result = await result
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 742, in run
    yielded = self.gen.throw(*exc_info)  # type: ignore
  File "/opt/conda/lib/python3.8/site-packages/notebook/services/sessions/handlers.py", line 69, in post
    model = yield maybe_future(
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 742, in run
    yielded = self.gen.throw(*exc_info)  # type: ignore
  File "/opt/conda/lib/python3.8/site-packages/notebook/services/sessions/sessionmanager.py", line 88, in create_session
    kernel_id = yield self.start_kernel_for_session(session_id, path, name, type, kernel_name)
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 742, in run
    yielded = self.gen.throw(*exc_info)  # type: ignore
  File "/opt/conda/lib/python3.8/site-packages/notebook/services/sessions/sessionmanager.py", line 100, in start_kernel_for_session
    kernel_id = yield maybe_future(
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 735, in run
    value = future.result()
  File "/opt/conda/lib/python3.8/site-packages/notebook/services/kernels/kernelmanager.py", line 176, in start_kernel
    kernel_id = await maybe_future(self.pinned_superclass.start_kernel(self, **kwargs))
  File "/opt/conda/lib/python3.8/site-packages/jupyter_client/multikernelmanager.py", line 186, in start_kernel
    km.start_kernel(**kwargs)
  File "/opt/conda/lib/python3.8/site-packages/jupyter_client/manager.py", line 304, in start_kernel
    kernel_cmd, kw = self.pre_start_kernel(**kw)
  File "/opt/conda/lib/python3.8/site-packages/jupyter_client/manager.py", line 251, in pre_start_kernel
    self.write_connection_file()
  File "/opt/conda/lib/python3.8/site-packages/jupyter_client/connect.py", line 468, in write_connection_file
    self.connection_file, cfg = write_connection_file(self.connection_file,
  File "/opt/conda/lib/python3.8/site-packages/jupyter_client/connect.py", line 138, in write_connection_file
    with secure_write(fname) as f:
  File "/opt/conda/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/opt/conda/lib/python3.8/site-packages/jupyter_core/paths.py", line 445, in secure_write
    raise RuntimeError("Permissions assignment failed for secure file: '{file}'."
RuntimeError: Permissions assignment failed for secure file: '/home/jovyan/.local/share/jupyter/runtime/kernel-b23c2bc1-ff78-4d1d-8870-ace9c153b376.json'. Got '0o655' instead of '0o0600'.
```