### PR TITLE
Clean Conda caches after installation

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -79,3 +79,5 @@ else
     echo "installing Python packages..."
     python3 -m pip install --no-cache-dir -r /py_req_no_r.txt
 fi
+
+conda clean --all


### PR DESCRIPTION
This shaves another ~80MB off our Docker images.

https://docs.conda.io/projects/conda/en/latest/commands/clean.html