### PR TITLE
Update message for home page if no student courses found

### DIFF
--- a/pages/home/home.ejs
+++ b/pages/home/home.ejs
@@ -167,7 +167,10 @@
 
             <% if (locals.instructor_courses && instructor_courses.length > 0) { %>
               <div class="card-body">
-                No courses found with student access. Courses with instructor access are found in the list above. Use the “Add or remove courses” button to add a course as a student.
+                No courses found with student access. Courses with instructor access are found in the list above.
+                <% if (authn_provider_name !== 'LTI') { %>
+                  Use the “Add or remove courses” button to add a course as a student.
+                <% } %>
               </div>
             <% } else if (devMode) { %>
               <div class="card-body">
@@ -177,7 +180,10 @@
               </div>
             <% } else { %> <!-- devMode -->
               <div class="card-body">
-                No courses found. Use the “Add or remove courses” button to add one.
+                No courses found.
+                <% if (authn_provider_name !== 'LTI') { %>
+                  Use the “Add or remove courses” button to add one.
+                <% } %>
               </div>
             <% } %> <!-- devMode -->
 

--- a/pages/home/home.ejs
+++ b/pages/home/home.ejs
@@ -165,7 +165,11 @@
 
           <% if (locals.student_courses && student_courses.length == 0) { %>
 
-            <% if (devMode) { %>
+            <% if (locals.instructor_courses && instructor_courses.length > 0) { %>
+              <div class="card-body">
+                No courses found with student access. Courses with instructor access are found in the list above. Use the “Add or remove courses” button to add a course as a student.
+              </div>
+            <% } else if (devMode) { %>
               <div class="card-body">
                 No courses loaded. Click <strong>“Load from disk”</strong>
                 above and then click <strong>“PrairieLearn”</strong> in the top left corner to come back to


### PR DESCRIPTION
I updated this message for two reasons:

1. Instructors may be confused to see this list empty if they have accessed it before #3020.
2. In `devMode` this message asks to Load from disk, even if this was done already and all courses are in the instructor side (most common case for devMode).

Also remove the suggestion to use the enroll button if it's not shown.