### PR TITLE
Fixes "Show" button on Sync page refreshing the page

### DIFF
--- a/pages/courseSyncs/courseSyncs.ejs
+++ b/pages/courseSyncs/courseSyncs.ejs
@@ -118,7 +118,7 @@
                    tabindex="0" data-toggle="popover" data-html="true"
                    title="Questions using <%= image.image %>"
                    data-content="<%= include('listQuestionsPopover', {image}); %>"
-                   data-trigger="focus">
+                   data-trigger="focus" href="#">
                     Show
                   </a>
                   <% } else { %>


### PR DESCRIPTION
The Show button on the Sync page, which shows questions linked to a docker image, was reloading the page on click. This fixes that issue.