### PR TITLE
Remove all use of npm scripts and npx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,10 @@ jobs:
       run: docker exec test_container /PrairieLearn/docker/lint_js.sh
     - name: Run the Python linter
       run: docker exec test_container /PrairieLearn/docker/lint_python.sh
+    - name: Run the PrairieLib linter
+      run: docker exec test_container /PrairieLearn/docker/lint_prairielib.sh
+    - name: Run the grader_host linter
+      run: docker exec test_container /PrairieLearn/docker/lint_grader_host.sh
     - name: Run typechecker
       run: docker exec test_container /PrairieLearn/docker/typecheck.sh
     - name: Run the PrairieLib tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN chmod +x /PrairieLearn/docker/init.sh \
     && node server.js --migrate-and-exit \
     && su postgres -c "createuser -s root" \
     && /PrairieLearn/docker/start_postgres.sh stop \
-    && /PrairieLearn/docker/gen_ssl.sh
+    && /PrairieLearn/docker/gen_ssl.sh \
+    && git config --global user.email "dev@illinois.edu" \
+    && git config --global user.name "Dev User"
 
 HEALTHCHECK CMD curl --fail http://localhost:3000/pl/webhooks/ping || exit 1
 CMD /PrairieLearn/docker/init.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM prairielearn/plbase
 # Install Python/NodeJS dependencies before copying code to limit download size
 # when code changes.
 COPY package.json package-lock.json /PrairieLearn/
+COPY grader_host/package.json grader_host/package-lock.json /PrairieLearn/grader_host/
+COPY prairielib/package.json prairielib/package-lock.json /PrairieLearn/prairielib/
 RUN cd /PrairieLearn \
     && npm ci \
     && npm --force cache clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ FROM prairielearn/plbase
 COPY package.json package-lock.json /PrairieLearn/
 RUN cd /PrairieLearn \
     && npm ci \
+    && npm --force cache clean \
+    && cd /PrairieLearn/grader_host \
+    && npm ci \
+    && npm --force cache clean \
+    && cd /PrairieLearn/prairielib \
+    && npm ci \
     && npm --force cache clean
 
 # NOTE: Modify .dockerignore to whitelist files/directories to copy.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PATH := /PrairieLearn/node_modules/.bin/:$(PATH)
+PATH := node_modules/.bin/:$(PATH)
 
 start:
 	node server.js
@@ -23,7 +23,7 @@ lint-python:
 typecheck:
 	tsc
 depcheck:
-	-npx depcheck --ignore-patterns=public/**
+	-depcheck --ignore-patterns=public/**
 	@echo WARNING:
 	@echo WARNING: Before removing an unused package, also check that it is not used
 	@echo WARNING: by client-side code. Do this by running '"git grep <packagename>"'

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,13 @@ start-s3rver:
 
 test:
 	nyc --reporter=lcov mocha tests/index.js
+test-js: test
 test-sync:
 	mocha tests/sync/index.js
 test-nocoverage:
 	mocha tests/index.js
+test-python:
+	python3 /PrairieLearn/question-servers/freeformPythonLib/prairielearn_test.py
 
 lint: lint-js lint-python
 lint-js:

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -20,22 +20,15 @@ if [[ ! -z "$CONTAINERS" ]] ; then
     docker rm $CONTAINERS
 fi
 
-if [[ -f /efs/container/config.json ]] ; then
-    # we are running in production mode
-    node server --config /efs/container/config.json
-else
-    # we are running in local development mode
-    docker/start_s3rver.sh
-    docker/start_postgres.sh
-    docker/gen_ssl.sh
-    docker/start_redis.sh
-    if [[ $DONT_START_WORKSPACE_HOST_IN_INIT != "true" ]]; then
-        node workspace_host/interface &
-    fi
 
-    if [[ $NODEMON == "true" ]]; then
-        make start-nodemon
-    else
-        make --silent start
-    fi
+docker/start_support.sh
+
+if [[ $DONT_START_WORKSPACE_HOST_IN_INIT != "true" ]]; then
+    node workspace_host/interface &
+fi
+
+if [[ $NODEMON == "true" ]]; then
+    make start-nodemon
+else
+    make --silent start
 fi

--- a/docker/lint_grader_host.sh
+++ b/docker/lint_grader_host.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make -s -C /PrairieLearn/grader_host lint

--- a/docker/lint_prairielib.sh
+++ b/docker/lint_prairielib.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make -s -C /PrairieLearn/prairielib lint

--- a/docker/start_support.sh
+++ b/docker/start_support.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /PrairieLearn
+docker/start_s3rver.sh
+docker/start_postgres.sh
+docker/start_redis.sh
+docker/gen_ssl.sh

--- a/docker/test_grader_host.sh
+++ b/docker/test_grader_host.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-cd /PrairieLearn/grader_host
-npm ci
-npm test
+make -s -C /PrairieLearn/grader_host test

--- a/docker/test_js.sh
+++ b/docker/test_js.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
 cd /PrairieLearn
-docker/start_s3rver.sh
-docker/start_postgres.sh
-docker/start_redis.sh
-
-git config --global user.email "dev@illinois.edu"
-git config --global user.name "Dev User"
-
+docker/start_support.sh
 make test

--- a/docker/test_js.sh
+++ b/docker/test_js.sh
@@ -8,4 +8,4 @@ docker/start_redis.sh
 git config --global user.email "dev@illinois.edu"
 git config --global user.name "Dev User"
 
-npm test
+make test

--- a/docker/test_prairielib.sh
+++ b/docker/test_prairielib.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-cd /PrairieLearn/prairielib
-npm ci
-npm test
+make -s -C /PrairieLearn/prairielib test

--- a/docker/test_python.sh
+++ b/docker/test_python.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3 /PrairieLearn/question-servers/freeformPythonLib/prairielearn_test.py
+make -s -C /PrairieLearn test-python

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -75,7 +75,7 @@ make lint
 * Individual tests can be run with:
 
 ```sh
-npx mocha tests/[testName].js
+node_modules/.bin/mocha tests/[testName].js
 ```
 
 ## Debugging server-side JavaScript
@@ -104,7 +104,7 @@ debug('func()', 'param:', param);
 
 * As of 2017-08-08 we don't have very good coverage with debug output in code, but we are trying to add more as needed, especially in code in `lib/`.
 
-* `UnhandledPromiseRejectionWarning` errors are frequently due to improper async/await handling. Make sure you are calling async functions with `await`, and that async functions are not being called from callback-style code without a `callbackify()`. To get more information, NodeJS v14 can be run with the `--trace-warnings` flag. For example, `npx mocha --trace-warnings tests/index.js`.
+* `UnhandledPromiseRejectionWarning` errors are frequently due to improper async/await handling. Make sure you are calling async functions with `await`, and that async functions are not being called from callback-style code without a `callbackify()`. To get more information, NodeJS v14 can be run with the `--trace-warnings` flag. For example, `node_modules/.bin/mocha --trace-warnings tests/index.js`.
 
 ## Debugging client-side JavaScript
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -62,7 +62,7 @@ PrairieLearn
 
 ```sh
 # make sure you are in the top-level PrairieLearn/ directory
-npm test
+make test
 make lint
 ```
 

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -11,31 +11,64 @@ This page describes the procedure to run PrairieLearn within Docker, but using a
 git clone https://github.com/PrairieLearn/PrairieLearn.git
 ```
 
-* Install the Node.js packages.  This will use the version of `npm` that is pre-installed in the Docker image, so you don't need your own copy installed.
+* Run PrairieLearn with:
 
 ```sh
-docker run --rm -w /PrairieLearn -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /usr/local/bin/npm ci
+docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /bin/bash
+
+# following commands are inside the container:
+cd /PrairieLearn
+npm ci                   # install packages, repeat this after switching branches or pulling new code
+docker/start_support.sh  # start the DB, cache, etc.
+node server              # run PrairieLearn itself
+
+# now you can Ctrl-C and run "node server" again to restart PrairieLearn (after code edits, for example)
+# or Ctrl-C to stop PL and Ctrl-D to exit the container
 ```
 
-The path `/path/to/PrairieLearn` should be replaced with the *absolute* path to the PrairieLearn source on your computer.  If you're in the root of the source directory already, you can substitute `%cd%` (on Windows cmd), `${PWD}` (on Windows PowerShell), or `$PWD` (Linux, MacOS, and WSL) for `/path/to/PrairieLearn`.
+The path `/path/to/PrairieLearn` above should be replaced with the *absolute* path to the PrairieLearn source on your computer.  If you're in the root of the source directory already, you can substitute `%cd%` (on Windows cmd), `${PWD}` (on Windows PowerShell), or `$PWD` (Linux, MacOS, and WSL) for `/path/to/PrairieLearn`.
 
-By default, PrairieLearn will load `exampleCourse`, `testCourse`, and any courses mounted at `/course` and `/course[2-9]` in the Docker container.  To override this behavior, you can create a custom [`config.json` file](configJson.md).
 
-* Run it with:
+## Running the test suite
+
+The linters and tests for the Python and JavaScript code can be run with the following commands in a shell instance:
 
 ```sh
-docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn
+docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /bin/bash
+
+# following commands are inside the container:
+cd /PrairieLearn
+./docker/lint_js.sh
+./docker/lint_python.sh
+./docker/test_js.sh
+./docker/test_python.sh
 ```
 
-By default, PrairieLearn does not monitor for server-side changes, so it will **not** automatically restart the node server when you change the node source. To enable automatic live-reloading of server-side changes, use the `-e` flag to set the `NODEMON=true` environment variable:
+
+## Updating or building the Docker image
+
+The commands above all run PrairieLearn using local source inside the `prairielearn/prairielearn` image. This image has Python packages and other supporting files already installed. This should be periodically updated with:
 
 ```sh
-docker run -it --rm -p 3000:3000 -e NODEMON=true -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn
+docker pull prairielearn/prairielearn
 ```
 
-### Running a specific branch
+You can also build a local copy of this image and use it to make sure you have a version that corresponds exactly to your local source:
 
-By default, the above command will run PrairieLearn from the branch that is currently checked out in the directory `/path/to/PrairieLearn`. So, to run a different branch, just use commands like `git checkout BRANCH_NAME` or equivalent.
+```
+cd /path/to/PrairieLearn
+docker build -t local_prairielearn .
+
+# now use it with:
+docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn local_prairielearn /bin/bash
+```
+
+Above we are using the `local_prairielearn` image in place of the pre-built `prairielearn/prairielearn` image.
+
+
+## Running a specific branch in a pre-built container
+
+By default, the commands above will run PrairieLearn from the branch that is currently checked out in the directory `/path/to/PrairieLearn`. So, to run a different branch, just use commands like `git checkout BRANCH_NAME` or equivalent.
 
 It is also possible to run a branch other than `master` without cloning or checking out the code for that branch, as long as the branch has been pushed to GitHub.  If you would like to run a different branch (to test it, for example), the branch name can be appended to the end of the image name as such:
 
@@ -50,7 +83,8 @@ docker pull prairielearn/prairielearn:BRANCH_NAME
 docker run -it --rm -p 3000:3000 prairielearn/prairielearn:BRANCH_NAME
 ```
 
-### Running commands in Docker
+
+## Running commands in Docker
 
 If needed, you can run the container with a different command:
 
@@ -64,34 +98,27 @@ This can be used to, e.g., run scripts distributed with PrairieLearn by opening 
 docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /bin/bash
 ```
 
-#### Restarting the node server
-
-When making local changes to server-side code, it is faster to restart only the node server instead of the whole docker container. This can be done either
-
-* automatically by using the `-e NODEMON=true` setting as described earlier,
-
-* or manually by starting the server from a shell instance:
+You can also run only package installation with:
 
 ```sh
-/PrairieLearn/docker/init.sh
+docker run --rm -w /PrairieLearn -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn /usr/local/bin/npm ci
 ```
 
-and when any modifications are made, you can close the server with `<ctrl-C>` and re-run the init script.
 
-#### Tests from shell
+## Auto-restarting the node server
 
-The linters and tests for the Python and JavaScript code can be run with the following commands in a shell instance:
+The description at the start of this page suggests manually stopping and restarting PrairieLearn after you have edited any JavaScript files. You can alternatively use the `nodemon` package to watch for changes to code and auto-restart PrairieLearn. Two different ways to do this are:
+
+* Run PrairieLearn as described at the start of this page, but replace `node server` with `make start-nodemon`.
+
+* Run PrairieLearn automatically in the container and pass the `-e NODEMON=true` environment variable:
 
 ```sh
-cd /PrairieLearn
-./docker/start_postgres.sh
-./docker/lint_js.sh
-./docker/lint_python.sh
-./docker/test_js.sh
-./docker/test_python.sh
+docker run -it --rm -p 3000:3000 -e NODEMON=true -v /path/to/PrairieLearn:/PrairieLearn prairielearn/prairielearn
 ```
 
-### Connecting to an existing Docker container
+
+## Connecting to an existing Docker container
 
 The previous shells were launched in their own containers. If you want to open a shell in a Docker container that is *already running*, you can find the container's name and connect to it.
 
@@ -108,14 +135,14 @@ CONTAINER ID  IMAGE                      COMMAND              CREATED      STATU
 e0f522f41ea4  prairielearn/prairielearn  "/bin/sh -c /Prai…"  2 hours ago  Up 2 hours  0.0.0.0:3000->3000/tcp  upbeat_roentgen
 ```
 
-
 * Open a shell in your PrairieLearn container by running
 
 ```sh
 docker exec -it CONTAINER_NAME /bin/bash
 ```
 
-### Using tmux in a container
+
+## Using tmux in a container
 
 While developing, you might need or want to run multiple programs simultaneously (e.g., querying in `psql` without killing the `node` server). Rather than repeatedly canceling and restarting programs back and forth, you can use a terminal multiplexer like `tmux` to keep them running simultaneously.
 

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -109,7 +109,7 @@ docker run --rm -w /PrairieLearn -v /path/to/PrairieLearn:/PrairieLearn prairiel
 
 The description at the start of this page suggests manually stopping and restarting PrairieLearn after you have edited any JavaScript files. You can alternatively use the `nodemon` package to watch for changes to code and auto-restart PrairieLearn. Two different ways to do this are:
 
-* Run PrairieLearn as described at the start of this page, but replace `node server` with `make start-nodemon`.
+* Run PrairieLearn as described at the start of this page, but replace `make start` with `make start-nodemon`.
 
 * Run PrairieLearn automatically in the container and pass the `-e NODEMON=true` environment variable:
 

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -20,9 +20,9 @@ docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairiel
 cd /PrairieLearn
 npm ci                   # install packages, repeat this after switching branches or pulling new code
 docker/start_support.sh  # start the DB, cache, etc.
-node server              # run PrairieLearn itself
+make start               # run PrairieLearn itself
 
-# now you can Ctrl-C and run "node server" again to restart PrairieLearn (after code edits, for example)
+# now you can Ctrl-C and run "make start" again to restart PrairieLearn (after code edits, for example)
 # or Ctrl-C to stop PL and Ctrl-D to exit the container
 ```
 

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -38,10 +38,11 @@ docker run -it --rm -p 3000:3000 -v /path/to/PrairieLearn:/PrairieLearn prairiel
 
 # following commands are inside the container:
 cd /PrairieLearn
-./docker/lint_js.sh
-./docker/lint_python.sh
-./docker/test_js.sh
-./docker/test_python.sh
+docker/start_support.sh
+make lint-js
+make lint-python
+make test-js
+make test-python
 ```
 
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -77,7 +77,7 @@ psql -c "ALTER USER postgres WITH SUPERUSER;"
 
 ```sh
 cd PrairieLearn
-npm test
+make test
 ```
 
 * Run the linters:

--- a/grader_host/Makefile
+++ b/grader_host/Makefile
@@ -1,0 +1,11 @@
+PATH := node_modules/.bin/:$(PATH)
+
+start:
+	node index.js
+
+test: NODE_ENV=test
+test:
+	jest
+
+lint:
+	eslint --ext js "**/*.js"

--- a/grader_host/package.json
+++ b/grader_host/package.json
@@ -3,11 +3,6 @@
   "version": "0.0.3",
   "description": "PrairieLearn's grading agent",
   "main": "index.js",
-  "scripts": {
-    "test": "make test",
-    "lint": "make lint",
-    "start": "make start"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/PrairieLearn/PrairieGrader.git"

--- a/grader_host/package.json
+++ b/grader_host/package.json
@@ -4,9 +4,9 @@
   "description": "PrairieLearn's grading agent",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test jest",
-    "lint": "eslint --ext js \"**/*.js\"",
-    "start": "node index.js"
+    "test": "make test",
+    "lint": "make lint",
+    "start": "make start"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,6 @@
     "description": "PrairieLearn online problem-solving system",
     "version": "3.2.0",
     "private": true,
-    "scripts": {
-        "start": "make start",
-        "start-nodemon": "make start-nodemon",
-        "test": "make test",
-        "test-sync": "make test-sync",
-        "test-nocoverage": "make test-nocoverage",
-        "lint-js": "make lint-js",
-        "lint-python": "make lint-python",
-        "typecheck": "make typecheck"
-    },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.3",
         "@octokit/rest": "^18.7.1",

--- a/prairielib/Makefile
+++ b/prairielib/Makefile
@@ -1,0 +1,8 @@
+PATH := node_modules/.bin/:$(PATH)
+
+test: NODE_ENV=test
+test:
+	jest
+
+lint:
+	eslint --ext js "**/*.js"

--- a/prairielib/package.json
+++ b/prairielib/package.json
@@ -12,8 +12,8 @@
     "config.js"
   ],
   "scripts": {
-    "test": "NODE_ENV=test jest",
-    "lint": "eslint --ext js \"**/*.js\""
+    "test": "make test",
+    "lint": "make lint"
   },
   "author": "",
   "license": "AGPL-3.0",

--- a/prairielib/package.json
+++ b/prairielib/package.json
@@ -11,10 +11,6 @@
     "util.js",
     "config.js"
   ],
-  "scripts": {
-    "test": "make test",
-    "lint": "make lint"
-  },
   "author": "",
   "license": "AGPL-3.0",
   "dependencies": {


### PR DESCRIPTION
npm v7 has a horrible misfeature:

> When npm is run as root, scripts are always run with the effective uid and gid of the working directory owner.

(see https://blog.npmjs.org/post/626173315965468672/npm-v7-series-beta-release-and-semver-major)

This causes lots of problems when mounting a local copy of the PrairieLearn source into the container at `/PrairieLearn` because the working directory will be owned by a different user to the files inside the container (e.g., `/root/.gitconfig`), causing hard-to-debug errors due to permissions being wrong. For example, #4586 is caused by this.

@jonatanschroeder fixed most of this by switching from `npm` scripts to `make` in #3818, but we missed a few cases. This PR eradicates all remaining references to `npm` scripts and `npx`.

Fixes #4586 