### PR TITLE
fix: Don't error on 'null' in HTML templates

### DIFF
--- a/.changeset/fresh-months-tap.md
+++ b/.changeset/fresh-months-tap.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/html': patch
+---
+
+Fix rendering of null values in templates

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -39,6 +39,10 @@ describe('html', () => {
   it('omits boolean values from template', () => {
     assert.equal(html`<p>${true}${false}</p>`.toString(), '<p></p>');
   });
+
+  it('omits nullish values from template', () => {
+    assert.equal(html`<p>${null}${undefined}</p>`.toString(), '<p></p>');
+  });
 });
 
 describe('escapeHtml', () => {

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -9,10 +9,13 @@ function escapeValue(value: unknown): string {
     return value.map((val) => escapeValue(val)).join('');
   } else if (typeof value === 'string' || typeof value === 'number') {
     return ejs.escapeXML(String(value));
+  } else if (value == null) {
+    // undefined or null -- render nothing
+    return '';
   } else if (typeof value === 'object') {
-    throw new Error('Cannot interpolate object in template');
+    throw new Error(`Cannot interpolate object in template: ${JSON.stringify(value)}`);
   } else {
-    // This is undefined, null, or a boolean - don't render anything here.
+    // This is boolean - don't render anything here.
     return '';
   }
 }


### PR DESCRIPTION
Because `typeof null === 'object'`, we would previously throw an error when trying to render `null` values: https://github.com/PrairieLearn/PrairieLearn/blob/69b1ad97bd8f2bb88fb205b487ea23929bcfdfe5/packages/html/src/index.ts#L12

This PR also prints a more informative error message when an object can't be rendered.

@nwalters512 can you remind me how to release a new version of this library after this PR is merged?