### PR TITLE
feat: Improve performance of assessment_instances_select_log

### DIFF
--- a/database/tables/group_logs.pg
+++ b/database/tables/group_logs.pg
@@ -8,5 +8,5 @@ columns
 
 indexes
     group_logs_pkey: PRIMARY KEY (id) USING btree (id)
-    group_logs_group_id_user_id_idx: USING btree (group_id, user_id)
+    group_logs_group_id_idx: USING btree (group_id)
     group_logs_user_id_idx: USING btree (user_id)

--- a/database/tables/group_logs.pg
+++ b/database/tables/group_logs.pg
@@ -8,3 +8,5 @@ columns
 
 indexes
     group_logs_pkey: PRIMARY KEY (id) USING btree (id)
+    group_logs_group_id_user_id_idx: USING btree (group_id, user_id)
+    group_logs_user_id_idx: USING btree (user_id)

--- a/migrations/248_group_logs__indexes_add.sql
+++ b/migrations/248_group_logs__indexes_add.sql
@@ -1,0 +1,6 @@
+-- Optimizes for "find all logs for a certain user in a certain group"
+-- queries that's used for things like generating the log of all assessment events.
+CREATE INDEX group_logs_group_id_user_id_idx ON group_logs (group_id, user_id);
+
+-- Optimizes for "find all logs for a certain user" queries.
+CREATE INDEX group_logs_user_id_idx ON group_logs (user_id);

--- a/migrations/248_group_logs__indexes_add.sql
+++ b/migrations/248_group_logs__indexes_add.sql
@@ -1,6 +1,6 @@
--- Optimizes for "find all logs for a certain user in a certain group"
--- queries that's used for things like generating the log of all assessment events.
-CREATE INDEX group_logs_group_id_user_id_idx ON group_logs (group_id, user_id);
+-- Optimizes for "find all logs for a certain group" queries that are used for
+-- things like the instructor assessment instance logs.
+CREATE INDEX group_logs_group_id_idx ON group_logs (group_id);
 
 -- Optimizes for "find all logs for a certain user" queries.
 CREATE INDEX group_logs_user_id_idx ON group_logs (user_id);

--- a/tools/pg_describe
+++ b/tools/pg_describe
@@ -11,6 +11,7 @@ const databaseDescribe = require('../lib/databaseDescribe');
 
 const yargs = require('yargs')
     .usage('Usage: $0 <database name> [options]')
+    .demandCommand(1)
     .alias('o', 'output')
     .nargs('o', 1)
     .describe('o', 'Specify a directory to output files to')


### PR DESCRIPTION
This PR introduces two performance optimizations to the `assessment_instances_select_log` sproc:

- Restructures how we fetch from `page_view_logs`. Previously, we had a nested `SELECT 1 ...` query that would check for group `join` events in order to determine which users we had to show logs for. However, an `EXPLAIN ANALYZE ...` revealed that this resulted in a sequential scan of `group_logs` *per page view log*, which was very slow. Now, we first do a single filter of `group_logs` based on the `assessment_instance` ID to find all the user IDs we should fetch `page_view_logs` for, and then we filter `page_view_logs` on `assessment_instance_id` and `authn_user_id`. We can then reuse the results of that when we check for assessment/variant view logs.
- Adds indexes to the `group_logs` table so that we don't have to do a full sequential scan of it every time we want to query for logs from a particular group. This index may or may not end up being used in the `assessment_instances_select_log` sproc, as the group logs table is still small enough that the query planner may choose to do a sequential scan instead of an index scan.