### PR TITLE
Update R autograder to Ubuntu 22.04, R 4.2.1 and current packages

### DIFF
--- a/graders/r/Dockerfile
+++ b/graders/r/Dockerfile
@@ -2,38 +2,51 @@
 # as well as general support of STAT 477 Data Science Programming Methods
 # (which was formerly STAT 430 Topics - Data Science Programming Methods
 
-# Alton Barbehenn and Dirk Eddelbuettel, 2019-2021
+# Alton Barbehenn and Dirk Eddelbuettel, 2019-2022
 
-# We base this container on the 'r-ubuntu:20.04' container of the
-# Rocker Project. This offers us a well-understood and stable basis
+# We initially based this container on the 'r-ubuntu:20.04' container of the
+# Rocker Project which offers us a well-understood and stable basis
 # in the form of an Ubuntu LTS release, along with the a) ability to
 # deploy the current R version built on that release, and b) to source
 # several thousand CRAN packages as r-cran-* binaries via the PPA
 # See https://rocker-project.org for Rocker, and the README at
 # https://cran.r-project.org/bin/linux/ubuntu/ about R and the binaries
+# As of 2022, we extended this to r2u (see https://eddelbuettel.github.io/r2u/)
+# which offers _all_ of CRAN as .deb binaries. Among other things this saves us
+# one layer here as all R packages now comes as .deb via apt
+# (Note that r2u can use install.r but that require root to get from the user
+# process via systemd to apt, and the Docker build step does not allow for
+# the required security escalation so we just apt as previously but pointing
+# at a richer and larger repository with complete CRAN coverage.)
 
-FROM rocker/r-ubuntu:20.04
+FROM eddelbuettel/r2u:22.04
 
 # Needed to properly handle UTF-8
 ENV PYTHONIOENCODING=UTF-8
 
 # Install required libraries -- using prebuild binaries where available
 # We also install sqlite3 to support the SQL lectures
-RUN apt-get update && apt-get install -y \
+# NB Dirk needs the line to /etc/hosts to build this locally as he hosts r2u
+#  RUN echo "192.168.1.114 dirk.eddelbuettel.com" >> /etc/hosts && \
+RUN apt update && apt install -y \
         curl \
 	git \
+        r-cran-bench \        
 	r-cran-data.table \
 	r-cran-devtools \
         r-cran-diffobj \
 	r-cran-doparallel \
 	r-cran-dygraphs \
+        r-cran-flexdashboard \
 	r-cran-foreach \
 	r-cran-fs \
 	r-cran-future.apply \
+	r-cran-gapminder \
 	r-cran-gh \
 	r-cran-git2r \
 	r-cran-igraph \
 	r-cran-lahman \
+        r-cran-lintr \
 	r-cran-memoise \
 	r-cran-microbenchmark \
 	r-cran-nycflights13 \
@@ -49,13 +62,12 @@ RUN apt-get update && apt-get install -y \
 	r-cran-testthat \
 	r-cran-tidyverse \
 	r-cran-tinytest \
+        r-cran-ttdo \
+        r-cran-unix \
 	r-cran-xts \
 	sqlite3 \
         sudo \
         && echo "options(diffobj.brightness=\"dark\")" >> /etc/R/Rprofile.site
-
-# Install additional R packages from CRAN (on top of the ones pre-built as r-cran-*)
-RUN install.r bench flexdashboard gapminder lintr ttdo unix
 
 # Install plr (from sibbling PL repo), and visualTest from Mango
 RUN installGithub.r PrairieLearn/pl-r-helpers MangoTheCat/visualTest

--- a/graders/r/README.md
+++ b/graders/r/README.md
@@ -5,9 +5,14 @@ used in the [STAT 430](https://stat430.com) (2018-2020) and [STAT 447](https://s
 Urbana-Champaign. However, the container is perfectly generic and can be used
 for general R work as well.
 
-It is based on the [Rocker](https://rocker-project.org) container `r-ubuntu` in order to take
+It is based on the [Rocker](https://rocker-project.org) containers in order to take
 advantage of the prebuilt Ubuntu binaries available for the stable 'long-term support' (LTS)
 releases---both current versions of R itself, as well as current CRAN packages.
+In the most recent instance, it uses [r2u](https://eddelbuettel.github.io/r2u/)
+which offers _all_ of CRAN as fully depedency-resolved .deb binaries for both
+(current) LTS releases (as of Summer/Fall 2022 these are 20.04 and 22.04). We also
+rely on [r2u](https://eddelbuettel.github.io/r2u/) in the RStudio Server instance
+used for the course.
 
 ### R Packages Installed
 


### PR DESCRIPTION
This also switches the CRAN package injection from using the c2d4u repo with its ~5k packages to the newer r2u with full coverage, which reduces on RUN step as we no longer need any 'additional' CRAN packages installed from source.

Otherwise standard updated which @barbehenna tested locally based on a build we did in the predecessor repo.  The PR is otherwise very narrow and touches nothing outside the r-autograder directory.