### PR TITLE
Remove legacy mode for nodemon invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dev:
 start: start-support
 	@node server.js
 start-nodemon: start-support
-	@yarn nodemon -L server.js
+	@yarn nodemon server.js
 start-workspace-host: start-support kill-running-workspaces
 	@node workspace_host/interface.js
 start-executor:
@@ -41,7 +41,7 @@ test-python:
 # pytest uses to discover tests, but it isn't actually a test file itself. We
 # explicitly exclude it here.
 	@python3 -m pytest --ignore graders/python/python_autograder/pl_unit_test.py
-	
+
 lint: lint-js lint-python lint-html lint-links
 lint-js:
 	@yarn eslint --ext js --report-unused-disable-directives "**/*.js"


### PR DESCRIPTION
The legacy mode (`-L` flag) of `nodemon` is causing 100% CPU usage. Given it was (presumably) originally used to address cases of mounted drives inside containers, and those problems don't seem to be an issue anymore (tested on Windows at least), I propose removing the flag, which fixes the CPU usage issue.