### PR TITLE
feat: Add client column to db_running_queries query

### DIFF
--- a/admin_queries/db_running_queries.sql
+++ b/admin_queries/db_running_queries.sql
@@ -2,6 +2,7 @@ SELECT
     pid,
     age(clock_timestamp(), query_start),
     usename,
+    host(client_addr) || ':' || client_port AS client,
     state,
     query
 FROM pg_stat_activity


### PR DESCRIPTION
This could help a little bit with investigations of stuck queries by allowing us to identify which host is making the query.