### PR TITLE
fix: Embed multiple-choice HTML in span to account for inline-flex

### DIFF
--- a/elements/pl-checkbox/pl-checkbox.mustache
+++ b/elements/pl-checkbox/pl-checkbox.mustache
@@ -92,7 +92,7 @@
 {{#answers}}
     <li {{#inline}}class="list-inline-item"{{/inline}}>
         <div class="d-inline-flex align-items-center">
-        {{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{html}}}
+        <span>{{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{html}}}</span>
         {{#display_feedback}}
             <div class="pl-checkbox-feedback pl-checkbox-submission-feedback">
                 {{{feedback}}}

--- a/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -69,7 +69,7 @@
 {{^parse_error}}
 
 <div class="d-inline-flex align-items-center">
-    {{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{answer.html}}}
+    <span>{{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{answer.html}}}</span>
 
     {{#display_feedback}}
         <div class="pl-multiple-choice-feedback">


### PR DESCRIPTION
Recent changes in `pl-multiple-choice` and `pl-checkbox` included the use of `d-inline-flex` to allow for a cleaner visualization of the feedback element. This change, though, causes issues if the answer code contains HTML itself (e.g., `<b>` tags), as reported recently on Slack. This PR adds a span around the answer code to ensure that the answer HTML is not a direct child of the inline-flex parent, and thus the full answer is counted as a single child.