### PR TITLE
fix: Ensure compatibility with Babel+TypeScript in PrairieTest

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,3 +1,4 @@
+// @ts-check
 const redis = require('redis');
 
 const config = require('./config');
@@ -5,30 +6,36 @@ const logger = require('./logger');
 
 const callbacks = {};
 
+let useRedis = true;
+/** @type {import('redis').RedisClient} */
+let pub = null;
+/** @type {import('redis').RedisClient} */
+let sub = null;
+
 module.exports.init = function (callback) {
   if (!config.redisUrl) {
     // Skip redis; distribute messages immediately to this machine
-    this._useRedis = false;
+    useRedis = false;
     logger.info('Not using Redis for message passing');
     return callback(null);
   }
-  this._useRedis = true;
+
   logger.verbose(`Connecting to Redis at ${config.redisUrl}`);
 
   const redisOptions = {
     url: config.redisUrl,
   };
-  this._pub = redis.createClient(redisOptions);
-  this._sub = redis.createClient(redisOptions);
+  pub = redis.createClient(redisOptions);
+  sub = redis.createClient(redisOptions);
 
-  this._pub.on('error', (err) => {
+  pub.on('error', (err) => {
     logger.error('Redis publish error', err);
   });
-  this._sub.on('error', (err) => {
+  sub.on('error', (err) => {
     logger.error('Redis subscribe error', err);
   });
 
-  this._sub.on('message', (channel, rawMsg) => {
+  sub.on('message', (channel, rawMsg) => {
     try {
       const msg = JSON.parse(rawMsg);
       if (!('eventType' in msg) || !('data' in msg)) {
@@ -51,7 +58,7 @@ module.exports._handleMessage = function (channel, eventType, data) {
 };
 
 module.exports.emit = function (channel, eventType, data) {
-  if (!this._useRedis) {
+  if (!useRedis) {
     // Skip redis and distribute message locally immediately
     module.exports._handleMessage(channel, eventType, data);
     return;
@@ -60,14 +67,14 @@ module.exports.emit = function (channel, eventType, data) {
     eventType,
     data,
   };
-  this._pub.publish(channel, JSON.stringify(msg));
+  pub.publish(channel, JSON.stringify(msg));
 };
 
 module.exports.on = function (channel, eventType, callback) {
   if (!(channel in callbacks)) {
     callbacks[channel] = {};
-    if (this._useRedis) {
-      this._sub.subscribe(channel);
+    if (useRedis) {
+      sub.subscribe(channel);
     }
   }
   if (!(eventType in callbacks[channel])) {

--- a/prairielib/lib/sql-db.js
+++ b/prairielib/lib/sql-db.js
@@ -886,36 +886,56 @@ class PostgresPool {
 const defaultPool = new PostgresPool();
 
 module.exports = {
-  ...defaultPool,
-  // Class methods are non-enumerable, so we can't spread them. We'll manually
-  // attach them to `module.exports`.
-  initAsync: defaultPool.initAsync,
-  closeAsync: defaultPool.closeAsync,
-  getClientAsync: defaultPool.getClientAsync,
-  getClient: defaultPool.getClient,
-  queryWithClientAsync: defaultPool.queryWithClientAsync,
-  queryWithClientOneRowAsync: defaultPool.queryWithClientOneRowAsync,
-  queryWithClientZeroOrOneRowAsync: defaultPool.queryWithClientZeroOrOneRowAsync,
-  rollbackWithClientAsync: defaultPool.rollbackWithClientAsync,
-  rollbackWithClient: defaultPool.rollbackWithClient,
-  beginTransactionAsync: defaultPool.beginTransactionAsync,
-  beginTransaction: defaultPool.beginTransaction,
-  endTransactionAsync: defaultPool.endTransactionAsync,
-  endTransaction: defaultPool.endTransaction,
-  runInTransactionAsync: defaultPool.runInTransactionAsync,
-  runInTransaction: defaultPool.runInTransaction,
-  queryAsync: defaultPool.queryAsync,
-  queryOneRowAsync: defaultPool.queryOneRowAsync,
-  queryZeroOrOneRowAsync: defaultPool.queryZeroOrOneRowAsync,
-  callAsync: defaultPool.callAsync,
-  callOneRowAsync: defaultPool.callOneRowAsync,
-  callZeroOrOneRowAsync: defaultPool.callZeroOrOneRowAsync,
-  callWithClientAsync: defaultPool.callWithClientAsync,
-  callWithClientOneRowAsync: defaultPool.callWithClientOneRowAsync,
-  callWithClientZeroOrOneRowAsync: defaultPool.callWithClientZeroOrOneRowAsync,
-  setSearchSchema: defaultPool.setSearchSchema,
-  getSearchSchema: defaultPool.getSearchSchema,
-  setRandomSearchSchemaAsync: defaultPool.setRandomSearchSchemaAsync,
+  // We re-expose all functions from the default pool here to account for the
+  // default case of a shared global pool of clients. If someone want to create
+  // their own pool, we expose the `PostgresPool` class.
+  //
+  // Note that we explicitly bind all functions to `defaultPool`. This ensures
+  // that they'll be invoked with the correct `this` context, specifically when
+  // this module is imported as `import * as db from '...'` and that import is
+  // subsequently transformed by Babel to `interopRequireWildcard(...)`.
+  init: defaultPool.init.bind(defaultPool),
+  initAsync: defaultPool.initAsync.bind(defaultPool),
+  close: defaultPool.close.bind(defaultPool),
+  closeAsync: defaultPool.closeAsync.bind(defaultPool),
+  getClientAsync: defaultPool.getClientAsync.bind(defaultPool),
+  getClient: defaultPool.getClient.bind(defaultPool),
+  queryWithClient: defaultPool.queryWithClient.bind(defaultPool),
+  queryWithClientAsync: defaultPool.queryWithClientAsync.bind(defaultPool),
+  queryWithClientOneRow: defaultPool.queryWithClientOneRow.bind(defaultPool),
+  queryWithClientOneRowAsync: defaultPool.queryWithClientOneRowAsync.bind(defaultPool),
+  queryWithClientZeroOrOneRow: defaultPool.queryWithClientZeroOrOneRow.bind(defaultPool),
+  queryWithClientZeroOrOneRowAsync: defaultPool.queryWithClientZeroOrOneRowAsync.bind(defaultPool),
+  rollbackWithClientAsync: defaultPool.rollbackWithClientAsync.bind(defaultPool),
+  rollbackWithClient: defaultPool.rollbackWithClient.bind(defaultPool),
+  beginTransactionAsync: defaultPool.beginTransactionAsync.bind(defaultPool),
+  beginTransaction: defaultPool.beginTransaction.bind(defaultPool),
+  endTransactionAsync: defaultPool.endTransactionAsync.bind(defaultPool),
+  endTransaction: defaultPool.endTransaction.bind(defaultPool),
+  runInTransactionAsync: defaultPool.runInTransactionAsync.bind(defaultPool),
+  runInTransaction: defaultPool.runInTransaction.bind(defaultPool),
+  query: defaultPool.query.bind(defaultPool),
+  queryAsync: defaultPool.queryAsync.bind(defaultPool),
+  queryOneRow: defaultPool.queryOneRow.bind(defaultPool),
+  queryOneRowAsync: defaultPool.queryOneRowAsync.bind(defaultPool),
+  queryZeroOrOneRow: defaultPool.queryZeroOrOneRow.bind(defaultPool),
+  queryZeroOrOneRowAsync: defaultPool.queryZeroOrOneRowAsync.bind(defaultPool),
+  call: defaultPool.call.bind(defaultPool),
+  callAsync: defaultPool.callAsync.bind(defaultPool),
+  callOneRow: defaultPool.callOneRow.bind(defaultPool),
+  callOneRowAsync: defaultPool.callOneRowAsync.bind(defaultPool),
+  callZeroOrOneRow: defaultPool.callZeroOrOneRow.bind(defaultPool),
+  callZeroOrOneRowAsync: defaultPool.callZeroOrOneRowAsync.bind(defaultPool),
+  callWithClient: defaultPool.callWithClient.bind(defaultPool),
+  callWithClientAsync: defaultPool.callWithClientAsync.bind(defaultPool),
+  callWithClientOneRow: defaultPool.callWithClientOneRow.bind(defaultPool),
+  callWithClientOneRowAsync: defaultPool.callWithClientOneRowAsync.bind(defaultPool),
+  callWithClientZeroOrOneRow: defaultPool.callWithClientZeroOrOneRow.bind(defaultPool),
+  callWithClientZeroOrOneRowAsync: defaultPool.callWithClientZeroOrOneRowAsync.bind(defaultPool),
+  setSearchSchema: defaultPool.setSearchSchema.bind(defaultPool),
+  getSearchSchema: defaultPool.getSearchSchema.bind(defaultPool),
+  setRandomSearchSchema: defaultPool.setRandomSearchSchema.bind(defaultPool),
+  setRandomSearchSchemaAsync: defaultPool.setRandomSearchSchemaAsync.bind(defaultPool),
 };
 
 module.exports.PostgresPool = PostgresPool;

--- a/prairielib/lib/sql-db.test.js
+++ b/prairielib/lib/sql-db.test.js
@@ -1,14 +1,31 @@
 /* eslint-env jest */
 const sqldb = require('./sql-db');
 
+/**
+ * Returns true if the property on `PostgresPool` should be considered
+ * hidden - that is, if it should be available on the module's exports.
+ */
+function isHiddenProperty(property) {
+  switch (property) {
+    case 'pool':
+    case 'alsClient':
+    case 'searchSchema':
+      return true;
+    default:
+      return false;
+  }
+}
+
 describe('sqldb', () => {
   it('exports the full PostgresPool interface', () => {
     const pool = new sqldb.PostgresPool();
 
-    Object.getOwnPropertyNames(pool).forEach((prop) => {
-      expect(sqldb).toHaveProperty(prop);
-      expect(sqldb[prop]).toBeDefined();
-    });
+    Object.getOwnPropertyNames(pool)
+      .filter((n) => !isHiddenProperty(n))
+      .forEach((prop) => {
+        expect(sqldb).toHaveProperty(prop);
+        expect(sqldb[prop]).toBeDefined();
+      });
 
     Object.getOwnPropertyNames(Object.getPrototypeOf(pool)).forEach((prop) => {
       expect(sqldb).toHaveProperty(prop);


### PR DESCRIPTION
This PR fixes two issues with using PrairieLearn code in PrairieTest:

- Usage of `this` to refer to the context that `module.exports` functions are executed in (same issue as #5515).
- Exports from `sql-db.js` were being executed with the wrong `this` context when imported as `import * as db from '...'` in a file that was then processed by Babel.