### PR TITLE
feat: More stats for active course instance admin query

### DIFF
--- a/admin_queries/course_instance_active_enrollments.json
+++ b/admin_queries/course_instance_active_enrollments.json
@@ -1,5 +1,5 @@
 {
-    "description": "Course instances enrollments with a minimum modified instance question count.",
+    "description": "Course instances that are active within a given date range.",
     "params": [
         {
             "name": "institution_short_name",
@@ -8,22 +8,22 @@
         },
         {
             "name": "start_date",
-            "description": "Lower bound on instance question modification timestamps.",
+            "description": "Start of the date range (e.g., first day of the academic yaer).",
             "default": "2021-01-01T00:00:00"
         },
         {
             "name": "end_date",
-            "description": "Upper bound on instance question modification timestamps.",
+            "description": "End of the date range (e.g., last day of the academic year).",
             "default": "2022-01-01T00:00:00"
         },
         {
             "name": "minimum_instance_question_count",
-            "description": "Minimum number of modified instance questions for an enrollment to be included.",
+            "description": "Minimum number of modified instance questions for a student to be included.",
             "default": "10"
         },
         {
-            "name": "minimum_enrollment_count",
-            "description": "Minimum number of enrollments for a course instance to be included.",
+            "name": "minimum_student_count",
+            "description": "Minimum number of students for a course instance to be included.",
             "default": "10"
         }
     ]

--- a/admin_queries/course_instance_active_enrollments.sql
+++ b/admin_queries/course_instance_active_enrollments.sql
@@ -1,50 +1,96 @@
 WITH
-course_instance_user_instance_question_counts AS (
+course_instances_initial_selection AS (
+    -- First find any course instances with activity in
+    -- the given time period.
+    SELECT DISTINCT
+        ci.id
+    FROM
+        assessment_instances AS ai
+        JOIN assessments AS a ON (a.id = ai.assessment_id)
+        JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+        JOIN pl_courses AS c ON (c.id = ci.course_id)
+        JOIN institutions AS i ON (i.id = c.institution_id)
+    WHERE
+        ($institution_short_name = '' OR i.short_name = $institution_short_name)
+        AND ai.modified_at BETWEEN $start_date AND $end_date
+),
+course_instance_user_data AS (
+    -- Re-select this to get all course instance data,
+    -- not just that from the search date range.
     SELECT
         ci.id,
         u.user_id,
-        count(*) AS instance_question_count
+        (i.id = u.institution_id) AS is_institution_user,
+        count(*) AS instance_question_count,
+        count(*) FILTER (WHERE iq.modified_at BETWEEN $start_date AND $end_date) AS instance_question_within_dates_count,
+        min(iq.created_at) AS start_date,
+        max(iq.modified_at) AS end_date
     FROM
-        instance_questions AS iq
-        JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
-        JOIN assessments AS a ON (a.id = ai.assessment_id)
-        JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+        course_instances_initial_selection AS ciis
+        JOIN course_instances AS ci ON (ci.id = ciis.id)
+        JOIN assessments AS a ON (a.course_instance_id = ciis.id)
+        JOIN assessment_instances AS ai ON (ai.assessment_id = a.id)
+        JOIN instance_questions AS iq ON (iq.assessment_instance_id = ai.id)
         JOIN users AS u ON (u.user_id = iq.authn_user_id)
-        JOIN institutions AS i ON (i.id = u.institution_id)
-    WHERE
-        ($institution_short_name = '' OR i.short_name = $institution_short_name)
-        AND iq.modified_at > $start_date
-        AND iq.modified_at < $end_date
+        JOIN pl_courses AS c ON (c.id = ci.course_id)
+        JOIN institutions AS i ON (i.id = c.institution_id)
     GROUP BY
-        ci.id, u.user_id
+        ci.id, u.user_id, i.id, u.institution_id
 ),
-course_instance_student_counts AS (
-    SELECT
-        ciuiqc.id,
-        count(*) AS student_count
-    FROM
-        course_instance_user_instance_question_counts AS ciuiqc
-        JOIN enrollments AS e ON (e.course_instance_id = ciuiqc.id AND e.user_id = ciuiqc.user_id)
+course_instance_user_selection AS (
+    SELECT *
+    FROM course_instance_user_data
     WHERE
-        NOT users_is_instructor_in_course_instance(e.user_id, ciuiqc.id)
-        AND ciuiqc.instance_question_count >= $minimum_instance_question_count
+        NOT users_is_instructor_in_course_instance(user_id, id)
+        AND instance_question_count >= $minimum_instance_question_count
+),
+course_instance_data AS (
+    SELECT
+        id,
+        count(*) AS total_students,
+        count(*) FILTER (WHERE NOT is_institution_user) AS outside_students,
+        count(*) FILTER (WHERE instance_question_within_dates_count >= $minimum_instance_question_count) AS within_dates_students,
+        sum(instance_question_count) AS instance_question_count,
+        avg(instance_question_within_dates_count::double precision / instance_question_count::double precision * 100) AS activity_within_dates_perc,
+        percentile_disc(0.5) WITHIN GROUP (ORDER BY start_date) AS start_date,
+        percentile_disc(0.5) WITHIN GROUP (ORDER BY end_date) AS end_date
+    FROM
+        course_instance_user_selection
     GROUP BY
-        ciuiqc.id
+        id
 )
 SELECT
     i.short_name AS institution,
+    i.id AS institution_id,
     c.short_name AS course,
     c.id AS course_id,
     ci.short_name AS course_instance,
     ci.id AS course_instance_id,
-    cisc.student_count
+
+    -- total number of students in the course instance (over all time)
+    cid.total_students,
+
+    -- number of students in the course instance who are from a different institution (over all time)
+    cid.outside_students,
+
+    -- average percentage of question activity within the original search date range
+    round(cid.activity_within_dates_perc)::integer AS activity_within_dates_perc,
+
+    -- average number of instance questions per student in the course instance (over all students and all time)
+    round(cid.instance_question_count::double precision / cid.total_students::double precision)::integer AS questions_per_student,
+
+    -- approximate first date when most students starting working on questions in the course instance (over all students and all time)
+    cid.start_date::date,
+
+    -- approximate last date when most students last worked on questions in the course instance (over all students and all time)
+    cid.end_date::date
 FROM
-    course_instance_student_counts AS cisc
-    JOIN course_instances AS ci ON (ci.id = cisc.id)
+    course_instance_data AS cid
+    JOIN course_instances AS ci ON (ci.id = cid.id)
     JOIN pl_courses AS c ON (c.id = ci.course_id)
     JOIN institutions AS i ON (i.id = c.institution_id)
 WHERE
-    cisc.student_count >= $minimum_enrollment_count
+    cid.within_dates_students >= $minimum_student_count
 ORDER BY
     i.short_name,
     c.short_name,

--- a/admin_queries/course_instance_active_enrollments.sql
+++ b/admin_queries/course_instance_active_enrollments.sql
@@ -61,7 +61,6 @@ course_instance_data AS (
 )
 SELECT
     i.short_name AS institution,
-    i.id AS institution_id,
     c.short_name AS course,
     c.id AS course_id,
     ci.short_name AS course_instance,

--- a/admin_queries/course_instance_active_enrollments.sql
+++ b/admin_queries/course_instance_active_enrollments.sql
@@ -80,10 +80,10 @@ SELECT
     round(cid.instance_question_count::double precision / cid.total_students::double precision)::integer AS questions_per_student,
 
     -- approximate first date when most students starting working on questions in the course instance (over all students and all time)
-    cid.start_date::date,
+    to_char(cid.start_date, 'YYYY-MM-DD'),
 
     -- approximate last date when most students last worked on questions in the course instance (over all students and all time)
-    cid.end_date::date
+    to_char(cid.end_date, 'YYYY-MM-DD')
 FROM
     course_instance_data AS cid
     JOIN course_instances AS ci ON (ci.id = cid.id)

--- a/admin_queries/course_instance_active_enrollments.sql
+++ b/admin_queries/course_instance_active_enrollments.sql
@@ -82,7 +82,10 @@ SELECT
     to_char(cid.start_date, 'YYYY-MM-DD') AS start_date,
 
     -- approximate last date when most students last worked on questions in the course instance (over all students and all time)
-    to_char(cid.end_date, 'YYYY-MM-DD') AS end_date
+    to_char(cid.end_date, 'YYYY-MM-DD') AS end_date,
+
+    -- number of dates from start_date to end_date
+    round(extract(epoch from (end_date - start_date))::double precision / (24 * 60 * 60)::double precision)::integer AS duration_days
 FROM
     course_instance_data AS cid
     JOIN course_instances AS ci ON (ci.id = cid.id)

--- a/admin_queries/course_instance_active_enrollments.sql
+++ b/admin_queries/course_instance_active_enrollments.sql
@@ -79,10 +79,10 @@ SELECT
     round(cid.instance_question_count::double precision / cid.total_students::double precision)::integer AS questions_per_student,
 
     -- approximate first date when most students starting working on questions in the course instance (over all students and all time)
-    to_char(cid.start_date, 'YYYY-MM-DD'),
+    to_char(cid.start_date, 'YYYY-MM-DD') AS start_date,
 
     -- approximate last date when most students last worked on questions in the course instance (over all students and all time)
-    to_char(cid.end_date, 'YYYY-MM-DD')
+    to_char(cid.end_date, 'YYYY-MM-DD') AS end_date
 FROM
     course_instance_data AS cid
     JOIN course_instances AS ci ON (ci.id = cid.id)


### PR DESCRIPTION
This PR adds some more useful statistics to the `course_instance_active_enrollments` admin query. These should help to identify the term in which course instances were active.

I've tested this on the UIUC Staging server.