### PR TITLE
Add opacity attribute to some drawing elements

### DIFF
--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -137,6 +137,7 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `angle`        | float  | 0       | Angle of rotation around the start point of the line. Angles are measured from the horizontal axis and are positive clockwise.                                                                                                                      |
 | `x2`           | float  | -       | `x` position for the end point for the line, i.e., the horizontal distance from the left border of the canvas. By default, `(x2,y2)` are determined from `angle` and `width`. If `x2` and `y2` are provided, then `angle` and `width` are replaced. |
 | `y2`           | float  | -       | `y` position for the end point for the line, i.e., the vertical distance from the top border of the canvas. By default, `(x2,y2)` are determined from `angle` and `width`. If `x2` and `y2` are provided, then `angle` and `width` are replaced.    |
+| `opacity`      | float  | 1       | Set the opacity of the line                                                                                                                                                                                                                         |
 | `stroke-color` | string | black   | Set the color of the line ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) )                                                                                   |
 | `stroke-width` | float  | 2       | Set the width of the stroke.                                                                                                                                                                                                                        |
 | `dashed-size`  | float  | \_      | Creates a dashed line with equally spaced `dashed-size`px fills.                                                                                                                                                                                    |
@@ -179,9 +180,12 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `radius`       | float  | 20      | Radius of the circle.                                                                                                                                                            |
 | `start-angle`  | float  | 0       | Start angle of the arc. Angles are measured from the horizontal axis and are positive clockwise.                                                                                 |
 | `end-angle`    | float  | 90      | End angle of the arc. Angles are measured from the horizontal axis and are positive clockwise. Arcs are formed from `start-angle` to `end-angle` going on clockwise orientation. |
+| `opacity`      | float  | 1       | Set the opacity of the arc.                                                                                                                                                      |
 | `stroke-color` | string | black   | Set the stroke color of the line ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) ).        |
 | `stroke-width` | float  | 2       | Set the width of the stroke.                                                                                                                                                     |
 | `dashed-size`  | float  | \_      | Creates a dashed line with equally spaced `dashed-size`px fills.                                                                                                                 |
+
+
 
 #### Example implementations
 
@@ -212,6 +216,7 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `label`   | string | -       | Text to label the point.                                                                                                                                                 |
 | `offsetx` | float  | 5       | Horizontal distance of `label` from the point.                                                                                                                           |
 | `offsety` | float  | 5       | Vertical distance of `label` from the point.                                                                                                                             |
+| `opacity` | float  | 1       | Set the opacity of the point.                                                                                                                                            |
 | `color`   | string | black   | Set the fill color of the point ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) ). |
 
 #### Example implementations
@@ -244,6 +249,7 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `y2`           | float  | 20      | `y` position for vertex 2, i.e., the vertical distance from the top border of the canvas.                                                                                   |
 | `x3`           | float  | 20      | `x` position for vertex 3, i.e., the horizontal distance from the left border of the canvas.                                                                                |
 | `y3`           | float  | 20      | `y` position for vertex 3, i.e., the vertical distance from the top border of the canvas.                                                                                   |
+| `opacity`      | float  | 1       | Set the opacity of the entire element (both line and fill).                                                                                                                 |
 | `color`        | string | red1    | Set the fill color of the triangle ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) ). |
 | `stroke-color` | string | black   | Set the stroke color of the triangle.                                                                                                                                       |
 | `stroke-width` | float  | 1       | Set the width of the stroke.                                                                                                                                                |
@@ -278,6 +284,7 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `height`       | float  | 20      | Height of the rectangle.                                                                                                                                                     |
 | `width`        | float  | 20      | Width of the rectangle.                                                                                                                                                      |
 | `angle`        | float  | 0       | Angle of rotation around the center of the rectangle. Angles are measured from the horizontal axis and are positive clockwise.                                               |
+| `opacity`      | float  | 1       | Set the opacity of the entire element (both line and fill).                                                                                                                  |
 | `color`        | string | green1  | Set the fill color of the rectangle ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) ). |
 | `stroke-color` | string | black   | Set the stroke color of the rectangle.                                                                                                                                       |
 | `stroke-width` | float  | 1       | Set the width of the stroke.                                                                                                                                                 |
@@ -310,6 +317,7 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `x1`           | float  | 20      | `x` position for the center of the circle, i.e., the horizontal distance from the left border of the canvas.                                                              |
 | `y1`           | float  | 20      | `y` position for the center of the circle, i.e., the vertical distance from the top border of the canvas.                                                                 |
 | `radius`       | float  | 20      | Radius of the circle.                                                                                                                                                     |
+| `opacity`      | float  | 1       | Set the opacity of the entire element (both line and fill).                                                                                                               |
 | `color`        | string | gray1   | Set the fill color of the circle ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) ). |
 | `stroke-color` | string | black   | Set the stroke color of the circle.                                                                                                                                       |
 | `stroke-width` | float  | 1       | Set the width of the stroke.                                                                                                                                              |
@@ -342,6 +350,7 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | Attribute      | Type   | Default | Description                                                                                                                                                               |
 | -------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `plist`        | string | ''      | List of the vertices that form the polygon.                                                                                                                               |
+| `opacity`      | float  | 1       | Set the opacity of the entire element (both line and fill).                                                                                                               |
 | `color`        | string | gray1   | Set the fill color of the circle ( [PL colors](https://prairielearn.readthedocs.io/en/latest/course/#colors) or [HTML colors](https://htmlcolorcodes.com/color-chart/) ). |
 | `stroke-color` | string | black   | Set the stroke color of the circle.                                                                                                                                       |
 | `stroke-width` | float  | 1       | Set the width of the stroke.                                                                                                                                              |

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -185,8 +185,6 @@ A `pl-coordinates` element adds a 2D system of coordinates.
 | `stroke-width` | float  | 2       | Set the width of the stroke.                                                                                                                                                     |
 | `dashed-size`  | float  | \_      | Creates a dashed line with equally spaced `dashed-size`px fills.                                                                                                                 |
 
-
-
 #### Example implementations
 
 - [element/drawingGallery]: Image gallery with drawing objects

--- a/elements/pl-drawing/defaults.py
+++ b/elements/pl-drawing/defaults.py
@@ -26,6 +26,7 @@ drawing_defaults = {
     'angle': 0,
     'end-angle': 60,
     'radius': 20,
+    'opacity': 1,
     'stroke-width': 2,
     'selectable': False,
     'font-size': 16,

--- a/elements/pl-drawing/elements.py
+++ b/elements/pl-drawing/elements.py
@@ -934,6 +934,7 @@ class Point(BaseElement):
             'offsety': pl.get_float_attrib(el, 'offsety', 5),
             'originX': 'center',
             'originY': 'center',
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'fill': color,
             'selectable': drawing_defaults['selectable'],
             'evented': drawing_defaults['selectable']
@@ -953,7 +954,7 @@ class Point(BaseElement):
         return True
 
     def get_attributes():
-        return ['x1', 'y1', 'radius', 'label', 'offsetx', 'offsety', 'color']
+        return ['x1', 'y1', 'radius', 'label', 'offsetx', 'offsety', 'opacity', 'color']
 
 
 class Coordinates(BaseElement):
@@ -1092,6 +1093,7 @@ class Rectangle(BaseElement):
             'angle': pl.get_float_attrib(el, 'angle', drawing_defaults['angle']),
             'originX': 'center',
             'originY': 'center',
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'fill': color,
             'stroke': stroke_color,
             'strokeWidth': pl.get_float_attrib(el, 'stroke-width', drawing_defaults['stroke-width'] / 2),
@@ -1101,7 +1103,7 @@ class Rectangle(BaseElement):
         }
 
     def get_attributes():
-        return ['x1', 'y1', 'height', 'width', 'angle', 'color', 'stroke-color', 'stroke-width', 'selectable']
+        return ['x1', 'y1', 'height', 'width', 'angle', 'opacity', 'color', 'stroke-color', 'stroke-width', 'selectable']
 
 
 class Triangle(BaseElement):
@@ -1113,6 +1115,7 @@ class Triangle(BaseElement):
             'p2': {'x': pl.get_float_attrib(el, 'x2', 60), 'y': pl.get_float_attrib(el, 'y2', 40)},
             'p3': {'x': pl.get_float_attrib(el, 'x3', 40), 'y': pl.get_float_attrib(el, 'y3', 20)},
             'fill': color,
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'stroke': stroke_color,
             'strokeWidth': pl.get_float_attrib(el, 'stroke-width', drawing_defaults['stroke-width'] / 2),
             'strokeUniform': True,
@@ -1123,7 +1126,7 @@ class Triangle(BaseElement):
         }
 
     def get_attributes():
-        return ['x1', 'y1', 'x2', 'y2', 'x3', 'y3', 'color', 'stroke-color', 'stroke-width', 'selectable']
+        return ['x1', 'y1', 'x2', 'y2', 'x3', 'y3', 'color', 'opacity', 'stroke-color', 'stroke-width', 'selectable']
 
 
 class Circle(BaseElement):
@@ -1139,6 +1142,7 @@ class Circle(BaseElement):
             'offsety': pl.get_float_attrib(el, 'offsety', 5),
             'originX': 'center',
             'originY': 'center',
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'stroke': stroke_color,
             'fill': color,
             'strokeWidth': pl.get_float_attrib(el, 'stroke-width', drawing_defaults['stroke-width'] / 2),
@@ -1149,7 +1153,7 @@ class Circle(BaseElement):
         }
 
     def get_attributes():
-        return ['x1', 'y1', 'radius', 'color', 'stroke-color', 'stroke-width', 'label', 'offsetx', 'offsety', 'selectable']
+        return ['x1', 'y1', 'radius', 'opacity', 'color', 'stroke-color', 'stroke-width', 'label', 'offsetx', 'offsety', 'selectable']
 
 
 class Polygon(BaseElement):
@@ -1159,6 +1163,7 @@ class Polygon(BaseElement):
         stroke_color = pl.get_color_attrib(el, 'stroke-color', 'black')
         return {
             'pointlist': pointlist,
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'fill': color,
             'stroke': stroke_color,
             'strokeWidth': pl.get_float_attrib(el, 'stroke-width', 1),
@@ -1168,7 +1173,7 @@ class Polygon(BaseElement):
         }
 
     def get_attributes():
-        return ['plist', 'color', 'stroke-color', 'stroke-width', 'selectable']
+        return ['plist', 'opacity', 'color', 'stroke-color', 'stroke-width', 'selectable']
 
 
 class Spring(BaseElement):
@@ -1228,6 +1233,7 @@ class Line(BaseElement):
             'y2': y2,
             'originX': 'center',
             'originY': 'center',
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'stroke': stroke_color,
             'strokeWidth': pl.get_float_attrib(el, 'stroke-width', drawing_defaults['stroke-width']),
             'strokeDashArray': dashed_array,
@@ -1236,7 +1242,7 @@ class Line(BaseElement):
         }
 
     def get_attributes():
-        return ['x1', 'y1', 'width', 'angle', 'x2', 'y2', 'stroke-color', 'stroke-width', 'dashed-size']
+        return ['x1', 'y1', 'width', 'angle', 'x2', 'y2', 'opacity', 'stroke-color', 'stroke-width', 'dashed-size']
 
 
 class Arc(BaseElement):
@@ -1254,6 +1260,7 @@ class Arc(BaseElement):
             'radius': pl.get_float_attrib(el, 'radius', drawing_defaults['radius']),
             'startAngle': theta1,
             'endAngle': theta2,
+            'opacity': pl.get_float_attrib(el, 'opacity', drawing_defaults['opacity']),
             'stroke': stroke_color,
             'strokeWidth': pl.get_float_attrib(el, 'stroke-width', drawing_defaults['stroke-width']),
             'strokeDashArray': dashed_array,
@@ -1265,7 +1272,7 @@ class Arc(BaseElement):
         }
 
     def get_attributes():
-        return ['x1', 'y1', 'radius', 'start-angle', 'end-angle', 'stroke-color', 'stroke-width', 'dashed-size']
+        return ['x1', 'y1', 'radius', 'start-angle', 'end-angle', 'opacity', 'stroke-color', 'stroke-width', 'dashed-size']
 
 
 class Text(BaseElement):


### PR DESCRIPTION
This PR adds an opacity attribute to: rectangle, triangle, polygon, circle, line, arc, and point elements.

The `opacity` attribute partially addresses #5280 . It allows us to use `pl-drawing` and `pl-overlay` in combination, to ask questions where students "annotate" an image or graph by placing semi-transparent drawing elements on it.