### PR TITLE
Add builds for all images in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,19 @@ jobs:
     - name: Merge with master
       run: git -c user.name=dev -c user.email=dev@example.com merge origin/master
     - name: Build the plbase docker image if needed
-      run: sh ./tools/build-plbase-if-needed.sh
+      run: sh ./tools/build-image-if-needed.sh images/plbase prairielearn/plbase
+    - name: Build the grader-c docker image if needed
+      run: sh ./tools/build-image-if-needed.sh graders/c prairielearn/grader-c
+    - name: Build the grader-java docker image if needed
+      run: sh ./tools/build-image-if-needed.sh graders/java prairielearn/grader-java
+    - name: Build the grader-python docker image if needed
+      run: sh ./tools/build-image-if-needed.sh graders/python prairielearn/grader-python
+    - name: Build the grader-r docker image if needed
+      run: sh ./tools/build-image-if-needed.sh graders/r prairielearn/grader-r
+    - name: Build the workspace-jupyterlab docker image if needed
+      run: sh ./tools/build-image-if-needed.sh workspaces/jupyterlab prairielearn/workspace-jupyterlab
+    - name: Build the workspace-xtermjs docker image if needed
+      run: sh ./tools/build-image-if-needed.sh workspaces/xtermjs prairielearn/workspace-xtermjs
     - name: Build the testing docker image
       run: docker build -t pltest .
     - name: Start the container

--- a/tools/build-image-if-needed.sh
+++ b/tools/build-image-if-needed.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+  echo "USAGE: $0 build_directory tag_name" >& 2
+  echo "Example: $0 images/plbase prairielearn/plbase" >& 2
+  exit 1
+fi
+
+BUILD_DIRECTORY=$1
+TAG_NAME=$2
+
+if git diff --exit-code remotes/origin/master...HEAD -- ${BUILD_DIRECTORY}; then
+  echo "${BUILD_DIRECTORY} files not modified; no rebuild required"
+else
+  echo "${BUILD_DIRECTORY} files modified; ${TAG_NAME} requires a rebuild"
+  docker build ${BUILD_DIRECTORY} -t ${TAG_NAME}
+fi

--- a/tools/build-plbase-if-needed.sh
+++ b/tools/build-plbase-if-needed.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if git diff --exit-code remotes/origin/master...HEAD -- images/plbase; then
-  echo "prairielearn/plbase files not modified; no rebuild required"
-else
-  echo "prairielearn/plbase requires a rebuild"
-  docker build ./images/plbase -t prairielearn/plbase
-fi


### PR DESCRIPTION
We were previously only building the `plbase` image in CI. This PR also builds all images in `graders/` and `workspaces/`. The `graders/python` image currently fails to build because of version conflicts between numpy and tensorflow, which we didn't catch earlier because we weren't building that image in CI.