### PR TITLE
Fix tests by removing courseLive/Origin after failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ npm-debug.log
 /coverage/
 /.nyc_output/
 
+### Tests
+/tests/testFileEditor/courseLive/
+/tests/testFileEditor/courseOrigin/
+
 ## Programming languages
 
 ### Python

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ npm-debug.log
 ### Tests
 /tests/testFileEditor/courseLive/
 /tests/testFileEditor/courseOrigin/
+/tests/testFileEditor/courseDev/
 
 ## Programming languages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
                 "remark-rehype": "^8.1.0",
                 "request-promise-native": "^1.0.9",
                 "requirejs": "^2.3.5",
-                "rimraf": "^3.0.2",
                 "search-string": "^3.1.0",
                 "serve-favicon": "^2.5.0",
                 "showdown": "^1.9.1",
@@ -2048,7 +2047,10 @@
                 "node >=0.10.0"
             ],
             "dependencies": {
-                "moment": "^2.19.3"
+                "dtrace-provider": "~0.8",
+                "moment": "^2.19.3",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
             },
             "bin": {
                 "bunyan": "bin/bunyan"
@@ -2408,6 +2410,7 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -4578,6 +4581,10 @@
             "version": "4.5.1",
             "resolved": "https://registry.npmjs.org/fabric/-/fabric-4.5.1.tgz",
             "integrity": "sha512-s0ywa4WQh/QortuhlVkWOj692udzwI8cYWcLTlel/Jbhk3gevyB0fF/Rvo9in/bGV0c4TFl3cMiu6+wYwpfxdQ==",
+            "dependencies": {
+                "canvas": "^2.6.1",
+                "jsdom": "^15.2.1"
+            },
             "engines": {
                 "node": ">=8.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
         "remark-rehype": "^8.1.0",
         "request-promise-native": "^1.0.9",
         "requirejs": "^2.3.5",
-        "rimraf": "^3.0.2",
         "search-string": "^3.1.0",
         "serve-favicon": "^2.5.0",
         "showdown": "^1.9.1",

--- a/tests/testCourseEditor.js
+++ b/tests/testCourseEditor.js
@@ -1,9 +1,8 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 const assert = require('chai').assert;
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
-const rimraf = require('rimraf');
 const async = require('async');
 const ncp = require('ncp');
 const config = require('../lib/config');
@@ -436,6 +435,12 @@ function testEdit(params) {
 function createCourseFiles(callback) {
     async.series([
         (callback) => {
+            deleteCourseFiles((err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        (callback) => {
             const execOptions = {
                 cwd: '.',
                 env: process.env,
@@ -510,19 +515,19 @@ function createCourseFiles(callback) {
 function deleteCourseFiles(callback) {
     async.series([
         (callback) => {
-            rimraf(courseOriginDir, (err) => {
+            fs.remove(courseOriginDir, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });
         },
         (callback) => {
-            rimraf(courseLiveDir, (err) => {
+            fs.remove(courseLiveDir, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });
         },
         (callback) => {
-            rimraf(courseDevDir, (err) => {
+            fs.remove(courseDevDir, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });

--- a/tests/testFileEditor.js
+++ b/tests/testFileEditor.js
@@ -1,9 +1,8 @@
 const ERR = require('async-stacktrace');
 const request = require('request');
 const assert = require('chai').assert;
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
-const rimraf = require('rimraf');
 const async = require('async');
 const ncp = require('ncp');
 const config = require('../lib/config');
@@ -347,6 +346,12 @@ function badPost(action, fileEditContents, url) {
 function createCourseFiles(callback) {
     async.series([
         (callback) => {
+            deleteCourseFiles((err) => {
+                if (ERR(err, callback)) return;
+                callback(null);
+            });
+        },
+        (callback) => {
             const execOptions = {
                 cwd: '.',
                 env: process.env,
@@ -421,19 +426,19 @@ function createCourseFiles(callback) {
 function deleteCourseFiles(callback) {
     async.series([
         (callback) => {
-            rimraf(courseOriginDir, (err) => {
+            fs.remove(courseOriginDir, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });
         },
         (callback) => {
-            rimraf(courseLiveDir, (err) => {
+            fs.remove(courseLiveDir, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });
         },
         (callback) => {
-            rimraf(courseDevDir, (err) => {
+            fs.remove(courseDevDir, (err) => {
                 if (ERR(err, callback)) return;
                 callback(null);
             });


### PR DESCRIPTION
This fixes the tests in the case where a previous test run died and left behind the directories `tests/testFileEditor/courseLive` and `tests/testFileEditor/courseOrigin`. If these directories are left behind then the next test fails with:
```
Error: Command failed: git clone /PrairieLearn/tests/testFileEditor/courseOrigin /PrairieLearn/tests/testFileEditor/courseLive
fatal: destination path '/PrairieLearn/tests/testFileEditor/courseLive' already exists and is not an empty directory.
```

We now unconditionally remove these at the start of the relevant tests.

This PR also uninstalls the [`rimraf`](https://www.npmjs.com/package/rimraf) package and replaces it with `fs-extra.remove()`.
