### PR TITLE
fix: Correct typo in lib/workspace.js comment

### DIFF
--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -27,7 +27,7 @@ FROM
     -- Note that we specifically use a LEFT JOIN here - this is what allows the
     -- caller to differentiate between a chunk that exists and one that does not.
     -- Chunks that don't exist will have a NULL id, but they'll still contain
-    -- other information like the course instnace/assessment/question name so that
+    -- other information like the course instance/assessment/question name so that
     -- we can clean up unused chunks from disk.
     LEFT JOIN chunks ON (
         chunks.course_id = ($course_id)::bigint

--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -287,7 +287,7 @@ module.exports = {
         // Move any existing directory out of the way to get a clean start. This
         // should never happen in production environments, but when running
         // workspaces locally in development, we may end up trying to reuse the
-        // same workspace ID and thus directory, for intstance if the database
+        // same workspace ID and thus directory, for instance if the database
         // is reset in the middle of testing. In that case, we want to ensure
         // that we don't try to write on top of an existing directory, as this
         // could lead to unexpected behavior.


### PR DESCRIPTION
@echuber2 pointed out this typo in my comment after I merged #4791. Just for fun, I searched the codebase for `instn` and lo and behold, I'd made the same typo before 🙃 