### PR TITLE
Fix desktop workspace build on arm64

### DIFF
--- a/workspaces/desktop/Dockerfile
+++ b/workspaces/desktop/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 COPY pre-install.sh /pre-install.sh
-RUN /bin/sh /pre-install.sh
+RUN /bin/bash /pre-install.sh
 COPY code.desktop /usr/share/applications/code.desktop
 
 COPY pl-gosu-helper.sh /pl-gosu-helper.sh
@@ -11,7 +11,7 @@ COPY local /opt/defaults/local
 COPY server /opt/server
 
 COPY post-install.sh /post-install.sh
-RUN /bin/sh /post-install.sh
+RUN /bin/bash /post-install.sh
 
 USER 1001
 ENV PL_USER prairielearner

--- a/workspaces/desktop/pre-install.sh
+++ b/workspaces/desktop/pre-install.sh
@@ -15,8 +15,13 @@ useradd -u 1001 -g 1001 -m -d /home/prairielearner -s /bin/bash prairielearner
 # install needed apps
 apt-get install xfce4-terminal firefox build-essential geany emacs-gtk vim-gtk nano gedit less -y
 
-# install vscode
-wget "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64" -O /vscode.deb
+# install vscode depending on what architecture we're building on
+arch=$(uname -m)
+if [ "$arch" == 'x86_64' ]; then
+    wget "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64" -O /vscode.deb
+else
+    wget "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-arm64" -O /vscode.deb
+fi
 apt-get install /vscode.deb -y
 rm /vscode.deb
 

--- a/workspaces/desktop/pre-install.sh
+++ b/workspaces/desktop/pre-install.sh
@@ -17,10 +17,13 @@ apt-get install xfce4-terminal firefox build-essential geany emacs-gtk vim-gtk n
 
 # install vscode depending on what architecture we're building on
 arch=$(uname -m)
-if [ "$arch" == 'x86_64' ]; then
+if [[ $arch == x86_64 ]]; then
     wget "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64" -O /vscode.deb
-else
+elif [[ $arch == arm* ]] || [[ $arch == aarch64 ]]; then
     wget "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-arm64" -O /vscode.deb
+else
+    echo "Unknown architecture $arch"
+    exit 1
 fi
 apt-get install /vscode.deb -y
 rm /vscode.deb


### PR DESCRIPTION
Was previously broken because we were always downloading x64 vscode.  Now we download the correct version based on the platform.