### PR TITLE
Fix workspace host cleanup queries

### DIFF
--- a/cron/workspaceHostTransitions.sql
+++ b/cron/workspaceHostTransitions.sql
@@ -1,7 +1,7 @@
 -- BLOCK select_nonterminated_workspace_hosts
-SELECT instance_id
-FROM workspace_hosts
-WHERE state != 'terminated';
+SELECT wh.instance_id
+FROM workspace_hosts AS wh
+WHERE wh.state != 'terminated';
 
 -- BLOCK select_healthy_hosts
 SELECT
@@ -16,25 +16,27 @@ WHERE
     wh.state = 'draining';
 
 -- BLOCK set_host_unhealthy
-UPDATE workspace_hosts
+UPDATE workspace_hosts AS wh
 SET
     state = 'unhealthy',
     unhealthy_at = NOW(),
     unhealthy_reason = 'health check failed'
 WHERE
-    instance_id = $instance_id
+    wh.instance_id = $instance_id
     AND wh.state IN ('launching', 'ready', 'draining');
 
 -- BLOCK add_terminating_hosts
 INSERT INTO workspace_hosts
-    (state, state_changed_at, instance_id)
-    (SELECT 'terminating', NOW(), UNNEST($instances))
-ON CONFLICT (instance_id) DO UPDATE SET
+       (state,        state_changed_at, instance_id)
+SELECT 'terminating', NOW(),            UNNEST($instances)
+ON CONFLICT (instance_id) DO UPDATE
+SET
     state = EXCLUDED.state,
     state_changed_at = EXCLUDED.state_changed_at;
 
 -- BLOCK set_terminated_hosts_if_not_launching
 UPDATE workspace_hosts AS wh
-SET state='terminated',
+SET
+    state = 'terminated',
     terminated_at = NOW()
-WHERE instance_id IN (SELECT UNNEST($instances)) AND wh.state != 'launching';
+WHERE wh.instance_id IN (SELECT UNNEST($instances)) AND wh.state != 'launching';


### PR DESCRIPTION
We had inconsistent use of `AS wh` and using the `wh.` prefix. This broke the `set_host_unhealthy` and `set_terminated_hosts_if_not_launching` queries. I tidied up the other queries as well.

I haven't tested this.