### PR TITLE
Add alt-text attribute for <pl-figure>

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1194,6 +1194,7 @@ Attribute | Type | Default | Description
 `directory` | text | "clientFilesQuestion" | The directory that contains the file, either 'clientFilesQuestion' or 'clientFilesCourse' (see [client and server files](clientServerFiles.md)). A directory cannot be specified if `type='dynamic'`.
 `width` | number | `None` | Width of image (e.g., '250px').
 `inline` | boolean | false | Display figure inline with text (true) or on a separate line (false).
+`alt-text` | text | "PrairieLearn Figure" | Provide alt (alternative) text to improve accessibility of figures by describing the image or the purpose of the image.
 
 #### Dynamically generated figures
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1194,7 +1194,7 @@ Attribute | Type | Default | Description
 `directory` | text | "clientFilesQuestion" | The directory that contains the file, either 'clientFilesQuestion' or 'clientFilesCourse' (see [client and server files](clientServerFiles.md)). A directory cannot be specified if `type='dynamic'`.
 `width` | number | `None` | Width of image (e.g., '250px').
 `inline` | boolean | false | Display figure inline with text (true) or on a separate line (false).
-`alt-text` | text | "PrairieLearn Figure" | Provide alt (alternative) text to improve accessibility of figures by describing the image or the purpose of the image.
+`alt` | text | "" | Provide alt (alternative) text to improve accessibility of figures by describing the image or the purpose of the image. Default is an empty string.
 
 #### Dynamically generated figures
 

--- a/elements/pl-figure/pl-figure.mustache
+++ b/elements/pl-figure/pl-figure.mustache
@@ -1,8 +1,8 @@
 {{^inline}}
 <div class="container-fluid">
-    <img src="{{src}}" {{#width}}width="{{width}}"{{/width}} class="img-fluid mx-auto d-block" />
+    <img src="{{src}}" {{#width}}width="{{width}}"{{/width}} alt="{{alt}}" class="img-fluid mx-auto d-block" />
 </div>
 {{/inline}}
 {{#inline}}
-<img src="{{src}}" {{#width}}width="{{width}}"{{/width}} class="img-fluid mx-auto d-inline" />
+<img src="{{src}}" {{#width}}width="{{width}}"{{/width}} alt="{{alt}}" class="img-fluid mx-auto d-inline" />
 {{/inline}}

--- a/elements/pl-figure/pl-figure.py
+++ b/elements/pl-figure/pl-figure.py
@@ -8,7 +8,7 @@ WIDTH_DEFAULT = None
 TYPE_DEFAULT = 'static'
 DIRECTORY_DEFAULT = 'clientFilesQuestion'
 INLINE_DEFAULT = False
-ALT_TEXT_DEFAULT = 'PrairieLearn Figure'
+ALT_TEXT_DEFAULT = ''
 
 
 def prepare(element_html, data):

--- a/elements/pl-figure/pl-figure.py
+++ b/elements/pl-figure/pl-figure.py
@@ -8,11 +8,12 @@ WIDTH_DEFAULT = None
 TYPE_DEFAULT = 'static'
 DIRECTORY_DEFAULT = 'clientFilesQuestion'
 INLINE_DEFAULT = False
+ALT_TEXT_DEFAULT = 'PrairieLearn Figure'
 
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
-    pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['width', 'type', 'directory', 'inline'])
+    pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['width', 'type', 'directory', 'inline', 'alt-text'])
 
 
 def render(element_html, data):
@@ -29,6 +30,9 @@ def render(element_html, data):
 
     # Get inline (default is false)
     inline = pl.get_boolean_attrib(element, 'inline', INLINE_DEFAULT)
+
+    # Get alternate-text text (default is PrairieLearn Image)
+    alt_text = pl.get_string_attrib(element, 'alt-text', ALT_TEXT_DEFAULT)
 
     # Get base url, which depends on the type and directory
     if file_type == 'static':
@@ -53,7 +57,7 @@ def render(element_html, data):
     width = pl.get_string_attrib(element, 'width', WIDTH_DEFAULT)
 
     # Create and return html
-    html_params = {'src': file_url, 'width': width, 'inline': inline}
+    html_params = {'src': file_url, 'width': width, 'inline': inline, 'alt': alt_text}
     with open('pl-figure.mustache', 'r', encoding='utf-8') as f:
         html = chevron.render(f, html_params).strip()
 

--- a/elements/pl-figure/pl-figure.py
+++ b/elements/pl-figure/pl-figure.py
@@ -13,7 +13,7 @@ ALT_TEXT_DEFAULT = ''
 
 def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
-    pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['width', 'type', 'directory', 'inline', 'alt-text'])
+    pl.check_attribs(element, required_attribs=['file-name'], optional_attribs=['width', 'type', 'directory', 'inline', 'alt'])
 
 
 def render(element_html, data):
@@ -32,7 +32,7 @@ def render(element_html, data):
     inline = pl.get_boolean_attrib(element, 'inline', INLINE_DEFAULT)
 
     # Get alternate-text text (default is PrairieLearn Image)
-    alt_text = pl.get_string_attrib(element, 'alt-text', ALT_TEXT_DEFAULT)
+    alt_text = pl.get_string_attrib(element, 'alt', ALT_TEXT_DEFAULT)
 
     # Get base url, which depends on the type and directory
     if file_type == 'static':

--- a/exampleCourse/questions/element/figure/question.html
+++ b/exampleCourse/questions/element/figure/question.html
@@ -17,7 +17,7 @@
                 By default, <code>pl-figure</code> will read static files from the <code>clientFilesQuestion</code> directory or from <code>clientFilesCourse</code> directory if overridden using the <code>directory</code> attribute.
                 Depending on the display size of the window, the size of the displayed figure will automatically adjust to fit within the window.
             </p>
-            <pl-figure file-name="sin-x.png" alt-text="Graph of a sine wave"></pl-figure>
+            <pl-figure file-name="sin-x.png" alt="Graph of a sine wave"></pl-figure>
         </pl-question-panel>
     </div>
 </div>
@@ -33,7 +33,7 @@
                 Here is an example of a fixed width figure.
                 The width of the displayed figure can be set using the <code>width</code> attribute; the size of the figure will automatically shrink if the the specified <code>width</code> is too big for the display window.
             </p>
-            <pl-figure file-name="sin-x.png" width="300px" alt-text="Graph of a sine wave"></pl-figure>
+            <pl-figure file-name="sin-x.png" width="300px" alt="Graph of a sine wave"></pl-figure>
         </pl-question-panel>
     </div>
 </div>
@@ -49,7 +49,7 @@
                 Here is an example of a dynamic figure.  The contents of a dynamic image can be generated using the <code>file()</code> function inside <code>server.py</code> when
                 the attribute <code>type="dynamic"</code> is set in the element tag.
             </p>
-            <pl-figure file-name="cos-x.png" type="dynamic" alt-text="Graph of 1*cos(x) function"></pl-figure>
+            <pl-figure file-name="cos-x.png" type="dynamic" alt="Graph of 1*cos(x) function"></pl-figure>
         </pl-question-panel>
     </div>
 </div>
@@ -66,12 +66,12 @@
             </p>
             <br>
             <p>
-                Select <pl-figure file-name="true.png" inline="true" alt-text="Slider set to true"></pl-figure> instead of <pl-figure file-name="false.png" inline="true" alt-text="Slider set to false"></pl-figure> from below.
+                Select <pl-figure file-name="true.png" inline="true" alt="Slider set to true"></pl-figure> instead of <pl-figure file-name="false.png" inline="true" alt="Slider set to false"></pl-figure> from below.
             </p>
         </pl-question-panel>
         <pl-multiple-choice answers-name="booleans">
-            <pl-answer correct="true">Select this: <pl-figure file-name="true.png" inline="true" alt-text="Slider set to true"></pl-figure></pl-answer>
-            <pl-answer>Not this: <pl-figure file-name="false.png" inline="true" alt-text="Slider set to false"></pl-figure></pl-answer>
+            <pl-answer correct="true">Select this: <pl-figure file-name="true.png" inline="true" alt="Slider set to true"></pl-figure></pl-answer>
+            <pl-answer>Not this: <pl-figure file-name="false.png" inline="true" alt="Slider set to false"></pl-figure></pl-answer>
         </pl-multiple-choice>
         <br>
         <p>

--- a/exampleCourse/questions/element/figure/question.html
+++ b/exampleCourse/questions/element/figure/question.html
@@ -17,7 +17,7 @@
                 By default, <code>pl-figure</code> will read static files from the <code>clientFilesQuestion</code> directory or from <code>clientFilesCourse</code> directory if overridden using the <code>directory</code> attribute.
                 Depending on the display size of the window, the size of the displayed figure will automatically adjust to fit within the window.
             </p>
-            <pl-figure file-name="sin-x.png"></pl-figure>
+            <pl-figure file-name="sin-x.png" alt-text="Graph of a sine wave"></pl-figure>
         </pl-question-panel>
     </div>
 </div>
@@ -33,7 +33,7 @@
                 Here is an example of a fixed width figure.
                 The width of the displayed figure can be set using the <code>width</code> attribute; the size of the figure will automatically shrink if the the specified <code>width</code> is too big for the display window.
             </p>
-            <pl-figure file-name="sin-x.png" width="300px"></pl-figure>
+            <pl-figure file-name="sin-x.png" width="300px" alt-text="Graph of a sine wave"></pl-figure>
         </pl-question-panel>
     </div>
 </div>
@@ -49,7 +49,7 @@
                 Here is an example of a dynamic figure.  The contents of a dynamic image can be generated using the <code>file()</code> function inside <code>server.py</code> when
                 the attribute <code>type="dynamic"</code> is set in the element tag.
             </p>
-            <pl-figure file-name="cos-x.png" type="dynamic"></pl-figure>
+            <pl-figure file-name="cos-x.png" type="dynamic" alt-text="Graph of 1*cos(x) function"></pl-figure>
         </pl-question-panel>
     </div>
 </div>
@@ -66,12 +66,12 @@
             </p>
             <br>
             <p>
-                Select <pl-figure file-name="true.png" inline="true"></pl-figure> instead of <pl-figure file-name="false.png" inline="true"></pl-figure> from below.
+                Select <pl-figure file-name="true.png" inline="true" alt-text="Slider set to true"></pl-figure> instead of <pl-figure file-name="false.png" inline="true" alt-text="Slider set to false"></pl-figure> from below.
             </p>
         </pl-question-panel>
         <pl-multiple-choice answers-name="booleans">
-            <pl-answer correct="true">Select this: <pl-figure file-name="true.png" inline="true"></pl-figure></pl-answer>
-            <pl-answer>Not this: <pl-figure file-name="false.png" inline="true"></pl-figure></pl-answer>
+            <pl-answer correct="true">Select this: <pl-figure file-name="true.png" inline="true" alt-text="Slider set to true"></pl-figure></pl-answer>
+            <pl-answer>Not this: <pl-figure file-name="false.png" inline="true" alt-text="Slider set to false"></pl-figure></pl-answer>
         </pl-multiple-choice>
         <br>
         <p>


### PR DESCRIPTION
Added an alt text field for the pl-figure element for accessiblity reasons. Updated the element *.py files and documentations.

Couldn't use alt or alt-text as a variable name in Python because alt is a reserved word, so apologies on the inconsistent naming of the variables.

Chose "PrairieLearn Figure" as the default text but would happily change if there is a better choice here. Could also go with an empty string.