### PR TITLE
Add option to hide course instance from enrollment page

### DIFF
--- a/database/tables/course_instances.pg
+++ b/database/tables/course_instances.pg
@@ -2,6 +2,7 @@ columns
     course_id: bigint not null
     deleted_at: timestamp with time zone
     display_timezone: text
+    hide_in_enroll_page: boolean default false
     id: bigint not null default nextval('course_instances_id_seq'::regclass)
     long_name: text
     ps_linked: boolean not null default true

--- a/docs/courseInstance.md
+++ b/docs/courseInstance.md
@@ -104,6 +104,23 @@ The default timezone for course instances is the timezone of the course. This ca
 
 Allowable timezones are those in the TZ column in the [list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), which is a display version of the [IANA Time Zone Database](https://www.iana.org/time-zones).
 
+## Enrollment controls
+
+Students can enroll in a course instance through one of two ways:
+
+1. They can use a URL specific to the course instance or [to one of its assessments](assessment.md#linking-to-assessments). The appropriate link to provide to students can be found by opening the "Settings" tab of the Course Instance. This page includes, among other useful information, a Student Link that can be provided to students. This link points students to the list of assessments associated to the course instance, enrolling them automatically in the course instance if they are not yet enrolled.
+
+2. They can use the "Enroll" button in PrairieLearn's main page. This button opens a page listing all course instances that are currently available for enrollment, giving students the option to Add new courses.
+
+Some instructors may wish to hide their course from the list of available course instances in the Enroll page. This may be done to provide a small level of control over which students get access to the course, or to avoid confusion in case of course instances that are not expected to be visible to students in general. For these instances, the following setting will hide the course instance from the list of instances in the Enroll page, even if the instance is available for enrollment.
+
+```json
+{
+    "hideInEnrollPage": true
+}
+```
+
+Note that *this is not a security setting*. Students may still enroll in the course instance if they get access to the URL, either through friends or by [Forced Browing Attacks](https://owasp.org/www-community/attacks/Forced_browsing). Instructors that wish to actually restrict course enrollment to a specific list of students should instead use well-defined access rules with restrictions by UIDs, Institution, or through LTI support.
 
 ## LTI support
 

--- a/migrations/231_course_instances__hide_in_enroll_page__add.sql
+++ b/migrations/231_course_instances__hide_in_enroll_page__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE course_instances ADD COLUMN IF NOT EXISTS hide_in_enroll_page boolean DEFAULT false;

--- a/pages/enroll/enroll.sql
+++ b/pages/enroll/enroll.sql
@@ -16,6 +16,7 @@ WHERE
     u.user_id = $user_id
     AND ci.deleted_at IS NULL
     AND c.deleted_at IS NULL
+    AND NOT ci.hide_in_enroll_page
     AND check_course_instance_access(ci.id, COALESCE(e.role, 'Student'), u.uid, u.institution_id, $req_date)
 ORDER BY
     c.short_name, c.title, c.id, d.start_date DESC NULLS LAST, d.end_date DESC NULLS LAST, ci.id DESC;

--- a/schemas/schemas/infoCourseInstance.json
+++ b/schemas/schemas/infoCourseInstance.json
@@ -31,6 +31,11 @@
             "type": "boolean",
             "default": true
         },
+        "hideInEnrollPage": {
+            "description": "If set to true, hides the course instance in the enrollment page, so that only direct links to the course can be used for enrollment.",
+            "type": "boolean",
+            "default": false
+        },
         "userRoles": {
             "description": "Special roles for specific users (anyone not listed is assumed to be a 'Student').",
             "type": "object",

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -123,6 +123,7 @@ BEGIN
     SET
         long_name = src.data->>'long_name',
         display_timezone = src.data->>'display_timezone',
+        hide_in_enroll_page = (src.data->>'hide_in_enroll_page')::boolean,
         sync_errors = NULL,
         sync_warnings = src.warnings
     FROM disk_course_instances AS src

--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -148,6 +148,7 @@ const FILE_UUID_REGEX = /"uuid":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4
  * @property {string} longName
  * @property {number} number
  * @property {string} timezone
+ * @property {boolean} hideInEnrollPage
  * @property {{ [uid: string]: "Student" | "TA" | "Instructor"}} userRoles
  * @property {CourseInstanceAllowAccess[]} allowAccess
  * @property {boolean} allowIssueReporting

--- a/sync/fromDisk/courseInstances.js
+++ b/sync/fromDisk/courseInstances.js
@@ -28,6 +28,7 @@ function getParamsForCourseInstance(courseInstance, courseTimezone) {
         uuid: courseInstance.uuid,
         long_name: courseInstance.longName,
         number: courseInstance.number,
+        hide_in_enroll_page: courseInstance.hideInEnrollPage || false,
         display_timezone: courseInstance.timezone || courseTimezone || 'America/Chicago',
         access_rules: accessRules,
         user_roles: userRoles,


### PR DESCRIPTION
Some instructors may wish to hide their course from the list of available course instances in the Enroll page. This may be done to provide a small level of control over which students get access to the course, or to avoid confusion in case of course instances that are not expected to be visible to students in general. For these instances, this new setting will hide the course instance from the list of instances in the Enroll page, even if the instance is available for enrollment.