### PR TITLE
Remove unnecessary reloadElementsForCourse()

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -137,8 +137,9 @@ module.exports = {
     },
 
     async loadElementsForCourseAsync(course) {
-        if (courseElementsCache[course.id] !== undefined &&
-            courseElementsCache[course.id].commit_hash === course.commit_hash) {
+        if (courseElementsCache[course.id] !== undefined
+            && courseElementsCache[course.id].commit_hash
+            && courseElementsCache[course.id].commit_hash === course.commit_hash) {
             return courseElementsCache[course.id].data;
         }
 
@@ -219,8 +220,9 @@ module.exports = {
     },
 
     async loadExtensionsForCourseAsync(course) {
-        if (courseExtensionsCache[course.id] !== undefined &&
-            courseExtensionsCache[course.id].commit_hash === course.commit_hash) {
+        if (courseExtensionsCache[course.id] !== undefined
+            && courseExtensionsCache[course.id].commit_hash
+            && courseExtensionsCache[course.id].commit_hash === course.commit_hash) {
             return courseExtensionsCache[course.id].data;
         }
 
@@ -236,28 +238,6 @@ module.exports = {
     flushElementCache: function() {
         courseElementsCache = {};
         courseExtensionsCache = {};
-    },
-
-    /**
-     * Reloads all element files from a course.
-     * @param {string} courseDir
-     * @param {any} courseId
-     */
-    reloadElementsForCourse: async function(courseDir, courseId) {
-        let hash = null;
-        try {
-            hash = await courseUtil.getOrUpdateCourseCommitHashAsync({'id': courseId, 'path': courseDir});
-        } catch (err) {
-            /* If we can't get a course hash, this likely isn't a Git repo so fail silently.
-               This usually happens when we're running tests and have manually created a course directory structure */
-            logger.debug(`Could not load course commit hash for course ${courseId} (${courseDir}) - ${err}`);
-        }
-
-        const elements = await util.promisify(module.exports.loadElements)(path.join(courseDir, 'elements'), 'course');
-        courseElementsCache[courseId] = {
-            'commit_hash': hash,
-            'data': elements,
-        };
     },
 
     resolveElement: function(elementName, context) {

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -3,7 +3,6 @@ const async = require('async');
 const _ = require('lodash');
 const fs = require('fs-extra');
 const path = require('path');
-const util = require('util');
 const mustache = require('mustache');
 const cheerio = require('cheerio');
 const hash = require('crypto').createHash;

--- a/sync/syncFromDisk.js
+++ b/sync/syncFromDisk.js
@@ -57,7 +57,6 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
         await perf.timedAsync(`syncAssessments${ciid}`, () => syncAssessments.sync(courseId, courseInstanceId, courseInstanceData.assessments, questionIds));
     }));
     perf.end('syncAssessments');
-    await freeformServer.reloadElementsForCourse(courseDir, courseId);
     if (config.devMode) {
         logger.info('Flushing course element and extensions cache...');
         freeformServer.flushElementCache();


### PR DESCRIPTION
We currently call `reloadElementsForCourse()` towards the end of `syncDiskToSqlWithLock()`, but this is unnecessary because we always call `loadElementsForCourseAsync()` before running any course code and:

1. In production we always check the `commit_hash` for the course and reload elements if it has changed.
2. In dev mode (where there might not be a commit) we call `flushElementCache()` from `syncDiskToSqlWithLock()` which ensures we will always reload all elements.
3. During tests we might have `commit_hash = null` but we now check for this explicitly and always reload elements in this case.

All of the above also applies to course element extensions.