### PR TITLE
chore: Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Recommended way to use this file:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+# See https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame
+
+# Format all files with Prettier
+2f3b359987bebf00d45a8c32d58e3b302d117c4a


### PR DESCRIPTION
This PR adds a `.git-blame-ignore-revs` file, which can be used to configure Git to exclude certain commits when doing a `git blame`. Notably, this excludes 2f3b359987bebf00d45a8c32d58e3b302d117c4a, where I bulk-reformated all JS files with Prettier.

Note that GitHub does not yet understand this file; see https://github.community/t/support-ignore-revs-file-in-githubs-blame-view/3256 for the feature request.