### PR TITLE
[Group Work] display empty groups on instances and instance detail page

### DIFF
--- a/middlewares/selectAndAuthzAssessmentInstance.sql
+++ b/middlewares/selectAndAuthzAssessmentInstance.sql
@@ -26,7 +26,7 @@ SELECT
     assessment_instance_label(ai, a, aset) AS assessment_instance_label,
     assessment_label(a, aset) AS assessment_label,
     fl.list AS file_list,
-    to_jsonb(g) AS group_info
+    to_jsonb(g) AS group
 FROM
     assessment_instances AS ai
     JOIN assessments AS a ON (a.id = ai.assessment_id)

--- a/middlewares/selectAndAuthzAssessmentInstance.sql
+++ b/middlewares/selectAndAuthzAssessmentInstance.sql
@@ -25,7 +25,8 @@ SELECT
     to_jsonb(aai) AS authz_result,
     assessment_instance_label(ai, a, aset) AS assessment_instance_label,
     assessment_label(a, aset) AS assessment_label,
-    fl.list AS file_list
+    fl.list AS file_list,
+    to_jsonb(g) AS group_info
 FROM
     assessment_instances AS ai
     JOIN assessments AS a ON (a.id = ai.assessment_id)

--- a/middlewares/selectAndAuthzAssessmentInstance.sql
+++ b/middlewares/selectAndAuthzAssessmentInstance.sql
@@ -32,9 +32,9 @@ FROM
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
     JOIN pl_courses AS c ON (c.id = ci.course_id)
     JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-    LEFT JOIN group_users AS gu ON (gu.group_id = ai.group_id)
-    LEFT JOIN groups AS gr ON (gr.id = gu.group_id AND gr.deleted_at IS NULL)
-    JOIN users AS u ON (u.user_id = gu.user_id OR u.user_id = ai.user_id)
+    LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
+    LEFT JOIN users AS u ON (u.user_id = gu.user_id OR u.user_id = ai.user_id)
     LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
     JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, a.group_work) AS aai ON TRUE
     CROSS JOIN file_list AS fl

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -28,7 +28,7 @@
           <%= assessment_instance_label %>
           Summary:
           <% if (assessment.group_work) { %>
-            <%= group_info.name %> <i class="fas fa-users"></i>
+            <%= group.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>
@@ -37,8 +37,8 @@
         <table class="table table-sm table-hover two-column-description">
           <tbody>
             <% if (assessment.group_work) { %>
-              <tr><th>Name</th><td colspan="2"><%= group_info.name %></td></tr>
-              <tr><th>Group Members</th><td colspan="2"><%= group_info.uid_list %></td></tr>
+              <tr><th>Name</th><td colspan="2"><%= group.name %></td></tr>
+              <tr><th>Group Members</th><td colspan="2"><%= group.uid_list %></td></tr>
             <% } else { %>
               <tr><th>UID</th><td colspan="2"><%= instance_user.uid %></td></tr>
               <tr><th>Name</th><td colspan="2"><%= instance_user.name %></td></tr>
@@ -99,7 +99,7 @@
           <%= assessment_instance_label %>
           Questions:
           <% if (assessment.group_work) { %>
-            <%= group_info.name %> <i class="fas fa-users"></i>
+            <%= group.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>
@@ -189,7 +189,7 @@
           <%= assessment_instance_label %>
           Statistics:
           <% if (assessment.group_work) { %>
-            <%= group_info.name %> <i class="fas fa-users"></i>
+            <%= group.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>
@@ -245,7 +245,7 @@
           <%= assessment_instance_label %>
           Log:
           <% if (assessment.group_work) { %>
-            <%= group_info.name %> <i class="fas fa-users"></i>
+            <%= group.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -28,7 +28,7 @@
           <%= assessment_instance_label %>
           Summary:
           <% if (assessment.group_work) { %>
-            <%= instance_user.name %> (<%= group_info.name %>) <i class="fas fa-users"></i>
+            <%= group_info.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>
@@ -99,7 +99,7 @@
           <%= assessment_instance_label %>
           Questions:
           <% if (assessment.group_work) { %>
-            <%= instance_user.name %> (<%= group_info.name %>) <i class="fas fa-users"></i>
+            <%= group_info.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>
@@ -189,7 +189,7 @@
           <%= assessment_instance_label %>
           Statistics:
           <% if (assessment.group_work) { %>
-            <%= instance_user.name %> (<%= group_info.name %>) <i class="fas fa-users"></i>
+            <%= group_info.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>
@@ -245,7 +245,7 @@
           <%= assessment_instance_label %>
           Log:
           <% if (assessment.group_work) { %>
-            <%= instance_user.name %> (<%= group_info.name %>) <i class="fas fa-users"></i>
+            <%= group_info.name %> <i class="fas fa-users"></i>
           <% } else { %>
             <%= instance_user.name %> (<%= instance_user.uid %>)
           <% } %>

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const logCsvFilename = (locals) => {
     return sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course)
-        + sanitizeName.sanitizeString(locals.assessment.group_work ? locals.group_info.name : locals.instance_user.uid)
+        + sanitizeName.sanitizeString(locals.assessment.group_work ? locals.group.name : locals.instance_user.uid)
         + '_'
         + locals.assessment_instance.number
         + '_'
@@ -44,7 +44,7 @@ router.get('/', (req, res, next) => {
                         const params = {assessment_instance_id: res.locals.assessment_instance.id};
                         sqlDb.query(sql.select_group_info, params, (err, result) => {
                             if (ERR(err, next)) return;
-                            res.locals.group_info = result.rows[0];
+                            res.locals.group = result.rows[0];
                             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
                         });
                     } else {

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const logCsvFilename = (locals) => {
     return sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course)
-        + ((locals.assessment.group_work) ? (locals.group_info.name) : (sanitizeName.sanitizeString(locals.instance_user.uid)))
+        + sanitizeName.sanitizeString(locals.assessment.group_work ? locals.group_info.name : locals.instance_user.uid)
         + '_'
         + locals.assessment_instance.number
         + '_'

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const logCsvFilename = (locals) => {
     return sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course)
-        + locals.assessment.group_work ? + locals.group_info.name : sanitizeName.sanitizeString(locals.instance_user.uid)
+        + (locals.assessment.group_work ? locals.group_info.name : sanitizeName.sanitizeString(locals.filePrefix))
         + '_'
         + locals.assessment_instance.number
         + '_'
@@ -20,6 +20,7 @@ const logCsvFilename = (locals) => {
 };
 
 router.get('/', (req, res, next) => {
+    res.locals.logCsvFilename = logCsvFilename(res.locals);
     const params = {assessment_instance_id: res.locals.assessment_instance.id};
     sqlDb.query(sql.assessment_instance_stats, params, (err, result) => {
         if (ERR(err, next)) return;
@@ -44,11 +45,9 @@ router.get('/', (req, res, next) => {
                         sqlDb.query(sql.select_group_info, params, (err, result) => {
                             if (ERR(err, next)) return;
                             res.locals.group_info = result.rows[0];
-                            res.locals.logCsvFilename = logCsvFilename(res.locals);
                             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
                         });
                     } else {
-                        res.locals.logCsvFilename = logCsvFilename(res.locals);
                         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
                     }
                 });

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const logCsvFilename = (locals) => {
     return sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course)
-        + (locals.assessment.group_work ? locals.group_info.name : sanitizeName.sanitizeString(locals.filePrefix))
+        + ((locals.assessment.group_work) ? (locals.group_info.name) : (sanitizeName.sanitizeString(locals.instance_user.uid)))
         + '_'
         + locals.assessment_instance.number
         + '_'

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -12,7 +12,7 @@ const sql = sqlLoader.loadSqlEquiv(__filename);
 
 const logCsvFilename = (locals) => {
     return sanitizeName.assessmentFilenamePrefix(locals.assessment, locals.assessment_set, locals.course_instance, locals.course)
-        + sanitizeName.sanitizeString(locals.instance_user.uid)
+        + locals.assessment.group_work ? + locals.group_info.name : sanitizeName.sanitizeString(locals.instance_user.uid)
         + '_'
         + locals.assessment_instance.number
         + '_'
@@ -20,7 +20,6 @@ const logCsvFilename = (locals) => {
 };
 
 router.get('/', (req, res, next) => {
-    res.locals.logCsvFilename = logCsvFilename(res.locals);
     const params = {assessment_instance_id: res.locals.assessment_instance.id};
     sqlDb.query(sql.assessment_instance_stats, params, (err, result) => {
         if (ERR(err, next)) return;
@@ -45,9 +44,11 @@ router.get('/', (req, res, next) => {
                         sqlDb.query(sql.select_group_info, params, (err, result) => {
                             if (ERR(err, next)) return;
                             res.locals.group_info = result.rows[0];
+                            res.locals.logCsvFilename = logCsvFilename(res.locals);
                             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
                         });
                     } else {
+                        res.locals.logCsvFilename = logCsvFilename(res.locals);
                         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
                     }
                 });

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.sql
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.sql
@@ -85,8 +85,8 @@ SELECT
 FROM
     assessment_instances AS ai
     JOIN groups AS gr ON (gr.id = ai.group_id)
-    JOIN group_users AS gu ON (gu.group_id = gr.id)
-    JOIN users AS u ON (u.user_id = gu.user_id)
+    LEFT JOIN group_users AS gu ON (gu.group_id = gr.id)
+    LEFT JOIN users AS u ON (u.user_id = gu.user_id)
 WHERE 
     ai.id = $assessment_instance_id
     AND gr.deleted_at IS NULL

--- a/sprocs/group_info.sql
+++ b/sprocs/group_info.sql
@@ -17,8 +17,8 @@ BEGIN
     FROM
         group_configs AS gc
         JOIN groups AS gr ON (gr.group_config_id = gc.id)
-        JOIN group_users AS gu ON (gu.group_id = gr.id)
-        JOIN users AS u ON (u.user_id = gu.user_id)
+        LEFT JOIN group_users AS gu ON (gu.group_id = gr.id)
+        LEFT JOIN users AS u ON (u.user_id = gu.user_id)
     WHERE
         gc.deleted_at IS NULL
         AND gr.deleted_at IS NULL


### PR DESCRIPTION
Fixes #2990
Some students created a group, started an instance, and left the group. These "empty groups" are displayed on the Instructor Group page but not the Instructor Student page (instructorAssessmentInstances.ejs)

- [x] Modified the select rule to LEFT JOIN groups with no users -> instructor could now check the instance details for empty groups