### PR TITLE
chore: Refactor DB test helpers to use async/await

### DIFF
--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -1,7 +1,6 @@
 // @ts-check
 const pg = require('pg');
 const path = require('path');
-const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 const _ = require('lodash');
 const util = require('util');
 
@@ -40,7 +39,6 @@ async function runMigrationsAndSprocs(dbName, mochaThis, runMigrations) {
 }
 
 async function createFullDatabase(dbName, dropFirst, mochaThis) {
-  debug(`createFullDatabase(${dbName})`);
   // long timeout because DROP DATABASE might take a long time to error
   // if other processes have an open connection to that database
   mochaThis.timeout(20000);
@@ -56,7 +54,6 @@ async function createFullDatabase(dbName, dropFirst, mochaThis) {
 }
 
 async function createFromTemplate(dbName, dbTemplateName, dropFirst, mochaThis) {
-  debug(`createFromTemplate(${dbName}, ${dbTemplateName})`);
   // long timeout because DROP DATABASE might take a long time to error
   // if other processes have an open connection to that database
   mochaThis.timeout(20000);
@@ -67,7 +64,7 @@ async function createFromTemplate(dbName, dbTemplateName, dropFirst, mochaThis) 
   }
   await client.query(`CREATE DATABASE ${dbName} TEMPLATE ${dbTemplateName};`);
   await client.end();
-  runMigrationsAndSprocs(dbName, mochaThis, false);
+  await runMigrationsAndSprocs(dbName, mochaThis, false);
 }
 
 async function establishSql(dbName) {
@@ -138,7 +135,6 @@ module.exports = {
   // schema verification, where databaseDiff will set up a connection to the
   // desired database.
   beforeOnlyCreate: async function beforeOnlyCreate() {
-    debug(`beforeOnlyCreate()`);
     var that = this;
     await setupDatabases(that);
     await closeSql();
@@ -151,7 +147,6 @@ module.exports = {
   },
 
   dropTemplate: async function dropTemplate() {
-    debug(`dropTemplate()`);
     var that = this;
     await closeSql();
     await dropDatabase(

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -1,9 +1,9 @@
-const ERR = require('async-stacktrace');
-const async = require('async');
+// @ts-check
 const pg = require('pg');
 const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 const _ = require('lodash');
+const util = require('util');
 
 const sqldb = require('../prairielib/lib/sql-db');
 const migrations = require('../prairielib/lib/migrations');
@@ -15,378 +15,150 @@ const postgresqlDatabaseTemplate = 'pltest_template';
 const postgresqlHost = 'localhost';
 const initConString = 'postgres://postgres@localhost/postgres';
 
-var runMigrationsAndSprocs = function (dbName, mochaThis, runMigrations, callback) {
-  debug(`runMigrationsAndSprocs(${dbName})`);
+async function runMigrationsAndSprocs(dbName, mochaThis, runMigrations) {
   mochaThis.timeout(20000);
-  async.series(
-    [
-      function (callback) {
-        debug('runMigrationsAndSprocs(): initializing sqldb');
-        var pgConfig = {
-          user: postgresqlUser,
-          database: dbName,
-          host: postgresqlHost,
-          max: 10,
-          idleTimeoutMillis: 30000,
-        };
-        var idleErrorHandler = function (err) {
-          throw Error('idle client error', err);
-        };
-        sqldb.init(pgConfig, idleErrorHandler, function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        if (!runMigrations) {
-          debug('runMigrationsAndSprocs(): skipping migrations');
-          return callback(null);
-        }
-        debug('runMigrationsAndSprocs(): running migrations');
-        migrations.init(path.join(__dirname, '..', 'migrations'), 'prairielearn', function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      async () => {
-        debug('runMigrationsAndSprocs(): setting random search schema');
-        await sqldb.setRandomSearchSchemaAsync('test');
-      },
-      function (callback) {
-        debug('runMigrationsAndSprocs(): initializing sprocs');
-        sprocs.init(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        debug('runMigrationsAndSprocs(): closing sqldb');
-        sqldb.close(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-    ],
-    function (err) {
-      debug('runMigrationsAndSprocs(): complete');
-      if (ERR(err, callback)) return;
-      callback(null);
-    }
-  );
-};
-
-var createFullDatabase = function (dbName, dropFirst, mochaThis, callback) {
-  debug(`createFullDatabase(${dbName})`);
-  // long timeout because DROP DATABASE might take a long time to error
-  // if other processes have an open connection to that database
-  mochaThis.timeout(20000);
-  /** @type {import('pg').Client} */
-  var client;
-  async.series(
-    [
-      function (callback) {
-        debug('createFullDatabase(): connecting client');
-        client = new pg.Client(initConString);
-        client.connect(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        if (dropFirst) {
-          debug('createFullDatabase(): dropping database');
-          client.query('DROP DATABASE IF EXISTS ' + dbName + ';', function (err) {
-            if (ERR(err, callback)) return;
-            callback(null);
-          });
-        } else {
-          callback(null);
-        }
-      },
-      function (callback) {
-        debug('createFullDatabase(): creating database');
-        client.query('CREATE DATABASE ' + dbName + ';', function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        debug('createFullDatabase(): ending client');
-        client.end();
-        callback(null);
-      },
-      function (callback) {
-        debug('createFullDatabase(): calling runMigrationsAndSprocs()');
-        runMigrationsAndSprocs(dbName, mochaThis, true, function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-    ],
-    function (err) {
-      debug('createFullDatabase(): complete');
-      if (ERR(err, callback)) return;
-      callback(null);
-    }
-  );
-};
-
-var createFromTemplate = function (dbName, dbTemplateName, dropFirst, mochaThis, callback) {
-  debug(`createFromTemplate(${dbName}, ${dbTemplateName})`);
-  // long timeout because DROP DATABASE might take a long time to error
-  // if other processes have an open connection to that database
-  mochaThis.timeout(20000);
-  var client;
-  async.series(
-    [
-      function (callback) {
-        debug('createFromTemplate(): connecting client');
-        client = new pg.Client(initConString);
-        client.connect(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        if (dropFirst) {
-          debug('createFromTemplate(): dropping database');
-          client.query('DROP DATABASE IF EXISTS ' + dbName + ';', function (err) {
-            if (ERR(err, callback)) return;
-            callback(null);
-          });
-        } else {
-          callback(null);
-        }
-      },
-      function (callback) {
-        debug('createFromTemplate(): creating database');
-        client.query(`CREATE DATABASE ${dbName} TEMPLATE ${dbTemplateName};`, function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        debug('createFromTemplate(): ending client');
-        client.end();
-        callback(null);
-      },
-      function (callback) {
-        debug('createFromTemplate(): calling runMigrationsAndSprocs()');
-        runMigrationsAndSprocs(dbName, mochaThis, false, function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-    ],
-    function (err) {
-      debug('createFromTemplate(): complete');
-      if (ERR(err, callback)) return;
-      callback(null);
-    }
-  );
-};
-
-var establishSql = function (dbName, callback) {
-  debug(`establishSql(${dbName})`);
-  debug('establishSql(): initializing sqldb');
-  var pgConfig = {
+  const pgConfig = {
     user: postgresqlUser,
     database: dbName,
     host: postgresqlHost,
     max: 10,
     idleTimeoutMillis: 30000,
   };
-  var idleErrorHandler = function (err) {
-    throw Error('idle client error', err);
-  };
-  sqldb.init(pgConfig, idleErrorHandler, function (err) {
-    if (ERR(err, callback)) return;
-    callback(null);
-  });
-};
-
-var closeSql = function (callback) {
-  debug(`closeSql()`);
-  debug('closeSql(): closing sqldb');
-  sqldb.close(function (err) {
-    if (ERR(err, callback)) return;
-    callback(null);
-  });
-};
-
-var dropDatabase = function (dbName, mochaThis, callback, forceDrop = false) {
-  debug(`dropDatabase(${dbName})`);
-  if (_.has(process.env, 'PL_KEEP_TEST_DB') && !forceDrop) {
-    // eslint-disable-next-line no-console
-    console.log(`PL_KEEP_TEST_DB enviroment variable set, not dropping database ${dbName}`);
-    return callback(null);
+  function idleErrorHandler(err) {
+    throw err;
   }
+  await sqldb.initAsync(pgConfig, idleErrorHandler);
+
+  if (runMigrations) {
+    // @ts-expect-error
+    await util.promisify(migrations.init)(path.join(__dirname, '..', 'migrations'), 'prairielearn');
+  }
+
+  await sqldb.setRandomSearchSchemaAsync('test');
+  await util.promisify(sprocs.init)();
+  await sqldb.closeAsync();
+}
+
+async function createFullDatabase(dbName, dropFirst, mochaThis) {
+  debug(`createFullDatabase(${dbName})`);
   // long timeout because DROP DATABASE might take a long time to error
   // if other processes have an open connection to that database
   mochaThis.timeout(20000);
-  /** @type {import('pg').Client} */
-  var client;
-  async.series(
-    [
-      function (callback) {
-        debug('dropDatabase(): connecting client');
-        client = new pg.Client(initConString);
-        client.connect(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        debug('dropDatabase(): dropping database');
-        client.query('DROP DATABASE IF EXISTS ' + dbName + ';', function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        debug('dropDatabase(): ending client');
-        client.end();
-        callback(null);
-      },
-    ],
-    function (err) {
-      debug('dropDatabase(): complete');
-      if (ERR(err, callback)) return;
-      callback(null);
-    }
-  );
-};
 
-var databaseExists = function (dbName, callback) {
-  debug(`databaseExists(${dbName})`);
-  var existsResult = null;
-  var client;
-  async.series(
-    [
-      function (callback) {
-        debug('databaseExists(): connecting client');
-        client = new pg.Client(initConString);
-        client.connect(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        debug('databaseExists(): running query');
-        client.query(
-          `SELECT exists(SELECT * FROM pg_catalog.pg_database WHERE datname = '${dbName}');`,
-          function (err, result) {
-            if (ERR(err, callback)) return;
-            existsResult = result.rows[0].exists;
-            callback(null);
-          }
-        );
-      },
-      function (callback) {
-        debug('databaseExists(): ending client');
-        client.end();
-        callback(null);
-      },
-    ],
-    function (err) {
-      debug('databaseExists(): complete returning ' + existsResult);
-      if (ERR(err, callback)) return;
-      callback(null, existsResult);
-    }
-  );
-};
+  const client = new pg.Client(initConString);
+  await client.connect();
+  if (dropFirst) {
+    await client.query('DROP DATABASE IF EXISTS ' + dbName + ';');
+  }
+  await client.query('CREATE DATABASE ' + dbName + ';');
+  await client.end();
+  await runMigrationsAndSprocs(dbName, mochaThis, true);
+}
 
-var setupDatabases = function (mochaThis, callback) {
-  debug(`setupDatabases()`);
-  databaseExists(postgresqlDatabaseTemplate, (err, result) => {
-    if (ERR(err, callback));
-    if (result) {
-      createFromTemplate(
-        postgresqlDatabase,
-        postgresqlDatabaseTemplate,
-        true,
-        mochaThis,
-        function (err) {
-          if (ERR(err, callback)) return;
-          establishSql(postgresqlDatabase, function (err) {
-            if (ERR(err, callback)) return;
-            callback(null);
-          });
-        }
-      );
-    } else {
-      createFullDatabase(postgresqlDatabaseTemplate, true, mochaThis, function (err) {
-        if (ERR(err, callback)) return;
-        createFromTemplate(
-          postgresqlDatabase,
-          postgresqlDatabaseTemplate,
-          true,
-          mochaThis,
-          function (err) {
-            if (ERR(err, callback)) return;
-            establishSql(postgresqlDatabase, function (err) {
-              if (ERR(err, callback)) return;
-              callback(null);
-            });
-          }
-        );
-      });
-    }
-  });
-};
+async function createFromTemplate(dbName, dbTemplateName, dropFirst, mochaThis) {
+  debug(`createFromTemplate(${dbName}, ${dbTemplateName})`);
+  // long timeout because DROP DATABASE might take a long time to error
+  // if other processes have an open connection to that database
+  mochaThis.timeout(20000);
+  const client = new pg.Client(initConString);
+  await client.connect();
+  if (dropFirst) {
+    await client.query('DROP DATABASE IF EXISTS ' + dbName + ';');
+  }
+  await client.query(`CREATE DATABASE ${dbName} TEMPLATE ${dbTemplateName};`);
+  await client.end();
+  runMigrationsAndSprocs(dbName, mochaThis, false);
+}
+
+async function establishSql(dbName) {
+  const pgConfig = {
+    user: postgresqlUser,
+    database: dbName,
+    host: postgresqlHost,
+    max: 10,
+    idleTimeoutMillis: 30000,
+  };
+  function idleErrorHandler(err) {
+    throw err;
+  }
+  await sqldb.initAsync(pgConfig, idleErrorHandler);
+}
+
+async function closeSql() {
+  await sqldb.closeAsync();
+}
+
+async function dropDatabase(dbName, mochaThis, forceDrop = false) {
+  if (_.has(process.env, 'PL_KEEP_TEST_DB') && !forceDrop) {
+    // eslint-disable-next-line no-console
+    console.log(`PL_KEEP_TEST_DB enviroment variable set, not dropping database ${dbName}`);
+    return;
+  }
+
+  // long timeout because DROP DATABASE might take a long time to error
+  // if other processes have an open connection to that database
+  mochaThis.timeout(20000);
+
+  const client = new pg.Client(initConString);
+  await client.connect();
+  await client.query('DROP DATABASE IF EXISTS ' + dbName + ';');
+  await client.end();
+}
+
+async function databaseExists(dbName) {
+  const client = new pg.Client(initConString);
+  await client.connect();
+  const result = await client.query(
+    `SELECT exists(SELECT * FROM pg_catalog.pg_database WHERE datname = '${dbName}');`
+  );
+  const existsResult = result.rows[0].exists;
+  await client.end();
+  return existsResult;
+}
+
+async function setupDatabases(mochaThis) {
+  const exists = await databaseExists(postgresqlDatabaseTemplate);
+  if (exists) {
+    await createFromTemplate(postgresqlDatabase, postgresqlDatabaseTemplate, true, mochaThis);
+  } else {
+    await createFullDatabase(postgresqlDatabaseTemplate, true, mochaThis);
+    await createFromTemplate(postgresqlDatabase, postgresqlDatabaseTemplate, true, mochaThis);
+  }
+  await establishSql(postgresqlDatabase);
+}
 
 module.exports = {
-  before: function (callback) {
-    debug(`before()`);
+  before: async function before() {
     var that = this;
-    setupDatabases(that, (err) => {
-      if (ERR(err, callback)) return;
-      callback(null);
-    });
+    await setupDatabases(that);
   },
 
   // This version will only (re)create the database with migrations; it will
   // then close the connection in sqldb. This is necessary for database
   // schema verification, where databaseDiff will set up a connection to the
   // desired database.
-  beforeOnlyCreate: function (callback) {
+  beforeOnlyCreate: async function beforeOnlyCreate() {
     debug(`beforeOnlyCreate()`);
     var that = this;
-    setupDatabases(that, (err) => {
-      if (ERR(err, callback)) return;
-      closeSql((err) => {
-        if (ERR(err, callback)) return;
-        callback(null);
-      });
-    });
+    await setupDatabases(that);
+    await closeSql();
   },
 
-  after: function (callback) {
-    debug(`after()`);
+  after: async function after() {
     var that = this;
-    closeSql(function (err) {
-      if (ERR(err, callback)) return;
-      dropDatabase(postgresqlDatabase, that, function (err) {
-        if (ERR(err, callback)) return;
-        callback(null);
-      });
-    });
+    await closeSql();
+    await dropDatabase(postgresqlDatabase, that);
   },
 
-  dropTemplate: function (callback) {
+  dropTemplate: async function dropTemplate() {
     debug(`dropTemplate()`);
     var that = this;
-    closeSql(function (err) {
-      if (ERR(err, callback)) return;
-      dropDatabase(
-        postgresqlDatabaseTemplate,
-        that,
-        function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        },
-        true
-      ); // add flag to always drop the template regardless of PL_KEEP_TEST_DB env
-    });
+    await closeSql();
+    await dropDatabase(
+      postgresqlDatabaseTemplate,
+      that,
+      // Always drop the template regardless of PL_KEEP_TEST_DB env
+      true
+    );
   },
 };

--- a/tests/helperServer.js
+++ b/tests/helperServer.js
@@ -53,7 +53,7 @@ module.exports = {
           async () => {
             await aws.init();
           },
-          async function () {
+          async () => {
             debug('before(): initializing DB');
             // pass "this" explicitly to enable this.timeout() calls
             await helperDb.before.call(that);
@@ -217,7 +217,7 @@ module.exports = {
           localCache.close();
           callback(null);
         },
-        async function () {
+        async () => {
           debug('after(): finish DB');
           await helperDb.after.call(that);
         },

--- a/tests/helperServer.js
+++ b/tests/helperServer.js
@@ -220,12 +220,9 @@ module.exports = {
           localCache.close();
           callback(null);
         },
-        function (callback) {
+        async function () {
           debug('after(): finish DB');
-          helperDb.after.call(that, function (err) {
-            if (ERR(err, callback)) return;
-            callback(null);
-          });
+          await helperDb.after.call(that);
         },
       ],
       function (err) {

--- a/tests/helperServer.js
+++ b/tests/helperServer.js
@@ -53,13 +53,10 @@ module.exports = {
           async () => {
             await aws.init();
           },
-          function (callback) {
+          async function () {
             debug('before(): initializing DB');
             // pass "this" explicitly to enable this.timeout() calls
-            helperDb.before.call(that, function (err) {
-              if (ERR(err, callback)) return;
-              callback(null);
-            });
+            await helperDb.before.call(that);
           },
           util.callbackify(async () => {
             debug('before(): create tmp dir for config.filesRoot');


### PR DESCRIPTION
This refactoring lays the groundwork for additional refactoring to allow us to use Mocha's `--parallel` flag to speed up test runs.