### PR TITLE
Add authz cache for workspace proxy

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -144,6 +144,7 @@ config.workspaceDevHostInstanceId = 'devWSHost1';
 config.workspaceDevHostHostname = 'localhost';
 config.workspaceHostPort = 8081;
 config.workspaceDevContainerHostname = 'host.docker.internal';
+config.workspaceAuthzCookieMaxAgeMilliseconds = 60 * 1000;
 config.workspaceJobsDirectory = '/jobs/workspaces';
 config.workspaceJobsDirectoryOwnerUid = 0;
 config.workspaceJobsDirectoryOwnerGid = 0;

--- a/middlewares/authzWorkspace.js
+++ b/middlewares/authzWorkspace.js
@@ -13,9 +13,9 @@ const selectAndAuthzInstructorQuestion = promisify(require('./selectAndAuthzInst
 const authzHasCoursePreviewOrInstanceView = promisify(require('./authzHasCoursePreviewOrInstanceView'));
 
 module.exports = asyncHandler(async (req, res, next) => {
-    const result = await sqldb.queryOneRowAsync(sql.select_auth_data_from_workspace, {workspace_id: req.params.workspace_id});
+    // We rely on having res.locals.workspace_id already set to the correct value here
+    const result = await sqldb.queryOneRowAsync(sql.select_auth_data_from_workspace, {workspace_id: res.locals.workspace_id});
     _.assign(res.locals, result.rows[0]);
-    res.locals.workspace_id = req.params.workspace_id;
 
     if (res.locals.course_instance_id) {
         req.params.course_instance_id = res.locals.course_instance_id;

--- a/middlewares/authzWorkspaceCookieCheck.js
+++ b/middlewares/authzWorkspaceCookieCheck.js
@@ -1,0 +1,24 @@
+const asyncHandler = require('express-async-handler');
+
+const csrf = require('../lib/csrf');
+const config = require('../lib/config');
+
+module.exports = asyncHandler(async (req, res, next) => {
+    // This middleware looks for a workspace_id-specific cookie and,
+    // if found, skips the rest of authn/authz. The special cookie is
+    // set by middlewares/authzWorkspaceCookieSet.js
+
+    const workspace_id = res.locals.workspace_id;
+    const cookieName = `pl_authz_workspace_${workspace_id}`;
+    if (cookieName in req.cookies) {
+        // if we have a workspace authz cookie then we try and unpack it
+        const cookieData = csrf.getCheckedData(req.cookies[cookieName], config.secretKey, {maxAge: config.workspaceAuthzCookieMaxAgeMilliseconds});
+        // if the cookie unpacking failed then cookieData will be null
+        if (!cookieData) return next();
+        // if we have a valid cookie with matching workspace_id then skip the rest of authn/authz
+        if (cookieData?.workspace_id == workspace_id) return next('router');
+    }
+
+    // otherwise we fall through and proceed to the full authn/authz stack
+    next();
+});

--- a/middlewares/authzWorkspaceCookieCheck.js
+++ b/middlewares/authzWorkspaceCookieCheck.js
@@ -1,9 +1,7 @@
-const asyncHandler = require('express-async-handler');
-
 const csrf = require('../lib/csrf');
 const config = require('../lib/config');
 
-module.exports = asyncHandler(async (req, res, next) => {
+module.exports = (req, res, next) => {
     // This middleware looks for a workspace_id-specific cookie and,
     // if found, skips the rest of authn/authz. The special cookie is
     // set by middlewares/authzWorkspaceCookieSet.js
@@ -22,4 +20,4 @@ module.exports = asyncHandler(async (req, res, next) => {
 
     // otherwise we fall through and proceed to the full authn/authz stack
     next();
-});
+};

--- a/middlewares/authzWorkspaceCookieCheck.js
+++ b/middlewares/authzWorkspaceCookieCheck.js
@@ -13,9 +13,10 @@ module.exports = asyncHandler(async (req, res, next) => {
     if (cookieName in req.cookies) {
         // if we have a workspace authz cookie then we try and unpack it
         const cookieData = csrf.getCheckedData(req.cookies[cookieName], config.secretKey, {maxAge: config.workspaceAuthzCookieMaxAgeMilliseconds});
-        // if the cookie unpacking failed then cookieData will be null
-        if (!cookieData) return next();
-        // if we have a valid cookie with matching workspace_id then skip the rest of authn/authz
+
+        // if we have a valid cookie with matching workspace_id then
+        // short-circuit the current router to skip the rest of
+        // authn/authz
         if (cookieData?.workspace_id == workspace_id) return next('router');
     }
 

--- a/middlewares/authzWorkspaceCookieSet.js
+++ b/middlewares/authzWorkspaceCookieSet.js
@@ -1,9 +1,7 @@
-const asyncHandler = require('express-async-handler');
-
 const csrf = require('../lib/csrf');
 const config = require('../lib/config');
 
-module.exports = asyncHandler(async (req, res, next) => {
+module.exports = (req, res, next) => {
     // We should only have arrived here if we passed authn/authz and
     // are authorized to access res.locals.workspace_id. We will set a
     // short-lived cookie specific to this workspace_id that will let
@@ -18,4 +16,4 @@ module.exports = asyncHandler(async (req, res, next) => {
     const cookieData = csrf.generateToken(tokenData, config.secretKey);
     res.cookie(cookieName, cookieData, {maxAge: config.workspaceAuthzCookieMaxAgeMilliseconds});
     next();
-});
+};

--- a/middlewares/authzWorkspaceCookieSet.js
+++ b/middlewares/authzWorkspaceCookieSet.js
@@ -1,0 +1,21 @@
+const asyncHandler = require('express-async-handler');
+
+const csrf = require('../lib/csrf');
+const config = require('../lib/config');
+
+module.exports = asyncHandler(async (req, res, next) => {
+    // We should only have arrived here if we passed authn/authz and
+    // are authorized to access res.locals.workspace_id. We will set a
+    // short-lived cookie specific to this workspace_id that will let
+    // us bypass authn/authz in the future. This checking is done by
+    // middlewares/authzWorkspaceCookieCheck.js
+    
+    const workspace_id = res.locals.workspace_id;
+    const cookieName = `pl_authz_workspace_${workspace_id}`;
+    const tokenData = {
+        workspace_id: res.locals.workspace_id,
+    };
+    const cookieData = csrf.generateToken(tokenData, config.secretKey);
+    res.cookie(cookieName, cookieData, {maxAge: config.workspaceAuthzCookieMaxAgeMilliseconds});
+    next();
+});


### PR DESCRIPTION
This PR adds a cookie-based authz cache for workspaces. After successful authz for a workspace, we give the client a cookie that lets it bypass authz for this specific workspace for the next 60 seconds.

An alternative would be to cache authz server-side, by keying a redis entry off of the `pl_authn` cookie and the `workspace_id`. I don't have a strong opinion about whether its better to do this with a cookie or a server-side cache, but I went with the cookie because it's simple and doesn't add any load to our cache.