### PR TITLE
Replace `correct_answer` with `correct_answers`

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -262,7 +262,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answers-name` | string | — | Variable name to store data in.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answers` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`correct-answer` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
 `suffix` | text | — | A suffix to display after the input box (e.g., `suffix="$\rm m/s^2$"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
@@ -525,7 +525,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answers-name` | string | — | Variable name to store data in. If the correct answer `ans` is a `sympy` object, you should use `import prairielearn as pl` and `data['correct_answers'][answers-name] = pl.to_json(ans)`.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answers` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`correct-answer` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
 `variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
@@ -583,7 +583,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answers-name` | string | — | Variable name to store data in.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answers` | string | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`correct-answer` | string | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$x =$"`).
 `suffix` | text | — | A suffix to display after the input box (e.g., `suffix="items"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -262,7 +262,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answers-name` | string | — | Variable name to store data in.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answer` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`correct-answers` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
 `suffix` | text | — | A suffix to display after the input box (e.g., `suffix="$\rm m/s^2$"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
@@ -270,7 +270,7 @@ Attribute | Type | Default | Description
 `rtol` | number | 1e-2 | Relative tolerance for `comparison="relabs"`.
 `atol` | number | 1e-8 | Absolute tolerance for `comparison="relabs"`.
 `digits` | integer | 2 | number of digits that must be correct for `comparison="sigfig"` or `comparison="decdig"`.
-`allow-complex` | boolean | false | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answer'][answers-name] = pl.to_json(ans)`.
+`allow-complex` | boolean | false | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answers'][answers-name] = pl.to_json(ans)`.
 `allow-blank` | boolean | false |  Whether or not an empty input box is allowed. By default, empty input boxes will not be graded (invalid format).
 `blank-value` | string | 0 (zero) | Value to be used as an answer if element is left blank. Only applied if `allow-blank` is `true`. Must follow the same format as an expected user input (e.g., fractions if allowed, complex numbers if allowed, etc.).
 `show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
@@ -516,16 +516,16 @@ def generate(data):
   z = x + y + 1
 
   # Answer to fill in the blank input stored as JSON.
-  data['correct_answer']['symbolic_math'] = pl.to_json(z)
+  data['correct_answers']['symbolic_math'] = pl.to_json(z)
 ```
 
 #### Customizations
 
 Attribute | Type | Default | Description
 --- | --- | --- | ---
-`answers-name` | string | — | Variable name to store data in. If the correct answer `ans` is a `sympy` object, you should use `import prairielearn as pl` and `data['correct_answer'][answers-name] = pl.to_json(ans)`.
+`answers-name` | string | — | Variable name to store data in. If the correct answer `ans` is a `sympy` object, you should use `import prairielearn as pl` and `data['correct_answers'][answers-name] = pl.to_json(ans)`.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answer` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`correct-answers` | float | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
 `variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
@@ -583,7 +583,7 @@ Attribute | Type | Default | Description
 --- | --- | --- | ---
 `answers-name` | string | — | Variable name to store data in.
 `weight` | integer | 1 | Weight to use when computing a weighted average score over elements.
-`correct-answer` | string | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
+`correct-answers` | string | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `label` | text | — | A prefix to display before the input box (e.g., `label="$x =$"`).
 `suffix` | text | — | A suffix to display after the input box (e.g., `suffix="items"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
@@ -710,7 +710,7 @@ Attribute | Type | Default | Description
 `rtol` | number | 1e-2 | Relative tolerance for `comparison="relabs"`.
 `atol` | number | 1e-8 | Absolute tolerance for `comparison="relabs"`.
 `digits` | integer | 2 | number of digits that must be correct for `comparison="sigfig"` or `comparison="decdig"`.
-`allow-complex` | boolean | false | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answer'][answers-name] = pl.to_json(ans)`.
+`allow-complex` | boolean | false | Whether or not to allow complex numbers as answers. If the correct answer `ans` is a complex object, you should use `import prairielearn as pl` and `data['correct_answers'][answers-name] = pl.to_json(ans)`.
 `show-help-text` | boolean | true | Show the question mark at the end of the input displaying required input parameters.
 
 #### Details
@@ -867,7 +867,7 @@ Attribute | Type | Default | Description
 `body-canrotate` | boolean | true | If you can rotate the body in the UI.
 `camera-canmove` | boolean | true | If you can move the camera (i.e., change the view) in the UI.
 `body-pose-format` | string | rpy | Determines how `body-orientation` is interpreted. If `rpy` then `[roll, pitch, yaw]`. If `matrix` then 3x3 rotation matrix `[[...], [...], [...]]`. If `quaternion` then `[x, y, z, w]`. If `axisangle` then `[x, y, z, theta]` where `x, y, z` are coordinates of axis and `theta` is angle.
-`answer-pose-format` | string | rpy | Determines how the answer `data['correct_answer'][answer-name]` is interpreted. If `homogeneous`, then the answer must be a 4x4 homogeneous transformation matrix `[[...], [...], [...], [...]]`. Otherwise, the answer must be a list with two elements. The first element must describe position as `[x, y, z]`. The second element must describe orientation, interpreted based on `answer-pose-format`. If `rpy` then `[roll, pitch, yaw]`. If `matrix` then 3x3 rotation matrix `[[...], [...], [...]]`. If `quaternion` then `[x, y, z, w]`. If `axisangle` then `[x, y, z, theta]` where `x, y, z` are coordinates of axis and `theta` is angle.
+`answer-pose-format` | string | rpy | Determines how the answer `data['correct_answers'][answer-name]` is interpreted. If `homogeneous`, then the answer must be a 4x4 homogeneous transformation matrix `[[...], [...], [...], [...]]`. Otherwise, the answer must be a list with two elements. The first element must describe position as `[x, y, z]`. The second element must describe orientation, interpreted based on `answer-pose-format`. If `rpy` then `[roll, pitch, yaw]`. If `matrix` then 3x3 rotation matrix `[[...], [...], [...]]`. If `quaternion` then `[x, y, z, w]`. If `axisangle` then `[x, y, z, theta]` where `x, y, z` are coordinates of axis and `theta` is angle.
 `text-pose-format` | string | matrix | Determines how the pose of the body is displayed as text. If `matrix` then position is `[x, y, z]` and orientation is a 3x3 rotation matrix. If `quaternion` then position is `[x, y, z]` and orientation is `[x, y, z, w]`. If `homogeneous` then pose is a 4x4 homogeneous transformation matrix.
 `show-pose-in-question` | boolean | true | If the current pose of the body is displayed in the question panel.
 `show-pose-in-correct-answer` | boolean | true | If the current pose of the body is displayed in the correct answer panel.

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -30,7 +30,7 @@ Attribute | Type | Default | Description
 `height` | integer | 320 | Vertical height of the canvas (in pixels).
 `grid-size` | integer | 20 | Size of the square grid for the canvas background (in pixels). If `grid-size = 0`, then the background is white.
 `snap-to-grid` | boolean | false | If true, objects placed in the canvas snap to closest grid point. Otherwise, they can be placed outside of the grid.
-`correct-answer` | string | special | Correct answer for grading. Defaults to `data["correct-answers"][answers-name]`.
+`correct-answer` | string | special | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.
 `tol` | float | `0.5*grid-size` | Tolerance to check the position of objects (in pixels). The error is calculated as the absolute difference between expected position and submitted one.
 `angle-tol` | float | 10 | Tolerance to check angles (in degrees). The error is calculated as the absolute difference between expected angle and submitted one.
 `show-tolerance-hint` | boolean | true | Show tolerance hint under the canvas. The default is `true` when `gradable = true`.

--- a/docs/question.md
+++ b/docs/question.md
@@ -163,7 +163,7 @@ A complete `question.html` and `server.py` example looks like:
   If $x = {{params.x}}$ and $y$ is {{params.operation}} $x$, what is $y$?
 </pl-question-panel>
 
-<!-- y is defined by data["correct_answer"]["y"] in server.py's `generate()`. -->
+<!-- y is defined by data["correct_answers"]["y"] in server.py's `generate()`. -->
 <pl-number-input answers-name="y" label="$y =$"></pl-number-input>
 ```
 

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -39,9 +39,9 @@ def prepare(element_html, data):
 
     correct_answer = pl.get_string_attrib(element, 'correct-answer', CORRECT_ANSWER_DEFAULT)
     if correct_answer is not None:
-        if name in data['correct-answers']:
-            raise Exception('duplicate correct-answers variable name: %s' % name)
-        data['correct-answers'][name] = correct_answer
+        if name in data['correct_answers']:
+            raise Exception('duplicate correct_answers variable name: %s' % name)
+        data['correct_answers'][name] = correct_answer
 
     imaginary_unit = pl.get_string_attrib(element, 'imaginary-unit-for-display', IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT)
     if not (imaginary_unit == 'i' or imaginary_unit == 'j'):


### PR DESCRIPTION
I had a look at all of the example problems and all of them use `data["correct_answers"]` rather than `data["correct_answer"]`. In some cases in the docs, `correct_answer` is used and generates an error (specifically in the symbolic_input question.

It would be nice if someone could confirm this is the case before updating the documentation.