### PR TITLE
chore: Increase Yarn network timeout

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+network-timeout 60000


### PR DESCRIPTION
This is a followup to https://github.com/PrairieLearn/PrairieLearn/pull/5105 that tries to fix the new build failures on master by increasing the Yarn timeout. If this doesn't work, we may have to switch to Yarn 2.