### PR TITLE
Add a warning for unknown course staff on the Staff page

### DIFF
--- a/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ejs
+++ b/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ejs
@@ -56,10 +56,18 @@
             <th></th>
           </thead>
           <tbody>
+            <% let hasUnknownUsers = false; %>
             <% course_users.forEach(function(course_user, i) { %>
               <tr>
                 <td class="align-middle"><%= course_user.uid %></td>
-                <td class="align-middle"><%= (course_user.name || '—') %></td>
+                <td class="align-middle">
+                  <% if (course_user.name) { %>
+                  <%= course_user.name %>
+                  <% } else { %>
+                  <% hasUnknownUsers = true; %>
+                  <span class="text-danger">Unknown user</span>
+                  <% } %>
+                </td>
                 <td class="align-middle">
                   <% if (((course_user.user_id == authn_user.user_id) || (course_user.user_id == user.user_id)) &&
                          (!is_administrator)) {
@@ -218,6 +226,11 @@
           </tbody>
         </table>
         <small class="card-footer">
+          <% if (hasUnknownUsers) { %>
+          <p>
+            Users with name "<span class="text-danger">Unknown user</span>" either have never logged in or have an incorrect UID.
+          </p>
+          <% } %>
           <details>
             <summary>Recommended access levels</summary>
             <table class="table table-striped table-sm border" style="max-width: 45em">

--- a/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ejs
+++ b/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ejs
@@ -227,7 +227,7 @@
         </table>
         <small class="card-footer">
           <% if (hasUnknownUsers) { %>
-          <p>
+          <p class="alert alert-warning">
             Users with name "<span class="text-danger">Unknown user</span>" either have never logged in or have an incorrect UID.
           </p>
           <% } %>


### PR DESCRIPTION
We allow instructors to add arbitrary UIDs as course staff and we don't check whether they are valid users. This is helpful, because it allows instructors to add course staff without waiting for them to have logged in first. However, it can be confusing if a UID is spelled incorrectly or is missing the `@domain`. In this case the instructor will look at the Staff page and see the UID they entered, without realizing that it's incorrect.

At the moment the blank "Name" field is a sign that the UID is unrecognized. However, this signal is not clear enough for instructors (we just had a case of this).

This PR tries to signal more clearly to an instructor that a UID they entered is unrecognized.