### PR TITLE
Restore access to assessments column in questions page

### DIFF
--- a/pages/instructorQuestions/instructorQuestions.ejs
+++ b/pages/instructorQuestions/instructorQuestions.ejs
@@ -128,7 +128,7 @@
       }
 
       function genericFilterSearch(search, value) {
-          return $('<div>').html(value).find('.formatter-data').text().includes(search);
+          return $('<div>').html(value).find('.formatter-data').text().toUpperCase().includes(search.toUpperCase());
       }
 
       function badgeFilterSearch(search, value) {
@@ -138,7 +138,7 @@
           return !!values;
       }
       
-      //<% (locals.course_instances || []).forEach(course_instance => { %>
+      //<% (authz_data.course_instances || []).forEach(course_instance => { %>
       function assessments<%= course_instance.id %>List() {
           return assessmentsByCourseInstanceList(<%= course_instance.id %>);
       }
@@ -245,7 +245,7 @@
                   data-filter-custom-search="badgeFilterSearch"
                   data-visible="<%= has_legacy_questions %>"
                   data-switchable="true">Version</th>
-              <% (locals.course_instances || []).forEach(course_instance => { %>
+              <% (authz_data.course_instances || []).forEach(course_instance => { %>
               <th data-field="assessments_<%= course_instance.id %>"
                   data-class="align-middle text-nowrap"
                   data-formatter="assessments<%= course_instance.id %>Formatter"

--- a/pages/instructorQuestions/instructorQuestions.js
+++ b/pages/instructorQuestions/instructorQuestions.js
@@ -34,7 +34,7 @@ router.get('/', function(req, res, next) {
             };
             sqldb.query(sql.questions, params, function(err, result) {
                 if (ERR(err, callback)) return;
-                const ci_ids = _.map(res.locals.course_instances, ci => ci.id);
+                const ci_ids = _.map(res.locals.authz_data.course_instances, ci => ci.id);
                 res.locals.questions = _.map(result.rows, row => {
                     if (row.sync_errors)
                         row.sync_errors_ansified = ansiUp.ansi_to_html(row.sync_errors);


### PR DESCRIPTION
#3020 changed where authorized course_instances were found, but questions page was not updated to account for this new location. This PR restore access to the assessments columns in the questions page.

Also fixes #4682.