### PR TITLE
feat: Display recent admin query runs

### DIFF
--- a/pages/administratorQuery/administratorQuery.ejs
+++ b/pages/administratorQuery/administratorQuery.ejs
@@ -159,6 +159,50 @@
         <% } %>
       </div>
 
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white d-flex align-items-center">
+          Recent query runs
+        </div>
+        <div class="table-responsive">
+        <% if (recent_query_runs.length > 0) { %>
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Params</th>
+                <th>User name</th>
+                <th>User UID</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% recent_query_runs.forEach(run => { %>
+                <tr>
+                  <td>
+                    <a href="?query_run_id=<%= run.id %>">
+                      <%= run.formatted_date %>
+                    </a>
+                  </td>
+                  <td>
+                    <pre class="mb-0"><%= JSON.stringify(run.params) %></pre>
+                  </td>
+                  <td>
+                    <%= run.user_name %>
+                  </td>
+                  <td>
+                    <%= run.user_uid %>
+                  </td>
+                </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        <% } else { %>
+          <div class="card-body">
+            <div class="text-center text-muted">No recent runs found</div>
+          </div>
+        <% } %>
+        </div>
+      </div>
+
     </div>
   </body>
 </html>

--- a/pages/administratorQuery/administratorQuery.js
+++ b/pages/administratorQuery/administratorQuery.js
@@ -60,6 +60,11 @@ router.get(
       res.attachment(req.params.query + '.csv');
       res.send(await csvMaker.resultToCsvAsync(res.locals.result));
     } else {
+      const recentQueryRuns = await sqldb.queryAsync(sql.select_recent_query_runs, {
+        query_name: req.params.query,
+      });
+      res.locals.recent_query_runs = recentQueryRuns.rows;
+      console.log(res.locals.recent_query_runs);
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     }
   })

--- a/pages/administratorQuery/administratorQuery.js
+++ b/pages/administratorQuery/administratorQuery.js
@@ -64,7 +64,6 @@ router.get(
         query_name: req.params.query,
       });
       res.locals.recent_query_runs = recentQueryRuns.rows;
-      console.log(res.locals.recent_query_runs);
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     }
   })

--- a/pages/administratorQuery/administratorQuery.sql
+++ b/pages/administratorQuery/administratorQuery.sql
@@ -11,3 +11,17 @@ SELECT
     format_date_full_compact(date, config_select('display_timezone')) as formatted_date
 FROM query_runs
 WHERE id = $query_run_id;
+
+-- BLOCK select_recent_query_runs
+SELECT
+    qr.id,
+    qr.params,
+    format_date_full_compact(qr.date, config_select('display_timezone')) as formatted_date,
+    u.name AS user_name,
+    u.uid AS user_uid
+FROM
+    query_runs AS qr
+    LEFT JOIN users u ON (u.user_id = qr.authn_user_id)
+WHERE qr.name = $query_name
+ORDER BY date DESC
+LIMIT 10;


### PR DESCRIPTION
This PR adds a new "Recent query runs" panel to admin query pages. This makes it easier to access the results of recent runs without having to dive into the database to get a query run ID.

<img width="946" alt="Screen Shot 2022-03-21 at 16 04 46" src="https://user-images.githubusercontent.com/1476544/159377344-cf7757b6-92e0-46dd-98d7-a347fe7b13f6.png">
