### PR TITLE
fix: Exclude deleted questions when fetching question templates

### DIFF
--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -60,6 +60,7 @@ WITH RECURSIVE template_questions AS (
     FROM
         template_questions AS q
         JOIN questions AS tq ON (tq.qid = q.template_directory AND tq.course_id = q.course_id)
+    WHERE tq.deleted_at IS NULL
 )
 SELECT id FROM template_questions LIMIT 100; -- LIMIT prevents infinite recursion on circular templates
 


### PR DESCRIPTION
Fixes #5293 - see that ticket for more details.