### PR TITLE
Fix chunk generation when deleted course instances exist

### DIFF
--- a/lib/chunks.js
+++ b/lib/chunks.js
@@ -494,10 +494,8 @@ module.exports.diffChunks = async ({ coursePath, courseId, courseData, changedFi
       );
       if (
         hasClientFilesCourseInstanceDirectory &&
-        (!existingCourseChunks.courseInstances[ciid] ||
-          !existingCourseChunks.courseInstances[ciid].clientFilesCourseInstance ||
-          (changedCourseChunks.courseInstances[ciid] &&
-            changedCourseChunks.courseInstances[ciid].clientFilesCourseInstance))
+        (!existingCourseChunks.courseInstances[ciid]?.clientFilesCourseInstance ||
+          changedCourseChunks.courseInstances[ciid]?.clientFilesCourseInstance)
       ) {
         updatedChunks.push({
           type: 'clientFilesCourseInstance',
@@ -518,12 +516,8 @@ module.exports.diffChunks = async ({ coursePath, courseId, courseData, changedFi
         );
         if (
           hasClientFilesAssessmentDirectory &&
-          (!existingCourseChunks.courseInstances[ciid] ||
-            !existingCourseChunks.courseInstances[ciid].assessments ||
-            !existingCourseChunks.courseInstances[ciid].assessments.has(tid) ||
-            (changedCourseChunks.courseInstances[ciid] &&
-              changedCourseChunks.courseInstances[ciid].assessments &&
-              changedCourseChunks.courseInstances[ciid].assessments.has(tid)))
+          (!existingCourseChunks.courseInstances[ciid]?.assessments?.has(tid) ||
+            changedCourseChunks.courseInstances[ciid]?.assessments?.has(tid))
         ) {
           updatedChunks.push({
             type: 'clientFilesAssessment',
@@ -551,7 +545,7 @@ module.exports.diffChunks = async ({ coursePath, courseId, courseData, changedFi
 
       await Promise.all(
         [...courseInstanceInfo.assessments].map(async (tid) => {
-          const assessmentExists = !!courseData.courseInstances[ciid].assessments[tid];
+          const assessmentExists = !!courseData.courseInstances[ciid]?.assessments[tid];
           const clientFilesAssessmentExists = await fs.pathExists(
             path.join(
               coursePath,


### PR DESCRIPTION
Closes #6361.

AFAICT this occurred because there were existing chunks in the DB for course instances that no longer existed. Those course instances would have appeared in `existingCourseChunks`, but not in `courseData`, hence the error that we've seen.