### PR TITLE
Add pygraphviz to Jupyter workspace

### DIFF
--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -12,4 +12,9 @@ ENV NO_UPDATE_NOTIFIER=true
 ENV IPYTHONDIR=/tmp/ipython
 ENV YARN_CACHE_FOLDER=/tmp/yarn_cache
 
+USER root
+COPY install.sh /
+RUN /bin/bash /install.sh
+USER jovyan
+
 CMD ["start.sh", "jupyter", "lab"]

--- a/workspaces/jupyterlab/install.sh
+++ b/workspaces/jupyterlab/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Install dependencies and various libraries
+apt-get update && apt-get -y upgrade
+apt-get -y install graphviz graphviz-dev
+pip3 install pygraphviz
+
+rm /install.sh


### PR DESCRIPTION
Adds a small `install.sh` script like the other images, and installs `pygraphviz` in the default jupyter workspace image.