### PR TITLE
docker-compose: Separate commands for build / interactive / init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,32 @@
 version: '3.8'
+
+x-options:
+  &dev-options
+  image: prairielearn/prairielearn:local
+  ports:
+    - 3000:3000
+  volumes:
+    - ./testCourse:/course
+    - /var/run/docker.sock:/var/run/docker.sock
+    - ${HOME}/pl_ag_jobs:/jobs
+    - .:/PrairieLearn
+  container_name: pl
+  environment:
+    - HOST_JOBS_DIR=${HOME}/pl_ag_jobs
+    - NODEMON=true
+
 services:
-  pl:
+
+  build-dev:
     build:
       context: .
     image: prairielearn/prairielearn:local
-    ports:
-      - 3000:3000
-    volumes:
-      - ./testCourse:/course
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${HOME}/pl_ag_jobs:/jobs
-      - .:/PrairieLearn
-    container_name: pl
-    environment:
-      - HOST_JOBS_DIR=${HOME}/pl_ag_jobs
-      - NODEMON=true
+
+  # start server on development image
+  init: *dev-options
+  
+  # interactive terminal on development image
+  it:
+    << : *dev-options
+    working_dir: /PrairieLearn
+    command: bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,10 @@ services:
   init: *dev-options
   
   # interactive terminal on development image
-  it:
+  bash:
     << : *dev-options
+    stdin_open: true
+    tty: true
     working_dir: /PrairieLearn
     command: bash
+  


### PR DESCRIPTION
Instead of using one docker-compose service, why not multiple?

All commands rely on the image `prairielearn/prairielearn:local`
- `docker-compose build` to build `prairielearn/prairielearn:local`
- `docker-compose run init` to start the server 
- `docker-compose run bash` to start an interactive `bash` session

Notes:
- Building was moved out since you likely won't want to build the image every single time you start the dev server
- `bash` will start you in `/PrairieLearn`, so you no longer have to manually cd into it every time!