### PR TITLE
Remove all type annotations

### DIFF
--- a/elements/pl-order-blocks/dag_checker.py
+++ b/elements/pl-order-blocks/dag_checker.py
@@ -55,7 +55,7 @@ def dag_to_nx(depends_graph):
     return graph
 
 
-def grade_dag(order, group_belonging, depends_graph):
+def grade_dag(order, depends_graph, group_belonging):
     """In order for a student submission to a DAG graded question to be deemed correct, the student
     submission must be a topological sort of the DAG and blocks which are in the same pl-block-group
     as one another must all appear contiguously.

--- a/elements/pl-order-blocks/dag_checker.py
+++ b/elements/pl-order-blocks/dag_checker.py
@@ -1,10 +1,9 @@
-from typing import Mapping, Optional, Iterable
 from collections import Counter
 import networkx as nx
 import itertools
 
 
-def check_topological_sorting(order: list[str], graph: nx.DiGraph) -> int:
+def check_topological_sorting(order, graph):
     """
     :param order: candidate for topological sorting
     :param graph: graph to check topological sorting over
@@ -18,7 +17,7 @@ def check_topological_sorting(order: list[str], graph: nx.DiGraph) -> int:
     return len(order)
 
 
-def check_grouping(order: list[str], group_belonging: Mapping[str, Optional[int]]) -> int:
+def check_grouping(order, group_belonging):
     """
     :param order: candidate solution
     :param group_belonging: group that each block belongs to
@@ -46,7 +45,7 @@ def check_grouping(order: list[str], group_belonging: Mapping[str, Optional[int]
     return len(order)
 
 
-def dag_to_nx(depends_graph: Mapping[str, list[str]]) -> nx.DiGraph:
+def dag_to_nx(depends_graph):
     """Convert input graph format into NetworkX object to utilize their algorithms."""
     graph = nx.DiGraph()
     for node in depends_graph:
@@ -56,7 +55,7 @@ def dag_to_nx(depends_graph: Mapping[str, list[str]]) -> nx.DiGraph:
     return graph
 
 
-def grade_dag(order: list[str], depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, Optional[int]]) -> int:
+def grade_dag(order, group_belonging, depends_graph):
     """In order for a student submission to a DAG graded question to be deemed correct, the student
     submission must be a topological sort of the DAG and blocks which are in the same pl-block-group
     as one another must all appear contiguously.
@@ -76,7 +75,7 @@ def grade_dag(order: list[str], depends_graph: Mapping[str, list[str]], group_be
     return top_sort_correctness if top_sort_correctness < grouping_correctness else grouping_correctness
 
 
-def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable):
+def is_vertex_cover(G, vertex_cover):
     """ this function from
     https://docs.ocean.dwavesys.com/projects/dwave-networkx/en/latest/_modules/dwave_networkx/algorithms/cover.html#is_vertex_cover
     """
@@ -84,7 +83,7 @@ def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable):
     return all(u in cover or v in cover for u, v in G.edges)
 
 
-def lcs_partial_credit(order: list[str], depends_graph: Mapping[str, list[str]]) -> int:
+def lcs_partial_credit(order, depends_graph):
     """Computes the number of edits required to change the student solution into a correct solution using
     largest common subsequence edit distance (allows only additions and deletions, not replacing).
     The naive solution would be to enumerate all topological sorts, then get the edit distance to each of them,

--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -1,4 +1,3 @@
-from typing import Dict, Any
 import prairielearn as pl
 import lxml.html
 from lxml import etree
@@ -37,11 +36,11 @@ FIRST_WRONG_FEEDBACK = {
 }
 
 
-def filter_multiple_from_array(data: list[Dict[str, Any]], keys: list[str]) -> list[Dict[str, Any]]:
+def filter_multiple_from_array(data, keys):
     return [{key: item[key] for key in keys} for item in data]
 
 
-def prepare(element_html: str, data: pl.QuestionData) -> None:
+def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answers-name')
 
@@ -178,7 +177,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     data['correct_answers'][answer_name] = correct_answers
 
 
-def render(element_html: str, data: pl.QuestionData) -> str:
+def render(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answers-name')
 
@@ -326,7 +325,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         raise Exception('Invalid panel type')
 
 
-def parse(element_html: str, data: pl.QuestionData) -> None:
+def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answers-name')
 
@@ -372,7 +371,7 @@ def parse(element_html: str, data: pl.QuestionData) -> None:
         del data['submitted_answers'][answer_raw_name]
 
 
-def grade(element_html: str, data: pl.QuestionData) -> None:
+def grade(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     answer_name = pl.get_string_attrib(element, 'answers-name')
 
@@ -466,7 +465,7 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
     data['partial_scores'][answer_name] = {'score': round(final_score, 2), 'feedback': feedback, 'weight': answer_weight, 'first_wrong': first_wrong}
 
 
-def test(element_html: str, data: pl.ElementTestData) -> None:
+def test(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     grading_mode = pl.get_string_attrib(element, 'grading-method', 'ordered')
     answer_name = pl.get_string_attrib(element, 'answers-name')

--- a/question-servers/freeformPythonLib/prairielearn.py
+++ b/question-servers/freeformPythonLib/prairielearn.py
@@ -1,4 +1,3 @@
-from typing import Dict, Any, TypedDict, Literal
 import lxml.html
 import html
 import to_precision
@@ -16,33 +15,6 @@ import importlib
 import importlib.util
 import os
 import collections
-
-
-# TODO: This type definition should not yet be seen as authoritative, it may
-# need to be modified as we expand type checking to cover more of the element code.
-# The fields below containing 'Any' in the types are ones which are used
-# in different ways by different question elements. Ideally we would have
-# QuestionData be a generic type so that question elements could declare types
-# for their answer data, feedback data, etc., but TypedDicts with Generics are
-# not yet supported: https://bugs.python.org/issue44863
-class QuestionData(TypedDict):
-    format_errors: Dict[str, str]
-    score: float
-    feedback: Dict[str, str]
-    variant_seed: int
-    options: Dict[str, str]
-    editable: bool
-    panel: Literal['question', 'submission', 'answer']
-    partial_scores: Dict[str, Dict[str, Any]]
-    extensions: Dict[str, Any]
-    params: Dict[str, list[Any]]
-    correct_answers: Dict[str, list[Any]]
-    raw_submitted_answers: Dict[str, str]
-    submitted_answers: Dict[str, list[Any]]
-
-
-class ElementTestData(QuestionData):
-    test_type: Literal['correct', 'incorrect', 'invalid']
 
 
 def to_json(v):


### PR DESCRIPTION
This resolves an issue with a server that's running an older version of Python. Once the servers are all up to date with Python, we'll revert this to get type checking back.