### PR TITLE
Fix deletion of non-existent chunks

### DIFF
--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -536,23 +536,43 @@ module.exports.diffChunks = async ({ coursePath, courseId, courseData, changedFi
   );
 
   // Check for any deleted course instances or their assessments.
-  Object.entries(existingCourseChunks.courseInstances).forEach(([ciid, courseInstanceInfo]) => {
-    if (!courseData.courseInstances[ciid]) {
-      deletedChunks.push({
-        type: 'clientFilesCourseInstance',
-        courseInstanceName: ciid,
-      });
-      existingCourseChunks.courseInstances[ciid].assessments.forEach((tid) => {
+  await Promise.all(
+    Object.entries(existingCourseChunks.courseInstances).map(async ([ciid, courseInstanceInfo]) => {
+      const courseInstanceExists = !!courseData.courseInstances[ciid];
+      const clientFilesCourseInstanceExists = await fs.pathExists(
+        path.join(coursePath, 'courseInstances', ciid, 'clientFilesCourseInstance')
+      );
+      if (!courseInstanceExists || !clientFilesCourseInstanceExists) {
         deletedChunks.push({
-          type: 'clientFilesAssessment',
+          type: 'clientFilesCourseInstance',
           courseInstanceName: ciid,
-          assessmentName: tid,
         });
-      });
-    }
+      }
 
-    if ()
-  });
+      await Promise.all(
+        [...courseInstanceInfo.assessments].map(async (tid) => {
+          const assessmentExists = !!courseData.courseInstances[ciid].assessments[tid];
+          const clientFilesAssessmentExists = await fs.pathExists(
+            path.join(
+              coursePath,
+              'courseInstances',
+              ciid,
+              'assessments',
+              tid,
+              'clientFilesAssessment'
+            )
+          );
+          if (!courseInstanceExists || !assessmentExists || !clientFilesAssessmentExists) {
+            deletedChunks.push({
+              type: 'clientFilesAssessment',
+              courseInstanceName: ciid,
+              assessmentName: tid,
+            });
+          }
+        })
+      );
+    })
+  );
 
   return { updatedChunks, deletedChunks };
 };
@@ -708,7 +728,6 @@ module.exports.updateChunksForCourse = async ({
   });
 
   await module.exports.createAndUploadChunks(coursePath, courseId, updatedChunks);
-  console.log(deletedChunks);
   await module.exports.deleteChunks(courseId, deletedChunks);
 };
 
@@ -1005,7 +1024,6 @@ module.exports.ensureChunksForCourseAsync = async (courseId, chunks) => {
       // Blindly remove this chunk from disk - if it doesn't exist, `fs.remove`
       // will silently no-op.
       const chunkMetadata = module.exports.chunkMetadataFromDatabaseChunk(chunk);
-      console.log(chunkMetadata);
       await fs.remove(module.exports.coursePathForChunk(courseChunksDirs.course, chunkMetadata));
     })
   );

--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -968,12 +968,6 @@ module.exports.ensureChunksForCourseAsync = async (courseId, chunks) => {
   // in the results of `select_metadata_for_chunks`. If it does not, we remove
   // the chunk from the course's runtime directory.
   //
-  // At this time, we only do this for `elements`, `elementExtensions`,
-  // `serverFilesCourse`, and `clientFilesCourse`, since it's critical that they
-  // not be present on disk if they're removed from a course. If it becomes
-  // necessary to handle additional chunks in the future, this code can easily
-  // be extended to support that.
-  //
   // See https://github.com/PrairieLearn/PrairieLearn/issues/4692 for more details.
   const courseChunksDirs = module.exports.getChunksDirectoriesForCourseId(courseId);
   await Promise.all(

--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -475,6 +475,16 @@ module.exports.diffChunks = async ({ coursePath, courseId, courseData, changedFi
     }
   });
 
+  // Check for any deleted questions.
+  existingCourseChunks.questions.forEach((qid) => {
+    if (!courseData.questions[qid]) {
+      deletedChunks.push({
+        type: 'question',
+        questionName: qid,
+      });
+    }
+  });
+
   // Next: course instances and their assessments
   await async.each(
     Object.entries(courseData.courseInstances),
@@ -524,6 +534,25 @@ module.exports.diffChunks = async ({ coursePath, courseId, courseData, changedFi
       });
     }
   );
+
+  // Check for any deleted course instances or their assessments.
+  Object.entries(existingCourseChunks.courseInstances).forEach(([ciid, courseInstanceInfo]) => {
+    if (!courseData.courseInstances[ciid]) {
+      deletedChunks.push({
+        type: 'clientFilesCourseInstance',
+        courseInstanceName: ciid,
+      });
+      existingCourseChunks.courseInstances[ciid].assessments.forEach((tid) => {
+        deletedChunks.push({
+          type: 'clientFilesAssessment',
+          courseInstanceName: ciid,
+          assessmentName: tid,
+        });
+      });
+    }
+
+    if ()
+  });
 
   return { updatedChunks, deletedChunks };
 };
@@ -679,6 +708,7 @@ module.exports.updateChunksForCourse = async ({
   });
 
   await module.exports.createAndUploadChunks(coursePath, courseId, updatedChunks);
+  console.log(deletedChunks);
   await module.exports.deleteChunks(courseId, deletedChunks);
 };
 
@@ -975,6 +1005,7 @@ module.exports.ensureChunksForCourseAsync = async (courseId, chunks) => {
       // Blindly remove this chunk from disk - if it doesn't exist, `fs.remove`
       // will silently no-op.
       const chunkMetadata = module.exports.chunkMetadataFromDatabaseChunk(chunk);
+      console.log(chunkMetadata);
       await fs.remove(module.exports.coursePathForChunk(courseChunksDirs.course, chunkMetadata));
     })
   );

--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -36,9 +36,9 @@ FROM
         AND ((chunks_arr->>'assessmentId' IS NULL) OR (chunks.assessment_id = (chunks_arr->>'assessmentId')::bigint))
         AND ((chunks_arr->>'questionId' IS NULL) OR (chunks.question_id = (chunks_arr->>'questionId')::bigint))
     )
-    LEFT JOIN assessments AS a ON (a.id = chunks.assessment_id)
-    LEFT JOIN course_instances AS ci ON (ci.id = chunks.course_instance_id OR ci.id = a.course_instance_id)
-    LEFT JOIN questions AS q ON (q.id = chunks.question_id);
+    LEFT JOIN assessments AS a ON (a.id = (chunks_arr->>'assessmentId')::bigint)
+    LEFT JOIN course_instances AS ci ON (ci.id = (chunks_arr->>'coursInstanceId')::bigint OR ci.id = a.course_instance_id)
+    LEFT JOIN questions AS q ON (q.id = (chunks_arr->>'questionId')::bigint);
 
 -- BLOCK select_course_dir
 SELECT c.path

--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -37,7 +37,7 @@ FROM
         AND ((chunks_arr->>'questionId' IS NULL) OR (chunks.question_id = (chunks_arr->>'questionId')::bigint))
     )
     LEFT JOIN assessments AS a ON (a.id = (chunks_arr->>'assessmentId')::bigint)
-    LEFT JOIN course_instances AS ci ON (ci.id = (chunks_arr->>'coursInstanceId')::bigint OR ci.id = a.course_instance_id)
+    LEFT JOIN course_instances AS ci ON (ci.id = (chunks_arr->>'courseInstanceId')::bigint OR ci.id = a.course_instance_id)
     LEFT JOIN questions AS q ON (q.id = (chunks_arr->>'questionId')::bigint);
 
 -- BLOCK select_course_dir

--- a/tests/chunks.test.sql
+++ b/tests/chunks.test.sql
@@ -2,3 +2,18 @@
 SELECT *
 FROM pl_courses
 WHERE path = $course_path;
+
+-- BLOCK select_course_instance
+SELECT id
+FROM course_instances
+WHERE long_name = $long_name;
+
+-- BLOCK select_assessment
+SELECT id
+FROM assessments
+WHERE tid = $tid;
+
+-- BLOCK select_question
+SELECT id
+FROM questions
+WHERE qid = $qid;


### PR DESCRIPTION
Fixes the following Sentry error: https://sentry.io/organizations/prairielearn-inc/issues/3580869456/?project=6704263

Closes #6308.

When we're fetching chunks, we use the presence of an `id` field on the results of [`select_metadata_for_chunks`](https://github.com/PrairieLearn/PrairieLearn/blob/8e752630568f07b018096aaa7f93d92f0dd1335c/lib/chunks.sql#L18) to indicate whether or not a given chunk exists. If it does not, we remove that chunk from disk. However, this was failing for `clientFilesAssessment` chunks, as the resulting row from the database did not include the course instance name or the assessment name. This ultimately causes the following `path.join` call to fail since `chunkMetadata.courseInstanceName` and `chunkMetadata.assessmentName` are both `null`:

https://github.com/PrairieLearn/PrairieLearn/blob/8e752630568f07b018096aaa7f93d92f0dd1335c/lib/chunks.js#L219-L226

Similar issues occur for `clientFilesCourseInstance`; this PR fixes those too.

By changing the joins to use the input values directly instead of the columns on the `chunks` table, we ensure that we select all the necessary metadata.