### PR TITLE
fix: Remove unnecessary duplicate request from API download script

### DIFF
--- a/tools/api_download.py
+++ b/tools/api_download.py
@@ -71,7 +71,6 @@ def get_and_save_json(endpoint, filename, args, logfile):
     headers = {'Private-Token': args.token}
     log(logfile, f'downloading {url} ...')
     start_time = time.time()
-    r = requests.get(url, headers=headers)
     retry_502_max = 30
     retry_502_i = 0
     while True:


### PR DESCRIPTION
The script currently makes two requests for every piece of data, and ignores the result of the first one.