### PR TITLE
Fix auto course creation for editors who aren't owners

### DIFF
--- a/pages/instructorRequestCourse/instructorRequestCourse.sql
+++ b/pages/instructorRequestCourse/instructorRequestCourse.sql
@@ -39,5 +39,5 @@ LEFT JOIN users AS u ON u.user_id = cp.user_id;
 SELECT co.institution_id, co.display_timezone
 FROM course_permissions AS cp
 JOIN pl_courses AS co ON co.id = cp.course_id
-WHERE (cp.user_id = $user_id AND cp.course_role = 'Owner')
+WHERE (cp.user_id = $user_id AND (cp.course_role = 'Owner' OR cp.course_role = 'Editor'))
 LIMIT 1;


### PR DESCRIPTION
We auto-approve course creation for users who are Owners or Editors: https://github.com/PrairieLearn/PrairieLearn/blob/a8d7eabbd268ae76ebe7bc736394ce2ce1654a4e/sprocs/course_requests_insert.sql#L18

But when we get the existing course settings for the user we only look for Owners: https://github.com/PrairieLearn/PrairieLearn/blob/a8d7eabbd268ae76ebe7bc736394ce2ce1654a4e/pages/instructorRequestCourse/instructorRequestCourse.sql#L42

This means that a course Editor who requests a new course will be auto-approved, but we'll error out before actually creating the course.

Fixes #4630