### PR TITLE
C grader: fix arm build and invalid UTF characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,10 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 0
-    - name: Prepare buildx multiple-platform builder
-      run: docker buildx create --use --name mybuild node-amd64
-      run: docker buildx create --append --name mybuild node-arm64
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1 # https://github.com/marketplace/actions/docker-setup-qemu
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1 # https://github.com/marketplace/actions/docker-setup-buildx
     - name: Build the plbase docker image if needed
       run: sh ./tools/build-image-if-needed.sh images/plbase prairielearn/plbase
     - name: Build the grader-c docker image if needed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 0
+    - name: Prepare buildx multiple-platform builder
+      run: docker buildx create --use --name mybuild node-amd64
+      run: docker buildx create --append --name mybuild node-arm64
     - name: Build the plbase docker image if needed
       run: sh ./tools/build-image-if-needed.sh images/plbase prairielearn/plbase
     - name: Build the grader-c docker image if needed

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="jonatan@cs.ubc.ca"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y python3.8 gcc make python3-pip valgrind check pkg-config && apt clean
+RUN apt-get install -y python3.8 gcc make python3-pip valgrind check pkg-config python3-matplotlib && apt clean
 
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM --platform=$BUILDPLATFORM ubuntu:18.04
 
 LABEL maintainer="jonatan@cs.ubc.ca"
 

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM ubuntu:18.04
+FROM ubuntu:18.04
 
 LABEL maintainer="jonatan@cs.ubc.ca"
 

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -9,6 +9,10 @@ RUN apt install -y python3.8 gcc make python3-pip valgrind check pkg-config && a
 
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 
+# Needed for arm64 version
+RUN apt install -y python3.8-dev libjpeg9-dev
+RUN pip3 install Cython==0.29.24
+
 COPY requirements.txt /requirements.txt
 RUN pip3 install --no-cache-dir -r /requirements.txt
 

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -11,10 +11,6 @@ RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 
 RUN pip3 install -U pip==21.3.1
 
-# Needed for arm64 version
-# RUN apt-get install -y python3.8-dev libjpeg9-dev
-# RUN pip3 install Cython==0.29.24
-
 COPY requirements.txt /requirements.txt
 RUN pip3 install --no-cache-dir -r /requirements.txt
 

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -5,13 +5,15 @@ LABEL maintainer="jonatan@cs.ubc.ca"
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y python3.8 gcc make python3-pip valgrind check pkg-config python3-matplotlib && apt clean
+RUN apt-get install -y python3.8 gcc make python3-pip valgrind check pkg-config && apt clean
 
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 
+RUN pip3 install -U pip==21.3.1
+
 # Needed for arm64 version
-RUN apt-get install -y python3.8-dev libjpeg9-dev
-RUN pip3 install Cython==0.29.24
+# RUN apt-get install -y python3.8-dev libjpeg9-dev
+# RUN pip3 install Cython==0.29.24
 
 COPY requirements.txt /requirements.txt
 RUN pip3 install --no-cache-dir -r /requirements.txt

--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -4,13 +4,13 @@ LABEL maintainer="jonatan@cs.ubc.ca"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update
-RUN apt install -y python3.8 gcc make python3-pip valgrind check pkg-config && apt clean
+RUN apt-get update
+RUN apt-get install -y python3.8 gcc make python3-pip valgrind check pkg-config && apt clean
 
 RUN ln -sf /usr/bin/python3.8 /usr/bin/python3
 
 # Needed for arm64 version
-RUN apt install -y python3.8-dev libjpeg9-dev
+RUN apt-get install -y python3.8-dev libjpeg9-dev
 RUN pip3 install Cython==0.29.24
 
 COPY requirements.txt /requirements.txt

--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -284,7 +284,8 @@ class CGrader:
         separator_1 = ': ' if use_suite_title and use_case_name else ''
         separator_2 = ' - ' if use_unit_test_id and (use_suite_title or use_case_name) else ''
         try:
-            tree = ET.parse(log_file)
+            with open(log_file, 'r', errors='backslashreplace') as log:
+                tree = ET.parse(log)
             for suite in tree.getroot().findall('{*}suite'):
                 suite_title = suite.findtext('{*}title') if use_suite_title else ''
                 for test in suite.findall('{*}test'):

--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -2,4 +2,4 @@ matplotlib==3.3.4
 numpy==1.20.1
 Pillow==8.1.0
 sympy==1.7.1
-Cython==0.29.24
+

--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -2,3 +2,4 @@ matplotlib==3.3.4
 numpy==1.20.1
 Pillow==8.1.0
 sympy==1.7.1
+Cython==0.29.24

--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -1,4 +1,3 @@
-matplotlib==3.3.4
 numpy==1.20.1
 Pillow==8.1.0
 sympy==1.7.1

--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -1,4 +1,3 @@
-matplotlib==3.3.4
+matplotlib==3.5.0
 numpy==1.20.1
-Pillow==8.1.0
 sympy==1.7.1

--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -1,3 +1,4 @@
+matplotlib==3.3.4
 numpy==1.20.1
 Pillow==8.1.0
 sympy==1.7.1

--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -2,4 +2,3 @@ matplotlib==3.3.4
 numpy==1.20.1
 Pillow==8.1.0
 sympy==1.7.1
-

--- a/tools/build-image-if-needed.sh
+++ b/tools/build-image-if-needed.sh
@@ -15,6 +15,5 @@ if git diff --exit-code remotes/origin/master...HEAD -- ${BUILD_DIRECTORY}; then
   echo "${BUILD_DIRECTORY} files not modified; no rebuild required"
 else
   echo "${BUILD_DIRECTORY} files modified; ${TAG_NAME} requires a rebuild"
-  docker build ${BUILD_DIRECTORY} -t ${TAG_NAME}
-  docker buildx build --platform linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
 fi

--- a/tools/build-image-if-needed.sh
+++ b/tools/build-image-if-needed.sh
@@ -15,6 +15,5 @@ if git diff --exit-code remotes/origin/master...HEAD -- ${BUILD_DIRECTORY}; then
   echo "${BUILD_DIRECTORY} files not modified; no rebuild required"
 else
   echo "${BUILD_DIRECTORY} files modified; ${TAG_NAME} requires a rebuild"
-  docker buildx build --platform linux/amd64 --no-cache ${BUILD_DIRECTORY} -t ${TAG_NAME}
-  docker buildx build --platform linux/arm64 --no-cache ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
 fi

--- a/tools/build-image-if-needed.sh
+++ b/tools/build-image-if-needed.sh
@@ -15,5 +15,6 @@ if git diff --exit-code remotes/origin/master...HEAD -- ${BUILD_DIRECTORY}; then
   echo "${BUILD_DIRECTORY} files not modified; no rebuild required"
 else
   echo "${BUILD_DIRECTORY} files modified; ${TAG_NAME} requires a rebuild"
-  docker buildx build --platform linux/amd64,linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/amd64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
 fi

--- a/tools/build-image-if-needed.sh
+++ b/tools/build-image-if-needed.sh
@@ -15,6 +15,6 @@ if git diff --exit-code remotes/origin/master...HEAD -- ${BUILD_DIRECTORY}; then
   echo "${BUILD_DIRECTORY} files not modified; no rebuild required"
 else
   echo "${BUILD_DIRECTORY} files modified; ${TAG_NAME} requires a rebuild"
-  docker buildx build --platform linux/amd64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
-  docker buildx build --platform linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/amd64 --no-cache ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/arm64 --no-cache ${BUILD_DIRECTORY} -t ${TAG_NAME}
 fi

--- a/tools/build-image-if-needed.sh
+++ b/tools/build-image-if-needed.sh
@@ -16,4 +16,5 @@ if git diff --exit-code remotes/origin/master...HEAD -- ${BUILD_DIRECTORY}; then
 else
   echo "${BUILD_DIRECTORY} files modified; ${TAG_NAME} requires a rebuild"
   docker build ${BUILD_DIRECTORY} -t ${TAG_NAME}
+  docker buildx build --platform linux/arm64 ${BUILD_DIRECTORY} -t ${TAG_NAME}
 fi


### PR DESCRIPTION
This PR "fixes" two issues: 

* build of prairielearn/grader-c in arm64 (including cython and python3.8-dev in dependencies);
* crashing if XML file generated by Check contains characters that are not valid UTF-8.

It also adds arm64 building to CI to allow building errors to be caught on pull rather than on merge.