### PR TITLE
fix: Revert arm64 build changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@
 !.eslintrc.js
 !.prettierignore
 !.prettierrc.json
-!.yarnrc
 !tsconfig.json
 !admin_queries/
 !api/

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v2 # https://github.com/marketplace/actions/build-and-push-docker-images
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           no-cache: true
           tags: prairielearn/prairielearn:latest
@@ -159,3 +159,41 @@ jobs:
           push: true
           no-cache: true
           tags: prairielearn/workspace-xtermjs:latest
+
+
+      ######################################################################################################
+      ######################################################################################################
+      ######################################################################################################
+      ######################################################################################################
+      #
+      # ARM64
+      #
+      # We should be able to use `platforms: linux/amd64,linux/arm64`
+      # above to build all images on both platforms simultaneously,
+      # but the arm64 builds with postgres are currently not reliable
+      # on GitHub Actions. This seems to be because we are using qemu
+      # on x86 build hosts to build the arm64 images. A similar issue
+      # with postgis:
+      # https://github.com/postgis/docker-postgis/issues/216
+      #
+      # Note that we have also set `continue-on-error: true` for the
+      # separate arm64 builds. If these become reliable in the future
+      # then we should remove this.
+      #
+      ######################################################################################################
+      ######################################################################################################
+      ######################################################################################################
+      ######################################################################################################
+
+
+      ######################################################################################################
+      # prairielearn
+      - name: Build and push prairielearn/prairielearn
+        uses: docker/build-push-action@v2 # https://github.com/marketplace/actions/build-and-push-docker-images
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          no-cache: true
+          tags: prairielearn/prairielearn:arm
+        continue-on-error: true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-network-timeout 60000

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-network-timeout 300000
+network-timeout 60000


### PR DESCRIPTION
This PR reverts the changes from #5105, #5106, #5107 - I couldn't get the build passing, so I want to put master back in a good state until we can get to the bottom of why they're failing.