### PR TITLE
Use os._exit() to exit Python worker process

### DIFF
--- a/lib/python-caller-trampoline.py
+++ b/lib/python-caller-trampoline.py
@@ -68,7 +68,15 @@ def worker_loop():
                 outf.write(json_outp)
                 outf.write("\n");
                 outf.flush()
-                break
+                # `sys.exit()` allows the process to gracefully shut down. however, that
+                # makes things much slower than necessary, because we can't reuse this
+                # worker until control returns to the parent, and one or more things we
+                # load into the process take on the order of hundreds of milliseconds to
+                # clean themselves up. `os._exit()` is much closer to a POSIX `exit()`
+                # since it will immediately terminate the process - in our case, we don't
+                # care about graceful termination, we just want to get out of here as
+                # fast as possible.
+                os._exit(0)
 
             # re-seed the PRNGs
             if type(args[-1]) is dict:


### PR DESCRIPTION
While working on https://github.com/PrairieLearn/PrairieLearn/pull/1626, I noticed that Python processes took on the order of hundreds of milliseconds to exit and return control to the parent. When a Python process implicitly exits (or exits with `sys.exit()`), it doesn't actually exit immediately - it allows things to gracefully shut down and clean themselves up. While this is generally a good thing, in this case, we just want to get out of the process as fast as possible so we can re-use the worker. Switching to `os._exit()` allows us to do this.

For the metric of "delta between start of question generation to the instant that all the python callers used for that question are available again", this change reduces that metric from ~`1200ms` to ~`120ms`. This should allow us to dramatically increase response times under periods of high load - or, at least, allow us to use machines with fewer CPUs.