### PR TITLE
chore: Skip R logs if R packages won't be installed

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -63,9 +63,9 @@ if [[ "${arch}" != "aarch64" ]]; then # R is not yet supported on ARM64.
     echo "installing Python packages..."
     python3 -m pip install --no-cache-dir -r /python-requirements.txt
 
-    echo "installing R packages..."
-    echo "set SKIP_R_PACKAGES=yes to skip this step"
     if [[ "${SKIP_R_PACKAGES}" != "yes" ]] ; then
+        echo "installing R packages..."
+        echo "set SKIP_R_PACKAGES=yes to skip this step"
         Rscript /r-requirements.R
     fi
 else


### PR DESCRIPTION
We shouldn't log that we're installing R packages if we aren't actually installing them!