### PR TITLE
Added labels to images created by external graders.

### DIFF
--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -181,7 +181,16 @@ The `<pl-external-grader-results>` element is capable of rendering a list of tes
    "score": 0.25,
    "message": "Tests completed successfully.",
    "output": "Running tests...\nTest 1 passed\nTest 2 failed!\n...",
-   "images": ["data:image/png;base64,...", "data:image/jpeg;base64,..."],
+   "images": [
+      {
+         "label": "First Image",
+         "url": "data:image/png;base64,..."
+      },
+      {
+         "label": "Second Image",
+         "url": "data:image/jpeg;base64,..."
+      }
+   ],
    "tests": [
       {
          "name": "Test 1",
@@ -198,7 +207,14 @@ The `<pl-external-grader-results>` element is capable of rendering a list of tes
          "max_points": 3,
          "message": "Make sure that your code is doing the thing correctly.",
          "output": "Running test...\nYour output did not match the expected output.",
-         "images": ["data:image/gif;base64,...", "data:image/png;base64,..."],
+         "images": [{
+               "label": "First Image",
+               "url": "data:image/gif;base64,..."
+            },
+            {
+               "label": "First Image",
+               "url": "data:image/png;base64,..."
+            }],
       }
    ]
 }

--- a/elements/pl-external-grader-results/pl-external-grader-results.mustache
+++ b/elements/pl-external-grader-results/pl-external-grader-results.mustache
@@ -50,8 +50,8 @@
           <ul class="list-group list-group-flush">
               {{#images}}
                   <li class="list-group-item">
-                      <div><strong>Figure</strong></div>
-                      <img src="{{.}}"/>
+                      <div><strong>{{#label}}{{label}}{{/label}}{{^label}}Figure{{/label}}</strong></div>
+                      <img src="{{#url}}{{url}}{{/url}}{{^url}}{{.}}{{/url}}"/>
                   </li>
               {{/images}}
           </ul>
@@ -103,8 +103,8 @@
               {{#has_images}}
                   <li class="list-group-item">
                       {{#images}}
-                      <div><strong>Figure</strong></div>
-                      <img src="{{.}}"/>
+                      <div><strong>{{#label}}{{label}}{{/label}}{{^label}}Figure{{/label}}</strong></div>
+                      <img src="{{#url}}{{url}}{{/url}}{{^url}}{{.}}{{/url}}"/>
                       {{/images}}
                   </li>
               {{/has_images}}


### PR DESCRIPTION
Currently all images received from external autograders have the label "Figure". This change allows the specification of a label for each image. The previous functionality is kept if there is no label.