### PR TITLE
Improve workspace host error handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   pl:
-    image: prairielearn/prairielearn:latest
+    build:
+      context: .
+    image: prairielearn/prairielearn:local
     ports:
       - 3000:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: '3.8'
 services:
   pl:
-    build:
-      context: .
-    image: prairielearn/prairielearn:local
+    image: prairielearn/prairielearn:latest
     ports:
       - 3000:3000
     volumes:

--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -348,16 +348,17 @@ module.exports = {
     }
 
     if (workspace.state === 'running') {
-      // get the files directly from the host
+      // Attempt to get the files directly from the host.
       try {
         const action = 'getGradedFiles';
         zipPath = await module.exports.controlContainer(workspace_id, action);
       } catch (err) {
-        logger.error(err);
-        // something went wrong, so fall back to S3
+        logger.error('Error getting graded files from container', err);
       }
     }
 
+    // If this is null, something went wrong, so fall back to fetching from
+    // either S3 or the filesystem.
     if (zipPath == null) {
       if (workspace.homedir_location === 'S3') {
         zipPath = await module.exports.getGradedFilesFromS3(workspace_id);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "@prairielearn/html": "^2.0.0",
         "@prairielearn/opentelemetry": "^1.0.0",
         "@prairielearn/sentry": "^1.0.0",
-        "@types/body-parser": "^1.19.2",
         "ace-builds": "^1.10.1",
         "ajv": "^7.1.1",
         "ansi_up": "^5.1.0",
@@ -142,6 +141,7 @@
     "devDependencies": {
         "@changesets/cli": "^2.24.4",
         "@types/async": "^3.2.15",
+        "@types/body-parser": "^1.19.2",
         "@types/chai": "^4.3.0",
         "@types/chai-as-promised": "^7.1.5",
         "@types/cheerio": "^0.22.31",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@prairielearn/html": "^2.0.0",
         "@prairielearn/opentelemetry": "^1.0.0",
         "@prairielearn/sentry": "^1.0.0",
+        "@types/body-parser": "^1.19.2",
         "ace-builds": "^1.10.1",
         "ajv": "^7.1.1",
         "ansi_up": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-parser@*":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
-  integrity sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
+"@types/body-parser@*", "@types/body-parser@^1.19.2":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"


### PR DESCRIPTION
This PR makes a few improvements to workspace host error handling based on the errors we've seen in Sentry:

- Instead of writing the graded files archive to disk, we now directly pipe it to the response. This incidentally fixes an error where we were a) not awaiting the `fsPromises.unlink` return value and b) sometimes passing `undefined` to `fsPromises.unlink`
- The return value of `_getWorkspaceSettingsAsync` was previously unawaited; now it is.
- We weren't using the `new` keyword with `Stream.Transform`.

I also wired up Sentry request tracking for workspace host commands.