### PR TITLE
fix: Correctly get ID of existing variant in variants_insert

### DIFF
--- a/sprocs/variants_insert.sql
+++ b/sprocs/variants_insert.sql
@@ -42,7 +42,7 @@ BEGIN
         -- the database and use that instead.
         existing_variant := instance_questions_select_variant(instance_question_id, require_open);
         IF existing_variant IS NOT NULL THEN
-            SELECT variants_select(existing_variant->'id', real_question_id, instance_question_id)
+            SELECT variants_select((existing_variant->>'id')::bigint, real_question_id, instance_question_id)
             INTO variant;
             RETURN;
         END IF;


### PR DESCRIPTION
This bug was introduced in #5489, which manifested as the following error in production:

```
function variants_select(json, bigint, bigint) does not exist
```

Interestingly, this means we are indeed hitting race conditions in prod!