### PR TITLE
Remove confirmation from unhealthy hosts admin query

### DIFF
--- a/admin_queries/workspace_hosts_all_unhealthy.json
+++ b/admin_queries/workspace_hosts_all_unhealthy.json
@@ -5,10 +5,6 @@
             "name": "unhealthy_reason",
             "description": "Reason for setting all workspace hosts to unhealthy.",
             "default": "admin query"
-        },
-        {
-            "name": "confirm",
-            "description": "Type 'yes' to confirm."
         }
     ]
 }

--- a/admin_queries/workspace_hosts_all_unhealthy.sql
+++ b/admin_queries/workspace_hosts_all_unhealthy.sql
@@ -6,8 +6,7 @@ SET
     unhealthy_at = NOW(),
     unhealthy_reason = $unhealthy_reason
 WHERE
-    $confirm = 'yes'
-    AND wh.state IN ('launching', 'ready', 'draining')
+    wh.state IN ('launching', 'ready', 'draining')
 RETURNING
     wh.id AS workspace_host_id,
     wh.instance_id,


### PR DESCRIPTION
We only had the 'confirm' parameter so that the query wouldn't run
immediately on entry. Now that we have the 'unhealthy_reason' parameter,
we don't need 'confirm' anymore.