### PR TITLE
fix edge case in EJS for LTI admin page

### DIFF
--- a/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.ejs
+++ b/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.ejs
@@ -157,12 +157,14 @@
                     <option value="" <% if (!link.assessment_id) { %>selected<% } %>>
                       -- None
                     </option>
+                    <% if (assessments) { %>
                     <% assessments.forEach(function(a) { %>
                     <option value="<%= a.assessment_id %>"
                             <% if (link.assessment_id == a.assessment_id) { %>selected<% } %>
                             ><%= a.label %>: <%= a.title %> (<%= a.tid %>)
                     </option>
                     <% }); %>
+                    <% } %>
                   </select>
                 </form>
               </td>


### PR DESCRIPTION
Fixes #5672 

In the rare case that you initiate LTI linking from an LTI consumer on a new course instance with no assessments, visiting the LTI admin page crashes the template with a specific combination of variables being defined while `assessments` is null. This fix prevents iterating over the null array.

I haven't tested this yet due to the complexity of mocking the LTI consumer situation.