### PR TITLE
Improve syntax highlighting for instructor file browser

### DIFF
--- a/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -310,10 +310,10 @@ function browseFile(file_browser, callback) {
             }
           }
         } else {
-          // This is probably a text file. If it's is larger that 10MB, don't
+          // This is probably a text file. If it's is larger that 1MB, don't
           // attempt to read it; treat it like an opaque binary file.
           const { size } = await fs.stat(file_browser.paths.workingPath);
-          if (size > 10 * 1024 * 1024) {
+          if (size > 1 * 1024 * 1024) {
             file_browser.isBinary = true;
             return;
           }


### PR DESCRIPTION
This makes a few improvements to syntax highlighting in the instructor file browser:

- When checking if a file is binary and determining its MIME type, use methods that read a limited number of bytes directly from disk. This limits the memory consumption and IO usage for especially large files.
- Treat any text file larger than 1MB as a binary file to avoid reading it into memory or trying to highlight it.
- Instead of using `highlightAuto` to guess the language, we now first guess based on file extension. If that guess fails, we'll use `highlightAuto` to try to guess based on just the first 2000 bytes of the file. This improves the speed of guessing and ensures we don't run out of memory if we try to highlight a particularly large file.