### PR TITLE
Random fake data

### DIFF
--- a/exampleCourse/courseInstances/Sp15/assessments/hw04-demoQuestions/infoAssessment.json
+++ b/exampleCourse/courseInstances/Sp15/assessments/hw04-demoQuestions/infoAssessment.json
@@ -53,7 +53,8 @@
                 {"id": "demo/autograder/ansiOutput",           "points": 2, "maxPoints": 4},
                 {"id": "demo/overlayTriangle",                 "points": 2, "maxPoints": 4},
                 {"id": "demo/addHTMLtable",                    "points": 2, "maxPoints": 4},
-                {"id": "demo/insertEmbeddedVideo",             "points": 2, "maxPoints": 4}
+                {"id": "demo/insertEmbeddedVideo",             "points": 2, "maxPoints": 4},
+                {"id": "demo/randomFakeData",                  "points": 2, "maxPoints": 4}
             ]
         }
     ]

--- a/exampleCourse/questions/demo/randomFakeData/info.json
+++ b/exampleCourse/questions/demo/randomFakeData/info.json
@@ -1,0 +1,6 @@
+{
+  "uuid": "c1117c2d-e82c-4234-8c4e-f28f1e48e801",
+  "title": "Demo: Random fake data",
+  "topic": "Demo",
+  "type": "v3"
+}

--- a/exampleCourse/questions/demo/randomFakeData/info.json
+++ b/exampleCourse/questions/demo/randomFakeData/info.json
@@ -2,5 +2,6 @@
   "uuid": "c1117c2d-e82c-4234-8c4e-f28f1e48e801",
   "title": "Demo: Random fake data",
   "topic": "Demo",
+  "tags": ["v3", "MC"],
   "type": "v3"
 }

--- a/exampleCourse/questions/demo/randomFakeData/question.html
+++ b/exampleCourse/questions/demo/randomFakeData/question.html
@@ -1,0 +1,24 @@
+<pl-question-panel>
+  <p>4 employees at {{params.company}} were having lunch when they realized that they were all born in the same year. Their birthdays are:</p>
+  <ul>
+    {{#params.employees}}
+      <li><strong>{{name}}</strong>: {{birthday}}</li>
+    {{/params.employees}}
+  </ul>
+  <p>Who is the youngest?</p>  
+</pl-question-panel>
+
+<pl-multiple-choice answers-name="ans">
+  <pl-answer correct="true">
+    {{params.youngest}}
+  </pl-answer>
+  <pl-answer correct="false">
+    {{params.employee1}}
+  </pl-answer>
+  <pl-answer correct="false">
+    {{params.employee2}}
+  </pl-answer>
+  <pl-answer correct="false">
+    {{params.employee3}}
+  </pl-answer>
+</pl-multiple-choice>

--- a/exampleCourse/questions/demo/randomFakeData/server.py
+++ b/exampleCourse/questions/demo/randomFakeData/server.py
@@ -1,0 +1,39 @@
+import random
+import datetime
+from faker import Faker
+
+fake = Faker()
+
+
+def formatDate(date):
+    return date.strftime("%B %d, %Y")
+
+
+def appendEmployee(data, alias, birthdays):
+    name = fake.name()
+    birthday = formatDate(birthdays.pop(0))
+    data['params'][alias] = name
+
+    # Store in array to facilitate rendering list of employees in question.html template
+    data['params']['employees'].append({'name': name, 'birthday': birthday})
+
+
+def generate(data):
+    # Start with `set` to ensure uniqueness
+    birthdays = set()
+
+    year = 2000
+    while len(birthdays) < 4:
+        birthdays.add(fake.date_between(datetime.date(year, 1, 1),
+                                        datetime.date(year, 12, 31)))
+
+    # Once sorted, the first birthday belongs to the youngest employee
+    birthdays = sorted(list(birthdays))
+
+    data['params']['employees'] = []
+    appendEmployee(data, 'youngest', birthdays)
+    appendEmployee(data, 'employee1', birthdays)
+    appendEmployee(data, 'employee2', birthdays)
+    appendEmployee(data, 'employee3', birthdays)
+    random.shuffle(data['params']['employees'])
+    data['params']['company'] = fake.company()

--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -1,4 +1,5 @@
 chevron==0.14.0
+Faker==7.0.1
 flake8==3.9.0
 flake8-quotes==3.2.0
 lxml==4.6.3


### PR DESCRIPTION
Do you have a use case for inserting random fake data (e.g. company names, currencies, job titles, etc) into questions to throw off students who try to cheat by copying and searching questions on Google or question banks? I found it useful when randomizing sample questions that were sent to me by accounting professors.

This PR adds the following:

* [faker python library](https://faker.readthedocs.io/en/master/) to the list of required libraries for plbase
* An example of how to use faker inside PrairieLearn. The example was added to `hw04` of `exampleCourse` and it looks like this:

![image](https://user-images.githubusercontent.com/504505/114343519-e514e300-9b12-11eb-9942-24568466df51.png)
