### PR TITLE
Fix dev user not being set to admin

### DIFF
--- a/server.js
+++ b/server.js
@@ -1092,13 +1092,6 @@ if (config.startServer) {
             });
         },
         function(callback) {
-            if (!config.devMode) return callback(null);
-            module.exports.insertDevUser(function(err) {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        function(callback) {
             load.initEstimator('request', 1);
             load.initEstimator('authed_request', 1);
             load.initEstimator('python', 1, false);
@@ -1114,6 +1107,13 @@ if (config.startServer) {
         async () => {
             logger.verbose('Starting server...');
             await module.exports.startServerAsync();
+        },
+        function(callback) {
+            if (!config.devMode) return callback(null);
+            module.exports.insertDevUser(function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
         },
         function(callback) {
             socketServer.init(server, function(err) {


### PR DESCRIPTION
@tdy made the excellent observation that #3210 broke dev mode because the Dev user wasn't being set to admin.  This should fix that.

The issue was that the the dev user gets inserted as an administrator if `config.devMode` is set, but that was set when the server was started *after* the dev user got inserted into the db.