### PR TITLE
Fix legacy question data routes for instructor views

### DIFF
--- a/server.js
+++ b/server.js
@@ -657,11 +657,20 @@ module.exports.initExpress = function() {
     ]);
 
     // legacy client file paths
+    // handle routes with and without /preview/ in them to handle URLs with and without trailing slashes
     app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id/file', [
         require('./middlewares/selectAndAuthzInstructorQuestion'),
         require('./pages/legacyQuestionFile/legacyQuestionFile'),
     ]);
+    app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id/preview/file', [
+        require('./middlewares/selectAndAuthzInstructorQuestion'),
+        require('./pages/legacyQuestionFile/legacyQuestionFile'),
+    ]);
     app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id/text', [
+        require('./middlewares/selectAndAuthzInstructorQuestion'),
+        require('./pages/legacyQuestionText/legacyQuestionText'),
+    ]);
+    app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id/preview/text', [
         require('./middlewares/selectAndAuthzInstructorQuestion'),
         require('./pages/legacyQuestionText/legacyQuestionText'),
     ]);
@@ -923,11 +932,20 @@ module.exports.initExpress = function() {
     ]);
 
     // legacy client file paths
+    // handle routes with and without /preview/ in them to handle URLs with and without trailing slashes
     app.use('/pl/course/:course_id/question/:question_id/file', [
         require('./middlewares/selectAndAuthzInstructorQuestion'),
         require('./pages/legacyQuestionFile/legacyQuestionFile'),
     ]);
+    app.use('/pl/course/:course_id/question/:question_id/preview/file', [
+        require('./middlewares/selectAndAuthzInstructorQuestion'),
+        require('./pages/legacyQuestionFile/legacyQuestionFile'),
+    ]);
     app.use('/pl/course/:course_id/question/:question_id/text', [
+        require('./middlewares/selectAndAuthzInstructorQuestion'),
+        require('./pages/legacyQuestionText/legacyQuestionText'),
+    ]);
+    app.use('/pl/course/:course_id/question/:question_id/preview/text', [
         require('./middlewares/selectAndAuthzInstructorQuestion'),
         require('./pages/legacyQuestionText/legacyQuestionText'),
     ]);


### PR DESCRIPTION
Depending on the phase of rendering (before submission, after submission) the instructor question preview URLs sometimes have a trailing slash and sometimes do not. This matters when legacy question types (v2) set relative URLs like `.../text/xxx.png` because we will have either:
* NO trailing slash: `.../:question_id/preview` -> `.../:question_id/text/xxx.png`
* WITH trailing slash: `.../:question_id/preview/` -> `.../:question_id/preview/text/xxx.png`

To handle both cases this PR explicitly adds routes for the second case.