### PR TITLE
Fix assessment authorization with modules

### DIFF
--- a/middlewares/selectAndAuthzAssessment.sql
+++ b/middlewares/selectAndAuthzAssessment.sql
@@ -8,7 +8,7 @@ SELECT
 FROM
     assessments AS a
     JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-    JOIN assessment_modules AS am ON (am.id = a.assessment_module_id)
+    LEFT JOIN assessment_modules AS am ON (am.id = a.assessment_module_id)
     JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
     JOIN LATERAL authz_assessment(a.id, $authz_data, $req_date, ci.display_timezone) AS aa ON TRUE
 WHERE

--- a/pages/instructorAssessmentSettings/instructorAssessmentSettings.ejs
+++ b/pages/instructorAssessmentSettings/instructorAssessmentSettings.ejs
@@ -56,8 +56,12 @@
                     <tr>
                         <th scope="row">Module</th>
                         <td>
+                            <% if (assessment_module) { %>
                             <%= assessment_module.heading %> 
                             <span class="text-muted">(<%= assessment_module.name %>)</span>
+                            <% } else { %>
+                            <em>None</em>
+                            <% } %>
                         </td>
                     </tr>                    
                     <tr><th scope="row">AID</th>

--- a/pages/instructorAssessmentSettings/instructorAssessmentSettings.ejs
+++ b/pages/instructorAssessmentSettings/instructorAssessmentSettings.ejs
@@ -60,7 +60,7 @@
                             <%= assessment_module.heading %> 
                             <span class="text-muted">(<%= assessment_module.name %>)</span>
                             <% } else { %>
-                            <em>None</em>
+                            &mdash;
                             <% } %>
                         </td>
                     </tr>                    


### PR DESCRIPTION
PR #4360 introduced modules and does an unconditional JOIN on `assessment_modules` in `selectAndAuthzAssessment.sql`. However, modules are optional and so any assessment without one will return no rows from this query, thus failing authorization.

I will check other authz paths as well before merging this.