### PR TITLE
Facelift to authenticated homepage

### DIFF
--- a/pages/home/courseInstanceListEntry.ejs
+++ b/pages/home/courseInstanceListEntry.ejs
@@ -1,0 +1,15 @@
+<li class="d-flex mb-1" style="max-width: 100%;">
+  <a href="<%= href %>" class="py-2 px-3 mr-1 border rounded" style="max-width: 350px; overflow: hidden;">
+    <div style="font-size: 125%;">
+      <div class="font-weight-bold">
+        <%= course_instance.short_name %>
+      </div>
+      <div class="text-truncate text-dark" style="line-height: 1.3;">
+        <%= course_instance.title %>
+      </div>
+    </div>
+    <div class="text-muted text-truncate">
+      <%= course_instance.instance_long_name %>
+    </div>
+  </a>
+</li>

--- a/pages/home/courseListEntry.ejs
+++ b/pages/home/courseListEntry.ejs
@@ -1,0 +1,10 @@
+<li class="d-flex mb-1">
+  <a href="<%= href %>" class="py-2 px-3 mr-1 border rounded">
+    <div class="font-weight-bold">
+      <%= course.short_name %>
+    </div>
+    <div class="text-truncate" style="max-width: 400px;">
+      <%= course.title %>
+    </div>
+  </a>
+</li>

--- a/pages/home/home.ejs
+++ b/pages/home/home.ejs
@@ -119,68 +119,65 @@
 
         <%- include('../partials/advertisement'); %>
 
-        <% if (courses && courses.length > 0) { %>
-        <div class="card mb-4">
-          <div class="card-header bg-primary text-white">Courses</div>
-          <table class="table table-sm table-hover table-striped">
-            <tbody>
-              <% courses.forEach(function(course) { %>
-              <tr>
-                <td>
-                  <a href="<%= plainUrlPrefix %>/course/<%= course.id %>">
-                    <%= course.label %>
-                  </a>
-                </td>
-              </tr>
-              <% }); %>
-            </tbody>
-          </table>
-        </div><!-- card -->
-        <% } %> <!-- courses.length -->
+        <%# If the user doesn't have access to anything except for course instances, don't show multiple sections for courses. %> 
+        <% const showCoursesByCategory = (courses && courses.length > 0); %>
 
-        <div class="card mb-4">
-          <div class="card-header bg-primary text-white d-flex align-items-center">
-            <% if (courses && courses.length > 0) { %>
-            Course instances
-            <% } else { %>
-            Courses
-            <% } %>
-            <% if (authn_provider_name !== 'LTI') { %>
-            <a href="<%= plainUrlPrefix %>/enroll" class="btn btn-light btn-sm ml-auto">
+        <% if (showCoursesByCategory) { %>
+          <%# The course instances heading becomes an h1 otherwise %> 
+          <h1 class="h2 mb-4 font-weight-normal">Your courses</h1>
+        <% } %>
+
+        <%# Courses that the user is an administrator for %> 
+        <% if (showCoursesByCategory) { %>
+          <div class="border-bottom mb-3">
+            <h2 class="h4 font-weight-normal">
+              Managed courses
+            </h2>
+          </div>
+          <ul class="d-flex flex-wrap pl-0 mb-4">
+            <% courses.forEach(function(course) { %>
+              <%- include('courseListEntry.ejs', {
+                href: `${plainUrlPrefix}/course/${course.id}`,
+                compact: true,
+                course,
+              }); %>
+            <% }); %>
+          </ul>
+        <% } %>
+
+        <div class="d-flex justify-content-between align-items-baseline border-bottom mb-3">
+          <% if (showCoursesByCategory) { %>
+            <h2 class="h4 font-weight-normal">Course instances</h2>
+          <% } else { %>
+            <h1 class="h2 font-weight-normal">Your courses</h1>
+          <% } %>
+          <% if (authn_provider_name !== 'LTI') { %>
+            <a href="<%= plainUrlPrefix %>/enroll" class="ml-auto">
               <i class="fa fa-edit" aria-hidden="true"></i>
               <span class="d-none d-sm-inline">Add or remove courses</span>
             </a>
-            <% } %>
-          </div><!-- card-header -->
-
-          <% if (course_instances && course_instances.length == 0) { %>
+          <% } %>
+        </div>
+        <% if (course_instances && course_instances.length == 0) { %>
           <% if (devMode) { %>
-          <div class="card-body">
-            No courses loaded. Click <strong>“Load from disk”</strong>
-            above and then click <strong>“Home”</strong> to come back to
-            this page.
-          </div>
+            <div>
+              No courses loaded. Click <span class="badge border">Load from disk</span>
+              above and then click <strong>PrairieLearn</strong> to come back to
+              this page.
+            </div>
           <% } else { %> <!-- devMode -->
-          <div class="card-body">
-            No courses found. Use the “Add or remove courses” button to add one.
-          </div>
+            You aren't part of any courses. Use the “Add or remove courses” button to add one.
           <% } %> <!-- devMode -->
-          <% } else { %> <!-- course_instances.length -->
-          <table class="table table-sm table-hover table-striped">
-            <tbody>
-              <% course_instances.forEach(function(course_instance) { %>
-              <tr>
-                <td>
-                  <a href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>">
-                    <%= course_instance.label %>
-                  </a>
-                </td>
-              </tr>
-              <% }); %>
-            </tbody>
-          </table>
-          <% } %> <!-- course_instances.length -->
-        </div><!-- card -->
+        <% } else { %> <!-- course_instances.length -->
+          <ul class="d-flex flex-wrap pl-0 mb-4">
+            <% course_instances.forEach(function(course_instance) { %>
+              <%- include('courseInstanceListEntry.ejs', {
+                href: `${plainUrlPrefix}/course/${course_instance.id}`,
+                course_instance,
+              }); %>
+            <% }); %>
+          </ul>
+        <% } %> <!-- course_instances.length -->
       </div><!-- container -->
       <% } else { %> <!-- isAuthenticated -->
       <div class="position-relative bg-students text-white text-center pt-5">

--- a/pages/home/home.sql
+++ b/pages/home/home.sql
@@ -25,7 +25,8 @@ course_permissions_for_user AS (
 courses_list AS (
     SELECT
         coalesce(jsonb_agg(jsonb_build_object(
-            'label', c.short_name || ': ' || c.title,
+            'short_name', c.short_name,
+            'title', c.title,
             'id', c.id
         ) ORDER BY c.short_name, c.title, c.id), '[]'::jsonb) AS courses
     FROM
@@ -52,7 +53,9 @@ enrollments_for_user AS (
 course_instances_list AS (
     SELECT
         coalesce(jsonb_agg(jsonb_build_object(
-            'label', c.short_name || ': ' || c.title || ', ' || ci.long_name,
+            'short_name', c.short_name, 
+            'title', c.title, 
+            'instance_long_name', ci.long_name,
             'id', ci.id
         ) ORDER BY c.short_name, c.title, c.id, d.start_date DESC NULLS LAST, d.end_date DESC NULLS LAST, ci.id DESC), '[]'::jsonb) AS course_instances
     FROM


### PR DESCRIPTION
This is a redesign for the authenticated home page that is more accessibility-minded with the use of headers and lists instead of a single-column table. Visually, it's inspired by sites such as Gradescope and ClassTranscribe. 

# Screenshots

## Managing courses
| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/32315760/120523570-e502c800-c38a-11eb-8a3e-7d74e1dcd716.png) | ![](https://user-images.githubusercontent.com/32315760/120523567-e46a3180-c38a-11eb-8ff1-97d1fc2ff934.png) |

## No managed courses
| Before | After |
| --- | --- | 
| ![home-nomanage-before](https://user-images.githubusercontent.com/32315760/120523572-e502c800-c38a-11eb-96b9-f860f6e263e0.png) | ![home-nomanage-after](https://user-images.githubusercontent.com/32315760/120523571-e502c800-c38a-11eb-8020-81b5b7397756.png) |

You'll notice that the "Your courses" h1 tag replaces the h2 tag for "Course instances" if you're not staff on any courses. This ensures that there aren't too many headers on-screen if they aren't needed, and also makes sure that there's always an h1 tag.

# Loose ends
 - [ ] Fix tests that use this page after the design gets approved.
- @tdy Back when the landing page dropped, some people were asking why the landing and courses overview page were part of the same template. Now that time has passed, are you still committed to keeping these pages part of the same file? Now that only a couple of elements are shared between these pages, I think it would be nice for maintainability to move them into separate EJS files completely, and use partials to manage the shared elements.