### PR TITLE
Fix sync_assessments assertion

### DIFF
--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -424,6 +424,7 @@ BEGIN
     FROM assessments AS a
     WHERE
         a.deleted_at IS NULL
+        AND a.course_instance_id = syncing_course_instance_id
         AND (
             a.assessment_set_id IS NULL
             OR a.number IS NULL


### PR DESCRIPTION
This arose from #3250, but this only fixes the symptom of all courses being affected, and doesn't address the underlying bug.