### PR TITLE
Change workspace "launched_at" to denote start rather than end of launch

### DIFF
--- a/sprocs/workspaces_state_update.sql
+++ b/sprocs/workspaces_state_update.sql
@@ -16,7 +16,8 @@ BEGIN
         state = workspace_state,
         state_updated_at = now(),
         message = workspace_message,
-        message_updated_at = now()
+        message_updated_at = now(),
+        launched_at = CASE WHEN workspace_state = 'launching' THEN now() ELSE launched_at END
     WHERE
         w.id = workspace_id
     RETURNING

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -1128,11 +1128,8 @@ function initSequence(workspace_id, useInitialZip, res) {
                 logger.error(`Error for workspace_id=${workspace_id}: ${err}\n${err.stack}`);
             });
         } else {
-            sqldb.query(sql.update_workspace_launched_at_now, {workspace_id}, (err) => {
-                if (ERR(err)) return;
-                debug(`Container initialized for workspace_id=${workspace_id}`);
-                workspaceHelper.updateState(workspace_id, 'running', null);
-            });
+            debug(`Container initialized for workspace_id=${workspace_id}`);
+            workspaceHelper.updateState(workspace_id, 'running', null);
         }
     });
 }

--- a/workspace_host/interface.sql
+++ b/workspace_host/interface.sql
@@ -19,14 +19,6 @@ SET
 WHERE
     w.id = $workspace_id;
 
--- BLOCK update_workspace_launched_at_now
-UPDATE workspaces AS w
-SET
-    launched_at = now(),
-    heartbeat_at = now()
-WHERE
-    w.id = $workspace_id;
-
 -- BLOCK insert_workspace_hosts
 INSERT INTO workspace_hosts
         (instance_id,  hostname, state, state_changed_at, ready_at)


### PR DESCRIPTION
Per #3026:

* [x] remove the `update_workspace_launched_at_now` query from `interface.js`
* [x] modify [`sprocs/workspaces_state_update.sql`](https://github.com/PrairieLearn/PrairieLearn/blob/master/sprocs/workspaces_state_update.sql) to set `launching_at = now()` whenever we change to state `launching`