### PR TITLE
Fix missing launched_at in workspace_state_update sproc

### DIFF
--- a/sprocs/workspaces_state_update.sql
+++ b/sprocs/workspaces_state_update.sql
@@ -17,6 +17,7 @@ BEGIN
         state_updated_at = now(),
         message = workspace_message,
         message_updated_at = now(),
+        launched_at = CASE WHEN workspace_state = 'launching' THEN now() ELSE launched_at END,
         running_at = CASE WHEN workspace_state = 'running' THEN now() ELSE running_at END,
         stopped_at = CASE WHEN workspace_state = 'stopped' THEN now() ELSE stopped_at END
     WHERE

--- a/sprocs/workspaces_state_update.sql
+++ b/sprocs/workspaces_state_update.sql
@@ -1,4 +1,5 @@
-DROP FUNCTION IF EXISTS workspaces_state_update(bigint, text, text);
+DROP FUNCTION IF EXISTS workspaces_state_update(bigint, text);
+DROP FUNCTION IF EXISTS workspaces_state_update(bigint, enum_workspace_state, text);
 
 CREATE OR REPLACE FUNCTION
     workspaces_state_update(


### PR DESCRIPTION
Fixes #3211 (`launched_at` was mistakenly removed when merging #3135 with master)