### PR TITLE
fix: Use data attributes in pl-xss-safe

### DIFF
--- a/elements/pl-xss-safe/pl-xss-safe.mustache
+++ b/elements/pl-xss-safe/pl-xss-safe.mustache
@@ -1,7 +1,7 @@
-<script>
+<script data-code="{{contents}}" data-language="{{language}}">
 (function() {
-    let code = {{{quoted_code}}};
-    let language = "{{language}}";
+    let code = $(document.currentScript).data("code");
+    let language = $(document.currentScript).data("language");
     // Uses the same JS library as the pl-file-editor for markdown
     // conversion and xss filter for compatibility and to avoid
     // confusion

--- a/elements/pl-xss-safe/pl-xss-safe.py
+++ b/elements/pl-xss-safe/pl-xss-safe.py
@@ -2,7 +2,6 @@ import prairielearn as pl
 import lxml.html
 import chevron
 import os
-import json
 import base64
 
 SOURCE_FILE_NAME_DEFAULT = None

--- a/elements/pl-xss-safe/pl-xss-safe.py
+++ b/elements/pl-xss-safe/pl-xss-safe.py
@@ -58,13 +58,8 @@ def render(element_html, data):
     # Chop off ending newlines and spaces
     contents = contents.rstrip()
 
-    # JSON dumps adds the quotes and escapes needed to have the string
-    # be assigned to a JS expression.
-    quoted_code = json.dumps(contents)
-
     html_params = {
         'contents': contents,
-        'quoted_code': quoted_code,
         'language': pl.get_string_attrib(element, 'language', LANGUAGE_DEFAULT)
     }
 


### PR DESCRIPTION
Instead of templating the student-provided content to a variable in the `pl-xss-safe` element, it is passed as a data attribute (`data-code`). This removes an XSS vector where a closing `</script>` tag gets interpreted, so the content is never sanitized.

For consistency, the language is also passed as a data attribute (`data-language`).

@jonatanschroeder 