### PR TITLE
Add config vars for PG pool size and timeout

### DIFF
--- a/grader_host/config/base.yaml
+++ b/grader_host/config/base.yaml
@@ -91,3 +91,9 @@ properties:
   postgresqlPassword:
     default: null
     envVar: PG_PASSWORD
+  postgresqlPoolSize:
+    default: 2
+    envVar: PG_POOLSIZE
+  postgresqlIdleTimeoutMillis:
+    default: 30000
+    envVar: PG_IDLETIMEOUTMILLIS

--- a/grader_host/index.js
+++ b/grader_host/index.js
@@ -54,8 +54,8 @@ async.series(
         database: config.postgresqlDatabase,
         user: config.postgresqlUser,
         password: config.postgresqlPassword,
-        max: 2,
-        idleTimeoutMillis: 30000,
+        max: config.postgresqlPoolSize,
+        idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
       };
       globalLogger.info(
         'Connecting to database ' + pgConfig.user + '@' + pgConfig.host + ':' + pgConfig.database

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -169,8 +169,8 @@ async.series(
         database: config.postgresqlDatabase,
         host: config.postgresqlHost,
         password: config.postgresqlPassword,
-        max: 100,
-        idleTimeoutMillis: 30000,
+        max: config.postgresqlPoolSize,
+        idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
       };
       logger.verbose(
         `Connecting to database ${pgConfig.user}@${pgConfig.host}:${pgConfig.database}`


### PR DESCRIPTION
The main server process already has `config.postgresqlPoolSize` and `config.postgresqlIdleTimeoutMillis`. This PR adds them for workspace hosts and grader hosts. No defaults are changed by this PR so there will be no change in behavior unless the new config options are set.