### PR TITLE
Speed up instructor manual grading query

### DIFF
--- a/pages/instructorAssessmentManualGrading/assessment/assessment.sql
+++ b/pages/instructorAssessmentManualGrading/assessment/assessment.sql
@@ -1,6 +1,5 @@
 -- BLOCK select_questions_manual_grading
-WITH
-instance_questions_with_submission AS (
+WITH instance_questions_with_submission AS (
     SELECT
         iq.assessment_question_id,
         COUNT(1) FILTER (WHERE iq.requires_manual_grading) AS num_instance_questions_to_grade,

--- a/pages/instructorAssessmentManualGrading/assessment/assessment.sql
+++ b/pages/instructorAssessmentManualGrading/assessment/assessment.sql
@@ -1,7 +1,7 @@
 -- BLOCK select_questions_manual_grading
 WITH
 selected_instance_questions AS (
-    SELECT distinct on (iq.id)
+    SELECT DISTINCT ON (iq.id)
         iq.*
     FROM
         assessment_questions aq

--- a/pages/instructorAssessmentManualGrading/assessment/assessment.sql
+++ b/pages/instructorAssessmentManualGrading/assessment/assessment.sql
@@ -20,8 +20,8 @@ instance_questions_with_submission AS (
         JSONB_AGG(DISTINCT jsonb_build_object('user_id', agu.user_id, 'name', agu.name, 'uid', agu.uid)) FILTER (WHERE iq.requires_manual_grading AND iq.assigned_grader IS NOT NULL) AS assigned_graders,
         JSONB_AGG(DISTINCT jsonb_build_object('user_id', lgu.user_id, 'name', lgu.name, 'uid', lgu.uid)) FILTER (WHERE iq.last_grader IS NOT NULL) AS actual_graders
     FROM
-        selected_assessment_questions aq
-        JOIN instance_questions iq ON (iq.assessment_question_id = aq.id)
+        assessment_questions aq
+        JOIN selected_instance_questions iq ON (iq.assessment_question_id = aq.id)
         LEFT JOIN users agu ON (agu.user_id = iq.assigned_grader)
         LEFT JOIN users lgu ON (lgu.user_id = iq.last_grader)
     WHERE aq.assessment_id = $assessment_id


### PR DESCRIPTION
Fixes #6152 

This reduces the query execution time in #6152 from 2 minutes to 80 milliseconds.

The key change here was to move from the EXISTS sub-query over variants+submissions to JOINing over variants+submissions and then using DISTINCT to select one row per instance question.

I also moved the "only select instance questions with submissions" part of the query into its own separate CTE at the top. I don't think this was necessary but it made it easier to explore what was going on.

I don't understand why the query planner has trouble with the EXISTS sub-query, but I do personally find the new query to be "safer" in the sense that it's just a big sequence of JOINs that I know the query planner can handle without trouble.

## Bad CTE that uses a sequential scan:

```sql
selected_instance_questions AS (
    SELECT
        iq.*
    FROM
        assessment_questions aq
        JOIN instance_questions iq ON (iq.assessment_question_id = aq.id)
    WHERE aq.assessment_id = $assessment_id
          AND EXISTS(SELECT 1
                     FROM variants AS v JOIN submissions AS s ON (s.variant_id = v.id)
                     WHERE v.instance_question_id = iq.id)
),
```

## Good CTE that only uses index scans:

```sql
selected_instance_questions AS (
    SELECT DISTINCT ON (iq.id)
        iq.*
    FROM
        assessment_questions aq
        JOIN instance_questions iq ON (iq.assessment_question_id = aq.id)
        JOIN variants AS v ON (v.instance_question_id = iq.id)
        JOIN submissions AS s ON (s.variant_id = v.id)
    WHERE aq.assessment_id = $assessment_id
),
```