### PR TITLE
fix formatting for nested code fences (8 spaces, no backticks)

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -366,35 +366,34 @@ Example:
 If you have a block of text that you want to re-use in many questions, possibly with a few parameters substituted into it, you can do the following.
 
 1. Put a file called `local_template.py` into `serverFilesCourse` that contains:
-    ```
-    import chevron, os
-    
-    def render(data, template_filename, params):
-        with open(os.path.join(data["options"]["server_files_course_path"], template_filename)) as f:
-            return chevron.render(f, params)
-    ```
+
+        import chevron, os
+        
+        def render(data, template_filename, params):
+            with open(os.path.join(data["options"]["server_files_course_path"], template_filename)) as f:
+                return chevron.render(f, params)
+
 2. Put a template (this example is called `units_instructions.html`) into `serverFilesCourse`:
-    ```
-    <pl-question-panel>
-      <p>
-        All data for this problem is given in {{given_units}} units. Your answers should be in {{answer_units}}.
-      </p>
-    </pl-question-panel>
-    ```
+
+        <pl-question-panel>
+          <p>
+            All data for this problem is given in {{given_units}} units. Your answers should be in {{answer_units}}.
+          </p>
+        </pl-question-panel>
+
 3. In the `server.py` for a question, render the template like this:
-    ```
-    import local_template
-    
-    def generate(data):
-        data["params"]["units_instructions"] = local_template.render(data, "units_instructions.html", {
-            "given_units": "US customary",
-            "answer_units": "metric",
-        })
-    ```
+
+        import local_template
+        
+        def generate(data):
+            data["params"]["units_instructions"] = local_template.render(data, "units_instructions.html", {
+                "given_units": "US customary",
+                "answer_units": "metric",
+            })
+
 4. In the `question.html` for the same question, insert the rendered template like this (note the use of triple curly braces):
-    ```
-    {{{params.units_instructions}}}
-    ```
+
+        {{{params.units_instructions}}}
 
 ## How can I hide the correct answer when students see their grading results?
 


### PR DESCRIPTION
The "Read the Docs" setup doesn't seem to handle Markdown properly when backtick-fenced code blocks are nested in lists.

A workaround that seems to work is to use 8 spaces to indent the code block, no backticks, and a blank line before and after each code block. Unfortunately this doesn't let you specify a syntax for the block. (Or does it? Please let me know.)

There may be other places in the docs where this fix is still needed. Note that on GitHub, the problem isn't evident. You have to view it in "Read the Docs" mode.

Tested locally with:

```bash
cd PrairieLearn/docs
make preview
```

Thanks @mwest1066 and @jonatanschroeder for the preview tips.