### PR TITLE
Downgrade Ipython for Python grader

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -17,6 +17,6 @@ beautifulsoup4==4.9.1
 bokeh==2.2.1
 folium==0.11.0
 Pygments==2.6.1
-ipython==7.18.1
+ipython==7.16.1
 nbformat==5.0.7
 nbconvert==5.6.1


### PR DESCRIPTION
https://hub.docker.com/repository/registry-1.docker.io/prairielearn/grader-python/builds/524a6055-164c-476d-a992-18dcf137cbf9

Recent `prairielearn/grader-python` builds are failing because `ipython==7.18.1` is too new for the version of Python that is installed in the grader container. 