### PR TITLE
Remove aws-config.json support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ docker-compose.override.yml
 
 ## Config
 /config.json
-/aws-config.json
 
 ## Dependencies
 node_modules

--- a/grader_host/README.md
+++ b/grader_host/README.md
@@ -3,17 +3,3 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=PrairieLearn/PrairieGrader)](https://dependabot.com)
 
 An executor for PrairieLearn external grading jobs.
-
-## Using PrairieGrader
-
-```sh
-$ QUEUE_NAME=my_queue node index.js
-```
-
-PrairieGrader is configured via several environment variables:
-
-- `QUEUE_NAME`: The AWS SQS queue to pull grading jobs from. If `QUEUE_URL` is not specified, SQS will be queried for the URL of the queue by this name when PrairieGrader starts up. Defaults to `grading`.
-- `QUEUE_URL`: The URL of the AWS SQS queue to pull grading jobs from. If specified, `QUEUE_NAME` will not be used.
-- `LOG_GROUP`: The name of the AWS CloudWatch log group to send logs to. The log group will be created if it does not yet exist. Defaults to `grading_debug`.
-
-Like PrairieLearn, PrairieGrader will read AWS configuration from a `aws-config.json` file in the project root upon startup if it is present. Otherwise, it is assumed that AWS credentials can be obtained via [IAM Roles for EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).

--- a/grader_host/lib/config.js
+++ b/grader_host/lib/config.js
@@ -31,47 +31,19 @@ config.loadConfig = function (callback) {
         });
       },
       (callback) => {
-        // Try to grab AWS config from a file; assume Metadata Service will
-        // provide credentials if the file is missing
-        fs.readFile('./aws-config.json', (err, awsConfig) => {
-          if (err) {
-            // we don't have the AWS config file, assume we are inside
-            // EC2 and that we can get all config info from the
-            // metadata service
-            logger.info(
-              'Missing aws-config.json; credentials should be supplied by EC2 Metadata Service'
-            );
-            MetadataService.request(
-              '/latest/dynamic/instance-identity/document',
-              (err, document) => {
-                if (ERR(err, callback)) return;
-                try {
-                  const data = JSON.parse(document);
-                  logger.info('instance-identity', data);
-                  AWS.config.update({ region: data.region });
-                  exportedConfig.instanceIdentity = data;
-                  exportedConfig.runningInEc2 = true;
-                  exportedConfig.instanceId = data.instanceId;
-                } catch (err) {
-                  return callback(err);
-                }
-                callback(null);
-              }
-            );
-          } else {
-            // we do have the config file, it should provide all our
-            // info and we assume we are not running inside EC2
-            logger.info('Loading AWS config from aws-config.json');
-            AWS.config.loadFromPath('./aws-config.json');
-            exportedConfig.awsConfig = JSON.parse(awsConfig);
-            exportedConfig.runningInEc2 = false;
-            if (process.env.INSTANCE_ID) {
-              exportedConfig.instanceId = process.env.INSTANCE_ID;
-            } else {
-              exportedConfig.instanceId = os.hostname();
-            }
-            callback(null);
+        MetadataService.request('/latest/dynamic/instance-identity/document', (err, document) => {
+          if (ERR(err, callback)) return;
+          try {
+            const data = JSON.parse(document);
+            logger.info('instance-identity', data);
+            AWS.config.update({ region: data.region });
+            exportedConfig.instanceIdentity = data;
+            exportedConfig.runningInEc2 = true;
+            exportedConfig.instanceId = data.instanceId;
+          } catch (err) {
+            return callback(err);
           }
+          callback(null);
         });
       },
       (callback) => {

--- a/grader_host/lib/config.js
+++ b/grader_host/lib/config.js
@@ -1,9 +1,7 @@
 const ERR = require('async-stacktrace');
 const async = require('async');
-const fs = require('fs-extra');
 const path = require('path');
 const AWS = require('aws-sdk');
-const os = require('os');
 const _ = require('lodash');
 const configLib = require('../../prairielib/lib/config');
 

--- a/grader_host/lib/config.js
+++ b/grader_host/lib/config.js
@@ -37,7 +37,6 @@ config.loadConfig = function (callback) {
             const data = JSON.parse(document);
             logger.info('instance-identity', data);
             AWS.config.update({ region: data.region });
-            exportedConfig.instanceIdentity = data;
             exportedConfig.runningInEc2 = true;
             exportedConfig.instanceId = data.instanceId;
           } catch (err) {

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -13,16 +13,15 @@ const config = require('./config');
 module.exports.init = async function () {
   // If we are runningInEc2, then we are running on prod,
   // and so AWS will have already been configured.
+  // If we're not running in EC2,
   if (!config.runningInEc2) {
-    const configFile = path.join(process.cwd(), 'aws-config.json');
-    try {
-      await fs.promises.stat(configFile);
-      logger.info(`Loading AWS configuration from ${configFile}`);
-      AWS.config.loadFromPath(configFile);
-    } catch (err) {
-      logger.verbose('Using local s3rver AWS configuration');
-      AWS.config = module.exports.getS3RVERConfiguration();
-    }
+    logger.verbose('Using local s3rver AWS configuration');
+    AWS.config = new AWS.Config({
+      s3ForcePathStyle: true,
+      accessKeyId: 'S3RVER',
+      secretAccessKey: 'S3RVER',
+      endpoint: new AWS.Endpoint('http://localhost:5000'),
+    });
   }
 
   // It is important that we always do this:
@@ -94,15 +93,6 @@ module.exports.loadConfigSecrets = async function () {
   if (config.instanceIdEc2Override) {
     config.instanceId = config.instanceIdEc2Override;
   }
-};
-
-module.exports.getS3RVERConfiguration = function () {
-  return new AWS.Config({
-    s3ForcePathStyle: true,
-    accessKeyId: 'S3RVER',
-    secretAccessKey: 'S3RVER',
-    endpoint: new AWS.Endpoint('http://localhost:5000'),
-  });
 };
 
 /**

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -11,9 +11,8 @@ const logger = require('./logger');
 const config = require('./config');
 
 module.exports.init = async function () {
-  // If we are runningInEc2, then we are running on prod,
-  // and so AWS will have already been configured.
-  // If we're not running in EC2,
+  // If we're not running in EC2, assume we're running with a local s3rver instance.
+  // See https://github.com/jamhall/s3rver for more details.
   if (!config.runningInEc2) {
     logger.verbose('Using local s3rver AWS configuration');
     AWS.config = new AWS.Config({


### PR DESCRIPTION
This is a small bit of low-impact cleanup.

If someone wants to use AWS credentials when running locally, they should use the standard `AWS_*` environment variables (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html, e.g. `AWS_PROFILE`). This is the standard way that AWS clients work; there's no need for our own idiosyncratic layer on top of that.

If we find ourselves needed to do more than configure credentials, we should add support for e.g. and `aws.config` property in our standard `config.json` file.