### PR TITLE
docs: update request course and workshop 

### DIFF
--- a/docs/getStarted.md
+++ b/docs/getStarted.md
@@ -1,6 +1,6 @@
 # Create content in the browser
 
-Now that you have access to your course in [https://prairielearn.engr.illinois.edu/](https://prairielearn.engr.illinois.edu/), it is time to start creating course content.
+Now that you have access to your course in [https://prairielearn.org](https://prairielearn.org), it is time to start creating course content.
 
 This is a view of your course home page (or a similar variation, depending on when your course was originally created):
 

--- a/docs/workshop/index.md
+++ b/docs/workshop/index.md
@@ -1,89 +1,42 @@
 # PrairieLearn Workshop
 
-In this 5-day training course, we will provide an introduction to the following topics:
+In this training course, we will provide an introduction to the following topics:
 
 - how to create questions and assessments
 - overview of existing PL elements
 - how to use the external grader
 - how to use the drawing tools
 
-## What you need to do BEFORE the workshop
+## What you need to do before the workshop
 
-1. **Login to PrairieLearn** at [https://prairielearn.engr.illinois.edu/pl/](https://prairielearn.engr.illinois.edu/pl/) (in case you have never done this before). This is necessary so that we can give you access to PrairieLearn before the workshop starts.
+1. **Login to PrairieLearn** at [https://prairielearn.org](https://prairielearn.org) (in case you have never done this before). 
 
-2. **Request course access.** We are processing all the access requests using the PrairieLearn Slack [`#request-course`](https://go.illinois.edu/PrairieLearnSlack) channel. Check the options below for instructions.
+2. **Make sure you have access to a course space.** If you have not created a space for your course, you can use this [course request](https://www.prairielearn.org/pl/request_course) link. If you are a graduate teaching assistant or co-instructor, ask the main instructor to give you course access as "Editor" in the [Staff page](https://prairielearn.readthedocs.io/en/latest/course/#course-staff).
 
-3. **Complete Homework 0.** See below for instructions on Homework 0. It would be very helpful if you can do this before the first meeting on Monday.
+3. **Complete the ["Get Started" tutorial](https://prairielearn.readthedocs.io/en/latest/getStarted/)**, which will show you how to create:
 
-### Request access to a PrairieLearn course
+    - course instances
+    - assessments
+    - questions
 
-#### 1) You are a Course Instructor:
 
-Provide the following information in the [`#request-course`](https://go.illinois.edu/PrairieLearnSlack) channel:
-
-```
-Course rubric: XX-100
-Course name: <enter course name>
-Your email: netid@illinois.edu
-Your institution: UIUC
-```
-
-#### 2) You are a Teaching Assistant already assigned to a course
-
-Provide the following information in the [`#request-course`](https://go.illinois.edu/PrairieLearnSlack) channel:
-
-```
-I want access to the course listed below:
-Course rubric: XX-100
-Instructor name: <enter instructor name>
-Your email: netid@illinois.edu
-```
-
-#### 3) Others
-
-You may be a teaching assistant not yet assigned to a course, or just someone wanting to learn how to use PrairieLearn, without any connections to a course. Everyone is welcome!
-
-Provide the following information in the [`#request-course`](https://go.illinois.edu/PrairieLearnSlack) channel:
-
-```
-I want access to the training course TRAIN-101
-Your email: netid@illinois.edu
-```
-
-Note that we will add all teaching assistants to `TRAIN-101`, in addition to their assigned courses (in case that information is available).
-
-### Complete the Get Started tutorial
-
-Once you receive an email indicating that you have access to PrairieLearn, complete the [Get Started](../getStarted.md) tutorial, which will show you how to create:
-
-- course instances
-- assessments
-- questions
-
-If you are using the course `TRAIN-101`, when adding your course instance, use:
-
-```json
-"longName": "Summer 2020 xxxx"
-```
-
-where `xxxx` is your netid.
 
 ## Workshop Schedule
 
-#### [Day 1](lesson1.md): creating simple questions
+#### [Lesson 1](lesson1.md): creating simple questions
 
-#### [Day 2](lesson2.md): creating assessments
+#### [Lesson 2](lesson2.md): creating assessments
 
-#### [Day 3](lesson3.md): looking at more specialized elements
+#### [Lesson 3](lesson3.md): looking at more specialized elements
 
-#### [Day 4](lesson4.md): customizing the grading method
+#### [Lesson 4](lesson4.md): customizing the grading method
 
-#### [Day 5](lesson5.md): using graphical/drawing elements
+#### [Lesson 5](lesson5.md): using graphical/drawing elements
+
+## Workshop Videos
+
+This workshop was last offered in Summer 2020. You can watch the recorded videos on the [PrairieLearn MediaSpace channel](https://mediaspace.illinois.edu/channel/PrairieLearn/170964131)
 
 ## PrairieLearn Overview Video
 
 This [video](https://mediaspace.illinois.edu/media/t/1_e1gprkci/170964131) offers a high-level description of PrairieLearn and its usage in courses for homework and exams.
-
-## Workshop Videos
-
-The workshop videos are recorded and posted on the [PrairieLearn MediaSpace channel](https://mediaspace.illinois.edu/channel/PrairieLearn/170964131)

--- a/docs/workshop/index.md
+++ b/docs/workshop/index.md
@@ -9,17 +9,15 @@ In this training course, we will provide an introduction to the following topics
 
 ## What you need to do before the workshop
 
-1. **Login to PrairieLearn** at [https://prairielearn.org](https://prairielearn.org) (in case you have never done this before). 
+1. **Login to PrairieLearn** at [https://prairielearn.org](https://prairielearn.org) (in case you have never done this before).
 
 2. **Make sure you have access to a course space.** If you have not created a space for your course, you can use this [course request](https://www.prairielearn.org/pl/request_course) link. If you are a graduate teaching assistant or co-instructor, ask the main instructor to give you course access as "Editor" in the [Staff page](https://prairielearn.readthedocs.io/en/latest/course/#course-staff).
 
 3. **Complete the ["Get Started" tutorial](https://prairielearn.readthedocs.io/en/latest/getStarted/)**, which will show you how to create:
 
-    - course instances
-    - assessments
-    - questions
-
-
+   - course instances
+   - assessments
+   - questions
 
 ## Workshop Schedule
 

--- a/docs/workshop/lesson1.md
+++ b/docs/workshop/lesson1.md
@@ -105,7 +105,3 @@ Create one or two questions using some of these basic elements:
 `pl-number-input` [documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-number-input-element) and [example](https://prairielearn.engr.illinois.edu/pl/course/108/question/3131525/preview)
 
 `pl-figure` [documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-figure-element) and [example](https://prairielearn.engr.illinois.edu/pl/course/108/question/611923/preview)
-
-Copy the url link to your question in this spreadsheet:
-[https://docs.google.com/spreadsheets/d/1XeY-0o0guRGSFEK2E-pCHhW5qiGyBUFm2uo7e6SuzNM/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1XeY-0o0guRGSFEK2E-pCHhW5qiGyBUFm2uo7e6SuzNM/edit?usp=sharing).
-Use the tab for `Homework 1`. I will take a look at your question and provide feedback.

--- a/docs/workshop/lesson2.md
+++ b/docs/workshop/lesson2.md
@@ -93,7 +93,9 @@ Before you start creating your assessments, make sure you have at least 4 questi
 - Homework submitted at the deadline receive 100% credit. Homework submitted up to 4 days late receive 70% credit. Homework submitted at least 2 days before the deadline get 5% bonus.
 - Include two zones: one for easy questions, where each question has `"maxPoints": 5` and another one for more advanced questions, with `"maxPoints": 3`
 
-### Configuration 2: Synchronous online exam without proctoring
+[Assessment template](https://www.prairielearn.org/pl/course_instance/4970/assessment/2316937) from the Example Course
+
+### Configuration 2: Synchronous online exam without proctoring tool
 
 - Use `"mode": "Public"` (not using CBTF)
 - Use `"type":"Exam"`
@@ -114,6 +116,8 @@ Before you start creating your assessments, make sure you have at least 4 questi
 - Choose `startDate` and `endDate` to allow for a 1-hour window (this could be your lecture time). In `allowAccess`, set a time limit of 50 minutes. This gives extra 10-minutes for possible delays.
 - Add a password
 
+[Assessment template](https://www.prairielearn.org/pl/course_instance/4970/assessment/2316935) from the Example Course
+
 ### Configuration 3: Practice exams
 
 - Start from `Configuration 2`
@@ -121,7 +125,12 @@ Before you start creating your assessments, make sure you have at least 4 questi
 - Disable honor code message
 - You may want to adjust the `startDate` and `endDate` to give students more opportunity for practice
 
-### Configuration 4: Synchronous exam using CBTF
+
+[Assessment template](https://www.prairielearn.org/pl/course_instance/4970/assessment/1981282) from the Example Course
+
+### Configuration 4: Synchronous exam using PrairieTest
+
+When using [PrairieTest](https://www.prairietest.org/pt/docs/staff) to schedule and deliver PrairieLearn exams, you need to using the following configuration:
 
 - Start from `Configuration 2`
 - Remove `startDate` and `endDate` from `allowAccess`. Instead use:
@@ -138,8 +147,5 @@ You will be able to find the `examUuid` in the CBTF scheduler app.
 
 ## Homework 2
 
-Continue creating questions using the elements highlighted in lesson 1. Copy the url link to your question in this [spreadsheet]
-(https://docs.google.com/spreadsheets/d/1XeY-0o0guRGSFEK2E-pCHhW5qiGyBUFm2uo7e6SuzNM/edit#gid=1763628636).
-Use the tab for `Homework 2`. I will take a look at your question and provide feedback.
-
-You can also create one assessment as well. What options do you think will be useful for you in the Fall semester? We can provide feedback! Copy the link in the same [spreadsheet](https://docs.google.com/spreadsheets/d/1XeY-0o0guRGSFEK2E-pCHhW5qiGyBUFm2uo7e6SuzNM/edit#gid=1763628636).
+Continue creating questions using the elements highlighted in lesson 1. 
+You can also create one assessment. What options do you think will be useful for your course? You can take a look at different types of assessments in the [example course](https://www.prairielearn.org/pl/course_instance/4970/)

--- a/docs/workshop/lesson2.md
+++ b/docs/workshop/lesson2.md
@@ -125,7 +125,6 @@ Before you start creating your assessments, make sure you have at least 4 questi
 - Disable honor code message
 - You may want to adjust the `startDate` and `endDate` to give students more opportunity for practice
 
-
 [Assessment template](https://www.prairielearn.org/pl/course_instance/4970/assessment/1981282) from the Example Course
 
 ### Configuration 4: Synchronous exam using PrairieTest
@@ -147,5 +146,5 @@ You will be able to find the `examUuid` in the CBTF scheduler app.
 
 ## Homework 2
 
-Continue creating questions using the elements highlighted in lesson 1. 
+Continue creating questions using the elements highlighted in lesson 1.
 You can also create one assessment. What options do you think will be useful for your course? You can take a look at different types of assessments in the [example course](https://www.prairielearn.org/pl/course_instance/4970/)

--- a/docs/workshop/lesson3.md
+++ b/docs/workshop/lesson3.md
@@ -93,9 +93,7 @@ You can use `pl-overlay` to add the input boxes on top of the image.
 
 ## Homework 3
 
-Create new questions using some of the elements discussed today and add the url link to the
-[spreadsheet](https://docs.google.com/spreadsheets/d/1XeY-0o0guRGSFEK2E-pCHhW5qiGyBUFm2uo7e6SuzNM/edit#gid=1243482684).
-Use the tab for `Homework 3`. I will take a look at your question and provide feedback.
+Create new questions using some of the elements discussed today:
 
 `pl-matrix-component-input` [documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-matrix-component-input-element) and [example](https://prairielearn.engr.illinois.edu/pl/course/108/question/1793641/preview)
 
@@ -105,7 +103,7 @@ Use the tab for `Homework 3`. I will take a look at your question and provide fe
 
 `pl-variable-output` [documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-variable-output-element) and [example](https://prairielearn.engr.illinois.edu/pl/course/108/question/3637022/preview)
 
-`pl-python-variable` [documentation]() and [example](https://prairielearn.readthedocs.io/en/latest/elements/#pl-python-variable-element)
+`pl-python-variable` [documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-python-variable-element) and [example](https://prairielearn.readthedocs.io/en/latest/elements/#pl-python-variable-element)
 
 `pl-string-input` [documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-string-input-element) and [example](https://prairielearn.engr.illinois.edu/pl/course/108/question/1793642/preview)
 

--- a/docs/workshop/lesson4.md
+++ b/docs/workshop/lesson4.md
@@ -33,7 +33,7 @@ This is an example of a question that expects data collected from an experiment.
 The purpose of this experiment is to determine the convective heat transfer coefficients for natural convection over pin fins. Seven thermocouples are embedded along the length of the fin.
 One thermocouple is placed at the base of the fin, which is the reference position $x_0 = 0$. We denote the temperature
 at the base as $T_b = T(x_0)$. The other thermocouples are placed at positions $x_1$, $x_2$, ... with
-corresponsing temperatures $T_1$, $T_2$, etc. The pin fin has diameter $D$, length $L$ and is made of stainless steel with thermal conductivity $k = 20 \rm W/mK$.
+corresponding temperatures $T_1$, $T_2$, etc. The pin fin has diameter $D$, length $L$ and is made of stainless steel with thermal conductivity $k = 20 \rm W/mK$.
 
 Students will be asked to enter measurements for temperature and the position of the thermocouples. Make sure you think about the tolerances you expect for these variables.
 

--- a/docs/workshop/lesson4.md
+++ b/docs/workshop/lesson4.md
@@ -49,14 +49,14 @@ Take a look at the documentation for the [python auto grader](https://prairielea
 
 #### Example 4:
 
-Write a question that provides students with a matrix $A$, and asks them to  compute the following:
+Write a question that provides students with a matrix $A$, and asks them to compute the following:
 
 1. another matrix $B = \beta \, A$, where $\beta \in [2,9]$.
 
 2. a function that takes two matrices $M_1$ and $M_2$ as arguments, and returns:
 
-    - a matrix $C$ given by the element-wise multiplication of $M_1$ and $M_2$ (and hence $M_1$ and $M_2$ should have the same dimensions)
-    - the summation of all the entries of $C$
+   - a matrix $C$ given by the element-wise multiplication of $M_1$ and $M_2$ (and hence $M_1$ and $M_2$ should have the same dimensions)
+   - the summation of all the entries of $C$
 
 **PrairieLearn implementation:**
 
@@ -64,4 +64,4 @@ Write a question that provides students with a matrix $A$, and asks them to  com
 
 ## Homework 4
 
-Continue creating more questions using the PL elements that best fit your needs. The topics discussed today can be helpful when creating more advanced questions, but not everyone will need this type of customized grading. 
+Continue creating more questions using the PL elements that best fit your needs. The topics discussed today can be helpful when creating more advanced questions, but not everyone will need this type of customized grading.

--- a/docs/workshop/lesson4.md
+++ b/docs/workshop/lesson4.md
@@ -49,13 +49,14 @@ Take a look at the documentation for the [python auto grader](https://prairielea
 
 #### Example 4:
 
-Write a question where you provide a matrix $A$, and the code has to return the following:
+Write a question that provides students with a matrix $A$, and asks them to  compute the following:
 
-- another matrix $B = \beta \, A$, where $\beta \in [2,9]$.
+1. another matrix $B = \beta \, A$, where $\beta \in [2,9]$.
 
-- a function that takes two matrices $M_1$ and $M_2$ as arguments, and returns:
-  - a matrix $C$ given by the element-wise multiplication of $M_1$ and $M_2$ (and hence $M_1$ and $M_2$ should have the same dimensions)
-  - the summation of all the entries of $C$
+2. a function that takes two matrices $M_1$ and $M_2$ as arguments, and returns:
+
+    - a matrix $C$ given by the element-wise multiplication of $M_1$ and $M_2$ (and hence $M_1$ and $M_2$ should have the same dimensions)
+    - the summation of all the entries of $C$
 
 **PrairieLearn implementation:**
 
@@ -63,6 +64,4 @@ Write a question where you provide a matrix $A$, and the code has to return the 
 
 ## Homework 4
 
-Continue creating more questions using the PL elements that best fit your needs. The topics discussed today can be helpful when creating more advanced questions, but not everyone will need this type of customized grading. As usual, add the url link to the
-[spreadsheet](https://docs.google.com/spreadsheets/d/1XeY-0o0guRGSFEK2E-pCHhW5qiGyBUFm2uo7e6SuzNM/edit#gid=1243482684).
-Use the tab for `Homework 4`. I will take a look at your question and provide feedback.
+Continue creating more questions using the PL elements that best fit your needs. The topics discussed today can be helpful when creating more advanced questions, but not everyone will need this type of customized grading. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ extra_javascript:
   - mathjax-config.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js
 
-pages:
+nav:
 - Main: 'index.md'
 - Getting Started:
   - 'Requesting your course space': 'requestCourse.md'


### PR DESCRIPTION
This PR fixes the workshop documentation, removing outdated content:
- fixes links to PL and request course information
- remove mention to CBTF
- remove outdated reference to spreadsheet for the HW
   