### PR TITLE
Fix display of old submissions

### DIFF
--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -195,7 +195,7 @@
 
       <div id="more-submissions-collapser" class="collapse">
         <% submissions.slice(MAX_TOP_RECENTS).forEach(function(submission, idx) { %>
-          <%- include('submission', {submission: submission, submissionCount: submissions.length, submissionHtml: submissionHtmls[idx]}); %>
+          <%- include('submission', {submission: submission, submissionCount: submissions.length, submissionHtml: submissionHtmls[idx + MAX_TOP_RECENTS]}); %>
         <% }); %>
       </div>
 


### PR DESCRIPTION
CS 411 reported a strange issue with question display where the rendered submission didn't match the score: https://prairielearn.slack.com/archives/C266KEH9A/p1656516492465929.

It turns out #5793 inadvertently broke the display of older submissions - the rendered submission HTMLs weren't paired with the correct submission metadata (score, time, etc.).