### PR TITLE
fix: Exclude .yarnrc from .dockerignore; bump Yarn timeout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 !.eslintrc.js
 !.prettierignore
 !.prettierrc.json
+!.yarnrc
 !tsconfig.json
 !admin_queries/
 !api/

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-network-timeout 60000
+network-timeout 300000


### PR DESCRIPTION
`.dockerignore` strikes again... In #5106 I didn't explicitly exclude `.yarnrc`, so it didn't end up in the container and Yarn thus didn't use the modified timeout.

To avoid the overhead of another cycle, I also bumped the timeout up to 300s (5 minutes) since I saw that value recommended in a few other GitHub threads.