### PR TITLE
Use regex to route Shibboleth requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -426,7 +426,7 @@ module.exports.initExpress = function () {
   app.use(require('./middlewares/effectiveRequestChanged'));
   app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2'));
   app.use('/pl/oauth2callback', require('./pages/authCallbackOAuth2/authCallbackOAuth2'));
-  app.use('/pl/shibcallback', require('./pages/authCallbackShib/authCallbackShib'));
+  app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
   app.use('/pl/azure_login', require('./pages/authLoginAzure/authLoginAzure'));
   app.use('/pl/azure_callback', require('./pages/authCallbackAzure/authCallbackAzure'));
 


### PR DESCRIPTION
This should fix some issues we've been seeing in production with Shibboleth requests.