### PR TITLE
Remove NOT NULL constraint on submissions.regradable

### DIFF
--- a/database/tables/submissions.pg
+++ b/database/tables/submissions.pg
@@ -17,7 +17,7 @@ columns
     params: jsonb
     partial_scores: jsonb
     raw_submitted_answer: jsonb
-    regradable: boolean not null default false
+    regradable: boolean default false
     score: double precision
     sid: text
     submitted_answer: jsonb

--- a/migrations/234_submissions__regradable__add.sql
+++ b/migrations/234_submissions__regradable__add.sql
@@ -1,4 +1,4 @@
-ALTER TABLE submissions ADD COLUMN IF NOT EXISTS regradable boolean NOT NULL DEFAULT FALSE;
+ALTER TABLE submissions ADD COLUMN IF NOT EXISTS regradable boolean DEFAULT FALSE;
 
 UPDATE submissions
 SET regradable = (graded_at IS NOT NULL) OR (grading_requested_at IS NOT NULL);


### PR DESCRIPTION
Adding a column with a `NOT NULL` constraint requires rewriting the entire table and blocks writes while it's happening. This is too expensive for a large table like `submissions`. While it's nice to have `NOT NULL` on this column, it shouldn't actually be required.

Weirdly, everything I [can](https://brandur.org/postgres-default) [find](https://www.depesz.com/2018/04/04/waiting-for-postgresql-11-fast-alter-table-add-column-with-a-non-null-default/) about PG 11 seems to suggest that `ADD COLUMN ... NOT NULL DEFAULT FALSE` should be just as fast as `ADD COLUMN ... DEFAULT FALSE` (without the NOT NULL). But in my experiments the latter version is super fast (maybe 1 second for 45-million rows) while the former version is super slow (at least 10 minutes, at which point it was auto-killed).