### PR TITLE
Change sanitize function to properly handle null values

### DIFF
--- a/prairielib/lib/util.js
+++ b/prairielib/lib/util.js
@@ -6,7 +6,9 @@
  * @return {Object}     The sanitized object.
  */
 module.exports.sanitizeObject = function sanitizeObject(value) {
-    if (Array.isArray(value)) {
+    if (value === null) {
+        return null;
+    } else if (Array.isArray(value)) {
         return value.map(sanitizeObject);
     } else if (typeof value === 'string') {
         return value.replace('\u0000', '\\u0000');

--- a/prairielib/lib/util.test.js
+++ b/prairielib/lib/util.test.js
@@ -69,4 +69,16 @@ describe('sanitizeObject', () => {
     };
     check(input, expected);
   });
+
+  test('handles null values correctly', () => {
+    const input = {
+      test: 'test\u0000ing',
+      a: null,
+    };
+    const expected = {
+      test: 'test\\u0000ing',
+      a: null,
+    };
+    check(input, expected);
+  });
 });


### PR DESCRIPTION
The `sanitizeObject` function in prairielib uses `typeof value === 'object'` as a way to check if `value` is an object, but this expression is also true for `null`. This has implications in grader hosts, whenever autograders include, in the results, a key that points to `null`. Instead of treating the object as null, this would trigger a parsing error on the results object. This PR fixes it by handling null values explicitly.