### PR TITLE
fix: Improve security of cookies

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -811,7 +811,7 @@ function foo(p, callback) {
 
   1. We first redirect to a remote authentication service (either Shibboleth or Google OAuth2 servers). For Shibboleth this happens by the “Login to PL” button linking to `/pl/shibcallback` for which Apache handles the Shibboleth redirections. For Google the “Login to PL” button links to `/pl/auth2login` which sets up the authentication data and redirects to Google.
 
-  2. The remote authentication service redirects back to `/pl/shibcallback` (for Shibboleth) or `/pl/auth2callback` (for Google). These endpoints confirm authentication, create the user in the `users` table if necessary, set a signed `pl_authn` cookie in the browser with the authenticated `user_id`, and then redirect to the main PL homepage.
+  2. The remote authentication service redirects back to `/pl/shibcallback` (for Shibboleth) or `/pl/auth2callback` (for Google). These endpoints confirm authentication, create the user in the `users` table if necessary, set a signed `pl_authn` cookie in the browser with the authenticated `user_id`, and then redirect to the main PL homepage. This cookie is set with the `HttpOnly` attribute, which prevents client-side JavaScript from reading the cookie.
 
   3. Every other page authenticates using the signed browser `pl_authn` cookie. This is read by [`middlewares/authn.js`](https://github.com/PrairieLearn/PrairieLearn/blob/master/middlewares/authn.js) which checks the signature and then loads the user data from the DB using the `user_id`, storing it as `res.locals.authn_user`.
 

--- a/middlewares/authn.js
+++ b/middlewares/authn.js
@@ -176,6 +176,7 @@ module.exports = function (req, res, next) {
     res.cookie('pl_authn', pl_authn, {
       maxAge: config.authnCookieMaxAgeMilliseconds,
       httpOnly: true,
+      secure: true,
     });
 
     next();

--- a/middlewares/authn.js
+++ b/middlewares/authn.js
@@ -175,6 +175,7 @@ module.exports = function (req, res, next) {
     var pl_authn = csrf.generateToken(tokenData, config.secretKey);
     res.cookie('pl_authn', pl_authn, {
       maxAge: config.authnCookieMaxAgeMilliseconds,
+      httpOnly: true,
     });
 
     next();

--- a/middlewares/authzWorkspaceCookieSet.js
+++ b/middlewares/authzWorkspaceCookieSet.js
@@ -16,6 +16,8 @@ module.exports = (req, res, next) => {
   const cookieData = csrf.generateToken(tokenData, config.secretKey);
   res.cookie(cookieName, cookieData, {
     maxAge: config.workspaceAuthzCookieMaxAgeMilliseconds,
+    httpOnly: true,
+    secure: true,
   });
   next();
 };

--- a/pages/authCallbackAzure/authCallbackAzure.js
+++ b/pages/authCallbackAzure/authCallbackAzure.js
@@ -34,6 +34,7 @@ router.all('/', function (req, res, next) {
       var pl_authn = csrf.generateToken(tokenData, config.secretKey);
       res.cookie('pl_authn', pl_authn, {
         maxAge: config.authnCookieMaxAgeMilliseconds,
+        httpOnly: true,
       });
       var redirUrl = res.locals.homeUrl;
       if ('preAuthUrl' in req.cookies) {

--- a/pages/authCallbackAzure/authCallbackAzure.js
+++ b/pages/authCallbackAzure/authCallbackAzure.js
@@ -35,6 +35,7 @@ router.all('/', function (req, res, next) {
       res.cookie('pl_authn', pl_authn, {
         maxAge: config.authnCookieMaxAgeMilliseconds,
         httpOnly: true,
+        secure: true,
       });
       var redirUrl = res.locals.homeUrl;
       if ('preAuthUrl' in req.cookies) {

--- a/pages/authCallbackLti/authCallbackLti.js
+++ b/pages/authCallbackLti/authCallbackLti.js
@@ -130,6 +130,7 @@ router.post('/', function (req, res, next) {
         var pl_authn = csrf.generateToken(tokenData, config.secretKey);
         res.cookie('pl_authn', pl_authn, {
           maxAge: config.authnCookieMaxAgeMilliseconds,
+          httpOnly: true,
         });
 
         const params = {

--- a/pages/authCallbackLti/authCallbackLti.js
+++ b/pages/authCallbackLti/authCallbackLti.js
@@ -131,6 +131,7 @@ router.post('/', function (req, res, next) {
         res.cookie('pl_authn', pl_authn, {
           maxAge: config.authnCookieMaxAgeMilliseconds,
           httpOnly: true,
+          secure: true,
         });
 
         const params = {

--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -63,6 +63,7 @@ router.get('/', function (req, res, next) {
       res.cookie('pl_authn', pl_authn, {
         maxAge: config.authnCookieMaxAgeMilliseconds,
         httpOnly: true,
+        secure: true,
       });
       let redirUrl = res.locals.homeUrl;
       if ('preAuthUrl' in req.cookies) {

--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -62,6 +62,7 @@ router.get('/', function (req, res, next) {
       const pl_authn = csrf.generateToken(tokenData, config.secretKey);
       res.cookie('pl_authn', pl_authn, {
         maxAge: config.authnCookieMaxAgeMilliseconds,
+        httpOnly: true,
       });
       let redirUrl = res.locals.homeUrl;
       if ('preAuthUrl' in req.cookies) {

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -31,6 +31,7 @@ router.get('/:action?/:target(*)?', function (req, res, next) {
     var pl_authn = csrf.generateToken(tokenData, config.secretKey);
     res.cookie('pl_authn', pl_authn, {
       maxAge: config.authnCookieMaxAgeMilliseconds,
+      httpOnly: true,
     });
     if (req.params.action === 'redirect') return res.redirect('/' + req.params.target);
     var redirUrl = res.locals.homeUrl;

--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -32,6 +32,7 @@ router.get('/:action?/:target(*)?', function (req, res, next) {
     res.cookie('pl_authn', pl_authn, {
       maxAge: config.authnCookieMaxAgeMilliseconds,
       httpOnly: true,
+      secure: true,
     });
     if (req.params.action === 'redirect') return res.redirect('/' + req.params.target);
     var redirUrl = res.locals.homeUrl;

--- a/pages/authPassword/authPassword.js
+++ b/pages/authPassword/authPassword.js
@@ -15,11 +15,8 @@ router.post('/', function (req, res) {
     var pl_pw_origUrl = req.cookies.pl_pw_origUrl;
     var maxAge = 1000 * 60 * 60 * 12; // 12 hours
 
-    var pwCookie = csrf.generateToken(
-      { password: req.body.password, maxAge: maxAge },
-      config.secretKey
-    );
-    res.cookie('pl_assessmentpw', pwCookie, { maxAge: maxAge });
+    var pwCookie = csrf.generateToken({ password: req.body.password, maxAge }, config.secretKey);
+    res.cookie('pl_assessmentpw', pwCookie, { maxAge, httpOnly: true, secure: true });
     res.clearCookie('pl_pw_origUrl');
     return res.redirect(pl_pw_origUrl);
   }


### PR DESCRIPTION
This change ensures that our authentication cookie won't be accessible to client-side JavaScript, which is a security best practice (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies).