### PR TITLE
Run git clean before syncing from disk after performing an edit

### DIFF
--- a/lib/editors.js
+++ b/lib/editors.js
@@ -277,7 +277,11 @@ class Editor {
         courseUtil.updateCourseCommitHash(this.course, (err, hash) => {
           ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
           endGitHash = hash;
-          _syncFromDisk();
+
+          // Note that we perform a second `git clean` after writing to disk, as
+          // the write operations may have left some empty directories behind.
+          // This would most likely occur during a rename.
+          _clean(_syncFromDisk, _cleanup);
         });
       };
 

--- a/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -424,11 +424,7 @@ router.get('/*', function (req, res, next) {
     (err) => {
       if (err) {
         if (err.code === 'ENOENT' && file_browser.paths.branch.length > 1) {
-          res.redirect(
-            `${res.locals.urlPrefix}/${res.locals.navPage}/file_view/${encodePath(
-              file_browser.paths.branch.slice(-2)[0].path
-            )}`
-          );
+          res.redirect(`${req.baseUrl}/${encodePath(file_browser.paths.branch.slice(-2)[0].path)}`);
           return;
         } else {
           return ERR(err, next);

--- a/tests/courseEditor.test.js
+++ b/tests/courseEditor.test.js
@@ -1,5 +1,4 @@
 const ERR = require('async-stacktrace');
-const _ = require('lodash');
 const assert = require('chai').assert;
 const fs = require('fs-extra');
 const path = require('path');

--- a/tests/courseEditor.test.js
+++ b/tests/courseEditor.test.js
@@ -160,6 +160,10 @@ const testEditData = [
       'courseInstances/Fa18/assessments/newAssessment/nested/infoAssessment.json',
     ]),
   },
+  // This second rename specifically tests the case where an existing assessment
+  // is renamed such that it leaves behind an empty directory. We want to make
+  // sure that that empty directory is cleaned up and not treated as an actual
+  // assessment during sync.
   {
     button: 'changeAidButton',
     form: 'change-id-form',
@@ -178,19 +182,6 @@ const testEditData = [
       'questions/test/question/server.py',
       'courseInstances/Fa18/assessments/newAssessmentNotNested/infoAssessment.json',
     ]),
-    validate: async () => {
-      console.log('testing');
-      const assessments = await fs.readdir(
-        path.join(courseLiveDir, 'courseInstances/Fa18/assessments')
-      );
-      console.log(assessments);
-      for (const assessment of assessments) {
-        console.log(assessment);
-        console.log(
-          await fs.readdir(path.join(courseLiveDir, 'courseInstances/Fa18/assessments', assessment))
-        );
-      }
-    },
   },
   {
     form: 'delete-assessment-form',
@@ -449,11 +440,7 @@ function testEdit(params) {
       assert.isEmpty(results.rows);
     });
 
-    if (params.validate) {
-      it('passes custom validation', params.validate);
-    }
-
-    it('should pull', function (callback) {
+    it('should pull into dev directory', function (callback) {
       const execOptions = {
         cwd: courseDevDir,
         env: process.env,
@@ -464,7 +451,7 @@ function testEdit(params) {
       });
     });
 
-    it('should match contents', async () => {
+    it('should have correct contents', async () => {
       const files = await getFiles({ baseDir: courseDevDir });
       assert.sameMembers([...files], [...params.files]);
     });

--- a/tests/courseEditor.test.sql
+++ b/tests/courseEditor.test.sql
@@ -8,3 +8,67 @@ LIMIT 1;
 SELECT *
 FROM job_sequences
 WHERE id = $job_sequence_id;
+
+-- BLOCK select_sync_warnings_and_errors
+WITH course_errors AS (
+    SELECT
+        'course' AS type,
+        path AS id,
+        sync_warnings,
+        sync_errors
+    FROM pl_courses
+    WHERE
+        path = $course_path
+        AND (sync_warnings IS NOT NULL OR sync_warnings != '')
+        AND (sync_errors IS NOT NULL OR sync_errors != '')
+),
+course_instance_errors AS (
+    SELECT
+        'course_instance' AS type,
+        ci.short_name AS id,
+        ci.sync_warnings,
+        ci.sync_errors
+    FROM
+        course_instances AS ci
+        JOIN pl_courses AS c ON (ci.course_id = c.id)
+    WHERE
+        c.path = $course_path
+        AND (ci.sync_warnings IS NOT NULL OR ci.sync_warnings != '')
+        AND (ci.sync_errors IS NOT NULL OR ci.sync_errors != '')
+),
+question_errors AS (
+    SELECT
+        'question' AS type,
+        q.qid AS id,
+        q.sync_warnings,
+        q.sync_errors
+    FROM
+        questions AS q
+        JOIN pl_courses AS c ON (q.course_id = c.id)
+    WHERE
+        c.path = $course_path
+        AND (q.sync_warnings IS NOT NULL OR q.sync_warnings != '')
+        AND (q.sync_errors IS NOT NULL OR q.sync_errors != '')
+),
+assessment_errors AS (
+    SELECT
+        'assessment' AS type,
+        a.tid AS id,
+        a.sync_warnings,
+        a.sync_errors
+    FROM
+        assessments AS a
+        JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+        JOIN pl_courses AS c ON (ci.course_id = c.id)
+    WHERE
+        c.path = $course_path
+        AND (a.sync_warnings IS NOT NULL OR a.sync_warnings != '')
+        AND (a.sync_errors IS NOT NULL OR a.sync_errors != '')
+)
+SELECT * FROM course_errors
+UNION
+SELECT * FROM course_instance_errors
+UNION
+SELECT * FROM question_errors
+UNION
+SELECT * FROM assessment_errors;


### PR DESCRIPTION
This PR fixes the issues that @ffund reported on Slack this morning: https://prairielearn.slack.com/archives/C266KEH9A/p1663865172180029

For posterity, Fraida renamed an assessment from something like `foo/bar/infoAssessment.json` to `bar/baz/infoAssessment.json`. This left behind a `foo` directory that didn't contain any `infoAssessment.json` file in itself or its descendants, so that was flagged as a sync error.

After this PR, we'll now run `git clean -dfx` a second time after committing the edits to disk. This will ensure that no empty directories remain when we read in the course state from disk.