### PR TITLE
Change workspace init to keep hosts healthy on container errors

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -1075,7 +1075,6 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
             await _startContainerAsync(workspace);
             await _checkServerAsync(workspace);
             debug(`init: container initialized for workspace_id=${workspace_id}`);
-            await sqldb.queryAsync(sql.update_workspace_launched_at_now, {workspace_id});
             workspaceHelper.updateState(workspace_id, 'running', null);
         } catch (err) {
             workspaceHelper.updateState(workspace_id, 'stopped', `Error starting container. Click "Reboot" to try again.`);

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -838,15 +838,6 @@ function _getInitialFiles(workspace, callback) {
 }
 const _getInitialFilesAsync = util.promisify(_getInitialFiles);
 
-function _queryUpdateWorkspaceHostname(workspace_id, port, callback) {
-    const hostname = `${workspace_server_settings.server_to_container_hostname}:${port}`;
-    sqldb.query(sql.update_workspace_hostname, {workspace_id, hostname}, function(err, _result) {
-        if (ERR(err, callback)) return;
-        callback(null);
-    });
-}
-const _queryUpdateWorkspaceHostnameAsync = util.promisify(_queryUpdateWorkspaceHostname);
-
 function _pullImage(workspace, callback) {
     workspaceHelper.updateMessage(workspace.id, 'Checking image');
     const workspace_image = workspace.settings.workspace_image;
@@ -1064,7 +1055,8 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
 
         try {
             workspaceHelper.updateMessage(workspace.id, 'Creating container');
-            await _queryUpdateWorkspaceHostnameAsync (workspace.id, workspace.launch_port);
+            const hostname = `${workspace_server_settings.server_to_container_hostname}:${workspace.launch_port}`;
+            await sqldb.queryAsync(sql.update_workspace_hostname, { workspace_id, hostname });
             workspace.container = await _createContainerAsync(workspace);
         } catch (err) {
             workspaceHelper.updateState(workspace_id, 'stopped', `Error creating container. Click "Reboot" to try again.`);

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -509,6 +509,7 @@ async function dockerAttemptKillAndRemove(input) {
 async function markSelfUnhealthyAsync() {
     try {
         await sqldb.queryAsync(sql.mark_host_unhealthy, { instance_id: workspace_server_settings.instance_id });
+        logger.warn(`Marked self as unhealthy`);
     } catch (err) {
         /* This could error if we don't even have a DB connection, in that case we should let the main server
            mark us as unhealthy. */


### PR DESCRIPTION
Resolves #3081:

* [x] Rewrite `interface.initSequence()` as async/await rather than waterfall
* [x] Instead of always setting the host to unhealthy, just set workspace to `stopped` (with an appropriate error message) and return
