### PR TITLE
Remove update of auth_user_id when adding manual grade

### DIFF
--- a/sprocs/instance_questions_update_score.sql
+++ b/sprocs/instance_questions_update_score.sql
@@ -112,7 +112,6 @@ BEGIN
 
         UPDATE submissions AS s
         SET
-            auth_user_id = arg_authn_user_id,
             feedback = CASE
                 WHEN feedback IS NULL THEN arg_feedback
                 WHEN arg_feedback IS NULL THEN feedback


### PR DESCRIPTION
Field should not be updated, since the field is expected to represent the creation user.