### PR TITLE
Fix editor crash when existing objects don't have long names

### DIFF
--- a/lib/editors.js
+++ b/lib/editors.js
@@ -596,6 +596,7 @@ class Editor {
         function getNumberLongName(oldnames) {
             let number = 1;
             oldnames.forEach((oldname) => {
+                if (!_.isString(oldname)) return;
                 const found = oldname.match(new RegExp(`^New \\(([0-9]+)\\)$`));
                 if (found) {
                     const foundNumber = parseInt(found[1]);


### PR DESCRIPTION
The current code assumes that all DB ojects have "long names" (titles).
This assumption is no longer valid with the new robust sync code, which
will sync objects even if their titles are NULL.

Fixes #3320 