### PR TITLE
Fix grouping of assessments by module

### DIFF
--- a/pages/instructorAssessments/instructorAssessments.sql
+++ b/pages/instructorAssessments/instructorAssessments.sql
@@ -46,7 +46,7 @@ SELECT
         LAG (CASE WHEN $assessments_group_by = 'Set' THEN aset.id ELSE am.id END)
         OVER (
             PARTITION BY (CASE WHEN $assessments_group_by = 'Set' THEN aset.id ELSE am.id END)
-            ORDER BY aset.id, a.order_by, a.id NULLS FIRST
+            ORDER BY aset.number, a.order_by, a.id NULLS FIRST
         ) IS NULL
     ) AS start_new_assessment_group,
     (CASE WHEN $assessments_group_by = 'Set' THEN aset.heading ELSE am.heading END) AS assessment_group_heading,

--- a/pages/instructorAssessments/instructorAssessments.sql
+++ b/pages/instructorAssessments/instructorAssessments.sql
@@ -46,7 +46,7 @@ SELECT
         LAG (CASE WHEN $assessments_group_by = 'Set' THEN aset.id ELSE am.id END)
         OVER (
             PARTITION BY (CASE WHEN $assessments_group_by = 'Set' THEN aset.id ELSE am.id END)
-            ORDER BY aset.number, a.order_by, a.id NULLS FIRST
+            ORDER BY aset.number, a.order_by, a.id
         ) IS NULL
     ) AS start_new_assessment_group,
     (CASE WHEN $assessments_group_by = 'Set' THEN aset.heading ELSE am.heading END) AS assessment_group_heading,

--- a/pages/studentAssessments/studentAssessments.sql
+++ b/pages/studentAssessments/studentAssessments.sql
@@ -144,7 +144,7 @@ SELECT
         LAG (CASE WHEN $assessments_group_by = 'Set' THEN assessment_set_id ELSE assessment_module_id END) 
         OVER (
             PARTITION BY (CASE WHEN $assessments_group_by = 'Set' THEN assessment_set_id ELSE assessment_module_id END) 
-            ORDER BY assessment_set_number, assessment_order_by, assessment_id, assessment_instance_number NULLS FIRST
+            ORDER BY assessment_set_number, assessment_order_by, assessment_id, assessment_instance_number
         ) IS NULL
     ) AS start_new_assessment_group,
     (CASE WHEN $assessments_group_by = 'Set' THEN assessment_set_heading ELSE assessment_module_heading END) AS assessment_group_heading
@@ -155,5 +155,4 @@ WHERE
 ORDER BY 
     CASE WHEN $assessments_group_by = 'Module' THEN assessment_module_number END, 
     CASE WHEN $assessments_group_by = 'Module' THEN assessment_module_id END,
-    assessment_set_number, assessment_order_by, assessment_id, assessment_instance_number 
-    NULLS FIRST;
+    assessment_set_number, assessment_order_by, assessment_id, assessment_instance_number;

--- a/pages/studentAssessments/studentAssessments.sql
+++ b/pages/studentAssessments/studentAssessments.sql
@@ -144,7 +144,7 @@ SELECT
         LAG (CASE WHEN $assessments_group_by = 'Set' THEN assessment_set_id ELSE assessment_module_id END) 
         OVER (
             PARTITION BY (CASE WHEN $assessments_group_by = 'Set' THEN assessment_set_id ELSE assessment_module_id END) 
-            ORDER BY assessment_set_id, assessment_order_by, assessment_id, assessment_instance_number NULLS FIRST
+            ORDER BY assessment_set_number, assessment_order_by, assessment_id, assessment_instance_number NULLS FIRST
         ) IS NULL
     ) AS start_new_assessment_group,
     (CASE WHEN $assessments_group_by = 'Set' THEN assessment_set_heading ELSE assessment_module_heading END) AS assessment_group_heading


### PR DESCRIPTION
This should fix the issue that @mfsilva22 reported where assessments weren't being grouped correctly on the assessment pages.

I believe this works because the order of rows in the partition need to match that of the result set so that we put the "new section" marker in the correct place.

As for why this issue showed up in production and not locally: this is because ordering was dependent on IDs, which are not consistent between environments.