### PR TITLE
Bump ansi2html to 1.8.0 for color palette correctness

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -13,7 +13,7 @@ scipy==1.8.1
 sympy==1.10.1
 rpy2==3.5.2
 pygraphviz==1.6
-ansi2html==1.7.0
+ansi2html==1.8.0
 scikit-learn==1.1.1
 nltk==3.7
 Pygments==2.12.0


### PR DESCRIPTION
ansi2html version 1.8.0 was finally released, including some bugfixes for color palette handling that I contributed to. (I mentioned the color issues on PL Slack some time last year.) I don't think there are any breaking changes with this release, but I haven't tested it on PL yet.

Thanks to Prof. Jeff Erickson for commenting on the bugfix PR too.

https://github.com/pycontribs/ansi2html/releases/tag/1.8.0