### PR TITLE
Fix chai.assert typechecking

### DIFF
--- a/tests/sync/questionsSync.test.js
+++ b/tests/sync/questionsSync.test.js
@@ -86,10 +86,7 @@ describe('Question syncing', () => {
     let syncedTags = await util.dumpTable('tags');
     let syncedTag = syncedTags.find((tag) => tag.name === missingTagName);
     assert.isOk(syncedTag);
-    assert(
-      syncedTag.description && syncedTag.description.length > 0,
-      'tag should not have empty description'
-    );
+    assert.isNotEmpty(syncedTag.description, 'tag should not have empty description');
 
     // Subsequent syncs with the same data should succeed as well
     await util.overwriteAndSyncCourseData(courseData, courseDir);
@@ -116,10 +113,7 @@ describe('Question syncing', () => {
     let syncedTopics = await util.dumpTable('topics');
     let syncedTopic = syncedTopics.find((topic) => topic.name === missingTopicName);
     assert.isOk(syncedTopic);
-    assert(
-      syncedTopic.description && syncedTopic.description.length > 0,
-      'tag should not have empty description'
-    );
+    assert.isNotEmpty(syncedTopic.description, 'tag should not have empty description');
 
     // Subsequent syncs with the same data should succeed as well
     await util.overwriteAndSyncCourseData(courseData, courseDir);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,15 +1399,10 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai@*":
+"@types/chai@*", "@types/chai@^4.3.0":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
   integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
-
-"@types/chai@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
-  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
 
 "@types/cheerio@^0.22.31":
   version "0.22.31"


### PR DESCRIPTION
I ran `yarn-deduplicate`, which pulled in a new version of `@types/chai`. That resulted in two new type errors, courtesy of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59859. This PR fixes those.