### PR TITLE
C Grader: compilation warnings message on main results page.

### DIFF
--- a/docs/c-grader/index.md
+++ b/docs/c-grader/index.md
@@ -45,8 +45,6 @@ Most questions using this autograder will contain a `pl-file-editor` or `pl-file
 </pl-submission-panel>
 ```
 
-Any file submitted using a `pl-file-editor` or `pl-file-upload` will be available for use by the C grader. Other elements can also be accessed using the same `data` structure used in functions in `server.py`, as described below.
-
 ### `tests/test.py`
 
 The `test.py` file will contain the basic tests that must be executed by the C grader. A simple `test.py` will look like this:
@@ -67,7 +65,13 @@ g.start()
 
 The `tests` method above will contain the basis for user tests, and will have access to some regular functions provided by the C grader. Some methods that can be called are listed below.
 
-To create tests based on parameters defined by `server.py`, or to have access to submitted data from other elements such as `pl-string-input` elements, you can access the `self.data` dictionary. This dictionary contains the similar keys to those found in the `grade()` function in `server.py`, such as `self.data["params"]` or `self.data["submitted_answers"]`.
+Any file submitted using a `pl-file-editor` or `pl-file-upload` will
+be available for use by the C grader. To create tests based on
+parameters defined by `server.py`, or to have access to submitted data
+from other elements such as `pl-string-input` elements, you can access
+the `self.data` dictionary. This dictionary contains the similar keys
+to those found in the `grade()` function in `server.py`, such as
+`self.data["params"]` or `self.data["submitted_answers"]`.
 
 ## Available test options
 
@@ -83,6 +87,12 @@ By default, if the compilation fails, it will stop all tests and return the subm
 
 ```python
 self.test_compile_file('square.c', 'square', ungradable_if_failed=False)
+```
+
+By default, if the compilation succeeds but gives a warning, a message with the warning will be listed in the main results message, above the test results. If you would like the warnings to be listed only inside the results of the specific test, you can call the function with:
+
+```python
+self.test_compile_file('square.c', 'square', add_warning_result_msg=False)
 ```
 
 The results of the compilation will show up as a test named "Compilation", worth one point. To change the name and/or points, set the `name` or `points` argument as follows:
@@ -272,5 +282,5 @@ By default, the sandbox user will not have access to any files inside the `/grad
 self.change_mode('/grade/student/myfile.txt', '744')
 ```
 
-Any program compiled with `test_compile_file()` will be granted executable permissions (mode `755`, so these programs don't need to be explicitly allowed by your tests.
+Any program compiled with `test_compile_file()` will be granted executable permissions (mode `755`), so these programs don't need to be explicitly allowed by your tests.
 

--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -61,6 +61,7 @@ class CGrader:
 
     def test_compile_file(self, c_file, exec_file, main_file=None, add_c_file=None,
                           points=1, field=None, flags=None, name='Compilation',
+                          add_warning_result_msg=True,
                           ungradable_if_failed=True):
 
         if flags and not isinstance(flags, list):
@@ -100,8 +101,10 @@ class CGrader:
         if os.path.isfile(exec_file):
             self.change_mode(exec_file, '755')
         elif ungradable_if_failed:
-            self.result['message'] = 'Compilation errors, please fix and try again.\n\n' + out
+            self.result['message'] += f'Compilation errors, please fix and try again.\n\n{out}\n'
             raise UngradableException()
+        if out and add_warning_result_msg:
+            self.result['message'] += f'Compilation warnings:\n\n{out}\n'
         return self.add_test_result(name, output=out,
                                     points=os.path.isfile(exec_file),
                                     max_points=points, field=field)
@@ -262,8 +265,6 @@ class CGrader:
         except UngradableException:
             self.result['gradable'] = False
         finally:
-            if self.result['gradable']:
-                self.result['message'] = 'Tests completed'
             self.save_results()
 
     def tests(self):


### PR DESCRIPTION
From experience students tend to ignore compilation warnings if the compilation test passes. This PR highlights the warnings in the main tests message, so students can address them as a possible reason for their tests to be failing.