### PR TITLE
Fix unhandled errors in grader host

### DIFF
--- a/grader_host/index.js
+++ b/grader_host/index.js
@@ -480,16 +480,14 @@ function runJob(info, callback) {
           callback(null, container);
         });
       },
-      /**
-       * @param {import('dockerode').Container} container
-       */
-      async (container, callback) => {
+      async (container) => {
         const timeoutId = setTimeout(() => {
           results.timedOut = true;
           container.kill().catch((err) => {
             globalLogger.error('Error killing container', err);
           });
         }, jobTimeout * 1000);
+
         logger.info('Waiting for container to complete');
         try {
           await container.wait();

--- a/grader_host/lib/jobLogger.js
+++ b/grader_host/lib/jobLogger.js
@@ -7,23 +7,21 @@ const config = require('./config').config;
 module.exports = function (options) {
   const { bucket, rootKey } = options;
 
-  const s3LoggerStream = new S3StreamLogger({
-    bucket,
-    folder: rootKey,
-    name_format: 'output.log', // No need to rotate, all logs go to same file
-    upload_every: 1000, // Most jobs are short-lived, so push every second
-    buffer_size: 100 * 1000, // 100kB - this is increased from the default 10kB
+  const s3StreamLoggerTransport = new winston.transports.Stream({
+    stream: new S3StreamLogger({
+      bucket,
+      folder: rootKey,
+      name_format: 'output.log', // No need to rotate, all logs go to same file
+      upload_every: 1000, // Most jobs are short-lived, so push every second
+      buffer_size: 100 * 1000, // 100kB - this is increased from the default 10kB
+    }),
   });
 
-  s3LoggerStream.on('error', (err) => {
+  s3StreamLoggerTransport.on('error', (err) => {
     globalLogger.error(`Error writing to S3`, err);
   });
 
-  const transports = [
-    new winston.transports.Stream({
-      stream: s3LoggerStream,
-    }),
-  ];
+  const transports = [s3StreamLoggerTransport];
 
   if (config.useConsoleLoggingForJobs) {
     transports.push(new winston.transports.Console({ timestamp: true, colorize: true }));

--- a/grader_host/lib/jobLogger.js
+++ b/grader_host/lib/jobLogger.js
@@ -11,7 +11,12 @@ module.exports = function (options) {
     bucket,
     folder: rootKey,
     name_format: 'output.log', // No need to rotate, all logs go to same file
-    upload_every: 1000, // Most jobs are short-lived, so push every 1s
+    upload_every: 1000, // Most jobs are short-lived, so push every second
+    buffer_size: 100 * 1000, // 100kB - this is increased from the default 10kB
+  });
+
+  s3LoggerStream.on('error', (err) => {
+    globalLogger.error(`Error writing to S3`, err);
   });
 
   const transports = [


### PR DESCRIPTION
This PR fixes a few unhandled errors that were reported by Sentry:

- We weren't handling errors thrown from `container.kill()`; now we handle and log them.
- We weren't handling `'error'` events emitted from the S3 logger; I added error handling based on the `s3-streamlogger` docs: https://github.com/Coggle/s3-streamlogger#handling-logging-errors. I also increased the buffer size so that we'd be less likely to run into `SlowDown: Please reduce your request rate.` errors.