### PR TITLE
Fix grader-python build with compatible package versions

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -21,5 +21,5 @@ PuLP==2.4
 ipython==7.21.0
 nbformat==5.1.2
 nbconvert==6.0.7
-tensorflow==2.4.1
+tensorflow==2.5.0
 automata-lib==4.0.0.post1

--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -5,7 +5,7 @@ pandas==1.2.3
 scipy==1.6.1
 sympy==1.7.1
 Pillow==8.1.1
-pygraphviz==1.7
+pygraphviz==1.6
 defusedxml==0.6.0
 openpyxl==3.0.6
 scikit-learn==0.24.1

--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==3.3.4
 networkx==2.5
-numpy==1.20.1
+numpy==1.19.2
 pandas==1.2.3
 scipy==1.6.1
 sympy==1.7.1

--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==3.3.4
 networkx==2.5
-numpy==1.19.2
+numpy==1.19.4
 pandas==1.2.3
 scipy==1.6.1
 sympy==1.7.1


### PR DESCRIPTION
* Upgrade tensorflow from 2.4.1 to 2.5.0 to resolve "version not found" for 2.4.x
* Downgrade numpy from 1.20.1 to 1.19.4 because tensorflow doesn't yet support numpy version 1.20.x
* Downgrade pygraphviz from 1.7 to 1.6 because 1.7 doesn't build. The build failure is because it can't find `cgraph.h` which is in `/usr/include/graphviz/cgraph.h` (from the system package `graphviz-devel`). I don't know whose fault this is, but see https://github.com/pygraphviz/pygraphviz/issues/155

I'm not sure why the original numpy 1.20.0 upgrade PR (#3748) succeeded.