### PR TITLE
Documentation fix

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -883,7 +883,7 @@ app.use(/^\/?$/, function(req, res, _next) {res.redirect('/pl');});
 
 * The core files involved in question rendering are [lib/question.js](https://github.com/PrairieLearn/PrairieLearn/blob/master/lib/question.js), [lib/question.sql](https://github.com/PrairieLearn/PrairieLearn/blob/master/lib/question.sql), and [pages/partials/question.ejs](https://github.com/PrairieLearn/PrairieLearn/blob/master/pages/partials/question.ejs).
 
-* The above files are all called/included by each of the top-level pages that needs to render a question (e.g., `pages/instructorQuestion`, `pages/studentInstanceQuestionExam`, etc). Unfortunately the control-flow is complicated because we need to call `lib/question.js` during page data load, store the data it generates, and then later include the `pages/partials/question.ejs` template to actually render this data.
+* The above files are all called/included by each of the top-level pages that needs to render a question (e.g., `pages/instructorQuestionPreview`, `pages/studentInstanceQuestionExam`, etc). Unfortunately the control-flow is complicated because we need to call `lib/question.js` during page data load, store the data it generates, and then later include the `pages/partials/question.ejs` template to actually render this data.
 
 * For example, the exact control-flow for `pages/instructorQuestion` is:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -326,7 +326,7 @@ When previewing content within a local copy of PrairieLearn, the web version
 is powered by a docker container. At the end of a session, closing out of
 either the web browser or the terminal that launched the docker container
 will **not** stop PrairieLearn from running. Therefore, when relaunching the 
-docker version of PrairieLearn, the existing port my already be taken.
+docker version of PrairieLearn, the existing port may already be taken.
 For example, we would have:
 
 ```bash

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -14,7 +14,7 @@ git clone https://github.com/PrairieLearn/PrairieLearn.git
 * Install the Node.js packages.  This will use the version of `npm` that is pre-installed in the Docker image, so you don't need your own copy installed.
 
 ```sh
-docker run -w /PrairieLearn -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /usr/local/bin/npm ci
+docker run --rm -w /PrairieLearn -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /usr/local/bin/npm ci
 ```
 
 The path `/path/to/PrairieLearn` should be replaced with the *absolute* path to the PrairieLearn source on your computer.  If you're in the root of the source directory already, you can substitute `%cd%` (on Windows cmd), `${PWD}` (on Windows PowerShell), or `$PWD` (Linux, MacOS, and WSL) for `/path/to/PrairieLearn`.

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -17,7 +17,7 @@ git clone https://github.com/PrairieLearn/PrairieLearn.git
 docker run -w /PrairieLearn -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /usr/local/bin/npm ci
 ```
 
-The path `/path/to/PrairieLearn` should be replaced with the *absolute* path to the PrairieLearn source on your computer.  If you're in the root of the source directory already, you can substitute `%cd%` (on Windows) or `$PWD` (Linux and MacOS) for `/path/to/PrairieLearn`.
+The path `/path/to/PrairieLearn` should be replaced with the *absolute* path to the PrairieLearn source on your computer.  If you're in the root of the source directory already, you can substitute `%cd%` (on Windows cmd), `${PWD}` (on Windows PowerShell), or `$PWD` (Linux, MacOS, and WSL) for `/path/to/PrairieLearn`.
 
 By default, PrairieLearn will load `exampleCourse`, `testCourse`, and any courses mounted at `/course` and `/course[2-9]` in the Docker container.  To override this behavior, you can create a custom [`config.json` file](configJson.md).
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -50,8 +50,8 @@ python3.6 --version   # should return "Python 3.6" or higher
 * Install the Python libraries:
 
 ```sh
-cd PrairieLearn
-python3 -m pip install -r requirements.txt
+cd PrairieLearn/images/plbase
+python3 -m pip install -r python-requirements.txt
 ```
 
 * Create the database (one time only):


### PR DESCRIPTION
Some documentation fixes that I'd like to suggest.

### Summary:

*  Replace reference to `pages/instructorQuestion` with `pages/instructorQuestionPreview` here: https://prairielearn.readthedocs.io/en/latest/dev-guide/, as `pages/instructorQuestionPreview` superseded the former page here: https://github.com/PrairieLearn/PrairieLearn/commit/0019d997bf0d7e42588faa94130da23e4d84f888#diff-9672e40fe7e2b2b203956bdc79c5e450eb09be38c268458f5e17902fe8b0e581
* Add source directory options for PowerShell and WSL to accompany WIN CMD and macOS/Linux: https://prairielearn.readthedocs.io/en/latest/installingLocal/
* Suggest `--rm` when installing node packages inside a container as there's no need for the container to persist: https://prairielearn.readthedocs.io/en/latest/installingLocal/
* Change path to Python's `requirements.txt`, as the one that's currently referenced doesn't exist: https://prairielearn.readthedocs.io/en/latest/installingNative/
* Fix 'my' -> 'may' typo: https://prairielearn.readthedocs.io/en/latest/faq/