### PR TITLE
pl-file-editor markdown rendering: treat mid-word * and _ as literal, not bold/italics

### DIFF
--- a/elements/pl-file-editor/pl-file-editor.js
+++ b/elements/pl-file-editor/pl-file-editor.js
@@ -33,11 +33,11 @@ window.PLFileEditor = function(uuid, options) {
 
     if (options.minLines) {
         this.editor.setOption('minLines', options.minLines);
-    } 
+    }
 
     if (options.maxLines) {
         this.editor.setOption('maxLines', options.maxLines);
-    } 
+    }
 
     if (options.autoResize) {
         this.editor.setAutoScrollEditorIntoView(true);
@@ -47,7 +47,10 @@ window.PLFileEditor = function(uuid, options) {
     this.plOptionFocus = options.plOptionFocus;
 
     if (options.preview == 'markdown') {
-        let renderer = new showdown.Converter();
+        let renderer = new showdown.Converter({
+            'literalMidWordUnderscores':true,
+            'literalMidWordAsterisks':true,
+        });
 
         this.editor.session.on('change', () => {
             this.updatePreview(renderer.makeHtml(this.editor.getValue()));


### PR DESCRIPTION
Addresses #3164. Two downsides to this solution are

- It doesn't solve #3164 in 100% of cases, though the holdouts don't seem likely to be naturally occurring - e.g. `$3 *4 5* 6$` (with exactly that weird spacing) would still break the Latex rendering
- It does change how markdown is rendered even for folks not using Latex, e.g. 'foo_bar_baz' will now be rendered unchanged instead of italicizing the 'bar' (but how often does someone _actually_ want to italicize/bold in the middle of a word?)

If anyone objects to the second issue, I could create a new option for options.preview so the new rendering mode would be entirely opt-in.