### PR TITLE
Error handling in pl-matching if params is not set

### DIFF
--- a/elements/pl-matching/pl-matching.py
+++ b/elements/pl-matching/pl-matching.py
@@ -226,7 +226,7 @@ def parse(element_html, data):
 def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, 'answers-name')
-    display_statements, display_options = data['params'].get(name)
+    display_statements, display_options = data['params'].get(name, ([], []))
     submitted_answers = data['submitted_answers']
     counter_type = pl.get_string_attrib(element, 'counter-type', COUNTER_TYPE_DEFAULT)
     hide_score_badge = pl.get_boolean_attrib(element, 'hide-score-badge', HIDE_SCORE_BADGE_DEFAULT)


### PR DESCRIPTION
I had problems with this for a student that opened a question that had been released by mistake before it was properly set, but this can also be a problem if a question is changed after a submission had been made (bad practice, but should have a cleaner solution). Current version creates issues every time the question is opened. This should remove that problem