### PR TITLE
Bump Node.js from 14 to 16

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -37,7 +37,7 @@ cd /nvm
 git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --tags --max-count=1)`
 source /nvm/nvm.sh
 export NVM_SYMLINK_CURRENT=true
-nvm install 14
+nvm install 16
 npm install npm@latest -g
 for f in /nvm/current/bin/* ; do ln -s $f /usr/local/bin/`basename $f` ; done
 


### PR DESCRIPTION
According to the node [release schedule](https://nodejs.org/en/about/releases/) the LTS branch will switch to 16 on 2021-10-26.