### PR TITLE
Java autograder: force exit after saving results to close background threads

### DIFF
--- a/graders/java/JUnitAutograder.java
+++ b/graders/java/JUnitAutograder.java
@@ -54,6 +54,8 @@ public class JUnitAutograder implements TestExecutionListener {
             autograder.gradable = false;
         } finally {
             autograder.saveResults();
+            // Force exit to ensure any pending threads don't cause the autograder to hang
+            System.exit(0);
         }
     }
 


### PR DESCRIPTION
Some students have been creating background threads for some tasks, but don't close them properly when needed. This causes the autograder to hang after completing the JUnit tests. This PR forces the system to exit after results are saved, which also closes any pending threads.