### PR TITLE
docs: Add note about Java built-in assert statements

### DIFF
--- a/docs/java-grader/index.md
+++ b/docs/java-grader/index.md
@@ -108,6 +108,8 @@ import org.prairielearn.autograder.AutograderInfo;
 
 To change the order in which test results are shown to the user, you may use [the `@TestMethodOrder` annotation](https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-execution-order).
 
+The autograder will give a question points based on if a test passed or failed based on the default Java behaviour. Note that [Java's built-in assertions](https://docs.oracle.com/javase/7/docs/technotes/guides/language/assert.html) are disabled by default, and as such tests that rely on Java's `assert` keyword may not work as intended. If test failures based on `assert` statements are needed, the program must be set up to be compiled with the `-ea` option, [as listed below](#changing-compilation-options). An alternative is to use the `assertTrue` method in JUnit itself, with the benefit of providing more flexibility on the error message shown to students.
+
 ### Changing compilation options
 
 By default the Java compiler will show all compilation warnings to the user, except for `serial` (missing `serialVersionUID` on serializable classes). If you would like to change the compilation warnings or other compilation settings, you may do so by setting the `JDK_JAVAC_OPTIONS` environment variable in `info.json`, as follows:
@@ -128,7 +130,8 @@ The example above disables the `static` warning (use of static fields applied to
 
 - `-Xlint:none` or `-nowarn` to disable all warnings;
 - `-Xdoclint` to enable warnings for javadoc comments;
-- `-source 10` to compile using the Java 10 language version.
+- `-source 10` to compile using the Java 10 language version;
+- `-ea` to enable [Java assertions](https://docs.oracle.com/javase/7/docs/technotes/guides/language/assert.html).
 
 ### Libraries and instructor-provided classes
 


### PR DESCRIPTION
Adding documentation based on discussion with another instructor that was relying on Java `assert` statements, which are disabled by default by `javac`.