### PR TITLE
fix: Remove outdated column role from admin query

### DIFF
--- a/admin_queries/generate_assessment_instances.sql
+++ b/admin_queries/generate_assessment_instances.sql
@@ -13,7 +13,7 @@ FROM
     assessments AS a
     JOIN course_instances AS ci on (ci.id = a.course_instance_id)
     JOIN pl_courses AS c ON (c.id = ci.course_id)
-    JOIN enrollments AS e ON (e.course_instance_id = ci.id AND e.role = 'Student')
+    JOIN enrollments AS e ON (e.course_instance_id = ci.id)
     JOIN users AS u ON (u.user_id = e.user_id)
     JOIN assessment_instances_insert(a.id, u.user_id, a.group_work, u.user_id, $mode) AS aii ON TRUE
 WHERE


### PR DESCRIPTION
An admin query that adds an assessment instance to every student was still filtering by role "Student". The enrollment role has been deprecated since #3020 so the filter should have been removed.