### PR TITLE
Fix chunk symlinks to ensure overwriting old links

### DIFF
--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -701,7 +701,15 @@ const ensureChunk = async (courseId, chunk) => {
     });
 
     // Finally, link targetPath -> relativeUnpackPath
-    await fs.ensureSymlink(relativeUnpackPath, targetPath);
+    // Note that ensureSymlink() won't overwrite an existing targetPath
+    // See:
+    //     https://github.com/jprichardson/node-fs-extra/pull/869
+    //     https://github.com/jprichardson/node-fs-extra/issues/786
+    //     https://github.com/jprichardson/node-fs-extra/pull/826
+    // As a work-around, we symlink a temporary name and move it over targetPath
+    const tmpPath = `${targetPath}-${chunk.uuid}`;
+    await fs.ensureSymlink(relativeUnpackPath, tmpPath);
+    await fs.rename(tmpPath, targetPath);
 };
 
 /** @type {Map<string, Promise>} */


### PR DESCRIPTION
The `ensureSymlink()` function silently does nothing if the destination already exists, even if it isn't the correct symlink (see jprichardson/node-fs-extra#786, jprichardson/node-fs-extra#869, jprichardson/node-fs-extra#826). This means that with the new symlink chunk code (see #3354) we will never update a question chunk, even when there is a new version of the question available. To work around this we create the link with a temporary name and move it to the correct link name.