### PR TITLE
Fix disappearing feedback in gradeAsync

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1735,7 +1735,7 @@ module.exports = {
             raw_submitted_answer: resultData.raw_submitted_answers,
             partial_scores: resultData.partial_scores,
             score: resultData.score,
-            feedback: data.feedback,
+            feedback: resultData.feedback,
             gradable: resultData.gradable,
           },
         };


### PR DESCRIPTION
Fixes #6116 

This was a subtle typo in the recent async refactoring in `freeform.js`: `data.feedback` should be `resultData.feedback`.