### PR TITLE
fix: Change how workspace process is run in background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ start: start-support
 start-nodemon: start-support
 	@nodemon -L server.js
 start-workspace-host: start-support kill-running-workspaces
-	@node workspace_host/interface.js &
+	@node workspace_host/interface.js
 
 kill-running-workspaces:
 	@docker/kill_running_workspaces.sh

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo 'Starting PrairieLearn...'
-make -s -C /PrairieLearn start-workspace-host
+make -s -C /PrairieLearn start-workspace-host &
 if [[ $NODEMON == "true" ]]; then
     make -s -C /PrairieLearn start-nodemon
 else

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 echo 'Starting PrairieLearn...'
-make -s -C /PrairieLearn start-workspace-host &
 if [[ $NODEMON == "true" ]]; then
-    make -s -C /PrairieLearn start-nodemon
+    make -s -C /PrairieLearn -j 2 start-workspace-host start-nodemon
 else
-    make -s -C /PrairieLearn start
+    make -s -C /PrairieLearn -j 2 start-workspace-host start
 fi


### PR DESCRIPTION
For folks like me who frequently run natively (not in Docker), running `make start-workspace-host` would unexpectedly put the command in the background and render it unable to be stopped by Ctrl-C. This PR fixes that by removing the `&` from the `start-workspace-host` target and instead using `-j 2` to run both the PL server *and* the workspace host with the same invocation of Make.