### PR TITLE
Fix thin lines in math on Chrome/Windows

### DIFF
--- a/elements/pl-drawing/pl-drawing.mustache
+++ b/elements/pl-drawing/pl-drawing.mustache
@@ -20,7 +20,7 @@
 </span>
 {{/parse_error}}
 {{^parse_error}}
-<div id="drawing-interface-{{uuid}}" class="pl-drawing-container">
+<div id="drawing-interface-{{uuid}}" class="pl-drawing-container pl-requires-svg-mathjax">
     <div>
         <canvas width="{{width}}" height="{{height}}"> </canvas>
         {{#show_tolerance}}

--- a/pages/partials/mathjax.ejs
+++ b/pages/partials/mathjax.ejs
@@ -20,16 +20,6 @@
      onReady: (cb) => { MathJax.config.readyQueue.push(cb); },
      startup: {
          ready: () => {
-             if (MathJax.version === '3.0.5') {
-                 /* Work-around for SVG output on MathJax 3.0.5, we can remove this after
-                    it's been fixed. */
-                 const SVGWrapper = MathJax._.output.svg.Wrapper.SVGWrapper;
-                 const CommonWrapper = SVGWrapper.prototype.__proto__;
-                 SVGWrapper.prototype.unicodeChars = function (text, variant) {
-                     if (!variant) variant = this.variant || 'normal';
-                     return CommonWrapper.unicodeChars.call(this, text, variant);
-                 }
-             }
              MathJax.startup.defaultReady();
              MathJax.Hub = {
                  Queue: function(){

--- a/pages/partials/mathjax.ejs
+++ b/pages/partials/mathjax.ejs
@@ -1,4 +1,10 @@
 <script>
+
+ var outputComponent = 'output/chtml';
+ <% if (typeof questionHtml != 'undefined' && questionHtml.includes('pl-requires-svg-mathjax')) { %>
+     outputComponent = 'output/svg';
+ <% } %>
+
  var MathJax = {
      tex: {
          inlineMath: [['$', '$'], ['\\(', '\\)']]
@@ -7,7 +13,7 @@
          fontCache: 'global'
      },
      loader: {
-         load: ['input/tex', 'output/svg']
+         load: ['input/tex', outputComponent]
      },
      /* Register a callback to be run when MathJax is loaded, use MathJax.config.onReady() */
      readyQueue: [],


### PR DESCRIPTION
This is a hack to default to the CommonHTML MathJax renderer (which works on lo-dpi displays with Chrome/Windows) and only use the SVG MathJax renderer for elements that need it (at the moment only `pl-drawing`). Elements can choose to use SVG by adding the class `pl-requires-svg-mathjax` to their output HTML.

Fixes #3086