### PR TITLE
Add cla-assistant GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have reviewed and hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Pin to a specific version - this third-party action uses a personal access token
+        uses: cla-assistant/github-action@948230deb0d44dd38957592f08c6bd934d96d0cf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
+        with:
+          # Signatures are stored in https://github.com/PrairieLearn/cla
+          remote-organization-name: PrairieLearn 
+          remote-repository-name: cla 
+          path-to-signatures: signatures.json
+          path-to-document: https://github.com/PrairieLearn/cla/blob/main/CLA.md
+          branch: main
+          allowlist: nwalters512,mwest1066,mfsilva22
+          custom-pr-sign-comment: I have reviewed and hereby sign the CLA
+          create-file-commit-message: Create signatures.json
+          signed-commit-message: '$contributorName signed the CLA in https://github.com/PrairieLearn/PrairieLearn/pull/$pullRequestNo'
+          custom-notsigned-prcomment: 'Thanks for your contribution! Like many open source projects, we ask that you sign our [Contributor License Agreement](https://github.com/PrairieLearn/cla/blob/main/CLA.md) before we can accept your contribution. You can sign the CLA by posting a comment with the below format:<br/>'


### PR DESCRIPTION
This will prompt contributors to sign our CLA when they make a contribution for the first time.