### PR TITLE
Remove unused enrollment counts in authorization

### DIFF
--- a/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
+++ b/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
@@ -35,6 +35,12 @@ router.get('/', function(req, res, next) {
             const params = {
                 course_id: res.locals.course.id,
             };
+            // We use the list authz_data.course_instances rather than
+            // re-fetching the list of course instances, because we
+            // only want course instances which are accessible by both
+            // the authn user and the effective user, which is a bit
+            // complicated to compute. This is already computed in
+            // authz_data.course_instances.
             sqldb.query(sql.select_enrollment_counts, params, (err, result) => {
                 if (ERR(err, callback)) return;
                 res.locals.authz_data.course_instances.forEach(ci => {

--- a/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.sql
+++ b/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.sql
@@ -7,3 +7,16 @@ WHERE
     ci.uuid = $uuid
     AND ci.course_id = $course_id
     AND ci.deleted_at IS NULL;
+
+-- BLOCK select_enrollment_counts
+SELECT
+    ci.id AS course_instance_id,
+    COUNT(e.user_id) AS number
+FROM
+    course_instances AS ci
+    JOIN enrollments AS e ON (e.course_instance_id = ci.id)
+WHERE
+    ci.course_id = $course_id
+    AND NOT users_is_instructor_in_course_instance(e.user_id, e.course_instance_id)
+GROUP BY
+    ci.id;

--- a/sprocs/course_instances_with_staff_access.sql
+++ b/sprocs/course_instances_with_staff_access.sql
@@ -28,8 +28,7 @@ BEGIN
                 'formatted_end_date', CASE
                     WHEN d.end_date IS NULL THEN '—'
                     ELSE format_date_full_compact(d.end_date, ci.display_timezone)
-                END,
-                'number', e.number
+                END
             ) ORDER BY d.start_date DESC NULLS LAST, d.end_date DESC NULLS LAST, ci.id DESC
         )
     INTO
@@ -57,16 +56,7 @@ BEGIN
             WHERE
                 ar.course_instance_id = ci.id
                 AND ((ar.role > 'Student') IS NOT TRUE)
-        ) AS d,
-        LATERAL (
-            SELECT
-                count(e.user_id) AS number
-            FROM
-                enrollments AS e
-            WHERE
-                e.course_instance_id = ci.id
-                AND NOT users_is_instructor_in_course_instance(e.user_id, e.course_instance_id)
-        ) AS e
+        ) AS d
     WHERE
         c.id = course_instances_with_staff_access.course_id
         AND c.deleted_at IS NULL


### PR DESCRIPTION
Since #3020 was deployed we've been seeing much higher DB CPU loads. The main culprit is `sprocs/users_is_instructor_in_course_instance`, which we are currently calling about 20,000 times per second at the moment (averaged over the day, much more during peak load). I think the vast majority of these calls are coming from here: https://github.com/PrairieLearn/PrairieLearn/blob/1dfd2d9be1f713d96f75d625dbc2f449e4844c69/sprocs/course_instances_with_staff_access.sql#L68

The current flow is:
* On every authz in `middlewares/middlewares/authzCourseOrInstance.sql` we call `sprocs/course_instances_with_staff_access` to get the list of course instances to put in the navbar dropdown menu that allows rapid switching between course instances.
* In addition to finding the list of accessible course instances, `sprocs/course_instances_with_staff_access` also currently computes the enrollment in each one. I guess this was intended for display to the user in the dropdown switcher, but we don't currently display it (or use it in any other way).
* This enrollment calculation is counting the number of `enrollments` in each course instance. It is excluding instructors from this count by calling `sprocs/users_is_instructor_in_course_instance` on every enrollment.
* The function `sprocs/users_is_instructor_in_course_instance` is quite cheap (average time to execute is 33 microseconds) but, given the number of calls, it ends up being very expensive in total.

This PR removes the unused calculation of the enrollment count for the course instances. After this, I think the cost of authorization should be roughly the same as it was before #3020.