### PR TITLE
Start out pl-order-blocks in alphabetical order.

### DIFF
--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -166,6 +166,8 @@ def prepare(element_html, data):
         random.shuffle(mcq_options)
     elif source_blocks_order == 'ordered':
         mcq_options.sort(key=lambda a: a['index'])
+    elif source_blocks_order == 'alphabetized':
+        mcq_options.sort(key=lambda a: a['inner_html'])
     else:
         raise Exception('The specified option for the "source-blocks-order" attribute is invalid.')
 

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -47,16 +47,5 @@ has become increasingly complex, with many different possible combinations of op
   <pl-answer correct="true" tag="4" depends="2,3" > Since $A$ and $C$, we know $A \land C$</pl-answer>
 </pl-order-blocks>
 
-<pl-order-blocks answers-name="test5"
-  source-blocks-order="alphabetized"
-  grading-method="ranking"
-  partial-credit="none"
-  feedback="first-wrong">
-  <pl-answer correct="true" ranking="1"> d </pl-answer>
-  <pl-answer correct="true" ranking="2"> c </pl-answer>
-  <pl-answer correct="true" ranking="3"> b </pl-answer>
-  <pl-answer correct="true" ranking="3"> a </pl-answer>
-</pl-order-blocks>
-
 <!-- TODO add more to cover the rest of the possible option configurations. -->
 

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -47,4 +47,16 @@ has become increasingly complex, with many different possible combinations of op
   <pl-answer correct="true" tag="4" depends="2,3" > Since $A$ and $C$, we know $A \land C$</pl-answer>
 </pl-order-blocks>
 
+<pl-order-blocks answers-name="test5"
+  source-blocks-order="alphabetized"
+  grading-method="ranking"
+  partial-credit="none"
+  feedback="first-wrong">
+  <pl-answer correct="true" ranking="1"> d </pl-answer>
+  <pl-answer correct="true" ranking="2"> c </pl-answer>
+  <pl-answer correct="true" ranking="3"> b </pl-answer>
+  <pl-answer correct="true" ranking="3"> a </pl-answer>
+</pl-order-blocks>
+
 <!-- TODO add more to cover the rest of the possible option configurations. -->
+


### PR DESCRIPTION
Adds the `source-blocks-order='alphabetized'` option to `pl-order-blocks`. 

Also adds a new test in the relevant question for the test course. Hopefully resolves #4920!