### PR TITLE
Fix pl-multiple-choice feedback for pre-existing variants

### DIFF
--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -347,7 +347,7 @@ def grade(element_html, data):
 
     for option in data['params'][name]:
         if option['key'] == submitted_key:
-            feedback = option['feedback']
+            feedback = option.get('feedback', None)
 
     data['partial_scores'][name] = {'score': score, 'weight': weight, 'feedback': feedback}
 
@@ -375,7 +375,7 @@ def test(element_html, data):
             data['raw_submitted_answers'][name] = random_key
             for option in data['params'][name]:
                 if option['key'] == random_key:
-                    feedback = option['feedback']
+                    feedback = option.get('feedback', None)
             data['partial_scores'][name] = {'score': 0, 'weight': weight, 'feedback': feedback}
         else:
             # actually an invalid submission


### PR DESCRIPTION
PR #4656 makes pre-existing `pl-multiple-choice` variants ungradable because it doesn't have `feedback` stored in the options. It was almost ok, because most places used `options.get('feedback', None)` rather than `options['feedback']`, but there were two missing cases.