### PR TITLE
Allow params to be changed in grade()

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -498,7 +498,7 @@ module.exports = {
         /**************************************************************************************************************************************/
         //              property                 type       presentPhases                         changePhases
         /**************************************************************************************************************************************/
-        err = checkProp('params',                'object',  allPhases,                            ['generate', 'prepare']);                   if (err) return err;
+        err = checkProp('params',                'object',  allPhases,                            ['generate', 'prepare', 'grade']);          if (err) return err;
         err = checkProp('correct_answers',       'object',  allPhases,                            ['generate', 'prepare', 'parse', 'grade']); if (err) return err;
         err = checkProp('variant_seed',          'integer', allPhases,                            []);                                        if (err) return err;
         err = checkProp('options',               'object',  allPhases,                            []);                                        if (err) return err;


### PR DESCRIPTION
Fixes #3651

`params` is listed as changeable in the docs &mdash; this updates the code to reflect that.  Have tested this out locally and I don't see anything breaking because of it.