### PR TITLE
Fix unescaped backslash in JupyterLab demo notebook

### DIFF
--- a/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/workspace/Workbook.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Write a Python function `fib` that takes a number `n` and returns the $n^{\rm th}$ Fibonacci number, $F_n$."
+    "Write a Python function `fib` that takes a number `n` and returns the $n^{\\rm th}$ Fibonacci number, $F_n$."
    ]
   },
   {


### PR DESCRIPTION
`\rm` -> `\\rm`