### PR TITLE
Fix misplaced help line in pl-drawing

### DIFF
--- a/elements/pl-drawing/mechanicsObjects.js
+++ b/elements/pl-drawing/mechanicsObjects.js
@@ -2244,8 +2244,10 @@ mechanicsObjects.byType['pl-polygon'] = class extends PLDrawingBaseElement {
 
 mechanicsObjects.byType['pl-line'] = class extends PLDrawingBaseElement {
   static generate(canvas, options, submittedAnswer) {
-    let obj = new fabric.Line([options.x1, options.y1, options.x2, options.y2], options);
-
+    let obj = new fabric.Line(
+      [options.x1, options.y1, options.x2, options.y2],
+      _.omit(options, 'left', 'top')
+    );
     obj.setControlVisible('bl', false);
     obj.setControlVisible('tl', false);
     obj.setControlVisible('br', false);


### PR DESCRIPTION
fabric.js's line class doesn't like when both the `left`, `top` and the endpoints of the line are specified.  This was giving weird behavior where we would get things like this being displayed:

![image](https://user-images.githubusercontent.com/1790491/140672178-bcf0e9dc-a5b7-4107-b4ee-da0fad207fe7.png)

This PR should fix that