### PR TITLE
Fix workspace run command to be copy-pastable

### DIFF
--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -193,7 +193,7 @@ docker run -it --rm -p 3000:3000 \
   -v "$HOME/pl_ag_jobs:/jobs" \
   -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  --add-host=host.docker.internal:172.17.0.1 \ # this line is new vs MacOS
+  --add-host=host.docker.internal:172.17.0.1 `# this line is new vs MacOS` \
   prairielearn/prairielearn
 ```
 


### PR DESCRIPTION
Previous comment syntax couldn't be directly copy pasted. Borrowed syntax from external grading docs.