### PR TITLE
fix: Use Yarn to execute Node tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 export PATH := node_modules/.bin/:$(PATH)
 
 build:
-	@turbo run build
+	@yarn turbo run build
 
 dev:
-	@turbo run dev
+	@yarn turbo run dev
 
 start: start-support
 	@node server.js

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export PATH := node_modules/.bin/:$(PATH)
-
 build:
 	@yarn turbo run build
 
@@ -9,7 +7,7 @@ dev:
 start: start-support
 	@node server.js
 start-nodemon: start-support
-	@nodemon -L server.js
+	@yarn nodemon -L server.js
 start-workspace-host: start-support kill-running-workspaces
 	@node workspace_host/interface.js
 
@@ -27,15 +25,15 @@ start-s3rver:
 test: test-js test-python
 test-js: test-prairielearn test-prairielib test-grader-host test-packages
 test-prairielearn: start-support
-	@mocha --parallel "tests/**/*.test.{js,mjs}"
+	@yarn mocha --parallel "tests/**/*.test.{js,mjs}"
 test-prairielearn-serial: start-support
-	@mocha "tests/**/*.test.{js,mjs}"
+	@yarn mocha "tests/**/*.test.{js,mjs}"
 test-prairielib:
-	@jest prairielib/
+	@yarn jest prairielib/
 test-grader-host:
-	@jest grader_host/
+	@yarn jest grader_host/
 test-packages:
-	@turbo run test
+	@yarn turbo run test
 test-python:
 # `pl_unit_test.py` has an unfortunate file name - it matches the pattern that
 # pytest uses to discover tests, but it isn't actually a test file itself. We
@@ -44,28 +42,28 @@ test-python:
 	
 lint: lint-js lint-python lint-html lint-links
 lint-js:
-	@eslint --ext js "**/*.js"
-	@prettier --check "**/*.{js,ts,md}"
+	@yarn eslint --ext js "**/*.js"
+	@yarn prettier --check "**/*.{js,ts,md}"
 lint-python:
 	@python3 -m flake8 ./
 lint-html:
-	@htmlhint "testCourse/**/question.html" "exampleCourse/**/question.html"
+	@yarn htmlhint "testCourse/**/question.html" "exampleCourse/**/question.html"
 lint-links:
 	@node tools/validate-links.mjs
 
 format: format-js
 format-js:
-	@eslint --ext js --fix "**/*.js"
-	@prettier --write "**/*.{js,ts,md}"
+	@yarn eslint --ext js --fix "**/*.js"
+	@yarn prettier --write "**/*.{js,ts,md}"
 
 typecheck: typecheck-js typecheck-python
 typecheck-js:
-	@tsc
+	@yarn tsc
 typecheck-python:
-	@pyright
+	@yarn pyright
 
 depcheck:
-	-depcheck --ignore-patterns=public/**
+	-yarn depcheck --ignore-patterns=public/**
 	@echo WARNING:
 	@echo WARNING: Before removing an unused package, also check that it is not used
 	@echo WARNING: by client-side code. Do this by running '"git grep <packagename>"'
@@ -75,4 +73,4 @@ depcheck:
 	@echo WARNING:
 
 changeset:
-	@changeset
+	@yarn changeset


### PR DESCRIPTION
I believe this is needed to use the copy of `turbo` that's installed by `yarn`. Without this I get a "command not found" for `turbo` because I don't have it globally installed.