### PR TITLE
fix: Avoid acquiring additional database clients inside transactions

### DIFF
--- a/lib/code-caller.js
+++ b/lib/code-caller.js
@@ -4,6 +4,7 @@ const path = require('path');
 const child_process = require('child_process');
 const { v4: uuidv4 } = require('uuid');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
+const { AsyncResource } = require('async_hooks');
 
 const config = require('./config');
 const logger = require('./logger');
@@ -147,7 +148,13 @@ class PythonCaller {
       paths: localOptions.paths,
     };
     const callDataString = JSON.stringify(callData);
-    this.callback = callback;
+    // This ensures that the callback is invoked in the same execution context
+    // that `call()` was invoked in. This allows `AsyncLocalStorage` to work
+    // correctly during asynchronous operations invoking `call()`.
+    //
+    // See the `_callCallback` for a gotcha about how `this.callback` is
+    // ultimately invoked.
+    this.callback = AsyncResource.bind(callback);
     this.timeoutID = setTimeout(this._timeout.bind(this), localOptions.timeout);
 
     this.outputStdout = '';
@@ -192,7 +199,7 @@ class PythonCaller {
       callback(null, false);
     } else {
       debug(`exit restart(), state: ${String(this.state)}, uuid: ${this.uuid}`);
-      callback(new Error(`invalid state ${this.state}`));
+      callback(new Error(`invalid state ${String(this.state)}`));
     }
   }
 
@@ -389,7 +396,19 @@ class PythonCaller {
     if (err) err.data = this._errorData();
     const c = this.callback;
     this.callback = null;
-    c(err, data, output);
+    // The `AsyncResource.bind()` function that we use up in `call()` to
+    // associate this callback with the appropriate execution context had a
+    // breaking change in Node 16.0. Prior to that, the return value of
+    // `AsyncResource.bind()` expected the first argument to be the `this`
+    // value that the function would be invoked with, but that was changed in
+    // Node 16. So that our codebase remains compatible with Node 16+, we'll
+    // handle both cases here.
+    if (parseInt(process.versions.node.split('.')[0]) >= 16) {
+      c(err, data, output);
+    } else {
+      // Use empty `this` - it shouldn't matter given our current usage.
+      c({}, err, data, output);
+    }
     debug(`exit _callCallback(), state: ${String(this.state)}, uuid: ${this.uuid}`);
   }
 

--- a/lib/question.js
+++ b/lib/question.js
@@ -392,20 +392,6 @@ module.exports = {
     require_open,
     callback
   ) {
-    // This is (hopefully) temporary code to debug an issue where chunk servers
-    // get stuck inside of a transaction. We can possibly remove it once we
-    // identify and fix the issue.
-    const timeoutId = setTimeout(() => {
-      logger.error('ensureVariant transaction was not closed within 60 seconds', {
-        question_id,
-        instance_question_id,
-        user_id,
-        authn_user_id,
-        group_work,
-        course_instance_id,
-      });
-    }, 60 * 1000);
-
     let variant;
     sqldb.runInTransaction(
       (client, done) => {
@@ -441,7 +427,6 @@ module.exports = {
         );
       },
       (err) => {
-        clearTimeout(timeoutId);
         if (ERR(err, callback)) return;
         callback(null, variant);
       }
@@ -600,20 +585,6 @@ module.exports = {
    * @param {function} callback - A callback(err, submission_id) function.
    */
   saveSubmission(submission, variant, question, course, callback) {
-    // This is (hopefully) temporary code to debug an issue where chunk servers
-    // get stuck inside of a transaction. We can possibly remove it once we
-    // identify and fix the issue.
-    const timeoutId = setTimeout(() => {
-      const stringifiedSubmission = JSON.stringify(submission);
-      logger.error('saveSubmission transaction was not closed within 60 seconds', {
-        variant_id: variant.id,
-        question_id: question.id,
-        course_id: course.id,
-        submission: stringifiedSubmission.substring(0, 1000),
-        submission_size: stringifiedSubmission.length,
-      });
-    }, 60 * 1000);
-
     let submission_id;
     sqldb.runInTransaction(
       (client, done) => {
@@ -644,7 +615,6 @@ module.exports = {
         );
       },
       (err) => {
-        clearTimeout(timeoutId);
         if (ERR(err, callback)) return;
         callback(null, submission_id);
       }
@@ -862,17 +832,6 @@ module.exports = {
     overrideGradeRateCheck,
     callback
   ) {
-    // This is (hopefully) temporary code to debug an issue where chunk servers
-    // get stuck inside of a transaction. We can possibly remove it once we
-    // identify and fix the issue.
-    const timeoutId = setTimeout(() => {
-      logger.error('gradeVariant transaction was not closed within 60 seconds', {
-        variant_id: variant.id,
-        question_id: question.id,
-        course_id: course.id,
-      });
-    }, 60 * 1000);
-
     let grading_job_id;
     sqldb.runInTransaction(
       (client, done) => {
@@ -905,7 +864,6 @@ module.exports = {
         );
       },
       (err) => {
-        clearTimeout(timeoutId);
         if (ERR(err, callback)) return;
         if (grading_job_id !== undefined) {
           // We need to submit this grading job now that the
@@ -934,20 +892,6 @@ module.exports = {
    */
   saveAndGradeSubmission(submission, variant, question, course, overrideGradeRateCheck, callback) {
     debug('saveAndGradeSubmission()');
-
-    // This is (hopefully) temporary code to debug an issue where chunk servers
-    // get stuck inside of a transaction. We can possibly remove it once we
-    // identify and fix the issue.
-    const timeoutId = setTimeout(() => {
-      const stringifiedSubmission = JSON.stringify(submission);
-      logger.error('saveAndGradeSubmission transaction was not closed within 60 seconds', {
-        variant_id: variant.id,
-        question_id: question.id,
-        course_id: course.id,
-        submission: stringifiedSubmission.substring(0, 1000),
-        submission_size: stringifiedSubmission.length,
-      });
-    }, 60 * 1000);
 
     let submission_id, grading_job_id;
     sqldb.runInTransaction(
@@ -993,7 +937,6 @@ module.exports = {
         );
       },
       (err) => {
-        clearTimeout(timeoutId);
         if (ERR(err, callback)) return;
         debug('saveAndGradeSubmission()', 'returning submission_id:', submission_id);
         if (grading_job_id !== undefined) {
@@ -1351,17 +1294,6 @@ module.exports = {
   _testQuestion(question, group_work, course_instance, course, test_type, authn_user_id, callback) {
     debug('_testQuestion()');
 
-    // This is (hopefully) temporary code to debug an issue where chunk servers
-    // get stuck inside of a transaction. We can possibly remove it once we
-    // identify and fix the issue.
-    const timeoutId = setTimeout(() => {
-      logger.error('_testQuestion transaction was not closed within 60 seconds', {
-        variant_id: variant.id,
-        question_id: question.id,
-        course_id: course.id,
-      });
-    }, 60 * 1000);
-
     let variant,
       expected_submission = null,
       test_submission = null;
@@ -1425,7 +1357,6 @@ module.exports = {
         );
       },
       (err) => {
-        clearTimeout(timeoutId);
         if (ERR(err, callback)) return;
         debug('_testQuestion()', 'returning');
         callback(null, variant, expected_submission, test_submission);

--- a/lib/question.js
+++ b/lib/question.js
@@ -407,43 +407,45 @@ module.exports = {
     }, 60 * 1000);
 
     let variant;
-    sqldb.beginTransaction((err, client, done) => {
-      if (ERR(err, callback)) return;
-      async.series(
-        [
-          // Even though we only have a single series function,
-          // we use the async.series pattern for consistency and
-          // to make sure we correctly call endTransaction even
-          // in the presence of errors.
-          (callback) => {
-            this._ensureVariantWithClient(
-              client,
-              question_id,
-              instance_question_id,
-              user_id,
-              authn_user_id,
-              group_work,
-              course_instance_id,
-              course,
-              options,
-              require_open,
-              (err, ret_variant) => {
-                if (ERR(err, callback)) return;
-                variant = ret_variant;
-                callback(null);
-              }
-            );
-          },
-        ],
-        (err) => {
-          sqldb.endTransaction(client, done, err, (err) => {
-            clearTimeout(timeoutId);
-            if (ERR(err, callback)) return;
-            callback(null, variant);
-          });
-        }
-      );
-    });
+    sqldb.runInTransaction(
+      (client, done) => {
+        async.series(
+          [
+            // Even though we only have a single series function,
+            // we use the async.series pattern for consistency and
+            // to make sure we correctly call `done()` even
+            // in the presence of errors.
+            (callback) => {
+              this._ensureVariantWithClient(
+                client,
+                question_id,
+                instance_question_id,
+                user_id,
+                authn_user_id,
+                group_work,
+                course_instance_id,
+                course,
+                options,
+                require_open,
+                (err, ret_variant) => {
+                  if (ERR(err, callback)) return;
+                  variant = ret_variant;
+                  callback(null);
+                }
+              );
+            },
+          ],
+          (err) => {
+            done(err);
+          }
+        );
+      },
+      (err) => {
+        clearTimeout(timeoutId);
+        if (ERR(err, callback)) return;
+        callback(null, variant);
+      }
+    );
   },
 
   /**
@@ -613,38 +615,40 @@ module.exports = {
     }, 60 * 1000);
 
     let submission_id;
-    sqldb.beginTransaction((err, client, done) => {
-      if (ERR(err, callback)) return;
-      async.series(
-        [
-          // Even though we only have a single series function,
-          // we use the async.series pattern for consistency and
-          // to make sure we correctly call endTransaction even
-          // in the presence of errors.
-          (callback) => {
-            this._saveSubmissionWithClient(
-              client,
-              submission,
-              variant,
-              question,
-              course,
-              (err, ret_submission_id) => {
-                if (ERR(err, callback)) return;
-                submission_id = ret_submission_id;
-                callback(null);
-              }
-            );
-          },
-        ],
-        (err) => {
-          sqldb.endTransaction(client, done, err, (err) => {
-            clearTimeout(timeoutId);
-            if (ERR(err, callback)) return;
-            callback(null, submission_id);
-          });
-        }
-      );
-    });
+    sqldb.runInTransaction(
+      (client, done) => {
+        async.series(
+          [
+            // Even though we only have a single series function,
+            // we use the async.series pattern for consistency and
+            // to make sure we correctly call endTransaction even
+            // in the presence of errors.
+            (callback) => {
+              this._saveSubmissionWithClient(
+                client,
+                submission,
+                variant,
+                question,
+                course,
+                (err, ret_submission_id) => {
+                  if (ERR(err, callback)) return;
+                  submission_id = ret_submission_id;
+                  callback(null);
+                }
+              );
+            },
+          ],
+          (err) => {
+            done(err);
+          }
+        );
+      },
+      (err) => {
+        clearTimeout(timeoutId);
+        if (ERR(err, callback)) return;
+        callback(null, submission_id);
+      }
+    );
   },
 
   /**
@@ -870,50 +874,52 @@ module.exports = {
     }, 60 * 1000);
 
     let grading_job_id;
-    sqldb.beginTransaction((err, client, done) => {
-      if (ERR(err, callback)) return;
-      async.series(
-        [
-          // Even though we only have a single series function,
-          // we use the async.series pattern for consistency and
-          // to make sure we correctly call endTransaction even
-          // in the presence of errors.
-          (callback) => {
-            this._gradeVariantWithClient(
-              client,
-              variant,
-              check_submission_id,
-              question,
-              course,
-              authn_user_id,
-              overrideGradeRateCheck,
-              (err, ret_grading_job_id) => {
-                if (ERR(err, callback)) return;
-                grading_job_id = ret_grading_job_id;
-                callback(null);
-              }
-            );
-          },
-        ],
-        (err) => {
-          sqldb.endTransaction(client, done, err, (err) => {
-            clearTimeout(timeoutId);
+    sqldb.runInTransaction(
+      (client, done) => {
+        async.series(
+          [
+            // Even though we only have a single series function,
+            // we use the async.series pattern for consistency and
+            // to make sure we correctly call endTransaction even
+            // in the presence of errors.
+            (callback) => {
+              this._gradeVariantWithClient(
+                client,
+                variant,
+                check_submission_id,
+                question,
+                course,
+                authn_user_id,
+                overrideGradeRateCheck,
+                (err, ret_grading_job_id) => {
+                  if (ERR(err, callback)) return;
+                  grading_job_id = ret_grading_job_id;
+                  callback(null);
+                }
+              );
+            },
+          ],
+          (err) => {
+            done(err);
+          }
+        );
+      },
+      (err) => {
+        clearTimeout(timeoutId);
+        if (ERR(err, callback)) return;
+        if (grading_job_id !== undefined) {
+          // We need to submit this grading job now that the
+          // transaction has been committed
+          externalGrader.beginGradingJob(grading_job_id, (err) => {
             if (ERR(err, callback)) return;
-            if (grading_job_id !== undefined) {
-              // We need to submit this grading job now that the
-              // transaction has been committed
-              externalGrader.beginGradingJob(grading_job_id, (err) => {
-                if (ERR(err, callback)) return;
-                callback(null);
-              });
-            } else {
-              // We're done!
-              callback(null);
-            }
+            callback(null);
           });
+        } else {
+          // We're done!
+          callback(null);
         }
-      );
-    });
+      }
+    );
   },
 
   /**
@@ -944,63 +950,65 @@ module.exports = {
     }, 60 * 1000);
 
     let submission_id, grading_job_id;
-    sqldb.beginTransaction((err, client, done) => {
-      if (ERR(err, callback)) return;
-      async.series(
-        [
-          (callback) => {
-            this._saveSubmissionWithClient(
-              client,
-              submission,
-              variant,
-              question,
-              course,
-              (err, ret_submission_id) => {
-                if (ERR(err, callback)) return;
-                submission_id = ret_submission_id;
-                debug('saveAndGradeSubmission()', 'submission_id:', submission_id);
-                callback(null);
-              }
-            );
-          },
-          (callback) => {
-            this._gradeVariantWithClient(
-              client,
-              variant,
-              submission_id,
-              question,
-              course,
-              submission.auth_user_id,
-              overrideGradeRateCheck,
-              (err, ret_grading_job_id) => {
-                if (ERR(err, callback)) return;
-                grading_job_id = ret_grading_job_id;
-                debug('saveAndGradeSubmission()', 'graded');
-                callback(null);
-              }
-            );
-          },
-        ],
-        (err) => {
-          sqldb.endTransaction(client, done, err, (err) => {
-            clearTimeout(timeoutId);
+    sqldb.runInTransaction(
+      (client, done) => {
+        async.series(
+          [
+            (callback) => {
+              this._saveSubmissionWithClient(
+                client,
+                submission,
+                variant,
+                question,
+                course,
+                (err, ret_submission_id) => {
+                  if (ERR(err, callback)) return;
+                  submission_id = ret_submission_id;
+                  debug('saveAndGradeSubmission()', 'submission_id:', submission_id);
+                  callback(null);
+                }
+              );
+            },
+            (callback) => {
+              this._gradeVariantWithClient(
+                client,
+                variant,
+                submission_id,
+                question,
+                course,
+                submission.auth_user_id,
+                overrideGradeRateCheck,
+                (err, ret_grading_job_id) => {
+                  if (ERR(err, callback)) return;
+                  grading_job_id = ret_grading_job_id;
+                  debug('saveAndGradeSubmission()', 'graded');
+                  callback(null);
+                }
+              );
+            },
+          ],
+          (err) => {
+            done(err);
+          }
+        );
+      },
+      (err) => {
+        clearTimeout(timeoutId);
+        if (ERR(err, callback)) return;
+        debug('saveAndGradeSubmission()', 'returning submission_id:', submission_id);
+        if (grading_job_id !== undefined) {
+          // We need to submit this grading job now that the
+          // transaction has been committed
+          externalGrader.beginGradingJob(grading_job_id, (err) => {
             if (ERR(err, callback)) return;
-            debug('saveAndGradeSubmission()', 'returning submission_id:', submission_id);
-            if (grading_job_id !== undefined) {
-              // We need to submit this grading job now that the
-              // transaction has been committed
-              externalGrader.beginGradingJob(grading_job_id, (err) => {
-                if (ERR(err, callback)) return;
-                callback(null, submission_id);
-              });
-            } else {
-              // We're done!
-              callback(null, submission_id);
-            }
+            callback(null, submission_id);
           });
+        } else {
+          // We're done!
+          callback(null, submission_id);
         }
-      );
-    });
+      }
+    );
   },
 
   /**
@@ -1357,70 +1365,72 @@ module.exports = {
     let variant,
       expected_submission = null,
       test_submission = null;
-    sqldb.beginTransaction((err, client, done) => {
-      if (ERR(err, callback)) return;
-      async.series(
-        [
-          (callback) => {
-            const instance_question_id = null;
-            const course_instance_id = (course_instance && course_instance.id) || null;
-            const options = {};
-            const require_open = true;
-            this._ensureVariantWithClient(
-              client,
-              question.id,
-              instance_question_id,
-              authn_user_id,
-              authn_user_id,
-              group_work,
-              course_instance_id,
-              course,
-              options,
-              require_open,
-              (err, ret_variant) => {
-                if (ERR(err, callback)) return;
-                variant = ret_variant;
-                debug('_testQuestion()', 'created variant_id: :', variant.id);
-                callback(null);
-              }
-            );
-          },
-          (callback) => {
-            if (variant.broken) return callback(null);
-            this._testVariantWithClient(
-              client,
-              variant,
-              question,
-              course,
-              test_type,
-              authn_user_id,
-              (err, ret_expected_submission, ret_test_submission) => {
-                if (ERR(err, callback)) return;
-                expected_submission = ret_expected_submission;
-                test_submission = ret_test_submission;
-                debug(
-                  '_testQuestion()',
-                  'tested',
-                  'expected_submission_id:',
-                  expected_submission ? expected_submission.id : null,
-                  'test_submission_id:',
-                  test_submission ? test_submission.id : null
-                );
-                callback(null);
-              }
-            );
-          },
-        ],
-        (err) => {
-          sqldb.endTransaction(client, done, err, (err) => {
-            clearTimeout(timeoutId);
-            if (ERR(err, callback)) return;
-            debug('_testQuestion()', 'returning');
-            callback(null, variant, expected_submission, test_submission);
-          });
-        }
-      );
-    });
+    sqldb.runInTransaction(
+      (client, done) => {
+        async.series(
+          [
+            (callback) => {
+              const instance_question_id = null;
+              const course_instance_id = (course_instance && course_instance.id) || null;
+              const options = {};
+              const require_open = true;
+              this._ensureVariantWithClient(
+                client,
+                question.id,
+                instance_question_id,
+                authn_user_id,
+                authn_user_id,
+                group_work,
+                course_instance_id,
+                course,
+                options,
+                require_open,
+                (err, ret_variant) => {
+                  if (ERR(err, callback)) return;
+                  variant = ret_variant;
+                  debug('_testQuestion()', 'created variant_id: :', variant.id);
+                  callback(null);
+                }
+              );
+            },
+            (callback) => {
+              if (variant.broken) return callback(null);
+              this._testVariantWithClient(
+                client,
+                variant,
+                question,
+                course,
+                test_type,
+                authn_user_id,
+                (err, ret_expected_submission, ret_test_submission) => {
+                  if (ERR(err, callback)) return;
+                  expected_submission = ret_expected_submission;
+                  test_submission = ret_test_submission;
+                  debug(
+                    '_testQuestion()',
+                    'tested',
+                    'expected_submission_id:',
+                    expected_submission ? expected_submission.id : null,
+                    'test_submission_id:',
+                    test_submission ? test_submission.id : null
+                  );
+                  callback(null);
+                }
+              );
+            },
+          ],
+          (err) => {
+            done(err);
+          }
+        );
+      },
+      (err) => {
+        clearTimeout(timeoutId);
+        if (ERR(err, callback)) return;
+        debug('_testQuestion()', 'returning');
+        callback(null, variant, expected_submission, test_submission);
+      }
+    );
   },
 
   /**


### PR DESCRIPTION
When we generate/save/grade questions, we do so with a transaction held open to avoid duplicate work + data. However, on chunk servers, we actually run additional database queries while the transaction is held open, but we try to run the queries with a new client. During periods of high load (or if we just happen to get 10+ requests in the same small window of time), this means that we'd end up with 10 transactions held open. The only way to get out of the transaction is through a query that requires a new DB client, but all the DB clients were in use via the transactions. This is a classic deadlock scenario that ended up with entire servers being unable to respond to requests.

This PR fixes that by using [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage) to ensure that any queries executed during a transaction use the transaction's client instead of trying to acquire a new one.

@mwest1066 and I realized that there's really no good reason to hold transactions open while executing question code. In a future PR, we'll come back and refactor to avoid the need for transactions at all. I opened #5420 to track this.

This resolves https://github.com/PrairieLearnInc/sysconf/issues/28.