### PR TITLE
fix: Syntax error in vendored copy of jquery

### DIFF
--- a/public/localscripts/calculationQuestion/jquery.js
+++ b/public/localscripts/calculationQuestion/jquery.js
@@ -6495,7 +6495,7 @@ function css_defaultDisplay( nodeName ) {
 
 			// Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
 			doc = ( iframe[0].contentWindow || iframe[0].contentDocument ).document;
-			doc.write("<!doctype html><html lang="en"><body>");
+			doc.write("<!doctype html><html><body>");
 			doc.close();
 
 			display = actualDisplay( nodeName, doc );


### PR DESCRIPTION
This was added inadvertently in #3263, probably via find/replace, and wasn't caught during review. I only caught this now when indiscriminately running Prettier on all JS, which printed the following error:

```
[error] public/localscripts/calculationQuestion/jquery.js: SyntaxError: Unexpected token, expected "," (6498:42)
[error]   6496 |                        // Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
[error]   6497 |                        doc = ( iframe[0].contentWindow || iframe[0].contentDocument ).document;
[error] > 6498 |                        doc.write("<!doctype html><html lang="en"><body>");
[error]        |                                                              ^
[error]   6499 |                        doc.close();
[error]   6500 |
[error]   6501 |                        display = actualDisplay( nodeName, doc );
```

Rather than just fixing the syntax error and leaving `lang="en"` in place, I just dropped it entirely, since we shouldn't be modifying vendored code like this.