### PR TITLE
Restore AGPLv3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    PrairieLearn, an online, problem-driving learning system
-    Copyright (C) 2015-2021 University of Illinois at Urbana-Champaign
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
We messed up and filled in our own values into fields that were intentionally supposed to be placeholders in the license :sweat_smile: this fixes that