### PR TITLE
Fix LTI nonce re-use detection

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -58,7 +58,7 @@ module.exports.set = function(key, value, maxAgeMS=null) {
             // care if it errors
             if (maxAgeMS) {
                 // we don't log the error because it contains the cached value, which can be huge and which fills up the logs
-                cache.set(key, value, 'PX', maxAgeMS).catch(_err => logger.error('Cache set error', {key, maxAgeMS}));
+                cache.set(key, value, maxAgeMS).catch(_err => logger.error('Cache set error', {key, maxAgeMS}));
             } else {
                 // we don't log the error because it contains the cached value, which can be huge and which fills up the logs
                 cache.set(key, value).catch(_err => logger.error('Cache set error', {key}));


### PR DESCRIPTION
The LTI authentication code stores used nonces in the cache to detect whether a nonce has been re-used (not allowed). However, the cache code that sets values with a maxAge parameter was incorrect. It used the underlying redis syntax with a `PX` argument, whereas the `redis-lru.set()` function does not need (or support) this argument:
https://github.com/facundoolano/redis-lru/blob/40fcf9f7d4690ad126528547fafecd671fbfda26/index.js#L112

Note that the underlying code _does_ use `PX` because it's talking directly to redis:
https://github.com/facundoolano/redis-lru/blob/40fcf9f7d4690ad126528547fafecd671fbfda26/index.js#L119