### PR TITLE
Fix lib/aws error handling

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -60,18 +60,21 @@ module.exports.uploadToS3Async = async function (s3Bucket, s3Path, localPath, is
     } else {
         try {
             body = await fs.promises.readFile(localPath);
-        } catch(err) {
+        } catch (err) {
             return [localPath, s3Path, err];
         }
     }
 
-    const params = {
-        Bucket: s3Bucket,
-        Key: s3Path,
-        Body: body,
-    };
-    await s3.upload(params).promise();
-    logger.info(`Uploaded ${localPath} to s3://${s3Bucket}/${s3Path}`);
+    try {
+        await s3.upload({
+            Bucket: s3Bucket,
+            Key: s3Path,
+            Body: body,
+        }).promise();
+        logger.verbose(`Uploaded ${isDirectory ? 'directory' : 'file' } ${localPath} to s3://${s3Bucket}/${s3Path}`);
+    } catch (err) {
+        logger.error(`Error uploading ${isDirectory ? 'directory' : 'file' } ${localPath} to s3://${s3Bucket}/${s3Path}: ${err}`);
+    }
 };
 module.exports.uploadToS3 = util.callbackify(this.uploadToS3Async);
 
@@ -109,9 +112,9 @@ module.exports.uploadDirectoryToS3Async = async function(s3Bucket, s3Path, local
                         Body: fileBody,
                     };
                     await s3.upload(params).promise();
-                    logger.info(`Uploaded file ${localFilePath} to s3://${s3Bucket}/${s3FilePath}`);
+                    logger.verbose(`Uploaded file ${localFilePath} to s3://${s3Bucket}/${s3FilePath}`);
                 } catch (err) {
-                    logger.error(`Error syncing file ${localFilePath} to $s3://{s3Bucket}/${s3FilePath}: ${err}`);
+                    logger.error(`Error uploading file ${localFilePath} to s3://${s3Bucket}/${s3FilePath}: ${err}`);
                 }
             } else if (stat.isDirectory()) {
                 const s3DirPath = s3FilePath.endsWith('/') ? s3FilePath : `${s3FilePath}/`;
@@ -123,7 +126,7 @@ module.exports.uploadDirectoryToS3Async = async function(s3Bucket, s3Path, local
                     }).promise();
                     logger.info(`Uploaded directory ${localFilePath} to s3://${s3Bucket}/${s3DirPath}`);
                 } catch (err) {
-                    logger.error(`Error syncing directory ${localFilePath} to $s3://{s3Bucket}/${s3DirPath}: ${err}`);
+                    logger.error(`Error uploading directory ${localFilePath} to s3://${s3Bucket}/${s3DirPath}: ${err}`);
                 }
                 await walkDirectory(relFilePath);
             }
@@ -196,11 +199,14 @@ module.exports.deleteFromS3Async = async function (s3Bucket, s3Path, isDirectory
         s3Path += s3Path.endsWith('/') ? '' : '/';
     }
 
-    const params = {
-        Bucket: s3Bucket,
-        Key: s3Path,
-    };
-    await s3.deleteObject(params).promise();
-    debug(`Deleted s3://${s3Bucket}/${s3Path}`);
+    try {
+        await s3.deleteObject({
+            Bucket: s3Bucket,
+            Key: s3Path,
+        }).promise();
+        logger.verbose(`Deleted s3://${s3Bucket}/${s3Path}`);
+    } catch (err) {
+        logger.error(`Error deleting s3://${s3Bucket}/${s3Path}: ${err}`);
+    }
 };
 module.exports.deleteFromS3 = util.callbackify(this.deleteFromS3Async);


### PR DESCRIPTION
* [x] some `s3` calls weren't wrapped with try/catch (leading to some nebulous "access denied" errors)
* [x] misc logging fixes
* [ ] redo `readFile()` error handling
* [ ] prevent host from going unhealthy due to lib/aws errors