### PR TITLE
Remove empty feedback on MC and Checkbox elements

### DIFF
--- a/elements/pl-checkbox/pl-checkbox.py
+++ b/elements/pl-checkbox/pl-checkbox.py
@@ -163,7 +163,7 @@ def render(element_html, data):
                 'checked': (answer['key'] in submitted_keys),
                 'html': answer['html'].strip(),
                 'display_score_badge': score is not None and show_answer_feedback and answer['key'] in submitted_keys,
-                'display_feedback': answer['key'] in submitted_keys and feedback and feedback.get(answer['key'], None) is not None,
+                'display_feedback': answer['key'] in submitted_keys and feedback and feedback.get(answer['key'], None),
                 'feedback': feedback.get(answer['key'], None) if feedback else None
             }
             if answer_html['display_score_badge']:
@@ -301,7 +301,7 @@ def render(element_html, data):
                 if answer_item['display_score_badge']:
                     answer_item['correct'] = (submitted_key in correct_keys)
                     answer_item['incorrect'] = (submitted_key not in correct_keys)
-                answer_item['display_feedback'] = feedback and feedback.get(submitted_key, None) is not None
+                answer_item['display_feedback'] = feedback and feedback.get(submitted_key, None)
                 answer_item['feedback'] = feedback.get(submitted_key, None) if feedback else None
                 answers.append(answer_item)
 

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -228,7 +228,7 @@ def render(element_html, data):
                 'checked': (submitted_key == answer['key']),
                 'html': answer['html'],
                 'display_score_badge': display_score and submitted_key == answer['key'],
-                'display_feedback': submitted_key == answer['key'] and feedback is not None,
+                "display_feedback": submitted_key == answer["key"] and feedback,
                 'feedback': feedback
             }
             if answer_html['display_score_badge']:
@@ -290,7 +290,7 @@ def render(element_html, data):
                         html_params['incorrect'] = True
                 except Exception:
                     raise ValueError('invalid score' + score)
-            html_params['display_feedback'] = feedback is not None
+            html_params['display_feedback'] = bool(feedback)
             html_params['feedback'] = feedback
 
         with open('pl-multiple-choice.mustache', 'r', encoding='utf-8') as f:

--- a/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -228,7 +228,7 @@ def render(element_html, data):
                 'checked': (submitted_key == answer['key']),
                 'html': answer['html'],
                 'display_score_badge': display_score and submitted_key == answer['key'],
-                "display_feedback": submitted_key == answer["key"] and feedback,
+                'display_feedback': submitted_key == answer['key'] and feedback,
                 'feedback': feedback
             }
             if answer_html['display_score_badge']:


### PR DESCRIPTION
Closes #5399 

Fixes empty feedback div in multiple choice and checkbox questions by utilizing that `None` and empty strings both evaluate to `False` in python to set `display_feedback` boolean. Non-empty feedback strings will evaluate to `True`.