### PR TITLE
Introduce stop-gap for points computation when servers run different versions

### DIFF
--- a/sprocs/instance_questions_points_exam.sql
+++ b/sprocs/instance_questions_points_exam.sql
@@ -24,7 +24,7 @@ BEGIN
     -- exams don't use this, so just copy whatever was there before
     variants_points_list := iq.variants_points_list;
 
-    max_auto_points := COALESCE(aq.max_auto_points, 0);
+    max_auto_points := COALESCE(aq.max_auto_points, aq.max_points);
     max_manual_points := COALESCE(aq.max_manual_points, 0);
 
     -- Update points (instance_question will be closed when number_attempts exceeds bound,

--- a/sprocs/instance_questions_points_homework.sql
+++ b/sprocs/instance_questions_points_homework.sql
@@ -71,7 +71,7 @@ BEGIN
     FOR i in 1..length LOOP
         auto_points := auto_points + variants_points_list[i];
     END LOOP;
-    auto_points := least(auto_points, aq.max_auto_points);
+    auto_points := least(auto_points, max_auto_points);
 
     -- status
     IF correct THEN

--- a/sprocs/instance_questions_points_homework.sql
+++ b/sprocs/instance_questions_points_homework.sql
@@ -27,7 +27,7 @@ BEGIN
     SELECT * INTO iq FROM instance_questions WHERE id = instance_question_id;
     SELECT * INTO aq FROM assessment_questions WHERE id = iq.assessment_question_id;
 
-    max_auto_points := aq.max_auto_points;
+    max_auto_points := COALESCE(aq.max_auto_points, aq.max_points);
     highest_submission_score := greatest(submission_score, coalesce(iq.highest_submission_score, 0));
 
     open := TRUE;
@@ -41,8 +41,8 @@ BEGIN
         current_value := iq.current_value;
     END IF;
 
-    current_auto_value := current_value - aq.max_manual_points;
-    init_auto_points := aq.init_points - aq.max_manual_points;
+    current_auto_value := current_value - COALESCE(aq.max_manual_points, 0);
+    init_auto_points := aq.init_points - COALESCE(aq.max_manual_points, 0);
 
     -- modify variants_points_list
     variants_points_list := iq.variants_points_list;


### PR DESCRIPTION
The issue being resolved here is that there are servers running separately with different code, interacting with the same data. This is interfering with the assumptions made in #5909 regarding the values of `manual_points` and `auto_points` (and their derivatives) in multiple tables. This PR introduces UI changes to ensure that any updates made by one version are still consistent with the view of another version, particularly in questions that only use one grading method. In particular, `manual_points` and `auto_points` columns should be COALESCED with a suitable alternative as appropriate.

Once all production servers are running the new version, it should be possible to revert this PR to simplify the code.