### PR TITLE
Fix mode=Exam for in-person exams to require IP match

### DIFF
--- a/database/enums/enum_exam_type.pg
+++ b/database/enums/enum_exam_type.pg
@@ -1,0 +1,1 @@
+normal, review, final, online

--- a/database/tables/exams.pg
+++ b/database/tables/exams.pg
@@ -2,6 +2,7 @@ columns
     course_id: bigint not null
     exam_id: bigint not null default nextval('exams_exam_id_seq'::regclass)
     exam_string: text not null
+    exam_type: enum_exam_type
     uuid: uuid
 
 indexes

--- a/migrations/238_enum_exam_type__create.sql
+++ b/migrations/238_enum_exam_type__create.sql
@@ -1,0 +1,7 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT * FROM pg_type WHERE typname = 'enum_exam_type') THEN
+        CREATE TYPE enum_exam_type AS ENUM ('normal', 'review', 'final', 'online');
+    END IF;
+END;
+$$;

--- a/migrations/239_exams__exam_type__add.sql
+++ b/migrations/239_exams__exam_type__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE exams ADD COLUMN IF NOT EXISTS exam_type enum_exam_type;

--- a/sprocs/ip_to_mode.sql
+++ b/sprocs/ip_to_mode.sql
@@ -17,15 +17,18 @@ BEGIN
         mode := 'Public';
     END IF;
 
-    -- Do we have an active CBTF reservation, if so force mode to 'Exam'
+    -- Do we have an active online CBTF reservation, if so force mode to 'Exam'
     PERFORM *
-    FROM reservations AS r
+    FROM
+        reservations AS r
+        JOIN exams AS e USING (exam_id)
     WHERE
         r.user_id = ip_to_mode.authn_user_id
         AND r.delete_date IS NULL
         AND r.checked_in IS NOT NULL
         AND r.access_start IS NOT NULL
-        AND date BETWEEN r.access_start AND r.access_end;
+        AND date BETWEEN r.access_start AND r.access_end
+        AND e.exam_type = 'online';
 
     IF FOUND THEN
         mode := 'Exam';


### PR DESCRIPTION
This keeps the "force mode=Exam with a checked-in reservation" for online exams, but reverts back to the pre-pandemic behavior for in-person exams. That is, in-person exams will now require an IP match for mode=Exam