### PR TITLE
chore: Add logs to help diagnose freezing chunk servers

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -605,7 +605,7 @@ module.exports = {
       logger.error('saveSubmission transaction was not closed within 60 seconds', {
         variant_id: variant.id,
         question_id: question.id,
-        course_id: course,
+        course_id: course.id,
         submission,
       });
     }, 60 * 1000);
@@ -863,7 +863,7 @@ module.exports = {
       logger.error('gradeVariant transaction was not closed within 60 seconds', {
         variant_id: variant.id,
         question_id: question.id,
-        course_id: course,
+        course_id: course.id,
       });
     }, 60 * 1000);
 
@@ -934,7 +934,7 @@ module.exports = {
       logger.error('saveAndGradeSubmission transaction was not closed within 60 seconds', {
         variant_id: variant.id,
         question_id: question.id,
-        course_id: course,
+        course_id: course.id,
       });
     }, 60 * 1000);
 
@@ -1345,7 +1345,7 @@ module.exports = {
       logger.error('_testQuestion transaction was not closed within 60 seconds', {
         variant_id: variant.id,
         question_id: question.id,
-        course_id: course,
+        course_id: course.id,
       });
     }, 60 * 1000);
 

--- a/lib/question.js
+++ b/lib/question.js
@@ -602,11 +602,13 @@ module.exports = {
     // get stuck inside of a transaction. We can possibly remove it once we
     // identify and fix the issue.
     const timeoutId = setTimeout(() => {
+      const stringifiedSubmission = JSON.stringify(submission);
       logger.error('saveSubmission transaction was not closed within 60 seconds', {
         variant_id: variant.id,
         question_id: question.id,
         course_id: course.id,
-        submission,
+        submission: stringifiedSubmission.substring(0, 1000),
+        submission_size: stringifiedSubmission.length,
       });
     }, 60 * 1000);
 
@@ -931,11 +933,13 @@ module.exports = {
     // get stuck inside of a transaction. We can possibly remove it once we
     // identify and fix the issue.
     const timeoutId = setTimeout(() => {
+      const stringifiedSubmission = JSON.stringify(submission);
       logger.error('saveAndGradeSubmission transaction was not closed within 60 seconds', {
         variant_id: variant.id,
         question_id: question.id,
         course_id: course.id,
-        submission,
+        submission: stringifiedSubmission.substring(0, 1000),
+        submission_size: stringifiedSubmission.length,
       });
     }, 60 * 1000);
 

--- a/lib/question.js
+++ b/lib/question.js
@@ -392,6 +392,20 @@ module.exports = {
     require_open,
     callback
   ) {
+    // This is (hopefully) temporary code to debug an issue where chunk servers
+    // get stuck inside of a transaction. We can possibly remove it once we
+    // identify and fix the issue.
+    const timeoutId = setTimeout(() => {
+      logger.error('ensureVariant transaction was not closed within 60 seconds', {
+        question_id,
+        instance_question_id,
+        user_id,
+        authn_user_id,
+        group_work,
+        course_instance_id,
+      });
+    }, 60 * 1000);
+
     let variant;
     sqldb.beginTransaction((err, client, done) => {
       if (ERR(err, callback)) return;
@@ -423,6 +437,7 @@ module.exports = {
         ],
         (err) => {
           sqldb.endTransaction(client, done, err, (err) => {
+            clearTimeout(timeoutId);
             if (ERR(err, callback)) return;
             callback(null, variant);
           });
@@ -583,6 +598,18 @@ module.exports = {
    * @param {function} callback - A callback(err, submission_id) function.
    */
   saveSubmission(submission, variant, question, course, callback) {
+    // This is (hopefully) temporary code to debug an issue where chunk servers
+    // get stuck inside of a transaction. We can possibly remove it once we
+    // identify and fix the issue.
+    const timeoutId = setTimeout(() => {
+      logger.error('saveSubmission transaction was not closed within 60 seconds', {
+        variant_id: variant.id,
+        question_id: question.id,
+        course_id: course,
+        submission,
+      });
+    }, 60 * 1000);
+
     let submission_id;
     sqldb.beginTransaction((err, client, done) => {
       if (ERR(err, callback)) return;
@@ -609,6 +636,7 @@ module.exports = {
         ],
         (err) => {
           sqldb.endTransaction(client, done, err, (err) => {
+            clearTimeout(timeoutId);
             if (ERR(err, callback)) return;
             callback(null, submission_id);
           });
@@ -828,6 +856,17 @@ module.exports = {
     overrideGradeRateCheck,
     callback
   ) {
+    // This is (hopefully) temporary code to debug an issue where chunk servers
+    // get stuck inside of a transaction. We can possibly remove it once we
+    // identify and fix the issue.
+    const timeoutId = setTimeout(() => {
+      logger.error('gradeVariant transaction was not closed within 60 seconds', {
+        variant_id: variant.id,
+        question_id: question.id,
+        course_id: course,
+      });
+    }, 60 * 1000);
+
     let grading_job_id;
     sqldb.beginTransaction((err, client, done) => {
       if (ERR(err, callback)) return;
@@ -856,6 +895,7 @@ module.exports = {
         ],
         (err) => {
           sqldb.endTransaction(client, done, err, (err) => {
+            clearTimeout(timeoutId);
             if (ERR(err, callback)) return;
             if (grading_job_id !== undefined) {
               // We need to submit this grading job now that the
@@ -886,6 +926,18 @@ module.exports = {
    */
   saveAndGradeSubmission(submission, variant, question, course, overrideGradeRateCheck, callback) {
     debug('saveAndGradeSubmission()');
+
+    // This is (hopefully) temporary code to debug an issue where chunk servers
+    // get stuck inside of a transaction. We can possibly remove it once we
+    // identify and fix the issue.
+    const timeoutId = setTimeout(() => {
+      logger.error('saveAndGradeSubmission transaction was not closed within 60 seconds', {
+        variant_id: variant.id,
+        question_id: question.id,
+        course_id: course,
+      });
+    }, 60 * 1000);
+
     let submission_id, grading_job_id;
     sqldb.beginTransaction((err, client, done) => {
       if (ERR(err, callback)) return;
@@ -926,6 +978,7 @@ module.exports = {
         ],
         (err) => {
           sqldb.endTransaction(client, done, err, (err) => {
+            clearTimeout(timeoutId);
             if (ERR(err, callback)) return;
             debug('saveAndGradeSubmission()', 'returning submission_id:', submission_id);
             if (grading_job_id !== undefined) {
@@ -1284,6 +1337,18 @@ module.exports = {
    */
   _testQuestion(question, group_work, course_instance, course, test_type, authn_user_id, callback) {
     debug('_testQuestion()');
+
+    // This is (hopefully) temporary code to debug an issue where chunk servers
+    // get stuck inside of a transaction. We can possibly remove it once we
+    // identify and fix the issue.
+    const timeoutId = setTimeout(() => {
+      logger.error('_testQuestion transaction was not closed within 60 seconds', {
+        variant_id: variant.id,
+        question_id: question.id,
+        course_id: course,
+      });
+    }, 60 * 1000);
+
     let variant,
       expected_submission = null,
       test_submission = null;
@@ -1343,6 +1408,7 @@ module.exports = {
         ],
         (err) => {
           sqldb.endTransaction(client, done, err, (err) => {
+            clearTimeout(timeoutId);
             if (ERR(err, callback)) return;
             debug('_testQuestion()', 'returning');
             callback(null, variant, expected_submission, test_submission);

--- a/lib/question.js
+++ b/lib/question.js
@@ -935,6 +935,7 @@ module.exports = {
         variant_id: variant.id,
         question_id: question.id,
         course_id: course.id,
+        submission,
       });
     }, 60 * 1000);
 


### PR DESCRIPTION
In an effort to gain more information about the intermittent "stuck in transaction" problem that affects chunk servers, this PR adds logs that will dump out some information if transactions don't complete within 60 seconds. Hopefully this will allow us to identify a common cause during failures (a specific question, or course, a particularly large submission, etc.).