### PR TITLE
Introduce percent based calculation

### DIFF
--- a/api/v1/endpoints/queries.sql
+++ b/api/v1/endpoints/queries.sql
@@ -100,7 +100,8 @@ WITH object_data AS (
         aar.show_closed_assessment_score,
         format_date_iso8601(aar.start_date, ci.display_timezone) AS start_date,
         aar.time_limit_min,
-        aar.uids
+        aar.uids,
+        aar.percentage_credit_grading
     FROM
         assessments AS a
         JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
@@ -236,7 +237,8 @@ WITH object_data AS (
         s.correct,
         s.feedback,
         (row_number() OVER (PARTITION BY v.id ORDER BY s.date DESC, s.id DESC)) = 1 AS final_submission_per_variant,
-        (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC, s.id DESC)) = 1 AS best_submission_per_variant
+        (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC, s.id DESC)) = 1 AS best_submission_per_variant,
+        s.percentage_credit_grading
     FROM
         assessments AS a
         JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)

--- a/database/tables/assessment_access_rules.pg
+++ b/database/tables/assessment_access_rules.pg
@@ -2,6 +2,7 @@ columns
     active: boolean not null default true
     assessment_id: bigint not null
     credit: integer
+    percentage_credit_grading: boolean not null default false
     end_date: timestamp with time zone
     exam_uuid: uuid
     id: bigint not null default nextval('assessment_access_rules_id_seq'::regclass)

--- a/database/tables/submissions.pg
+++ b/database/tables/submissions.pg
@@ -24,6 +24,7 @@ columns
     true_answer: jsonb
     v2_score: double precision
     variant_id: bigint not null
+    percentage_credit_grading: boolean not null default false
 
 indexes
     submissions_pkey: PRIMARY KEY (id) USING btree (id)

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -38,6 +38,7 @@ Each `accessRule` is an object that specifies a set of circumstances under which
 | [`showClosedAssessment`](#showinghiding-closed-assessments)         |                | ✓          | Whether to allow viewing of assessment contents when closed (default `true`).                              | `"showClosedAssessment": false`                         |
 | [`showClosedAssessmentScore`](#showinghiding-all-score-information) |                | ✓          | Whether to allow viewing of the score of a closed assessment (default `true`).                             | `"showClosedAssessmentScore": false`                    |
 | [`active`](#active-assessments)                                     |                | ✓          | Whether the student can create a new assessment instance and submit answers to questions (default `true`). | `"active": false`                                       |
+| [`percentageCreditGrading`](#active-assessments)                                     |                | ✓          | Whether the credit field uses the default or percentage based calculations (default `false`). | `"percentageCreditGrading": false`                                       |
 
 Each access rule will only grant access if all of the restrictions are satisfied.
 
@@ -78,7 +79,13 @@ In general usage it is best to set `"mode": "Public"` for any homework (assessme
 
 When the available credit is less than 100%, the percentage score is calculated as `min(credit, points / maxPoints * 100)`. However, the student's percentage score will never decrease, so if they've already earned a higher percentage score then they will keep it. For example, if `credit = 80` and `maxPoints = 10`, then when a student has `points = 8` then they will have a percentage score of 80%, and when they have `points = 9` or `points = 10` they will still have a percentage score of 80%.
 
+To change how the percentage score is calculated (for less than 100%), see the `percentageCreditGrading` flag.
+
 When the available credit is more than 100%, then the percentage score is calculated as `points / maxPoints * 100` when `points < maxPoints`. However, if `points = maxPoints` then the percentage score is taken to be the credit value. For example, if `credit = 120` then the student will see their percentage score rise towards 100% as their `points` increase towards `maxPoints`, and then when their `points` reaches `maxPoints` their percentage score will suddenly jump to 120%. If [`maxBonusPoints`](assessment.md#assessment-points) is used, and the student is able to obtain points above `maxPoints`, then the student's percentage score will be based on this credit as a percentage, i.e., their score will be computed as `credit * points / maxPoints`. For example, if `maxPoints = 10`, `maxBonusPoints = 2`, `credit = 120` and the student obtained 11 points, their score will be `120 * 11 / 10 = 132%`.
+
+## Percentage Credit Grading
+
+When the available credit is less than 100% and the flag is set to true, the formula to calculate the percentage score will instead become `(credit / 100) * points / maxPoints * 100)`. For example, if `credit = 50` and `maxPoints = 10`, then when a student has `points = 6` then they will have a percentage score of 30% as opposed to 50% in the default credit calculation (`min(credit, points / maxPoints * 100)`).
 
 ## Time limits
 

--- a/lib/question.js
+++ b/lib/question.js
@@ -556,6 +556,7 @@ module.exports = {
             submission.mode,
             submission.variant_id,
             submission.auth_user_id,
+            submission.percentage_credit_grading,
           ];
           sqldb.callWithClientOneRow(client, 'submissions_insert', params, (err, result) => {
             if (ERR(err, callback)) return;
@@ -1031,6 +1032,7 @@ module.exports = {
             null, // mode
             variant.id,
             authn_user_id,
+            false, // percentage_credit_grading
           ];
           sqldb.callWithClientOneRow(client, 'submissions_insert', params, (err, result) => {
             if (ERR(err, callback)) return;

--- a/migrations/000_initial_state.sql
+++ b/migrations/000_initial_state.sql
@@ -370,7 +370,8 @@ CREATE TABLE IF NOT EXISTS submissions (
     graded_at TIMESTAMP WITH TIME ZONE,
     score DOUBLE PRECISION,
     correct BOOLEAN,
-    feedback JSONB
+    feedback JSONB,
+    percentage_credit_grading BOOLEAN DEFAULT FALSE
 );
 
 -- job_sequences

--- a/migrations/245_assessment_access_rules__percentage_credit_grading__add.sql
+++ b/migrations/245_assessment_access_rules__percentage_credit_grading__add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessment_access_rules ADD COLUMN percentage_credit_grading boolean NOT NULL DEFAULT false;

--- a/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
+++ b/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
@@ -46,7 +46,11 @@ SELECT
     CASE
         WHEN aar.active THEN 'True'
         ELSE 'False'
-    END AS active
+    END AS active,
+    CASE
+        WHEN aar.percentage_credit_grading THEN 'True'
+        ELSE 'False'
+    END AS percentage_credit_grading
 FROM
     assessment_access_rules AS aar
     JOIN assessments AS a ON (a.id = aar.assessment_id)

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -157,6 +157,7 @@ WITH all_submissions AS (
         g.name AS group_name,
         groups_uid_list(g.id) AS uid_list,
         su.uid AS submission_user
+        s.percentage_credit_grading,
     FROM
         assessments AS a
         JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)

--- a/pages/studentAssessments/studentAssessments.sql
+++ b/pages/studentAssessments/studentAssessments.sql
@@ -24,7 +24,8 @@ WITH
             NULL::integer AS assessment_instance_id,
             NULL::integer AS assessment_instance_number,
             NULL::integer AS assessment_instance_score_perc,
-            NULL::boolean AS assessment_instance_open
+            NULL::boolean AS assessment_instance_open,
+            aa.percentage_credit_grading
         FROM
             assessments AS a
             JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
@@ -60,7 +61,8 @@ WITH
             ai.id AS assessment_instance_id,
             ai.number AS assessment_instance_number,
             ai.score_perc AS assessment_instance_score_perc,
-            ai.open AS assessment_instance_open
+            ai.open AS assessment_instance_open,
+            mia.percentage_credit_grading
         FROM
             assessment_instances AS ai
             JOIN multiple_instance_assessments AS mia ON (mia.assessment_id = ai.assessment_id)
@@ -92,7 +94,8 @@ WITH
             ai.id AS assessment_instance_id,
             ai.number AS assessment_instance_number,
             ai.score_perc AS assessment_instance_score_perc,
-            ai.open AS assessment_instance_open
+            ai.open AS assessment_instance_open,
+            aa.percentage_credit_grading
         FROM
             -- join group_users first to find all group assessments
             group_configs AS gc

--- a/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
+++ b/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
@@ -49,6 +49,7 @@ function processSubmission(req, res, callback) {
     submitted_answer: submitted_answer,
     credit: res.locals.authz_result.credit,
     mode: res.locals.authz_data.mode,
+    percentage_credit_grading: res.locals.authz_result.percentage_credit_grading,
   };
   sqldb.callOneRow(
     'variants_ensure_instance_question',

--- a/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
+++ b/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
@@ -42,6 +42,7 @@ function processSubmission(req, res, callback) {
     submitted_answer: submitted_answer,
     credit: res.locals.authz_result.credit,
     mode: res.locals.authz_data.mode,
+    percentage_credit_grading: res.locals.authz_result.percentage_credit_grading,
   };
   sqldb.callOneRow(
     'variants_ensure_instance_question',

--- a/schemas/schemas/infoAssessment.json
+++ b/schemas/schemas/infoAssessment.json
@@ -236,6 +236,11 @@
                     "description": "Whether the student can create a new assessment instance and submit answers to questions. If set to false, the available credit must be 0.",
                     "type": "boolean",
                     "default": true
+                },
+                "percentageCreditGrading": {
+                  "description": "Whether credit will be multiplied to the current score as a percentage (100 being full marks). If set to false, minimum of credit and score will be taken.",
+                  "type": "boolean",
+                  "default": false
                 }
             }
         },

--- a/sprocs/authz_assessment.sql
+++ b/sprocs/authz_assessment.sql
@@ -16,7 +16,8 @@ CREATE FUNCTION
         OUT show_closed_assessment_score boolean, -- If students can view their grade after the assessment is closed
         OUT active boolean,         -- If the assessment is visible but not active
         OUT next_active_time text,  -- The next time the assessment becomes active. This is non-null only if the assessment is not currently active but will be later.
-        OUT access_rules JSONB       -- For display to the user. The currently active rule is marked by 'active' = TRUE.
+        OUT access_rules JSONB,     -- For display to the user. The currently active rule is marked by 'active' = TRUE.
+        OUT percentage_credit_grading boolean  -- Will the credit field be used for percentage credit grading?
     )
 AS $$
 DECLARE
@@ -96,5 +97,6 @@ BEGIN
     show_closed_assessment_score := user_result.show_closed_assessment_score;
     active := user_result.active;
     next_active_time := user_result.next_active_time;
+    percentage_credit_grading := user_result.percentage_credit_grading;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/authz_assessment_instance.sql
+++ b/sprocs/authz_assessment_instance.sql
@@ -19,7 +19,8 @@ CREATE FUNCTION
         OUT show_closed_assessment_score boolean, -- If students can view their grade after the assessment is closed
         OUT active boolean,         -- If the assessment is visible but not active
         OUT next_active_time text,  -- The next time the assessment becomes active. This is non-null only if the assessment is not currently active but will be later.
-        OUT access_rules JSONB       -- For display to the user. The currently active rule is marked by 'active' = TRUE.
+        OUT access_rules JSONB,      -- For display to the user. The currently active rule is marked by 'active' = TRUE.
+        OUT percentage_credit_grading boolean   -- Will the credit field be used for percentage credit grading?
     )
 AS $$
 DECLARE
@@ -48,6 +49,7 @@ BEGIN
     show_closed_assessment_score := assessment_result.show_closed_assessment_score;
     active := assessment_result.active;
     next_active_time := assessment_result.next_active_time;
+    percentage_credit_grading := assessment_result.percentage_credit_grading;
 
     time_limit_expired := FALSE;
     IF assessment_instance.date_limit IS NOT NULL AND assessment_instance.date_limit < req_date THEN

--- a/sprocs/grading_jobs_insert_external_manual.sql
+++ b/sprocs/grading_jobs_insert_external_manual.sql
@@ -12,13 +12,14 @@ DECLARE
     instance_question_id bigint;
     assessment_instance_id bigint;
     grading_method enum_grading_method;
+    percentage_credit_grading boolean;
 BEGIN
     -- ######################################################################
     -- get the related objects
 
     -- we must have a variant, but we might not have an assessment_instance
-    SELECT s.credit,       v.id, q.grading_method,                iq.id,                  ai.id
-    INTO     credit, variant_id,   grading_method, instance_question_id, assessment_instance_id
+    SELECT s.credit,       v.id, q.grading_method,                iq.id,                  ai.id, s.percentage_credit_grading
+    INTO     credit, variant_id,   grading_method, instance_question_id, assessment_instance_id,   percentage_credit_grading
     FROM
         submissions AS s
         JOIN variants AS v ON (v.id = s.variant_id)
@@ -80,7 +81,7 @@ BEGIN
 
     IF assessment_instance_id IS NOT NULL THEN
         PERFORM instance_questions_update_in_grading(instance_question_id, authn_user_id);
-        PERFORM assessment_instances_grade(assessment_instance_id, authn_user_id, credit);
+        PERFORM assessment_instances_grade(assessment_instance_id, authn_user_id, credit, FALSE, FALSE, percentage_credit_grading);
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/grading_jobs_insert_internal.sql
+++ b/sprocs/grading_jobs_insert_internal.sql
@@ -23,13 +23,14 @@ DECLARE
     assessment_instance_id bigint;
     grading_method enum_grading_method;
     new_correct boolean;
+    percentage_credit_grading boolean;
 BEGIN
     -- ######################################################################
     -- get the related objects
 
     -- we must have a variant, but we might not have an assessment_instance
-    SELECT s.credit,       v.id, q.grading_method,              iq.id,                  ai.id
-    INTO     credit, variant_id,   grading_method, instance_question_id, assessment_instance_id
+    SELECT s.credit,       v.id, q.grading_method,                iq.id,                  ai.id, s.percentage_credit_grading
+    INTO     credit, variant_id,   grading_method, instance_question_id, assessment_instance_id,   percentage_credit_grading
     FROM
         submissions AS s
         JOIN variants AS v ON (v.id = s.variant_id)
@@ -105,7 +106,7 @@ BEGIN
         PERFORM variants_update_after_grading(variant_id, grading_job.correct);
         IF assessment_instance_id IS NOT NULL THEN
            PERFORM instance_questions_grade(instance_question_id, grading_job.score, grading_job.id, grading_job.auth_user_id);
-           PERFORM assessment_instances_grade(assessment_instance_id, grading_job.auth_user_id, credit);
+           PERFORM assessment_instances_grade(assessment_instance_id, grading_job.auth_user_id, credit, FALSE, FALSE, percentage_credit_grading);
         END IF;
     END IF;
 END;

--- a/sprocs/submissions_insert.sql
+++ b/sprocs/submissions_insert.sql
@@ -10,6 +10,7 @@ CREATE FUNCTION
         IN mode enum_mode,
         IN variant_id bigint,
         IN authn_user_id bigint,
+        IN percentage_credit_grading boolean,
         OUT submission_id bigint
     )
 AS $$
@@ -82,9 +83,9 @@ BEGIN
 
     INSERT INTO submissions
             (variant_id, auth_user_id, raw_submitted_answer, submitted_answer, format_errors,
-            credit, mode, duration, params, true_answer, gradable, broken, regradable)
+            credit, mode, duration, params, true_answer, gradable, broken, regradable, percentage_credit_grading)
     VALUES  (variant_id, authn_user_id, raw_submitted_answer, submitted_answer, format_errors,
-            credit, mode, delta, variant.params, variant.true_answer, gradable, broken, regradable)
+            credit, mode, delta, variant.params, variant.true_answer, gradable, broken, regradable, percentage_credit_grading)
     RETURNING id
     INTO submission_id;
 

--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -212,7 +212,8 @@ BEGIN
                 end_date,
                 show_closed_assessment,
                 show_closed_assessment_score,
-                active)
+                active,
+                percentage_credit_grading)
             (
                 SELECT
                     new_assessment_id,
@@ -229,7 +230,8 @@ BEGIN
                     input_date(access_rule->>'end_date', COALESCE(ci.display_timezone, c.display_timezone, 'America/Chicago')),
                     (access_rule->>'show_closed_assessment')::boolean,
                     (access_rule->>'show_closed_assessment_score')::boolean,
-                    (access_rule->>'active')::boolean
+                    (access_rule->>'active')::boolean,
+                    (access_rule->>'percentage_credit_grading')::boolean
                 FROM
                     assessments AS a
                     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
@@ -251,7 +253,8 @@ BEGIN
                 end_date = EXCLUDED.end_date,
                 show_closed_assessment = EXCLUDED.show_closed_assessment,
                 show_closed_assessment_score = EXCLUDED.show_closed_assessment_score,
-                active = EXCLUDED.active;
+                active = EXCLUDED.active,
+                percentage_credit_grading = EXCLUDED.percentage_credit_grading;
         END LOOP;
 
         -- Delete excess access rules

--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -269,6 +269,7 @@ const FILE_UUID_REGEX =
  * @property {number} timeLimitMin
  * @property {string} password
  * @property {SEBConfig} SEBConfig
+ * @property {boolean} percentageCreditGrading
  */
 
 /**
@@ -1104,6 +1105,10 @@ async function validateAssessment(assessment, questions) {
 
     if ('active' in rule && rule.active === false && 'credit' in rule && rule.credit !== 0) {
       errors.push(`Invalid allowAccess rule: credit must be 0 if active is false`);
+    }
+
+    if ('percentageCreditGrading' in rule && !('credit' in rule)) {
+      errors.push('Invalid allowAccess rule: credit must be declared if percentageCreditGrading is declared')
     }
 
     errors.push(...allowAccessResult.errors);

--- a/sync/fromDisk/assessments.js
+++ b/sync/fromDisk/assessments.js
@@ -95,6 +95,7 @@ function getParamsForAssessment(assessmentInfoFile, questionIds) {
         show_closed_assessment: !!_.get(accessRule, 'showClosedAssessment', true),
         show_closed_assessment_score: !!_.get(accessRule, 'showClosedAssessmentScore', true),
         active: !!_.get(accessRule, 'active', true),
+        percentage_credit_grading: !!_.get(accessRule, 'percentageCreditGrading', false),
       };
     });
 

--- a/tests/sync/util.js
+++ b/tests/sync/util.js
@@ -82,6 +82,7 @@ const syncFromDisk = require('../../sync/syncFromDisk');
  * @property {number} timeLimitMin
  * @property {string} password
  * @property {SEBConfig} SEBConfig
+ * @property {boolean} percentageCreditGrading
  */
 
 /**


### PR DESCRIPTION
This PR adds the optional `percentageCreditGrading` boolean flag to switch credit calculations (<100) from the default `min(credit, points / max_points * 100)` to percent based calculation mentioned in #3451.

The implementation defaults to the previous method of calculation.