### PR TITLE
Don't send "Workspace is not running" errors to Sentry

### DIFF
--- a/server.js
+++ b/server.js
@@ -275,10 +275,6 @@ module.exports.initExpress = function () {
         { workspace_id }
       );
 
-      if (req.upgrade === true) {
-        throw error.make(404, 'Workspace is not running');
-      }
-
       if (result.rows.length === 0) {
         // If updating this message, also update the message our Sentry
         // `beforeSend` handler.

--- a/server.js
+++ b/server.js
@@ -276,6 +276,8 @@ module.exports.initExpress = function () {
       );
 
       if (result.rows.length === 0) {
+        // If updating this message, also update the message our Sentry
+        // `beforeSend` handler.
         throw error.make(404, 'Workspace is not running');
       }
 
@@ -1764,6 +1766,17 @@ if (config.startServer) {
           await Sentry.init({
             dsn: config.sentryDsn,
             environment: config.sentryEnvironment,
+            beforeSend: (event) => {
+              // The following error message should match the error that's thrown
+              // from the `router` function in our `http-proxy-middleware` config.
+              if (event?.message === 'Workspace is not running') {
+                // This will be necessary until we can consume the following change:
+                // https://github.com/chimurai/http-proxy-middleware/pull/823
+                return null;
+              }
+
+              return event;
+            },
           });
         }
 


### PR DESCRIPTION
Throwing an error in the `router` function of `http-proxy-middleware` currently produces an unhandled exception. Until https://github.com/chimurai/http-proxy-middleware/pull/823 is merged, we need special handling to avoid blowing through our Sentry error budget.