### PR TITLE
feat(opentelemetry): Don't handle SIGTERM by default

### DIFF
--- a/.changeset/pink-cameras-wink.md
+++ b/.changeset/pink-cameras-wink.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/opentelemetry': mainor
+---
+
+Don't handle `SIGTERM`; expose `shutdown()` function

--- a/server.js
+++ b/server.js
@@ -1608,6 +1608,7 @@ module.exports.initExpress = function () {
 //////////////////////////////////////////////////////////////////////
 // Server startup ////////////////////////////////////////////////////
 
+/** @type {import('http').Server | import('https').Server} */
 var server;
 
 module.exports.startServer = async () => {
@@ -1938,6 +1939,15 @@ if (config.startServer) {
           logger.info('exit option passed, quitting...');
           process.exit(0);
         }
+
+        process.on('SIGTERM', () => {
+          opentelemetry
+            .shutdown()
+            .catch((err) => logger.error('Error shutting down OpenTelemetry', err))
+            .finally(() => {
+              process.exit(0);
+            });
+        });
       }
     }
   );


### PR DESCRIPTION
Before this change, a process receiving `SIGTERM` wouldn't actually terminate. Now, it does!

Instead of having `@prairielearn/opentelemetry` handle `SIGTERM`, I opted to just expose a `shutdown()` function that a consumer could call. This makes it possible to coordinate with other handlers that need to do something before the process exits.

I tested this locally by setting `"openTelemetryEnabled": true` in my `config.json`, starting PL, finding its PID with `ps aux | grep "node server.js"`, and then running `kill -TERM $PID`