### PR TITLE
Added download button to pl-file-preview.

### DIFF
--- a/elements/pl-file-preview/pl-file-preview.mustache
+++ b/elements/pl-file-preview/pl-file-preview.mustache
@@ -16,6 +16,11 @@
               <p class="file-status">uploaded</p>
             </div>
             <div class="file-status-container-right">
+              <a download="{{name}}" class="btn btn-outline-secondary btn-sm"
+                 onclick="event.stopPropagation();"
+                 href="data:application/octet-stream;base64,{{contentsb64}}">
+                 Download
+              </a>
               <button type="button" class="btn btn-outline-secondary btn-sm file-preview-button">
                 <i class="file-preview-icon fa fa-angle-down"></i>
               </button>

--- a/elements/pl-file-preview/pl-file-preview.py
+++ b/elements/pl-file-preview/pl-file-preview.py
@@ -31,13 +31,15 @@ def render(element_html, data):
     if len(submitted_files) > 0:
         files = []
         for idx, file in enumerate(submitted_files):
+            b64contents = file['contents'] or ''
             try:
-                contents = base64.b64decode(file['contents'] or '').decode()
+                contents = base64.b64decode(b64contents).decode()
             except UnicodeDecodeError:
                 contents = 'Unable to decode file.'
             files.append({
                 'name': file['name'],
                 'contents': contents,
+                'contentsb64': b64contents,
                 'index': idx
             })
         html_params['has_files'] = True


### PR DESCRIPTION
One of the issues in #3159.

The button is currently created with base64 blob in the link itself, which works fine for small enough files, but may cause the page to take longer to load if the file is too big. Alternative would be to create a new URL entrypoint for downloading, but that would probably take more work.