### PR TITLE
Fix formatting of group members for empty/deleted groups in students tab

### DIFF
--- a/pages/instructorAssessmentInstances/instructorAssessmentInstancesClientJS.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstancesClientJS.ejs
@@ -203,6 +203,7 @@ function scorebarFormatter(score, row) {
 
 function listFormatter(list, row) {
 
+    if (!list || !list[0]) list = ['(empty)'];
     return '<small>' + list.join(', ') + '</small>';
 }
 


### PR DESCRIPTION
The page was crashing when an assessment instance wasn't properly assigned to a group (e.g., a group was deleted or an instance was created before the assessment was setup as groupwork).