### PR TITLE
Improve creation of Docker images

### DIFF
--- a/images/executor/Dockerfile
+++ b/images/executor/Dockerfile
@@ -1,11 +1,6 @@
 FROM prairielearn/prairielearn
 WORKDIR /PrairieLearn/
 
-# We need pkill in this image
-RUN yum -y install procps-ng && yum clean all
-
-RUN pip3 install psutil
-
 # Create our unprivileged user
 RUN groupadd executor \
     && useradd -g executor executor \

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -10,31 +10,32 @@ amazon-linux-extras install -y \
     redis4.0
 
 # Notes:
-# - `libjpeg-devel` is needed by the Pillow package
 # - `gcc-c++` is needed to build the native bindings in `packages/bind-mount`
-# `texlive` and `texlive-dvipng` are needed for matplotlib LaTeX labels
+# - `libjpeg-devel` is needed by the Pillow package
+# - `procps-ng` is needed for the `pkill` executable, which is used by `zygote.py`
+# - `texlive` and `texlive-dvipng` are needed for matplotlib LaTeX labels
 yum -y install \
-    tmux \
-    postgresql-server \
-    postgresql-contrib \
-    man \
+    dos2unix \
     emacs-nox \
     gcc \
-    make \
-    lsof \
-    openssl \
-    dos2unix \
-    tar \
-    ImageMagick \
-    texlive \
-    texlive-dvipng \
+    gcc-c++ \
     git \
     graphviz \
     graphviz-devel \
+    ImageMagick \
     libjpeg-devel \
-    gcc-c++
+    lsof \
+    make \
+    man \
+    openssl \
+    postgresql-contrib \
+    postgresql-server \
+    procps-ng \
+    tar \
+    texlive \
+    texlive-dvipng \
+    tmux
 
-yum clean all
 
 echo "installing node via nvm"
 git clone https://github.com/creationix/nvm.git /nvm
@@ -74,5 +75,8 @@ else
     python3 -m pip install --no-cache-dir -r /py_req_no_r.txt
 fi
 
+# Clear various caches to keep the final image size down.
+yum clean all
 conda clean --all
+nvm cache clear
 rm Miniforge3-Linux-${arch}.sh

--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -27,3 +27,4 @@ statsmodels==0.13.2
 openpyxl==3.0.10
 pytest==7.1.2
 typing-extensions==4.3.0
+psutil==5.9.2


### PR DESCRIPTION
A few minor optimizations to the creation of our Docker image:

- We now run `nvm cache clear` to remove cached Node downloads
- `psutil` is now listed in `python-requirements.txt` (this should be slightly faster, and will allow Dependabot to update it)
- `procps-ng` is installed in `plbase` instead of in the `executor` image (this should be faster, as we don't have to download the RPM repository metadata again)