### PR TITLE
Improve performance of errorAbandonedJobs

### DIFF
--- a/database/tables/jobs.pg
+++ b/database/tables/jobs.pg
@@ -30,6 +30,7 @@ columns
 indexes
     jobs_pkey: PRIMARY KEY (id) USING btree (id)
     jobs_job_sequence_id_number_in_sequence_key: UNIQUE (job_sequence_id, number_in_sequence) USING btree (job_sequence_id, number_in_sequence)
+    jobs_status_idx: USING btree (status)
 
 foreign-key constraints
     jobs_assessment_id_fkey: FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/lib/server-jobs.sql
+++ b/lib/server-jobs.sql
@@ -138,7 +138,8 @@ WHERE
 
 -- BLOCK select_running_jobs
 SELECT
-    j.*
+    j.id,
+    j.job_sequence_id
 FROM
     jobs AS j
 WHERE

--- a/migrations/20221011010233_jobs__status__add_index.sql
+++ b/migrations/20221011010233_jobs__status__add_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX jobs_status_idx ON jobs (status);


### PR DESCRIPTION
This PR makes two improvements to the performance of `errorAbandonedJobs`, which runs once every 10 minutes:

- Add an index of `jobs.status`. This avoid a table scan to find the jobs in the 'Running' state when executing `select_running_jobs`.
- Select only the columns we need, not all of them (this will likely have a very negligible impact on performance).