### PR TITLE
docs typo fix: "the answer" not "or answer"

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1769,7 +1769,7 @@ Displays the contents of question directions.
 Contents are only shown during question input portion. When a student
 either makes a submission or receives the correct answer, the information
 between these tags is hidden. If content exists outside of a question panel,
-then it will be displayed alongside or answer.
+then it will be displayed alongside the answer.
 
 #### Example implementations
 

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -185,6 +185,17 @@ def evaluate(expr, locals_for_eval={}):
     if '#' in expr:
         raise HasCommentError(expr.find('#'))
 
+    from sympy.parsing.sympy_parser import stringify_expr
+    from sympy.parsing.sympy_parser import standard_transformations
+    from sympy.parsing.sympy_parser import implicit_multiplication_application
+    # TODO: may want `function_exponentiation` as well
+    T = standard_transformations + (implicit_multiplication_application, )
+    # TODO: we probably need this to avoid sin -> s*i*n.  How does this relate
+    # to the allow list below?
+    global_dict = {}
+
+    expr = stringify_expr(expr, locals_for_eval, global_dict, T)
+
     # Parse (convert string to AST)
     try:
         root = ast.parse(expr, mode='eval')

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -206,6 +206,7 @@ def evaluate(expr, locals_for_eval={}):
     global_dict['min'] = Min
 
     T = standard_transformations + (implicit_multiplication_application, )
+    # TODO: is `locals_for_eval` appropriate as local_dict here?
     expr = stringify_expr(expr, locals_for_eval, global_dict, T)
 
     # Parse (convert string to AST)

--- a/lib/python_helper_sympy.py
+++ b/lib/python_helper_sympy.py
@@ -189,11 +189,23 @@ def evaluate(expr, locals_for_eval={}):
     from sympy.parsing.sympy_parser import standard_transformations
     from sympy.parsing.sympy_parser import implicit_multiplication_application
     # TODO: may want `function_exponentiation` as well
-    T = standard_transformations + (implicit_multiplication_application, )
-    # TODO: we probably need this to avoid sin -> s*i*n.  How does this relate
-    # to the allow list below?
-    global_dict = {}
 
+    # copy-paste job from sympy/parsing/sympy_parser.py to build global_dict
+    # TODO: maybe we can ask SymPy to split out to `_make_std_global_dict()`
+    import types
+    import builtins
+    from sympy.functions.elementary.miscellaneous import Max, Min
+
+    global_dict = {}
+    exec('from sympy import *', global_dict)
+    builtins_dict = vars(builtins)
+    for name, obj in builtins_dict.items():
+        if isinstance(obj, types.BuiltinFunctionType):
+            global_dict[name] = obj
+    global_dict['max'] = Max
+    global_dict['min'] = Min
+
+    T = standard_transformations + (implicit_multiplication_application, )
     expr = stringify_expr(expr, locals_for_eval, global_dict, T)
 
     # Parse (convert string to AST)


### PR DESCRIPTION
Actually my understanding of panels is so incredibly low * that someone
should double-check whether this is the correct fix.

* bad attitude due to 1.5 hours of `*-panel` debugging.  If I actually learn enough to understand I will try to improve these docs but prognosis is dim