### PR TITLE
Only run CI once for PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This PR changes the triggers for our CI workflow so that we only run one CI job per commit on a pull request. Previously, we ran two, which more quickly exhausted our maximum parallel jobs and made folks wait longer to get a green result to merge.

Per suggestion from @SethPoulsen, I'm lifting this change out of #1626 so it can be reviewed and merged independently.