### PR TITLE
Fix workspace_hosts_find_terminable sproc

### DIFF
--- a/sprocs/workspace_hosts_find_terminable.sql
+++ b/sprocs/workspace_hosts_find_terminable.sql
@@ -15,7 +15,7 @@ BEGIN
             wh.*
         FROM
             workspace_hosts AS wh
-        HAVING
+        WHERE
             (((wh.state = 'draining' OR wh.state = 'unhealthy') AND wh.load_count = 0) OR
             (wh.state = 'unhealthy' AND (now() - wh.unhealthy_at) > make_interval(secs => unhealthy_timeout_sec)) OR
             (wh.state = 'launching' AND (now() - wh.launched_at) > make_interval(secs => launch_timeout_sec)))


### PR DESCRIPTION
Change `HAVING` to `WHERE`, this used to be a `GROUP BY` query but this was never switched over.