### PR TITLE
Add support for leading and trailing code in Python autograder

### DIFF
--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -141,6 +141,10 @@ Note that `Feedback.set_score()` is used to set the correctness of the test case
 
 The server parameters in `data` can be accessed from within the test cases using `self.data`.
 
+### Leading and Trailing Code
+
+If the optional files `tests/leading_code.py` and/or `tests/trailing_code.py` exist, the autograder will automatically prepend and append the contents to the user's submission before grading.  This can be useful if alternative input methods are used, e.g. for Parson's problem questions to provide python imports or other code that must be run.
+
 #### Multiple Iterations
 
 By setting the `total_iters` class variable, the test suite can be run for multiple iterations.  To prevent a specific test case from being run multiple times, you can add the `@not_repeated` decorator to it.

--- a/exampleCourse/courseInstances/Sp15/assessments/hw06-demoPythonAutograder/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/hw06-demoPythonAutograder/infoAssessment.json
@@ -33,14 +33,15 @@
     "zones": [
         {
             "questions": [
-                {"id": "demo/autograder/codeEditor",            "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/codeUpload",            "points": 1, "maxPoints": 5},
+                {"id": "demo/autograder/codeEditor",                   "points": 1, "maxPoints": 5},
+                {"id": "demo/autograder/codeUpload",                   "points": 1, "maxPoints": 5},
                 {"id": "demo/autograder/python/square",                "points": 1, "maxPoints": 5},
                 {"id": "demo/autograder/python/numpy",                 "points": 1, "maxPoints": 5},
                 {"id": "demo/autograder/python/pandas",                "points": 1, "maxPoints": 5},
                 {"id": "demo/autograder/python/plots",                 "points": 1, "maxPoints": 5},
                 {"id": "demo/autograder/python/random",                "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/ansiOutput",                      "points": 2, "maxPoints": 4}
+                {"id": "demo/autograder/python/leadingTrailing",       "points": 1, "maxPoints": 5},
+                {"id": "demo/autograder/ansiOutput",                   "points": 2, "maxPoints": 4}
             ]
         }
     ]

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/info.json
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/info.json
@@ -1,0 +1,20 @@
+{
+    "uuid": "12ead399-f913-4a0c-9922-f46a2fccb4ad",
+    "title": "Autograder demo: Adding leading/trailing code",
+    "topic": "Autograder",
+    "tags": [
+        "v3",
+        "Fa20",
+        "nnytko2",
+        "short-coding"
+    ],
+    "type": "v3",
+    "singleVariant": true,
+    "gradingMethod": "External",
+    "externalGradingOptions": {
+        "enabled": true,
+        "image": "prairielearn/grader-python",
+        "entrypoint": "/python_autograder/run.sh",
+        "timeout": 60
+    }
+}

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/question.html
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/question.html
@@ -1,0 +1,28 @@
+<pl-question-panel>
+    <p>
+        <i>
+            This question defines the files <code class="user-output">leading_code.py</code> and <code class="user-output">trailing_code.py</code> to automatically prepend/append code to the student's answer before grading.  Adding these files allows one to automatically handle imports, function definitions, etc.  The contents of the leading and trailing code files are displayed in the code blocks below.
+        </i>
+    </p>
+
+    <p>
+        Complete the function below that computes one iteration of <i>gradient descent</i>:
+
+        $$ {\bf x}_{n+1} = {\bf x}_n - \alpha \nabla f\left({\bf x}_n\right) $$
+
+        Specifically, compute the value of <code class="user-output">x_new</code> (${\bf x}_{n+1}$) given ${\bf x}_n$, $\alpha$, and $\nabla f\left({\bf x}_n\right)$.
+    </p>
+
+    <hr>
+
+    <pl-code source-file-name="tests/leading_code.py" language="python"></pl-code>
+    <div class="mb-2 pl-4" style="padding-left: 2.5rem">
+        <pl-string-input answers-name="answer" display="block" placeholder="x_new = ..."></pl-string-input>
+    </div>
+    <pl-code source-file-name="tests/trailing_code.py" language="python"></pl-code>
+</pl-question-panel>
+
+<pl-submission-panel>
+    <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
+</pl-submission-panel>

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/server.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/server.py
@@ -1,0 +1,23 @@
+import base64
+
+def generate(data):
+    data['params']['names_for_user'] = []
+    data['params']['names_from_user'] = [
+        {'name': 'gradient_descent'}
+    ]
+
+def base64_encode_string(s):
+    # do some wonky encode/decode because base64 expects a bytes object
+    return base64.b64encode(s.encode('utf-8')).decode('utf-8')
+
+def parse(data):
+    answer = data['submitted_answers']['answer']
+    answer = (' '*4) + answer.strip() + '\n' # add 4 spaces in front and a newline at the end
+
+    # ship the answer off to the autograder
+    data['submitted_answers']['_files'] = [
+        {
+            'name': 'user_code.py',
+            'contents': base64_encode_string(answer)
+        }
+    ]

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/ans.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/ans.py
@@ -1,0 +1,8 @@
+def f(x):
+    return x ** 2
+
+def df(x):
+    return 2 * x
+
+def gradient_descent(x, alpha):
+    return x - alpha * df(x)

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/initial_code.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/initial_code.py
@@ -1,0 +1,4 @@
+import numpy as np
+import numpy.linalg as la
+
+x = la.solve(A, b)

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/leading_code.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/leading_code.py
@@ -1,0 +1,8 @@
+def f(x):
+    return x ** 2
+
+def df(x):
+    return 2 * x
+
+def gradient_descent(x, alpha):
+    grad_f = df(x)

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/test.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/test.py
@@ -1,0 +1,25 @@
+from pl_helpers import name, points, not_repeated
+from pl_unit_test import PLTestCase
+from code_feedback import Feedback
+import numpy as np
+
+class Test(PLTestCase):
+    @points(1)
+    @name('gradient_descent()')
+    def test_0(self):
+        tests = 50
+        points = 0
+
+        xs = np.linspace(-1, 1, tests)
+        alphas = np.linspace(0.1, 0.001, tests)
+        np.random.shuffle(xs)
+        np.random.shuffle(alphas)
+
+        for i in range(tests):
+            x = xs[i]
+            alpha = alphas[i]
+            ref_xnew = self.ref.gradient_descent(x, alpha)
+            st_xnew = Feedback.call_user(self.st.gradient_descent, x, alpha)
+            if Feedback.check_scalar(f'x={x}, alpha={alpha}', ref_xnew, st_xnew, report_success=True, report_failure=True):
+                points += 1
+        Feedback.set_score(points / tests)

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/trailing_code.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/trailing_code.py
@@ -1,0 +1,1 @@
+    return x_new

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -150,7 +150,7 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     except Exception:
         err = sys.exc_info()
 
-    # Now that user code has been run, replace deleted files incase we are to run the tests again.
+    # Now that user code has been run, replace deleted files in case we are to run the tests again.
     with open(join(filenames_dir, 'data.json'), 'w', encoding='utf-8') as f:
         json.dump(data, f)
     with open(fname_ref, 'w', encoding='utf-8') as f:

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -81,6 +81,8 @@ def execute_code(fname_ref, fname_student, include_plt=False,
     os.remove(join(filenames_dir, 'data.json'))
     os.remove(fname_ref)
     os.remove(join(filenames_dir, 'setup_code.py'))
+    os.remove(join(filenames_dir, 'leading_code.py'))
+    os.remove(join(filenames_dir, 'trailing_code.py'))
     os.remove(join(filenames_dir, 'test.py'))
 
     repeated_setup_name = 'repeated_setup()'
@@ -147,12 +149,20 @@ def execute_code(fname_ref, fname_student, include_plt=False,
         err = None
     except Exception:
         err = sys.exc_info()
+
+    # Now that user code has been run, replace deleted files incase we are to run the tests again.
     with open(join(filenames_dir, 'data.json'), 'w', encoding='utf-8') as f:
         json.dump(data, f)
     with open(fname_ref, 'w', encoding='utf-8') as f:
         f.write(str_ref)
     with open(join(filenames_dir, 'setup_code.py'), 'w', encoding='utf-8') as f:
         f.write(str_setup)
+    if len(str_leading) > 0:
+        with open(join(filenames_dir, 'leading_code.py'), 'w', encoding='utf-8') as f:
+            f.write(str_leading)
+    if len(str_trailing) > 0:
+        with open(join(filenames_dir, 'trailing_code.py'), 'w', encoding='utf-8') as f:
+            f.write(str_trailing)
     with open(join(filenames_dir, 'test.py'), 'w', encoding='utf-8') as f:
         f.write(str_test)
     if err is not None:

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -22,6 +22,15 @@ def set_random_seed(seed=None):
     random.seed(seed)
 
 
+def try_read(fname):
+    try:
+        with open(fname, 'r', encoding='utf-8') as f:
+            contents = f.read()
+    except:
+        contents = ''
+    return contents
+
+
 def execute_code(fname_ref, fname_student, include_plt=False,
                  console_output_fname=None, test_iter_num=0, ipynb_key="#grade"):
     """
@@ -51,20 +60,24 @@ def execute_code(fname_ref, fname_student, include_plt=False,
         str_setup = f.read()
     with open(fname_ref, 'r', encoding='utf-8') as f:
         str_ref = f.read()
-    try:
-        with open(join(filenames_dir, 'leading_code.py'), 'r', encoding='utf-8') as f:
-            str_leading = f.read()
-    except:
-        str_leading = ''
+
+    # Read in leading, trailing code
+    str_leading = try_read(join(filenames_dir, 'leading_code.py'))
+    str_trailing = try_read(join(filenames_dir, 'trailing_code.py'))
+
+    # Read student code (and transform if necessary) and append leading/trailing code
     with open(fname_student, 'r', encoding='utf-8') as f:
         filename, extension = splitext(fname_student)
         if extension == '.ipynb':
-            str_student = str_leading + pl_helpers.extract_ipynb_contents(f, ipynb_key)
+            str_student = pl_helpers.extract_ipynb_contents(f, ipynb_key)
         else:
             str_student = f.read()
+    str_student = str_leading + str_student + str_trailing
+
     with open(join(filenames_dir, 'test.py'), encoding='utf-8') as f:
         str_test = f.read()
 
+    # Delete sensitive code so students can't read e.g. test cases or setup code
     os.remove(join(filenames_dir, 'data.json'))
     os.remove(fname_ref)
     os.remove(join(filenames_dir, 'setup_code.py'))

--- a/graders/python/python_autograder/run.sh
+++ b/graders/python/python_autograder/run.sh
@@ -44,7 +44,15 @@ chmod 1777 "$MERGE_DIR"
 export FILENAMES_DIR=$MERGE_DIR'/filenames'
 mkdir $FILENAMES_DIR
 chmod 777 $FILENAMES_DIR
-mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $MERGE_DIR/leading_code.py $JOB_DIR/data/data.json $FILENAMES_DIR
+mv $MERGE_DIR/ans.py $MERGE_DIR/setup_code.py $MERGE_DIR/test.py $JOB_DIR/data/data.json $FILENAMES_DIR
+
+# Leading and trailing code are optional -- check if they exist before we move them.
+if [[ -f "$MERGE_DIR/leading_code.py" ]]; then
+    mv $MERGE_DIR/leading_code.py $FILENAMES_DIR
+fi
+if [[ -f "$MERGE_DIR/trailing_code.py" ]]; then
+    mv $MERGE_DIR/trailing_code.py $FILENAMES_DIR
+fi
 
 ##########################
 # RUN


### PR DESCRIPTION
Adds support for `tests/trailing_code.py` for python autograder and a small blurb to the documentation.

Adds example question `demo/autograder/python/leadingTrailing`:

![image](https://user-images.githubusercontent.com/1790491/103176848-d09a2c80-483a-11eb-8e88-6c415f71e777.png)

Closes #3613 