### PR TITLE
Proper archive files access control

### DIFF
--- a/pages/instructorGradingJob/instructorGradingJob.ejs
+++ b/pages/instructorGradingJob/instructorGradingJob.ejs
@@ -58,6 +58,7 @@
               </tr>
             </thead>
             <tbody>
+              <% if (authz_data.has_course_permission_view) { %>
               <tr>
                 <td>
                   <a href="<%= urlPrefix %>/grading_job/<%= grading_job.id %>/file/job.tar.gz">job.tar.gz</a>
@@ -75,6 +76,7 @@
                   A snapshot of <code>/grade</code> after your job has been executed.
                 </td>
               </tr>
+              <% } %>
               <tr>
                 <td>
                   <a href="<%= urlPrefix %>/grading_job/<%= grading_job.id %>/file/results.json">results.json</a>

--- a/pages/instructorGradingJob/instructorGradingJob.js
+++ b/pages/instructorGradingJob/instructorGradingJob.js
@@ -40,11 +40,14 @@ router.get('/:job_id', (req, res, next) => {
   });
 });
 
-const allowedFiles = ['job.tar.gz', 'archive.tar.gz', 'output.log', 'results.json'];
+const allowedFilesViewer = ['job.tar.gz', 'archive.tar.gz', 'output.log', 'results.json'];
+const allowedFilesPreviewer = ['output.log', 'results.json'];
 
 router.get('/:job_id/file/:file', (req, res, next) => {
   const file = req.params.file;
-  if (allowedFiles.indexOf(file) === -1) {
+  const allowList = res.locals.authz_data.has_course_permission_view ? allowedFilesViewer : allowedFilesPreviewer;
+
+  if (allowList.indexOf(file) === -1) {
     return next(new Error(`Unknown file ${file}`));
   }
 

--- a/pages/instructorGradingJob/instructorGradingJob.js
+++ b/pages/instructorGradingJob/instructorGradingJob.js
@@ -45,7 +45,9 @@ const allowedFilesPreviewer = ['output.log', 'results.json'];
 
 router.get('/:job_id/file/:file', (req, res, next) => {
   const file = req.params.file;
-  const allowList = res.locals.authz_data.has_course_permission_view ? allowedFilesViewer : allowedFilesPreviewer;
+  const allowList = res.locals.authz_data.has_course_permission_view
+    ? allowedFilesViewer
+    : allowedFilesPreviewer;
 
   if (allowList.indexOf(file) === -1) {
     return next(new Error(`Unknown file ${file}`));


### PR DESCRIPTION
Files like archive.tar.gz and job.tar.gz should not be accessible to course content previewers.