### PR TITLE
Fix broken link to external grader page

### DIFF
--- a/docs/question.md
+++ b/docs/question.md
@@ -449,6 +449,6 @@ For most [elements] there are four different ways of grading the student answer.
 
 3. Write a [custom `grade(data)`](#question-serverpy) function in server.py that checks `data["submitted_answers"][VAR_NAME]` and sets scores. This can do anything, including having multiple correct answers, testing properties of the submitted answer for correctness, compute correct answers of some elements based on the value of other elements, etc.
 
-4. Write an [external grader](externalGrading), though this is typically applied to more complex questions like coding.
+4. Write an [external grader](externalGrading.md), though this is typically applied to more complex questions like coding.
 
 If a question has more than one of the above options, each of them overrides the one before it. Even if options 3 (custom grade function) or 4 (external grader) are used, then it can still be helpful to set a correct answer so that it is shown to students as a sample of what would be accepted. If there are multiple correct answers then it's probably a good idea to add a note with [`pl-answer-panel`](elements/#pl-answer-panel-element) that any correct answer would be accepted and this displayed answer is only an example.


### PR DESCRIPTION
At the bottom of the [Question configuration](https://prairielearn.readthedocs.io/en/latest/question/) documentation page, there is a broken link to the [External grading](https://prairielearn.readthedocs.io/en/latest/externalGrading/) page. This PR fixes the issue.