### PR TITLE
Add config option to hide the Shibboleth login button

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -144,6 +144,7 @@ config.SEBDownloadUrl = null;
 config.awsRegion = 'us-east-2';
 config.awsServiceGlobalOptions = {};
 config.hasShib = false;
+config.hideShibLogin = false;
 config.shibLinkText = 'Sign in with Illinois';
 config.shibLinkLogo = '/images/illinois_logo.svg';
 config.shibLinkColors = {

--- a/pages/authLogin/authLogin.ejs
+++ b/pages/authLogin/authLogin.ejs
@@ -104,7 +104,7 @@
               <span class="font-weight-bold">DevMode by-pass</span>
             </a>
           <% } %>
-          <% if (config.hasShib) { %>
+          <% if (config.hasShib && !config.hideShibLogin) { %>
             <a class="btn btn-shib w-100 position-relative" href="/pl/shibcallback" role="button">
               <% if (config.shibLinkLogo != null) { %>
                 <img src="<%- config.shibLinkLogo %>" class="social-icon"/>


### PR DESCRIPTION
This will be useful as we transition from Apache Shibboleth to using PrairieLearn's built-in support for SAML authentication that was introduced in #6112.