### PR TITLE
Fix error in pl-matrix-component-input for non-numpy answer

### DIFF
--- a/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -143,7 +143,7 @@ def render(element_html, data):
             if a_submitted is not None and len(a_submitted.shape) == 2:
                 m, n = np.shape(a_submitted)
         else:
-            a_tru = pl.from_json(data['correct_answers'].get(name, None))
+            a_tru = np.array(pl.from_json(data['correct_answers'].get(name, None)))
             if a_tru is not None and len(a_tru.shape) == 2:
                 m, n = np.shape(a_tru)
             else:


### PR DESCRIPTION
The `pl-matrix-component-input` element allows a matrix of ints to be set as the correct answer, even if it is not a numpy array. However, if this is done, and there is a parse error in the submission (e.g., one of the elements is left blank), this will cause a set of issues to be raised, due to a render error in this element that assumes that correct answer is a numpy array. This PR fixes that issue by ensuring the array is converted to a numpy array if necessary.