### PR TITLE
Set search-formatter = false where needed

### DIFF
--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -257,7 +257,8 @@
                   data-sortable="true"
                   data-class="text-center align-middle"
                   data-formatter="scorebarFormatter"
-                  data-switchable="true">Score</th>
+                  data-switchable="true"
+                  data-search-formatter="false">Score</th>
               <th data-field="date_formatted"
                   data-sortable="true"
                   data-sort-name="date"
@@ -277,7 +278,8 @@
                   data-sort-name="time_remaining_sec"
                   data-formatter="timeRemainingLimitFormatter"
                   data-class="text-center align-middle text-nowrap"
-                  data-switchable="true">Remaining
+                  data-switchable="true"
+                  data-search-formatter="false">Remaining
                 <button class="btn btn-xs" type="button" title="Show remaining time help" data-toggle="modal" data-target="#time-remaining-help">
                   <i class="bi-question-circle-fill" aria-hidden="true"></i>
                 </button></th>
@@ -287,12 +289,14 @@
                   data-sort-name="total_time_sec"
                   data-formatter="timeRemainingLimitFormatter"
                   data-class="text-center align-middle"
-                  data-switchable="true">Total Time Limit</th>
+                  data-switchable="true"
+                  data-search-formatter="false">Total Time Limit</th>
               <th data-field="action_button"
                   data-sortable="false"
                   data-formatter="actionButtonFormatter"
                   data-class="text-center align-middle"
-                  data-switchable="false"></th>
+                  data-switchable="false"
+                  data-search-formatter="false"></th>
             </tr>
           </thead>
         </table>

--- a/pages/instructorGradebook/instructorGradebook.ejs
+++ b/pages/instructorGradebook/instructorGradebook.ejs
@@ -213,7 +213,8 @@
                     data-sortable="true"
                     data-class="text-nowrap"
                     data-formatter="gradeFormatter"
-                    data-sort-order="desc"><%- include('../partials/assessment', {assessment: assessment}); %></th>
+                    data-sort-order="desc"
+                    data-search-formatter="false"><%- include('../partials/assessment', {assessment: assessment}); %></th>
                 <% }); %>
               </tr>
             </thead>


### PR DESCRIPTION
Fixes #5108 . It turns out, most search tables were not affected as the "formatting" that was the issue was correlated with buttons and badges. As such, all columns with buttons and badges now have the appropriate flag. This is why the questions page is not affected, as the columns that would have been affected don't allow for free-input search.