### PR TITLE
Add pandoc to graders/r/Dockerfile

### DIFF
--- a/graders/r/Dockerfile
+++ b/graders/r/Dockerfile
@@ -31,6 +31,7 @@ ENV PYTHONIOENCODING=UTF-8
 RUN apt update && apt install -y \
         curl \
 	git \
+        pandoc \
         r-cran-bench \        
 	r-cran-data.table \
 	r-cran-devtools \


### PR DESCRIPTION
This minimal PR adds `pandoc` ~and `pandoc-citeproc`~ to the R autograder container.