### PR TITLE
Replace references to core scripts with node modules

### DIFF
--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -125,7 +125,7 @@ configure them for your element as follows:
     "controller": "pl-my-element.py",
     "dependencies": {
         "coreScripts": [
-            "d3.min.js"
+            "PrairieUtil.js"
         ],
         "nodeModulesScripts": [
             "three/build/three.min.js"
@@ -149,7 +149,7 @@ The different types of dependency properties currently available are summarized 
 Property | Description
 --- | ---
 `coreStyles` | The styles required by this element, relative to `[PrairieLearn directory]/public/stylesheets`.
-`coreScripts` | The scripts required by this element, relative to `[PrairieLearn directory]/public/javascripts`.
+`coreScripts` | The scripts required by this element, relative to `[PrairieLearn directory]/public/javascripts`. Scripts in this directory are mainly used for compatibility with legacy elements and questions, and should be avoided if an alternative is available.
 `nodeModulesStyles` | The styles required by this element, relative to `[PrairieLearn directory]/node_modules`.
 `nodeModulesScripts` | The scripts required by this element, relative to `[PrairieLearn directory]/node_modules`.
 `elementStyles` | The styles required by this element relative to the element's directory, which is either `[PrairieLearn directory]/elements/this-element-name` or `[course directory]/elements/this-element-name`.

--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -110,23 +110,14 @@ The above function descriptions describe the typical variables that will be read
 
 ### Element dependencies
 
-It's likely that your element will depend on certain client-side assets,
-such as scripts or stylesheets. To keep clean separation of HTML, CSS, and JS,
-you can place those dependencies in other files. If you depend on libraries like
-`lodash` or `d3`, you can also express that need. PrairieLearn will compile a list
-of all dependencies needed by all elements on a page, dedup the dependencies,
-and ensure they are loaded on the page.
+It's likely that your element will depend on certain client-side assets, such as scripts or stylesheets. To keep clean separation of HTML, CSS, and JS, you can place those dependencies in other files. If you depend on libraries like `lodash` or `d3`, you can also link to node modules containing these libraries. PrairieLearn will compile a list of all dependencies needed by all elements on a page, deduplicate the dependencies, and ensure they are loaded on the page.
 
-Dependencies are listed in your element's `info.json`. You can
-configure them for your element as follows:
+Dependencies are listed in your element's `info.json`. You can configure them for your element as follows:
 
 ```json
 {
     "controller": "pl-my-element.py",
     "dependencies": {
-        "coreScripts": [
-            "PrairieUtil.js"
-        ],
         "nodeModulesScripts": [
             "three/build/three.min.js"
         ],
@@ -148,14 +139,15 @@ The different types of dependency properties currently available are summarized 
 
 Property | Description
 --- | ---
-`coreStyles` | The styles required by this element, relative to `[PrairieLearn directory]/public/stylesheets`.
-`coreScripts` | The scripts required by this element, relative to `[PrairieLearn directory]/public/javascripts`. Scripts in this directory are mainly used for compatibility with legacy elements and questions, and should be avoided if an alternative is available.
 `nodeModulesStyles` | The styles required by this element, relative to `[PrairieLearn directory]/node_modules`.
 `nodeModulesScripts` | The scripts required by this element, relative to `[PrairieLearn directory]/node_modules`.
 `elementStyles` | The styles required by this element relative to the element's directory, which is either `[PrairieLearn directory]/elements/this-element-name` or `[course directory]/elements/this-element-name`.
 `elementScripts` | The scripts required by this element relative to the element's directory, which is either `[PrairieLearn directory]/elements/this-element-name` or `[course directory]/elements/this-element-name`.
 `clientFilesCourseStyles` | The styles required by this element relative to `[course directory]/clientFilesCourse`. *(Note: This property is only available for elements hosted in a specific course's directory, not system-wide PrairieLearn elements.)*
 `clientFilesCourseScripts` | The scripts required by this element relative to `[course directory]/clientFilesCourse`. *(Note: This property is only available for elements hosted in a specific course's directory, not system-wide PrairieLearn elements.)*
+
+The `coreScripts` and `coreStyles` properties are used in legacy elements and questions, but are deprecated should not be used in new objects. It lists scripts and styles required by this element, relative to `[PrairieLearn directory]/public/javascripts` and `[PrairieLearn directory]/public/stylesheets`, respectively. Scripts in `[PrairieLearn directory]/public/javascripts` are mainly used for compatibility with legacy elements and questions, while styles in `[PrairieLearn directory]/public/stylesheets` are reserved for [styles used by specific pages rather than individual elements](dev-guide.md#html-style).
+
 
 You can also find the types of dependencies defined in these schema files:
 

--- a/docs/elementExtensions.md
+++ b/docs/elementExtensions.md
@@ -13,8 +13,6 @@ The `info.json` file is structurally similar to the element info file and may co
 {
     "controller": "Python script",
     "dependencies": {
-        "coreStyles": ["Core PL styles"],
-        "coreScripts": ["Core PL JavaScripts"],
         "nodeModulesStyles": ["Node modules styles"],
         "nodeModulesScripts": ["Node modules JavaScripts"],
         "clientFilesCourseStyles": ["Client files course styles"],
@@ -88,8 +86,6 @@ Similar to how questions and elements may require client-side assets, extensions
 
 Property | Description
 --- | ---
-`coreStyles` | The styles required by this extension, relative to `[PrairieLearn directory]/public/stylesheets`.
-`coreScripts` | The scripts required by this extension, relative to `[PrairieLearn directory]/public/javascripts`. Scripts in this directory are mainly used for compatibility with legacy elements and questions, and should be avoided if an alternative is available.
 `nodeModulesStyles` | The styles required by this extension, relative to `[PrairieLearn directory]/node_modules`.
 `nodeModulesScripts` | The scripts required by this extension, relative to `[PrairieLearn directory]/node_modules`.
 `elementStyles` | The styles required by this element relative to the extension's directory,`[course directory]/elementExtensions/element-name/extension-name`.

--- a/docs/elementExtensions.md
+++ b/docs/elementExtensions.md
@@ -89,7 +89,7 @@ Similar to how questions and elements may require client-side assets, extensions
 Property | Description
 --- | ---
 `coreStyles` | The styles required by this extension, relative to `[PrairieLearn directory]/public/stylesheets`.
-`coreScripts` | The scripts required by this extension, relative to `[PrairieLearn directory]/public/javascripts`.
+`coreScripts` | The scripts required by this extension, relative to `[PrairieLearn directory]/public/javascripts`. Scripts in this directory are mainly used for compatibility with legacy elements and questions, and should be avoided if an alternative is available.
 `nodeModulesStyles` | The styles required by this extension, relative to `[PrairieLearn directory]/node_modules`.
 `nodeModulesScripts` | The scripts required by this extension, relative to `[PrairieLearn directory]/node_modules`.
 `elementStyles` | The styles required by this element relative to the extension's directory,`[course directory]/elementExtensions/element-name/extension-name`.

--- a/docs/question.md
+++ b/docs/question.md
@@ -84,7 +84,7 @@ These dependencies are specified in the `info.json` file, and can be configured 
 {
     "dependencies": {
         "coreScripts": [
-            "d3.min.js"
+            "PrairieUtil.js"
         ],
         "nodeModulesScripts": [
             "three/build/three.min.js"
@@ -108,7 +108,7 @@ The different types of dependency properties available are summarized in this ta
 Property | Description
 --- | ---
 `coreStyles` |  The styles required by this question, relative to `[PrairieLearn directory]/public/stylesheets`.
-`coreScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/public/javascripts`.
+`coreScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/public/javascripts`. Scripts in this directory are mainly used for compatibility with legacy elements and questions, and should be avoided if an alternative is available.
 `nodeModulesStyles` | The styles required by this question, relative to `[PrairieLearn directory]/node_modules`.
 `nodeModulesScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/node_modules`.
 `clientFilesQuestionStyles` | The scripts required by this question relative to the question's `clientFilesQuestion` directory.

--- a/docs/question.md
+++ b/docs/question.md
@@ -76,16 +76,13 @@ For details see the [format specification for question `info.json`](https://gith
 
 ### Question Dependencies
 
-Your question can load client-side assets such as scripts or stylesheets from different sources.  A full list of dependencies will be compiled based on the question's needs and any dependencies needed by page elements, then they will be de-duped and loaded onto the page.
+Your question can load client-side assets such as scripts or stylesheets from different sources.  A full list of dependencies will be compiled based on the question's needs and any dependencies needed by page elements, then they will be deduplicated and loaded onto the page.
 
 These dependencies are specified in the `info.json` file, and can be configured as follows:
 
 ```json
 {
     "dependencies": {
-        "coreScripts": [
-            "PrairieUtil.js"
-        ],
         "nodeModulesScripts": [
             "three/build/three.min.js"
         ],
@@ -107,8 +104,6 @@ The different types of dependency properties available are summarized in this ta
 
 Property | Description
 --- | ---
-`coreStyles` |  The styles required by this question, relative to `[PrairieLearn directory]/public/stylesheets`.
-`coreScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/public/javascripts`. Scripts in this directory are mainly used for compatibility with legacy elements and questions, and should be avoided if an alternative is available.
 `nodeModulesStyles` | The styles required by this question, relative to `[PrairieLearn directory]/node_modules`.
 `nodeModulesScripts` | The scripts required by this question, relative to `[PrairieLearn directory]/node_modules`.
 `clientFilesQuestionStyles` | The scripts required by this question relative to the question's `clientFilesQuestion` directory.

--- a/elements/pl-drawing/info.json
+++ b/elements/pl-drawing/info.json
@@ -2,12 +2,11 @@
     "controller": "pl-drawing.py",
     "dependencies": {
         "nodeModulesScripts": [
-           "fabric/dist/fabric.js"
+            "fabric/dist/fabric.js",
+            "lodash/lodash.js"
         ],
         "coreScripts": [
-            "sylvester.js",
-            "sha1.js",
-            "underscore.js"
+            "sylvester.js"
         ],
         "elementScripts": [
             "pl-drawing.js",

--- a/elements/pl-file-upload/info.json
+++ b/elements/pl-file-upload/info.json
@@ -1,9 +1,9 @@
 {
     "controller": "pl-file-upload.py",
     "dependencies": {
-        "coreScripts": [
-            "lodash.min.js",
-            "dropzone.js"
+        "nodeModulesScripts": [
+            "lodash/lodash.min.js",
+            "dropzone/dist/dropzone.js"
         ],
         "elementScripts": [
             "pl-file-upload.js"

--- a/elements/pl-matrix-component-input/info.json
+++ b/elements/pl-matrix-component-input/info.json
@@ -4,9 +4,6 @@
         "nodeModulesScripts": [
             "clipboard/dist/clipboard.min.js"
         ],
-        "coreScripts": [
-            "PrairieUtil.js"
-        ],
         "elementStyles": [
             "pl-matrix-component-input.css"
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
                 "detect-mocha": "^0.1.0",
                 "diff": "^5.0.0",
                 "dockerode": "^3.2.1",
+                "dropzone": "^5.9.2",
                 "ejs": "^3.1.6",
                 "express": "^4.17.1",
                 "express-async-handler": "^1.1.4",
@@ -3856,6 +3857,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dropzone": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.9.2.tgz",
+            "integrity": "sha512-5t2z51DzIsWDbTpwcJIvUlwxBbvcwdCApz0yb9ecKJwG155Xm92KMEZmHW1B0MzoXOKvFwdd0nPu5cpeVcvPHQ=="
         },
         "node_modules/dtrace-provider": {
             "version": "0.8.8",
@@ -15654,6 +15660,11 @@
             "requires": {
                 "is-obj": "^2.0.0"
             }
+        },
+        "dropzone": {
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.9.2.tgz",
+            "integrity": "sha512-5t2z51DzIsWDbTpwcJIvUlwxBbvcwdCApz0yb9ecKJwG155Xm92KMEZmHW1B0MzoXOKvFwdd0nPu5cpeVcvPHQ=="
         },
         "dtrace-provider": {
             "version": "0.8.8",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "detect-mocha": "^0.1.0",
         "diff": "^5.0.0",
         "dockerode": "^3.2.1",
+        "dropzone": "^5.9.2",
         "ejs": "^3.1.6",
         "express": "^4.17.1",
         "express-async-handler": "^1.1.4",

--- a/schemas/schemas/infoElementCore.json
+++ b/schemas/schemas/infoElementCore.json
@@ -26,7 +26,8 @@
                     "anyOf": [{"type": "string"}, {"type": "array"}, {"type": "object"}]
                 },
                 "coreStyles": {
-                    "description": "The styles required by this element from /public/stylesheets.",
+                    "description": "[DEPRECATED, DO NOT USE] The styles required by this element from /public/stylesheets.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .css file located in /public/stylesheets.",
@@ -34,7 +35,8 @@
                     }
                 },
                 "coreScripts": {
-                    "description": "The scripts required by this element from /public/javascripts.",
+                    "description": "[DEPRECATED, DO NOT USE] The scripts required by this element from /public/javascripts.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .js file located in /public/javascripts.",

--- a/schemas/schemas/infoElementCourse.json
+++ b/schemas/schemas/infoElementCourse.json
@@ -26,7 +26,8 @@
                     "anyOf": [{"type": "string"}, {"type": "array"}, {"type": "object"}]
                 },
                 "coreStyles": {
-                    "description": "The styles required by this element from /public/stylesheets.",
+                    "description": "[DEPRECATED, DO NOT USE] The styles required by this element from /public/stylesheets.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .css file located in /public/stylesheets.",
@@ -34,7 +35,8 @@
                     }
                 },
                 "coreScripts": {
-                    "description": "The scripts required by this element from /public/javascripts.",
+                    "description": "[DEPRECATED, DO NOT USE] The scripts required by this element from /public/javascripts.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .js file located in /public/javascripts.",

--- a/schemas/schemas/infoElementExtension.json
+++ b/schemas/schemas/infoElementExtension.json
@@ -15,7 +15,8 @@
             "additionalProperties": false,
             "properties": {
                 "coreStyles": {
-                    "description": "The styles required by this extension from /public/stylesheets.",
+                    "description": "[DEPRECATED, DO NOT USE] The styles required by this extension from /public/stylesheets.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .css file located in /public/stylesheets.",
@@ -23,7 +24,8 @@
                     }
                 },
                 "coreScripts": {
-                    "description": "The scripts required by this extension from /public/javascripts.",
+                    "description": "[DEPRECATED, DO NOT USE] The scripts required by this extension from /public/javascripts.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .js file located in /public/javascripts.",

--- a/schemas/schemas/infoQuestion.json
+++ b/schemas/schemas/infoQuestion.json
@@ -149,7 +149,8 @@
                     "anyOf": [{"type": "string"}, {"type": "array"}, {"type": "object"}]
                 },
                 "coreStyles": {
-                    "description": "The styles required by this question from /public/stylesheets.",
+                    "description": "[DEPRECATED, DO NOT USE] The styles required by this question from /public/stylesheets.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .css file located in /public/stylesheets.",
@@ -157,7 +158,8 @@
                     }
                 },
                 "coreScripts": {
-                    "description": "The scripts required by this question from /public/javascripts.",
+                    "description": "[DEPRECATED, DO NOT USE] The scripts required by this question from /public/javascripts.",
+                    "deprecated": true,
                     "type": "array",
                     "items": {
                         "description": "A .js file located in /public/javascripts.",


### PR DESCRIPTION
Replaced references to:

* `underscore.js` and `lodash.min.js` -> `node_modules/lodash/lodash.min.sh` (resolves #4654 );
* `sha1.js` -> not in use in modern elements/codes/questions;
* `dropzone.js` -> `node_modules/dropzone/dist/dropzone.js`;

Old copies of core scripts are kept for backwards compatibility. References to `PrairieUtil.js` (mainly code to create a copy to clipboard button) are kept, as well as any code for deprecated elements and v2 questions.

Since `sylvester.js` doesn't have an easy browser-friendly NPM package (the existing packages are mostly for node), it's kept as is for now as well.

Still missing: documentation to encourage new development using node modules instead of core scripts were appropriate.