### PR TITLE
fix: update mkdocs to use nav instead of pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ extra_javascript:
   - mathjax-config.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js
 
-pages:
+nav:
 - Main: 'index.md'
 - Getting Started:
   - 'Requesting your course space': 'requestCourse.md'


### PR DESCRIPTION
when trying to run docs locally today (`make preview` from the docs folder), I received the following message:

INFO   - Building documentation...
ERROR  - Config value: 'pages'. Error: The configuration option 'pages' was
      removed from MkDocs. Use 'nav' instead.
Aborted with 1 Configuration Errors!

This PR replaces `pages` with `nav`. I am able to successfully run the documentation after this update.

