### PR TITLE
pl-order-blocks: fix incorrect internal conversion from ranking to dag grading

### DIFF
--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -417,15 +417,17 @@ def grade(element_html, data):
 
         if grading_mode == 'ranking':
             true_answer_list = sorted(true_answer_list, key=lambda x: int(x['ranking']))
-            true_answer = [answer['ranking'] for answer in true_answer_list]
-            lines_of_rank = {rank: [str(i) for i, x in enumerate(true_answer) if x == rank] for rank in set(true_answer)}
+            true_answer = [answer['tag'] for answer in true_answer_list]
+            tag_to_rank = {answer['tag']: answer['ranking'] for answer in true_answer_list}
+            lines_of_rank = {rank: [tag for tag in tag_to_rank if tag_to_rank[tag] == rank] for rank in set(tag_to_rank.values())}
 
             cur_rank_depends = []
             prev_rank = None
-            for i, ranking in enumerate(true_answer):
+            for tag in true_answer:
+                ranking = tag_to_rank[tag]
                 if prev_rank is not None and ranking != prev_rank:
                     cur_rank_depends = lines_of_rank[prev_rank]
-                depends_graph[str(i)] = cur_rank_depends
+                depends_graph[tag] = cur_rank_depends
                 prev_rank = ranking
 
         elif grading_mode == 'dag':


### PR DESCRIPTION
Fix #5300 

The new code to convert the ranking to the DAG grading wrongly assumed that the answer blocks would be in some correct order in the HTML.

NOTE that users should still write their problems with the answer in the correct order in the HTML, because the order given in the HTML is the order that will be shown to students as the 'correct' solution. This is a documented known problem that I just haven't gotten around to fixing yet (see e.g. #4650).