### PR TITLE
Clean yum cache in executor image

### DIFF
--- a/images/executor/Dockerfile
+++ b/images/executor/Dockerfile
@@ -2,7 +2,7 @@ FROM prairielearn/prairielearn
 WORKDIR /PrairieLearn/
 
 # We need pkill in this image
-RUN yum -y install procps-ng
+RUN yum -y install procps-ng && yum clean all
 
 RUN pip3 install psutil
 


### PR DESCRIPTION
This shaves several hundred MB off the size of the executor image.

https://github.com/wagoodman/dive looks to be a great tool for identifying where the biggest parts of a Docker image come from.