### PR TITLE
Fix access rules role sync

### DIFF
--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -201,6 +201,7 @@ BEGIN
                 assessment_id,
                 number,
                 mode,
+                role,
                 credit,
                 uids,
                 time_limit_min,
@@ -217,6 +218,7 @@ BEGIN
                     new_assessment_id,
                     (access_rule->>'number')::integer,
                     (access_rule->>'mode')::enum_mode,
+                    'Student'::enum_role,
                     (access_rule->>'credit')::integer,
                     jsonb_array_to_text_array(access_rule->'uids'),
                     (access_rule->>'time_limit_min')::integer,
@@ -238,6 +240,7 @@ BEGIN
             ON CONFLICT (number, assessment_id) DO UPDATE
             SET
                 mode = EXCLUDED.mode,
+                role = EXCLUDED.role,
                 credit = EXCLUDED.credit,
                 time_limit_min = EXCLUDED.time_limit_min,
                 password = EXCLUDED.password,

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -144,6 +144,7 @@ BEGIN
         INSERT INTO course_instance_access_rules (
             course_instance_id,
             number,
+            role,
             uids,
             start_date,
             end_date,
@@ -151,6 +152,7 @@ BEGIN
         ) SELECT
             syncing_course_instance_id,
             number,
+            'Student'::enum_role,
             CASE
                 WHEN access_rule->'uids' = null::JSONB THEN NULL
                 ELSE jsonb_array_to_text_array(access_rule->'uids')
@@ -162,6 +164,7 @@ BEGIN
             JSONB_ARRAY_ELEMENTS(valid_course_instance.data->'access_rules') WITH ORDINALITY AS t(access_rule, number)
         ON CONFLICT (number, course_instance_id) DO UPDATE
         SET
+            role = EXCLUDED.role,
             uids = EXCLUDED.uids,
             start_date = EXCLUDED.start_date,
             end_date = EXCLUDED.end_date,


### PR DESCRIPTION
Fixes #4687 

As reported by Geoff Herman, the access rule sync process is ignoring the first access rule of every assessment. This rule used to be (in his case) the rule assigned to TAs. The current sync process updates the rules based on their number, so the first rule being updated will be the one that used to be the TA role. Since the role wasn't updated anymore, and TA roles are ignored, this caused this role to now be ignored. This PR restores the update of the role, but setting it to Student always.

This is necessary until #4659 is merged, so if #4659 becomes ready really fast (which I don't think will happen), this is a workaround.

@mwest1066 this is probably one to be merged ASAP.