### PR TITLE
Show correct answer panel after scoring 100 percent on single variant HW question

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1474,6 +1474,9 @@ module.exports = {
           locals.variantAttemptsLeft = assessment_question.tries_per_variant - variant.num_tries;
           locals.variantAttemptsTotal = assessment_question.tries_per_variant;
         }
+        if (question.single_variant && instance_question.score_perc >= 100.0) {
+          locals.showTrueAnswer = true;
+        }
       }
       if (assessment.type === 'Exam') {
         if (assessment_instance.open && instance_question.open) {


### PR DESCRIPTION
Fixes #5914

The correct answer panel is the standard place to share extra detail and explanation with students.

Currently, on Homework-type assessments, students only see the correct answer panel after they've exhausted all attempts at a variant. Since students get unlimited attempts on single variant questions in Homework-type assessments, they will never see the correct answer panel and the accompanying explanation.

With this PR, students will see the correct answer panel on a single variant Homework question after scoring 100%. 

(note: they are not restricted from further submissions, so they can still try out other possible answers, e.g. in the case where there is more than one correct answer.)