### PR TITLE
fix: Use correct regex to filter /pl/webhooks/ping requests

### DIFF
--- a/lib/tracing.js
+++ b/lib/tracing.js
@@ -208,7 +208,7 @@ const sdk = new NodeSDK({
           /\/socket.io\//,
           // We get several of these per second; they just chew through our event quota.
           // They don't really do anything interesting anyways.
-          /\/pl\/webhooks\/ping\//,
+          /\/pl\/webhooks\/ping/,
         ],
       },
     }),


### PR DESCRIPTION
I got the regex wrong in https://github.com/PrairieLearn/PrairieLearn/pull/4971 - `/pl/webhooks/ping` does not include a trailing slash. This PR fixes the regex to correctly exclude ping requests from being collected by our OpenTelemetry instrumentation.