### PR TITLE
Fix forced-question-order for unsynced courses

### DIFF
--- a/database/tables/assessment_questions.pg
+++ b/database/tables/assessment_questions.pg
@@ -11,7 +11,7 @@ columns
     average_submission_score_variance: double precision
     deleted_at: timestamp with time zone
     discrimination: double precision
-    effective_advance_score_perc: double precision
+    effective_advance_score_perc: double precision default 0
     first_submission_score_hist: double precision[]
     first_submission_score_variance: double precision
     force_max_points: boolean default false

--- a/migrations/246_assessment_questions__effective_advance_score_perc__default.sql
+++ b/migrations/246_assessment_questions__effective_advance_score_perc__default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE assessment_questions ALTER COLUMN effective_advance_score_perc SET DEFAULT 0;


### PR DESCRIPTION
This is a cleaner fix for #5425 that simply adds a default value for `assessment_questions.effective_advance_score_perc`. As of PG v11 adding a default value does not cause any DB writes until rows are rewritten, so it's effectively free.