### PR TITLE
Add gcc g++ compiler to plbase image

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -11,6 +11,9 @@ amazon-linux-extras install -y \
     postgresql11 \
     redis4.0
 
+# Notes:
+# - `libjpeg-devel` is needed by the Pillow package
+# - `gcc-c++` is needed to build the native bindings in `packages/bind-mount`
 yum -y install \
     postgresql-server \
     postgresql-contrib \
@@ -29,7 +32,8 @@ yum -y install \
     git \
     graphviz \
     graphviz-devel \
-    libjpeg-devel # Needed by the Pillow package
+    libjpeg-devel \
+    gcc-c++
 
 yum clean all
 


### PR DESCRIPTION
Doing this independently of #5993 so that we can build and publish a new base image. It looks as though the `pltest` image used in CI is built from the *latest* version of `prairielearn/plbase` from Dockerhub, not the version of `plbase` that we actually build during CI. That's a problem we should solve, but not one I can right now.