### PR TITLE
Update README and documentation index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 PrairieLearn is an online problem-driven learning system for creating homeworks and tests. It allows questions to be written using arbitrary HTML, JavaScript, and Python, thus enabling very powerful questions that can randomize and autograde themselves, and can access client- and server-side libraries to handle tasks such as graphical drawing, symbolic algebra, and student code compilation and execution.
 
-[![GitHub Actions build status](https://github.com/PrairieLearn/PrairieLearn/actions/workflows/main.yml/badge.svg)](https://github.com/PrairieLearn/PrairieLearn/actions/workflows/main.yml) [![License](https://img.shields.io/github/license/PrairieLearn/PrairieLearn.svg)](https://github.com/PrairieLearn/PrairieLearn/blob/master/LICENSE)
+[![GitHub Actions build status](https://github.com/PrairieLearn/PrairieLearn/actions/workflows/main.yml/badge.svg)](https://github.com/PrairieLearn/PrairieLearn/actions/workflows/main.yml)
 
-Documentation website: [https://prairielearn.readthedocs.io/](https://prairielearn.readthedocs.io/)
+Documentation: [https://prairielearn.readthedocs.io/](https://prairielearn.readthedocs.io/)
 
 Paid hosting and support: [https://www.prairielearn.com/](https://www.prairielearn.com/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,12 @@
 # PrairieLearn
 
-PrairieLearn is an online problem-driven learning system for creating homeworks and tests. It allows questions to be written using arbitrary HTML/JavaScript, thus enabling very powerful questions that can randomize and autograde themselves, and can access client- and server-side libraries to handle tasks such as graphical drawing, symbolic algebra, and student code compilation and execution.
+PrairieLearn is an online problem-driven learning system for creating homeworks and tests. It allows questions to be written using arbitrary HTML, JavaScript, and Python, thus enabling very powerful questions that can randomize and autograde themselves, and can access client- and server-side libraries to handle tasks such as graphical drawing, symbolic algebra, and student code compilation and execution.
 
-**Get started with PrairieLearn**
+[![GitHub Actions build status](https://github.com/PrairieLearn/PrairieLearn/actions/workflows/main.yml/badge.svg)](https://github.com/PrairieLearn/PrairieLearn/actions/workflows/main.yml)
 
-[![](https://img.shields.io/badge/-request%20course-brightgreen)](requestCourse.md)
-[![](https://img.shields.io/badge/-create%20content-blue)](getStarted.md)
+Paid hosting and support: [https://www.prairielearn.com/](https://www.prairielearn.com/)
 
----
+## Getting started
 
-[![Latest version](https://img.shields.io/github/tag/PrairieLearn/PrairieLearn.svg?label=version)](https://github.com/PrairieLearn/PrairieLearn/blob/master/ChangeLog.md) — see [ChangeLog](https://github.com/PrairieLearn/PrairieLearn/blob/master/ChangeLog.md)
-
-[![Docker build status](https://img.shields.io/docker/automated/prairielearn/prairielearn.svg)](https://hub.docker.com/r/prairielearn/prairielearn/builds/) — see [Installation instructions](installing.md)
-
-[![Build Status](https://img.shields.io/travis/PrairieLearn/PrairieLearn/master.svg)](https://travis-ci.org/PrairieLearn/PrairieLearn) — see [Developer documentation](dev-guide.md)
-
-[![Coverage Status](https://coveralls.io/repos/github/PrairieLearn/PrairieLearn/badge.svg?branch=master)](https://coveralls.io/github/PrairieLearn/PrairieLearn?branch=master)
-
-[![License](https://img.shields.io/github/license/PrairieLearn/PrairieLearn.svg)](https://github.com/PrairieLearn/PrairieLearn/blob/master/LICENSE) — see [License](https://github.com/PrairieLearn/PrairieLearn/blob/master/LICENSE)
+- [Request a course](requestCourse.md)
+- [Create content](getStarted.md)


### PR DESCRIPTION
This PR brings the README and documentation page in sync with each other. It removes outdated references to Coveralls, Docker builds, Travis, our license, and our changelog.