### PR TITLE
Reset outputBoth in CodeCallerContainer

### DIFF
--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -130,6 +130,7 @@ class CodeCallerContainer {
     // These will accumulate output from the container.
     this.outputStdout = '';
     this.outputStderr = '';
+    this.outputBoth = '';
 
     // for error logging
     this.lastCallData = null;
@@ -239,6 +240,7 @@ class CodeCallerContainer {
     // Reset output accumulators.
     this.outputStdout = '';
     this.outputStderr = '';
+    this.outputBoth = '';
 
     const deferred = deferredPromise();
     this.callback = (err, result, output) => {


### PR DESCRIPTION
This fixes an issue where error information from previous calls would incorrectly be shown if a code caller timed out. Now, the error output is reset on each new call.

This code is not yet running in production, so there was no risk of information leakage across courses.

Closes https://github.com/PrairieLearnInc/sysconf/issues/446.