### PR TITLE
Avoid table scans when querying for course issues

### DIFF
--- a/pages/instructorIssues/instructorIssues.sql
+++ b/pages/instructorIssues/instructorIssues.sql
@@ -42,6 +42,7 @@ SELECT
     COUNT(*) OVER() AS issue_count
 FROM
     issues_select_with_filter (
+        $course_id,
         $filter_is_open,
         $filter_is_closed,
         $filter_manually_reported,
@@ -61,10 +62,9 @@ FROM
     LEFT JOIN instance_questions AS iq ON (iq.id = i.instance_question_id)
     LEFT JOIN variants AS v ON (v.id = i.variant_id)
 WHERE
-    i.course_id = $course_id
-    AND i.course_caused
+    i.course_caused
 ORDER BY
-    i.date DESC, i.id
+    i.date DESC, i.id DESC
 LIMIT
     $limit
 OFFSET

--- a/sprocs/issues_select_with_filter.sql
+++ b/sprocs/issues_select_with_filter.sql
@@ -1,5 +1,6 @@
 CREATE FUNCTION
     issues_select_with_filter (
+        course_id bigint,
         filter_is_open boolean,
         filter_is_closed boolean,
         filter_manually_reported boolean,
@@ -18,7 +19,8 @@ AS $$
         LEFT JOIN questions AS q ON (q.id = i.question_id)
         LEFT JOIN users AS u ON (u.user_id = i.user_id)
     WHERE
-        ((filter_is_open::boolean IS NULL) OR (i.open = filter_is_open::boolean))
+        i.course_id = issues_select_with_filter.course_id
+        AND ((filter_is_open::boolean IS NULL) OR (i.open = filter_is_open::boolean))
         AND ((filter_is_closed::boolean IS NULL) OR (i.open != filter_is_closed::boolean))
         AND ((filter_manually_reported::boolean IS NULL) OR (i.manually_reported = filter_manually_reported::boolean))
         AND ((filter_automatically_reported::boolean IS NULL) OR (i.manually_reported != filter_automatically_reported::boolean))


### PR DESCRIPTION
This PR applies the course ID filter earlier inside the `issues_select_with_filter` sproc. This should avoid doing a full table scan on `issues` every time the issues page is rendered.

Originally described in https://github.com/PrairieLearnInc/sysconf/issues/397.