### PR TITLE
Handle errors when encoding question data into JSON

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1710,32 +1710,36 @@ module.exports = {
             callback(null);
           });
         },
-        (callback) => {
-          var questionJson = JSON.stringify({
-            questionFilePath: locals.calculationQuestionFileUrl,
-            questionGeneratedFilePath: locals.calculationQuestionGeneratedFileUrl,
-            effectiveQuestionType: locals.effectiveQuestionType,
-            course: locals.course,
-            courseInstance: locals.course_instance,
-            variant: {
-              id: locals.variant.id,
-              params: locals.variant.params,
-            },
-            submittedAnswer:
-              locals.showSubmissions && locals.submission
-                ? locals.submission.submitted_answer
-                : null,
-            feedback: locals.showFeedback && locals.submission ? locals.submission.feedback : null,
-            trueAnswer: locals.showTrueAnswer ? locals.variant.true_answer : null,
-            submissions: locals.showSubmissions ? locals.submissions : null,
-          });
-          var encodedJson = encodeURIComponent(questionJson);
-          locals.questionJsonBase64 = Buffer.from(encodedJson).toString('base64');
+        async () => {
+          if (locals.question.type !== 'Freeform') {
+            const questionJson = JSON.stringify({
+              questionFilePath: locals.calculationQuestionFileUrl,
+              questionGeneratedFilePath: locals.calculationQuestionGeneratedFileUrl,
+              effectiveQuestionType: locals.effectiveQuestionType,
+              course: locals.course,
+              courseInstance: locals.course_instance,
+              variant: {
+                id: locals.variant.id,
+                params: locals.variant.params,
+              },
+              submittedAnswer:
+                locals.showSubmissions && locals.submission
+                  ? locals.submission.submitted_answer
+                  : null,
+              feedback:
+                locals.showFeedback && locals.submission ? locals.submission.feedback : null,
+              trueAnswer: locals.showTrueAnswer ? locals.variant.true_answer : null,
+              submissions: locals.showSubmissions ? locals.submissions : null,
+            });
+
+            const encodedJson = encodeURIComponent(questionJson);
+            locals.questionJsonBase64 = Buffer.from(encodedJson).toString('base64');
+          }
+
           locals.video = null;
           locals.iqqrcode = new QR({
             content: `${config.PLpeekUrl}/${locals.variant.instance_question_id}`,
           }).svg();
-          callback(null);
         },
       ],
       (err) => {


### PR DESCRIPTION
The switch from using callbacks to an `async` function means we can now properly catch and handle errors if something fails (for instance, we saw a case in the wild where the encoded JSON exceeded the maximum size of a string in Node).

Relatedly, we will now only generate the base-64 encoded JSON when we're rendering a legacy (v2, not Freeform) question, as Freeform questions don't make use of that value at all.