### PR TITLE
Fix attribute name answer-name for pl-threejs

### DIFF
--- a/elements/pl-threejs/pl-threejs.py
+++ b/elements/pl-threejs/pl-threejs.py
@@ -28,7 +28,7 @@ GRADE_DEFAULT = True
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     required_attribs = [
-        'answer_name',          # key for 'submitted_answers' and 'true_answers'
+        'answer-name',          # key for 'submitted_answers' and 'true_answers'
     ]
     optional_attribs = [
         'body-position',        # [x, y, z]


### PR DESCRIPTION
Not much to say: wrong attribute name being used in prepare, was causing even the example course sample of pl-threejs to fail.