### PR TITLE
Fix incorrect heading level in docs

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1764,7 +1764,7 @@ Displays the contents of question directions.
 <pl-question-panel> This is question-panel text. </pl-question-panel>
 ```
 
-### Details
+#### Details
 
 Contents are only shown during question input portion. When a student
 either makes a submission or receives the correct answer, the information


### PR DESCRIPTION
In the docs, Elements for writing questions > Conditional elements > pl-question-panel element > Details had a heading level inconsistent with the rest.

![image](https://user-images.githubusercontent.com/2316553/174619164-0fbe3b14-7a4c-45e9-a116-3174b76f0e1f.png)
