### PR TITLE
Fix doc link in news item

### DIFF
--- a/docs/course.md
+++ b/docs/course.md
@@ -216,7 +216,7 @@ The assessment set order in `infoCourse.json` is the order in which the assessme
 }
 ```
 
-## Assessment modules
+## Assessment modules<a id="modules"></a>
 
 Each assessment in the course belongs to a _module_ defined in `infoCourse.json`. Modules can represent course topics, chapters or sections, or in PrairieLearn terms, a collection of assessments related to one another, but not necessarily of the same type. This means you can have a module with two homeworks, one lab, and one exam, for example.
 

--- a/docs/course.md
+++ b/docs/course.md
@@ -216,7 +216,7 @@ The assessment set order in `infoCourse.json` is the order in which the assessme
 }
 ```
 
-## Assessment modules<a id="modules"></a>
+## Assessment modules
 
 Each assessment in the course belongs to a _module_ defined in `infoCourse.json`. Modules can represent course topics, chapters or sections, or in PrairieLearn terms, a collection of assessments related to one another, but not necessarily of the same type. This means you can have a module with two homeworks, one lab, and one exam, for example.
 

--- a/news_items/038_organize_by_module/index.html
+++ b/news_items/038_organize_by_module/index.html
@@ -16,7 +16,7 @@
     This organization selection is done at the course instance level. 
     Thus you can sort some sections/semesters of your course by "Sets",
     and some others by "Modules". Visit the 
-    <a href="https://prairielearn.readthedocs.io/en/latest/course/#modules">
+    <a href="https://prairielearn.readthedocs.io/en/latest/course/#assessment-modules">
         PrairieLearn documentation
     </a> 
     for more information.


### PR DESCRIPTION
The link in the news item has the wrong fragment (`#` part).