### PR TITLE
Fix forced-question-order for unsynced courses, v2

### DIFF
--- a/migrations/247_assessment_questions__effective_advance_score_perc__update.sql
+++ b/migrations/247_assessment_questions__effective_advance_score_perc__update.sql
@@ -1,0 +1,3 @@
+UPDATE assessment_questions
+SET effective_advance_score_perc = 0
+WHERE effective_advance_score_perc IS NULL;


### PR DESCRIPTION
#5426 was not enough to fix the problem, because the `effective_advance_score_perc` was already created before we applied the new default. This means that existing rows with NULL values were not updated with the default. It would have been ok if we'd set the default when creating the column, but that's not retroactively possible. This PR fixes this by updating the existing rows to be the default. This will bring the DB up to the state it would have been in if we'd had a default value for the column originally.