### PR TITLE
Implemented correct mcq past z

### DIFF
--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -91,7 +91,7 @@ def prepare(element_html, data):
     display_answers = []
     correct_answer_list = []
     for (i, (index, correct, html)) in enumerate(sampled_answers):
-        keyed_answer = {'key': chr(ord('a') + i), 'html': html}
+        keyed_answer = {'key': pl.index2key(i), 'html': html}
         display_answers.append(keyed_answer)
         if correct:
             correct_answer_list.append(keyed_answer)
@@ -369,7 +369,7 @@ def test(element_html, data):
     correct_answer_list = data['correct_answers'].get(name, [])
     correct_keys = [answer['key'] for answer in correct_answer_list]
     number_answers = len(data['params'][name])
-    all_keys = [chr(ord('a') + i) for i in range(number_answers)]
+    all_keys = [pl.index2key(i) for i in range(number_answers)]
 
     result = data['test_type']
 

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -186,7 +186,19 @@ def prepare(element_html, data):
     display_answers = []
     correct_answer = None
     for (i, (index, correct, html)) in enumerate(sampled_answers):
-        keyed_answer = {'key': chr(ord('a') + i), 'html': html}
+        if i >= 26:
+            n = i
+            base_26_str = ""
+            while not n < 26:
+                base_26_str = "{:02d}".format(n % 26) + base_26_str
+                n = n // 26 - 1
+            base_26_str = "{:02d}".format(n) + base_26_str
+            base_26_int = [int(base_26_str[i : i + 2]) for i in range(0, len(base_26_str), 2)]
+            letter = "".join([chr(ord('a') + i) for i in base_26_int])
+        else:
+            letter = chr(ord('a') + i)
+
+        keyed_answer = {'key': letter, 'html': html}
         display_answers.append(keyed_answer)
         if correct:
             correct_answer = keyed_answer

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -186,19 +186,7 @@ def prepare(element_html, data):
     display_answers = []
     correct_answer = None
     for (i, (index, correct, html)) in enumerate(sampled_answers):
-        if i >= 26:
-            n = i
-            base_26_str = ''
-            while not n < 26:
-                base_26_str = '{:02d}'.format(n % 26) + base_26_str
-                n = n // 26 - 1
-            base_26_str = '{:02d}'.format(n) + base_26_str
-            base_26_int = [int(base_26_str[i:i + 2]) for i in range(0, len(base_26_str), 2)]
-            letter = ''.join([chr(ord('a') + i) for i in base_26_int])
-        else:
-            letter = chr(ord('a') + i)
-
-        keyed_answer = {'key': letter, 'html': html}
+        keyed_answer = {'key': pl.index2key(i), 'html': html}
         display_answers.append(keyed_answer)
         if correct:
             correct_answer = keyed_answer
@@ -359,7 +347,7 @@ def test(element_html, data):
     if correct_key is None:
         raise Exception('could not determine correct_key')
     number_answers = len(data['params'][name])
-    all_keys = [chr(ord('a') + i) for i in range(number_answers)]
+    all_keys = [pl.index2key(i) for i in range(number_answers)]
     incorrect_keys = list(set(all_keys) - set([correct_key]))
 
     result = data['test_type']

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -188,13 +188,13 @@ def prepare(element_html, data):
     for (i, (index, correct, html)) in enumerate(sampled_answers):
         if i >= 26:
             n = i
-            base_26_str = ""
+            base_26_str = ''
             while not n < 26:
-                base_26_str = "{:02d}".format(n % 26) + base_26_str
+                base_26_str = '{:02d}'.format(n % 26) + base_26_str
                 n = n // 26 - 1
-            base_26_str = "{:02d}".format(n) + base_26_str
-            base_26_int = [int(base_26_str[i : i + 2]) for i in range(0, len(base_26_str), 2)]
-            letter = "".join([chr(ord('a') + i) for i in base_26_int])
+            base_26_str = '{:02d}'.format(n) + base_26_str
+            base_26_int = [int(base_26_str[i:i + 2]) for i in range(0, len(base_26_str), 2)]
+            letter = ''.join([chr(ord('a') + i) for i in base_26_int])
         else:
             letter = chr(ord('a') + i)
 

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -1090,7 +1090,7 @@ def index2key(i):
     """
     index2key(i)
 
-    Used when generating alphabet ordered lists.
+    Used when generating ordered lists of the form ['a', 'b', ..., 'z', 'aa', 'ab', ..., 'zz', 'aaa', 'aab', ...]
 
     Returns alphabetic key in the form [a-z]* from a given integer (i = 0, 1, 2, ...).
     """

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -1092,7 +1092,7 @@ def index2key(i):
 
     Used when generating alphabet ordered lists.
 
-    Returns alphabetic key in the form [a-z]* from given integer (i) representing alphabet index (base-0).
+    Returns alphabetic key in the form [a-z]* from a given integer (i = 0, 1, 2, ...).
     """
     if i >= 26:
         n = i

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -1085,6 +1085,7 @@ def escape_invalid_string(string):
     """
     return f'<code class="user-output-invalid">{html.escape(escape_unicode_string(string))}</code>'
 
+
 def index2key(i):
     """
     index2key(i)
@@ -1104,5 +1105,5 @@ def index2key(i):
         key = ''.join([chr(ord('a') + i) for i in base_26_int])
     else:
         key = chr(ord('a') + i)
-    
+
     return key

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -1084,3 +1084,25 @@ def escape_invalid_string(string):
     Wraps and escapes string in <code> tags.
     """
     return f'<code class="user-output-invalid">{html.escape(escape_unicode_string(string))}</code>'
+
+def index2key(i):
+    """
+    index2key(i)
+
+    Used when generating alphabet ordered lists.
+
+    Returns alphabetic key in the form [a-z]* from given integer (i) representing alphabet index (base-0).
+    """
+    if i >= 26:
+        n = i
+        base_26_str = ''
+        while not n < 26:
+            base_26_str = '{:02d}'.format(n % 26) + base_26_str
+            n = n // 26 - 1
+        base_26_str = '{:02d}'.format(n) + base_26_str
+        base_26_int = [int(base_26_str[i:i + 2]) for i in range(0, len(base_26_str), 2)]
+        key = ''.join([chr(ord('a') + i) for i in base_26_int])
+    else:
+        key = chr(ord('a') + i)
+    
+    return key


### PR DESCRIPTION
This should fix issue #3133 

Loops past `z` to `aa`, works for arbitrary number of options, e.g `.... -> zzzy -> zzzz -> aaaaa -> aaaab -> ....`