### PR TITLE
Update plots for d3 from v3 to v4+ (currently v6.3.1)

### DIFF
--- a/public/localscripts/histmini.js
+++ b/public/localscripts/histmini.js
@@ -22,9 +22,10 @@ function histmini(selector, data, options) {
         width = options.width - margin.left - margin.right,
         height = options.height - margin.top - margin.bottom;
 
-    var x = d3.scaleOrdinal()
+    var x = d3.scaleBand()
         .domain(d3.range(data.length))
-        .rangeRoundBands([0, width], 0.2);
+        .rangeRound([0, width])
+        .padding(0.2);
 
     var ymin = (options.ymin == "auto" ? _(data).min() : options.ymin);
     var ymax = (options.ymax == "auto" ? _(data).max() : options.ymax);

--- a/public/localscripts/histmini.js
+++ b/public/localscripts/histmini.js
@@ -48,7 +48,7 @@ function histmini(selector, data, options) {
         .attr("class", "bar")
         .attr("x", function(d, i) {return x(i);})
         .attr("y", function(d, i) {return y(d);})
-        .attr("width", function(d, i) {return x.rangeBand();})
+        .attr("width", function(d, i) {return x.bandwidth();})
         .attr("height", function(d, i) {return y(0) - y(d);});
 
     svg.append("line")

--- a/public/localscripts/histmini.js
+++ b/public/localscripts/histmini.js
@@ -22,13 +22,13 @@ function histmini(selector, data, options) {
         width = options.width - margin.left - margin.right,
         height = options.height - margin.top - margin.bottom;
 
-    var x = d3.scale.ordinal()
+    var x = d3.scaleOrdinal()
         .domain(d3.range(data.length))
         .rangeRoundBands([0, width], 0.2);
 
     var ymin = (options.ymin == "auto" ? _(data).min() : options.ymin);
     var ymax = (options.ymax == "auto" ? _(data).max() : options.ymax);
-    var y = d3.scale.linear()
+    var y = d3.scaleLinear()
         .domain([ymin, ymax])
         .range([height, 0]);
 

--- a/public/localscripts/histmini.js
+++ b/public/localscripts/histmini.js
@@ -52,8 +52,16 @@ function histmini(selector, data, options) {
         .attr("height", function(d, i) {return y(0) - y(d);});
 
     svg.append("line")
-        .attr({x1: 0, y1: 0, x2: width, y2: 0, "class": "x axis"})
+        .attr('x1', 0)
+        .attr('y1', 0)
+        .attr('x2', width)
+        .attr('y2', 0)
+        .attr('class', 'x axis');
 
     svg.append("line")
-        .attr({x1: 0, y1: height, x2: width, y2: height, "class": "x axis"})
+        .attr('x1', 0)
+        .attr('y1', height)
+        .attr('x2', width)
+        .attr('y2', height)
+        .attr('class', 'x axis');
 };

--- a/public/localscripts/histmini.js
+++ b/public/localscripts/histmini.js
@@ -33,7 +33,7 @@ function histmini(selector, data, options) {
         .domain([ymin, ymax])
         .range([height, 0]);
 
-    var color = d3.scale.category10();
+    var color = d3.scaleOrdinal(d3.schemeCategory10);
 
     var svg = d3.select($(selector).get(0)).append("svg")
         .attr("width", width + margin.left + margin.right)

--- a/public/localscripts/histogram.js
+++ b/public/localscripts/histogram.js
@@ -21,39 +21,35 @@ function histogram(selector, data, xgrid, options) {
 
     var xmin = (options.xmin == "auto" ? _(xgrid).min() : options.xmin);
     var xmax = (options.xmax == "auto" ? _(xgrid).max() : options.xmax);
-    var x = d3.scale.linear()
+    var x = d3.scaleLinear()
         .domain([xmin, xmax])
         .range([0, width]);
 
     var ymin = (options.ymin == "auto" ? _(data).min() : options.ymin);
     var ymax = (options.ymax == "auto" ? _(data).max() : options.ymax);
-    var y = d3.scale.linear()
+    var y = d3.scaleLinear()
         .domain([ymin, ymax])
         .nice()
         .range([height, 0]);
 
     var xTickFormat = (options.xTickLabels == "auto" ? null
                        : function(d, i) {return options.xTickLabels[i];});
-    var xAxis = d3.svg.axis()
+    var xAxis = d3.axisBottom()
         .scale(x)
         .tickValues(xgrid)
-        .tickFormat(xTickFormat)
-        .orient("bottom");
+        .tickFormat(xTickFormat);
 
-    var yAxis = d3.svg.axis()
-        .scale(y)
-        .orient("left");
+    var yAxis = d3.axisLeft()
+        .scale(y);
     
-    var xGrid = d3.svg.axis()
+    var xGrid = d3.axisBottom()
         .scale(x)
         .tickValues(xgrid)
-        .orient("bottom")
         .tickSize(-height)
         .tickFormat("");
 
-    var yGrid = d3.svg.axis()
+    var yGrid = d3.axisLeft()
         .scale(y)
-        .orient("left")
         .tickSize(-width)
         .tickFormat("");
 

--- a/public/localscripts/parallel_histograms.js
+++ b/public/localscripts/parallel_histograms.js
@@ -31,17 +31,18 @@ function parallel_histograms(selector, data, options) {
     var numBuckets = data[0].histogram.length;
     var numDays = data.length;
 
-    var yOrdinal = d3.scaleOrdinal()
+    var yOrdinal = d3.scaleBand()
         .domain(d3.range(numBuckets))
-        .rangeRoundBands([0, height]);
+        .rangeRound([0, height]);
 
     var yLinear = d3.scaleLinear()
         .domain([0, numBuckets])
         .range([0, height]);
 
-    var xOrdinal = d3.scaleOrdinal()
+    var xOrdinal = d3.scaleBand()
         .domain(d3.range(numDays))
-        .rangeRoundBands([0, width], 0.0);
+        .rangeRound([0, width])
+        .padding(0.0);
 
     var xLinear = d3.scaleLinear()
         .domain([0, numDays])

--- a/public/localscripts/parallel_histograms.js
+++ b/public/localscripts/parallel_histograms.js
@@ -55,9 +55,8 @@ function parallel_histograms(selector, data, options) {
 
     var yTickFormat = (function(d, i) {return data[i].label;});
 
-    var verticalGridLinear = d3.svg.axis()
+    var verticalGridLinear = d3.axisBottom()
         .scale(xLinear)
-        .orient("bottom")
         .tickSize(-height)
         .tickFormat("");
 
@@ -66,9 +65,8 @@ function parallel_histograms(selector, data, options) {
         .attr("transform", "translate(" + yAxisWidth + "," + heightWithPadding + ")")
         .call(verticalGridLinear);
 
-    var verticalGridOrdinal = d3.svg.axis()
+    var verticalGridOrdinal = d3.axisBottom()
         .scale(xOrdinal)
-        .orient("bottom")
         .tickSize(-height)
         .tickFormat("");
 
@@ -77,9 +75,8 @@ function parallel_histograms(selector, data, options) {
         .attr("transform", "translate(" + yAxisWidth + "," + heightWithPadding + ")")
         .call(verticalGridOrdinal);
 
-    var horizontalGrid = d3.svg.axis()
+    var horizontalGrid = d3.axisLeft()
         .scale(yLinear)
-        .orient("left")
         .tickSize(-width)
         .tickFormat("");
 
@@ -123,8 +120,7 @@ function parallel_histograms(selector, data, options) {
             .attr("y2", function(d) {return heightWithPadding - yLinear(Math.min(100, mean) / 100 * numBuckets);});
     }
 
-    var yAxis = d3.svg.axis()
-        .orient("left")
+    var yAxis = d3.axisLeft()
         .tickFormat(function(d, i) {
           return yTickLabels[i];
         })
@@ -155,7 +151,7 @@ function parallel_histograms(selector, data, options) {
     var xTickFormat = (options.xTickLabels == "auto" ? null
                        : function(d, i) {return options.xTickLabels[i];});
 
-    var xAxis = d3.svg.axis()
+    var xAxis = d3.axisBottom()
         .scale(xOrdinal)
         .tickFormat(function(d, i) {
             return data[i].label;

--- a/public/localscripts/parallel_histograms.js
+++ b/public/localscripts/parallel_histograms.js
@@ -31,19 +31,19 @@ function parallel_histograms(selector, data, options) {
     var numBuckets = data[0].histogram.length;
     var numDays = data.length;
 
-    var yOrdinal = d3.scale.ordinal()
+    var yOrdinal = d3.scaleOrdinal()
         .domain(d3.range(numBuckets))
         .rangeRoundBands([0, height]);
 
-    var yLinear = d3.scale.linear()
+    var yLinear = d3.scaleLinear()
         .domain([0, numBuckets])
         .range([0, height]);
 
-    var xOrdinal = d3.scale.ordinal()
+    var xOrdinal = d3.scaleOrdinal()
         .domain(d3.range(numDays))
         .rangeRoundBands([0, width], 0.0);
 
-    var xLinear = d3.scale.linear()
+    var xLinear = d3.scaleLinear()
         .domain([0, numDays])
         .range([0, width]);
 

--- a/public/localscripts/scatter.js
+++ b/public/localscripts/scatter.js
@@ -44,31 +44,27 @@ function scatter(selector, xdata, ydata, options) {
     var xTickFormat = (options.xTickLabels == "auto" ? null
                        : function(d, i) {return options.xTickLabels[i];});
 
-    var xAxis = d3.svg.axis()
+    var xAxis = d3.axisBottom()
         .scale(x)
         .tickValues(options.xgrid)
-        .tickFormat(xTickFormat)
-        .orient("bottom");
+        .tickFormat(xTickFormat);
 
     var yTickFormat = (options.yTickLabels == "auto" ? null
                        : function(d, i) {return options.yTickLabels[i];});
-    var yAxis = d3.svg.axis()
+    var yAxis = d3.axisLeft()
         .scale(y)
         .tickValues(options.ygrid)
-        .tickFormat(yTickFormat)
-        .orient("left");
+        .tickFormat(yTickFormat);
 
-    var xGrid = d3.svg.axis()
+    var xGrid = d3.axisBottom()
         .scale(x)
         .tickValues(options.xgrid)
-        .orient("bottom")
         .tickSize(-height)
         .tickFormat("");
 
-    var yGrid = d3.svg.axis()
+    var yGrid = d3.axisLeft()
         .scale(y)
         .tickValues(options.ygrid)
-        .orient("left")
         .tickSize(-width)
         .tickFormat("");
 

--- a/public/localscripts/scatter.js
+++ b/public/localscripts/scatter.js
@@ -26,13 +26,13 @@ function scatter(selector, xdata, ydata, options) {
 
     var xmin = (options.xmin == "auto" ? _(options.xgrid).min() : options.xmin);
     var xmax = (options.xmax == "auto" ? _(options.xgrid).max() : options.xmax);
-    var x = d3.scale.linear()
+    var x = d3.scaleLinear()
         .domain([xmin, xmax])
         .range([0, width]);
 
     var ymin = (options.ymin == "auto" ? _(options.ygrid).min() : options.ymin);
     var ymax = (options.ymax == "auto" ? _(options.ygrid).max() : options.ymax);
-    var y = d3.scale.linear()
+    var y = d3.scaleLinear()
         .domain([ymin, ymax])
         .range([height, 0]);
 

--- a/public/localscripts/stacked_histogram.js
+++ b/public/localscripts/stacked_histogram.js
@@ -19,13 +19,13 @@ function stacked_histogram(selector, data, data2, bucketNames, options) {
     var width = 600 - options.leftMargin - options.rightMargin;
     var height = 371 - options.topMargin - options.bottomMargin;
 
-    var x = d3.scale.ordinal()
+    var x = d3.scaleOrdinal()
         .domain(bucketNames)
         .rangeBands([0, width]);
 
     var ymin = (options.ymin == "auto" ? _(data).min() : options.ymin);
     var ymax = (options.ymax == "auto" ? _(data).max() + _(data2).max() : options.ymax);
-    var y = d3.scale.linear()
+    var y = d3.scaleLinear()
         .domain([ymin, ymax])
         .nice()
         .range([height, 0]);

--- a/public/localscripts/stacked_histogram.js
+++ b/public/localscripts/stacked_histogram.js
@@ -32,18 +32,15 @@ function stacked_histogram(selector, data, data2, bucketNames, options) {
 
     var xTickFormat = (options.xTickLabels == "auto" ? null
                        : function(d, i) {return options.xTickLabels[i];});
-    var xAxis = d3.svg.axis()
+    var xAxis = d3.axisBottom()
         .scale(x)
-        .tickFormat(xTickFormat)
-        .orient("bottom");
+        .tickFormat(xTickFormat);
 
-    var yAxis = d3.svg.axis()
-        .scale(y)
-        .orient("left");
+    var yAxis = d3.axisLeft()
+        .scale(y);
     
-    var yGrid = d3.svg.axis()
+    var yGrid = d3.axisLeft()
         .scale(y)
-        .orient("left")
         .tickSize(-width)
         .tickFormat("");
 


### PR DESCRIPTION
PR #3649 changed the d3 import from a local copy to an npm-installed version, which had the side-effect of upgrading it from v3 to v6. It turns out that v3 -> v4 had many breaking changes in the d3 API, which we had been shielded from until now. This PR fixes the local PL client-side plotting scripts to work with d3 v4+. The key changes are:

* Change `scale.{linear,ordinal}` -> `scale{Linear,Ordinal}`. See https://stackoverflow.com/a/47068531
* Change `svg.axis` -> `axis{Bottom,Left}`. See https://stackoverflow.com/a/40465701
* Change `rangeRoundBands` -> `rangeRound.padding`. See https://stackoverflow.com/a/40229243
* Change `scale.category10` -> `scaleOrdinal(d3.schemeCategory10)`. See https://stackoverflow.com/a/38391511
* Change `rangeBand` -> `bandwidth`. See https://stackoverflow.com/a/40083541
* Change `attr({...})` to separate `attr(key,val)`. See https://stackoverflow.com/a/38684633

Fixes #3678 