### PR TITLE
Show enrolled hidden courses and instructor access in enroll page

### DIFF
--- a/pages/enroll/enroll.ejs
+++ b/pages/enroll/enroll.ejs
@@ -27,6 +27,11 @@
               <td class="align-middle">
                 <%= course_instance.label %>
               </td>
+              <% if (course_instance.instructor_access) { %>
+              <td class="align-middle text-center">
+                <span class="badge badge-info">instructor access</span>
+              </td>
+              <% } else { %>
               <td>
                 <% if (!course_instance.enrolled) { %>
                 <button type="button" class="btn btn-sm btn-info" data-toggle="modal" data-target="#addModal<%= modalIdx %>">
@@ -103,6 +108,7 @@
                 </div>
                 <% } %>
               </td>
+              <% } %>
             </tr>
             <%# incrementing modalIdx must be done before closing the forEach function block: %>
             <% ; modalIdx++; }); %>

--- a/pages/enroll/enroll.ejs
+++ b/pages/enroll/enroll.ejs
@@ -28,7 +28,7 @@
                 <%= course_instance.label %>
               </td>
               <% if (course_instance.instructor_access) { %>
-              <td class="align-middle text-center">
+              <td class="align-middle text-center" colspan="2">
                 <span class="badge badge-info">instructor access</span>
               </td>
               <% } else { %>

--- a/pages/enroll/enroll.sql
+++ b/pages/enroll/enroll.sql
@@ -3,7 +3,8 @@ SELECT
     c.short_name || ': ' || c.title || ', ' || ci.long_name AS label,
     c.short_name || ', ' || ci.short_name AS short_label,
     ci.id AS course_instance_id,
-    (e.id IS NOT NULL) AS enrolled
+    (e.id IS NOT NULL) AS enrolled,
+    users_is_instructor_in_course(u.user_id, c.id) AS instructor_access
 FROM
     users AS u
     CROSS JOIN (
@@ -17,9 +18,8 @@ WHERE
     AND ci.deleted_at IS NULL
     AND c.deleted_at IS NULL
     AND c.example_course IS FALSE
-    AND users_is_instructor_in_course(u.user_id, c.id) IS FALSE
     AND check_course_instance_access(ci.id, u.uid, u.institution_id, $req_date)
-    AND NOT ci.hide_in_enroll_page
+    AND (NOT ci.hide_in_enroll_page OR e.id IS NOT NULL)
 ORDER BY
     c.short_name, c.title, c.id, d.start_date DESC NULLS LAST, d.end_date DESC NULLS LAST, ci.id DESC;
 


### PR DESCRIPTION
Resolves #6349. If a student is enrolled in a course, the `hideInEnrollPage` flag is ignored to allow a student to remove a course.

Also allows courses to be listed in the enrollment page (partially handles the comment in https://github.com/PrairieLearn/PrairieLearn/issues/3149#issuecomment-1252837329).