### PR TITLE
Fix CW/CCW arrowheads in pl-drawing

### DIFF
--- a/elements/pl-drawing/elements.py
+++ b/elements/pl-drawing/elements.py
@@ -732,7 +732,8 @@ class ArcVector(BaseElement):
             'offset_forward': offset_forward,
             'offset_backward': offset_backward,
             'originY': 'center',
-            'selectable': drawing_defaults['selectable']
+            'selectable': drawing_defaults['selectable'],
+            'clockwiseDirection': clockwise_direction
         }
 
     def is_gradable():

--- a/elements/pl-drawing/mechanicsObjects.js
+++ b/elements/pl-drawing/mechanicsObjects.js
@@ -1126,6 +1126,7 @@ mechanicsObjects.pulley = fabric.util.createClass(fabric.Object, {
     this.originX = 'center';
     this.originY = 'center';
     this.objectCaching = false;
+    this.color = this.fill;
 
     const update_visuals = () => {
       this.left = this.x1;
@@ -1195,6 +1196,7 @@ mechanicsObjects.pulley = fabric.util.createClass(fabric.Object, {
   _render: function (ctx) {
     /* Draw pulley circle */
     ctx.beginPath();
+    ctx.fillStyle = this.color;
     ctx.arc(0, 0, this.radius, 0, 2 * Math.PI);
     ctx.fill();
     ctx.stroke();
@@ -2759,7 +2761,7 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
 
 mechanicsObjects.byType['pl-arc-vector'] = class extends PLDrawingBaseElement {
   static generate(canvas, options, submittedAnswer) {
-    if (options['clockwise-direction']) {
+    if (options['clockwiseDirection']) {
       options.drawStartArrow = false;
       options.drawEndArrow = true;
     } else {


### PR DESCRIPTION
Fixes the `clockwiseDirection` not doing anything; it wasn't being passed to the JS side.  Also, fixes pulleys being rendered as full black.