### PR TITLE
Fix creation of dev mode user

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -278,7 +278,7 @@ config.homepageFooterText = null;
 config.homepageFooterTextHref = null;
 
 config.attachedFilesDialogEnabled = true;
-config.devMode = false;
+config.devMode = (process.env.NODE_ENV ?? 'development') === 'development';
 
 // This will be populated by `lib/aws.js` later
 config.awsServiceGlobalOptions = {};

--- a/server.js
+++ b/server.js
@@ -83,7 +83,6 @@ module.exports.initExpress = function () {
   app.set('views', path.join(__dirname, 'pages'));
   app.set('view engine', 'ejs');
   app.set('trust proxy', config.trustProxy);
-  config.devMode = app.get('env') === 'development';
 
   // If we're set up with Sentry, use its middleware to record requests.
   if (config.sentryDsn) {


### PR DESCRIPTION
Fixes the following issue reported in Slack: https://prairielearn.slack.com/archives/C266KEH9A/p1664576961459249. tl;dr: users running locally were no longer admins, which naturally causes a lot of problems.

I inadvertently broke this this morning with #6383 when I shifted the call to `insertDevUser` _after_ the call to `startServer()`. I didn't realize that `config.devMode` was set in `startServer()`, so `config.devMode` was false when we checked whether or not to insert the dev user.

The fact that `config.devMode` isn't available during parts of server initialization strikes me as the kind of idiosyncrasy that'll cause future problems, so I opted to fix this by computing `config.devMode` when config is actually initialized.

This no longer uses `app.get('env')`, but the behavior should be identical because that would return `development` if `process.env.NODE_ENV` isn't defined.