### PR TITLE
fix: Don't disable instrumentation if OpenTelemetry isn't enabled

### DIFF
--- a/.changeset/stale-actors-repeat.md
+++ b/.changeset/stale-actors-repeat.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/opentelemetry': patch
+---
+
+Don't disable instrumentation if OpenTelemetry isn't enabled

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -128,8 +128,13 @@ export interface OpenTelemetryConfig {
  */
 export async function init(config: OpenTelemetryConfig) {
   if (!config.openTelemetryEnabled) {
-    // Just disable all of the OTEL instrumentations to avoid any unnecessary overhead.
-    instrumentations.forEach((i) => i.disable());
+    // If not enabled, do nothing. We used to disable the instrumentations, but
+    // per maintainers, that can actually be problematic. See the comments on
+    // https://github.com/open-telemetry/opentelemetry-js-contrib/issues/970
+    // The Express instrumentation also logs a benign error, which can be
+    // confusing to users. There's a fix in progress if we want to switch back
+    // to disabling instrumentations in the future:
+    // https://github.com/open-telemetry/opentelemetry-js-contrib/pull/972
     return;
   }
 


### PR DESCRIPTION
Fixes the issue [reported on Slack](https://prairielearn.slack.com/archives/C0XBTPZMZ/p1649879271667649
) where the following is logged three times at startup:

```
no function to unwrap.
Error
  at ExpressInstrumentation.unwrap [as _unwrap] (/PrairieLearn/node_modules/shimmer/index.js:84:13)
  at InstrumentationNodeModuleDefinition.unpatch (/PrairieLearn/node_modules/@opentelemetry/instrumentation-express/build/src/instrumentation.js:72:22)
  at ExpressInstrumentation.disable (/PrairieLearn/node_modules/@opentelemetry/instrumentation/build/src/platform/node/instrumentation.js:123:24)
  at /PrairieLearn/packages/opentelemetry/dist/index.js:108:43
  at Array.forEach (<anonymous>)
  at Object.init (/PrairieLearn/packages/opentelemetry/dist/index.js:108:26)
  at async.series.msg (/PrairieLearn/server.js:1687:29)
```

We can consider reverting this once https://github.com/open-telemetry/opentelemetry-js-contrib/pull/972 lands, but per https://github.com/open-telemetry/opentelemetry-js-contrib/issues/970#issuecomment-1097782740, we might actually want this change to be permanent.