### PR TITLE
Set error status code before Sentry error middleware

### DIFF
--- a/pages/error/error.js
+++ b/pages/error/error.js
@@ -5,33 +5,11 @@ var jsonStringifySafe = require('json-stringify-safe');
 
 var logger = require('../../lib/logger');
 
-/**
- * Attempts to extract a numeric status code from a Postgres error object.
- * The convention we use is to use a `ERRCODE` value of `ST###`, where ###
- * is the three-digit HTTP status code.
- *
- * For example, the following exception would set a 404 status code:
- *
- * RAISE EXCEPTION 'Entity not found' USING ERRCODE = 'ST404';
- *
- * @param {any} err
- * @returns {number | null} The extracted HTTP status code
- */
-function maybeGetStatusCodeFromSqlError(err) {
-  const rawCode = err?.data?.sqlError?.code;
-  if (!rawCode?.startsWith('ST')) return null;
-
-  const parsedCode = Number(rawCode.toString().substring(2));
-  if (Number.isNaN(parsedCode)) return null;
-
-  return parsedCode;
-}
-
 /** @type {import('express').ErrorRequestHandler} */
 module.exports = function (err, req, res, _next) {
   const errorId = res.locals.error_id;
 
-  err.status = err.status ?? maybeGetStatusCodeFromSqlError(err) ?? 500;
+  err.status = err.status ?? 500;
   res.status(err.status);
 
   var referrer = req.get('Referrer') || null;

--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ module.exports.initExpress = function () {
   app.set('view engine', 'ejs');
   app.set('trust proxy', config.trustProxy);
 
-  // If we're set up with Sentry, use its middleware to record requests.
+  // This should come first so that we get instrumentation on all our requests.
   app.use(Sentry.Handlers.requestHandler());
 
   // Set res.locals variables first, so they will be available on


### PR DESCRIPTION
Followup to #6360. Our error handler runs after the Sentry error handler, which means `err.status` wasn't set in time for Sentry to read it.