### PR TITLE
Fix race condition in server jobs

### DIFF
--- a/cron/index.js
+++ b/cron/index.js
@@ -49,7 +49,8 @@ module.exports = {
       {
         name: 'errorAbandonedJobs',
         module: require('./errorAbandonedJobs'),
-        intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalErrorAbandonedJobsSec,
+        // intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalErrorAbandonedJobsSec,
+        intervalSec: 0.0001,
       },
       {
         name: 'sendExternalGraderStats',
@@ -311,7 +312,8 @@ module.exports = {
     } else if (job.intervalSec === 'daily') {
       interval_secs = 12 * 60 * 60;
     } else {
-      return callback(new Error(`cron: ${job.name} invalid intervalSec: ${job.intervalSec}`));
+      interval_secs = job.intervalSec;
+      // return callback(new Error(`cron: ${job.name} invalid intervalSec: ${job.intervalSec}`));
     }
     const params = {
       name: job.name,

--- a/lib/server-jobs.js
+++ b/lib/server-jobs.js
@@ -106,12 +106,6 @@ Job.prototype.debug = function (_msg) {
 Job.prototype.finish = function (code, signal) {
   var that = this;
 
-  if (!module.exports.liveJobs[that.id]) {
-    // Guard against handling job exit more than once
-    return;
-  }
-  delete module.exports.liveJobs[that.id];
-
   var params = {
     job_id: that.id,
     stderr: that.stderr,
@@ -120,7 +114,15 @@ Job.prototype.finish = function (code, signal) {
     exit_code: code,
     exit_signal: signal,
   };
-  sqldb.queryOneRow(sql.update_job_on_close, params, function (err, result) {
+  sqldb.queryZeroOrOneRow(sql.update_job_on_close, params, function (err, result) {
+    if (result?.rowCount === 0) {
+      // No jobs were actually updated; a job probably finished twice.
+      // Do nothing.
+      return;
+    }
+
+    delete module.exports.liveJobs[that.id];
+
     socketServer.io.to('job-' + that.id).emit('update');
     if (that.options.job_sequence_id != null) {
       socketServer.io.to('jobSequence-' + that.options.job_sequence_id).emit('update');
@@ -369,47 +371,62 @@ module.exports.killJob = function (job_id, callback) {
 module.exports.killJobAsync = util.promisify(module.exports.killJob);
 
 module.exports.errorAbandonedJobs = function (callback) {
-  sqldb.query(sql.select_running_jobs, [], function (err, result) {
-    if (ERR(err, callback)) return;
-    async.each(
-      result.rows,
-      function (row, callback) {
-        if (!_.has(module.exports.liveJobs, row.id)) {
-          logger.debug('Job abandoned by server, id: ' + row.id);
-          var params = {
-            job_id: row.id,
-            stderr: null,
-            stdout: null,
-            output: null,
-            error_message: 'Job abandoned by server',
-          };
-          sqldb.query(sql.update_job_on_error, params, function (err, _result) {
-            socketServer.io.to('job-' + row.id).emit('update');
-            if (row.job_sequence_id != null) {
-              socketServer.io.to('jobSequence-' + row.job_sequence_id).emit('update');
-            }
-            if (ERR(err, function () {})) {
-              logger.error('errorAbandonedJobs: error updating job on error', err);
-            }
+  // The old implementation of this suffered from a race condition.
+  // We would get a list of *all* running jobs, then compare with the contents
+  // of `liveJobs` in memory. However, if a job was marked as successful
+  // and removed from `liveJobs` in between the query and the check, we'd
+  // incorrectly think that the job was abandoned. Now, we only look at the
+  // jobs that *don't* match any of the IDs of `liveJobs`.
+  console.log('job ids:', Object.keys(module.exports.liveJobs));
+  sqldb.query(
+    sql.select_running_jobs_excluding_ids,
+    {
+      job_ids: Object.keys(module.exports.liveJobs),
+    },
+    function (err, result) {
+      if (ERR(err, callback)) return;
+      console.log('abandoned rows', result.rows);
+      async.each(
+        result.rows,
+        function (row, callback) {
+          if (!_.has(module.exports.liveJobs, row.id)) {
+            console.log('Abandoned job', row.id);
+            logger.debug('Job abandoned by server, id: ' + row.id);
+            const params = {
+              job_id: row.id,
+              stderr: null,
+              stdout: null,
+              output: null,
+              error_message: 'Job abandoned by server',
+            };
+            sqldb.query(sql.update_job_on_error, params, function (err, _result) {
+              socketServer.io.to('job-' + row.id).emit('update');
+              if (row.job_sequence_id != null) {
+                socketServer.io.to('jobSequence-' + row.job_sequence_id).emit('update');
+              }
+              if (ERR(err, function () {})) {
+                logger.error('errorAbandonedJobs: error updating job on error', err);
+              }
+              callback(null);
+            });
+          } else {
+            callback(null);
+          }
+        },
+        function (err) {
+          if (ERR(err, callback)) return;
+
+          sqldb.query(sql.error_abandoned_job_sequences, [], function (err, result) {
+            if (ERR(err, callback)) return;
+            result.rows.forEach(function (row) {
+              socketServer.io.to('jobSequence-' + row.id).emit('update');
+            });
             callback(null);
           });
-        } else {
-          callback(null);
         }
-      },
-      function (err) {
-        if (ERR(err, callback)) return;
-
-        sqldb.query(sql.error_abandoned_job_sequences, [], function (err, result) {
-          if (ERR(err, callback)) return;
-          result.rows.forEach(function (row) {
-            socketServer.io.to('jobSequence-' + row.id).emit('update');
-          });
-          callback(null);
-        });
-      }
-    );
-  });
+      );
+    }
+  );
 };
 module.exports.errorAbandonedJobsAsync = util.promisify(module.exports.errorAbandonedJobs);
 


### PR DESCRIPTION
After enabling extra logging in #5690, it became clear that the intermittent test failures in CI were related to our ["error abandoned jobs" cronjob](https://github.com/PrairieLearn/PrairieLearn/blob/master/cron/errorAbandonedJobs.js), as all the failing server jobs were labeled as "Job abandoned by server".

I was able to reliably reproduce the failures locally by setting the interval for that cron job to `0.0001` (10 thousand times a second, I believe). This uncovers a race condition in the `errorAbandonedJobs` function. If a job is running when the `select_running_jobs` query is executed but is then marked as succeeded in between the query result being received and checked against `liveJobs`, it will no longer be present in `liveJobs` and will thus be marked as abandoned.

This is a similar problem to what's in `#3160` - we're trying to maintain the same state both in the database and in memory, and doing that incorrectly can lead to problems. I believe that making server jobs multi-server safe would also fix this bug. But until then, the changes in this PR should at least fix the flaky tests.