### PR TITLE
fix: Show plot labels in stats pages

### DIFF
--- a/public/stylesheets/local.css
+++ b/public/stylesheets/local.css
@@ -57,6 +57,7 @@ line.axis {
 .statsPlot .label {
     font-size: 14px;
     font-weight: normal;
+    fill: black;
 }
 
 .statsPlot .fitLine {


### PR DESCRIPTION
Fix #5535. The issue was that labels were white on a white background. This PR just changes them to be black.