### PR TITLE
Fix instructor grading panel refresh

### DIFF
--- a/lib/question.sql
+++ b/lib/question.sql
@@ -123,7 +123,7 @@ FROM
     LEFT JOIN course_instances AS ci ON (ci.id = v.course_instance_id)
     JOIN pl_courses AS c ON (c.id = q.course_id)
     JOIN LATERAL instance_questions_next_allowed_grade(iq.id) AS iqnag ON TRUE
-    JOIN next_iq ON (next_iq.current_id = iq.id)
+    LEFT JOIN next_iq ON (next_iq.current_id = iq.id)
 WHERE
     s.id = $submission_id
     AND gj.id = (


### PR DESCRIPTION
(as discovered and fixed by @nwalters512) Fixes an incorrect JOIN introduced by #4497. The JOIN assumes that submissions have an associated instance question, which is only true for student questions. For instructor questions this JOIN means that external grading questions fail to re-render the submission panel after grading is complete.