### PR TITLE
Change MathJax fontCache from global to local

### DIFF
--- a/pages/partials/mathjax.ejs
+++ b/pages/partials/mathjax.ejs
@@ -21,7 +21,7 @@ var MathJax = {
         inlineMath: [['$', '$'], ['\\(', '\\)']]
     },
     svg: {
-        fontCache: 'global'
+        fontCache: 'local'
     },
     loader: {
         load: ['input/tex', 'ui/menu', outputComponent]


### PR DESCRIPTION
Maybe closes https://github.com/PrairieLearn/PrairieLearn/issues/6495 (untested on Windows yet -- could be barking up the wrong tree)

This changes the `fontCache` setting for MathJax to `local`, which should create one or several cache(s) within each SVG object instead of one per page.

For background: I'm wondering if the issues @trombonekenny describes in https://github.com/PrairieLearn/PrairieLearn/issues/6495 might be due to the other recent changes to MathJax handling (https://github.com/PrairieLearn/PrairieLearn/pull/6358, https://github.com/PrairieLearn/PrairieLearn/pull/6442) which load MathJax asynchronously, combined with the fact that we have MathJax set to use the _global_ font cache injected on the page. ([See the MathJax developer explanation at the comment linked here.](https://github.com/mathjax/MathJax/issues/2897#issuecomment-1180218087))

On a related note, I see we have this code that tries to manually copy the globally cached parts for `pl-drawing`:

https://github.com/PrairieLearn/PrairieLearn/blob/master/elements/pl-drawing/mechanicsObjects.js#L887

Keeping in mind other weirdness that font rendering has exhibited in `pl-drawing`, and in light of what the code linked in `mechanicsObjects.js` does, maybe we should just set `fontCache` to `'none'` instead, which I think does the same thing natively, inlining each shape. ([MathJax doc reference](https://docs.mathjax.org/en/latest/options/output/svg.html#option-descriptions); see also the MathJax developer's explanation linked above.)