### PR TITLE
Add workaround for Firefox not showing borders in sticky columns

### DIFF
--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -16,6 +16,7 @@
       position: sticky;
       left: 0;
       background: white;
+      background-clip: padding-box;
       box-shadow: inset -1px 0 #dee2e6;
     }
     .table-hover tbody tr:hover td.sticky-column {

--- a/pages/instructorGradebook/instructorGradebook.ejs
+++ b/pages/instructorGradebook/instructorGradebook.ejs
@@ -135,6 +135,7 @@
       position: sticky;
       left: 0;
       background: white;
+      background-clip: padding-box;
       box-shadow: inset -1px 0 #dee2e6;
     }
     .table-hover tbody tr:hover td.sticky-column {

--- a/pages/instructorQuestions/instructorQuestions.ejs
+++ b/pages/instructorQuestions/instructorQuestions.ejs
@@ -154,6 +154,7 @@
           position: sticky;
           left: 0;
           background: white;
+          background-clip: padding-box;
           box-shadow: inset -1px 0 #dee2e6;
       }
       .table-hover tbody tr:hover td.sticky-column {


### PR DESCRIPTION
Firefox has a bug whereas if a background is set to a `td` where the table has `border-collapse`, the border disappears. The workaround is to use `background-clip: padding-box`, which ensures the background doesn't apply to the border itself. Should not make a difference for other browsers, since this setting should only make a difference from the default if the border uses opaque/transparent elements.

See https://bugzilla.mozilla.org/show_bug.cgi?id=688556, https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip

