### PR TITLE
Fix workspace heartbeat/timeout race condition

### DIFF
--- a/sprocs/workspaces_state_update.sql
+++ b/sprocs/workspaces_state_update.sql
@@ -19,6 +19,7 @@ BEGIN
         message = workspace_message,
         message_updated_at = now(),
         launched_at = CASE WHEN workspace_state = 'launching' THEN now() ELSE launched_at END,
+        heartbeat_at = CASE WHEN workspace_state = 'running' THEN now() ELSE heartbeat_at END,
         running_at = CASE WHEN workspace_state = 'running' THEN now() ELSE running_at END,
         stopped_at = CASE WHEN workspace_state = 'stopped' THEN now() ELSE stopped_at END
     WHERE


### PR DESCRIPTION
Fixes #3227 

After #3189 lowered `config.cronIntervalWorkspaceTimeoutSec` to 60, heartbeats and timeouts were both firing at 60 sec intervals, so workspaces were being stopped before heartbeats could register.

* [x] explicitly set `heartbeat_at = now()` when state changes to `running`
* [x] test locally