### PR TITLE
Allow file URLs to be used in renderEjs and loadSqlEquiv

### DIFF
--- a/.changeset/slimy-moles-study.md
+++ b/.changeset/slimy-moles-study.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/html-ejs': minor
+---
+
+Allow file URLs to be passed to `renderEjs`

--- a/packages/html-ejs/src/index.ts
+++ b/packages/html-ejs/src/index.ts
@@ -24,5 +24,5 @@ export function renderEjs(filePathOrUrl: string, template: string, data: any = {
     resolvedPath = fileURLToPath(filePathOrUrl);
   }
 
-  return unsafeHtml(ejs.render(template, data, { views: [path.dirname(filePathOrUrl)] }));
+  return unsafeHtml(ejs.render(template, data, { views: [path.dirname(resolvedPath)] }));
 }

--- a/packages/html-ejs/src/index.ts
+++ b/packages/html-ejs/src/index.ts
@@ -1,5 +1,6 @@
 import ejs from 'ejs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { unsafeHtml, type HtmlSafeString } from '@prairielearn/html';
 /**
@@ -9,11 +10,19 @@ import { unsafeHtml, type HtmlSafeString } from '@prairielearn/html';
  * The resulting string is assumed to be appropriately escaped and will be used
  * verbatim in the resulting HTML.
  *
- * @param filename The name of the file from which relative includes should be resolved.
+ * @param filePathOrUrl The path or file URL of the file from which relative includes should be resolved.
  * @param template The raw EJS template string.
  * @param data Any data to be made available to the template.
  * @returns The rendered EJS.
  */
-export function renderEjs(filename: string, template: string, data: any = {}): HtmlSafeString {
-  return unsafeHtml(ejs.render(template, data, { views: [path.dirname(filename)] }));
+export function renderEjs(filePathOrUrl: string, template: string, data: any = {}): HtmlSafeString {
+  let resolvedPath = filePathOrUrl;
+
+  // This allows for us to pass `import.meta.url` to this function in ES Modules
+  // environments where `__filename` is not available.
+  if (filePathOrUrl.startsWith('file://')) {
+    resolvedPath = fileURLToPath(filePathOrUrl);
+  }
+
+  return unsafeHtml(ejs.render(template, data, { views: [path.dirname(filePathOrUrl)] }));
 }

--- a/prairielib/lib/sql-loader.js
+++ b/prairielib/lib/sql-loader.js
@@ -1,16 +1,15 @@
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
-
-module.exports = {};
+const url = require('url');
 
 module.exports.load = function (filename) {
-  var sql = {};
+  const sql = {};
   sql.all = fs.readFileSync(filename, 'utf8');
-  var lines = sql.all.split(/\r?\n/);
-  var blockRE = /^ *-- *BLOCK +([^ ]+) *$/;
-  var blockName = null;
-  _(lines).forEach(function (line) {
+  const lines = sql.all.split(/\r?\n/);
+  const blockRE = /^ *-- *BLOCK +([^ ]+) *$/;
+  let blockName = null;
+  lines.forEach((line) => {
     var result = blockRE.exec(line);
     if (result) {
       blockName = result[1];
@@ -23,16 +22,25 @@ module.exports.load = function (filename) {
   return sql;
 };
 
-/* Replace the extension of the given filename with ".sql" and load it.
+/**
+ * Replace the extension of the given filename with ".sql" and load it.
+ *
+ * @param filename A filename or file URL of a non-SQL file (e.g., `__filename` or `import.meta.url`).
+ * @returns The SQL data structure.
+ */
+module.exports.loadSqlEquiv = function (filePathOrUrl) {
+  let resolvedPath = filePathOrUrl;
 
-   @param filename A filename of a non-SQL file (e.g., __filename in NodeJS).
-   @return The SQL data structure.
-*/
-module.exports.loadSqlEquiv = function (filename) {
-  var components = path.parse(filename);
+  // This allows for us to pass `import.meta.url` to this function in ES Modules
+  // environments where `__filename` is not available.
+  if (filePathOrUrl.startsWith('file://')) {
+    resolvedPath = url.fileURLToPath(filePathOrUrl);
+  }
+
+  const components = path.parse(resolvedPath);
   components.ext = '.sql';
   delete components.base;
   // var sqlFilename = path.format(components); // FIXME: this doesn't work in node 0.12? It should work.
-  var sqlFilename = path.join(components.dir, components.name) + components.ext;
-  return this.load(sqlFilename);
+  const sqlFilename = path.join(components.dir, components.name) + components.ext;
+  return module.exports.load(sqlFilename);
 };

--- a/prairielib/lib/sql-loader.js
+++ b/prairielib/lib/sql-loader.js
@@ -1,6 +1,5 @@
-var _ = require('lodash');
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 const url = require('url');
 
 module.exports.load = function (filename) {
@@ -13,7 +12,7 @@ module.exports.load = function (filename) {
     var result = blockRE.exec(line);
     if (result) {
       blockName = result[1];
-      if (_.has(sql, blockName)) throw new Error(`${filename}: duplicate BLOCK name: ${blockName}`);
+      if (sql[blockName]) throw new Error(`${filename}: duplicate BLOCK name: ${blockName}`);
       sql[blockName] = line;
     } else if (blockName) {
       sql[blockName] += '\n' + line;

--- a/prairielib/lib/sql-loader.js
+++ b/prairielib/lib/sql-loader.js
@@ -25,7 +25,7 @@ module.exports.load = function (filename) {
 /**
  * Replace the extension of the given filename with ".sql" and load it.
  *
- * @param filename A filename or file URL of a non-SQL file (e.g., `__filename` or `import.meta.url`).
+ * @param filename A path or file URL of a non-SQL file (e.g., `__filename` or `import.meta.url`).
  * @returns The SQL data structure.
  */
 module.exports.loadSqlEquiv = function (filePathOrUrl) {


### PR DESCRIPTION
This will help ease the transition to ESM, as we can just pass `import.meta.url` directly to these functions.