### PR TITLE
Added /grade/serverFilesCourse to PYTHONPATH in cgrader

### DIFF
--- a/graders/c/Dockerfile
+++ b/graders/c/Dockerfile
@@ -18,7 +18,7 @@ ENV LANG=en_US.UTF-8
 ENV LC_LANG=en_US.UTF-8
 
 ENV PYTHONIOENCODING=UTF-8
-ENV PYTHONPATH=/cgrader/
+ENV PYTHONPATH=/cgrader/:/grade/serverFilesCourse
 
 RUN groupadd sbuser
 RUN useradd -g sbuser sbuser


### PR DESCRIPTION
Updated the DockerFile for cgrader to include /grade/serverFilesCourse in PYTHONPATH.  This will allow any python files copied from serverFilesCourse to be importable in the testing script.

This was discussed in [How to append to environment variable in external graders? #6048](https://github.com/PrairieLearn/PrairieLearn/discussions/6048)