### PR TITLE
Ensuring that Save and Grade button shows up on internal and/or exter…

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1292,7 +1292,7 @@ module.exports = {
         }
 
         if (question && question.grading_method_manual) {
-            locals.showGradeButton = false;
+            locals.showGradeButton = question.grading_method_internal || question.grading_method_external ? true : false;
             locals.showManualGradingMsg = true;
         }
 


### PR DESCRIPTION
In the `manual-grading-col-split` branch, the "Save & Grade" button does NOT show up on questions where the `gradingMethods` property includes the "Manual" grading method enum. This is intended, as students cannot request that manual questions are graded. An instructor must manually perform this action. However, this becomes a problem when the "Manual" grading method is combined with an "Internal"/"External" grading method. The "Save & Grade" button still does NOT show up.

The consequence of the button not showing up may be confusing to the student and also cause load on the server when an assignment finally closes and all of these manual grading enabled questions with an internal/external flag are graded. Furthermore, we need to clarify what the expectation is for the manual grader. My intuition suggests that if, and only if, an internal and/or external grading method is combined with the manual grading method, then an instructor should NOT be able to manually grade the question. It would be risky if an instructor were able to grade a question that is not closed and may not have the internal/external grading portion submitted.

We may want to accept this PR so that the "Save and Grade" button is enabled where internal and/or external grading takes place alongside manual grading. If this PR is accepted, then there would be an agreement to only allow manual grading actions by an instructor/TA to take place after internal/external grading actions have been performed (detected in the grading_jobs objects) if and only if the internal/external grading methods are combined with the manual grading method. 