### PR TITLE
Update chunks to allow duplicate entity UUIDs

### DIFF
--- a/sprocs/chunks_insert.sql
+++ b/sprocs/chunks_insert.sql
@@ -14,9 +14,9 @@ BEGIN
         a.id,
         (chunk->>'uuid')::uuid
     FROM unnest(generated_chunks) AS chunk(json)
-    LEFT JOIN questions AS q ON (q.uuid = (chunk->>'questionUuid')::uuid AND q.qid = (chunk->>'questionName') AND q.course_id = in_course_id)
-    LEFT JOIN course_instances AS ci ON (ci.uuid = (chunk->>'courseInstanceUuid')::uuid AND ci.short_name = (chunk->>'courseInstanceName') AND ci.course_id = in_course_id)
-    LEFT JOIN assessments AS a ON (a.uuid = (chunk->>'assessmentUuid')::uuid AND a.tid = (chunk->>'assessmentName') AND a.course_instance_id = ci.id)
+    LEFT JOIN questions AS q ON (q.qid = (chunk->>'questionName') AND q.deleted_at IS NULL AND q.course_id = in_course_id)
+    LEFT JOIN course_instances AS ci ON (ci.short_name = (chunk->>'courseInstanceName') AND ci.deleted_at IS NULL AND ci.course_id = in_course_id)
+    LEFT JOIN assessments AS a ON (a.tid = (chunk->>'assessmentName') AND a.deleted_at IS NULL AND a.course_instance_id = ci.id)
     ON CONFLICT (type, course_id, coalesce(question_id, -1), coalesce(course_instance_id, -1), coalesce(assessment_id, -1)) DO UPDATE
     SET
         type = EXCLUDED.type,


### PR DESCRIPTION
Tested and seems to work on `TEST 101` on staging.prairielearn.org:

```
staging=> select c.*, q.uuid, q.qid from chunks as c left join questions as q on q.id = c.question_id where c.course_id=4 and c.type='question';
  id  |                 uuid                 |   type   | course_id | course_instance_id | assessment_id | question_id |                 uuid                 |         qid
------+--------------------------------------+----------+-----------+--------------------+---------------+-------------+--------------------------------------+----------------------
  241 | 36ab7b98-e395-409a-9353-89d0e59f82b5 | question |         4 |                    |               |        3901 |                                      | New_1
  126 | 76b2520a-9b89-442b-920b-558010cb03c3 | question |         4 |                    |               |        3900 | a4b08bde-6ee5-4b31-836a-80d142dffa3a | sampleMultipleChoice
 2693 | fcb6b607-2933-4889-9df5-a973866c5b48 | question |         4 |                    |               |        5288 |                                      | New_1_copy1
```

(Side note, conflicting UUID questions don't have a populated `uuid` column in the db. Is this intended to get around db constraints?)

Follow's @mwest1066 's suggestion of updating the sproc to match on *IDs that are not deleted.

Resolves #3136 