### PR TITLE
Add back button to question manual grading page

### DIFF
--- a/pages/partials/instructorGradingPanel.ejs
+++ b/pages/partials/instructorGradingPanel.ejs
@@ -5,6 +5,11 @@
         <% if (typeof submission_updated !== 'undefined' && submission_updated === true) { %>
             <blockquote style="color: red">Submission updated</blockquote>
         <% } %>
+        <a class="btn btn-primary mb-2" href="<%= urlPrefix %>/assessment/<%= assessment_instance.assessment_id %>/assessment_question/<%= instance_question.assessment_question_id %>/manual_grading">
+          <i class="fas fa-arrow-left"></i>
+          Back to Question
+        </a>
+
         <form name="instance_question-manual-grade-update-form" method="POST">
             <input type="hidden" name="__action" value="add_manual_grade">
             <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">


### PR DESCRIPTION
Without a back button on this page, you have to go through 4+ clicks just to switch which student you are grading: 

Assessments -> Assessment Name -> Manual Grading -> Question Name

This is a bit much, I think we should have the back button here. 

Currently looks like this: 
![image](https://user-images.githubusercontent.com/25016959/143906582-c9af1b9b-e616-4675-bb20-3c66c92c6dfe.png)

Which is a good start, but I'm happy for input on the UI, I'm not totally stuck on it or anything.