### PR TITLE
Fix feedback retrieval if key not one of options

### DIFF
--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -345,6 +345,7 @@ def grade(element_html, data):
     if (submitted_key is not None and submitted_key == correct_key):
         score = 1
 
+    feedback = None
     for option in data['params'][name]:
         if option['key'] == submitted_key:
             feedback = option.get('feedback', None)


### PR DESCRIPTION
Fixes #4854 . The issue happens if the key selected by the user does not match any of the existing options, or if no option was selected. While this would typically cause `parse` to mark the question as ungradable, if the question implements its own version of `parse` that removes `data['format_errors']` then `grade` is called and causes an error.