### PR TITLE
pl-order-blocks: Fix nodes without edges not added to solution graph 

### DIFF
--- a/elements/pl-order-blocks/dag_checker.py
+++ b/elements/pl-order-blocks/dag_checker.py
@@ -62,6 +62,7 @@ def dag_to_nx(depends_graph):
     """Convert input graph format into NetworkX object to utilize their algorithms."""
     graph = nx.DiGraph()
     for node in depends_graph:
+        graph.add_node(node)
         for node2 in depends_graph[node]:
             # the depends graph lists the *incoming* edges of a node
             graph.add_edge(node2, node)


### PR DESCRIPTION
Fixes #5478

I think there are also other cases where this same bug would give incorrect credit, e.g. in cases where there are some nodes in the graph that are disconnected from the rest of the graph.