### PR TITLE
pl-file-upload: warning if uploaded file is empty

### DIFF
--- a/elements/pl-file-upload/pl-file-upload.js
+++ b/elements/pl-file-upload/pl-file-upload.js
@@ -56,6 +56,10 @@ window.PLFileUpload.prototype.initializeTemplate = function() {
                 var dataUrl = e.target.result;
 
                 var commaSplitIdx = dataUrl.indexOf(',');
+                if (commaSplitIdx == -1) {
+                    that.addWarningMessage('<strong>' + acceptedName + '</strong>' + ' is empty, ignoring file.');
+                    return;
+                }
 
                 // Store the file as base-64 encoded data
                 var base64FileData = dataUrl.substring(commaSplitIdx + 1);


### PR DESCRIPTION
Fixes #4828. I'm assuming empty files are to be considered invalid/ungradable in the context of uploading data (similar to an empty answer for typical submission elements), so this is replacing the incorrect behaviour with a warning and ignoring blank files on upload.