### PR TITLE
Add config option to control news item initialization

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -54,6 +54,7 @@ config.fileUploadMaxBytes = 1e7;
 config.fileUploadMaxParts = 1000;
 config.fileStoreS3Bucket = 'file-store';
 config.fileStoreStorageTypeDefault = 'S3';
+config.initNewsItems = true;
 config.cronActive = true;
 config.cronOverrideAllIntervalsSec = null;
 config.cronIntervalAutoFinishExamsSec = 10 * 60;

--- a/server.js
+++ b/server.js
@@ -1777,6 +1777,7 @@ if (config.startServer) {
         });
       },
       function (callback) {
+        if (!config.initNewsItems) return callback(null);
         const notify_with_new_server = false;
         news_items.init(notify_with_new_server, function (err) {
           if (ERR(err, callback)) return;


### PR DESCRIPTION
This is for canary servers, which will have news items that the older stable servers do not. We do not want the canary servers to add their unreleased news items to the DB.