### PR TITLE
docs: Fix indentation in `workspaceOptions` list

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs>=1.0
+mdx_truly_sane_lists>=1.2

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -55,17 +55,17 @@ questions
 The question's `info.json` should set the `singleVariant` and `workspaceOptions` properties:
 
 - `"singleVariant": true` will prevent student workspaces from resetting due to new variants being generated
-    - Note that new variants will still be generated in `Staff view`
+  - Note that new variants will still be generated in `Staff view`
 - `workspaceOptions` contains the following properties:
-    - `image`: Docker Hub image serving the IDE and containing the desired compilers, debuggers, etc.
-    - `port`: port number used by the workspace app inside the Docker image
-    - `home`: home directory inside the Docker image -- this should match the running user's home directory specified by the image maintainer and can't be used (for example) to switch the running user or their home directory
-    - `gradedFiles` (optional, default none): list of file paths (relative to the `home` path) that will be copied out of the workspace container for grading. Files can be in subdirectories, but the files must be explicitly listed (e.g. listing `dir/file.txt` is okay, but specifying `dir` alone is not). If a file is in a subdirectory, the relative path to the file will be reconstructed inside the autograder.
-    - `args` (optional, default none): command line arguments to pass to the Docker image
-    - `syncIgnore` (optional, default none): list of files or directories that will be excluded from sync
-    - `rewriteUrl` (optional, default true): if true, the URL will be rewritten such that the workspace container will see all requests as originating from /
-    - `enableNetworking` (optional, default false): whether the workspace should be allowed to connect to the public internet. This is disabled by default to make secure, isolated execution the default behavior. This restriction is not enforced when running PrairieLearn in local development mode. It is strongly recommended to use the default (no networking) for exam questions, because network access can be used to enable cheating. Only enable networking for homework questions, and only if it is strictly required, for example for downloading data from the internet.
-    - `environment` (optional, default `{}`): environment variables to set inside the workspace container. Set variables using `{"VAR": "value", ...}`, and unset variables using `{"VAR": null}` (no quotes around `null`).
+  - `image`: Docker Hub image serving the IDE and containing the desired compilers, debuggers, etc.
+  - `port`: port number used by the workspace app inside the Docker image
+  - `home`: home directory inside the Docker image -- this should match the running user's home directory specified by the image maintainer and can't be used (for example) to switch the running user or their home directory
+  - `gradedFiles` (optional, default none): list of file paths (relative to the `home` path) that will be copied out of the workspace container for grading. Files can be in subdirectories, but the files must be explicitly listed (e.g. listing `dir/file.txt` is okay, but specifying `dir` alone is not). If a file is in a subdirectory, the relative path to the file will be reconstructed inside the autograder.
+  - `args` (optional, default none): command line arguments to pass to the Docker image
+  - `syncIgnore` (optional, default none): list of files or directories that will be excluded from sync
+  - `rewriteUrl` (optional, default true): if true, the URL will be rewritten such that the workspace container will see all requests as originating from /
+  - `enableNetworking` (optional, default false): whether the workspace should be allowed to connect to the public internet. This is disabled by default to make secure, isolated execution the default behavior. This restriction is not enforced when running PrairieLearn in local development mode. It is strongly recommended to use the default (no networking) for exam questions, because network access can be used to enable cheating. Only enable networking for homework questions, and only if it is strictly required, for example for downloading data from the internet.
+  - `environment` (optional, default `{}`): environment variables to set inside the workspace container. Set variables using `{"VAR": "value", ...}`, and unset variables using `{"VAR": null}` (no quotes around `null`).
 
 #### `info.json` for ungraded workspace
 

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -55,17 +55,17 @@ questions
 The question's `info.json` should set the `singleVariant` and `workspaceOptions` properties:
 
 - `"singleVariant": true` will prevent student workspaces from resetting due to new variants being generated
-  - Note that new variants will still be generated in `Staff view`
+    - Note that new variants will still be generated in `Staff view`
 - `workspaceOptions` contains the following properties:
-  - `image`: Docker Hub image serving the IDE and containing the desired compilers, debuggers, etc.
-  - `port`: port number used by the workspace app inside the Docker image
-  - `home`: home directory inside the Docker image -- this should match the running user's home directory specified by the image maintainer and can't be used (for example) to switch the running user or their home directory
-  - `gradedFiles` (optional, default none): list of file paths (relative to the `home` path) that will be copied out of the workspace container for grading. Files can be in subdirectories, but the files must be explicitly listed (e.g. listing `dir/file.txt` is okay, but specifying `dir` alone is not). If a file is in a subdirectory, the relative path to the file will be reconstructed inside the autograder.
-  - `args` (optional, default none): command line arguments to pass to the Docker image
-  - `syncIgnore` (optional, default none): list of files or directories that will be excluded from sync
-  - `rewriteUrl` (optional, default true): if true, the URL will be rewritten such that the workspace container will see all requests as originating from /
-  - `enableNetworking` (optional, default false): whether the workspace should be allowed to connect to the public internet. This is disabled by default to make secure, isolated execution the default behavior. This restriction is not enforced when running PrairieLearn in local development mode. It is strongly recommended to use the default (no networking) for exam questions, because network access can be used to enable cheating. Only enable networking for homework questions, and only if it is strictly required, for example for downloading data from the internet.
-  - `environment` (optional, default `{}`): environment variables to set inside the workspace container. Set variables using `{"VAR": "value", ...}`, and unset variables using `{"VAR": null}` (no quotes around `null`).
+    - `image`: Docker Hub image serving the IDE and containing the desired compilers, debuggers, etc.
+    - `port`: port number used by the workspace app inside the Docker image
+    - `home`: home directory inside the Docker image -- this should match the running user's home directory specified by the image maintainer and can't be used (for example) to switch the running user or their home directory
+    - `gradedFiles` (optional, default none): list of file paths (relative to the `home` path) that will be copied out of the workspace container for grading. Files can be in subdirectories, but the files must be explicitly listed (e.g. listing `dir/file.txt` is okay, but specifying `dir` alone is not). If a file is in a subdirectory, the relative path to the file will be reconstructed inside the autograder.
+    - `args` (optional, default none): command line arguments to pass to the Docker image
+    - `syncIgnore` (optional, default none): list of files or directories that will be excluded from sync
+    - `rewriteUrl` (optional, default true): if true, the URL will be rewritten such that the workspace container will see all requests as originating from /
+    - `enableNetworking` (optional, default false): whether the workspace should be allowed to connect to the public internet. This is disabled by default to make secure, isolated execution the default behavior. This restriction is not enforced when running PrairieLearn in local development mode. It is strongly recommended to use the default (no networking) for exam questions, because network access can be used to enable cheating. Only enable networking for homework questions, and only if it is strictly required, for example for downloading data from the internet.
+    - `environment` (optional, default `{}`): environment variables to set inside the workspace container. Set variables using `{"VAR": "value", ...}`, and unset variables using `{"VAR": null}` (no quotes around `null`).
 
 #### `info.json` for ungraded workspace
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,12 @@ docs_dir: docs
 # Fix "Edit on GitHub" link: (defaults to edit/master/docs/, note the s)
 edit_uri: blob/master/docs/
 
+markdown_extensions:
+  # Allows us to use 2-space indents on lists, which is compatible with how
+  # Prettier formats Markdown files.
+  # https://pypi.org/project/mdx-truly-sane-lists/
+  - mdx_truly_sane_lists
+
 extra_javascript:
   - mathjax-config.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js


### PR DESCRIPTION
Readthedocs markdown needs 4 space indent for nested lists.