### PR TITLE
Fix a very small typo in docs.

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -516,7 +516,7 @@ def generate(data):
   z = x + y + 1
 
   # Answer to fill in the blank input stored as JSON.
-  data['correct_answer']['symbolic_math'] = pl.to_json(z)
+  data['correct_answers']['symbolic_math'] = pl.to_json(z)
 ```
 
 #### Customizations


### PR DESCRIPTION
The docs' example for symbolic inputs incorrectly refers to data["correct_answer"] instead of data["correct_answers"]. Quite a minor error, but I thought it was worth correcting.