### PR TITLE
Fix allowRealTimeGrading:false bug to allow 1-element points arrays

### DIFF
--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -895,8 +895,8 @@ async function validateAssessment(assessment, questions) {
     };
     (assessment.zones || []).forEach(zone => {
         (zone.questions || []).map(zoneQuestion => {
-            if (!allowRealTimeGrading && Array.isArray(zoneQuestion.points)) {
-                errors.push(`Cannot specify an array of points for a question if real-time grading is disabled`);
+            if (!allowRealTimeGrading && Array.isArray(zoneQuestion.points) && zoneQuestion.points.length > 1) {
+                errors.push(`Cannot specify more than 1 point value for a question if real-time grading is disabled`);
             }
             // We'll normalize either single questions or alternative groups
             // to make validation easier
@@ -907,8 +907,8 @@ async function validateAssessment(assessment, questions) {
             } else if ('alternatives' in zoneQuestion) {
                 zoneQuestion.alternatives.forEach(alternative => checkAndRecordQid(alternative.id));
                 alternatives = zoneQuestion.alternatives.map(alternative => {
-                    if (!allowRealTimeGrading && Array.isArray(alternative.points)) {
-                        errors.push(`Cannot specify an array of points for an alternative if real-time grading is disabled`);
+                    if (!allowRealTimeGrading && Array.isArray(alternative.points) && alternative.points.length > 1) {
+                        errors.push(`Cannot specify more than 1 point value for an alternative if real-time grading is disabled`);
                     }
                     return {
                         points: alternative.points || zoneQuestion.points,

--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -896,7 +896,7 @@ async function validateAssessment(assessment, questions) {
     (assessment.zones || []).forEach(zone => {
         (zone.questions || []).map(zoneQuestion => {
             if (!allowRealTimeGrading && Array.isArray(zoneQuestion.points) && zoneQuestion.points.length > 1) {
-                errors.push(`Cannot specify an an array of multiple point values for a question if real-time grading is disabled`);
+                errors.push(`Cannot specify an array of multiple point values for a question if real-time grading is disabled`);
             }
             // We'll normalize either single questions or alternative groups
             // to make validation easier

--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -896,7 +896,7 @@ async function validateAssessment(assessment, questions) {
     (assessment.zones || []).forEach(zone => {
         (zone.questions || []).map(zoneQuestion => {
             if (!allowRealTimeGrading && Array.isArray(zoneQuestion.points) && zoneQuestion.points.length > 1) {
-                errors.push(`Cannot specify more than 1 point value for a question if real-time grading is disabled`);
+                errors.push(`Cannot specify an an array of multiple point values for a question if real-time grading is disabled`);
             }
             // We'll normalize either single questions or alternative groups
             // to make validation easier
@@ -908,7 +908,7 @@ async function validateAssessment(assessment, questions) {
                 zoneQuestion.alternatives.forEach(alternative => checkAndRecordQid(alternative.id));
                 alternatives = zoneQuestion.alternatives.map(alternative => {
                     if (!allowRealTimeGrading && Array.isArray(alternative.points) && alternative.points.length > 1) {
-                        errors.push(`Cannot specify more than 1 point value for an alternative if real-time grading is disabled`);
+                        errors.push(`Cannot specify an array of multiple point values for an alternative if real-time grading is disabled`);
                     }
                     return {
                         points: alternative.points || zoneQuestion.points,

--- a/tests/sync/assessmentsSync.js
+++ b/tests/sync/assessmentsSync.js
@@ -468,7 +468,7 @@ describe('Assessment syncing', () => {
     assert.match(syncedAssessment.sync_errors, /Real-time grading cannot be disabled for Homework-type assessments/);
   });
 
-  it('records an error if points array is specified for a question when real-time grading is disallowed', async () => {
+  it('records an error if multiple-element points array is specified for a question when real-time grading is disallowed', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData);
     assessment.allowRealTimeGrading = false;
@@ -485,10 +485,34 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('fail');
-    assert.match(syncedAssessment.sync_errors, /Cannot specify an array of points for a question/);
+    assert.match(syncedAssessment.sync_errors, /Cannot specify more than 1 point value for a question/);
   });
 
-  it('records an error if points array is specified for an alternative when real-time grading is disallowed', async () => {
+  it('accepts one-element points array being specified for a question when real-time grading is disallowed', async () => {
+    const courseData = util.getCourseData();
+    const assessment = makeAssessment(courseData);
+    assessment.allowRealTimeGrading = false;
+    assessment.zones = [{
+      title: 'zone 1',
+      questions: [{
+        id: util.QUESTION_ID,
+        points: [5],
+      }, {
+        id: util.ALTERNATIVE_QUESTION_ID,
+        points: [10],
+      }],
+    }];
+    courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['points_array_size_one'] = assessment;
+    await util.writeAndSyncCourseData(courseData);
+    const syncedAssessment = await findSyncedAssessment('points_array_size_one');
+    const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
+    assert.deepEqual(firstAssessmentQuestion.points_list, [5]);
+
+    const secondAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
+    assert.deepEqual(secondAssessmentQuestion.points_list, [10]);
+  });
+
+  it('records an error if multiple-element points array is specified for an alternative when real-time grading is disallowed', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData);
     assessment.allowRealTimeGrading = false;
@@ -507,7 +531,34 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('fail');
-    assert.match(syncedAssessment.sync_errors, /Cannot specify an array of points for an alternative/);
+    assert.match(syncedAssessment.sync_errors, /Cannot specify more than 1 point value for an alternative/);
+  });
+
+  it('accepts one-element points array being specified for an alternative when real-time grading is disallowed', async () => {
+    const courseData = util.getCourseData();
+    const assessment = makeAssessment(courseData);
+    assessment.allowRealTimeGrading = false;
+    assessment.zones = [{
+      title: 'zone 1',
+      questions: [{
+        points: [10],
+        alternatives: [{
+          id: util.QUESTION_ID,
+        }, {
+          id: util.ALTERNATIVE_QUESTION_ID,
+          points: [5],
+        }],
+      }],
+    }];
+    courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['points_array_size_one'] = assessment;
+    await util.writeAndSyncCourseData(courseData);
+    const syncedAssessment = await findSyncedAssessment('points_array_size_one');
+
+    const firstAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
+    assert.deepEqual(firstAssessmentQuestion.points_list, [10]);
+
+    const secondAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
+    assert.deepEqual(secondAssessmentQuestion.points_list, [5]);
   });
 
   it('records a warning if the same UUID is used multiple times in one course instance', async () => {

--- a/tests/sync/assessmentsSync.js
+++ b/tests/sync/assessmentsSync.js
@@ -488,7 +488,7 @@ describe('Assessment syncing', () => {
     assert.match(syncedAssessment.sync_errors, /Cannot specify an array of multiple point values for a question/);
   });
 
-  it('accepts a points array of size 1 being specified for a question when real-time grading is disallowed', async () => {
+  it('accepts a single-element points array being specified for a question when real-time grading is disallowed', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData);
     assessment.allowRealTimeGrading = false;
@@ -538,7 +538,7 @@ describe('Assessment syncing', () => {
     assert.match(syncedAssessment.sync_errors, /Cannot specify an array of multiple point values for an alternative/);
   });
 
-  it('accepts a points array of size 1 being specified for an alternative when real-time grading is disallowed', async () => {
+  it('accepts a single-element points array being specified for an alternative when real-time grading is disallowed', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData);
     assessment.allowRealTimeGrading = false;

--- a/tests/sync/assessmentsSync.js
+++ b/tests/sync/assessmentsSync.js
@@ -488,7 +488,7 @@ describe('Assessment syncing', () => {
     assert.match(syncedAssessment.sync_errors, /Cannot specify an array of multiple point values for a question/);
   });
 
-  it('accepts one-element points array being specified for a question when real-time grading is disallowed', async () => {
+  it('accepts a points array of size 1 being specified for a question when real-time grading is disallowed', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData);
     assessment.allowRealTimeGrading = false;
@@ -538,7 +538,7 @@ describe('Assessment syncing', () => {
     assert.match(syncedAssessment.sync_errors, /Cannot specify an array of multiple point values for an alternative/);
   });
 
-  it('accepts one-element points array being specified for an alternative when real-time grading is disallowed', async () => {
+  it('accepts a points array of size 1 being specified for an alternative when real-time grading is disallowed', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData);
     assessment.allowRealTimeGrading = false;

--- a/tests/sync/assessmentsSync.js
+++ b/tests/sync/assessmentsSync.js
@@ -504,7 +504,7 @@ describe('Assessment syncing', () => {
     }];
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['points_array_size_one'] = assessment;
     await util.writeAndSyncCourseData(courseData);
-    const syncedAssessment = await findSyncedAssessment('points_array_size_one');
+    const syncedAssessment = await getSyncedAssessmentData('points_array_size_one');
     const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
     assert.deepEqual(firstAssessmentQuestion.points_list, [5]);
 
@@ -552,7 +552,7 @@ describe('Assessment syncing', () => {
     }];
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['points_array_size_one'] = assessment;
     await util.writeAndSyncCourseData(courseData);
-    const syncedAssessment = await findSyncedAssessment('points_array_size_one');
+    const syncedAssessment = await getSyncedAssessmentData('points_array_size_one');
 
     const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
     assert.deepEqual(firstAssessmentQuestion.points_list, [10]);

--- a/tests/sync/assessmentsSync.js
+++ b/tests/sync/assessmentsSync.js
@@ -485,7 +485,7 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('fail');
-    assert.match(syncedAssessment.sync_errors, /Cannot specify more than 1 point value for a question/);
+    assert.match(syncedAssessment.sync_errors, /Cannot specify an array of multiple point values for a question/);
   });
 
   it('accepts one-element points array being specified for a question when real-time grading is disallowed', async () => {
@@ -504,12 +504,16 @@ describe('Assessment syncing', () => {
     }];
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['points_array_size_one'] = assessment;
     await util.writeAndSyncCourseData(courseData);
-    const syncedAssessment = await getSyncedAssessmentData('points_array_size_one');
-    const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
+    const syncedData = await getSyncedAssessmentData('points_array_size_one');
+    
+    const firstAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
     assert.deepEqual(firstAssessmentQuestion.points_list, [5]);
 
-    const secondAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
+    const secondAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
     assert.deepEqual(secondAssessmentQuestion.points_list, [10]);
+
+    const syncedAssessment = await findSyncedAssessment('points_array_size_one');
+    assert.equal(syncedAssessment.sync_errors, null);
   });
 
   it('records an error if multiple-element points array is specified for an alternative when real-time grading is disallowed', async () => {
@@ -531,7 +535,7 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('fail');
-    assert.match(syncedAssessment.sync_errors, /Cannot specify more than 1 point value for an alternative/);
+    assert.match(syncedAssessment.sync_errors, /Cannot specify an array of multiple point values for an alternative/);
   });
 
   it('accepts one-element points array being specified for an alternative when real-time grading is disallowed', async () => {
@@ -552,13 +556,16 @@ describe('Assessment syncing', () => {
     }];
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['points_array_size_one'] = assessment;
     await util.writeAndSyncCourseData(courseData);
-    const syncedAssessment = await getSyncedAssessmentData('points_array_size_one');
+    const syncedData = await getSyncedAssessmentData('points_array_size_one');
 
-    const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
+    const firstAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
     assert.deepEqual(firstAssessmentQuestion.points_list, [10]);
 
-    const secondAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
+    const secondAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
     assert.deepEqual(secondAssessmentQuestion.points_list, [5]);
+
+    const syncedAssessment = await findSyncedAssessment('points_array_size_one');
+    assert.equal(syncedAssessment.sync_errors, null);
   });
 
   it('records a warning if the same UUID is used multiple times in one course instance', async () => {

--- a/tests/sync/assessmentsSync.js
+++ b/tests/sync/assessmentsSync.js
@@ -508,7 +508,7 @@ describe('Assessment syncing', () => {
     const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
     assert.deepEqual(firstAssessmentQuestion.points_list, [5]);
 
-    const secondAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
+    const secondAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
     assert.deepEqual(secondAssessmentQuestion.points_list, [10]);
   });
 
@@ -554,10 +554,10 @@ describe('Assessment syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('points_array_size_one');
 
-    const firstAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
+    const firstAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.QUESTION_ID);
     assert.deepEqual(firstAssessmentQuestion.points_list, [10]);
 
-    const secondAssessmentQuestion = syncedData.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
+    const secondAssessmentQuestion = syncedAssessment.assessment_questions.find(aq => aq.question.qid === util.ALTERNATIVE_QUESTION_ID);
     assert.deepEqual(secondAssessmentQuestion.points_list, [5]);
   });
 


### PR DESCRIPTION
Closes #2211 

* Add unit tests and edit titles of tests for allowRealTimeGrading:false used with arrays

* Update error messages when a points array with multiple elements is used in this case