### PR TITLE
Fix sprocs init for repeated test runs

### DIFF
--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -78,6 +78,7 @@ var createFullDatabase = function(dbName, dropFirst, mochaThis, callback) {
             });
         },
         function(callback) {
+            debug('createFullDatabase(): setting random search schema');
             sqldb.setRandomSearchSchema('test', (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
@@ -141,6 +142,20 @@ var createFromTemplate = function(dbName, dbTemplateName, dropFirst, mochaThis, 
             debug('createFromTemplate(): ending client');
             client.end();
             callback(null);
+        },
+        function(callback) {
+            debug('createFromTemplate(): setting random search schema');
+            sqldb.setRandomSearchSchema('test', (err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        function(callback) {
+            debug('createFromTemplate(): initializing sprocs');
+            sprocs.init(function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
         },
     ], function(err) {
         debug('createFromTemplate(): complete');

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -15,6 +15,66 @@ const postgresqlDatabaseTemplate = 'pltest_template';
 const postgresqlHost = 'localhost';
 const initConString = 'postgres://postgres@localhost/postgres';
 
+var runMigrationsAndSprocs = function(dbName, mochaThis, runMigrations, callback) {
+    debug(`runMigrationsAndSprocs(${dbName})`);
+    mochaThis.timeout(20000);
+    async.series([
+        function(callback) {
+            debug('runMigrationsAndSprocs(): initializing sqldb');
+            var pgConfig = {
+                user: postgresqlUser,
+                database: dbName,
+                host: postgresqlHost,
+                max: 10,
+                idleTimeoutMillis: 30000,
+            };
+            var idleErrorHandler = function(err) {
+                throw Error('idle client error', err);
+            };
+            sqldb.init(pgConfig, idleErrorHandler, function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        function(callback) {
+            if (!runMigrations) {
+                debug('runMigrationsAndSprocs(): skipping migrations');
+                return callback(null);
+            }
+            debug('runMigrationsAndSprocs(): running migrations');
+            migrations.init(path.join(__dirname, '..', 'migrations'), 'prairielearn', function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        function(callback) {
+            debug('runMigrationsAndSprocs(): setting random search schema');
+            sqldb.setRandomSearchSchema('test', (err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        function(callback) {
+            debug('runMigrationsAndSprocs(): initializing sprocs');
+            sprocs.init(function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        function(callback) {
+            debug('runMigrationsAndSprocs(): closing sqldb');
+            sqldb.close(function(err) {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+    ], function(err) {
+        debug('runMigrationsAndSprocs(): complete');
+        if (ERR(err, callback)) return;
+        callback(null);
+    });
+};
+
 var createFullDatabase = function(dbName, dropFirst, mochaThis, callback) {
     debug(`createFullDatabase(${dbName})`);
     // long timeout because DROP DATABASE might take a long time to error
@@ -54,46 +114,8 @@ var createFullDatabase = function(dbName, dropFirst, mochaThis, callback) {
             callback(null);
         },
         function(callback) {
-            debug('createFullDatabase(): initializing sqldb');
-            var pgConfig = {
-                user: postgresqlUser,
-                database: dbName,
-                host: postgresqlHost,
-                max: 10,
-                idleTimeoutMillis: 30000,
-            };
-            var idleErrorHandler = function(err) {
-                throw Error('idle client error', err);
-            };
-            sqldb.init(pgConfig, idleErrorHandler, function(err) {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        function(callback) {
-            debug('createFullDatabase(): running migrations');
-            migrations.init(path.join(__dirname, '..', 'migrations'), 'prairielearn', function(err) {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        function(callback) {
-            debug('createFullDatabase(): setting random search schema');
-            sqldb.setRandomSearchSchema('test', (err) => {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        function(callback) {
-            debug('createFullDatabase(): initializing sprocs');
-            sprocs.init(function(err) {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        function(callback) {
-            debug('createFullDatabase(): closing sqldb');
-            sqldb.close(function(err) {
+            debug('createFullDatabase(): calling runMigrationsAndSprocs()');
+            runMigrationsAndSprocs(dbName, mochaThis, true, function(err) {
                 if (ERR(err, callback)) return;
                 callback(null);
             });
@@ -144,15 +166,8 @@ var createFromTemplate = function(dbName, dbTemplateName, dropFirst, mochaThis, 
             callback(null);
         },
         function(callback) {
-            debug('createFromTemplate(): setting random search schema');
-            sqldb.setRandomSearchSchema('test', (err) => {
-                if (ERR(err, callback)) return;
-                callback(null);
-            });
-        },
-        function(callback) {
-            debug('createFromTemplate(): initializing sprocs');
-            sprocs.init(function(err) {
+            debug('createFromTemplate(): calling runMigrationsAndSprocs()');
+            runMigrationsAndSprocs(dbName, mochaThis, false, function(err) {
                 if (ERR(err, callback)) return;
                 callback(null);
             });


### PR DESCRIPTION
We were correctly initializing sprocs in the test suite using the new random-schema-based method (see #4412), but we were only initializing them for the first run of the tests, when we do a full database creation. On repeated runs of the tests we use a copy of the existing template DB and in this case we were not initializing the sprocs. This PR adds the new sproc initialization method to the repeated-test-case setup. Fixes #4585