### PR TITLE
Format total points in student Homework instance

### DIFF
--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
@@ -22,6 +22,7 @@
       });
     </script>
     <%- include('../partials/navbar', {navPage: 'assessment_instance'}); %>
+    <%- include('../partials/pointsFormatter'); %>
     <div id="content" class="container">
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">
@@ -33,7 +34,7 @@
         <div class="card-body">
           <div class="row align-items-center mb-4">
             <div class="col-md-3 col-sm-6 col-xs-12">
-              Total points: <%= assessment_instance.points %>/<%= assessment_instance.max_points %>
+              Total points: <%= getStringFromFloat(assessment_instance.points) %>/<%= assessment_instance.max_points %>
             </div>
             <div class="col-md-3 col-sm-6 col-xs-12">
               <%- include('../partials/scorebar', {score: assessment_instance.score_perc}) %>

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
@@ -22,7 +22,6 @@
       });
     </script>
     <%- include('../partials/navbar', {navPage: 'assessment_instance'}); %>
-    <%- include('../partials/pointsFormatter'); %>
     <div id="content" class="container">
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">
@@ -34,6 +33,7 @@
         <div class="card-body">
           <div class="row align-items-center mb-4">
             <div class="col-md-3 col-sm-6 col-xs-12">
+              <%- include('../partials/pointsFormatter'); %>
               Total points: <%= getStringFromFloat(assessment_instance.points) %>/<%= assessment_instance.max_points %>
             </div>
             <div class="col-md-3 col-sm-6 col-xs-12">


### PR DESCRIPTION
Truncates the "total points" section on the student homework instance page to 2 decimal points at most, so that ugly cases like this don't occur:
![image](https://user-images.githubusercontent.com/32315760/91887245-2590b200-ec50-11ea-83b0-70f584cde043.png)

[This already happens in the student exam instance page](https://github.com/PrairieLearn/PrairieLearn/blob/truncateScore/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs#L83), it just wasn't added for homework.