### PR TITLE
fix: Gracefully handle missing LTI callback URL

### DIFF
--- a/lib/ltiOutcomes.js
+++ b/lib/ltiOutcomes.js
@@ -64,6 +64,15 @@ function updateScore(ai_id, callback) {
 
     var info = result.rows[0];
 
+    // It's possible for a user to enter via LTI but for the assessment to not
+    // have a callback URL set, for instance, if the instructor forgot to set
+    // one or if the assessment is a practice exam that doesn't need to have
+    // scores reported back to the course. Instead of propagating an error to
+    // the user, we'll just silently do nothing.
+    if (!info.lis_outcome_service_url) {
+      return callback(null);
+    }
+
     var score = info.score_perc / 100;
     if (score > 1) {
       score = 1.0;

--- a/lib/ltiOutcomes.js
+++ b/lib/ltiOutcomes.js
@@ -64,15 +64,6 @@ function updateScore(ai_id, callback) {
 
     var info = result.rows[0];
 
-    // It's possible for a user to enter via LTI but for the assessment to not
-    // have a callback URL set, for instance, if the instructor forgot to set
-    // one or if the assessment is a practice exam that doesn't need to have
-    // scores reported back to the course. Instead of propagating an error to
-    // the user, we'll just silently do nothing.
-    if (!info.lis_outcome_service_url) {
-      return callback(null);
-    }
-
     var score = info.score_perc / 100;
     if (score > 1) {
       score = 1.0;

--- a/lib/ltiOutcomes.sql
+++ b/lib/ltiOutcomes.sql
@@ -6,5 +6,5 @@ FROM
     JOIN lti_outcomes AS lo USING(assessment_id, user_id)
     JOIN lti_credentials AS lc ON(lc.id = lo.lti_credential_id)
 WHERE
-    ai.id = $ai_id
+    ai.id = $ai_id AND lo.lis_outcome_service_url IS NOT NULL
 ;


### PR DESCRIPTION
[As reported on Slack](https://prairielearn.slack.com/archives/C266KEH9A/p1655148217555639), it's possible that an LTI assessment might be missing a callback URL to report the score, resulting in an error like the following:

```
options.uri is a required argument
```

This PR updates our LTI code to gracefully handle that case.