### PR TITLE
Enable Sentry for graders and workspaces

### DIFF
--- a/grader_host/index.js
+++ b/grader_host/index.js
@@ -8,6 +8,8 @@ const AWS = require('aws-sdk');
 const { exec } = require('child_process');
 const path = require('path');
 const byline = require('byline');
+const Sentry = require('@prairielearn/sentry');
+
 const sqldb = require('../prairielib/lib/sql-db');
 const sanitizeObject = require('../prairielib/lib/util').sanitizeObject;
 
@@ -45,6 +47,12 @@ async.series(
       });
     },
     async () => {
+      if (config.sentryDsn) {
+        await Sentry.init({
+          dsn: config.sentryDsn,
+          environment: config.sentryEnvironment,
+        });
+      }
       await lifecycle.init();
     },
     (callback) => {

--- a/grader_host/index.js
+++ b/grader_host/index.js
@@ -128,6 +128,9 @@ async.series(
     },
   ],
   (err) => {
+    Sentry.captureException(err, {
+      level: 'fatal',
+    });
     globalLogger.error('Error in main loop:', err);
     util.callbackify(lifecycle.abandonLaunch)((err) => {
       if (err) globalLogger.error('Error in lifecycle.abandon():', err);

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -20,6 +20,7 @@ const net = require('net');
 const unzipper = require('unzipper');
 const stream = require('stream');
 const asyncHandler = require('express-async-handler');
+const Sentry = require('@prairielearn/sentry');
 
 const dockerUtil = require('../lib/dockerUtil');
 const awsHelper = require('../lib/aws');
@@ -150,6 +151,14 @@ async.series(
         workspace_server_settings.hostname = config.workspaceDevHostHostname;
         workspace_server_settings.server_to_container_hostname =
           config.workspaceDevContainerHostname;
+      }
+    },
+    async () => {
+      if (config.sentryDsn) {
+        await Sentry.init({
+          dsn: config.sentryDsn,
+          environment: config.sentryEnvironment,
+        });
       }
     },
     (callback) => {


### PR DESCRIPTION
Followup to https://github.com/PrairieLearn/PrairieLearn/pull/6182 that enables Sentry for grader and workspace host.

This doesn't yet capture *every* type of error; just global ones and a few specific local errors that I picked basically at random.