### PR TITLE
fix: Grading methods test not submitting manual answer

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -510,6 +510,10 @@ module.exports = {
     async.series(
       [
         (callback) => {
+          if (question.grading_method == 'Manual') return callback(new NoSubmissionError());
+          callback(null);
+        },
+        (callback) => {
           var params = [variant.id, check_submission_id];
           sqldb.callZeroOrOneRow(
             'variants_select_submission_for_grading',

--- a/lib/question.js
+++ b/lib/question.js
@@ -510,7 +510,13 @@ module.exports = {
     async.series(
       [
         (callback) => {
-          if (question.grading_method === 'Manual') return callback(new NoSubmissionError());
+          if (question.grading_method === 'Manual') {
+            // The button to make a submission won't be available to students
+            // on manualy-graded questions; this is just here to handle the
+            // case where someone tries to be clever and manually post a response
+            // with a `grade` action.
+            return callback(new NoSubmissionError());
+          }
           callback(null);
         },
         (callback) => {

--- a/lib/question.js
+++ b/lib/question.js
@@ -510,7 +510,7 @@ module.exports = {
     async.series(
       [
         (callback) => {
-          if (question.grading_method == 'Manual') return callback(new NoSubmissionError());
+          if (question.grading_method === 'Manual') return callback(new NoSubmissionError());
           callback(null);
         },
         (callback) => {

--- a/tests/gradingMethods.test.js
+++ b/tests/gradingMethods.test.js
@@ -214,13 +214,8 @@ describe('Grading method(s)', function () {
             $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
               'href'
             );
-
-          // open page to produce variant because we want to get the correct answer
-          await fetch(iqUrl);
-          // get variant params
-          iqId = parseInstanceQuestionId(iqUrl);
         });
-        it('should NOT be possible to submit a grade action to "Manual" type question', async () => {
+        it('should be possible to submit a grade action to "Manual" type question', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'grade', [
             { name: 'fib.py', contents: Buffer.from(fibonacciSolution).toString('base64') },
           ]);
@@ -250,11 +245,6 @@ describe('Grading method(s)', function () {
             $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
               'href'
             );
-
-          // open page to produce variant because we want to get the correct answer
-          await fetch(iqUrl);
-          // get variant params
-          iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should be possible to submit a save action to "Manual" type question', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'save', [

--- a/tests/gradingMethods.test.js
+++ b/tests/gradingMethods.test.js
@@ -122,7 +122,7 @@ describe('Grading method(s)', function () {
 
   after('reset default user', () => setUser(defaultUser));
 
-  describe('`gradingMethod` configuration (deprecated, backwards compatible)', () => {
+  describe('`gradingMethod` configuration', () => {
     describe('"Internal"', () => {
       describe('"grade" action', () => {
         before(
@@ -206,18 +206,29 @@ describe('Grading method(s)', function () {
 
     describe('"Manual"', () => {
       describe('"grade" action', () => {
-        before(
-          'load page as student and submit "grade" action to "Manual" type question',
-          async () => {
-            const hm1Body = await loadHomeworkPage(mockStudents[0]);
-            $hm1Body = cheerio.load(hm1Body);
-            iqUrl =
-              siteUrl +
-              $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
-                'href'
-              );
-          }
-        );
+        before('load page as student to "Manual" type question', async () => {
+          const hm1Body = await loadHomeworkPage(mockStudents[0]);
+          $hm1Body = cheerio.load(hm1Body);
+          iqUrl =
+            siteUrl +
+            $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
+              'href'
+            );
+
+          // open page to produce variant because we want to get the correct answer
+          await fetch(iqUrl);
+          // get variant params
+          iqId = parseInstanceQuestionId(iqUrl);
+        });
+        it('should NOT be possible to submit a grade action to "Manual" type question', async () => {
+          gradeRes = await saveOrGrade(iqUrl, {}, 'grade', [
+            { name: 'fib.py', contents: Buffer.from(fibonacciSolution).toString('base64') },
+          ]);
+          assert.equal(gradeRes.status, 200);
+
+          questionsPage = await gradeRes.text();
+          $questionsPage = cheerio.load(questionsPage);
+        });
         it('should NOT result in any grading jobs', async () => {
           const grading_jobs = (await sqlDb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
           assert.lengthOf(grading_jobs, 0);
@@ -229,24 +240,30 @@ describe('Grading method(s)', function () {
           assert.lengthOf($questionsPage('.grading-block'), 0);
         });
       });
+
       describe('"save" action', () => {
-        before(
-          'load page as student and submit "grade" action to "Manual" type question',
-          async () => {
-            const hm1Body = await loadHomeworkPage(mockStudents[0]);
-            $hm1Body = cheerio.load(hm1Body);
-            iqUrl =
-              siteUrl +
-              $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
-                'href'
-              );
-          }
-        );
+        before('load page as student to "Manual" type question', async () => {
+          const hm1Body = await loadHomeworkPage(mockStudents[0]);
+          $hm1Body = cheerio.load(hm1Body);
+          iqUrl =
+            siteUrl +
+            $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
+              'href'
+            );
+
+          // open page to produce variant because we want to get the correct answer
+          await fetch(iqUrl);
+          // get variant params
+          iqId = parseInstanceQuestionId(iqUrl);
+        });
         it('should be possible to submit a save action to "Manual" type question', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'save', [
             { name: 'fib.py', contents: Buffer.from(fibonacciSolution).toString('base64') },
           ]);
           assert.equal(gradeRes.status, 200);
+
+          questionsPage = await gradeRes.text();
+          $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
           const grading_jobs = (await sqlDb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;


### PR DESCRIPTION
The current grading methods tests was not properly submitting an answer to test if the submission process worked. As a result, the testing was done based on outdated variable values from internal grading instead of from manual grading itself. This PR fixes the test to actually submit a value.

A result of this distinction is that it detected a case where questions with manual grading were allowing a grade action which had been disabled in the UI. This PR also fixes the error that the test originally failed to identify.