### PR TITLE
Ensure socket.io has started before processing external grading results

### DIFF
--- a/server.js
+++ b/server.js
@@ -1923,12 +1923,7 @@ if (config.startServer) {
           callback(null);
         });
       },
-      function (callback) {
-        cron.init(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
+      async () => await codeCaller.init(),
       (callback) => {
         redis.init((err) => {
           if (ERR(err, callback)) return;
@@ -1937,6 +1932,12 @@ if (config.startServer) {
       },
       (callback) => {
         cache.init((err) => {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      function (callback) {
+        cron.init(function (err) {
           if (ERR(err, callback)) return;
           callback(null);
         });
@@ -1950,9 +1951,6 @@ if (config.startServer) {
         load.initEstimator('python_worker_idle', 1, false);
         load.initEstimator('python_callback_waiting', 1);
         callback(null);
-      },
-      async () => {
-        await codeCaller.init();
       },
       async () => {
         logger.verbose('Starting server...');

--- a/server.js
+++ b/server.js
@@ -1987,6 +1987,8 @@ if (config.startServer) {
         callback(null);
       },
       async () => await freeformServer.init(),
+      // These should be the last things to start before we actually start taking
+      // requests, as they may actually end up executing course code.
       (callback) => {
         if (!config.externalGradingEnableResults) return callback(null);
         externalGraderResults.init((err) => {

--- a/server.js
+++ b/server.js
@@ -1941,19 +1941,6 @@ if (config.startServer) {
           callback(null);
         });
       },
-      (callback) => {
-        externalGrader.init(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        if (!config.externalGradingEnableResults) return callback(null);
-        externalGraderResults.init((err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
       async () => await assets.init(),
       function (callback) {
         load.initEstimator('request', 1);
@@ -1986,6 +1973,19 @@ if (config.startServer) {
       },
       function (callback) {
         externalGradingSocket.init(function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      (callback) => {
+        externalGrader.init(function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      (callback) => {
+        if (!config.externalGradingEnableResults) return callback(null);
+        externalGraderResults.init((err) => {
           if (ERR(err, callback)) return;
           callback(null);
         });

--- a/server.js
+++ b/server.js
@@ -1924,6 +1924,7 @@ if (config.startServer) {
         });
       },
       async () => await codeCaller.init(),
+      async () => await assets.init(),
       (callback) => {
         redis.init((err) => {
           if (ERR(err, callback)) return;
@@ -1936,13 +1937,6 @@ if (config.startServer) {
           callback(null);
         });
       },
-      function (callback) {
-        cron.init(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      async () => await assets.init(),
       function (callback) {
         load.initEstimator('request', 1);
         load.initEstimator('authed_request', 1);
@@ -1981,13 +1975,6 @@ if (config.startServer) {
           callback(null);
         });
       },
-      (callback) => {
-        if (!config.externalGradingEnableResults) return callback(null);
-        externalGraderResults.init((err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
       async () => workspace.init(),
       function (callback) {
         serverJobs.init(function (err) {
@@ -1999,8 +1986,19 @@ if (config.startServer) {
         nodeMetrics.init();
         callback(null);
       },
-      async () => {
-        await freeformServer.init();
+      async () => await freeformServer.init(),
+      (callback) => {
+        if (!config.externalGradingEnableResults) return callback(null);
+        externalGraderResults.init((err) => {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      function (callback) {
+        cron.init(function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
       },
     ],
     function (err, data) {


### PR DESCRIPTION
We observed some crashes during boot during a recent deployment that were causes because we started processing external grading results before actually starting the websocket server. This PR fixes that, and reorders a few other startup processes as well.