### PR TITLE
Install newer versions of Python deps for Apple Silicon compat

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -9,7 +9,7 @@ pandas==1.3.2
 pycryptodome==3.10.1
 pyquaternion==0.9.9
 regex==2021.8.28
-scipy==1.7.1
+scipy==1.7.2
 sympy==1.8
 rpy2==3.4.5
 pygraphviz==1.6
@@ -24,5 +24,5 @@ recommonmark==0.7.1
 mkdocs-material==7.2.6
 PuLP==2.5.0
 text-unidecode==1.3
-statsmodels==0.12.2
+statsmodels==0.13.1
 openpyxl==3.0.7


### PR DESCRIPTION
Apple Silicon support for Python is... iffy, right now. Many packages, especially all the ones that we use that rely heavily on native code, don't have prebuilt binaries available. So, I had to build them from source, which required installing a lot of extra dependencies. Even then, some things wouldn't build without a version bump, which is what this PR does!

As far as I can tell, `statsmodels==0.13.0` didn't actually contain any breaking changes, per the [release notes](https://www.statsmodels.org/devel/release/version0.13.0.html). So I feel pretty good about this not breaking anything.