### PR TITLE
fix: Ensure DB client is released if transaction errors

### DIFF
--- a/prairielib/lib/sql-db.js
+++ b/prairielib/lib/sql-db.js
@@ -369,6 +369,7 @@ module.exports.rollbackWithClientAsync = async function (client) {
   // From https://node-postgres.com/features/transactions
   try {
     await client.query('ROLLBACK');
+    client.release();
   } catch (err) {
     // If there was a problem rolling back the query, something is
     // seriously messed up. Return the error to the release() function to


### PR DESCRIPTION
This was introduced by me in #4989 - I didn't properly translate the old code into async/await. This meant that we were leaking DB clients if transactions ever errored.