### PR TITLE
Remove TensorFlow from grader-python

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -21,5 +21,4 @@ PuLP==2.4
 ipython==7.25.0
 nbformat==5.1.2
 nbconvert==6.1.0
-tensorflow==2.5.0
 automata-lib==4.0.0.post1


### PR DESCRIPTION
TensorFlow has been causing significant issues because it does not track latest versions of NumPy very quickly, so this PR removes it from the default python grading image. We will encourage anyone who needs TF (or similar libraries such as PyTorch) to make their own copy of the `grader-python` image where they can add TF and select appropriate versions of NumPy and other libraries.