### PR TITLE
Remove uploaded files from instructor assessment instance log

### DIFF
--- a/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
+++ b/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
@@ -54,7 +54,7 @@ router.get('/:assessment_instance_id/submissions', (req, res, next) => {
 });
 
 router.get('/:assessment_instance_id/log', (req, res, next) => {
-    const params = [req.params.assessment_instance_id];
+    const params = [req.params.assessment_instance_id, true];
     sqldb.call('assessment_instances_select_log', params, (err, result) => {
         if (ERR(err, next)) return;
         res.status(200).send(result.rows);

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.ejs
@@ -248,9 +248,10 @@
         </div>
         <div class="card-body">
           <small>
-            Download <a href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>/<%= logCsvFilename %>"><%= logCsvFilename %></a>.
-
             Click on a column header to sort. Shift-click on a second header to sub-sort.
+            Download <a href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>/<%= logCsvFilename %>"><%= logCsvFilename %></a>.
+            Uploaded student files are not shown above or in the CSV file.
+            Student files can be downloaded on the <a href="<%= urlPrefix %>/assessment/<%= assessment.id %>/downloads">Downloads</a> tab.
           </small>
         </div>
 
@@ -311,6 +312,8 @@
         <div class="card-footer">
           <small>
             Download <a href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>/<%= logCsvFilename %>"><%= logCsvFilename %></a>.
+            Uploaded student files are not shown above or in the CSV file.
+            Student files can be downloaded on the <a href="<%= urlPrefix %>/assessment/<%= assessment.id %>/downloads">Downloads</a> tab.
           </small>
         </div>
       </div>

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -36,7 +36,7 @@ router.get('/', (req, res, next) => {
                 if (ERR(err, next)) return;
                 res.locals.instance_questions = result.rows;
 
-                const params = [res.locals.assessment_instance.id];
+                const params = [res.locals.assessment_instance.id, false];
                 sqlDb.call('assessment_instances_select_log', params, (err, result) => {
                     if (ERR(err, next)) return;
                     res.locals.log = result.rows;
@@ -58,7 +58,7 @@ router.get('/', (req, res, next) => {
 
 router.get('/:filename', (req, res, next) => {
     if (req.params.filename == logCsvFilename(res.locals)) {
-        const params = [res.locals.assessment_instance.id];
+        const params = [res.locals.assessment_instance.id, false];
         sqlDb.call('assessment_instances_select_log', params, (err, result) => {
             if (ERR(err, next)) return;
             const log = result.rows;

--- a/sprocs/assessment_instances_select_log.sql
+++ b/sprocs/assessment_instances_select_log.sql
@@ -1,8 +1,10 @@
 DROP FUNCTION IF EXISTS assessment_instances_select_log(bigint);
+DROP FUNCTION IF EXISTS assessment_instances_select_log(bigint,boolean);
 
 CREATE OR REPLACE FUNCTION
     assessment_instances_select_log ( 
-        ai_id bigint
+        ai_id bigint,
+        include_files boolean
     ) 
     RETURNS TABLE(
         event_name text,
@@ -93,7 +95,7 @@ BEGIN
                     v.number AS variant_number,
                     s.id AS submission_id,
                     jsonb_build_object(
-                      'submitted_answer', s.submitted_answer,
+                      'submitted_answer', CASE WHEN include_files THEN s.submitted_answer ELSE (s.submitted_answer - '_files') END,
                       'correct', s.correct
                     ) AS data
                 FROM
@@ -154,7 +156,7 @@ BEGIN
                         'correct', gj.correct,
                         'score', gj.score,
                         'feedback', gj.feedback,
-                        'submitted_answer', s.submitted_answer,
+                        'submitted_answer', CASE WHEN include_files THEN s.submitted_answer ELSE (s.submitted_answer - '_files') END,
                         'submission_id', s.id
                     ) AS data
                 FROM
@@ -189,7 +191,7 @@ BEGIN
                         'correct', gj.correct,
                         'score', gj.score,
                         'feedback', gj.feedback,
-                        'submitted_answer', s.submitted_answer,
+                        'submitted_answer', CASE WHEN include_files THEN s.submitted_answer ELSE (s.submitted_answer - '_files') END,
                         'true_answer', v.true_answer
                     ) AS data
                 FROM


### PR DESCRIPTION
Until #3035 or equivalent is merged we are storing files as JSONB in the DB. This produces problems when viewing the assessment instance log because the files are too big. Recent math exams have been having students upload large PDFs which break the rendering of the assessment instance page because of this problem.

To fix the problem, this PR strips the files from the submitted answer JSON when getting the log. This is the same technique used when downloading submissions: https://github.com/PrairieLearn/PrairieLearn/blob/a4380b697baa6db8a288d35995424c833f363567/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql#L111 This PR only conditionally strips the files. It strips them for the HTML page and the corresponding CSV download, but it keeps them for the API access to the log.

Fixes #2168