### PR TITLE
chore: Improve error handling when loading JSON config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -311,14 +311,9 @@ config.loadConfigAsync = async (file) => {
     }
 
     if (exists) {
-        try {
-            const fileConfig = await jsonLoad.readJSONAsync(file);
-            await jsonLoad.validateJSONAsync(fileConfig, schemas.serverConfig);
-            _.assign(config, fileConfig);
-        } catch (err) {
-            logger.error(err);
-            process.exit(1);
-        }
+        const fileConfig = await jsonLoad.readJSONAsync(file);
+        await jsonLoad.validateJSONAsync(fileConfig, schemas.serverConfig);
+        _.assign(config, fileConfig);
     } else {
         logger.info(file + ' not found, using default configuration');
     }


### PR DESCRIPTION
While testing another branch, I made a typo in my local `config.json` file, which left me with a completely unhelpful error message:

![Screen Shot 2021-10-19 at 1 21 04 PM](https://user-images.githubusercontent.com/1476544/137984547-0bffc5f3-27e2-4576-8b89-5cc4bceca452.png)

This is because Winston is just terrible and doesn't know how to log error objects correctly. To avoid this, I removed the code in `lib/config.js` that catches errors so that the error can be propagated all the way up to `server.js`, where it can be correctly logged:

![Screen Shot 2021-10-19 at 1 21 42 PM](https://user-images.githubusercontent.com/1476544/137985045-a9c240ec-37a6-417e-af3a-52e13932e70f.png)
