### PR TITLE
Show correct answer in manual grading page regardless of status

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1630,6 +1630,9 @@ module.exports = {
             authz_result
           );
           _.assign(locals, newLocals);
+          if (locals.manualGradingInterface && question?.show_correct_answer) {
+            locals.showTrueAnswer = true;
+          }
           callback(null);
         },
         (callback) => {

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -163,7 +163,7 @@
   </div>
   <% } %>
 
-  <% if (showTrueAnswer || question_context == 'manual_grading') { %>
+  <% if (showTrueAnswer) { %>
   <div class="card mb-4 grading-block">
     <div class="card-header bg-secondary text-white">Correct answer</div>
     <div class="card-body answer-body">

--- a/pages/partials/question.ejs
+++ b/pages/partials/question.ejs
@@ -163,7 +163,7 @@
   </div>
   <% } %>
 
-  <% if (showTrueAnswer) { %>
+  <% if (showTrueAnswer || question_context == 'manual_grading') { %>
   <div class="card mb-4 grading-block">
     <div class="card-header bg-secondary text-white">Correct answer</div>
     <div class="card-body answer-body">


### PR DESCRIPTION
As discussed with @ffund, the manual grading page should always show the correct answer.