### PR TITLE
Add a Docker Compose File

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,17 @@
-version: '3.2'
+version: '3.8'
 services:
   pl:
     build:
       context: .
+    image: prairielearn/prairielearn:local
     ports:
       - 3000:3000
     volumes:
       - ./testCourse:/course
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HOME}/pl_ag_jobs:/jobs
+      - .:/PrairieLearn
     container_name: pl
     environment:
       - HOST_JOBS_DIR=${HOME}/pl_ag_jobs
-
-    # Starts the server with a different starting command
-    # Replaces /PrairieLearn/docker/init.sh
-    # This isn't functional on windows machines
-    # command: /PrairieLearn/docker/start_workspace.sh
+      - NODEMON=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.2'
+services:
+  pl:
+    build:
+      context: .
+    ports:
+      - 3000:3000
+    volumes:
+      - ./testCourse:/course
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${HOME}/pl_ag_jobs:/jobs
+    container_name: pl
+    environment:
+      - HOST_JOBS_DIR=${HOME}/pl_ag_jobs
+
+    # Starts the server with a different starting command
+    # Replaces /PrairieLearn/docker/init.sh
+    # This isn't functional on windows machines
+    # command: /PrairieLearn/docker/start_workspace.sh

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -89,14 +89,14 @@ The server will be available on port `3000`.
 
 The equivalent `docker run` command to perform all these actions would be:
 ```sh
-docker build -t prairielearn . 
+docker build -t prairielearn/prairielearn:local . 
 docker run -it --rm \
       -p 3000:3000 \
       - ./testCourse:/course \
       -v ${HOME}/pl_ag_jobs:/jobs -e HOST_JOBS_DIR=${HOME}/pl_ag_jobs \
       -v .:/PrairieLearn -e NODEMON=true \
       -v /var/run/docker.sock:/var/run/docker.sock
-      prairielearn
+      prairielearn/prairielearn
 ```
 
 ### Useful Commands

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -72,6 +72,51 @@ E.g., to start a shell in a container started with `--name pl`:
 docker exec -it pl /bin/bash
 ```
 
+## Docker-Compose
+
+### Basics
+
+A docker-compose file describes the services an application needs to run. In our case, we use `docker-compose` to configure and run the PrairieLearn docker container locally.
+
+To run PrairieLearn with `docker-compose`, run `docker-compose up pl`. This will, in order:
+
+- Build the PL docker image, and tag it as `prairielearn/prairielearn:local`
+- Mount `./testCourse` as a volume for a test course
+- Set up the container to run [external grading jobs](externalGrading.md)
+- Mount the current directory as `/PrairieLearn` and enable `nodemon`, so the container live reloads
+
+The server will be available on port `3000`.
+
+The equivalent `docker run` command to perform all these actions would be:
+```sh
+docker build -t prairielearn . 
+docker run -it --rm \
+      -p 3000:3000 \
+      - ./testCourse:/course \
+      -v ${HOME}/pl_ag_jobs:/jobs -e HOST_JOBS_DIR=${HOME}/pl_ag_jobs \
+      -v .:/PrairieLearn -e NODEMON=true \
+      -v /var/run/docker.sock:/var/run/docker.sock
+      prairielearn
+```
+
+### Useful Commands
+
+Usually, you will not have to rebuild the base image. If you do, then you can either run `docker-compose build pl` or `docker-compose up --build pl` (the later will rebuild the image, and then start the container).
+
+To remove all containers and clean up compose artifacts, run `docker-compose down`.
+
+Most `docker` commands map directly to `docker-compose` commands. You can use `docker-compose run pl ...` to run the container as if you were typing `docker run ...`, or `docker-compose exec pl ...` to execute a command on the running container.
+
+## Multiple Compose Files
+
+If you're developing locally, and want to override parts of the config, you can create your own compose file (perhaps `docker-compose.local.yml`). Then, if you type:
+
+```sh
+docker-compose -f docker-compose.yml -f docker-compose.local.yml ...
+```
+
+compose will use values from `docker-compose.local.yml` to override those from `docker-compose.yml`.
+
 ## Docker Hub
 
 Docker Hub automatically (re)builds the `prairielearn/prairielearn` image

--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -256,13 +256,6 @@ mkdir "$HOME/pl_ag_jobs"
 ```
 - Modify your PL docker run call to include the jobs directory.
 
-##### Docker Compose
-We have a `docker-compose.yml` in the top level of the PraireLearn repository which will build a local image of PraireLearn and run it in a container named `pl`. The test course directory will be mounted as a course.
-
-To build the image and start the container, type `docker-compose up` in the root directory. 
-
-To remove the container, type `docker-compose down`. To force the image to rebuild before restarting the container, type `docker-compose build`.
-
 ##### Shell Command
 On MacOS and Linux, `cd` to your course directory and copy-paste the following command:
 ```sh

--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -254,9 +254,16 @@ Running PrairieLearn locally with externally graded question support looks somet
 ```bash
 mkdir "$HOME/pl_ag_jobs"
 ```
-
 - Modify your PL docker run call to include the jobs directory.
 
+##### Docker Compose
+We have a `docker-compose.yml` in the top level of the PraireLearn repository which will build a local image of PraireLearn and run it in a container named `pl`. The test course directory will be mounted as a course.
+
+To build the image and start the container, type `docker-compose up` in the root directory. 
+
+To remove the container, type `docker-compose down`. To force the image to rebuild before restarting the container, type `docker-compose build`.
+
+##### Shell Command
 On MacOS and Linux, `cd` to your course directory and copy-paste the following command:
 ```sh
 docker run -it --rm -p 3000:3000 \


### PR DESCRIPTION
In order to make it easier to pop up a local build of PraireLearn, I've created a docker compose file that emulates the ["running locally with docker"](https://prairielearn.readthedocs.io/en/latest/externalGrading/#running-locally-on-docker) command from the ReadTheDocs.

I've had some issues trying to get alternative start commands to run on windows due to the split terminal--I don't know if this works on other OSes.

There's more comments on `docker-compose` in the comments of #3174.