### PR TITLE
On demand rendering of older submissions

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1689,7 +1689,7 @@ module.exports = {
             locals.variant,
             locals.question,
             locals.submission,
-            locals.submissions,
+            locals.submissions.slice(0, 3), // Only first three submissions are rendered initially
             locals.course,
             locals.course_instance,
             locals,
@@ -1890,6 +1890,7 @@ module.exports = {
                   submission,
                   submissionHtml: htmls.submissionHtmls[0],
                   submissionCount: submission_count,
+                  expanded: true,
                   urlPrefix,
                   plainUrlPrefix: config.urlPrefix,
                 };

--- a/pages/partials/externalGradingLiveUpdate.ejs
+++ b/pages/partials/externalGradingLiveUpdate.ejs
@@ -1,4 +1,3 @@
-<% if (question.grading_method == 'External') { %>
 <script>
   $(function() {
     var variantId = '<%= variant.id %>';
@@ -8,7 +7,7 @@
     var csrfToken = '<%= __csrf_token %>';
 
     // Render initial grading states into the DOM
-    var gradingPending = false;
+    var gradingPending = false, renderingPending = false;
     $('[id^=submission-]').each(function(index, elem) {
       // Ensure that this is a valid submission element
       if (!/^submission-\d+$/.test($(elem).attr('id'))) {
@@ -21,10 +20,14 @@
       if (status !== 'graded' && status !== 'canceled') {
         gradingPending = true;
       }
+
+      if (!$(elem).data('rendered')) {
+        renderingPending = true;
+      }
     });
 
-    // If everything has been graded or was canceled, don't even open a socket
-    if (!gradingPending) {
+    // If everything has been graded or was canceled, and everything is rendered, don't even open a socket
+    if (!gradingPending && !renderingPending) {
       return;
     }
 
@@ -61,7 +64,7 @@
       });
     }
 
-    function fetchResults(submissionId) {
+    window.fetchResults = (submissionId) => {
       var wasModalOpen = ($('#submissionInfoModal-' + submissionId).data('bs.modal') || {})._isShown;
       $('#submissionInfoModal-' + submissionId).modal('hide');
       socket.emit('getResults', {
@@ -78,7 +81,7 @@
         authorized_edit: <%= !locals.authz_result || locals.authz_result.authorized_edit %>
       }, function(msg) {
         // We're done with the socket for this incarnation of the page
-        socket.close();
+        if (!renderingPending) socket.close();
         if (msg.submissionPanel) {
           $('#submission-' + submissionId).replaceWith(function() {
             return $(msg.submissionPanel).fadeIn('slow');
@@ -137,4 +140,3 @@
     }
   });
 </script>
-<% } %>

--- a/pages/partials/submission.ejs
+++ b/pages/partials/submission.ejs
@@ -1,5 +1,5 @@
 <!-- Keeping "graded" state in the DOM is bad, yet here we are. -->
-<div data-grading-job-status="<%= submission.grading_job_status %>" data-grading-job-id="<%= submission.grading_job_id %>" id="submission-<%= submission.id %>">
+<div data-grading-job-status="<%= submission.grading_job_status %>" data-grading-job-id="<%= submission.grading_job_id %>" id="submission-<%= submission.id %>" data-rendered="<%= submissionHtml !== undefined %>">
 
 <% if (course.manual_grading_visible && submission.feedback?.manual) { %>
 <div class="card mb-4 grading-block border-info">
@@ -23,7 +23,7 @@
 <% } %>
 
 <div class="card mb-4" data-testid="submission-block">
-  <div class="card-header bg-light text-dark d-flex align-items-center submission-header <% if (submission.submission_number != submissionCount) { %> collapsed <% } %>" data-toggle="collapse" data-target="#submission-<%= submission.id %>-body">
+  <div class="card-header bg-light text-dark d-flex align-items-center submission-header <% if (submission.submission_number != submissionCount && !locals.expanded) { %> collapsed <% } %>" data-toggle="collapse" data-target="#submission-<%= submission.id %>-body" <% if (submissionHtml === undefined) { %>oncclick="fetchResults(<%= submission.id %>)"<% } %> >
     <div class="mr-auto">
       <div>
         <span class="mr-2">
@@ -44,7 +44,7 @@
     </button>
   </div>
 
-  <div class="collapse <% if (submission.submission_number == submissionCount) { %>show<% } %>" id="submission-<%= submission.id %>-body">
+  <div class="collapse <% if (submission.submission_number == submissionCount || locals.expanded) { %>show<% } %>" id="submission-<%= submission.id %>-body">
     <div class="card-body submission-body" >
       <%- submissionHtml %>
     </div>


### PR DESCRIPTION
Resolves #6365. Only the rendering of the submission block is lazy, the page is still rendered as usual. The code takes advantage of the fact that submissions are collapsed individually by default (so there is an easy trigger for retrieving the rendered submission), and that the external grading process already uses sockets for retrieving submission renders after grading is complete (so there is a path for retrieving this data).