### PR TITLE
Remove debugging code during sync

### DIFF
--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -745,7 +745,6 @@ async function loadInfoForDirectory({ coursePath, directory, infoFilename, defau
                     }
                     _.assign(infoFiles, subInfoFiles);
                 } catch (e) {
-                    console.log('error', path.join(relativeDir, dir), e.code);
                     if (e.code === 'ENOTDIR') {
                         // This wasn't a directory; ignore it.
                     } else if (e.code === 'ENOENT') {


### PR DESCRIPTION
We had a left-over `console.log()`.