### PR TITLE
pl-order-blocks: Rename variables in dag_checker for consistency

### DIFF
--- a/elements/pl-order-blocks/dag_checker.py
+++ b/elements/pl-order-blocks/dag_checker.py
@@ -3,23 +3,23 @@ import networkx as nx
 import itertools
 
 
-def check_topological_sorting(order, graph):
+def check_topological_sorting(submission, graph):
     """
-    :param order: candidate for topological sorting
+    :param submission: candidate for topological sorting
     :param graph: graph to check topological sorting over
     :return: index of first element not topologically sorted, or length of list if sorted
     """
     seen = set()
-    for i, node in enumerate(order):
+    for i, node in enumerate(submission):
         if node is None or not all(u in seen for (u, _) in graph.in_edges(node)):
             return i
         seen.add(node)
-    return len(order)
+    return len(submission)
 
 
-def check_grouping(order, group_belonging):
+def check_grouping(submission, group_belonging):
     """
-    :param order: candidate solution
+    :param submission: candidate solution
     :param group_belonging: group that each block belongs to
     :return: index of first element breaking condition that members of the same group must be
     adjacent, or length of list if they all meet the condition
@@ -27,7 +27,7 @@ def check_grouping(order, group_belonging):
     group_sizes = Counter(group_belonging.values())
     cur_group = None
     cur_group_size = 0
-    for i, node in enumerate(order):
+    for i, node in enumerate(submission):
         group_id = group_belonging.get(node)
         if group_id is not None and cur_group is None:
             cur_group = group_id
@@ -42,7 +42,7 @@ def check_grouping(order, group_belonging):
                     cur_group_size = 0
             else:
                 return i
-    return len(order)
+    return len(submission)
 
 
 def dag_to_nx(depends_graph):
@@ -55,11 +55,11 @@ def dag_to_nx(depends_graph):
     return graph
 
 
-def grade_dag(order, depends_graph, group_belonging):
+def grade_dag(submission, depends_graph, group_belonging):
     """In order for a student submission to a DAG graded question to be deemed correct, the student
     submission must be a topological sort of the DAG and blocks which are in the same pl-block-group
     as one another must all appear contiguously.
-    :param order: the block ordering given by the student
+    :param submission: the block ordering given by the student
     :param depends_graph: The dependency graph between blocks specified in the question
     :param group_belonging: which pl-block-group each block belongs to, specified in the question
     :return: length of list that meets both correctness conditions, starting from the beginning
@@ -69,8 +69,8 @@ def grade_dag(order, depends_graph, group_belonging):
     if not nx.is_directed_acyclic_graph(graph):
         raise Exception('Dependency between blocks does not form a Directed Acyclic Graph; Problem unsolvable.')
 
-    top_sort_correctness = check_topological_sorting(order, graph)
-    grouping_correctness = check_grouping(order, group_belonging)
+    top_sort_correctness = check_topological_sorting(submission, graph)
+    grouping_correctness = check_grouping(submission, group_belonging)
 
     return top_sort_correctness if top_sort_correctness < grouping_correctness else grouping_correctness
 

--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -411,7 +411,7 @@ def grade(element_html, data):
         final_score = 1 if student_answer == true_answer else 0
 
     elif grading_mode in ['ranking', 'dag']:
-        order = [ans['tag'] for ans in student_answer]
+        submission = [ans['tag'] for ans in student_answer]
         depends_graph = {}
         group_belonging = {}
 
@@ -432,8 +432,8 @@ def grade(element_html, data):
             depends_graph = {ans['tag']: ans['depends'] for ans in true_answer_list}
             group_belonging = {ans['tag']: ans['group'] for ans in true_answer_list}
 
-        num_initial_correct = grade_dag(order, depends_graph, group_belonging)
-        first_wrong = -1 if num_initial_correct == len(order) else num_initial_correct
+        num_initial_correct = grade_dag(submission, depends_graph, group_belonging)
+        first_wrong = -1 if num_initial_correct == len(submission) else num_initial_correct
 
         true_answer_length = len(depends_graph.keys())
         if partial_credit_type == 'none':
@@ -442,7 +442,7 @@ def grade(element_html, data):
             elif num_initial_correct < true_answer_length:
                 final_score = 0
         elif partial_credit_type == 'lcs':
-            edit_distance = lcs_partial_credit(order, depends_graph, group_belonging)
+            edit_distance = lcs_partial_credit(submission, depends_graph, group_belonging)
             final_score = max(0, float(true_answer_length - edit_distance) / true_answer_length)
 
         if final_score < 1:


### PR DESCRIPTION
Rename some variables in the grading code for internal consistency as well as better consistency with the naming in the upcoming paper about the grading algorithm.