### PR TITLE
fix: Add missing argument when grading all assessment instances

### DIFF
--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -398,9 +398,11 @@ module.exports = {
                 job.verbose(
                   `Grading assessment instance #${row.instance_number} for ${row.username}`
                 );
+                const requireOpen = true;
                 module.exports.gradeAssessmentInstance(
                   row.assessment_instance_id,
                   authn_user_id,
+                  requireOpen,
                   close,
                   overrideGradeRate,
                   (err) => {


### PR DESCRIPTION
Fixes #5526.

As discussed in #5526, I think we should make `gradeAssessmentInstance()` return without error if the instance is closed and `requireOpen == true`. That could wait for a later PR, however.