### PR TITLE
Update deprecated mdast option

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -85,7 +85,7 @@ const processor = unified()
     .use(math)
     .use(handleCode)
     .use(handleMath)
-    .use(remark2rehype, { allowDangerousHTML: true })
+    .use(remark2rehype, { allowDangerousHtml: true })
     .use(raw)
     .use(stringify);
 


### PR DESCRIPTION
This was changed in https://github.com/syntax-tree/mdast-util-to-hast/pull/39

Currently emits a harmless warning, but the option has been renamed and the old name is deprecated.