### PR TITLE
Temporarily downgrade networkx

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.4.3
-networkx==2.8
+networkx==2.6.2
 numpy==1.21.2
 pandas==1.3.2
 scipy==1.7.1


### PR DESCRIPTION
This reverts the change from #5650. `networkx==2.8` requires `scipy>=1.8`, but we currently have an older version installed (`1.7.1`). Rather than bumping `scipy` right now, we're going to wait til after finals are over. I opened #5685 to track that.

Fixes #5679.