### PR TITLE
[Group Work] Enforce g.deleted_at

### DIFF
--- a/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -65,8 +65,8 @@ FROM
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
     JOIN pl_courses AS c ON (c.id = ci.course_id)
     JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-    LEFT JOIN groups AS gr ON (gr.id = ai.group_id AND gr.deleted_at IS NULL)
-    LEFT JOIN group_users AS gu ON (gu.group_id = gr.id)
+    LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
     JOIN users AS u ON (u.user_id = gu.user_id OR u.user_id = ai.user_id)
     LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
     JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, a.group_work) AS aai ON TRUE

--- a/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -65,8 +65,8 @@ FROM
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
     JOIN pl_courses AS c ON (c.id = ci.course_id)
     JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-    LEFT JOIN group_users AS gu ON (gu.group_id = ai.group_id)
-    LEFT JOIN groups AS gr ON (gr.id = gu.group_id AND gr.deleted_at IS NULL)
+    LEFT JOIN groups AS gr ON (gr.id = ai.group_id AND gr.deleted_at IS NULL)
+    LEFT JOIN group_users AS gu ON (gu.group_id = gr.id)
     JOIN users AS u ON (u.user_id = gu.user_id OR u.user_id = ai.user_id)
     LEFT JOIN enrollments AS e ON (e.user_id = u.user_id AND e.course_instance_id = ci.id)
     JOIN LATERAL authz_assessment_instance(ai.id, $authz_data, $req_date, ci.display_timezone, a.group_work) AS aai ON TRUE

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.sql
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.sql
@@ -22,12 +22,14 @@ FROM
     JOIN questions AS q ON (q.id = aq.question_id)
     JOIN assessments AS a ON (ai.assessment_id = a.id)
     JOIN course_instances AS ci ON (a.course_instance_id = ci.id)
-    LEFT JOIN group_users AS gu ON (ai.group_id = gu.group_id)
+    LEFT JOIN groups AS g ON (g.id = ai.group_id)
+    LEFT JOIN group_users AS gu ON (g.id = gu.group_id)
     JOIN enrollments AS e ON ( ((ai.user_id = e.user_id) OR (e.user_id = gu.user_id))AND ci.id = e.course_instance_id)
 WHERE
     ai.id=$assessment_instance_id
     AND aq.deleted_at IS NULL
     AND q.deleted_at IS NULL
+    AND g.deleted_at IS NULL
 GROUP BY
     q.id,
     iq.id,


### PR DESCRIPTION
fix #3077 

- [x] An order issue at selectAndAuthzInstanceQuestion.sql
- [x] Go over all files and find another potential issue at instructorAssessmentInstance.sql

@mwest1066 Please check whether my understanding is correct:
1. When using LEFT JOIN, the order matters. We should LEFT JOIN group and confirm its deleted_at first, then group_users. This order is critical if I am putting the check on the same line with LEFT JOIN
```
LEFT JOIN groups AS gr ON (gr.id = ai.group_id AND gr.deleted_at IS NULL)
LEFT JOIN group_users AS gu ON (gu.group_id = gr.id)
```
2. The order will not matter when I put the deleted_at check in the WHERE clause
```
LEFT JOIN groups AS gr ON (gr.id = ai.group_id)
LEFT JOIN group_users AS gu ON (gu.group_id = gr.id)
WHERE gr.deleted_at IS NULL
```