### PR TITLE
fix: pl-dropdown proper use of inline tags

### DIFF
--- a/elements/pl-dropdown/pl-dropdown.mustache
+++ b/elements/pl-dropdown/pl-dropdown.mustache
@@ -40,9 +40,9 @@
               });
             </script>
             <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-            <button id="pl-dropdown-popover-button-{{uuid}}" class="btn btn-sm btn-secondary small border"
+            <button id="pl-dropdown-popover-button-{{uuid}}" class="btn btn-sm btn-secondary small border ml-1"
                     data-placement="auto" data-trigger="focus" data-toggle="popover"
-                    data-html="true" style="margin-left: 5px" title="Format Error" data-container="body"
+                    data-html="true" title="Format Error" data-container="body"
                     data-content="{{parse-error}}">
               Why <i class="fa fa-question-circle" aria-hidden="true"></i>
             </button>

--- a/elements/pl-dropdown/pl-dropdown.mustache
+++ b/elements/pl-dropdown/pl-dropdown.mustache
@@ -1,15 +1,6 @@
-<script>
-    $(function(){
-        $('#pl-dropdown-{{uuid}} [data-toggle="popover"]').popover({
-            sanitize: false,
-            container: 'body',
-            template: '<div class="popover pl-dropdown-popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>',
-        });
-    });
-</script>
 
 {{#question}}
-    <div id="pl-dropdown-{{uuid}}" class="d-inline-block form-group form-inline">
+    <span class="d-inline-block form-group form-inline">
         <select name="{{answers-name}}" class="form-control" {{^editable}}disabled{{/editable}}>
             {{#options}}
                 <option value="{{value}}" {{#selected}}selected{{/selected}}>{{{value}}}</option>
@@ -23,11 +14,11 @@
                 <span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>
             {{/correct}}
         {{/has_submission}}
-    </div>
+    </span>
 {{/question}}
 
 {{#submission}}
-    <div id="pl-dropdown-{{uuid}}" class="d-inline-block">
+    <span id="pl-dropdown-{{uuid}}" class="d-inline-block">
 
         {{^parse-error}}
             <code class="user-output">{{{submitted-answer}}}</code>
@@ -43,15 +34,20 @@
         {{/parse-error}}
 
         {{#parse-error}}
+            <script>
+              $(function(){
+                  $('#pl-dropdown-{{uuid}} [data-toggle="popover"]').popover({ sanitize: false });
+              });
+            </script>
             <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-            <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse-error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+            <button href="javascript:void(0);" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-container="body" data-content="{{parse-error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
         {{/parse-error}}
-    </div>
+    </span>
 {{/submission}}
 
 
 {{#answer}}
-    <div id="pl-dropdown-{{uuid}}" class="d-inline-block">
+    <span class="d-inline-block">
         <code class="user-output">{{{correct-answer}}}</code>
-    </div>
+    </span>
 {{/answer}}

--- a/elements/pl-dropdown/pl-dropdown.mustache
+++ b/elements/pl-dropdown/pl-dropdown.mustache
@@ -18,7 +18,7 @@
 {{/question}}
 
 {{#submission}}
-    <span id="pl-dropdown-{{uuid}}" class="d-inline-block">
+    <span class="d-inline-block">
 
         {{^parse-error}}
             <code class="user-output">{{{submitted-answer}}}</code>
@@ -36,11 +36,16 @@
         {{#parse-error}}
             <script>
               $(function(){
-                  $('#pl-dropdown-{{uuid}} [data-toggle="popover"]').popover({ sanitize: false });
+                  $('#pl-dropdown-popover-button-{{uuid}}').popover({ sanitize: false });
               });
             </script>
             <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-            <button href="javascript:void(0);" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-container="body" data-content="{{parse-error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
+            <button id="pl-dropdown-popover-button-{{uuid}}" class="btn btn-sm btn-secondary small border"
+                    data-placement="auto" data-trigger="focus" data-toggle="popover"
+                    data-html="true" style="margin-left: 5px" title="Format Error" data-container="body"
+                    data-content="{{parse-error}}">
+              Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+            </button>
         {{/parse-error}}
     </span>
 {{/submission}}

--- a/exampleCourse/questions/element/dropdown/question.html
+++ b/exampleCourse/questions/element/dropdown/question.html
@@ -1,18 +1,24 @@
-<p> Select the correct word in the following quotes:</p>
-<p>
-The 
-<pl-dropdown answers-name="aristotle">
+<pl-question-panel>
+  <p>
+    Select the correct word in the following quotes:
+  </p>
+</pl-question-panel>
 
+<p>
+  The 
+  <pl-dropdown answers-name="aristotle">
     {{#params.aristotle}}
         <pl-answer correct="{{tag}}">{{ans}}</pl-answer>
     {{/params.aristotle}}
-
-</pl-dropdown> 
-is more than the sum of its parts.</p>
-
+  </pl-dropdown> 
+  is more than the sum of its parts.
+</p>
 <p>
-A <pl-dropdown sort="ascend" answers-name="hume">
+  A
+  <pl-dropdown sort="ascend" answers-name="hume">
     <pl-answer correct="true">wise</pl-answer>
     <pl-answer correct="false">clumsy</pl-answer>
     <pl-answer correct="false">reckless</pl-answer>
-</pl-dropdown> man proportions his belief to the evidence.</p>
+  </pl-dropdown>
+  man proportions his belief to the evidence.
+</p>

--- a/exampleCourse/questions/element/dropdown/question.html
+++ b/exampleCourse/questions/element/dropdown/question.html
@@ -1,4 +1,5 @@
 <p> Select the correct word in the following quotes:</p>
+<p>
 The 
 <pl-dropdown answers-name="aristotle">
 
@@ -7,10 +8,11 @@ The
     {{/params.aristotle}}
 
 </pl-dropdown> 
-is more than the sum of its parts. <p></p>
+is more than the sum of its parts.</p>
 
+<p>
 A <pl-dropdown sort="ascend" answers-name="hume">
     <pl-answer correct="true">wise</pl-answer>
     <pl-answer correct="false">clumsy</pl-answer>
     <pl-answer correct="false">reckless</pl-answer>
-</pl-dropdown> man proportions his belief to the evidence. <p></p>
+</pl-dropdown> man proportions his belief to the evidence.</p>


### PR DESCRIPTION
Fixes #5898. Dropdown was using div instead of span for an object intended to be inline. Also removed the dropdown id for parts that didn't use them.