### PR TITLE
Fix displaying of notebooks on error in Python grader

### DIFF
--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -4,26 +4,12 @@ import json
 import numpy as np
 import numpy.random
 import random
+import io
+import pl_helpers
 from os.path import join
 from os.path import splitext
 from types import ModuleType, FunctionType
 from copy import deepcopy
-
-import io
-from IPython import get_ipython
-from nbformat import read
-from IPython.core.interactiveshell import InteractiveShell
-
-def extract_cell_content(f, ipynb_key):
-    nb = read(f, 4)
-    shell = InteractiveShell.instance()
-    content = ''
-    for cell in nb.cells:
-        if cell['cell_type'] == 'code':
-            code = shell.input_transformer_manager.transform_cell(cell.source)
-            if code.strip().startswith(ipynb_key):
-                content += code
-    return content
 
 class UserCodeFailed(Exception):
     def __init__(self, err, *args):
@@ -73,7 +59,7 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     with open(fname_student, 'r', encoding='utf-8') as f:
         filename, extension = splitext(fname_student)
         if extension == '.ipynb':
-            str_student = str_leading + extract_cell_content(f, ipynb_key)
+            str_student = str_leading + pl_helpers.extract_ipynb_contents(f, ipynb_key)
         else:
             str_student = f.read()
     with open(join(filenames_dir, 'test.py'), encoding='utf-8') as f:

--- a/graders/python/python_autograder/pl_result.py
+++ b/graders/python/python_autograder/pl_result.py
@@ -76,7 +76,7 @@ class PLTestResult(unittest.TestResult):
                 Feedback.set_name('error')
             Feedback.add_feedback(''.join(tr_list))
             Feedback.add_feedback('\n\nYour code:\n\n')
-            print_student_code(st_code=Feedback.test.student_code_abs_path)
+            print_student_code(st_code=Feedback.test.student_code_abs_path, ipynb_key=Feedback.test.ipynb_key)
         else:
             tr_list = traceback.format_exception(*err)
             test_id = test.id().split()[0]

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -4,7 +4,7 @@ import json
 from os.path import join
 from types import FunctionType
 from collections import namedtuple
-from pl_helpers import (points, name, save_plot, print_student_code, not_repeated)
+from pl_helpers import (points, name, save_plot, not_repeated)
 from pl_execute import execute_code
 from code_feedback import Feedback
 


### PR DESCRIPTION
Resolves #3015 

When students submit a notebook that contains a syntax error or some other error, the grader will now only show their code instead of the entire contents of the notebook.  This was leading to issues where grading results were over 1mb, because the whole notebook and any executed cells were being printed.

Before:
<img width="731" alt="image" src="https://user-images.githubusercontent.com/1790491/92635908-2e126980-f29c-11ea-8d2e-9bc8d1cb3807.png">


After:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/1790491/92635829-13d88b80-f29c-11ea-9381-c779409df312.png">
