### PR TITLE
Stashing tested changes to add new function names to the pl-symbolic-…

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -499,7 +499,7 @@ Fill in the blank field that allows for mathematical symbol input.
 
 **question.html**
 ```html
-<pl-symbolic-input answers-name="symbolic_math" variables="x, y" label="$z =$"></pl-symbolic-input>
+<pl-symbolic-input answers-name="symbolic_math" variables="x, y" extra-functions="loglog, zeta" label="$z =$"></pl-symbolic-input>
 ```
 
 **server.py**
@@ -529,6 +529,8 @@ Attribute | Type | Default | Description
 `label` | text | — | A prefix to display before the input box (e.g., `label="$F =$"`).
 `display` | "block" or "inline" | "inline" | How to display the input field.
 `variables` | string | — | A comma-delimited list of symbols that can be used in the symbolic expression.
+`enable-more-function-names` | boolean | false | Whether to include extra sets of reserved function names used in the symbolic expression.
+`extra-functions` | string | - | A comma-delimited list of extra function names that can be used in the symbolic expression. Note that an exception is raised if the list contains one or more names that coincide with extisting reserved functions.
 `allow-complex` | boolean | false | Whether complex numbers (expressions with `i` or `j` as the imaginary unit) are allowed.
 `imaginary-unit-for-display` | string | `i` | The imaginary unit that is used for display. It must be either `i` or `j`. Again, this is *only* for display. Both `i` and `j` can be used by the student in their submitted answer, when `allow-complex="true"`.
 `allow-blank` | boolean | false |  Whether or not an empty input box is allowed. By default, an empty input box will not be graded (invalid format).


### PR DESCRIPTION
# Overview

This pull request (PR) enables the functionality I requested in issue #4268. I have tested it and everything seems to work. I have also updated the element documentation as a part of this PR. 

## New functionality

This PR enables the following extra tags within the ``pl-symbolic-input` element for symbolic formula parsing:
* Added a few extra default function names including the following defaults: ``sec, csc, cot, arccos, arcsin, arctan, ln, re, im, max, min``.
* Enables the setting ``enable-more-function-names="true|false"`` (default: ``false``) which enables *even more* reserved function names. These extra function names include the following: ``cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, asech, acsch, acith, sgn, abs, arg, ceil, floor, frac``.
* Enables the setting ``extra-functions="<list of comma delimited names>"`` to allow on-the-fly user defined settings of reserved function names for symbolic processing.
## Notes:

Notice that due to the way the ``pl-symbolic-input`` tags are handled in each ``question.html``, the collection of functions added within all of the combined 'extra-functions' tag settings are globally defined within each ``question.html``.

## Examples

**(question.html):**
```xml
<pl-symbolic-input answers-name="z" variables="a, m" enable-more-function-names="true" allow-complex="true" label="$z=$"></pl-symbolic-input>
<pl-symbolic-input answers-name="z" variables="a, m" extra-functions="loglog, zeta" allow-complex="true" label="$z=$"></pl-symbolic-input>
```
**(server.py):**
```python
import sympy
import prairielearn as pl

def generate(data):
    sympy.var('y b a m')
    x = (y - b) / a 
    z = m * (sympy.cos(a) + sympy.I * sympy.sin(a))
    c = a + sympy.I * b 
    data['correct_answers']['x'] = pl.to_json(x)
    data['correct_answers']['z'] = 'loglog(a) * zeta(m)'
    data['correct_answers']['I'] = 'V / R'
    data['correct_answers']['c'] = pl.to_json(c)
    data['correct_answers']['dx'] = 'x' 
    x = sympy.var('x')
    data['correct_answers']['simplify'] = pl.to_json(x**2+x+1)
```