### PR TITLE
Fix unload confirmation by filtering question form serialization

### DIFF
--- a/public/localscripts/questionPageScripts.js
+++ b/public/localscripts/questionPageScripts.js
@@ -1,6 +1,6 @@
 function confirmOnUnload() {
     const form = $('form.question-form');
-    const getForm = () => form.serialize().split('&')[0];
+    const getForm = () => form.find(':not([name="__variant_id"]):not([name="__csrf_token"])').serialize();
 
     // Set form state on load and submit
     var initialForm = getForm();

--- a/public/localscripts/questionPageScripts.js
+++ b/public/localscripts/questionPageScripts.js
@@ -1,6 +1,6 @@
 function confirmOnUnload() {
     const form = $('form.question-form');
-    const getForm = () => form.serialize();
+    const getForm = () => form.serialize().split('&')[0];
 
     // Set form state on load and submit
     var initialForm = getForm();


### PR DESCRIPTION
With Jonatan's question:

* On submission, the question form gets serialized with `__variant_id` and `__csrf_token` query params
* On reload, those params are gone (thus the confirmation dialog)

---

* [x] Fix #3153 by stripping `__variant_id` and `__csrf_token` when checking initial/current form states
