### PR TITLE
Fix error handling during SAML authentication

### DIFF
--- a/ee/auth/saml/index.js
+++ b/ee/auth/saml/index.js
@@ -7,8 +7,8 @@ const strategy = new MultiSamlStrategy(
   {
     passReqToCallback: true,
     getSamlOptions(req, done) {
-      getInstitutionSamlProvider(req.params.institution_id).then(
-        (samlProvider) => {
+      getInstitutionSamlProvider(req.params.institution_id)
+        .then((samlProvider) => {
           if (!samlProvider) {
             return done(new Error('No SAML provider found for given institution'));
           }
@@ -31,9 +31,8 @@ const strategy = new MultiSamlStrategy(
             privateKey: samlProvider.private_key,
             decryptionPvk: samlProvider.private_key,
           });
-        },
-        (err) => done(err)
-      );
+        })
+        .catch((err) => done(err));
     },
   },
   function (req, profile, done) {

--- a/ee/auth/saml/router.js
+++ b/ee/auth/saml/router.js
@@ -15,7 +15,7 @@ const { getInstitutionSamlProvider } = require('../../institution/utils');
 
 const router = Router({ mergeParams: true });
 
-router.get('/login', function (req, res, next) {
+router.get('/login', (req, res, next) => {
   // @ts-expect-error Missing `additionalParams` on the type.
   passport.authenticate('saml', {
     failureRedirect: '/pl',


### PR DESCRIPTION
Without this, an error during SAML authentication would crash the server, which is obviously no good!