### PR TITLE
Grading pre post split

### DIFF
--- a/database/tables/grading_jobs.pg
+++ b/database/tables/grading_jobs.pg
@@ -15,6 +15,7 @@ columns
     grading_started_at: timestamp with time zone
     grading_submitted_at: timestamp with time zone
     id: bigint not null default nextval('grading_jobs_id_seq'::regclass)
+    manual_score: double precision
     output: text
     partial_scores: jsonb
     s3_bucket: text
@@ -22,6 +23,7 @@ columns
     score: double precision
     submission_id: bigint not null
     v2_score: double precision
+    weight_score: double precision
 
 indexes
     grading_jobs_pkey: PRIMARY KEY (id) USING btree (id)

--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -12,6 +12,7 @@ columns
     external_grading_timeout: integer
     grading_method: enum_grading_method not null default 'Internal'::enum_grading_method
     id: bigint not null default nextval('questions_id_seq'::regclass)
+    manual_grading_score_limit: double precision
     number: integer
     options: jsonb
     partial_credit: boolean default true

--- a/exampleCourse/questions/demo/autograder/codeUpload/question.html
+++ b/exampleCourse/questions/demo/autograder/codeUpload/question.html
@@ -18,6 +18,12 @@
   <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
 
   <pl-file-upload file-names="fib.py"></pl-file-upload>
+
+  A <pl-dropdown sort="ascend" answers-name="hume">
+    <pl-answer correct="true">wise</pl-answer>
+    <pl-answer correct="false">clumsy</pl-answer>
+    <pl-answer correct="false">reckless</pl-answer>
+  </pl-dropdown> man proportions his belief to the evidence. <p></p>
 </pl-question-panel>
 
 <pl-submission-panel>

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -327,7 +327,7 @@ module.exports = {
                 }
                 // 0 is valid score
                 if (content.grading.score === 0 || content.grading.score) {
-                    if (content.grading.partial_scores && content.grading.partial_scores.length > 0) {
+                    if (content.grading.partial_scores && Object.keys(content.grading.partial_scores).length) {
                         content.grading['status'] = 'pre-graded';
                         content.grading['score'] = formulas.calcQuestionScore(content.grading.partialScores, content.grading.partialCredit);
                     }

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -10,6 +10,7 @@ const logger = require('../lib/logger');
 const question = require('../lib/question');
 const externalGrader = require('./externalGrader');
 const externalGradingSocket = require('../lib/externalGradingSocket');
+const formulas = require('../lib/formulas');
 const sqldb = require('@prairielearn/prairielib/sql-db');
 const sqlLoader = require('@prairielearn/prairielib/sql-loader');
 const ltiOutcomes = require('../lib/ltiOutcomes');
@@ -282,11 +283,11 @@ module.exports = {
     /**
      * Process the result of an external grading job.
      *
-     * @param {Obect} content - The grading job data to process.
+     * @param {Object} content - The grading job data to process.
      */
     processGradingResult(content) {
         async.series([
-            (callback) => {
+            async (callback) => {
                 if (!_(content.grading).isObject()) {
                     return callback(error.makeWithData('invalid grading', {content: content}));
                 }
@@ -308,6 +309,17 @@ module.exports = {
                     if (content.grading.score < 0 || content.grading.score > 1) {
                         return callback(error.makeWithData('grading.score out of range', {content: content}));
                     }
+                    if (content.grading.score && content.grading.partialScores && content.grading.partialScores.length > 0) {
+                        return callback(error.makeWithData('cannot submit both a grading.score and a grading.partial_scores.'));
+                    }
+                    // if (content.grading.score.isNumber() && content.grading.partial_scores) {
+                    //     return callback(error.makeWithData('cannot submit partial grades and grade score', {content: content}));
+                    // }
+                }
+
+                if (content.grading.partial_scores && content.grading.partial_scores.length > 0) {
+
+                    content.grading['score'] = formulas.calcQuestionScore(content.grading.partialScores, content.grading.partialCredit);
                 }
                 
                 const params = [
@@ -320,6 +332,7 @@ module.exports = {
                     content.grading.endTime,
                     gradable,
                 ];
+
                 sqldb.call('grading_jobs_process_external', params, (err) => {
                     if (ERR(err, callback)) return;
                     callback(null);

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -287,7 +287,15 @@ module.exports = {
      */
     processGradingResult(content) {
         async.series([
-            async (callback) => {
+            (callback) => {
+                // We need to know partial_credit bool to grade partial_scores
+                sqldb.queryOneRow(sql.select_question_for_grading_job, {grading_job_id: content.gradingId}, (err, result) => {
+                    if (ERR(err, callback)) return;
+                    if (content && content.grading) content.grading['partialCredit'] = result.rows[0].partial_credit;
+                    callback(null);
+                });
+            },
+            (callback) => {
                 if (!_(content.grading).isObject()) {
                     return callback(error.makeWithData('invalid grading', {content: content}));
                 }
@@ -309,16 +317,19 @@ module.exports = {
                     if (content.grading.score < 0 || content.grading.score > 1) {
                         return callback(error.makeWithData('grading.score out of range', {content: content}));
                     }
-                    if (content.grading.score && content.grading.partialScores && content.grading.partialScores.length > 0) {
-                        return callback(error.makeWithData('cannot submit both a grading.score and a grading.partial_scores.'));
-                    }
+                    // Try to warn them, but if score is legitimately 0 it is valid score but false here:
+                    // if (content.grading.score && content.grading.partialScores && content.grading.partialScores.length > 0) {
+                    //     return callback(error.makeWithData('cannot submit both a grading.score and grading.partial_scores.'), {content: content});
+                    // }
+                    // Solution: just grade partials if they are submitted and not deal with this backwards compatible issue
                     // if (content.grading.score.isNumber() && content.grading.partial_scores) {
                     //     return callback(error.makeWithData('cannot submit partial grades and grade score', {content: content}));
                     // }
                 }
 
                 if (content.grading.partial_scores && content.grading.partial_scores.length > 0) {
-
+                    // unfortunately, we have no way to know if valid container score = 0
+                    content.grading['status'] = 'pre-graded';
                     content.grading['score'] = formulas.calcQuestionScore(content.grading.partialScores, content.grading.partialCredit);
                 }
                 

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -321,16 +321,16 @@ module.exports = {
                     // if (content.grading.score && content.grading.partialScores && content.grading.partialScores.length > 0) {
                     //     return callback(error.makeWithData('cannot submit both a grading.score and grading.partial_scores.'), {content: content});
                     // }
-                    // Solution: just grade partials if they are submitted and not deal with this backwards compatible issue
                     // if (content.grading.score.isNumber() && content.grading.partial_scores) {
                     //     return callback(error.makeWithData('cannot submit partial grades and grade score', {content: content}));
                     // }
                 }
-
-                if (content.grading.partial_scores && content.grading.partial_scores.length > 0) {
-                    // unfortunately, we have no way to know if valid container score = 0
-                    content.grading['status'] = 'pre-graded';
-                    content.grading['score'] = formulas.calcQuestionScore(content.grading.partialScores, content.grading.partialCredit);
+                // 0 is valid score
+                if (content.grading.score === 0 || content.grading.score) {
+                    if (content.grading.partial_scores && content.grading.partial_scores.length > 0) {
+                        content.grading['status'] = 'pre-graded';
+                        content.grading['score'] = formulas.calcQuestionScore(content.grading.partialScores, content.grading.partialCredit);
+                    }
                 }
                 
                 const params = [

--- a/lib/assessment.sql
+++ b/lib/assessment.sql
@@ -20,3 +20,15 @@ FROM
     LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
 WHERE
     gj.id = $grading_job_id;
+
+-- BLOCK select_question_for_grading_job
+SELECT 
+    q.*
+FROM 
+    grading_jobs AS gj
+    JOIN submissions as s ON (s.id = gj.submission_id)
+    JOIN variants AS v ON (v.id = s.variant_id)
+    LEFT JOIN questions as q ON (q.id = v.question_id)
+WHERE
+    gj.id = $grading_job_id;
+

--- a/lib/externalGrader.js
+++ b/lib/externalGrader.js
@@ -111,8 +111,8 @@ function handleGraderError(jobId, err) {
         gradingId: jobId,
         grading: {
             score: 0,
-            partialCredit: question.partialCredit,
-            partialScores: [],
+            partialCredit: null,
+            partialScores: null,
             startTime: null,
             endTime: null,
             feedback: {

--- a/lib/externalGrader.js
+++ b/lib/externalGrader.js
@@ -96,7 +96,6 @@ module.exports._beginGradingJob = function(grading_job, submission, variant, que
     gradeRequest.on('results', (gradingResult) => {
         // This event will only be fired when running locally; in production,
         // external grader results wil be delivered via webhook.
-
         module.exports.assessment.processGradingResult(gradingResult);
         logger.verbose(`Successfully processed grading job ${grading_job.id}`);
     });

--- a/lib/externalGrader.js
+++ b/lib/externalGrader.js
@@ -64,6 +64,8 @@ module.exports._beginGradingJob = function(grading_job, submission, variant, que
             gradingId: grading_job.id,
             grading: {
                 score: 0,
+                partialCredit: question.partial_credit,
+                partialScores: [],
                 feedback: {
                     succeeded: true,
                     message: 'External grading is not enabled :(',
@@ -94,6 +96,10 @@ module.exports._beginGradingJob = function(grading_job, submission, variant, que
     gradeRequest.on('results', (gradingResult) => {
         // This event will only be fired when running locally; in production,
         // external grader results wil be delivered via webhook.
+
+        // We need the partialCredit flag if partial_scores are returned from container
+        if (typeof gradingResult.partialCredit !== 'undefined') gradingResult['partialCredit'] = question.partial_credit;
+
         module.exports.assessment.processGradingResult(gradingResult);
         logger.verbose(`Successfully processed grading job ${grading_job.id}`);
     });
@@ -109,6 +115,8 @@ function handleGraderError(jobId, err) {
         gradingId: jobId,
         grading: {
             score: 0,
+            partialCredit: question.partialCredit,
+            partialScores: [],
             startTime: null,
             endTime: null,
             feedback: {

--- a/lib/externalGrader.js
+++ b/lib/externalGrader.js
@@ -65,7 +65,7 @@ module.exports._beginGradingJob = function(grading_job, submission, variant, que
             grading: {
                 score: 0,
                 partialCredit: question.partial_credit,
-                partialScores: [],
+                partialScores: submission.partial_scores,
                 feedback: {
                     succeeded: true,
                     message: 'External grading is not enabled :(',
@@ -96,9 +96,6 @@ module.exports._beginGradingJob = function(grading_job, submission, variant, que
     gradeRequest.on('results', (gradingResult) => {
         // This event will only be fired when running locally; in production,
         // external grader results wil be delivered via webhook.
-
-        // We need the partialCredit flag if partial_scores are returned from container
-        if (typeof gradingResult.partialCredit !== 'undefined') gradingResult['partialCredit'] = question.partial_credit;
 
         module.exports.assessment.processGradingResult(gradingResult);
         logger.verbose(`Successfully processed grading job ${grading_job.id}`);

--- a/lib/formulas.js
+++ b/lib/formulas.js
@@ -3,22 +3,22 @@ const _ = require('lodash');
 const formulas = module.exports;
 
 formulas.calcQuestionScore = (partialScores, partialCredit) => {
-    let score = 0;
+    let questionScore = 0;
     if (partialCredit) {
         let total_weight = 0, total_weight_score = 0;
         _.each(partialScores, value => {
-            const score = _.get(value, 'score', 0);
+            const partialScore = _.get(value, 'score', 0);
             const weight = _.get(value, 'weight', 1);
             total_weight += weight;
-            total_weight_score += weight * score;
+            total_weight_score += weight * partialScore;
         });
-        score = total_weight_score / (total_weight == 0 ? 1 : total_weight);
+        questionScore = total_weight_score / (total_weight == 0 ? 1 : total_weight);
     } else {
         if (_.size(partialScores) > 0 && _.every(partialScores, value => _.get(value, 'score', 0) >= 1)) {
-            score = 1;
+            questionScore = 1;
         }
     }
-    return score;
+    return questionScore;
 };
 
 formulas.calcAssessmentScore = (...assessment_score_args) => {

--- a/lib/formulas.js
+++ b/lib/formulas.js
@@ -2,6 +2,15 @@ const _ = require('lodash');
 
 const formulas = module.exports;
 
+/**
+ * Pre-grading calculation: 
+ * 
+ * Calculate a score for a question based on the partial_scores (submitted from question parts)
+ * submitted for each question part.
+ * @param {Object} partialScores Each key in object contains a {score: number, weight: number} type as value. 
+ * @param {Boolean} partialCredit Set in info.json on Question to use weighting when calc score from partial scores.
+ * @return Number - Returns caculated score
+ */
 formulas.calcQuestionScore = (partialScores, partialCredit) => {
     let questionScore = 0;
     if (partialCredit) {

--- a/lib/formulas.js
+++ b/lib/formulas.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const formulas = module.exports;
 
 formulas.calcQuestionScore = (partialScores, partialCredit) => {
-    let score;
+    let score = 0;
     if (partialCredit) {
         let total_weight = 0, total_weight_score = 0;
         _.each(partialScores, value => {

--- a/lib/formulas.js
+++ b/lib/formulas.js
@@ -1,0 +1,23 @@
+const _ = require('lodash');
+
+const formulas = module.exports;
+
+formulas.calcQuestionScore = (partialScores, partialCredit = true) => {
+    let score;
+    if (partialCredit) {
+        let total_weight = 0, total_weight_score = 0;
+        _.each(partialScores, value => {
+            const score = _.get(value, 'score', 0);
+            const weight = _.get(value, 'weight', 1);
+            total_weight += weight;
+            total_weight_score += weight * score;
+        });
+        score = total_weight_score / (total_weight == 0 ? 1 : total_weight);
+    } else {
+        if (_.size(partialScores) > 0 && _.every(partialScores, value => _.get(value, 'score', 0) >= 1)) {
+            score = 1;
+        }
+    }
+    return score;
+};
+

--- a/lib/formulas.js
+++ b/lib/formulas.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 const formulas = module.exports;
 
-formulas.calcQuestionScore = (partialScores, partialCredit = true) => {
+formulas.calcQuestionScore = (partialScores, partialCredit) => {
     let score;
     if (partialCredit) {
         let total_weight = 0, total_weight_score = 0;
@@ -21,3 +21,7 @@ formulas.calcQuestionScore = (partialScores, partialCredit = true) => {
     return score;
 };
 
+formulas.calcAssessmentScore = (...assessment_score_args) => {
+    console.log(assessment_score_args);
+    return null;
+};

--- a/lib/question.js
+++ b/lib/question.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 const async = require('async');

--- a/lib/question.js
+++ b/lib/question.js
@@ -564,7 +564,15 @@ module.exports = {
                     debug('_gradeVariantWithClient()', 'completed grade()', 'hasFatalIssue:', hasFatalIssue);
                     callback(null);
                 });
+                // Partial scores should now be produced by the internal grading logic. What about external?
             },
+            // How do we know if there is additional grading to do?
+            // We either get partial scores back, or none. 
+            // Some elements just cannot be graded. ie. Overlay element.
+            // File-editor-stuff should be external graded.
+            // Values that are submitted into the external grader are usually submitted through the _file_editor or _files attributes.
+            // If we have a _file_editor or _files attribute, it could signal external grading.
+            // The grade() function should be what does the grading.
             (callback) => {
                 const studentMessage = 'Error grading submission';
                 const courseData = {variant, question, submission, course};

--- a/lib/question.js
+++ b/lib/question.js
@@ -551,28 +551,18 @@ module.exports = {
                 });
             },
             (callback) => {
-
-                // THIS IS WHERE WE WANT TO DO THE PRE-GRADING.
-                // 1. INTERNAL AND EXTERNAL GRADING HAVE TO RUN. 
-                //    QUESTION. Can they run consistently here? Is there any reaosn why not? 
-
-                // Took out the internal and external conditional to see if we can pre-grade external grade and internal grade mixed questions.
-                    questionModule.grade(submission, variant, question, course, (err, ret_courseIssues, ret_data) => {
-                        if (ERR(err, callback)) return;
-                        courseIssues = ret_courseIssues;
-                        data = ret_data;
-                        const hasFatalIssue = _.some(_.map(courseIssues, 'fatal'));
-                        if (hasFatalIssue) data.gradable = false;
-                        data.broken = hasFatalIssue;
-                        debug('_gradeVariantWithClient()', 'completed grade()', 'hasFatalIssue:', hasFatalIssue);
-                        callback(null);
-                    });
-                    
-                    // for External or Manual grading we don't do anything
-                    // courseIssues = [];
-                    // data = {};
-                    // callback(null);
-
+                // Took out the internal and external branching to see if we can pre-grade external grade and internal grade mixed questions.
+                // Assumption: Unified model exists and properly constructed code will not break this chain.
+                questionModule.grade(submission, variant, question, course, (err, ret_courseIssues, ret_data) => {
+                    if (ERR(err, callback)) return;
+                    courseIssues = ret_courseIssues;
+                    data = ret_data;
+                    const hasFatalIssue = _.some(_.map(courseIssues, 'fatal'));
+                    if (hasFatalIssue) data.gradable = false;
+                    data.broken = hasFatalIssue;
+                    debug('_gradeVariantWithClient()', 'completed grade()', 'hasFatalIssue:', hasFatalIssue);
+                    callback(null);
+                });
             },
             (callback) => {
                 const studentMessage = 'Error grading submission';

--- a/lib/question.js
+++ b/lib/question.js
@@ -475,6 +475,39 @@ module.exports = {
         });
     },
 
+    // Can't do pre and post grade splits like this, as external grader MUST continue to produce scores for already
+    // implemented questions.
+
+    // Is there a way to return data from external grader with a handler to continue POST logic section?
+
+    /**
+     * Pre-Grade takes internal or external submission and produces partial_grades for post-grading.
+     * @param {*} client 
+     * @param {*} variant 
+     * @param {*} check_submission_id 
+     * @param {*} question 
+     * @param {*} course 
+     * @param {*} authn_user_id 
+     * @param {*} callback 
+     */
+    _preGradeVariantWithClient(client, variant, check_submission_id, question, course, authn_user_id, callback) {
+
+    },
+
+    /**
+     * Post-Grade takes partial_grades and submission data to produce a submission score for a variant
+     * @param {*} client 
+     * @param {*} variant 
+     * @param {*} check_submission_id 
+     * @param {*} question 
+     * @param {*} course 
+     * @param {*} authn_user_id 
+     * @param {*} callback 
+     */
+    _postGradeVariantWithClient(client, variant, check_submission_id, question, course, authn_user_id, callback) {
+
+    },
+
     /**
      * Internal worker for gradeVariant(). Do not call directly.
      * @protected
@@ -518,8 +551,12 @@ module.exports = {
                 });
             },
             (callback) => {
-                if (question.grading_method == 'Internal') {
-                    // for Internal grading we call the grading code
+
+                // THIS IS WHERE WE WANT TO DO THE PRE-GRADING.
+                // 1. INTERNAL AND EXTERNAL GRADING HAVE TO RUN. 
+                //    QUESTION. Can they run consistently here? Is there any reaosn why not? 
+
+                // Took out the internal and external conditional to see if we can pre-grade external grade and internal grade mixed questions.
                     questionModule.grade(submission, variant, question, course, (err, ret_courseIssues, ret_data) => {
                         if (ERR(err, callback)) return;
                         courseIssues = ret_courseIssues;
@@ -530,12 +567,12 @@ module.exports = {
                         debug('_gradeVariantWithClient()', 'completed grade()', 'hasFatalIssue:', hasFatalIssue);
                         callback(null);
                     });
-                } else {
+                    
                     // for External or Manual grading we don't do anything
-                    courseIssues = [];
-                    data = {};
-                    callback(null);
-                }
+                    // courseIssues = [];
+                    // data = {};
+                    // callback(null);
+
             },
             (callback) => {
                 const studentMessage = 'Error grading submission';
@@ -663,6 +700,11 @@ module.exports = {
             if (ERR(err, callback)) return;
             async.series([
                 (callback) => {
+                    if(submission) console.log(submission);
+                    if (ERR(err, callback)) return;
+                    callback(null);
+                },
+                (callback) => {
                     this._saveSubmissionWithClient(client, submission, variant, question, course, (err, ret_submission_id) => {
                         if (ERR(err, callback)) return;
                         submission_id = ret_submission_id;
@@ -671,6 +713,8 @@ module.exports = {
                     });
                 },
                 (callback) => {
+                    // await this._preGradeVariantWithClient(client, variant, submission_id, question, course, submission.auth_user_id);
+                    // await this._postGradeVariantWithClient(client, variant, submission_id, question, course, submission.auth_user_id);
                     this._gradeVariantWithClient(client, variant, submission_id, question, course, submission.auth_user_id, (err, ret_grading_job_id) => {
                         if (ERR(err, callback)) return;
                         grading_job_id = ret_grading_job_id;

--- a/migrations/220_grading_jobs__manual_grading.sql
+++ b/migrations/220_grading_jobs__manual_grading.sql
@@ -1,0 +1,2 @@
+ALTER TABLE grading_jobs ADD COLUMN IF NOT EXISTS manual_score double precision;
+ALTER TABLE grading_jobs ADD COLUMN IF NOT EXISTS weight_score double precision;

--- a/migrations/221_questions__manual_grading_score_limit.sql
+++ b/migrations/221_questions__manual_grading_score_limit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE questions ADD COLUMN IF NOT EXISTS manual_grading_score_limit double precision;

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -622,7 +622,6 @@ module.exports = {
             processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {
                 if (phase == 'grade' || phase == 'test') {
                     data.score = formulas.calcQuestionScore(data.partial_scores, context.question.partial_credit);
-                    data.feedback = {};
                 }
 
                 callback(null, courseIssues, data, questionHtml, fileData, renderedElementNames);

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -621,7 +621,7 @@ module.exports = {
 
             processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {
                 if (phase == 'grade' || phase == 'test') {
-                    data.score = this.calcScore(data.partial_scores, context.question.partial_credit);
+                    data.score = formulas.calcQuestionScore(data.partial_scores, context.question.partial_credit);
                 }
 
                 callback(null, courseIssues, data, questionHtml, fileData, renderedElementNames);

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -620,7 +620,7 @@ module.exports = {
             }
 
             processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {
-                if (phase == 'grade' || phase == 'test') {
+                if (phase == 'grade') {
                     data.score = formulas.calcQuestionScore(data.partial_scores, context.question.partial_credit);
                 }
 

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -622,6 +622,7 @@ module.exports = {
             processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {
                 if (phase == 'grade' || phase == 'test') {
                     data.score = formulas.calcQuestionScore(data.partial_scores, context.question.partial_credit);
+                    data.feedback = {};
                 }
 
                 callback(null, courseIssues, data, questionHtml, fileData, renderedElementNames);

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -620,7 +620,7 @@ module.exports = {
             }
 
             processFunction(...args, (courseIssues, data, questionHtml, fileData, renderedElementNames) => {
-                if (phase == 'grade') {
+                if (phase == 'grade' || phase == 'test') {
                     data.score = formulas.calcQuestionScore(data.partial_scores, context.question.partial_credit);
                 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -32,6 +32,7 @@ require('./testApi');
 require('./testLti');
 require('./testCron');
 require('./testNewsItems');
+require('./testManualGrading');
 require('./testZoneGradingHomework');
 require('./testZoneGradingExam');
 require('./testSproc-check_course_instance_access');

--- a/tests/testManualGrading.js
+++ b/tests/testManualGrading.js
@@ -1,0 +1,84 @@
+var ERR = require('async-stacktrace');
+var _ = require('lodash');
+var assert = require('chai').assert;
+var request = require('request');
+var cheerio = require('cheerio');
+
+var config = require('../lib/config');
+var sqldb = require('@prairielearn/prairielib/sql-db');
+var sqlLoader = require('@prairielearn/prairielib/sql-loader');
+var sql = sqlLoader.loadSqlEquiv(__filename);
+
+var helperServer = require('./helperServer');
+var helperQuestion = require('./helperQuestion');
+
+const locals = {};
+
+locals.siteUrl = 'http://localhost:' + config.serverPort;
+locals.baseUrl = locals.siteUrl + '/pl';
+locals.courseBaseUrl = locals.baseUrl + '/course/1';
+locals.courseInstanceBaseUrl = locals.baseUrl + '/course_instance/1/instructor';
+locals.questionBaseUrl = locals.courseInstanceBaseUrl + '/question';
+locals.questionPreviewTabUrl = '/preview';
+locals.questionSettingsTabUrl = '/settings';
+locals.questionsUrl = locals.courseInstanceBaseUrl + '/course_admin/questions';
+locals.questionsUrlCourse = locals.courseBaseUrl + '/course_admin/questions';
+locals.isStudentPage = false;
+
+describe('Instructor manual grading', function() {
+    this.timeout(60000);
+
+    before('set up testing server', helperServer.before());
+    after('shut down testing server', helperServer.after);
+
+    // describe('the database', function() {
+    //     it('should contain question with manual grading question', function(callback) {
+    //         sqldb.query(sql.select_manual_grading_question, [], function(err, result) {
+    //             if (ERR(err, callback)) return;
+    //             if (result.rowCount == 0) {
+    //                 return callback(new Error('no questions in DB'));
+    //             }
+    //             locals.questions = result.rows;
+    //             callback(null);
+    //         });
+    //     });
+    // });
+
+    describe('Manual grading features', () => {
+        it('Front-end should be able to see prior grading info on manual grading question', () => {
+            // Coordinate with mebird
+        });
+
+        it('Should be able to override prior grade, 100% of question value, if override mode option set on question', () => {
+            // allows for 100% of the question to be determined by the value entered manually
+        });
+    });
+
+    describe('Manual grading weighted score', () => {
+        it('Weighted grading should result in a grade of x% of final mark for manual score', () => {
+
+        });
+
+        it('Weighted grading should result autograded score being 100-x where x is manual score', () => {
+
+        });
+    });
+
+    describe('Manual grading post-grade results', () => {
+        it('Should produce a post-grade score after internal grader has run', () => {
+
+        });
+
+        it('Should produce a post-grade score after external grader has run on manual graded question', () => {
+
+        });
+
+        it('Should produce a post-grade score after manual grade operation', () => {
+
+        });
+    });
+
+    describe('Manual grading pre-grade and post-grade internal and external chaining ', () => {
+        it('Internal grader should produce pre-score partials and ')
+    });
+});

--- a/tests/testManualGrading.js
+++ b/tests/testManualGrading.js
@@ -44,17 +44,17 @@ describe('Instructor manual grading', function() {
     //     });
     // });
 
-    describe('Manual grading features', () => {
+    describe('1. Override prior grade', () => {
         it('Front-end should be able to see prior grading info on manual grading question', () => {
             // Coordinate with mebird
         });
 
-        it('Should be able to override prior grade, 100% of question value, if override mode option set on question', () => {
+        it('Should be able to override prior grade, for 100% of question value, if override mode option set on question', () => {
             // allows for 100% of the question to be determined by the value entered manually
         });
     });
 
-    describe('Manual grading weighted score', () => {
+    describe('2. Manual grading weighted score', () => {
         it('Weighted grading should result in a grade of x% of final mark for manual score', () => {
 
         });
@@ -79,6 +79,10 @@ describe('Instructor manual grading', function() {
     });
 
     describe('Manual grading pre-grade and post-grade internal and external chaining ', () => {
-        it('Internal grader should produce pre-score partials and ')
+        it('Internal grader should produce pre-score partials and post-score, but send pre-score to external grader for further post-grading', () => {
+
+        });
+
+        it('External grader should produce ')
     });
 });

--- a/tests/testManualGrading.sql
+++ b/tests/testManualGrading.sql
@@ -1,0 +1,3 @@
+
+-- BLOCK select_assessment_for_grading_job
+SELECT * FROM assessments;


### PR DESCRIPTION
## To do: 

- Must implement statuses in `instance_question` that determine if an item has been pre-graded or post-graded. (Old convention is to use the graded_at timestamp to know if something has been graded).
- Pre-graded `instance questions` are anything that have finished the grading run but has unmarked manual grading objects. 
- Figure out a manual grading flag. Perhaps just default to manual graded = false and the UI can use JavaScript/Locals to determine if manual grading element exists on front-end. 
- 

## Questions for @cheeren and @mebird (for meeting): 
--------------------------------
- It seems like something is ready to be post-graded if it has completed pre-grading by an internal or external grading operation and has either been manually graded or is precluded from manual grading. Can we agree?
- It seems like a pre-grade operation should return the 
- What is the criteria to be precluded OR included for manual grading, other than having a pre-grade? (@mebird, what data do you need sent to the front-end here to determine if an item is manually gradable on the front-end? status, and is there something in the question that labels something for later manual grading?)

## Cover these requirements below

### Instance Question Ready to be Post-Graded:

- Has been pre-graded by internal OR external grader OR both grader types
   AND
- IF AND ONLY IF all manual grade objects that exist on an `instance question` have been manually graded.

To implement the above, we can add a hook after the end of the grading cycle to always check if manual grading exists on the object. If it does, then label the instance question as pre-graded and await for manual grading. 

@mebird We will send back information about an `instance question` that is loaded on the instructor UI with a pre-graded or post-graded status. Your logic should run when something is in pre-graded state, but not sure about post-graded state, eh?
@cheeren We have to assess whether we want this UI logic to be available for the post-graded `instance questions`. Perhaps we are blocked by the `regrading` topic? Or perhaps, as manual grading only occurs after internal and external grading, then we can always re-submit the manual grade scores and re-tabulate the final score? Post-graded items can still be manually re-graded as many times as you want, in other words, as it doesn't have too many moving parts, I beileve. 

### Internal Grader:
-------------------

Summary: The internal grader is already used by instructors' question banks. We should leave this logic intact. It 1) produces a partial score and 2) a tabulated score with the partial score data that, so far exists. This data can be sent to the external grader operation, returned, and the concatenated data from internal and external grading can be available for the manual grader operation.

- [ ] Occurs before any external grading to ensure that external grading container receives pre-tabulated `partial scores` and pre-grade `scores` that are finalized after external grading and/or manual grading have completed.
- [ ] Does not stamp a pre-graded or post-graded status.

### External Grader:
-------------------

Summary: The external grader is already used by instructors' grading containers. Backwards compatibility must be maintained for external grading containers that already exist and produce a score from partial scores (post-grading).  The external grading containers that already exist return a `grade` instead of `partial_scores`. 

Hence, the external grader will have to stamp a:
- [ ] Does NOT stamp a pre-graded or post-graded status.
- [ ] Needs to query database to get `partial_scores` from internal grader as input for its own internal sake.
- [ ] Can produce the score for a question (if it does, then we do not partial grade)
- [ ] Can produce partial_scores for a question (if it does, then we partial grade to produce a score)

### Manual Grading:

- [ ] Receives `[questionName]`: {score: number, weight: number} type Array object from an endpoint.
- [ ] Manual Grading Controller takes pre-graded scores (either an internal or external container run, or both) and re-calculates with the prior `partial score` and new `manual scores` to produce the final `score` object. 
- [ ] Does not make sense to stamp a manual graded status here, as condition for post-grading is that [Instance Question Ready to be Post Graded](#instance-question-ready-to-be-post-graded)

### Test Acceptance Criteria:

- [ ] An `instance question` can be labelled as pre-graded, which enables the manual grading UI.
  - [ ] The `instance question` is ONLY labelled as pre-graded, even if it returns a tabulated `score` from `partial scores` because the grade could potentially be changed at the mid-MANUAL step.
- [ ] Every `instance question` that finishes the pre-grading steps is sent for post-grading IF AND ONLY IF there are no manual grading questions to be submitted.
- [ ] Backwards compatibility is provided for old external grading containers that simply produce a score and reach POST-grade state. @cheeren How do we know if this is an old container?


  ::: BUT perhaps this summary makes the most sense:

  - IF pre-grade has run, and no manual grading to do, then runs post-grading operation.
  - IF pre-grade has run, and manual grading to do, then still in pre-grading state.
  - IF post-grade state has been reached, then pre-grade necessarily is complete and manual grading has OR has not run.
