### PR TITLE
Use correct path in response logs

### DIFF
--- a/middlewares/logResponse.js
+++ b/middlewares/logResponse.js
@@ -3,6 +3,10 @@ const logger = require('../lib/logger');
 const { enrichSentryScope } = require('../lib/sentry');
 
 module.exports = function (req, res, next) {
+  // Capture the path at the start of the request; it may have been rewritten
+  // by the time the finish handler executes.
+  const path = req.path;
+
   if (req.method !== 'OPTIONS') {
     res.once('finish', function () {
       // Attach information to the Sentry scope so that we can more easily
@@ -17,7 +21,7 @@ module.exports = function (req, res, next) {
         ip: req.ip,
         forwardedIP: req.headers['x-forwarded-for'],
         method: req.method,
-        path: req.path,
+        path,
         params: req.params,
         body: req.body,
         authn_user_id: res.locals && res.locals.authn_user ? res.locals.authn_user.user_id : null,


### PR DESCRIPTION
Express can mutate `Request#path` as it's passed around between middleware, so we were seeing inaccurate paths in our response logs. This PR changes the logging middleware to capture the path at the start of the request.