### PR TITLE
Fix "terminable" host naming

### DIFF
--- a/cron/workspaceHostTransitions.js
+++ b/cron/workspaceHostTransitions.js
@@ -79,7 +79,7 @@ async function terminateHosts() {
         config.workspaceHostUnhealthyTimeoutSec,
         config.workspaceHostLaunchTimeoutSec,
     ];
-    const hosts = (await sqldb.callAsync('workspace_hosts_find_terminable', params)).rows[0].terminated_hosts || [];
+    const hosts = (await sqldb.callAsync('workspace_hosts_find_terminable', params)).rows[0].terminable_hosts || [];
     if (hosts.length > 0) {
         logger.debug('Found terminable hosts', hosts);
         await ec2.terminateInstances({ InstanceIds: hosts }).promise();


### PR DESCRIPTION
This fixes a bug introduced by PR #3068, which changed "terminated" to
"terminating" in the sproc but did not update the corresponding JS file.
In addition this PR renames this variable to "terminable" to better
match the meaning and usage in the JS caller.