### PR TITLE
feat: Allow configurable sample rate for OpenTelemetry

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -198,6 +198,14 @@ config.openTelemetryEnabled = false;
  * @type {'console' | 'honeycomb'}
  */
 config.openTelemetryExporter = 'console';
+/** @type {'always-on' | 'always-off' | 'trace-id-ratio'} */
+config.openTelemetrySamplerType = 'always-on';
+/**
+ * Only applies if `openTelemetrySamplerType` is `trace-id-ratio`.
+ *
+ * @type {number}
+ */
+config.openTelemetrySampleRate = 1;
 config.honeycombApiKey = null;
 config.honeycombDataset = 'prairielearn-dev';
 

--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -7,7 +7,13 @@ const { Resource } = require('@opentelemetry/resources');
 const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector-grpc');
 const { ExpressLayerType } = require('@opentelemetry/instrumentation-express');
-const { ExportResultCode } = require('@opentelemetry/core');
+const {
+  ExportResultCode,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+  AlwaysOnSampler,
+  AlwaysOffSampler,
+} = require('@opentelemetry/core');
 
 /**
  * Will (possibly) contain a `SpanExporter` that will export to Honeycomb, the
@@ -81,6 +87,41 @@ const delayedTraceExporter = {
   },
 };
 
+/** @typedef {import('@opentelemetry/api').Sampler} Sampler */
+
+/**
+ * The sample rate is configurable, but our configuration isn't actually loaded
+ * until after the SDK is constructed. So that we can update the sampler and the
+ * sample rate, this sampler wraps another sampler that we can adjust after it's
+ * been constructed.
+ *
+ * @implements {Sampler}
+ */
+class ConfigurableSampler {
+  constructor() {
+    this._sampler = new AlwaysOnSampler();
+  }
+
+  shouldSample(...args) {
+    return this._sampler.shouldSample(...args);
+  }
+
+  /**
+   * Updates the underlying sampler that's used.
+   * 
+   * @param {Sampler} sampler 
+   */
+  setSampler(sampler) {
+    this._sampler = sampler;
+  }
+
+  toString() {
+    return this._sampler.toString();
+  }
+}
+
+const sampler = new ConfigurableSampler();
+
 const sdk = new NodeSDK({
   resource: new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: 'prairielearn',
@@ -94,6 +135,7 @@ const sdk = new NodeSDK({
       ignoreLayersType: [ExpressLayerType.MIDDLEWARE],
     },
   })],
+  sampler,
 });
 
 /** @type {(() => void)[]} */
@@ -134,24 +176,48 @@ module.exports.init = async function init(config) {
     delayedTraceExporterStopped = true;
     await sdk.shutdown();
   } else {
-    if (config.openTelemetryExporter === 'console') {
-      // Export spans to the console for testing purposes.
-      maybeExporter = new ConsoleSpanExporter();
-    } else if (config.openTelemetryExporter === 'honeycomb') {
-      // Create a Honeycomb exporter with the appropriate metadata from the
-      // config we've been provided with.
-      const metadata = new Metadata();
+    switch (config.openTelemetryExporter) {
+      case 'console': {
+        // Export spans to the console for testing purposes.
+        maybeExporter = new ConsoleSpanExporter();
+        break;
+      }
+      case 'honeycomb': {
+        // Create a Honeycomb exporter with the appropriate metadata from the
+        // config we've been provided with.
+        const metadata = new Metadata();
 
-      metadata.set('x-honeycomb-team', config.honeycombApiKey);
-      metadata.set('x-honeycomb-dataset', config.honeycombDataset);
+        metadata.set('x-honeycomb-team', config.honeycombApiKey);
+        metadata.set('x-honeycomb-dataset', config.honeycombDataset);
 
-      maybeExporter = new CollectorTraceExporter({
-        url: 'grpc://api.honeycomb.io:443/',
-        credentials: credentials.createSsl(),
-        metadata,
-      });
-    } else {
-      throw new Error(`Unknown OpenTelemetry exporter: ${config.openTelemetryExporter}`);
+        maybeExporter = new CollectorTraceExporter({
+          url: 'grpc://api.honeycomb.io:443/',
+          credentials: credentials.createSsl(),
+          metadata,
+        });
+        break;
+      }
+      default:
+        throw new Error(`Unknown OpenTelemetry exporter: ${config.openTelemetryExporter}`);
+    }
+
+    switch (config.openTelemetrySamplerType) {
+      case 'always-on': {
+        sampler.setSampler(new AlwaysOnSampler());
+        break;
+      }
+      case 'always-off': {
+        sampler.setSampler(new AlwaysOffSampler());
+        break;
+      }
+      case 'trace-id-ratio': {
+        sampler.setSampler(new ParentBasedSampler({
+          root: new TraceIdRatioBasedSampler(config.openTelemetrySampleRate),
+        }));
+        break;
+      }
+      default:
+        throw new Error(`Unknown OpenTelemetry sampler type: ${config.openTelemetrySamplerType}`);
     }
 
     // Flush any buffered traces to the newly-created exporter.


### PR DESCRIPTION
We're currently sending waaaay too many events to Honeycomb for our quota. This allows us to sample events and configure how exactly they're sampled.