### PR TITLE
Remove verify-changelog.sh script

### DIFF
--- a/tools/verify-changelog.sh
+++ b/tools/verify-changelog.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-! git diff --exit-code master -- ChangeLog.md


### PR DESCRIPTION
This is no longer needed as we're no longer updating the changelog.