### PR TITLE
docs: Fix typo in pl-question-panel description

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1769,7 +1769,7 @@ Displays the contents of question directions.
 Contents are only shown during question input portion. When a student
 either makes a submission or receives the correct answer, the information
 between these tags is hidden. If content exists outside of a question panel,
-then it will be displayed alongside or answer.
+then it will be displayed alongside the answer.
 
 #### Example implementations
 


### PR DESCRIPTION
Actually my understanding of panels is so incredibly low * that someone
should double-check whether this is the correct fix.

* bad attitude due to 1.5 hours of `*-panel` debugging.  If I actually learn enough to understand I will try to improve these docs but prognosis is dim