### PR TITLE
Fix check of authorized_edit permission in question page

### DIFF
--- a/pages/partials/externalGradingLiveUpdate.ejs
+++ b/pages/partials/externalGradingLiveUpdate.ejs
@@ -74,7 +74,7 @@
         // Indicates whether submissions are allowed, either because
         // the instance question is part of the current user's
         // assessment instance (authorized_edit==true) or because the
-        // question is open in preview mode (auth_result==undefined)
+        // question is open in preview mode (authz_result==undefined)
         authorized_edit: <%= !locals.authz_result || locals.authz_result.authorized_edit %>
       }, function(msg) {
         // We're done with the socket for this incarnation of the page


### PR DESCRIPTION
Fixes #4715.

The issue was that the expression was treating `authz_result` being null as false, when it should be treated as true. `authz_result` is null if there is no assessment instance involved.