### PR TITLE
Add contrib nbextensions for export_embedded

### DIFF
--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -12,4 +12,6 @@ ENV NO_UPDATE_NOTIFIER=true
 ENV IPYTHONDIR=/tmp/ipython
 ENV YARN_CACHE_FOLDER=/tmp/yarn_cache
 
+RUN pip install --no-cache-dir jupyter_contrib_nbextensions
+
 CMD ["start.sh", "jupyter", "lab"]


### PR DESCRIPTION
This allows you to do: *(note the `_embed` part!)*

```
!jupyter nbconvert *.ipynb --to html_embed
```

from a notebook cell, which is helpful for exporting notebooks as PDF. (It's also possible for students to pip install this themselves, but that's going to waste a lot of bandwidth over time.)