### PR TITLE
Use instance_questions_update_score to save scores in manual grading

### DIFF
--- a/pages/instructorQuestionManualGrading/instructorQuestionManualGrading.js
+++ b/pages/instructorQuestionManualGrading/instructorQuestionManualGrading.js
@@ -7,6 +7,7 @@ const question = require('../../lib/question');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 const error = require('../../prairielib/lib/error');
 const sqlDb = require('../../prairielib/lib/sql-db');
+const ltiOutcomes = require('../../lib/ltiOutcomes');
 const logger = require('../../lib/logger');
 
 // Other cases to figure out later: grading in progress, question is broken...
@@ -89,7 +90,7 @@ router.get('/', (req, res, next) => {
 router.post('/', function (req, res, next) {
   if (req.body.__action === 'add_manual_grade') {
     const note = req.body.submission_note;
-    const score = req.body.submission_score_percent;
+    const score_perc = req.body.submission_score_percent;
     const params = [res.locals.instance_question.id];
 
     sqlDb.callZeroOrOneRow(
@@ -106,46 +107,40 @@ router.post('/', function (req, res, next) {
         Object.assign(res.locals, { question, variant, submission });
 
         const params = [
-          submission.id,
+          req.body.assessment_id,
+          null, // assessment_instance_id,
+          submission.id, // submission_id
+          null, // instance_question_id,
+          null, // uid
+          null, // assessment_instance_number
+          null, // qid
+          score_perc,
+          null, // points
+          { manual: note }, // feedback
+          null, // partial_scores
           res.locals.authn_user.user_id,
-          submission.gradable,
-          submission.broken,
-          submission.format_errors,
-          submission.partial_scores,
-          score / 100, // overwrite submission score
-          submission.v2_score,
-          { manual: note }, // overwrite feedback
-          submission.submitted_answer,
-          submission.params,
-          submission.true_answer,
         ];
 
-        sqlDb.callOneRow('grading_jobs_insert_internal', params, (err, result) => {
+        /**
+         *  TODO: calling 'instance_questions_update_score' may not be the perfect thing to do
+         * here, because it won't respect the 'credit' property of the assessment_instance.
+         * However, allowing the 'credit' calculation in a manually graded problem is also problematic,
+         * because it means that the behavior of the instructor editing the score on the manual grading
+         * page would be different than the behavior of the instructor editing the score on any of the other
+         * pages where they can edit score. Fundamentally, we need to rethink how to treat questions
+         * that are manually graded within PrairieLearn and how to handle those score calculations.
+         */
+        sqlDb.call('instance_questions_update_score', params, (err, _result) => {
           if (ERR(err, next)) return;
-
-          /* If the submission was marked invalid during grading the grading job will
-                   be marked ungradable and we should bail here to prevent LTI updates. */
-          res.locals['grading_job'] = result.rows[0];
-          if (!res.locals['grading_job'].gradable) {
-            return next(error.make(400, 'Invalid submission error'));
-          }
-
-          res.locals['submission_updated'] = true;
-          debug(
-            '_gradeVariantWithClient()',
-            'inserted',
-            'grading_job.id:',
-            res.locals['grading_job'].id
-          );
-          res.redirect(
-            `${res.locals.urlPrefix}/assessment/${req.body.assessment_id}/assessment_question/${req.body.assessment_question_id}/next_ungraded`
-          );
+          ltiOutcomes.updateScore(req.body.assessment_instance_id, null, (err) => {
+            if (ERR(err, next)) return;
+            res.redirect(
+              `${res.locals.urlPrefix}/assessment/${req.body.assessment_id}/assessment_question/${req.body.assessment_question_id}/next_ungraded`
+            );
+          });
         });
       }
     );
-
-    // } else if (req.body.__action === 'update_manual_grade') {
-    // TODO: Update grade in DB?
   } else {
     return next(
       error.make(400, 'unknown __action', {


### PR DESCRIPTION
Previously, the manual grading page was using `grading_jobs_insert_internal` which was a total hack, because that's supposed to be for autograded questions. This caused a couple of issues including: 
- questions could only be graded once from the manual grading page, it wouldn't save properly if you tried to go back and change the grade
- inconsistent behavior based on 'credit' depending on which page you manually enter the grade on (still not totally clear what we should do here)

This solution isn't probably the end of this, we need to think more deeply about how scores from manual grading should be handled.

However, it will get use something that 'mostly works' for now, which is better than what we currently have.