### PR TITLE
chore: Use TRUNCATE to reset database state in sync tests

### DIFF
--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -144,8 +144,8 @@ module.exports.beforeOnlyCreate = async function beforeOnlyCreate() {
 module.exports.after = async function after() {
   var that = this;
   await closeSql();
-  // const dbName = module.exports.getDatabaseNameForCurrentWorker();
-  // await dropDatabase(dbName, that);
+  const dbName = module.exports.getDatabaseNameForCurrentWorker();
+  await dropDatabase(dbName, that);
 };
 
 module.exports.createTemplate = async function createTemplate(mochaThis) {

--- a/tests/sync/assessmentSetsSync.test.js
+++ b/tests/sync/assessmentSetsSync.test.js
@@ -34,10 +34,10 @@ function makeAssessmentSet() {
 }
 
 describe('Assessment set syncing', () => {
-  // Uncomment whenever you change relevant sprocs or migrations
-  // before('remove the template database', helperDb.dropTemplate);
-  beforeEach('set up testing database', helperDb.before);
-  afterEach('tear down testing database', helperDb.after);
+  before('set up testing database', helperDb.before);
+  after('tear down testing database', helperDb.after);
+
+  beforeEach('reset testing database', helperDb.resetDatabase);
 
   it('adds a new assessment set', async () => {
     const { courseData, courseDir } = await util.createAndSyncCourseData();

--- a/tests/sync/assessmentsSync.test.js
+++ b/tests/sync/assessmentsSync.test.js
@@ -65,10 +65,10 @@ async function findSyncedUndeletedAssessment(tid) {
 }
 
 describe('Assessment syncing', () => {
-  // Uncomment whenever you change relevant sprocs or migrations
-  // before('remove the template database', helperDb.dropTemplate);
-  beforeEach('set up testing database', helperDb.before);
-  afterEach('tear down testing database', helperDb.after);
+  before('set up testing database', helperDb.before);
+  after('tear down testing database', helperDb.after);
+
+  beforeEach('reset testing database', helperDb.resetDatabase);
 
   it('allows nesting of assessments in subfolders', async () => {
     const courseData = util.getCourseData();

--- a/tests/sync/courseInstancesSync.test.js
+++ b/tests/sync/courseInstancesSync.test.js
@@ -26,10 +26,10 @@ function makeCourseInstance() {
 }
 
 describe('Course instance syncing', () => {
-  // Uncomment whenever you change relevant sprocs or migrations
-  // before('remove the template database', helperDb.dropTemplate);
-  beforeEach('set up testing database', helperDb.before);
-  afterEach('tear down testing database', helperDb.after);
+  before('set up testing database', helperDb.before);
+  after('tear down testing database', helperDb.after);
+
+  beforeEach('reset testing database', helperDb.resetDatabase);
 
   it('allows nesting of course instances in subfolders', async () => {
     const courseData = util.getCourseData();

--- a/tests/sync/initialSync.test.js
+++ b/tests/sync/initialSync.test.js
@@ -3,10 +3,10 @@ const util = require('./util');
 const helperDb = require('../helperDb');
 
 describe('Initial Sync', () => {
-  // Uncomment whenever you change relevant sprocs or migrations
-  // before('remove the template database', helperDb.dropTemplate);
-  beforeEach('set up testing database', helperDb.before);
-  afterEach('tear down testing database', helperDb.after);
+  before('set up testing database', helperDb.before);
+  after('tear down testing database', helperDb.after);
+
+  beforeEach('reset testing database', helperDb.resetDatabase);
 
   it('correctly syncs content from disk to the database', async () => {
     const { courseData, courseDir } = await util.createAndSyncCourseData();

--- a/tests/sync/questionsSync.test.js
+++ b/tests/sync/questionsSync.test.js
@@ -39,8 +39,10 @@ async function findSyncedUndeletedQuestion(qid) {
 describe('Question syncing', () => {
   // Uncomment whenever you change relevant sprocs or migrations
   // before('remove the template database', helperDb.dropTemplate);
-  beforeEach('set up testing database', helperDb.before);
-  afterEach('tear down testing database', helperDb.after);
+  before('set up testing database', helperDb.before);
+  after('tear down testing database', helperDb.after);
+
+  beforeEach('reset testing database', helperDb.resetDatabase);
 
   it('allows nesting of questions in subfolders', async () => {
     const courseData = util.getCourseData();

--- a/tests/sync/tagsTopicsSync.test.js
+++ b/tests/sync/tagsTopicsSync.test.js
@@ -101,10 +101,10 @@ async function testDuplicate(entityName) {
 }
 
 describe('Tag/topic syncing', () => {
-  // Uncomment whenever you change relevant sprocs or migrations
-  // before('remove the template database', helperDb.dropTemplate);
-  beforeEach('set up testing database', helperDb.before);
-  afterEach('tear down testing database', helperDb.after);
+  before('set up testing database', helperDb.before);
+  after('tear down testing database', helperDb.after);
+
+  beforeEach('reset testing database', helperDb.resetDatabase);
 
   it('adds a new tag', async () => {
     await testAdd('tags');


### PR DESCRIPTION
This builds on and depends on the work in #5352. I'm just submitting as a separate PR for easier review.

This uses `TRUNCATE` to reset the database state instead of recreating the entire DB from scratch for each test. This is much faster: when running tests serially (this is close to what happens on CI since the GitHub runners only have two cores), this change cuts the time to run the sync tests from 24 seconds to just 12!