### PR TITLE
Configure HTTP keep-alive timeout

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -45,6 +45,14 @@ config.authUin = '000000000'; // to specify the user uin on a local server (with
 config.authnCookieMaxAgeMilliseconds = 30 * 24 * 60 * 60 * 1000;
 config.serverType = 'http';
 config.serverPort = '3000';
+config.serverTimeout = 10 * 60 * 1000; // 10 minutes
+/**
+ * How many milliseconds to wait before destroying a socket that is being
+ * kept alive. This should always be greater than the timeout at the load
+ * balancer. The default here works for AWS ALBs, where the default timeout is
+ * 60 seconds. This should be adjusted appropriately for other load balancers.
+ */
+config.serverKeepAliveTimeout = 65 * 1000;
 config.serverCanonicalHost = null; // should be set to, e.g., https://www.prairielearn.org if server uses proxy/load balancer
 config.runMigrations = true;
 config.sslCertificateFile = '/etc/pki/tls/certs/localhost.crt';

--- a/server.js
+++ b/server.js
@@ -1691,17 +1691,17 @@ module.exports.startServer = async () => {
     const ca = [await fs.promises.readFile(config.sslCAFile)];
     var options = { key, cert, ca };
     server = https.createServer(options, app);
-    server.listen(config.serverPort);
-    server.timeout = 600000; // 10 minutes
     logger.verbose('server listening to HTTPS on port ' + config.serverPort);
   } else if (config.serverType === 'http') {
     server = http.createServer(app);
-    server.listen(config.serverPort);
-    server.timeout = 600000; // 10 minutes
     logger.verbose('server listening to HTTP on port ' + config.serverPort);
   } else {
     throw new Error('unknown serverType: ' + config.serverType);
   }
+
+  server.keepAliveTimeout = config.serverKeepAliveTimeout;
+  server.timeout = config.serverTimeout;
+  server.listen(config.serverPort);
 
   // Wait for the server to either start successfully or error out.
   await new Promise((resolve, reject) => {

--- a/server.js
+++ b/server.js
@@ -1699,8 +1699,8 @@ module.exports.startServer = async () => {
     throw new Error('unknown serverType: ' + config.serverType);
   }
 
-  server.keepAliveTimeout = config.serverKeepAliveTimeout;
   server.timeout = config.serverTimeout;
+  server.keepAliveTimeout = config.serverKeepAliveTimeout;
   server.listen(config.serverPort);
 
   // Wait for the server to either start successfully or error out.


### PR DESCRIPTION
This should resolve the occasional 502s we see in the load balancer logs.

See the following for more details:

- https://www.tessian.com/blog/how-to-fix-http-502-errors/
- https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout

Closes https://github.com/PrairieLearnInc/sysconf/issues/398