### PR TITLE
fix: Don't export normal-looking pg-pool.connect spans

### DIFF
--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -8,12 +8,14 @@ const { Resource } = require('@opentelemetry/resources');
 const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 const { OTLPTraceExporter } = require('@opentelemetry/exporter-otlp-grpc');
 const { ExpressLayerType } = require('@opentelemetry/instrumentation-express');
+const { BatchSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const {
   ExportResultCode,
   ParentBasedSampler,
   TraceIdRatioBasedSampler,
   AlwaysOnSampler,
   AlwaysOffSampler,
+  hrTimeToMilliseconds,
 } = require('@opentelemetry/core');
 
 /**
@@ -122,12 +124,66 @@ class ConfigurableSampler {
   }
 }
 
+/** @typedef {import('@opentelemetry/sdk-trace-base').ReadableSpan} ReadableSpan */
+
+/**
+ * Extends `BatchSpanProcessor` to give it the ability to filter out spans
+ * before they're queued up to send. This enhances our samping process so
+ * that we can filter spans _after_ they've been emitted.
+ */
+class FilterBatchSpanProcessor extends BatchSpanProcessor {
+  /**
+   * @param {import('@opentelemetry/sdk-trace-base').SpanExporter} exporter 
+   * @param {(span: ReadableSpan) => boolean} filter 
+   */
+  constructor(exporter, filter) {
+    super(exporter);
+    this.filter = filter;
+  }
+
+  /**
+   * This is invoked after a span is "finalized". `super.onEnd` will queue up
+   * the span to be exported, but if we don't call that, we can just drop the
+   * span and the parent will be none the wiser!
+   * 
+   * @param {ReadableSpan} span 
+   */
+  onEnd(span) {
+    if (!this.filter(span)) return;
+
+    super.onEnd(span);
+  }
+}
+
 const sampler = new ConfigurableSampler();
+
+/**
+ * This will be used with our {@link FilterBatchSpanProcessor} to filter out
+ * events that we're not interested in. This helps reduce our event volume
+ * but still gives us fine-grained control over which events we keep.
+ * 
+ * @param {ReadableSpan} span 
+ */
+function filter(span) {
+  if (span.name === 'pg-pool.connect') {
+    // Looking at historical data, this generally happens in under a millisecond,
+    // precisely because we maintain a pool of long-lived connections. The only
+    // time obtaining a client should take longer than that is if we're
+    // establishing a connection for the first time, which should happen only at
+    // bootup, or if a connection errors out. Those are the cases we're
+    // interested in, so we'll filter accordingly.
+    return hrTimeToMilliseconds(span.duration) > 1;
+  }
+
+  // Always return true so that we default to including a span.
+  return true;
+}
 
 const sdk = new NodeSDK({
   resource: new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: 'prairielearn',
   }),
+  spanProcessor: new FilterBatchSpanProcessor(delayedTraceExporter, filter),
   traceExporter: delayedTraceExporter,
   instrumentations: [getNodeAutoInstrumentations({
     '@opentelemetry/instrumentation-express': {


### PR DESCRIPTION
This PR enhances our ability to sample + filter spans. In particular, it allows us to individually evaluate each span _after_ it's been emitted and decide if it should be exported. The main motivation for this is to exclude "normal-looking" `pg-pool.connect` spans. One of those is emitted _every time_ we do something with the database, and in the vast majority of cases they only take several microseconds. By omitting any spans where the duration is less than a millisecond, we can save many millions of events per day and claw back some of our event budget to use for more interesting things.