### PR TITLE
Typo in example note of "What To Tell Students"

### DIFF
--- a/docs/whatToTellStudents.md
+++ b/docs/whatToTellStudents.md
@@ -23,7 +23,7 @@ If you answer a question incorrectly, one thing happens:
 
 <ul><li>The value goes back to what it was originally (1x).</li></ul>
 
-This system rewards repeated correct answers, which tend to demonstrate mastery. There is no penalty (other than resetting the value) for answering a question incorrectly, so don't be afraid to submit an answer. Similarly, don't be afraid to keep doing a question after you reach the point maximum - your point total with <em>never</em> go down!
+This system rewards repeated correct answers, which tend to demonstrate mastery. There is no penalty (other than resetting the value) for answering a question incorrectly, so don't be afraid to submit an answer. Similarly, don't be afraid to keep doing a question after you reach the point maximum - your point total will <em>never</em> go down!
 
 HW1.1 is due at 10:59AM on Friday, January 27. There is no need to "submit" your homework. The system will record whatever your score is at that time.
 


### PR DESCRIPTION
There is a typo in the example piazza note under "What to tell students":
```...your point total with never go down!``` -> ```...your point total will never go down!```