### PR TITLE
Fix migrations/229_group_config_unique_index.sql

### DIFF
--- a/database/tables/group_configs.pg
+++ b/database/tables/group_configs.pg
@@ -13,8 +13,7 @@ columns
 
 indexes
     group_configs_pkey: PRIMARY KEY (id) USING btree (id)
-    unique_group_config_per_assessment: UNIQUE USING btree (assessment_id)
-    group_configs_assessment_id_key: USING btree (assessment_id)
+    group_configs_assessment_id_key: UNIQUE USING btree (assessment_id)
     group_configs_course_instance_id_key: USING btree (course_instance_id)
 
 foreign-key constraints
@@ -22,4 +21,4 @@ foreign-key constraints
     group_configs_course_instance_id_fkey: FOREIGN KEY (course_instance_id) REFERENCES course_instances(id) ON UPDATE CASCADE ON DELETE CASCADE
 
 referenced by
-    groups: FOREIGN KEY (group_config_id) REFERENCES group_configs(id) ON UPDATE CASCADE ON DELETE CASCADE
+    groups: FOREIGN KEY (group_config_id) REFERENCES group_configs(id) ON UPDATE CASCADE ON DELETE SET NULL

--- a/database/tables/group_users.pg
+++ b/database/tables/group_users.pg
@@ -8,5 +8,5 @@ indexes
     group_users_user_id_key: USING btree (user_id)
 
 foreign-key constraints
-    group_users_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id)
-    group_users_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id)
+    group_users_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
+    group_users_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/groups.pg
+++ b/database/tables/groups.pg
@@ -15,11 +15,11 @@ indexes
 
 foreign-key constraints
     groups_course_instance_id_fkey: FOREIGN KEY (course_instance_id) REFERENCES course_instances(id) ON UPDATE CASCADE ON DELETE CASCADE
-    groups_group_config_id_fkey: FOREIGN KEY (group_config_id) REFERENCES group_configs(id) ON UPDATE CASCADE ON DELETE CASCADE
+    groups_group_config_id_fkey: FOREIGN KEY (group_config_id) REFERENCES group_configs(id) ON UPDATE CASCADE ON DELETE SET NULL
 
 referenced by
     assessment_instances: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     audit_logs: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_users: FOREIGN KEY (group_id) REFERENCES groups(id)
+    group_users: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     last_accesses: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     variants: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/users.pg
+++ b/database/tables/users.pg
@@ -40,7 +40,7 @@ referenced by
     grading_jobs: FOREIGN KEY (auth_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     grading_jobs: FOREIGN KEY (graded_by) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     grading_jobs: FOREIGN KEY (grading_request_canceled_by) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_users: FOREIGN KEY (user_id) REFERENCES users(user_id)
+    group_users: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     instance_questions: FOREIGN KEY (authn_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     issues: FOREIGN KEY (authn_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE SET NULL
     issues: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE SET NULL

--- a/migrations/229_group_config_unique_index.sql
+++ b/migrations/229_group_config_unique_index.sql
@@ -1,3 +1,14 @@
-DROP INDEX unique_group_config_per_assessment;
+ALTER TABLE group_users DROP CONSTRAINT IF EXISTS group_users_group_id_fkey;
+ALTER TABLE group_users ADD CONSTRAINT group_users_group_id_fkey FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
-CREATE UNIQUE INDEX unique_group_config_per_assessment ON group_configs (assessment_id);
+ALTER TABLE group_users DROP CONSTRAINT IF EXISTS group_users_user_id_fkey;
+ALTER TABLE group_users ADD CONSTRAINT group_users_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE groups DROP CONSTRAINT IF EXISTS groups_group_config_id_fkey;
+ALTER TABLE groups ADD CONSTRAINT groups_group_config_id_fkey FOREIGN KEY (group_config_id) REFERENCES group_configs(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+DELETE FROM group_configs WHERE deleted_at IS NOT NULL;
+
+DROP INDEX IF EXISTS unique_group_config_per_assessment;
+DROP INDEX IF EXISTS group_configs_assessment_id_key;
+CREATE UNIQUE INDEX group_configs_assessment_id_key ON group_configs (assessment_id);


### PR DESCRIPTION
The previous version of `migrations/229_group_config_unique_index.sql` simply changed the `unique_group_config_per_assessment` index to be unique. But this is not possible because we had previously been setting `deleted_at` on group configs and creating new ones for the same assessment, so we had multiple group configs with the same `assessment_id`.

This PR hard-deletes any soft-deleted group configs so that there is only one group config per assessment, allowing the creation of the new unique index. To speed up the deletion this PR changes the ON DELETE behavior of groups to SET NULL for `group_config_id` changes.

The previous version of the migration also resulted in two redundant indexes, which this PR fixes.