### PR TITLE
fix: Invoke callback even if server job is running

### DIFF
--- a/lib/server-jobs.js
+++ b/lib/server-jobs.js
@@ -393,6 +393,8 @@ module.exports.errorAbandonedJobs = function (callback) {
             }
             callback(null);
           });
+        } else {
+          callback(null);
         }
       },
       function (err) {


### PR DESCRIPTION
If the `errorAbandonedJobs` cronjob happens to run while a job is in progress, it will fail to invoke `callback()`, which in turn won't ever release the lock. Since locks are implemented via DB clients, it'll hold the client until our idle-in-transaction timeout is hit 10 minutes later and kill the server.

This PR ensures that we always call `callback()`.