### PR TITLE
Add math to pl-rich-text-editor

### DIFF
--- a/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -43,14 +43,25 @@ class MathFormula extends Embed  {
   static create(value) {
     const node = super.create(value);    
     if (typeof value === 'string') {
-      let html = MathJax.tex2chtml(value);
-      let formatted = html.innerHTML
-      node.innerHTML = "&#65279;" + formatted +"&#65279;";
-      MathJax.typeset();
-      node.setAttribute('data-value', value);
-      node.contentEditable = 'false';
+      this.waitUntilLoaded(node, value);
+      
     }
     return node;
+  }
+
+  static waitUntilLoaded(node, value) {
+    if(document.readyState !== 'complete'){
+      window.setTimeout(this.waitUntilLoaded, 200, node, value);
+    }
+    else{
+      let html = MathJax.tex2chtml(value);
+      let formatted = html.innerHTML
+      node.innerHTML = "&#65279;" + formatted + "&#65279;" + " ";
+      MathJax.typeset()
+      node.contentEditable = 'false';
+      node.setAttribute('data-value', value);
+      return node;
+    }
   }
 
   static value(domNode) {


### PR DESCRIPTION
Implements #4928

This is a tremendously awkward implementation, but I'm not sure how better to implement this. Quill, long story short, was not designed to work with MathJax.
Some good things with this implementation:
1. It overrides Quill's default formula implementation, meaning that the UI needs not be touched. 

Some bugs/weaknesses exist with this implementation:

1. A space character is added at the end of the mathjax text. This is required as when rendered after a page refresh, the cursor disappears if the mathjax text is the last text in the box.  
2. MathJax rendering *must* occur after the page is fully loaded. While I tried to get various async functions to work, the reality remained that none of them would work if they were initially called prior to page load completion. Hence, the timeouts. 
3. When using the "bubble" theme, it may be expected that highlighting text would change that text into LaTeX. It does not. This is intended behavior in Quill, but it is counterintuitive and un-user-friendly. 
