### PR TITLE
fix: Only consider gradable submissions in question stats

### DIFF
--- a/sprocs/instance_questions_calculate_stats.sql
+++ b/sprocs/instance_questions_calculate_stats.sql
@@ -15,6 +15,7 @@ WITH first_calculation AS (
         variants AS v
         JOIN submissions AS s ON (s.variant_id = v.id)
     WHERE v.instance_question_id = instance_question_id_param
+          AND s.gradable IS TRUE
 ),
 second_calculation AS (
     SELECT array_increments_above_max(submission_score_array_var) AS incremental_submission_score_array_var

--- a/sprocs/instance_questions_calculate_stats.sql
+++ b/sprocs/instance_questions_calculate_stats.sql
@@ -14,8 +14,9 @@ WITH first_calculation AS (
     FROM
         variants AS v
         JOIN submissions AS s ON (s.variant_id = v.id)
-    WHERE v.instance_question_id = instance_question_id_param
-          AND s.gradable IS TRUE
+    WHERE
+        v.instance_question_id = instance_question_id_param
+        AND s.gradable IS TRUE
 ),
 second_calculation AS (
     SELECT array_increments_above_max(submission_score_array_var) AS incremental_submission_score_array_var


### PR DESCRIPTION
As reported on Slack, the stats were giving weird results if the first submission was non-gradable (score set to null). In that case the first submission has a grade of null, but max and average did not count that submission. For consistency this PR updates it so only gradable submissions are included in stats.