### PR TITLE
Fix forced-question-order for unsynced courses

### DIFF
--- a/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -56,7 +56,7 @@ SELECT
             ELSE aq.max_points
         END,
         'remaining_points', iq.points_list[(iq.number_attempts + 2):array_length(iq.points_list, 1)],
-        'advance_score_perc', aq.effective_advance_score_perc,
+        'advance_score_perc', coalesce(aq.effective_advance_score_perc, 0),
         'sequence_locked', iqi.sequence_locked
     ) AS instance_question_info,
     to_jsonb(aq) AS assessment_question,

--- a/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.sql
+++ b/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.sql
@@ -56,7 +56,7 @@ SELECT
     (z.max_points IS NOT NULL) AS zone_has_max_points,
     z.best_questions AS zone_best_questions,
     (z.best_questions IS NOT NULL) AS zone_has_best_questions,
-    aq.effective_advance_score_perc AS assessment_question_advance_score_perc,
+    coalesce(aq.effective_advance_score_perc, 0) AS assessment_question_advance_score_perc,
     q.sync_errors,
     q.sync_warnings
 FROM

--- a/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.sql
+++ b/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.sql
@@ -14,7 +14,7 @@ SELECT
     (z.best_questions IS NOT NULL) AS zone_has_best_questions,
     (SELECT count(*) FROM files AS f WHERE f.instance_question_id = iq.id AND f.deleted_at IS NULL) AS file_count,
     qo.sequence_locked AS sequence_locked,
-    (lag(aq.effective_advance_score_perc) OVER w) AS prev_advance_score_perc,
+    (lag(coalesce(aq.effective_advance_score_perc, 0)) OVER w) AS prev_advance_score_perc,
     'Question ' || (lag(qo.question_number) OVER w) AS prev_title,
     (lag(qo.sequence_locked) OVER w) AS prev_sequence_locked,
     iqnag.*

--- a/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.sql
+++ b/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.sql
@@ -23,7 +23,7 @@ SELECT
     (z.best_questions IS NOT NULL) AS zone_has_best_questions,
     (SELECT count(*) FROM files AS f WHERE f.instance_question_id = iq.id AND f.deleted_at IS NULL) AS file_count,
     qo.sequence_locked AS sequence_locked,
-    (lag(aq.effective_advance_score_perc) OVER w) AS prev_advance_score_perc,
+    (lag(coalesce(aq.effective_advance_score_perc, 0)) OVER w) AS prev_advance_score_perc,
     (lag(qo.question_number) OVER w) AS prev_title,
     (lag(qo.sequence_locked) OVER w) AS prev_sequence_locked
 FROM

--- a/sprocs/question_order.sql
+++ b/sprocs/question_order.sql
@@ -19,7 +19,7 @@ WITH locks_next AS (
             (iq.open = false) 
             OR -- Score >= unlock score
             (100*COALESCE(iq.highest_submission_score, 0)
-                >= aq.effective_advance_score_perc) 
+                >= coalesce(aq.effective_advance_score_perc, 0))
         ) AS locking
     FROM
         assessment_instances ai 


### PR DESCRIPTION
PR #4497 only worked if a course was synced after the new code was active. It added the column `assessment_questions.effective_advance_score_perc` which had no default, so all existing questions have NULL in this column. The sync code was modified by #4497 to set a default value of `0` for the column, but that only happens after a course is synced.

The `effective_advance_score_perc` is used by #4497 in the authz code to compute the `is_sequence_locked` variable, assuming that `effective_advance_score_perc` is not NULL: https://github.com/PrairieLearn/PrairieLearn/blob/822235c5f67018a478195acf167425f0c2253f7d/sprocs/question_order.sql#L22

For unsynced courses, the NULL value in `effective_advance_score_perc` means that `is_sequence_locked` will be NULL for all questions. This is used to check authorization here: https://github.com/PrairieLearn/PrairieLearn/blob/822235c5f67018a478195acf167425f0c2253f7d/middlewares/selectAndAuthzInstanceQuestion.sql#L88

Because `is_sequence_locked = NULL`, the expression `NOT is_sequence_locked` is also NULL, so we deny access to the question.

This PR fixes the bug by explicitly using `coalesce(effective_advance_score_perc, 0)` everywhere.