### PR TITLE
chore: Add s3rver file store to ignore list for nodemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
         "ignore": [
             "public/*",
             "exampleCourse/*",
-            "testCourse/*"
+            "testCourse/*",
+            "s3rver/file-store/*"
         ],
         "ext": "js,json,sql"
     },

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
             "public/*",
             "exampleCourse/*",
             "testCourse/*",
-            "s3rver/file-store/*"
+            "s3rver/*"
         ],
         "ext": "js,json,sql"
     },


### PR DESCRIPTION
I noticed that every time I saved a file in the Web interface `nodemon` would restart the server. This seems to be related to the fact that saving a file in the file editing interfaces causes a JSON file to be added to `s3rver/file-store`, which triggers `nodemon` to restart the server. This change causes this directory to be ignored by `nodemon`.