### PR TITLE
Replace npm scripts with make targets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@
 !exampleCourse/
 !grader_host/
 !lib/
+!Makefile
 !middlewares/
 !migrations/
 !models/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PATH := /PrairieLearn/node_modules/.bin/:$(PATH)
+
+start:
+	node server.js
+start-nodemon:
+	nodemon -L server.js
+start-s3rver:
+	mkdir -p /s3rver
+	s3rver --directory /s3rver --port 5000 --configure-bucket workspaces --configure-bucket chunks --configure-bucket file-store
+
+test:
+	nyc --reporter=lcov mocha tests/index.js
+test-sync:
+	mocha tests/sync/index.js
+test-nocoverage:
+	mocha tests/index.js
+
+lint: lint-js lint-python
+lint-js:
+	eslint --ext js "**/*.js"
+lint-python:
+	python3 -m flake8 ./
+typecheck:
+	tsc

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -34,8 +34,8 @@ else
     fi
 
     if [[ $NODEMON == "true" ]]; then
-        npm run start-nodemon
+        make start-nodemon
     else
-        npm start --silent
+        make --silent start
     fi
 fi

--- a/docker/lint_js.sh
+++ b/docker/lint_js.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd /PrairieLearn
-npm run lint-js -s
+make -s -C /PrairieLearn lint-js

--- a/docker/lint_python.sh
+++ b/docker/lint_python.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd /PrairieLearn
-npm run lint-python -s
+make -s -C /PrairieLearn lint-python

--- a/docker/start_s3rver.sh
+++ b/docker/start_s3rver.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-mkdir -p /s3rver
-npx s3rver --directory /s3rver --port 5000 --configure-bucket workspaces --configure-bucket chunks --configure-bucket file-store > /dev/null &
+make start-s3rver > /dev/null &

--- a/docker/start_workspace.sh
+++ b/docker/start_workspace.sh
@@ -12,7 +12,7 @@ if [[ ! -z "$CONTAINERS" ]] ; then
 fi
 
 export DONT_START_WORKSPACE_HOST_IN_INIT=true
-[[ $NODEMON == true ]] && HOST_NODE="npx nodemon -L" || HOST_NODE=node
+[[ $NODEMON == true ]] && HOST_NODE="/PrairieLearn/node_modules/.bin/nodemon -L" || HOST_NODE=node
 
 cd /PrairieLearn
 tmux "${args[@]}" new-session \; \

--- a/docker/typecheck.sh
+++ b/docker/typecheck.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd /PrairieLearn
-npm run typecheck -s
+make -s -C /PrairieLearn typecheck

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -63,7 +63,7 @@ PrairieLearn
 ```sh
 # make sure you are in the top-level PrairieLearn/ directory
 npm test
-npm run lint -s
+make lint
 ```
 
 * The above tests are run by the CI server on every push to GitHub.
@@ -876,7 +876,7 @@ router.post('/', function(req, res, next) {
 app.use(/^\/?$/, function(req, res, _next) {res.redirect('/pl');});
 ```
 
-* To lint the code, use `npm run lint -s`. This is also run by the CI tests.
+* To lint the code, use `make lint`. This is also run by the CI tests.
 
 
 ## Question-rendering control flow

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -84,8 +84,7 @@ npm test
 
 ```sh
 cd PrairieLearn
-npm run lint-js -s
-npm run lint-python -s
+make lint # or lint-js for Javascript only, or lint-python for Python only
 ```
 
 * Create the file `PrairieLearn/config.json` with the path of your local course repository and with the path of a directory into which temporary files will be saved when using the in-browser file editor (edit both paths as needed):

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
     "version": "3.2.0",
     "private": true,
     "scripts": {
-        "start": "node server.js",
-        "start-nodemon": "npx nodemon -L server.js",
-        "test": "nyc --reporter=lcov mocha tests/index.js",
-        "test-sync": "mocha tests/sync/index.js",
-        "test-nocoverage": "mocha tests/index.js",
-        "lint-js": "eslint --ext js \"**/*.js\"",
-        "lint-python": "python3 -m flake8 ./",
-        "typecheck": "tsc"
+        "start": "make start",
+        "start-nodemon": "make start-nodemon",
+        "test": "make test",
+        "test-sync": "make test-sync",
+        "test-nocoverage": "make test-nocoverage",
+        "lint-js": "make lint-js",
+        "lint-python": "make lint-python",
+        "typecheck": "make typecheck"
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.1",


### PR DESCRIPTION
Given some changes in behaviour in NPM 7, this PR replaces all `npm run` scripts with `make` targets.