### PR TITLE
Python grader: update scipy requirement to 1.8.0 for networkx

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -2,7 +2,7 @@ matplotlib==3.4.3
 networkx==2.8
 numpy==1.21.2
 pandas==1.3.2
-scipy==1.7.1
+scipy==1.8.0
 sympy==1.8
 Pillow==8.4.0
 pygraphviz==1.6


### PR DESCRIPTION
Fixes #5679 so that networkx will work as expected.

However, we need to be sure that updating scipy won't break anything else for other users. If this unacceptable, then perhaps networkx needs to be downgraded to what it was previously.