### PR TITLE
feat: Add assessment submissions API endpoint

### DIFF
--- a/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
+++ b/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
@@ -43,6 +43,7 @@ router.get('/:unsafe_assessment_instance_id/instance_questions', (req, res, next
 router.get('/:unsafe_assessment_instance_id/submissions', (req, res, next) => {
   const params = {
     course_instance_id: res.locals.course_instance.id,
+    unsafe_assessment_id: null,
     unsafe_assessment_instance_id: req.params.unsafe_assessment_instance_id,
     unsafe_submission_id: null,
   };

--- a/api/v1/endpoints/courseInstanceAssessments/index.js
+++ b/api/v1/endpoints/courseInstanceAssessments/index.js
@@ -62,4 +62,17 @@ router.get('/:unsafe_assessment_id/assessment_access_rules', (req, res, next) =>
   });
 });
 
+router.get('/:unsafe_assessment_id/submissions', (req, res, next) => {
+  const params = {
+    course_instance_id: res.locals.course_instance.id,
+    unsafe_assessment_id: req.params.unsafe_assessment_id,
+    unsafe_assessment_instance_id: null,
+    unsafe_submission_id: null,
+  };
+  sqldb.queryOneRow(sql.select_submissions, params, (err, result) => {
+    if (ERR(err, next)) return;
+    res.status(200).send(result.rows[0].item);
+  });
+});
+
 module.exports = router;

--- a/api/v1/endpoints/courseInstanceSubmissions/index.js
+++ b/api/v1/endpoints/courseInstanceSubmissions/index.js
@@ -13,6 +13,7 @@ const sql = sqlLoader.load(path.join(__dirname, '..', 'queries.sql'));
 router.get('/:unsafe_submission_id', (req, res, next) => {
   const params = {
     course_instance_id: res.locals.course_instance.id,
+    unsafe_assessment_id: null,
     unsafe_assessment_instance_id: null,
     unsafe_submission_id: req.params.unsafe_submission_id,
   };

--- a/api/v1/endpoints/queries.sql
+++ b/api/v1/endpoints/queries.sql
@@ -257,6 +257,7 @@ WITH object_data AS (
         JOIN submissions AS s ON (s.variant_id = v.id)
     WHERE
         ci.id = $course_instance_id
+        AND ($unsafe_assessment_id::bigint IS NULL OR a.id = $unsafe_assessment_id)
         AND ($unsafe_assessment_instance_id::bigint IS NULL OR ai.id = $unsafe_assessment_instance_id)
         AND ($unsafe_submission_id::bigint IS NULL OR s.id = $unsafe_submission_id)
 )

--- a/docs/api.md
+++ b/docs/api.md
@@ -79,6 +79,11 @@ In the endpoint list below, path components starting with a colon like
   - `/pl/api/v1/course_instances/:course_instance_id/assessments/:assessment_id/assessment_access_rules`
   - All assessment access rules for a given assessment.
 
+- **Assessment submissions list:**
+
+  - `/pl/api/v1/course_instances/:course_instance_id/assessment/:assessment_id/submissions`
+  - All submissions for a given assessment.
+
 - **One assessment instance:**
 
   - `/pl/api/v1/course_instances/:course_instance_id/assessment_instances/:assessment_instance_id`
@@ -89,7 +94,7 @@ In the endpoint list below, path components starting with a colon like
   - `/pl/api/v1/course_instances/:course_instance_id/assessment_instances/:assessment_instance_id/instance_questions`
   - All instance questions for a given assessment instance.
 
-- **Submissions list:**
+- **Instance submissions list:**
 
   - `/pl/api/v1/course_instances/:course_instance_id/assessment_instances/:assessment_instance_id/submissions`
   - All submissions for a given assessment instance.

--- a/tests/testApi.js
+++ b/tests/testApi.js
@@ -148,7 +148,7 @@ describe('API', function () {
       locals.assessment_id = assessment.assessment_id;
     });
 
-    step('GET to API for single assesment succeeds', async function () {
+    step('GET to API for single assessment succeeds', async function () {
       locals.apiAssessmentUrl =
         locals.apiCourseInstanceUrl + `/assessments/${locals.assessment_id}`;
 
@@ -206,12 +206,12 @@ describe('API', function () {
       assert.equal(json.max_points, helperExam.assessmentMaxPoints);
     });
 
-    step('GET to API for assessment submissions succeeds', async function () {
-      locals.apiSubmissionsUrl =
+    step('GET to API for assessment instance submissions succeeds', async function () {
+      locals.apiAssessmentInstanceSubmissionsUrl =
         locals.apiCourseInstanceUrl +
         `/assessment_instances/${locals.assessment_instance_id}/submissions`;
 
-      const res = await fetch(locals.apiSubmissionsUrl, {
+      const res = await fetch(locals.apiAssessmentInstanceSubmissionsUrl, {
         headers: {
           'Private-Token': locals.api_token,
         },
@@ -291,6 +291,22 @@ describe('API', function () {
 
       const json = await res.json();
       assert.lengthOf(json, 1);
+    });
+
+    step('GET to API for assessment submissions succeeds', async function () {
+      locals.apiAssessmentSubmissionsUrl =
+        locals.apiCourseInstanceUrl + `/assessments/${locals.assessment_id}/submissions`;
+
+      const res = await fetch(locals.apiAssessmentSubmissionsUrl, {
+        headers: {
+          'Private-Token': locals.api_token,
+        },
+      });
+      assert.equal(res.status, 200);
+
+      const json = await res.json();
+      assert.lengthOf(json, 1);
+      assert.equal(json[0].instance_question_points, assessmentPoints);
     });
 
     step('GET to API for course instance access rules succeeds', async function () {


### PR DESCRIPTION
We're currently scraping all submissions across all assessment instances to calculate potential student grades at arbitrary deadlines. It would be nice to have this endpoint, as the 2 current alternatives are:
- `all_submissions.csv`, which is frontend-only and not easily automatable
- `GET /api/v1/course_instances/:course_instance_id/assessments/:assessment_id/assessment_instances` + multiple `GET /api/v1/course_instances/:id/assessment_instances/:assessment_instance_id/submissions` calls, which gets fairly expensive as we reach several hundred/thousand assessment instances