### PR TITLE
Fix getCachedDataOrCompute function

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1877,7 +1877,7 @@ module.exports = {
           cacheHit: true,
         };
       } else {
-        doCompute(cacheKey);
+        return doCompute(cacheKey);
       }
     };
 


### PR DESCRIPTION
This manifested during testing with the following error:

```
Cannot destructure property 'data' of '(intermediate value)' as it is undefined.
```