### PR TITLE
Install @types/yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
         "@types/pg": "^8.6.5",
         "@types/tmp": "^0.2.3",
         "@types/uuid": "^8.3.4",
+        "@types/yargs": "^17.0.12",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
         "coveralls": "^3.1.1",

--- a/tools/pg-describe.js
+++ b/tools/pg-describe.js
@@ -31,12 +31,14 @@ const yargs = require('yargs')
   )
   .strict();
 
-if (yargs.argv._.length !== 1) {
+// TODO: remove cast once `@types/yargs` is fixed
+// https://github.com/yargs/yargs/issues/2175
+const argv = /** @type {Record<string, any>} */ (yargs.argv);
+
+if (argv._.length !== 1) {
   yargs.showHelp();
   process.exit(1);
 }
-
-const argv = yargs.argv;
 
 // Disable color if we're not attached to a tty
 const coloredOutput = !argv.o && process.stdout.isTTY;

--- a/tools/pg-diff.js
+++ b/tools/pg-diff.js
@@ -21,24 +21,26 @@ const yargs = require('yargs')
   )
   .strict();
 
-const args = yargs.argv;
+// TODO: remove cast once `@types/yargs` is fixed
+// https://github.com/yargs/yargs/issues/2175
+const argv = /** @type {Record<string, any>} */ (yargs.argv);
 
 const options = {
   outputFormat: 'string',
   coloredOutput: process.stdout.isTTY,
 };
 
-if (args.db && !Array.isArray(args.db) && args.dir && !Array.isArray(args.dir)) {
+if (argv.db && !Array.isArray(argv.db) && argv.dir && !Array.isArray(argv.dir)) {
   // Ensure correct ordering for the sake of diffs
   if (process.argv.indexOf('--db') < process.argv.indexOf('--dir')) {
-    databaseDiff.diffDatabaseAndDirectory(args.db, args.dir, options, handleResults);
+    databaseDiff.diffDatabaseAndDirectory(argv.db, argv.dir, options, handleResults);
   } else {
-    databaseDiff.diffDirectoryAndDatabase(args.dir, args.db, options, handleResults);
+    databaseDiff.diffDirectoryAndDatabase(argv.dir, argv.db, options, handleResults);
   }
-} else if (args.db && Array.isArray(args.db) && args.db.length === 2 && !args.dir) {
-  databaseDiff.diffDatabases(args.db[0], args.db[1], options, handleResults);
-} else if (args.dir && Array.isArray(args.dir) && args.dir.length === 2 && !args.db) {
-  databaseDiff.diffDirectories(args.dir[0], args.dir[1], options, handleResults);
+} else if (argv.db && Array.isArray(argv.db) && argv.db.length === 2 && !argv.dir) {
+  databaseDiff.diffDatabases(argv.db[0], argv.db[1], options, handleResults);
+} else if (argv.dir && Array.isArray(argv.dir) && argv.dir.length === 2 && !argv.db) {
+  databaseDiff.diffDirectories(argv.dir[0], argv.dir[1], options, handleResults);
 } else {
   yargs.showHelp();
   process.exit(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,6 +1796,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^17.0.12":
+  version "17.0.12"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.12.tgz#0745ff3e4872b4ace98616d4b7e37ccbd75f9526"
+  integrity sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"


### PR DESCRIPTION
This should unblock #6289; see https://github.com/yargs/yargs/issues/2175 for the root cause of the blockage (the Jest types are now pulling in `@types/yargs`).