### PR TITLE
pl-order-blocks: Allow indentation under the DAG grading mode

### DIFF
--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -91,7 +91,7 @@ def prepare(element_html, data):
         elif grading_method in ['ranking', 'ordered']:
             pl.check_attribs(html_tags, required_attribs=[], optional_attribs=['correct', 'ranking', 'indent'])
         elif grading_method == 'dag':
-            pl.check_attribs(html_tags, required_attribs=[], optional_attribs=['correct', 'tag', 'depends', 'comment'])
+            pl.check_attribs(html_tags, required_attribs=[], optional_attribs=['correct', 'tag', 'depends', 'comment', 'indent'])
 
         is_correct = pl.get_boolean_attrib(html_tags, 'correct', PL_ANSWER_CORRECT_DEFAULT)
         answer_indent = pl.get_integer_attrib(html_tags, 'indent', None)


### PR DESCRIPTION
co-authored with @CoffeePoweredComputers 