### PR TITLE
Fix layout of zone info badges and move into partial

### DIFF
--- a/pages/partials/zoneInfoBadge.ejs
+++ b/pages/partials/zoneInfoBadge.ejs
@@ -1,0 +1,10 @@
+<a
+  tabindex="0"
+  class="btn btn-xs btn-secondary badge badge-secondary text-white font-weight-normal py-1"
+  role="button"
+  data-toggle="popover" data-trigger="focus" data-container="body"
+  data-html="true"
+  data-content="<%= zoneInfo.popoverContent %>
+">
+  <%= zoneInfo.mainContent %>&nbsp;<i class="far fa-question-circle" aria-hidden="true"></i>
+ </a>

--- a/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs
+++ b/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.ejs
@@ -180,16 +180,16 @@
               <th colspan="5">
                 <%= instance_question.zone_title %>
                 <% if (instance_question.zone_has_max_points) { %>
-                 &nbsp;<a tabindex="0" class="btn btn-xs btn-secondary" role="button"
-                    data-toggle="popover" data-trigger="focus" data-container="body"
-                    data-html="true"
-                    data-content="Of the points that you are awarded for answering these questions, at most <%= instance_question.zone_max_points %> will count toward your total points."><span class="badge badge-secondary align-top">maximum <%= instance_question.zone_max_points %> points &nbsp;<i class="far fa-question-circle" aria-hidden="true"></i></span></a>
+                  <%- include('../partials/zoneInfoBadge', { zoneInfo: {
+                    popoverContent: `Of the points that you are awarded for answering these questions, at most ${instance_question.zone_max_points} will count toward your total points.`,
+                    mainContent: `Maximum ${instance_question.zone_max_points} points`
+                  }}); %>
                 <% } %>
                 <% if (instance_question.zone_has_best_questions) { %>
-                 &nbsp;<a tabindex="0" class="btn btn-xs btn-secondary" role="button"
-                    data-toggle="popover" data-trigger="focus" data-container="body"
-                    data-html="true"
-                    data-content="Of these questions, only the <%= instance_question.zone_best_questions %> with the highest number of awarded points will count toward your total points."><span class="badge badge-secondary align-top">best <%= instance_question.zone_best_questions %> questions &nbsp;<i class="far fa-question-circle" aria-hidden="true"></i></span></a>
+                  <%- include('../partials/zoneInfoBadge', { zoneInfo: {
+                    popoverContent: `Of these questions, only the ${instance_question.zone_best_questions} with the highest number of awarded points will count toward your total points.`,
+                    mainContent: `Best ${instance_question.zone_best_questions} questions`
+                  }}); %>
                 <% } %>
               </th>
             </tr>

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.ejs
@@ -99,16 +99,16 @@
               <th colspan="4">
                 <%= question.zone_title %>
                 <% if (question.zone_has_max_points) { %>
-                    &nbsp;<a tabindex="0" class="btn btn-xs btn-secondary" role="button"
-                       data-toggle="popover" data-trigger="focus" data-container="body"
-                       data-html="true"
-                       data-content="Of the points that you are awarded for answering these questions, at most <%= question.zone_max_points %> will count toward your total points."><span class="badge badge-secondary align-top">maximum <%= question.zone_max_points %> points &nbsp;<i class="far fa-question-circle" aria-hidden="true"></i></span></a>
+                  <%- include('../partials/zoneInfoBadge', { zoneInfo: {
+                    popoverContent: `Of the points that you are awarded for answering these questions, at most ${question.zone_max_points} will count toward your total points.`,
+                    mainContent: `Maximum ${question.zone_max_points} points`
+                  }}); %>
                 <% } %>
                 <% if (question.zone_has_best_questions) { %>
-                    &nbsp;<a tabindex="0" class="btn btn-xs btn-secondary" role="button"
-                       data-toggle="popover" data-trigger="focus" data-container="body"
-                       data-html="true"
-                       data-content="Of these questions, only the <%= question.zone_best_questions %> with the highest number of awarded points will count toward your total points."><span class="badge badge-secondary align-top">best <%= question.zone_best_questions %> questions &nbsp;<i class="far fa-question-circle" aria-hidden="true"></i></span></a>
+                  <%- include('../partials/zoneInfoBadge', { zoneInfo: {
+                    popoverContent: `Of these questions, only the ${question.zone_best_questions} with the highest number of awarded points will count toward your total points.`,
+                    mainContent: `Best ${question.zone_best_questions} questions`
+                  }}); %>
                 <% } %>
               </th>
             </tr>


### PR DESCRIPTION
At some point, the text inside of these badges got misaligned. Now they display properly and the code is simplified by moving them into a partial.

# Now
![image](https://user-images.githubusercontent.com/32315760/91906168-5cc18c00-ec6d-11ea-892e-db09f5375b9f.png)

# Before 
![image](https://user-images.githubusercontent.com/32315760/91906226-719e1f80-ec6d-11ea-9019-4cf294ae1121.png)
