### PR TITLE
feat(html): Add type constraints for interpolated values

### DIFF
--- a/.changeset/eight-carrots-hug.md
+++ b/.changeset/eight-carrots-hug.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/html': minor
+---
+
+Type constraints for interpolated values

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -31,6 +31,7 @@ describe('html', () => {
 
   it('errors when interpolating object', () => {
     assert.throws(
+      // @ts-expect-error
       () => html`<p>${{ foo: 'bar' }}</p>`.toString(),
       'Cannot interpolate object in template'
     );

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -54,7 +54,9 @@ export class HtmlSafeString {
   }
 }
 
-export function html(strings: TemplateStringsArray, ...values: any[]): HtmlSafeString {
+export type HtmlValue = string | number | boolean | HtmlSafeString | undefined | null | HtmlValue[];
+
+export function html(strings: TemplateStringsArray, ...values: HtmlValue[]): HtmlSafeString {
   return new HtmlSafeString(strings, values);
 }
 


### PR DESCRIPTION
Now, we'll get compile-time warnings for trying to interpolate objects in an `html` tagged template literal. This matches the runtime behavior, which is to throw an error.

Closes https://github.com/PrairieLearnInc/PrairieTest/issues/464.