### PR TITLE
Changes to Show/Hide answer button in instructor panel

### DIFF
--- a/pages/partials/instructorInfoPanel.ejs
+++ b/pages/partials/instructorInfoPanel.ejs
@@ -38,7 +38,7 @@
   </div>
   <div class="d-flex flex-wrap pb-2">
     <div class="pr-1">
-      <a class="card-link" data-toggle="collapse" href="#instructorTrue_answer">Show/Hide answer</a>
+      <button class="btn btn-link" data-toggle="collapse" data-target="#instructorTrue_answer">Show/Hide answer</button>
     </div>
     <div class="collapse" id="instructorTrue_answer">
         <code><%= JSON.stringify(variant.true_answer); %></code>


### PR DESCRIPTION
In Edge Chromium, in the instructor's panel, the link to show/hide the answer wasn't working. It seems Edge (or some script I can't find) replaces the href attribute from `#instructorTrue_answer` to the full URL followed by this tag (which would be innocuous if this were an actual link). This doesn't seem to be a problem in Chrome or Firefox, or even when running on localhost. This PR changes the link to a button, using `data-target` instead of `href`, which according to Bootstrap documentation (https://getbootstrap.com/docs/4.0/components/collapse/) should have equivalent functionality.