### PR TITLE
Attempt to fix R installation

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -64,7 +64,7 @@ bash Miniforge3-Linux-${arch}.sh -b -p /usr/local -f
 # If R package installation is specifically disabled, we'll avoid installing anything R-related.
 if [[ "${SKIP_R_PACKAGES}" != "yes" ]]; then
     echo "installing R..."
-    conda install --channel r r-essentials
+    conda install --channel r r-base r-essentials
 
     echo "installing Python packages..."
     python3 -m pip install --no-cache-dir -r /python-requirements.txt


### PR DESCRIPTION
Before this change, Conda would take ages (and sometimes get OOM-killed) when trying to "solve" the environment. I don't know why this fixes things, but coupled with a larger instance type, we can now build AMIs again!

Inspired by a recommended way of installing documented at https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/.