### PR TITLE
Fix issues_question_id_open_idx index

### DIFF
--- a/database/tables/issues.pg
+++ b/database/tables/issues.pg
@@ -24,7 +24,7 @@ indexes
     issues_course_id_open_idx: USING btree (course_id, course_caused, open)
     issues_course_instance_id_idx: USING btree (course_instance_id)
     issues_instance_question_id_idx: USING btree (instance_question_id)
-    issues_question_id_open_idx: USING btree (question_id, course_caused, open)
+    issues_question_id_course_caused_open_idx: USING btree (question_id, course_caused, open)
     issues_user_id_idx: USING btree (user_id)
     issues_variant_id_idx: USING btree (variant_id)
 

--- a/database/tables/issues.pg
+++ b/database/tables/issues.pg
@@ -24,7 +24,7 @@ indexes
     issues_course_id_open_idx: USING btree (course_id, course_caused, open)
     issues_course_instance_id_idx: USING btree (course_instance_id)
     issues_instance_question_id_idx: USING btree (instance_question_id)
-    issues_question_id_open_idx: USING btree (question_id, open)
+    issues_question_id_open_idx: USING btree (question_id, course_caused, open)
     issues_user_id_idx: USING btree (user_id)
     issues_variant_id_idx: USING btree (variant_id)
 

--- a/database/tables/issues.pg
+++ b/database/tables/issues.pg
@@ -24,7 +24,7 @@ indexes
     issues_course_id_open_idx: USING btree (course_id, course_caused, open)
     issues_course_instance_id_idx: USING btree (course_instance_id)
     issues_instance_question_id_idx: USING btree (instance_question_id)
-    issues_question_id_open_idx: USING btree (course_id, course_caused, open)
+    issues_question_id_open_idx: USING btree (question_id, open)
     issues_user_id_idx: USING btree (user_id)
     issues_variant_id_idx: USING btree (variant_id)
 

--- a/migrations/20221011211919_issues__question_id__add_index.sql
+++ b/migrations/20221011211919_issues__question_id__add_index.sql
@@ -1,0 +1,7 @@
+-- There was previously another index of the same name, but it didn't actually
+-- index on the question ID; it was a misnamed duplicate of another index.
+-- We'll drop it and replace it with the correct index.
+
+DROP INDEX IF EXISTS issues_question_id_open_idx;
+
+CREATE INDEX issues_question_id_open_idx ON issues (question_id, open);

--- a/migrations/20221011211919_issues__question_id__add_index.sql
+++ b/migrations/20221011211919_issues__question_id__add_index.sql
@@ -4,4 +4,4 @@
 
 DROP INDEX IF EXISTS issues_question_id_open_idx;
 
-CREATE INDEX issues_question_id_open_idx ON issues (question_id, open);
+CREATE INDEX issues_question_id_open_idx ON issues (question_id, course_caused, open);

--- a/migrations/20221011211919_issues__question_id__add_index.sql
+++ b/migrations/20221011211919_issues__question_id__add_index.sql
@@ -4,4 +4,4 @@
 
 DROP INDEX IF EXISTS issues_question_id_open_idx;
 
-CREATE INDEX issues_question_id_open_idx ON issues (question_id, course_caused, open);
+CREATE INDEX issues_question_id_course_caused_open_idx ON issues (question_id, course_caused, open);


### PR DESCRIPTION
The existing `issues_question_id_open_idx` index was actually a duplicate of the `issues_course_id_open_idx` index. This PR drops that existing index and replaces it with the one we actually want.

This should eliminate the table scan from the following query:

https://github.com/PrairieLearn/PrairieLearn/blob/d5c54956a74ae90a5182ca23fb6eaba094c60f90/middlewares/selectAndAuthzInstructorQuestion.sql#L6