### PR TITLE
Ensure remove-spaces on pl-string-input removes all whitespace

### DIFF
--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -243,8 +243,8 @@ def grade(element_html, data):
 
     # Remove the blank spaces between characters
     if (remove_spaces):
-        a_sub = "".join(a_sub.split())
-        a_tru = "".join(a_tru.split())
+        a_sub = ''.join(a_sub.split())
+        a_tru = ''.join(a_tru.split())
 
     # Modify string case for submission and true answer to be lower.
     if (ignore_case):

--- a/elements/pl-string-input/pl-string-input.py
+++ b/elements/pl-string-input/pl-string-input.py
@@ -243,8 +243,8 @@ def grade(element_html, data):
 
     # Remove the blank spaces between characters
     if (remove_spaces):
-        a_sub = a_sub.replace(' ', '')
-        a_tru = a_tru.replace(' ', '')
+        a_sub = "".join(a_sub.split())
+        a_tru = "".join(a_tru.split())
 
     # Modify string case for submission and true answer to be lower.
     if (ignore_case):


### PR DESCRIPTION
The `remove-leading-training` option removes all whitespace from the beginning and end of a string, but `remove-spaces` only removed the space character. Other whitespace (tabs, for example) were not removed.

This PR updates `remove-spaces` to remove other whitespace as well.