### PR TITLE
Change user error log level to verbose

### DIFF
--- a/pages/error/error.js
+++ b/pages/error/error.js
@@ -12,7 +12,7 @@ module.exports = function(err, req, res, _next) {
     res.status(err.status);
     var referrer = req.get('Referrer') || null;
     logger.log(
-        (err.status >= 500) ? 'error' : 'info',
+        (err.status >= 500) ? 'error' : 'verbose',
         'Error page',
         {
             msg: err.message,


### PR DESCRIPTION
Reducing log level from `info` will avoid spamming syslog with user errors. System errors (status >= 500) will still go to syslog.