### PR TITLE
Extra Docker install notes for MacOS

### DIFF
--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -50,6 +50,22 @@ docker pull prairielearn/prairielearn:BRANCH_NAME
 docker run -it --rm -p 3000:3000 prairielearn/prairielearn:BRANCH_NAME
 ```
 
+### Alternate solution to long development build times (build from scratch from a specific branch)
+
+To replace the core `python` files one modifies in development there is another work around. Most likely, the developer is posting commits onto a fork of the `PrairieLearn` repository on GitHub and expects to eventually submit a pull request for the active branch they use locally. Suppose that your local changes to the development code are located in the directory `~/PrairieLearn`.
+
+To build a `docker` image from the fork with the source for a particular branch, run the following commands first (this initial step will take a while to complete): 
+```bash
+$ docker build --no-cache https://github.com/TheGHUserName/PrairieLearn.git#exact-branch-name
+$ export PLDIR_MAPS="-v $(greadlink -f ~/PrairieLearn/docs):/PrairieLearn/docs \
+      -v $(greadlink -f ~/PrairieLearn/elements):/PrairieLearn/elements \
+      -v $(greadlink -f ~/PrairieLearn/exampleCourse):/PrairieLearn/exampleCourse \
+      -v $(greadlink -f ~/PrairieLearn/lib):/PrairieLearn/lib" 
+$ docker images
+$ docker run -it --rm -p 3000:3000 $PLDIR_MAPS MOST-RECENT-IMAGE-NAME-FROM-ABOVE
+```
+Then you can connect to the running instance of `PrairieLearn` through the web browser method listed above. Note that `greadlink` is available on MacOS by running `brew install coreutils`. On Linux and other Unix machines, a standard `readlink -f path` will work in the `export` commands provided in the last terminal listings. 
+
 ### Running commands in Docker
 
 If needed, you can run the container with a different command:


### PR DESCRIPTION
Moving some helpful documentation for MacOS from PR #4334:

### Alternate solution to long development build times

To replace the core `python` files one modifies in development there is another work around. Most likely, the developer is posting commits onto a fork of the `PrairieLearn` repository on GitHub and expects to eventually submit a pull request for the active branch they use locally. Suppose that your local changes to the development code are located in the directory `~/PrairieLearn`.

To build a `docker` image from the fork with the source for a particular branch, run the following commands first (this initial step will take a while to complete): 
```bash
$ docker build --no-cache https://github.com/TheGHUserName/PrairieLearn.git#exact-branch-name
$ export PLDIR_MAPS="-v $(greadlink -f ~/PrairieLearn/docs):/PrairieLearn/docs \
      -v $(greadlink -f ~/PrairieLearn/elements):/PrairieLearn/elements \
      -v $(greadlink -f ~/PrairieLearn/exampleCourse):/PrairieLearn/exampleCourse \
      -v $(greadlink -f ~/PrairieLearn/lib):/PrairieLearn/lib" 
$ docker images
$ docker run -it --rm -p 3000:3000 $PLDIR_MAPS MOST-RECENT-IMAGE-NAME-FROM-ABOVE
```
Then you can connect to the running instance of `PrairieLearn` through the web browser method listed above. Note that `greadlink` is available on MacOS by running `brew install coreutils`. On Linux and other Unix machines, a standard `readlink -f path` will work in the `export` commands provided in the last terminal listings. 
