### PR TITLE
Improve time limit sorting behaviour in assessment instances list

### DIFF
--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -296,6 +296,7 @@
               <th data-field="time_remaining"
                   data-sortable="true"
                   data-sort-name="time_remaining_sec"
+                  data-sorter="timeRemainingLimitSorter"
                   data-formatter="timeRemainingLimitFormatter"
                   data-class="text-center align-middle text-nowrap"
                   data-switchable="true"

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstancesClientJS.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstancesClientJS.ejs
@@ -273,7 +273,7 @@ function detailsLinkSorter(valueA, valueB, rowA, rowB) {
 function timeRemainingLimitSorter(valueA, valueB, rowA, rowB) {
     // Closed assessments are listed first, followed by time limits
     // ascending, followed by open without a time limit
-    return (rowA.open - rowB.open) || ((valueA ?? Infinity) - (valueB ?? Infinity));
+    return (Number(rowA.open) - Number(rowB.open)) || ((valueA ?? Infinity) - (valueB ?? Infinity));
 }
 
 function actionButtonFormatter(_value, row, index) {

--- a/pages/instructorAssessmentInstances/instructorAssessmentInstancesClientJS.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstancesClientJS.ejs
@@ -270,6 +270,12 @@ function detailsLinkSorter(valueA, valueB, rowA, rowB) {
     return compare;
 }
 
+function timeRemainingLimitSorter(valueA, valueB, rowA, rowB) {
+    // Closed assessments are listed first, followed by time limits
+    // ascending, followed by open without a time limit
+    return (rowA.open - rowB.open) || ((valueA ?? Infinity) - (valueB ?? Infinity));
+}
+
 function actionButtonFormatter(_value, row, index) {
     const ai_id = row.assessment_instance_id;
     var container = $('<div>');


### PR DESCRIPTION
Resolves #6341. Sorts closed assessments first (somewhat equivalent to expired/negative time limit), then assessments with a time limit, then assessments with no time limit (equivalent to infinite time limit).