### PR TITLE
Fix grading results refresh when external grader completes

### DIFF
--- a/pages/partials/questionScorePanel.ejs
+++ b/pages/partials/questionScorePanel.ejs
@@ -52,7 +52,7 @@
 
   <% if (assessment.allow_issue_reporting) { %>
   <div class="card-footer">
-    <% if (!authz_result.authorized_edit) { /* assessment_instance is open */ %>
+    <% if (locals.authz_result && !authz_result.authorized_edit) { /* instructor viewing student assessment */ %>
       <div class="alert alert-warning mt-2" role="alert">
         You are viewing the question instance of a different user and so are not authorized to report an error.
       </div>


### PR DESCRIPTION
Fixes #4694.

This page still has a problem that affects a very narrow set of circumstances: the check that this is controlling is to ensure that, if an instructor opens a student's instance question, they don't report an error as that student by mistake. Similar controls are in place to avoid attaching files or submitting answers:

https://github.com/PrairieLearn/PrairieLearn/blob/8558e7e799739caaef86670209f5eebe1c1d5a6b/pages/partials/attachFilePanel.ejs#L46
https://github.com/PrairieLearn/PrairieLearn/blob/8558e7e799739caaef86670209f5eebe1c1d5a6b/pages/partials/questionFooter.ejs#L5
https://github.com/PrairieLearn/PrairieLearn/blob/8558e7e799739caaef86670209f5eebe1c1d5a6b/pages/partials/questionFooter.ejs#L75

This works fine for the most common cases, but if an instructor opens the instance question after the student submitted, but before the grades come back, when the grading is complete they will have the ability to perform all of the tasks listed above (submitting a new answer, attaching a file or reporting an issue). I realize the timing for this needs to be very strict, but I'm wondering if this should be taken into consideration. @mwest1066 thoughts?