### PR TITLE
Initialize freeform code before taking requests

### DIFF
--- a/server.js
+++ b/server.js
@@ -1948,9 +1948,26 @@ if (config.startServer) {
           callback(null);
         });
       },
+      async () => await freeformServer.init(),
       function (callback) {
         if (!config.devMode) return callback(null);
         module.exports.insertDevUser(function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      async () => {
+        logger.verbose('Starting server...');
+        await module.exports.startServer();
+      },
+      function (callback) {
+        socketServer.init(server, function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      function (callback) {
+        externalGradingSocket.init(function (err) {
           if (ERR(err, callback)) return;
           callback(null);
         });
@@ -1972,7 +1989,6 @@ if (config.startServer) {
         nodeMetrics.init();
         callback(null);
       },
-      async () => await freeformServer.init(),
       // These should be the last things to start before we actually start taking
       // requests, as they may actually end up executing course code.
       (callback) => {
@@ -1984,22 +2000,6 @@ if (config.startServer) {
       },
       function (callback) {
         cron.init(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      async () => {
-        logger.verbose('Starting server...');
-        await module.exports.startServer();
-      },
-      function (callback) {
-        socketServer.init(server, function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        externalGradingSocket.init(function (err) {
           if (ERR(err, callback)) return;
           callback(null);
         });

--- a/server.js
+++ b/server.js
@@ -1948,25 +1948,9 @@ if (config.startServer) {
           callback(null);
         });
       },
-      async () => {
-        logger.verbose('Starting server...');
-        await module.exports.startServer();
-      },
       function (callback) {
         if (!config.devMode) return callback(null);
         module.exports.insertDevUser(function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        socketServer.init(server, function (err) {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      function (callback) {
-        externalGradingSocket.init(function (err) {
           if (ERR(err, callback)) return;
           callback(null);
         });
@@ -2000,6 +1984,22 @@ if (config.startServer) {
       },
       function (callback) {
         cron.init(function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      async () => {
+        logger.verbose('Starting server...');
+        await module.exports.startServer();
+      },
+      function (callback) {
+        socketServer.init(server, function (err) {
+          if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      function (callback) {
+        externalGradingSocket.init(function (err) {
           if (ERR(err, callback)) return;
           callback(null);
         });


### PR DESCRIPTION
Followup to #6335. I don't think we caught this at the time, but we were actually waiting until *after* we had started the server before we would init the freeform code (basically, constructing the element cache). We need that in place before we can serve requests.

This shouldn't have mattered in practice, as we'd need to pass a couple of health check intervals before we actually received traffic. However, this is still more correct.