### PR TITLE
Fix join code naming bug

### DIFF
--- a/pages/studentAssessmentHomework/studentAssessmentHomework.js
+++ b/pages/studentAssessmentHomework/studentAssessmentHomework.js
@@ -90,8 +90,8 @@ router.post('/', function(req, res, next) {
         });
     } else if (req.body.__action == 'joinGroup') {
         try{
-            const group_name = req.body.joincode.split('-')[0];
-            const join_code = req.body.joincode.split('-')[1].toUpperCase();
+            const group_name = req.body.joinCode.split('-')[0];
+            const join_code = req.body.joinCode.split('-')[1].toUpperCase();
             if (join_code.length != 4) {
                 throw 'invalid length of join code';
             }
@@ -120,7 +120,7 @@ router.post('/', function(req, res, next) {
                         res.locals.permissions = result.rows[0];            
                         res.locals.groupsize = 0;
                         //display the error on frontend
-                        res.locals.usedjoincode = req.body.joincode;
+                        res.locals.usedjoincode = req.body.joinCode;
                         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
                     });
                 }
@@ -135,7 +135,7 @@ router.post('/', function(req, res, next) {
                 res.locals.permissions = result.rows[0];            
                 res.locals.groupsize = 0;
                 //display the error on frontend
-                res.locals.usedjoincode = req.body.joincode;
+                res.locals.usedjoincode = req.body.joinCode;
                 res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
             });
         }

--- a/tests/testGroupStudent.js
+++ b/tests/testGroupStudent.js
@@ -304,7 +304,7 @@ describe('Group based homework assess control on student side', function() {
             var form = {
                 __action: 'joinGroup',
                 __csrf_token: locals.__csrf_token,
-                joincode: locals.joinCode,
+                joinCode: locals.joinCode,
             };
             request.post({url: locals.assessmentUrl, form: form, followAllRedirects: true}, function (error, response, body) {
                 if (ERR(error, callback)) return;
@@ -371,7 +371,7 @@ describe('Group based homework assess control on student side', function() {
             var form = {
                 __action: 'joinGroup',
                 __csrf_token: locals.__csrf_token,
-                joincode: locals.joinCode,
+                joinCode: locals.joinCode,
             };
             request.post({url: locals.assessmentUrl, form: form, followAllRedirects: true}, function (error, response, body) {
                 if (ERR(error, callback)) return;
@@ -436,7 +436,7 @@ describe('Group based homework assess control on student side', function() {
             var form = {
                 __action: 'joinGroup',
                 __csrf_token: locals.__csrf_token,
-                joincode: locals.joinCode,
+                joinCode: locals.joinCode,
             };
             request.post({url: locals.assessmentUrl, form: form, followAllRedirects: true}, function (error, response, body) {
                 if (ERR(error, callback)) return;
@@ -762,7 +762,7 @@ describe('Group based homework assess control on student side', function() {
             var form = {
                 __action: 'joinGroup',
                 __csrf_token: locals.__csrf_token,
-                joincode: locals.joinCode,
+                joinCode: locals.joinCode,
             };
             request.post({url: locals.assessmentUrl_2, form: form, followAllRedirects: true}, function (error, response, body) {
                 if (ERR(error, callback)) return;


### PR DESCRIPTION
Tracked down by @andrewstec:

#3023 renamed `joincode` to `joinCode` on the EJS side but not JS.