### PR TITLE
Bug fix: changing call type for return of multiple rows

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -574,7 +574,7 @@ module.exports = {
                     data.params,
                     data.true_answer,
                 ];
-                sqldb.callWithClientOneRow(client, 'grading_jobs_insert', params, (err, result) => {
+                sqldb.callWithClient(client, 'grading_jobs_insert', params, (err, result) => {
                     if (ERR(err, callback)) return;
 
                     /* If the submission was marked invalid during grading the grading job will


### PR DESCRIPTION
Bug (two parts): 

1) When an 'External' enum is enabled on the `gradingMethods` property, internal grading and external grading occurs because internal grading is enabled on all questions. This returns two rows instead of one row, which breaks the SQL call expecting one row returned. 
2) After the SQL call is changed to allow for two rows returned, we ONLY see 'Internal' grading actions on the front-end. 

After 1 is fixed on the back-end, 2 becomes apparent.

**We only see this Internal action:**
![image](https://user-images.githubusercontent.com/7872295/128051425-ff337ddd-546d-4355-b3e5-1b34034e12e5.png)
As we see, it is configured for external grading too though.
![image](https://user-images.githubusercontent.com/7872295/128051354-dfff658c-52a6-4904-a323-fa7c69ec48a9.png)


**We should also see this External action (taken from a working External grading question):** 

![image](https://user-images.githubusercontent.com/7872295/128051193-8545168f-b073-4d9b-8cd0-f0db95ea78b4.png)
