### PR TITLE
Handle case where buildLocals throws an error

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1609,7 +1609,12 @@ module.exports = {
           _.assign(locals, urls);
           callback(null);
         },
-        (callback) => {
+        // `_buildLocals` can throw, for instance if an instructor creates an
+        // assessment instance, changes the assessment type from Homework to Exam,
+        // and then views the original instance. So, we use an `async` function
+        // here so that the error will be caught and propagated without us having
+        // to manually catch it and pass it along via `callback`.
+        async () => {
           const {
             variant,
             question,
@@ -1633,7 +1638,6 @@ module.exports = {
           if (locals.manualGradingInterface && question?.show_correct_answer) {
             locals.showTrueAnswer = true;
           }
-          callback(null);
         },
         (callback) => {
           var params = {


### PR DESCRIPTION
This puts a bandaid over the issue described in #6169. While it doesn't prevent an error, it does prevent that error from crashing the entire server.