### PR TITLE
Fix course element extensions caching

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -109,12 +109,12 @@ module.exports.courseElementAssetPath = (courseHash, urlPrefix, assetPath) => {
  * Takes into account the URL prefix and course hash to allow for
  * clients to immutably cache assets.
  *
- * @param {string} urlPrefix
  * @param {string} courseHash
+ * @param {string} urlPrefix
  * @param {string} assetPath
  * @returns {string}
  */
-module.exports.courseElementExtensionAssetPath = (urlPrefix, courseHash, assetPath) => {
+module.exports.courseElementExtensionAssetPath = (courseHash, urlPrefix, assetPath) => {
   if (!courseHash) {
     // If for some reason we don't have a course hash, fall back to the
     // non-cached path so that we don't accidentally instruct the client


### PR DESCRIPTION
The `courseHash` and `urlPrefix` args were switched in `assets.courseElementExtensionAssetPath`, which was causing the question `demo/drawing/extensions ` to break.  This flips them to match `assets.courseElementAssetPath`.