### PR TITLE
Fix external grader usage of async.waterfall

### DIFF
--- a/grader_host/index.js
+++ b/grader_host/index.js
@@ -494,6 +494,8 @@ function runJob(info, callback) {
         } finally {
           clearTimeout(timeoutId);
         }
+
+        return container;
       },
       (container, callback) => {
         timeReporter.reportEndTime(jobId, (err, time) => {


### PR DESCRIPTION
This fixes a bug I inadvertently introduced in #6339.