### PR TITLE
Use 403 status code when exam time limit has expired

### DIFF
--- a/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
+++ b/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
@@ -101,7 +101,9 @@ router.post('/', function (req, res, next) {
 
   if (req.body.__action === 'grade' || req.body.__action === 'save') {
     if (res.locals.authz_result.time_limit_expired) {
-      return next(new Error('time limit is expired, please go back and finish your assessment'));
+      return next(
+        error.make(403, 'time limit is expired, please go back and finish your assessment')
+      );
     }
     if (req.body.__action === 'grade' && !res.locals.assessment.allow_real_time_grading) {
       next(error.make(403, 'Real-time grading is not allowed for this assessment'));


### PR DESCRIPTION
This will keep this event out of Sentry, and it also more accurately reflects what the error actually is.