### PR TITLE
[Group Work] Group Config - Student Permission Checkboxes

### DIFF
--- a/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
+++ b/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
@@ -213,7 +213,7 @@
                   <br>
                   <label for="formman">Student Permissions</label> <br>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" id = 'joincheck' name="joincheck" value="true">
+                    <input class="form-check-input" type="checkbox" name="joincheck" value="<%- config_info.student_authz_join ? 'true' : 'false' %>">
                     <label class="form-check-label" for="inlineCheckbox1">Join Groups</label>
                   </div>
                   <div class="form-check form-check-inline">

--- a/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
+++ b/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
@@ -424,16 +424,6 @@
         <% } %>
       </div>
       <script>
-        if (<%- config_info.student_authz_join %>) {
-          document.getElementById("joincheck").checked = true;
-        }
-        if (<%- config_info.student_authz_create %>) {
-          document.getElementById("createcheck").checked = true;
-        }
-
-        if (<%- config_info.student_authz_leave %>) {
-          document.getElementById("leavecheck").checked = true;
-        }
         $(function () {
           $("#usersTable").tablesorter({
             theme: "bootstrap",

--- a/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
+++ b/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
@@ -213,15 +213,15 @@
                   <br>
                   <label for="formman">Student Permissions</label> <br>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" name="joincheck" value="<%- config_info.student_authz_join ? 'true' : 'false' %>">
+                    <input class="form-check-input" type="checkbox" name="joincheck" <%= config_info.student_authz_join ? "checked" : "" %>>
                     <label class="form-check-label" for="inlineCheckbox1">Join Groups</label>
                   </div>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" name="createcheck" value="<%- config_info.student_authz_create ? 'true' : 'false' %>">
+                    <input class="form-check-input" type="checkbox" name="createcheck" <%= config_info.student_authz_create ? "checked" : "" %>>
                     <label class="form-check-label" for="inlineCheckbox2">Create Groups</label>
                   </div>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" name="leavecheck" value="<%- config_info.student_authz_leave ? 'true' : 'false' %>">
+                    <input class="form-check-input" type="checkbox" name="leavecheck" <%= config_info.student_authz_leave ? "checked" : "" %>>
                     <label class="form-check-label" for="inlineCheckbox3">Leave Groups</label>
                   </div>                   
                 </div>

--- a/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
+++ b/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
@@ -217,11 +217,11 @@
                     <label class="form-check-label" for="inlineCheckbox1">Join Groups</label>
                   </div>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" id = 'createcheck' name="createcheck" value="true">
+                    <input class="form-check-input" type="checkbox" name="createcheck" value="<%- config_info.student_authz_create ? 'true' : 'false' %>">
                     <label class="form-check-label" for="inlineCheckbox2">Create Groups</label>
                   </div>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" id = 'leavecheck' name="leavecheck" value="true">
+                    <input class="form-check-input" type="checkbox" name="leavecheck" value="<%- config_info.student_authz_leave ? 'true' : 'false' %>">
                     <label class="form-check-label" for="inlineCheckbox3">Leave Groups</label>
                   </div>                   
                 </div>

--- a/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
+++ b/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
@@ -201,29 +201,27 @@
               </div>
               <form name="config-group-form" method="POST">
                 <div class="modal-body">
-                  <span class="badge badge-secondary">minimum size</span> <%= config_info.minimum %><br>
-                  <span class="badge badge-secondary">maximum size</span> <%= config_info.maximum %><br>
-                  <span class="badge badge-secondary">Student Permissions</span> <%= config_info.permission %><br>
-                  <br>
                   <div class="form-min">
                     <label for="formmin">Minimum group size</label>
-                    <input type="text" value=<%= config_info.defaultMin %> class="form-control" id="formmin" name="minsize">
+                    <input type="number" value=<%= config_info.defaultMin %> class="form-control" id="formmin" name="minsize">
                   </div>
+                  <br>
                   <div class="form-max">
                     <label for="formman">Maximum group size</label>
-                    <input type="text" value=<%= config_info.defaultMax %> class="form-control" id="formmax" name="maxsize">
+                    <input type="number" value=<%= config_info.defaultMax %> class="form-control" id="formmax" name="maxsize">
                   </div>
+                  <br>
                   <label for="formman">Student Permissions</label> <br>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" name="joincheck" value="true">
+                    <input class="form-check-input" type="checkbox" id = 'joincheck' name="joincheck" value="true">
                     <label class="form-check-label" for="inlineCheckbox1">Join Groups</label>
                   </div>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" name="createcheck" value="true">
+                    <input class="form-check-input" type="checkbox" id = 'createcheck' name="createcheck" value="true">
                     <label class="form-check-label" for="inlineCheckbox2">Create Groups</label>
                   </div>
                   <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" name="leavecheck" value="true">
+                    <input class="form-check-input" type="checkbox" id = 'leavecheck' name="leavecheck" value="true">
                     <label class="form-check-label" for="inlineCheckbox3">Leave Groups</label>
                   </div>                   
                 </div>
@@ -426,6 +424,16 @@
         <% } %>
       </div>
       <script>
+        if (<%- config_info.student_authz_join %>) {
+          document.getElementById("joincheck").checked = true;
+        }
+        if (<%- config_info.student_authz_create %>) {
+          document.getElementById("createcheck").checked = true;
+        }
+
+        if (<%- config_info.student_authz_leave %>) {
+          document.getElementById("leavecheck").checked = true;
+        }
         $(function () {
           $("#usersTable").tablesorter({
             theme: "bootstrap",

--- a/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
+++ b/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
@@ -35,16 +35,6 @@ function obtainInfo(req, res, next){
         res.locals.config_info.defaultMin = res.locals.config_info.minimum || 2;
         res.locals.config_info.defaultMax = res.locals.config_info.maximum || 5;
 
-        res.locals.config_info.permission = '';
-        if (res.locals.config_info.student_authz_join) {
-            res.locals.config_info.permission += 'join ';
-        }
-        if (res.locals.config_info.student_authz_create) {
-            res.locals.config_info.permission += 'create ';
-        }
-        if (res.locals.config_info.student_authz_leave) {
-            res.locals.config_info.permission += 'leave ';
-        }
         const params = {
             assessment_id: res.locals.assessment.id,
             course_instance_id: res.locals.config_info.course_instance_id,


### PR DESCRIPTION
Fix [Issue#2924](https://github.com/PrairieLearn/PrairieLearn/issues/2924) "When I check Join Groups, Create Groups, and Leave Groups, the checkboxes don't stay checked when re-opening config. Student Permissions at the top indicates that those settings have been applied, but it would be nice to have the checkboxes reflect the current status of the permissions when opening" @glherman
- [x] set input type for group size to be number
- [x] display checked checkboxes according to the current student permissions (instructors do not need to recheck them again)
- [x] delete redundant display
![image](https://user-images.githubusercontent.com/16861955/92268975-e610d280-eea8-11ea-86a3-9d01d0c45ba6.png)