### PR TITLE
fix: Java autograder repeat test if multiple test classes

### DIFF
--- a/graders/java/JUnitAutograder.java
+++ b/graders/java/JUnitAutograder.java
@@ -60,7 +60,7 @@ public class JUnitAutograder implements TestExecutionListener {
     public void runTests() throws UngradableException {
 
         for (String classSrcName : testClasses) {
-	    LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
+            LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
             String className = classSrcName
                 .replaceFirst("^/grade/tests/junit/", "")
                 .replaceFirst("\\.java$", "")

--- a/graders/java/JUnitAutograder.java
+++ b/graders/java/JUnitAutograder.java
@@ -59,9 +59,8 @@ public class JUnitAutograder implements TestExecutionListener {
 
     public void runTests() throws UngradableException {
 
-        LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
-
         for (String classSrcName : testClasses) {
+	    LauncherDiscoveryRequestBuilder requestBuilder = LauncherDiscoveryRequestBuilder.request();
             String className = classSrcName
                 .replaceFirst("^/grade/tests/junit/", "")
                 .replaceFirst("\\.java$", "")


### PR DESCRIPTION
As reported by @NormanCHutchinson, the Java autograder was repeating tests any time more than one JUnit test class was found in the junit folder. So if there were classes A, B and C, the execution of A would run the tests of A, the execution of B would run the tests of A and B, and the execution of C would run the tests of A, B and C. Caused by the reuse of a request builder in the JUnit launcher API.