### PR TITLE
Remove superfluous "* 2" on color palette

### DIFF
--- a/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -15,7 +15,7 @@ ansi2html_style.SCHEME['iterm'] = (
     '#0037da', '#c930c7', '#00c5c7', '#c7c7c7',
     '#676767', '#ff6d67', '#5ff967', '#fefb67',
     '#6871ff', '#ff76ff', '#5ffdff', '#feffff',
-) * 2
+)
 conv = Ansi2HTMLConverter(inline=True, scheme='iterm')
 
 


### PR DESCRIPTION
The palette shown already specifies all 16 colors explicitly, so there's no need to duplicate to get the second 8 (the "bright" set). Coincidentally, the library automatically generates a "bright" variant of the first eight colors for the second eight, if they aren't already specified.

By the way, the built-in "xterm" palette is very similar to the one defined here.