### PR TITLE
enhancements for tmux script in light of yarn, local mounting

### DIFF
--- a/tools/start_workspace_tmux.sh
+++ b/tools/start_workspace_tmux.sh
@@ -1,7 +1,37 @@
 #!/bin/bash
 
+# These options affect the appearance of the tmux view.
 export PL_TMUX_SHOW_TIPS=1
 export PL_TMUX_BOTTOM_PANE_PERCENT=40
+
+# If you're using the terminal inside VS Code, you may also need this VS Code
+# setting to be able to select text:
+# "terminal.integrated.macOptionClickForcesSelection": true
+
+# These options can help if you are using this script as an entrypoint for the
+# Docker version of PL:
+
+# INVOKE_YARN: Yarn can be invoked to install npm packages upon load.
+# Set to 1 to enable, 0 to disable.
+INVOKE_YARN=1
+
+# CHOWN_GENERATED_FILES: If you are running this script in a Linux container
+# with /PrairieLearn mounted from a local path for development, we can change
+# the ownership of generated files back to your normal user account when the
+# session ends. This will be detected from the uid:gid set on the
+# /PrairieLearn directory itself. You can disable this feature to avoid
+# slowdowns at session exit, but that may leave node_modules owned by root in
+# some cases.
+# Set to 1 to enable, 0 to disable.
+CHOWN_GENERATED_FILES=1
+
+# If you want to kill lingering PrairieLearn workspace containers before or
+# after the session, these options can be set to 1. This can help to avoid
+# issues or save memory.
+KILL_WORKSPACES_BEFORE=1
+KILL_WORKSPACES_AFTER=1
+
+# -------
 
 pl_tmux_show_tips () {
   clear
@@ -14,10 +44,6 @@ pl_tmux_show_tips () {
   echo "- tmux mouse support interferes with your terminal's mouse selection, so to select text, maximize a pane first and then hold Shift (Win/Lin) or Fn (macOS) to select text normally."
   echo "- End the tmux session with: tmux kill-window (or you can Ctrl-C and \"exit\" each pane)"
 }
-
-# If you're using the terminal inside VS Code, you may also need this VS Code
-# setting to be able to select text:
-# "terminal.integrated.macOptionClickForcesSelection": true
 
 TMUX_CONF=/PrairieLearn/.tmux.conf
 [[ -f $TMUX_CONF ]] && args=(-f $TMUX_CONF) || args=()
@@ -72,15 +98,22 @@ pl_tmux_start_workspace_pane () {
 
 export -f pl_tmux_check_http pl_tmux_check_https pl_tmux_check_lin_host pl_tmux_wait_alive pl_tmux_start_server_pane pl_tmux_start_workspace_pane pl_tmux_show_tips
 
-# kill any containers with a name like workspace-*
-CONTAINERS=$(docker ps -aq --filter "name=workspace-")
-if [[ ! -z "$CONTAINERS" ]] ; then
-  echo Killing existing workspace containers: $CONTAINERS
-  docker kill $CONTAINERS
-  docker rm $CONTAINERS
+if [ ${KILL_WORKSPACES_BEFORE:0} -eq 1 ]; then
+  # kill any containers with a name like workspace-*
+  CONTAINERS=$(docker ps -aq --filter "name=workspace-")
+  if [[ ! -z "$CONTAINERS" ]] ; then
+    echo Killing existing workspace containers: $CONTAINERS
+    docker kill $CONTAINERS
+    docker rm $CONTAINERS
+  fi
 fi
 
 cd /PrairieLearn
+
+if [ ${INVOKE_YARN:0} -eq 1 ]; then
+  yarn config set --home enableTelemetry 0
+  yarn || { echo "Yarn had an error. Giving up." ; exit 1 ; }
+fi
 
 # Check if tmux is an old or new version.
 if [[ "$(tmux -V)" =~ [0-9][^[:space:]]* ]]; then
@@ -113,4 +146,25 @@ else
     send-keys "pl_tmux_start_workspace_pane" C-m \; \
     select-pane -t 2 \; \
     send-keys "pl_tmux_show_tips" C-m
+fi
+
+# We only intend to do this when running in the Docker with /PrairieLearn
+# mounted from a local checkout.
+if [[ "$OSTYPE" == *linux* && -w /PrairieLearn ]]; then
+  PL_DIR_UID=$(stat -c '%u' /PrairieLearn)
+  PL_DIR_GID=$(stat -c '%g' /PrairieLearn)
+  if [ ${PL_DIR_UID:0} -gt 0 -a ${CHOWN_GENERATED_FILES:0} -eq 1 ] ; then
+    echo "Retaking ownership of files in /PrairieLearn to match local uid:gid ${PL_DIR_UID}:${PL_DIR_GID}..."
+    chown -R "${PL_DIR_UID}:${PL_DIR_GID}" /PrairieLearn && echo "Done"
+  fi
+fi
+
+if [ ${KILL_WORKSPACES_AFTER:0} -eq 1 ]; then
+  # Kill any lingering workspaces to clean up.
+  CONTAINERS=$(docker ps -aq --filter "name=workspace-")
+  if [[ ! -z "$CONTAINERS" ]] ; then
+    echo Killing remaining workspace containers: $CONTAINERS
+    docker kill $CONTAINERS
+    docker rm $CONTAINERS
+  fi
 fi


### PR DESCRIPTION
I've made several additions to the optional tmux entrypoint script in `tools/`. Now it can optionally invoke yarn upon load and re-chown generated files in a dev mount (e.g. `node_modules`...) back to the local user's uid:gid. Also, kill lingering workspaces upon exit.