### PR TITLE
Fix flapping during external grader autoscaling

### DIFF
--- a/cron/externalGraderLoad.js
+++ b/cron/externalGraderLoad.js
@@ -317,6 +317,22 @@ function sendStatsToCloudWatch(stats, callback) {
                     Value: stats.desired_instances_by_history_users,
                 },
                 {
+                    MetricName: 'DesiredInstancesCurrent',
+                    Dimensions: dimensions,
+                    StorageResolution: 1,
+                    Timestamp: stats.timestamp_formatted,
+                    Unit: 'Count',
+                    Value: stats.desired_instances_current,
+                },
+                {
+                    MetricName: 'DesiredInstancesHistory',
+                    Dimensions: dimensions,
+                    StorageResolution: 1,
+                    Timestamp: stats.timestamp_formatted,
+                    Unit: 'Count',
+                    Value: stats.desired_instances_history,
+                },
+                {
                     MetricName: 'DesiredInstances',
                     Dimensions: dimensions,
                     StorageResolution: 1,

--- a/sprocs/grader_loads_current.sql
+++ b/sprocs/grader_loads_current.sql
@@ -232,8 +232,8 @@ BEGIN
         ('desired_instances_by_history_jobs', desired_instances_by_history_jobs),
         ('desired_instances_by_current_users', desired_instances_by_current_users),
         ('desired_instances_by_history_users', desired_instances_by_history_users),
-        ('desired_instances_current', desired_instances_current);
-        ('desired_instances_history', desired_instances_history);
+        ('desired_instances_current', desired_instances_current),
+        ('desired_instances_history', desired_instances_history),
         ('desired_instances', desired_instances);
 
     -- ######################################################################

--- a/sprocs/grader_loads_current.sql
+++ b/sprocs/grader_loads_current.sql
@@ -42,7 +42,9 @@ CREATE OR REPLACE FUNCTION
         OUT desired_instances_by_history_jobs double precision,
         OUT desired_instances_by_current_users double precision,
         OUT desired_instances_by_history_users double precision,
-        OUT desired_instances integer,      -- the actual number of requested grading instances
+        OUT desired_instances_current integer,  -- instantaneous number of requested grading instances
+        OUT desired_instances_history integer,  -- max of historical values
+        OUT desired_instances integer,          -- the actual number of requested grading instances
         OUT timestamp_formatted text
     )
 AS $$
@@ -171,7 +173,7 @@ BEGIN
     desired_instances_by_history_jobs := history_jobs * history_capacity_factor / jobs_per_instance;
     desired_instances_by_current_users := predicted_jobs_by_current_users / jobs_per_instance;
     desired_instances_by_history_users := predicted_jobs_by_history_users / jobs_per_instance;
-    desired_instances := ceiling(greatest(
+    desired_instances_current := ceiling(greatest(
         1,
         desired_instances_by_ungraded_jobs,
         desired_instances_by_current_jobs,
@@ -179,6 +181,18 @@ BEGIN
         desired_instances_by_current_users,
         desired_instances_by_history_users
     ));
+
+    -- ######################################################################
+    -- anti-flapping using historical information
+
+    SELECT coalesce(max(value), 0)
+    INTO desired_instances_history
+    FROM time_series
+    WHERE
+        name = 'desired_instances'
+        AND date > now() - history_interval;
+
+    desired_instances := greatest(desired_instances_current, desired_instances_history);
 
     -- ######################################################################
     -- write data to time_series table
@@ -218,6 +232,8 @@ BEGIN
         ('desired_instances_by_history_jobs', desired_instances_by_history_jobs),
         ('desired_instances_by_current_users', desired_instances_by_current_users),
         ('desired_instances_by_history_users', desired_instances_by_history_users),
+        ('desired_instances_current', desired_instances_current);
+        ('desired_instances_history', desired_instances_history);
         ('desired_instances', desired_instances);
 
     -- ######################################################################


### PR DESCRIPTION
The external grader fleet autoscaling code using multiple metrics to
estimate the desired number of graders. Most of these take a `max()`
over recent historical data and so are not subject to "flapping" (rapid
upscaling followed by immediate downscaling). However, we also use the
instantaneous number of ungraded jobs to compute the desired number of
graders, which can rapidly fluctuate. To avoid the flapping that this
can cause, this PR unconditionally latches the desired number of graders
to a `max()` over the recent past. This will avoid flapping due to
upscaling-then-downscaling. We can still have downscaling-then-upscaling
flapping, but we want that because it's caused by the need to respond to
actual load increases.