### PR TITLE
Add logs to help debug failing question tests in CI

### DIFF
--- a/tests/helperQuestion.js
+++ b/tests/helperQuestion.js
@@ -787,23 +787,23 @@ module.exports = {
           setTimeout(checkComplete, 10);
         });
         it('should be successful and produce no issues', async function () {
+          const issues = await sqldb.queryAsync(sql.select_issues_for_last_variant, []);
+
           // To aid in debugging, if the job failed, we'll fetch the logs from
-          // all child jobs and print them out.
+          // all child jobs and print them out. We'll also log any issues. We
+          // do this before making assertions to ensure that they're printed.
           if (locals.job_sequence.status !== 'Success') {
             console.log(locals.job_sequence);
             const params = { job_sequence_id: locals.job_sequence_id };
             const result = await sqldb.queryAsync(sql.select_jobs, params);
             console.log(result.rows);
           }
-          assert.equal(locals.job_sequence.status, 'Success');
-
-          const issues = await sqldb.queryAsync(sql.select_issues_for_last_variant, []);
-          if (issues.rowCount > 0) {
-            throw new Error(
-              `found ${issues.rowCount} issues (expected zero issues):\n` +
-                JSON.stringify(issues.rows, null, '    ')
-            );
+          if (issues.rows.length > 0) {
+            console.log(issues.rows);
           }
+
+          assert.equal(locals.job_sequence.status, 'Success');
+          assert.length(issues.rows, 0);
         });
       });
     });

--- a/tests/helperQuestion.js
+++ b/tests/helperQuestion.js
@@ -803,7 +803,7 @@ module.exports = {
           }
 
           assert.equal(locals.job_sequence.status, 'Success');
-          assert.length(issues.rows, 0);
+          assert.lengthOf(issues.rows, 0);
         });
       });
     });

--- a/tests/helperQuestion.js
+++ b/tests/helperQuestion.js
@@ -776,8 +776,8 @@ module.exports = {
             var params = { job_sequence_id: locals.job_sequence_id };
             sqldb.queryOneRow(sql.select_job_sequence, params, (err, result) => {
               if (ERR(err, callback)) return;
-              locals.job_sequence_status = result.rows[0].status;
-              if (locals.job_sequence_status === 'Running') {
+              locals.job_sequence = result.rows[0];
+              if (locals.job_sequence.status === 'Running') {
                 setTimeout(checkComplete, 10);
               } else {
                 callback(null);
@@ -786,23 +786,24 @@ module.exports = {
           };
           setTimeout(checkComplete, 10);
         });
-        it('should be successful', function () {
-          assert.equal(locals.job_sequence_status, 'Success');
-        });
-        it('should produce no issues', function (callback) {
-          sqldb.query(sql.select_issues_for_last_variant, [], (err, result) => {
-            if (ERR(err, callback)) return;
-            if (result.rowCount > 0) {
-              callback(
-                new Error(
-                  `found ${result.rowCount} issues (expected zero issues):\n` +
-                    JSON.stringify(result.rows, null, '    ')
-                )
-              );
-              return;
-            }
-            callback(null);
-          });
+        it('should be successful and produce no issues', async function () {
+          // To aid in debugging, if the job failed, we'll fetch the logs from
+          // all child jobs and print them out.
+          if (locals.job_sequence.status !== 'Success') {
+            console.log(locals.job_sequence);
+            const params = { job_sequence_id: locals.job_sequence_id };
+            const result = await sqldb.queryAsync(sql.select_jobs, params);
+            console.log(result.rows);
+          }
+          assert.equal(locals.job_sequence.status, 'Success');
+
+          const issues = await sqldb.queryAsync(sql.select_issues_for_last_variant, []);
+          if (issues.rowCount > 0) {
+            throw new Error(
+              `found ${issues.rowCount} issues (expected zero issues):\n` +
+                JSON.stringify(issues.rows, null, '    ')
+            );
+          }
         });
       });
     });


### PR DESCRIPTION
I've noticed tests, specifically "Auto-test questions in exampleCourse", failing intermittently in CI, e.g. on https://github.com/PrairieLearn/PrairieLearn/pull/5673 (failing run: https://github.com/PrairieLearn/PrairieLearn/runs/6234885939). We don't currently have enough logs for the failure case to tell went wrong. This PR adds those. This is consistent with the [logs in the `waitForJobSequence` function](https://github.com/PrairieLearn/PrairieLearn/blob/529f6dffb1b5b79d1d0ebf777a99741eab8f6aa7/tests/helperQuestion.js#L39).