### PR TITLE
Fix exception in ordered grading of order blocks.

### DIFF
--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -409,7 +409,7 @@ def grade(element_html, data):
                 else:
                     feedback = DAG_FIRST_WRONG_FEEDBACK['wrong-at-block'].format(str(first_wrong + 1))
 
-    if check_indentation:
+    if check_indentation and final_score > 0:
         student_answer_indent = filter_multiple_from_array(data['submitted_answers'][answer_name], ['indent'])
         student_answer_indent = list(map(lambda x: x['indent'], student_answer_indent))
         true_answer_indent = filter_multiple_from_array(data['correct_answers'][answer_name], ['indent'])


### PR DESCRIPTION
Fixes #4792.

I believe this fix is sufficient, but a second pair of eyes would be great.

The justification: the error occurs when "ordered" grading is used (student must put specific blocks in one specific order; every other arrangement is scored a 0), and the student uses a larger number of blocks than required in the official solution. The loop on line 417 enumerates over the student's selected blocks, but uses these indices to compare against the solution blocks; therefore giving out-of-bounds exceptions if there are more student blocks than solution. There seems to be an assumption on this line that the two lists have equivalent blocks at equivalent indices, i.e., that the student got the question correct and now indentation needs to be checked. This assumption is violated if the student didn't get the question right, for example by using too many blocks.

Such a submission is graded a 0 by the existing code. We can avoid checking indentation at all by requiring a non-zero final_score before doing so. Since the indentation score is ultimately multiplied by the final_score, it is pointless to check indentation on a submission with a final_score of 0.

This should suffice until a meaningful way of giving partial credit in this grading method is achieved, as discussed in #4652 .