### PR TITLE
fix: Don't install anything R-related if SKIP_R_PACKAGES is set

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -29,8 +29,7 @@ yum -y install \
     git \
     graphviz \
     graphviz-devel \
-    # Needed by the Pillow package
-    libjpeg
+    libjpeg # Needed by the Pillow package
 
 yum clean all
 

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -66,11 +66,9 @@ if [[ "${arch}" != "aarch64"  ]] && [[ "${SKIP_R_PACKAGES}" != "yes" ]]; then
     echo "installing Python packages..."
     python3 -m pip install --no-cache-dir -r /python-requirements.txt
 
-    if [[ "${SKIP_R_PACKAGES}" != "yes" ]] ; then
-        echo "installing R packages..."
-        echo "set SKIP_R_PACKAGES=yes to skip this step"
-        Rscript /r-requirements.R
-    fi
+    echo "installing R packages..."
+    echo "set SKIP_R_PACKAGES=yes to skip this step"
+    Rscript /r-requirements.R
 else
     echo "R package installation is disabled"
     sed '/rpy2/d' /python-requirements.txt > /py_req_no_r.txt # Remove rpy2 package.

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -56,7 +56,9 @@ arch=`uname -m`
 curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${arch}.sh
 bash Miniforge3-Linux-${arch}.sh -b -p /usr/local -f
 
-if [[ "${arch}" != "aarch64" ]]; then # R is not yet supported on ARM64.
+# R is not yet supported on ARM64. If we're on ARM64 or R package installation
+# is specifically disabled, we'll avoid installing anything R-related.
+if [[ "${arch}" != "aarch64"  ]] && [[ "${SKIP_R_PACKAGES}" != "yes" ]]; then
     echo "installing R..."
     conda install r-essentials
 
@@ -69,6 +71,7 @@ if [[ "${arch}" != "aarch64" ]]; then # R is not yet supported on ARM64.
         Rscript /r-requirements.R
     fi
 else
+    echo "R package installation is disabled"
     sed '/rpy2/d' /python-requirements.txt > /py_req_no_r.txt # Remove rpy2 package.
     echo "installing Python packages..."
     python3 -m pip install --no-cache-dir -r /py_req_no_r.txt

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -28,7 +28,9 @@ yum -y install \
     texlive-dvipng \
     git \
     graphviz \
-    graphviz-devel
+    graphviz-devel \
+    # Needed by the Pillow package
+    libjpeg
 
 yum clean all
 

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -29,7 +29,7 @@ yum -y install \
     git \
     graphviz \
     graphviz-devel \
-    libjpeg # Needed by the Pillow package
+    libjpeg-devel # Needed by the Pillow package
 
 yum clean all
 


### PR DESCRIPTION
R packages take up a lot of time and space, so I'll often set `SKIP_R_PACKAGES=yes` when I'm trying to work quickly in a non-production environment, e.g. build a new EC2 AMI to test. However, even with that flag set, we would still install `r-essentials` and `rpy2`. This PR changes that such that `SKIP_R_PACKAGES=yes` won't install *anything* R-related.