### PR TITLE
Add header to pl-symbolic-input format info

### DIFF
--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -98,7 +98,7 @@ ${{a_tru}}$
 {{/answer}}
 
 {{#format}}
-<p>Your answer must be a symbolic expression. All numbers must be rational - so, <code class="user-output">1/2</code> instead of <code class="user-output">0.5</code>.
+<p><strong>General format information:</strong><br>Your answer must be a symbolic expression. All numbers must be rational - so, <code class="user-output">1/2</code> instead of <code class="user-output">0.5</code>.
 {{^allow_complex}}Complex numbers are not allowed.{{/allow_complex}}</p>
 
 <p>


### PR DESCRIPTION
When showing the "Why?" popover with a format error, it seems that some users are confusing the generic format info with the specific error information at the top. This PR adds a header to try and make this clearer.