### PR TITLE
If plbase-install.sh fails, the plbase build should also fail

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 yum install -y tmux
 


### PR DESCRIPTION
Otherwise, you could have cases where the plbase image succeeds to
build, but doesn't function properly, as in this build where python
packages weren't installed properly:
https://github.com/PrairieLearn/PrairieLearn/runs/4101152775?check_suite_focus=true