### PR TITLE
Add raw submitted answer to assessment instance log

### DIFF
--- a/sprocs/assessment_instances_select_log.sql
+++ b/sprocs/assessment_instances_select_log.sql
@@ -125,7 +125,8 @@ BEGIN
                     jsonb_build_object(
                       'submitted_answer', CASE WHEN include_files THEN s.submitted_answer ELSE (s.submitted_answer - '_files') END,
                       'raw_submitted_answer', CASE WHEN include_files THEN s.raw_submitted_answer
-                      ELSE (SELECT JSONB_OBJECT_AGG(key, value) FROM JSONB_EACH(s.raw_submitted_answer) WHERE key !~ '^_') END,
+                      -- Elements that produce files (upload, editor, etc.) will use keys like '_file_upload_XXX' or equivalent
+                      ELSE (SELECT JSONB_OBJECT_AGG(key, value) FROM JSONB_EACH(s.raw_submitted_answer) WHERE STARTS_WITH(key, '_')) END,
                       'correct', s.correct
                     ) AS data
                 FROM

--- a/sprocs/assessment_instances_select_log.sql
+++ b/sprocs/assessment_instances_select_log.sql
@@ -124,6 +124,8 @@ BEGIN
                     s.id AS log_id,
                     jsonb_build_object(
                       'submitted_answer', CASE WHEN include_files THEN s.submitted_answer ELSE (s.submitted_answer - '_files') END,
+                      'raw_submitted_answer', CASE WHEN include_files THEN s.raw_submitted_answer
+                      ELSE (SELECT JSONB_OBJECT_AGG(key, value) FROM JSONB_EACH(s.raw_submitted_answer) WHERE key !~ '^_') END,
                       'correct', s.correct
                     ) AS data
                 FROM

--- a/sprocs/assessment_instances_select_log.sql
+++ b/sprocs/assessment_instances_select_log.sql
@@ -126,7 +126,7 @@ BEGIN
                       'submitted_answer', CASE WHEN include_files THEN s.submitted_answer ELSE (s.submitted_answer - '_files') END,
                       'raw_submitted_answer', CASE WHEN include_files THEN s.raw_submitted_answer
                       -- Elements that produce files (upload, editor, etc.) will use keys like '_file_upload_XXX' or equivalent
-                      ELSE (SELECT JSONB_OBJECT_AGG(key, value) FROM JSONB_EACH(s.raw_submitted_answer) WHERE STARTS_WITH(key, '_')) END,
+                      ELSE (SELECT JSONB_OBJECT_AGG(key, value) FROM JSONB_EACH(s.raw_submitted_answer) WHERE NOT STARTS_WITH(key, '_')) END,
                       'correct', s.correct
                     ) AS data
                 FROM


### PR DESCRIPTION
Based on discussion on Slack. Given the raw submitted answer for questions with files will contain the base64 content of the file for a key like `_file_upload_XXX` or `_file_editor_XXX`, keys that start with a `_` are removed for cases where files should not be included.