### PR TITLE
Disable timeLimitMin for CBTF assessments

### DIFF
--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -103,7 +103,7 @@ The above example will give students 90 minutes for this exam, and they must sta
 
 ![Time limit illustrations](exam_timer.svg)
 
-**Note that time limits should not be set for exams in the CBTF (Computer-Based Testing Facility). Instead, such exams should set `"mode": "Exam"` and the time limits will be enforced by the CBTF scheduling software.**
+**Note that time limits should not be set for exams in the CBTF (Computer-Based Testing Facility). Instead, such exams should set `"mode": "Exam"`, in which case `timeLimitMin` will have no effect and the time limits will be enforced by the CBTF scheduling software.**
 
 ## Passwords
 

--- a/sprocs/check_assessment_access.sql
+++ b/sprocs/check_assessment_access.sql
@@ -42,6 +42,7 @@ BEGIN
         -- Resolve race condition by subtracting 31 sec from end_date.
         -- Use 31 instead of 30 to force rounding (time_limit_min is in minutes).
         CASE WHEN aar.time_limit_min IS NULL THEN NULL
+             WHEN aar.mode = 'Exam' THEN NULL
              ELSE LEAST(aar.time_limit_min, EXTRACT(EPOCH FROM aar.end_date - now() - INTERVAL '31 seconds') / 60)::integer
         END AS time_limit_min,
         aar.password,

--- a/testCourse/courseInstances/Sp15/assessments/exam1-automaticTestSuite/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam1-automaticTestSuite/infoAssessment.json
@@ -13,6 +13,7 @@
         {
             "mode": "Exam",
             "credit": 100,
+            "timeLimitMin": 50,
             "startDate": "1900-07-07T23:59:59",
             "endDate": "2300-07-10T23:59:59"
         }

--- a/tests/testAccess.js
+++ b/tests/testAccess.js
@@ -305,26 +305,6 @@ describe('Access control', function() {
         });
     };
 
-    const getAssessmentInstanceCountdown = function(cookies, expectedStatusCode, callback) {
-        request({url: assessmentInstanceUrl, jar: cookies}, function (error, response, body) {
-            if (error) {
-                return callback(error);
-            }
-            if (response.statusCode != expectedStatusCode) {
-                return callback(new Error('bad status: ' + response.statusCode));
-            }
-            page = body;
-            try {
-                $ = cheerio.load(page);
-                elemList = $('#countdownDisplay');
-                assert.lengthOf(elemList, 0);
-            } catch (err) {
-                return callback(err);
-            }
-            callback(null);
-        });
-    };
-
     describe('9. GET to assessment_instance URL', function() {
         it('as student should return 403', function(callback) {
             getAssessmentInstance(cookiesStudent(), 403, callback);
@@ -586,7 +566,16 @@ describe('Access control', function() {
             getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
         it('should not contain countdown timer', function(callback) {
-            getAssessmentInstanceCountdown(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), 200, function() {
+                try {
+                    $ = cheerio.load(page);
+                    elemList = $('#countdownDisplay');
+                    assert.lengthOf(elemList, 0);
+                } catch (err) {
+                    return callback(err);
+                }
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
             getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);

--- a/tests/testAccess.js
+++ b/tests/testAccess.js
@@ -566,7 +566,8 @@ describe('Access control', function() {
             getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
         it('should not contain countdown timer', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 200, function() {
+            getAssessmentInstance(cookiesStudentExam(), 200, function(err) {
+                if (ERR(err, callback)) return;
                 try {
                     $ = cheerio.load(page);
                     elemList = $('#countdownDisplay');

--- a/tests/testAccess.js
+++ b/tests/testAccess.js
@@ -292,44 +292,51 @@ describe('Access control', function() {
 
     /**********************************************************************/
 
-    var getAssessmentInstance = function(cookies, callback) {
+    var getAssessmentInstance = function(cookies, expectedStatusCode, callback) {
         request({url: assessmentInstanceUrl, jar: cookies}, function (error, response, body) {
             if (error) {
                 return callback(error);
             }
+            if (response.statusCode != expectedStatusCode) {
+                return callback(new Error('bad status: ' + response.statusCode));
+            }
             page = body;
-            callback(null, response, body);
+            callback(null);
+        });
+    };
+
+    const getAssessmentInstanceCountdown = function(cookies, expectedStatusCode, callback) {
+        request({url: assessmentInstanceUrl, jar: cookies}, function (error, response, body) {
+            if (error) {
+                return callback(error);
+            }
+            if (response.statusCode != expectedStatusCode) {
+                return callback(new Error('bad status: ' + response.statusCode));
+            }
+            page = body;
+            try {
+                $ = cheerio.load(page);
+                elemList = $('#countdownDisplay');
+                assert.lengthOf(elemList, 0);
+            } catch (err) {
+                return callback(err);
+            }
+            callback(null);
         });
     };
 
     describe('9. GET to assessment_instance URL', function() {
         it('as student should return 403', function(callback) {
-            getAssessmentInstance(cookiesStudent(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudent(), 403, callback);
         });
         it('as student in Exam mode before time period should return 403', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeAssessment(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamBeforeAssessment(), 403, callback);
         });
         it('as student in Exam mode after time period should return 403', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterAssessment(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamAfterAssessment(), 403, callback);
         });
         it('as student in Exam mode should load successfully', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
         it('should parse', function() {
             $ = cheerio.load(page);
@@ -458,11 +465,7 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 403, callback);
         });
     });
 
@@ -475,25 +478,13 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 403, callback);
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
         });
     });
 
@@ -505,25 +496,13 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
         });
     });
 
@@ -537,11 +516,7 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
     });
 
@@ -553,11 +528,7 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
     });
 
@@ -569,11 +540,7 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 403, callback);
         });
     });
 
@@ -585,11 +552,7 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 403, callback);
         });
     });
 
@@ -602,25 +565,13 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 403, callback);
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
         });
     });
 
@@ -632,39 +583,16 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExam(), 200, callback);
         });
         it('should not contain countdown timer', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), function(err, response, body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
-                try {
-                    $ = cheerio.load(body);
-                    elemList = $('#countdownDisplay');
-                    assert.lengthOf(elemList, 0);
-                } catch (err) {
-                    return callback(err);
-                }
-                callback(null);
-            });
+            getAssessmentInstanceCountdown(cookiesStudentExam(), 200, callback);
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
-                if (ERR(err, callback)) return;
-                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
-                callback(null);
-            });
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
         });
     });
 

--- a/tests/testAccess.js
+++ b/tests/testAccess.js
@@ -305,6 +305,26 @@ describe('Access control', function() {
         });
     };
 
+    const getAssessmentInstanceCountdown = function(cookies, expectedStatusCode, callback) {
+        request({url: assessmentInstanceUrl, jar: cookies}, function (error, response, body) {
+            if (error) {
+                return callback(error);
+            }
+            if (response.statusCode != expectedStatusCode) {
+                return callback(new Error('bad status: ' + response.statusCode));
+            }
+            page = body;
+            try {
+                $ = cheerio.load(page);
+                elemList = $('#countdownDisplay');
+                assert.lengthOf(elemList, 0);
+            } catch (err) {
+                return callback(err);
+            }
+            callback(null);
+        });
+    };
+
     describe('9. GET to assessment_instance URL', function() {
         it('as student should return 403', function(callback) {
             getAssessmentInstance(cookiesStudent(), 403, callback);
@@ -564,6 +584,9 @@ describe('Access control', function() {
         });
         it('should enable access to the assessment_instance', function(callback) {
             getAssessmentInstance(cookiesStudentExam(), 200, callback);
+        });
+        it('should not contain countdown timer', function(callback) {
+            getAssessmentInstanceCountdown(cookiesStudentExam(), 200, callback);
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
             getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);

--- a/tests/testAccess.js
+++ b/tests/testAccess.js
@@ -292,51 +292,44 @@ describe('Access control', function() {
 
     /**********************************************************************/
 
-    var getAssessmentInstance = function(cookies, expectedStatusCode, callback) {
+    var getAssessmentInstance = function(cookies, callback) {
         request({url: assessmentInstanceUrl, jar: cookies}, function (error, response, body) {
             if (error) {
                 return callback(error);
             }
-            if (response.statusCode != expectedStatusCode) {
-                return callback(new Error('bad status: ' + response.statusCode));
-            }
             page = body;
-            callback(null);
-        });
-    };
-
-    const getAssessmentInstanceCountdown = function(cookies, expectedStatusCode, callback) {
-        request({url: assessmentInstanceUrl, jar: cookies}, function (error, response, body) {
-            if (error) {
-                return callback(error);
-            }
-            if (response.statusCode != expectedStatusCode) {
-                return callback(new Error('bad status: ' + response.statusCode));
-            }
-            page = body;
-            try {
-                $ = cheerio.load(page);
-                elemList = $('#countdownDisplay');
-                assert.lengthOf(elemList, 0);
-            } catch (err) {
-                return callback(err);
-            }
-            callback(null);
+            callback(null, response, body);
         });
     };
 
     describe('9. GET to assessment_instance URL', function() {
         it('as student should return 403', function(callback) {
-            getAssessmentInstance(cookiesStudent(), 403, callback);
+            getAssessmentInstance(cookiesStudent(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('as student in Exam mode before time period should return 403', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeAssessment(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamBeforeAssessment(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('as student in Exam mode after time period should return 403', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterAssessment(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamAfterAssessment(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('as student in Exam mode should load successfully', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should parse', function() {
             $ = cheerio.load(page);
@@ -465,7 +458,11 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 403, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -478,13 +475,25 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 403, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -496,13 +505,25 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -516,7 +537,11 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -528,7 +553,11 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -540,7 +569,11 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 403, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -552,7 +585,11 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 403, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -565,13 +602,25 @@ describe('Access control', function() {
             });
         });
         it('should block access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 403, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 
@@ -583,16 +632,39 @@ describe('Access control', function() {
             });
         });
         it('should enable access to the assessment_instance', function(callback) {
-            getAssessmentInstance(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should not contain countdown timer', function(callback) {
-            getAssessmentInstanceCountdown(cookiesStudentExam(), 200, callback);
+            getAssessmentInstance(cookiesStudentExam(), function(err, response, body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 200) return callback(new Error(`bad status: ${response.statusCode}`));
+                try {
+                    $ = cheerio.load(body);
+                    elemList = $('#countdownDisplay');
+                    assert.lengthOf(elemList, 0);
+                } catch (err) {
+                    return callback(err);
+                }
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance before the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamBeforeReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamBeforeReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
         it('should block access to the assessment_instance after the reservation', function(callback) {
-            getAssessmentInstance(cookiesStudentExamAfterReservation(), 403, callback);
+            getAssessmentInstance(cookiesStudentExamAfterReservation(), function(err, response, _body) {
+                if (ERR(err, callback)) return;
+                if (response.statusCode != 403) return callback(new Error(`bad status: ${response.statusCode}`));
+                callback(null);
+            });
         });
     });
 


### PR DESCRIPTION
Resolves #2054:

* [x] Add a second CASE option like `WHEN aar.mode = 'Exam' THEN NULL` here: https://github.com/PrairieLearn/PrairieLearn/blob/4fb8e0c5f31f69cfce4b1a6271b63409d59d45cd/sprocs/check_assessment_access.sql#L44
* [x] Add a documentation note near "Note that time limits should not be set for exams" to say that time limits will not activate in Exam mode: https://github.com/PrairieLearn/PrairieLearn/blob/master/docs/accessControl.md
* [x] Add test to check for `#countdownDisplay`