### PR TITLE
Add config options for compliance with Chinese regulations

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -263,6 +263,13 @@ config.honeycombDataset = 'prairielearn-dev';
 config.sentryDsn = null;
 config.sentryEnvironment = 'development';
 
+/**
+ * In some markets, such as China, the title of all pages needs to be a
+ * specific string in order to comply with local regulations. If this option
+ * is set, it will be used verbatim as the `<title>` of all pages.
+ */
+config.titleOverride = null;
+
 config.attachedFilesDialogEnabled = true;
 config.devMode = false;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -270,6 +270,13 @@ config.sentryEnvironment = 'development';
  */
 config.titleOverride = null;
 
+/**
+ * Similarly, China also requires us to include a registration number and link
+ * to a specific page on the homepage footer.
+ */
+config.homepageFooterText = null;
+config.homepageFooterTextHref = null;
+
 config.attachedFilesDialogEnabled = true;
 config.devMode = false;
 

--- a/pages/home/home.ejs
+++ b/pages/home/home.ejs
@@ -494,6 +494,10 @@
       <div class="bg-flourish h-flourish"></div>
       <% } %>
       <div class="<%= isAuthenticated ? 'bg-secondary p-1' : 'container' %>">
+        <% if (config.homepageFooterText) { %>
+          <a class="text-light" href="<%= config.homepageFooterTextLink %>"><%= config.homepageFooterText %></a>
+        <% } %>
+        &middot;
         &copy; 2021 <a class="text-nowrap text-light" href="https://illinois.edu">University of Illinois at Urbana-Champaign</a>
         &middot;
         <a class="text-nowrap text-light" href="https://www.vecteezy.com/free-vector/nature">Nature Vectors by Vecteezy</a>

--- a/pages/home/home.ejs
+++ b/pages/home/home.ejs
@@ -496,8 +496,8 @@
       <div class="<%= isAuthenticated ? 'bg-secondary p-1' : 'container' %>">
         <% if (config.homepageFooterText) { %>
           <a class="text-light" href="<%= config.homepageFooterTextLink %>"><%= config.homepageFooterText %></a>
+          &middot;
         <% } %>
-        &middot;
         &copy; 2021 <a class="text-nowrap text-light" href="https://illinois.edu">University of Illinois at Urbana-Champaign</a>
         &middot;
         <a class="text-nowrap text-light" href="https://www.vecteezy.com/free-vector/nature">Nature Vectors by Vecteezy</a>

--- a/pages/partials/title.ejs
+++ b/pages/partials/title.ejs
@@ -60,9 +60,15 @@
     }
 %>
 <title>
+
+  <%# In some markets (such as China), the title needs to be a specific string to meet legal requirements. %>
+  <% if (config.titleOverride) { %>
+    <%= config.titleOverride %>
+  <% } else { %>
     <% if (config.devMode) { %>[DEV]<% } %>    
     <% if (navTrace.length > 0) { %>
         <%= navTrace.join(" - ") + " | " %>
     <% } %>
     PrairieLearn
+  <% } %>
 </title>

--- a/pages/partials/title.ejs
+++ b/pages/partials/title.ejs
@@ -60,8 +60,6 @@
     }
 %>
 <title>
-
-  <%# In some markets (such as China), the title needs to be a specific string to meet legal requirements. %>
   <% if (config.titleOverride) { %>
     <%= config.titleOverride %>
   <% } else { %>


### PR DESCRIPTION
We were notified by ZJUI that we need to make specific changes to our site to comply with local regulations:

- We need to change the `<title>` on all pages to a specific value.
- We need to add the website registration number and a link to the [Ministry of Industry and Information Technology](https://en.wikipedia.org/wiki/Ministry_of_Industry_and_Information_Technology) domain registration website.

Adding these config values will allow us to comply with regulations without hardcoding anything specific into PrairieLearn's source code.