### PR TITLE
Use appropriate HTTP status codes for SQL exceptions

### DIFF
--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -37,7 +37,7 @@ module.exports = {
     };
     sqldb.query(sql.check_belongs, params, (err, result) => {
       if (ERR(err, callback)) return;
-      if (result.rowCount !== 1) return callback(new Error('access denied'));
+      if (result.rowCount !== 1) return callback(error.make(403, 'access denied'));
       callback(null);
     });
   },

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -228,30 +228,18 @@ module.exports = {
     async.series(
       [
         async () => {
-          try {
-            if (requireOpen) {
-              await sqldb.callAsync('assessment_instances_ensure_open', [assessment_instance_id]);
-            }
+          if (requireOpen) {
+            await sqldb.callAsync('assessment_instances_ensure_open', [assessment_instance_id]);
+          }
 
-            if (close) {
-              // If we're supposed to close the assessment, do it *before* we
-              // we start grading. This avoids a race condition where the student
-              // makes an additional submission while grading is already in progress.
-              await sqldb.callAsync('assessment_instances_close', [
-                assessment_instance_id,
-                authn_user_id,
-              ]);
-            }
-          } catch (err) {
-            // Either of the above sprocs may raise an exception if the
-            // assessment instance is closed. If that happens, translate it
-            // into a 403 response. Otherwise, monitoring would pick up a 500
-            // response and flag that as an unexpected error.
-            if (err.message?.includes('assessment instance is not open')) {
-              throw error.make(403, 'Assessment instance is not open');
-            } else {
-              throw err;
-            }
+          if (close) {
+            // If we're supposed to close the assessment, do it *before* we
+            // we start grading. This avoids a race condition where the student
+            // makes an additional submission while grading is already in progress.
+            await sqldb.callAsync('assessment_instances_close', [
+              assessment_instance_id,
+              authn_user_id,
+            ]);
           }
         },
         (callback) => {

--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -228,18 +228,30 @@ module.exports = {
     async.series(
       [
         async () => {
-          if (requireOpen) {
-            await sqldb.callAsync('assessment_instances_ensure_open', [assessment_instance_id]);
-          }
+          try {
+            if (requireOpen) {
+              await sqldb.callAsync('assessment_instances_ensure_open', [assessment_instance_id]);
+            }
 
-          if (close) {
-            // If we're supposed to close the assessment, do it *before* we
-            // we start grading. This avoids a race condition where the student
-            // makes an additional submission while grading is already in progress.
-            await sqldb.callAsync('assessment_instances_close', [
-              assessment_instance_id,
-              authn_user_id,
-            ]);
+            if (close) {
+              // If we're supposed to close the assessment, do it *before* we
+              // we start grading. This avoids a race condition where the student
+              // makes an additional submission while grading is already in progress.
+              await sqldb.callAsync('assessment_instances_close', [
+                assessment_instance_id,
+                authn_user_id,
+              ]);
+            }
+          } catch (err) {
+            // Either of the above sprocs may raise an exception if the
+            // assessment instance is closed. If that happens, translate it
+            // into a 403 response. Otherwise, monitoring would pick up a 500
+            // response and flag that as an unexpected error.
+            if (err.message?.includes('assessment instance is not open')) {
+              throw error.make(403, 'Assessment instance is not open');
+            } else {
+              throw err;
+            }
           }
         },
         (callback) => {
@@ -310,7 +322,7 @@ module.exports = {
           // cronjob runs after `assessment_instances_close` but before the above
           // calls to `gradeVariant` have finished. In that case, we'll
           // concurrently try to grade the same variant twice. This shouldn't
-          // impact correctness, as `gradeVariant` is resiliant to being run
+          // impact correctness, as `gradeVariant` is resilient to being run
           // multiple times concurrently. The only bad thing that will happen
           // is that we'll have wasted some work, but that's acceptable.
           await sqldb.queryAsync(sql.unset_grading_needed, { assessment_instance_id });

--- a/lib/question.js
+++ b/lib/question.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const unzipper = require('unzipper');
 const showdown = require('showdown');
 
+const error = require('../prairielib/lib/error');
 const config = require('./config');
 const csrf = require('./csrf');
 const externalGrader = require('./externalGrader');
@@ -247,6 +248,12 @@ module.exports = {
           require_open,
         ];
         sqldb.callOneRow('variants_insert', params, (err, result) => {
+          if (err?.message?.includes('assessment instance is not open')) {
+            // Translate this into a 403 response so that monitoring doesn't see
+            // this as a 500.
+            return callback(error.make(403, 'Assessment instance is not open'));
+          }
+
           if (ERR(err, callback)) return;
           const variant = result.rows[0].variant;
           debug('variants_insert', variant);
@@ -471,6 +478,12 @@ module.exports = {
             submission.auth_user_id,
           ];
           sqldb.callOneRow('submissions_insert', params, (err, result) => {
+            if (err?.message?.includes('assessment instance is not open')) {
+              // Translate this into a 403 response so that monitoring doesn't see
+              // this as a 500.
+              return callback(error.make(403, 'Assessment instance is not open'));
+            }
+
             if (ERR(err, callback)) return;
             submission_id = result.rows[0].submission_id;
             debug('saveSubmission()', 'inserted', 'submission_id:', submission_id);

--- a/lib/question.js
+++ b/lib/question.js
@@ -478,10 +478,12 @@ module.exports = {
             submission.auth_user_id,
           ];
           sqldb.callOneRow('submissions_insert', params, (err, result) => {
+            // Translate "not open" errors into a 403 response so that
+            // monitoring doesn't see them as a 500.
             if (err?.message?.includes('assessment instance is not open')) {
-              // Translate this into a 403 response so that monitoring doesn't see
-              // this as a 500.
               return callback(error.make(403, 'Assessment instance is not open'));
+            } else if (err?.message?.includes('variant is not open')) {
+              return callback(error.make(403, 'Variant is not open'));
             }
 
             if (ERR(err, callback)) return;

--- a/lib/question.js
+++ b/lib/question.js
@@ -12,7 +12,6 @@ const fs = require('fs');
 const unzipper = require('unzipper');
 const showdown = require('showdown');
 
-const error = require('../prairielib/lib/error');
 const config = require('./config');
 const csrf = require('./csrf');
 const externalGrader = require('./externalGrader');

--- a/lib/question.js
+++ b/lib/question.js
@@ -248,12 +248,6 @@ module.exports = {
           require_open,
         ];
         sqldb.callOneRow('variants_insert', params, (err, result) => {
-          if (err?.message?.includes('assessment instance is not open')) {
-            // Translate this into a 403 response so that monitoring doesn't see
-            // this as a 500.
-            return callback(error.make(403, 'Assessment instance is not open'));
-          }
-
           if (ERR(err, callback)) return;
           const variant = result.rows[0].variant;
           debug('variants_insert', variant);
@@ -478,14 +472,6 @@ module.exports = {
             submission.auth_user_id,
           ];
           sqldb.callOneRow('submissions_insert', params, (err, result) => {
-            // Translate "not open" errors into a 403 response so that
-            // monitoring doesn't see them as a 500.
-            if (err?.message?.includes('assessment instance is not open')) {
-              return callback(error.make(403, 'Assessment instance is not open'));
-            } else if (err?.message?.includes('variant is not open')) {
-              return callback(error.make(403, 'Variant is not open'));
-            }
-
             if (ERR(err, callback)) return;
             submission_id = result.rows[0].submission_id;
             debug('saveSubmission()', 'inserted', 'submission_id:', submission_id);

--- a/pages/error/error.js
+++ b/pages/error/error.js
@@ -1,14 +1,38 @@
+// @ts-check
 var _ = require('lodash');
 var path = require('path');
 var jsonStringifySafe = require('json-stringify-safe');
 
 var logger = require('../../lib/logger');
 
+/**
+ * Attempts to extract a numeric status code from a Postgres error object.
+ * The convention we use is to use a `ERRCODE` value of `ST###`, where ###
+ * is the three-digit HTTP status code.
+ *
+ * For example, the following exception would set a 404 status code:
+ *
+ * RAISE EXCEPTION 'Entity not found' USING ERRCODE = 'ST404';
+ *
+ * @param {any} err
+ * @returns {number | null}
+ */
+function maybeGetStatusCodeFromSqlError(err) {
+  const rawCode = err?.data?.sqlError?.code;
+  if (!rawCode || !rawCode.startsWith('ST')) return null;
+  const code = rawCode.substring(2);
+  const parsedCode = Number(code);
+  if (Number.isNaN(parsedCode)) return null;
+  return parsedCode;
+}
+
+/** @type {import('express').ErrorRequestHandler} */
 module.exports = function (err, req, res, _next) {
   const errorId = res.locals.error_id;
 
-  err.status = err.status || 500;
+  err.status = err.status ?? maybeGetStatusCodeFromSqlError(err) ?? 500;
   res.status(err.status);
+
   var referrer = req.get('Referrer') || null;
   logger.log(err.status >= 500 ? 'error' : 'verbose', 'Error page', {
     msg: err.message,

--- a/pages/error/error.js
+++ b/pages/error/error.js
@@ -15,14 +15,15 @@ var logger = require('../../lib/logger');
  * RAISE EXCEPTION 'Entity not found' USING ERRCODE = 'ST404';
  *
  * @param {any} err
- * @returns {number | null}
+ * @returns {number | null} The extracted HTTP status code
  */
 function maybeGetStatusCodeFromSqlError(err) {
   const rawCode = err?.data?.sqlError?.code;
-  if (!rawCode || !rawCode.startsWith('ST')) return null;
-  const code = rawCode.substring(2);
-  const parsedCode = Number(code);
+  if (!rawCode?.startsWith('ST')) return null;
+
+  const parsedCode = Number(rawCode.toString().substring(2));
   if (Number.isNaN(parsedCode)) return null;
+
   return parsedCode;
 }
 

--- a/sprocs/assessment_instances_ensure_open.sql
+++ b/sprocs/assessment_instances_ensure_open.sql
@@ -11,8 +11,8 @@ BEGIN
     FROM assessment_instances
     WHERE id = assessment_instance_id;
 
-    IF NOT FOUND THEN RAISE EXCEPTION 'no such assessment_instance_id: %', assessment_instance_id; END IF;
+    IF NOT FOUND THEN RAISE EXCEPTION 'no such assessment_instance_id: %', assessment_instance_id USING ERRCODE = 'ST404'; END IF;
 
-    IF NOT current_open THEN RAISE EXCEPTION 'assessment instance is not open: %', assessment_instance_id; END IF;
+    IF NOT current_open THEN RAISE EXCEPTION 'assessment instance is not open: %', assessment_instance_id USING ERRCODE = 'ST403'; END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/variants_ensure_open.sql
+++ b/sprocs/variants_ensure_open.sql
@@ -11,8 +11,8 @@ BEGIN
     FROM variants
     WHERE id = variant_id;
 
-    IF NOT FOUND THEN RAISE EXCEPTION 'no such variant_id: %', variant_id; END IF;
+    IF NOT FOUND THEN RAISE EXCEPTION 'no such variant_id: %', variant_id USING ERRCODE = 'ST404'; END IF;
 
-    IF NOT current_open THEN RAISE EXCEPTION 'variant is not open: %', variant_id; END IF;
+    IF NOT current_open THEN RAISE EXCEPTION 'variant is not open: %', variant_id USING ERRCODE = 'ST403'; END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
This should clean up reports of 500 errors from Sentry and our load balancer logs, which should improve the signal-to-noise ratio there.

I don't *love* inspecting the text of error messages here, but it's the simplest option considering that the sprocs that are raising these exceptions are themselves called from inside *other* sprocs.