### PR TITLE
Update status from saved to incorrect in homeworks upon grading

### DIFF
--- a/migrations/20221018160700_instance_questions__status__update.sql
+++ b/migrations/20221018160700_instance_questions__status__update.sql
@@ -1,0 +1,10 @@
+UPDATE instance_questions iq
+SET status = 'incorrect'
+WHERE iq.status = 'saved'
+      AND CARDINALITY(iq.variants_points_list) > 0
+      AND (SELECT s.graded_at
+           FROM variants v LEFT JOIN submissions s ON (s.variant_id = v.id)
+           WHERE v.instance_question_id = iq.id
+           ORDER BY s.date DESC
+           LIMIT 1) IS NOT NULL
+RETURNING iq.*;

--- a/migrations/20221018160700_instance_questions__status__update.sql
+++ b/migrations/20221018160700_instance_questions__status__update.sql
@@ -2,6 +2,7 @@ UPDATE instance_questions iq
 SET status = 'incorrect'
 WHERE iq.status = 'saved'
       AND CARDINALITY(iq.variants_points_list) > 0
+      AND iq.modified_at > now() - interval '3 months'
       AND (SELECT s.graded_at
            FROM variants v LEFT JOIN submissions s ON (s.variant_id = v.id)
            WHERE v.instance_question_id = iq.id

--- a/sprocs/instance_questions_points_homework.sql
+++ b/sprocs/instance_questions_points_homework.sql
@@ -79,7 +79,7 @@ BEGIN
     ELSE
         -- use current status unless it's 'unanswered'
         status := iq.status;
-        IF iq.status = 'unanswered' THEN
+        IF iq.status IN ('unanswered', 'saved') THEN
             status := 'incorrect';
         END IF;
     END IF;

--- a/sprocs/instance_questions_points_homework.sql
+++ b/sprocs/instance_questions_points_homework.sql
@@ -77,7 +77,7 @@ BEGIN
     IF correct THEN
         status := 'correct';
     ELSE
-        -- use current status unless it's 'unanswered'
+        -- use current status unless it's 'unanswered' or 'saved'
         status := iq.status;
         IF iq.status IN ('unanswered', 'saved') THEN
             status := 'incorrect';


### PR DESCRIPTION
The instance question status indicates how the grading of the instance question is applied. In particular, I believe the intention is:

* unanswered: no submission;
* saved: submission saved, but not graded;
* invalid: submission saved, but parsing failed;
* grading: submission saved and grading requested but still waiting for completion (external grading);
* correct/incorrect: submission saved and graded, and more submissions allowed;
* complete: submission saved and graded, and no more submissions allowed (exams).

These are not properly handled right now. A homework question has the status "saved" until it is correct (i.e., "incorrect" is not used). Exams handle this properly.

Also, the "grading" status is never used (from what I could tell), the status in place while grading is actually "saved".

This PR updates the homework processing to set the status to "incorrect" if it was graded and not correct. It does not change the grading status.