### PR TITLE
Change workspace progress indicator to be rate limited

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -157,6 +157,7 @@ config.workspaceLoadLaunchTag = 'workspace-host';
 config.workspaceHostUnhealthyTimeoutSec = 12 * 60 * 60;
 config.workspaceHostLaunchTimeoutSec = 10 * 60;
 config.workspaceUrlRewriteCacheMaxAgeSec = 60 * 60;
+config.workspacePercentMessageRateLimitSec = 1;
 
 config.chunksS3Bucket = 'prairielearn.dev.chunks';
 config.chunksGenerator = false; /* Should we generate chunks? */

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -960,7 +960,7 @@ function _pullImage(workspace, callback) {
                     const date = Date.now();
                     const percentDelta = percent - percentCache;
                     const dateDeltaSec = (date - dateCache) / 1000;
-                    if ((percentDelta > 0) && (dateDeltaSec > 1)) {
+                    if ((percentDelta > 0) && (dateDeltaSec >= config.workspacePercentMessageRateLimitSec)) {
                         percentCache = percent;
                         dateCache = date;
                         percentDisplayed = true;

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -925,6 +925,7 @@ function _pullImage(workspace, callback) {
             let current, total = 0, fraction = 0;
             let currentBase, fractionBase;
             let outputCount = 0;
+            let percentCache = 0, dateCache = Date.now();
             docker.modem.followProgress(stream, (err) => {
                 if (ERR(err, callback)) return;
                 if (percentDisplayed) {
@@ -956,9 +957,16 @@ function _pullImage(workspace, callback) {
                     const fractionIncrement = (total > currentBase) ? ((current - currentBase) / (total - currentBase)) : 0;
                     fraction = fractionBase + (1 - fractionBase) * fractionIncrement;
                     const percent = Math.floor(fraction * 100);
-                    const toDatabase = false;
-                    percentDisplayed = true;
-                    workspaceHelper.updateMessage(workspace.id, `Pulling image (${percent}%)`, toDatabase);
+                    const date = Date.now();
+                    const percentDelta = percent - percentCache;
+                    const dateDeltaSec = (date - dateCache) / 1000;
+                    if ((percentDelta > 0) && (dateDeltaSec > 1)) {
+                        percentCache = percent;
+                        dateCache = date;
+                        percentDisplayed = true;
+                        const toDatabase = false;
+                        workspaceHelper.updateMessage(workspace.id, `Pulling image (${percent}%)`, toDatabase);
+                    }
                 }
             });
         });

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -925,7 +925,7 @@ function _pullImage(workspace, callback) {
             let current, total = 0, fraction = 0;
             let currentBase, fractionBase;
             let outputCount = 0;
-            let percentCache = 0, dateCache = Date.now();
+            let percentCache = -1, dateCache = Date.now() - 1e6;
             docker.modem.followProgress(stream, (err) => {
                 if (ERR(err, callback)) return;
                 if (percentDisplayed) {


### PR DESCRIPTION
Resolves #3027:

Only update the percent message if these two conditions are met:

* [x] The value of `percent` is different to when we last called `updateMessage()`
* [x] It's at least `config.workspacePercentMessageRateLimitSec` since we last called `updateMessage()`