### PR TITLE
fix: Don't cache rejected chunk promises

### DIFF
--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -938,6 +938,14 @@ module.exports.ensureChunksForCourseAsync = async (courseId, chunks) => {
     }
     const chunkPromise = ensureChunk(courseId, chunk);
     pendingChunksMap.set(pendingChunkKey, chunkPromise);
+    chunkPromise.finally(() => {
+      // Once the promise has settled, remove it from our collection of
+      // pending promises. This helps prevent memory leaks and, more
+      // importantly, ensures we don't cache rejected promises - if loading
+      // a chunk fails for some reason, this will ensure we try to load it
+      // again the next time it's requested.
+      pendingChunksMap.delete(pendingChunkKey);
+    });
     return chunkPromise;
   });
 


### PR DESCRIPTION
As described in #3939, we were previously caching chunk promises indefinitely. This is a memory leak (although we haven't yet had it impact anything in production) and also means we were caching _rejected_ promises. So, if a chunk failed to load, it would fail to load forever since we had cached the failure.

This PR ensures that a chunk loading promise is removed from our cache once it settles.

Closes #3939.