### PR TITLE
fix: Proper error message if external grader has invalid score

### DIFF
--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -436,18 +436,26 @@ module.exports = {
       [
         (callback) => {
           if (!_(content.grading).isObject()) {
-            return callback(error.makeWithData('invalid grading', { content: content }));
+            content.grading = {
+              feedback: {
+                succeeded: false,
+                gradable: false,
+                message: 'Error parsing external grading results: result data is not an object.',
+                original_content: content,
+              },
+            };
           }
           if (_(content.grading).has('feedback') && !_(content.grading.feedback).isObject()) {
-            return callback(
-              error.makeWithData('invalid grading.feedback', {
-                content: content,
-              })
-            );
+            content.grading.feedback = {
+              succeeded: false,
+              gradable: false,
+              message: 'Error parsing external grading results: grading feedback is not an object.',
+              original_feedback: content.grading.feedback,
+            };
           }
 
           const succeeded = !!_.get(content, 'grading.feedback.results.succeeded', true);
-          const gradable = !!_.get(content, 'grading.feedback.results.gradable', true);
+          let gradable = !!_.get(content, 'grading.feedback.results.gradable', true);
           if (!succeeded) {
             content.grading.score = 0;
           }
@@ -455,18 +463,24 @@ module.exports = {
           if (gradable) {
             // We only care about the score if it is gradable.
             if (!_(content.grading.score).isNumber()) {
-              return callback(
-                error.makeWithData('invalid grading.score', {
-                  content: content,
-                })
-              );
+              content.grading.feedback = {
+                succeeded: false,
+                gradable: false,
+                message: 'Error parsing external grading results: score is not a number.',
+                original_feedback: content.grading.feedback,
+              };
+              content.grading.score = 0;
+              gradable = false;
             }
             if (content.grading.score < 0 || content.grading.score > 1) {
-              return callback(
-                error.makeWithData('grading.score out of range', {
-                  content: content,
-                })
-              );
+              content.grading.feedback = {
+                succeeded: false,
+                gradable: false,
+                message: 'Error parsing external grading results: score is out of range.',
+                original_feedback: content.grading.feedback,
+              };
+              content.grading.score = 0;
+              gradable = false;
             }
           }
 

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -463,7 +463,7 @@ module.exports = {
               content.grading.score = 0;
               gradable = false;
             }
-            if (!_(content.grading.score).isNumber()) {
+            if (!_(content.grading.score).isFinite()) {
               content.grading.feedback = {
                 results: { succeeded: false, gradable: false },
                 message: 'Error parsing external grading results: score is not a number.',

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -436,22 +436,14 @@ module.exports = {
       [
         (callback) => {
           if (!_(content.grading).isObject()) {
-            content.grading = {
-              feedback: {
-                succeeded: false,
-                gradable: false,
-                message: 'Error parsing external grading results: result data is not an object.',
-                original_content: content,
-              },
-            };
+            return callback(error.makeWithData('invalid grading', { content: content }));
           }
           if (_(content.grading).has('feedback') && !_(content.grading.feedback).isObject()) {
-            content.grading.feedback = {
-              succeeded: false,
-              gradable: false,
-              message: 'Error parsing external grading results: grading feedback is not an object.',
-              original_feedback: content.grading.feedback,
-            };
+            return callback(
+              error.makeWithData('invalid grading.feedback', {
+                content: content,
+              })
+            );
           }
 
           const succeeded = !!_.get(content, 'grading.feedback.results.succeeded', true);
@@ -462,10 +454,18 @@ module.exports = {
 
           if (gradable) {
             // We only care about the score if it is gradable.
+            if (typeof content.grading.score === 'undefined') {
+              content.grading.feedback = {
+                results: { succeeded: false, gradable: false },
+                message: 'Error parsing external grading results: score was not provided.',
+                original_feedback: content.grading.feedback,
+              };
+              content.grading.score = 0;
+              gradable = false;
+            }
             if (!_(content.grading.score).isNumber()) {
               content.grading.feedback = {
-                succeeded: false,
-                gradable: false,
+                results: { succeeded: false, gradable: false },
                 message: 'Error parsing external grading results: score is not a number.',
                 original_feedback: content.grading.feedback,
               };
@@ -474,8 +474,7 @@ module.exports = {
             }
             if (content.grading.score < 0 || content.grading.score > 1) {
               content.grading.feedback = {
-                succeeded: false,
-                gradable: false,
+                results: { succeeded: false, gradable: false },
                 message: 'Error parsing external grading results: score is out of range.',
                 original_feedback: content.grading.feedback,
               };


### PR DESCRIPTION
Resolves #6255. The format of the message is somewhat analogous to what would be printed if results.json did not exist or could not be parsed as JSON.