### PR TITLE
fix: Typescript-compatible exports in aws.js

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -149,7 +149,7 @@ module.exports.uploadToS3Async = async function (
   }
   return res;
 };
-module.exports.uploadToS3 = util.callbackify(this.uploadToS3Async);
+module.exports.uploadToS3 = util.callbackify(module.exports.uploadToS3Async);
 
 /**
  * Recursively upload a directory to a path in S3, including empty
@@ -219,7 +219,7 @@ module.exports.uploadDirectoryToS3Async = async function (
 
   await walkDirectory('');
 };
-module.exports.uploadDirectoryToS3 = util.callbackify(this.uploadDirectoryToS3Async);
+module.exports.uploadDirectoryToS3 = util.callbackify(module.exports.uploadDirectoryToS3Async);
 
 /**
  * Download a file or directory from S3.
@@ -274,7 +274,7 @@ module.exports.downloadFromS3Async = async function (s3Bucket, s3Path, localPath
       });
   });
 };
-module.exports.downloadFromS3 = util.callbackify(this.downloadFromS3Async);
+module.exports.downloadFromS3 = util.callbackify(module.exports.downloadFromS3Async);
 
 /**
  * Delete a file or directory from S3.
@@ -317,4 +317,4 @@ module.exports.getFromS3Async = async function (bucket, key, buffer = true) {
   }
 };
 
-module.exports.deleteFromS3 = util.callbackify(this.deleteFromS3Async);
+module.exports.deleteFromS3 = util.callbackify(module.exports.deleteFromS3Async);


### PR DESCRIPTION
This fixes the error `TypeError: Cannot read property 'uploadDirectoryToS3Async' of undefined` when importing `lib/aws.js` from typescript.