### PR TITLE
Direct standard input to nodemon for local Docker runs

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -2,7 +2,8 @@
 
 echo 'Starting PrairieLearn...'
 if [[ $NODEMON == "true" ]]; then
-    make -s -C /PrairieLearn -j 2 start-workspace-host start-nodemon
+    # start-nodemon is listed first so it can use standard input
+    make -s -C /PrairieLearn -j 2 start-nodemon start-workspace-host
 else
     make -s -C /PrairieLearn -j 2 start-workspace-host start
 fi

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -5,5 +5,5 @@ if [[ $NODEMON == "true" ]]; then
     # start-nodemon is listed first so it can use standard input
     make -s -C /PrairieLearn -j 2 start-nodemon start-workspace-host
 else
-    make -s -C /PrairieLearn -j 2 start-workspace-host start
+    make -s -C /PrairieLearn -j 2 start start-workspace-host
 fi


### PR DESCRIPTION
When a local docker process runs, it uses `make -j` to start the workspace host and PrairieLearn server in parallel. This is typically fine, since in most cases stdin isn't used by either the server or the workspace host, however when nodemon is used (`-e NODEMON=true`), nodemon relies on standard input to allow user-led restart of the server (by typing `rs`). This PR ensures that nodemon receives access to standard input so that this restarting is possible, by ensuring it is the first job listed in make (https://www.gnu.org/software/make/manual/html_node/Parallel-Input.html).