### PR TITLE
Fix proxy error reporting to client

### DIFF
--- a/server.js
+++ b/server.js
@@ -214,11 +214,12 @@ const workspaceProxyOptions = {
         }
     },
     onError: (err, req, res) => {
-        logger.error(`Error proxying workspace request: ${err}`);
+        logger.error(`Error proxying workspace request: ${err}`, {err, url: req.url});
         /* Check to make sure we weren't already in the middle of sending a response
            before replying with an error 500 */
         if (!res.headersSent) {
-            res.status(500).send('Error proxying workspace request');
+            res.writeHead(500, { 'Content-Type': 'text/plain' });
+            res.send('Error proxying workspace request');
         }
     },
 };

--- a/server.js
+++ b/server.js
@@ -217,9 +217,10 @@ const workspaceProxyOptions = {
         logger.error(`Error proxying workspace request: ${err}`, {err, url: req.url});
         /* Check to make sure we weren't already in the middle of sending a response
            before replying with an error 500 */
-        if (!res.headersSent) {
-            res.writeHead(500, { 'Content-Type': 'text/plain' });
-            res.send('Error proxying workspace request');
+        if (res && !res.headersSent) {
+            if (res.status && res.send) {
+                res.status(500).send('Error proxying workspace request');
+            }
         }
     },
 };


### PR DESCRIPTION
It turns out that the `res` object here doesn't support the `status()`
method for some reason (perhaps it's not actually an ExpressJS `res`
object?). In any case, we'll revert to the basic type of error reporting
that used to work.

Fixes #3104 