### PR TITLE
Added download button to file upload element

### DIFF
--- a/elements/pl-file-upload/pl-file-upload.js
+++ b/elements/pl-file-upload/pl-file-upload.js
@@ -168,6 +168,8 @@ window.PLFileUpload.prototype.renderFileList = function() {
             $fileStatusContainerLeft.append('<p class="file-status">uploaded</p>');
         }
         if (fileData) {
+            var download = '<a download="' + fileName + '" class="btn btn-outline-secondary btn-sm" id="file-download-' + uuid + '-' + index + '" onclick="event.stopPropagation();" href="data:application/octet-stream;base64,' + fileData + '">Download</a>'
+            
             var $preview = $('<div class="file-preview collapse" id="file-preview-' + uuid + '-' + index + '"><pre class="bg-dark text-white rounded p-3 mb-0"><code></code></pre></div>');
             if (isExpanded) {
                 $preview.addClass('in');
@@ -183,7 +185,7 @@ window.PLFileUpload.prototype.renderFileList = function() {
                 $preview.find('code').text('Unable to decode file.');
             }
             $file.append($preview);
-            $fileStatusContainer.append('<div class="file-status-container-right"><button type="button" class="btn btn-outline-secondary btn-sm file-preview-button"><span class="file-preview-icon fa fa-angle-down"></span></button></div>');
+            $fileStatusContainer.append('<div class="file-status-container-right">' + download + '<button type="button" class="btn btn-outline-secondary btn-sm file-preview-button"><span class="file-preview-icon fa fa-angle-down"></span></button></div>');
         }
 
         $fileList.append($file);

--- a/elements/pl-file-upload/pl-file-upload.js
+++ b/elements/pl-file-upload/pl-file-upload.js
@@ -168,7 +168,7 @@ window.PLFileUpload.prototype.renderFileList = function() {
             $fileStatusContainerLeft.append('<p class="file-status">uploaded</p>');
         }
         if (fileData) {
-            var download = '<a download="' + fileName + '" class="btn btn-outline-secondary btn-sm" id="file-download-' + uuid + '-' + index + '" onclick="event.stopPropagation();" href="data:application/octet-stream;base64,' + fileData + '">Download</a>'
+            var download = '<a download="' + fileName + '" class="btn btn-outline-secondary btn-sm" id="file-download-' + uuid + '-' + index + '" onclick="event.stopPropagation();" href="data:application/octet-stream;base64,' + fileData + '">Download</a>';
             
             var $preview = $('<div class="file-preview collapse" id="file-preview-' + uuid + '-' + index + '"><pre class="bg-dark text-white rounded p-3 mb-0"><code></code></pre></div>');
             if (isExpanded) {

--- a/elements/pl-file-upload/pl-file-upload.js
+++ b/elements/pl-file-upload/pl-file-upload.js
@@ -168,8 +168,8 @@ window.PLFileUpload.prototype.renderFileList = function() {
             $fileStatusContainerLeft.append('<p class="file-status">uploaded</p>');
         }
         if (fileData) {
-            var download = '<a download="' + fileName + '" class="btn btn-outline-secondary btn-sm" id="file-download-' + uuid + '-' + index + '" onclick="event.stopPropagation();" href="data:application/octet-stream;base64,' + fileData + '">Download</a>';
-            
+            var download = '<a download="' + fileName + '" class="btn btn-outline-secondary btn-sm mr-1" onclick="event.stopPropagation();" href="data:application/octet-stream;base64,' + fileData + '">Download</a>';
+
             var $preview = $('<div class="file-preview collapse" id="file-preview-' + uuid + '-' + index + '"><pre class="bg-dark text-white rounded p-3 mb-0"><code></code></pre></div>');
             if (isExpanded) {
                 $preview.addClass('in');


### PR DESCRIPTION
The existing file upload element didn't allow download.  (Download buttons appeared only in the corresponding pl_file_preview element, which requires the user to first save or save & grade.  This is non-intuitive.) 

I basically copied the code from: https://github.com/PrairieLearn/PrairieLearn/pull/3217/files

Currently the download button is too close to the 'Show Preview' button.  I don't know the preferred way to add some space between them. 

(Also, I apologize for not making this branch in my own repo... I didn't see the contributing guidelines until the patch was complete.)