### PR TITLE
fix: Build arm64 version of PrairieLearn image

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v2 # https://github.com/marketplace/actions/build-and-push-docker-images
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           no-cache: true
           tags: prairielearn/prairielearn:latest
@@ -159,41 +159,3 @@ jobs:
           push: true
           no-cache: true
           tags: prairielearn/workspace-xtermjs:latest
-
-
-      ######################################################################################################
-      ######################################################################################################
-      ######################################################################################################
-      ######################################################################################################
-      #
-      # ARM64
-      #
-      # We should be able to use `platforms: linux/amd64,linux/arm64`
-      # above to build all images on both platforms simultaneously,
-      # but the arm64 builds with postgres are currently not reliable
-      # on GitHub Actions. This seems to be because we are using qemu
-      # on x86 build hosts to build the arm64 images. A similar issue
-      # with postgis:
-      # https://github.com/postgis/docker-postgis/issues/216
-      #
-      # Note that we have also set `continue-on-error: true` for the
-      # separate arm64 builds. If these become reliable in the future
-      # then we should remove this.
-      #
-      ######################################################################################################
-      ######################################################################################################
-      ######################################################################################################
-      ######################################################################################################
-
-
-      ######################################################################################################
-      # prairielearn
-      - name: Build and push prairielearn/prairielearn
-        uses: docker/build-push-action@v2 # https://github.com/marketplace/actions/build-and-push-docker-images
-        with:
-          context: .
-          platforms: linux/arm64
-          push: true
-          no-cache: true
-          tags: prairielearn/prairielearn:arm
-        continue-on-error: true


### PR DESCRIPTION
As far as we can tell, the arm64 variant of the `prairielearn/prairielearn` image has been building successfully on master for some time now. This should allow us to build it normally with the amd64 image, instead of separately at the end of the workflow with `continue-on-error: true` set to ignore errors.

There's no great way to test this from a branch - I'll monitor the master build once this lands, and if it turns out that this broke something, I'll revert it again.

Closes https://github.com/PrairieLearn/PrairieLearn/issues/4671.