### PR TITLE
Fix sync error in the face of renames and duplicate UUIDs

### DIFF
--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -81,7 +81,7 @@ BEGIN
                 )
             )
         )
-        ORDER BY src_tid, (src.tid = dest.tid) DESC NULLS LAST
+        ORDER BY src_tid, (src.uuid = dest.uuid) DESC NULLS LAST
     ),
     deactivate_unmatched_dest_rows AS (
         UPDATE assessments AS dest

--- a/sprocs/sync_assessments.sql
+++ b/sprocs/sync_assessments.sql
@@ -66,12 +66,22 @@ BEGIN
 
     WITH
     matched_rows AS (
-        SELECT src.tid AS src_tid, src.uuid AS src_uuid, dest.id AS dest_id -- matched_rows cols have underscores
+        -- See `sync_questions.sql` for an explanation of the use of DISTINCT ON.
+        SELECT DISTINCT ON (src_tid)
+            src.tid AS src_tid,
+            src.uuid AS src_uuid,
+            dest.id AS dest_id
         FROM disk_assessments AS src LEFT JOIN assessments AS dest ON (
             dest.course_instance_id = syncing_course_instance_id
-            AND (src.uuid = dest.uuid
-                 OR ((src.uuid IS NULL OR dest.uuid IS NULL)
-                     AND src.tid = dest.tid AND dest.deleted_at IS NULL)))
+            AND (
+                src.uuid = dest.uuid
+                OR (
+                    (src.uuid IS NULL OR dest.uuid IS NULL)
+                    AND src.tid = dest.tid AND dest.deleted_at IS NULL
+                )
+            )
+        )
+        ORDER BY src_tid, (src.tid = dest.tid) DESC NULLS LAST
     ),
     deactivate_unmatched_dest_rows AS (
         UPDATE assessments AS dest

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -49,12 +49,22 @@ BEGIN
 
     WITH
     matched_rows AS (
-        SELECT src.short_name AS src_short_name, src.uuid AS src_uuid, dest.id AS dest_id -- matched_rows cols have underscores
+        -- See `sync_questions.sql` for an explanation of the use of DISTINCT ON.
+        SELECT DISTINCT ON (src_short_name)
+            src.short_name AS src_short_name,
+            src.uuid AS src_uuid,
+            dest.id AS dest_id
         FROM disk_course_instances AS src LEFT JOIN course_instances AS dest ON (
             dest.course_id = syncing_course_id
-            AND (src.uuid = dest.uuid
-                 OR ((src.uuid IS NULL OR dest.uuid IS NULL)
-                     AND src.short_name = dest.short_name AND dest.deleted_at IS NULL)))
+            AND (
+                src.uuid = dest.uuid
+                OR (
+                    (src.uuid IS NULL OR dest.uuid IS NULL)
+                    AND src.short_name = dest.short_name AND dest.deleted_at IS NULL
+                )
+            )
+        )
+        ORDER BY src_short_name, (src.short_name = dest.short_name) DESC NULLS LAST
     ),
     deactivate_unmatched_dest_rows AS (
         UPDATE course_instances AS dest

--- a/sprocs/sync_course_instances.sql
+++ b/sprocs/sync_course_instances.sql
@@ -64,7 +64,7 @@ BEGIN
                 )
             )
         )
-        ORDER BY src_short_name, (src.short_name = dest.short_name) DESC NULLS LAST
+        ORDER BY src_short_name, (src.uuid = dest.uuid) DESC NULLS LAST
     ),
     deactivate_unmatched_dest_rows AS (
         UPDATE course_instances AS dest

--- a/sprocs/sync_questions.sql
+++ b/sprocs/sync_questions.sql
@@ -46,12 +46,35 @@ BEGIN
 
     WITH
     matched_rows AS (
-        SELECT src.qid AS src_qid, src.uuid AS src_uuid, dest.id AS dest_id -- matched_rows cols have underscores
+        -- DISTINCT ON is necessary to ensure that we only try to update one
+        -- row per qid. See comment below in ORDER BY for more details.
+        SELECT DISTINCT ON (src_qid)
+            src.qid AS src_qid,
+            src.uuid AS src_uuid,
+            dest.id AS dest_id
         FROM disk_questions AS src LEFT JOIN questions AS dest ON (
             dest.course_id = syncing_course_id
-            AND (src.uuid = dest.uuid
-                 OR ((src.uuid IS NULL OR dest.uuid IS NULL)
-                     AND src.qid = dest.qid AND dest.deleted_at IS NULL)))
+            AND (
+                src.uuid = dest.uuid
+                OR (
+                    (src.uuid IS NULL OR dest.uuid IS NULL)
+                    AND src.qid = dest.qid AND dest.deleted_at IS NULL
+                )
+            )
+        )
+        ORDER BY
+            -- This ORDER BY clause is necessary for DISTINCT ON
+            src_qid,
+            -- Together with the use of DISTINCT ON, this ORDER BY clause
+            -- ensures that, when given the choice between matching based on
+            -- qid or uuid, we prefer matching based on uuid. This avoids a
+            -- scenario where we try to insert a new row with a UUID that's
+            -- already in use in another row.
+            --
+            -- See https://github.com/PrairieLearn/PrairieLearn/issues/6539 for
+            -- a case where this occurred, including a description of how to
+            -- reproduce it.
+            (src.uuid = dest.uuid) DESC NULLS LAST
     ),
     deactivate_unmatched_dest_rows AS (
         UPDATE questions AS dest

--- a/tests/sync/assessmentsSync.test.js
+++ b/tests/sync/assessmentsSync.test.js
@@ -1672,10 +1672,10 @@ describe('Assessment syncing', () => {
     assert.isUndefined(originalAssessmentRow);
 
     // New assessments should exist and have the correct UUIDs.
-    const newAssessmentRow1 = assessments.find((q) => q.qid === 'b' && q.deleted_at === null);
+    const newAssessmentRow1 = assessments.find((a) => a.tid === 'b' && a.deleted_at === null);
     assert.isNull(newAssessmentRow1.deleted_at);
     assert.equal(newAssessmentRow1.uuid, '0e8097aa-b554-4908-9eac-d46a78d6c249');
-    const newAssessmentRow2 = assessments.find((q) => q.qid === 'c' && q.deleted_at === null);
+    const newAssessmentRow2 = assessments.find((a) => a.tid === 'c' && a.deleted_at === null);
     assert.isNull(newAssessmentRow2.deleted_at);
     assert.equal(newAssessmentRow2.uuid, '0e3097ba-b554-4908-9eac-d46a78d6c249');
   });

--- a/tests/sync/assessmentsSync.test.js
+++ b/tests/sync/assessmentsSync.test.js
@@ -748,7 +748,7 @@ describe('Assessment syncing', () => {
       foundContributor,
       secondAssessmentQuestion
     );
-    assert.isFalse(secondQuestionContributorPermission);
+    assert.isOk(secondQuestionContributorPermission);
     assert.isTrue(
       !secondQuestionContributorPermission.can_view &&
         !secondQuestionContributorPermission.can_submit,

--- a/tests/sync/courseInstancesSync.test.js
+++ b/tests/sync/courseInstancesSync.test.js
@@ -355,7 +355,7 @@ describe('Course instance syncing', () => {
     assert.isNull(newCourseInstanceRow1.deleted_at);
     assert.equal(newCourseInstanceRow1.uuid, '0e8097aa-b554-4908-9eac-d46a78d6c249');
     const newCourseInstanceRow2 = courseInstances.find(
-      (q) => q.qid === 'c' && q.deleted_at === null
+      (q) => q.short_name === 'c' && q.deleted_at === null
     );
     assert.isNull(newCourseInstanceRow2.deleted_at);
     assert.equal(newCourseInstanceRow2.uuid, '0e3097ba-b554-4908-9eac-d46a78d6c249');

--- a/tests/sync/courseInstancesSync.test.js
+++ b/tests/sync/courseInstancesSync.test.js
@@ -311,4 +311,53 @@ describe('Course instance syncing', () => {
     assert.equal(deletedCourseInstance.uuid, originalCourseInstance.courseInstance.uuid);
     assert.equal(deletedCourseInstance.sync_errors, null);
   });
+
+  // https://github.com/PrairieLearn/PrairieLearn/issues/6539
+  it('handles unique sequence of renames and duplicate UUIDs', async () => {
+    const courseData = util.getCourseData();
+
+    // Start with a clean slate.
+    courseData.courseInstances = {};
+
+    // Write and sync a single course instance.
+    const originalCourseInstance = makeCourseInstance();
+    originalCourseInstance.courseInstance.uuid = '0e8097aa-b554-4908-9eac-d46a78d6c249';
+    courseData.courseInstances['a'] = originalCourseInstance;
+    const courseDir = await util.writeAndSyncCourseData(courseData);
+
+    // Now "move" the above course instance to a new directory AND add another with the
+    // same UUID.
+    delete courseData.courseInstances['a'];
+    courseData.courseInstances['b'] = originalCourseInstance;
+    courseData.courseInstances['c'] = originalCourseInstance;
+    await util.overwriteAndSyncCourseData(courseData, courseDir);
+
+    // Now "fix" the duplicate UUID.
+    courseData.courseInstances['c'] = {
+      ...originalCourseInstance,
+      courseInstance: {
+        ...originalCourseInstance.courseInstance,
+        uuid: '0e3097ba-b554-4908-9eac-d46a78d6c249',
+      },
+    };
+    await util.overwriteAndSyncCourseData(courseData, courseDir);
+
+    const courseInstances = await util.dumpTable('course_instances');
+
+    // Original course instance should not exist.
+    const originalCourseInstanceRow = courseInstances.find((ci) => ci.short_name === 'a');
+    assert.isUndefined(originalCourseInstanceRow);
+
+    // New course instances should exist and have the correct UUIDs.
+    const newCourseInstanceRow1 = courseInstances.find(
+      (ci) => ci.short_name === 'b' && ci.deleted_at === null
+    );
+    assert.isNull(newCourseInstanceRow1.deleted_at);
+    assert.equal(newCourseInstanceRow1.uuid, '0e8097aa-b554-4908-9eac-d46a78d6c249');
+    const newCourseInstanceRow2 = courseInstances.find(
+      (q) => q.qid === 'c' && q.deleted_at === null
+    );
+    assert.isNull(newCourseInstanceRow2.deleted_at);
+    assert.equal(newCourseInstanceRow2.uuid, '0e3097ba-b554-4908-9eac-d46a78d6c249');
+  });
 });

--- a/tests/sync/questionsSync.test.js
+++ b/tests/sync/questionsSync.test.js
@@ -369,18 +369,18 @@ describe('Question syncing', () => {
     // Write and sync a single question.
     const originalQuestion = makeQuestion(courseData);
     originalQuestion.uuid = '0e8097aa-b554-4908-9eac-d46a78d6c249';
-    courseData.questions['templates/simple_randomized_mcq'] = originalQuestion;
+    courseData.questions['a'] = originalQuestion;
     const courseDir = await util.writeAndSyncCourseData(courseData);
 
     // Now "move" the above question to a new directory AND add another with the
     // same UUID.
-    delete courseData.questions['templates/simple_randomized_mcq'];
-    courseData.questions['firas_templates/simple_randomized_mcq'] = originalQuestion;
-    courseData.questions['firas_test/modulo_variable'] = originalQuestion;
+    delete courseData.questions['a'];
+    courseData.questions['b'] = originalQuestion;
+    courseData.questions['c'] = originalQuestion;
     await util.overwriteAndSyncCourseData(courseData, courseDir);
 
     // Now "fix" the duplicate UUID.
-    courseData.questions['firas_test/modulo_variable'] = {
+    courseData.questions['c'] = {
       ...originalQuestion,
       uuid: '0e3097ba-b554-4908-9eac-d46a78d6c249',
     };
@@ -389,18 +389,14 @@ describe('Question syncing', () => {
     const questions = await util.dumpTable('questions');
 
     // Original question should not exist.
-    const originalQuestionRow = questions.find((q) => q.qid === 'templates/simple_randomized_mcq');
+    const originalQuestionRow = questions.find((q) => q.qid === 'a');
     assert.isUndefined(originalQuestionRow);
 
     // New questions should exist and have the correct UUIDs.
-    const newQuestionRow1 = questions.find(
-      (q) => q.qid === 'firas_templates/simple_randomized_mcq' && q.deleted_at === null
-    );
+    const newQuestionRow1 = questions.find((q) => q.qid === 'b' && q.deleted_at === null);
     assert.isNull(newQuestionRow1.deleted_at);
     assert.equal(newQuestionRow1.uuid, '0e8097aa-b554-4908-9eac-d46a78d6c249');
-    const newQuestionRow2 = questions.find(
-      (q) => q.qid === 'firas_test/modulo_variable' && q.deleted_at === null
-    );
+    const newQuestionRow2 = questions.find((q) => q.qid === 'c' && q.deleted_at === null);
     assert.isNull(newQuestionRow2.deleted_at);
     assert.equal(newQuestionRow2.uuid, '0e3097ba-b554-4908-9eac-d46a78d6c249');
   });

--- a/tests/sync/questionsSync.test.js
+++ b/tests/sync/questionsSync.test.js
@@ -358,4 +358,26 @@ describe('Question syncing', () => {
     assert.equal(deletedQuestion.uuid, originalQuestion.uuid);
     assert.equal(deletedQuestion.sync_errors, null);
   });
+
+  it.only('reproduces problem Firas reported', async () => {
+    const courseData = util.getCourseData();
+    const originalQuestion = makeQuestion(courseData);
+    originalQuestion.uuid = '0e8097aa-b554-4908-9eac-d46a78d6c249';
+    courseData.questions['templates/simple_randomized_mcq'] = originalQuestion;
+    const courseDir = await util.writeAndSyncCourseData(courseData);
+
+    // Now move the above question to a new directory AND add another with the
+    // same UUID.
+    delete courseData.questions['templates/simple_randomized_mcq'];
+    courseData.questions['firas_templates/simple_randomized_mcq'] = originalQuestion;
+    courseData.questions['firas_test/modulo_variable'] = { ...originalQuestion };
+    await util.overwriteAndSyncCourseData(courseData, courseDir);
+
+    // Now "fix" the duplicate UUID.
+    courseData.questions['firas_test/modulo_variable'] = {
+      ...originalQuestion,
+      uuid: '0e3097ba-b554-4908-9eac-d46a78d6c249',
+    };
+    await util.overwriteAndSyncCourseData(courseData, courseDir);
+  });
 });

--- a/tests/sync/questionsSync.test.js
+++ b/tests/sync/questionsSync.test.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 const util = require('./util');
 const helperDb = require('../helperDb');
+const sqldb = require('../../prairielib/lib/sql-db');
 const { idsEqual } = require('../../lib/id');
 
 const { assert } = chai;
@@ -359,8 +360,15 @@ describe('Question syncing', () => {
     assert.equal(deletedQuestion.sync_errors, null);
   });
 
+  // https://github.com/PrairieLearn/PrairieLearn/issues/6539
   it.only('reproduces problem Firas reported', async () => {
     const courseData = util.getCourseData();
+
+    // Start with a clean slate.
+    courseData.courseInstances = {};
+    courseData.questions = {};
+
+    // Write and sync a single question.
     const originalQuestion = makeQuestion(courseData);
     originalQuestion.uuid = '0e8097aa-b554-4908-9eac-d46a78d6c249';
     courseData.questions['templates/simple_randomized_mcq'] = originalQuestion;
@@ -370,7 +378,7 @@ describe('Question syncing', () => {
     // same UUID.
     delete courseData.questions['templates/simple_randomized_mcq'];
     courseData.questions['firas_templates/simple_randomized_mcq'] = originalQuestion;
-    courseData.questions['firas_test/modulo_variable'] = { ...originalQuestion };
+    courseData.questions['firas_test/modulo_variable'] = originalQuestion;
     await util.overwriteAndSyncCourseData(courseData, courseDir);
 
     // Now "fix" the duplicate UUID.
@@ -378,6 +386,99 @@ describe('Question syncing', () => {
       ...originalQuestion,
       uuid: '0e3097ba-b554-4908-9eac-d46a78d6c249',
     };
-    await util.overwriteAndSyncCourseData(courseData, courseDir);
+    console.log('courseData', courseData);
+    console.log('questions', await util.dumpTable('questions'));
+    await sqldb.runInTransactionAsync(async () => {
+      await sqldb.queryAsync(
+        `
+          CREATE TEMPORARY TABLE disk_questions (
+          qid TEXT NOT NULL,
+          uuid uuid,
+          errors TEXT,
+          warnings TEXT,
+          data JSONB
+      ) ON COMMIT DROP;`,
+        {}
+      );
+      await sqldb.queryAsync(
+        `
+      INSERT INTO disk_questions (
+          qid,
+          uuid,
+          errors,
+          warnings,
+          data
+      ) SELECT
+          entries->>0,
+          (entries->>1)::uuid,
+          entries->>2,
+          entries->>3,
+          (entries->4)::JSONB
+      FROM UNNEST($disk_questions_data::JSONB[]) AS entries;
+    `,
+
+        {
+          disk_questions_data: [
+            '["firas_templates/simple_randomized_mcq","0e8097aa-b554-4908-9eac-d46a78d6c249","","",{"type":"Freeform","title":"Test question","partial_credit":true,"client_files":["client.js","question.html","answer.html"],"topic":"Test","grading_method":"Internal","single_variant":false,"show_correct_answer":true,"external_grading_environment":{},"dependencies":{},"workspace_environment":{}}]',
+            '["firas_test/modulo_variable","0e3097ba-b554-4908-9eac-d46a78d6c249","","",{"type":"Freeform","title":"Test question","partial_credit":true,"client_files":["client.js","question.html","answer.html"],"topic":"Test","grading_method":"Internal","single_variant":false,"show_correct_answer":true,"external_grading_environment":{},"dependencies":{},"workspace_environment":{}}]',
+          ],
+        }
+      );
+      console.log(
+        'disk_questions',
+        (await sqldb.queryAsync('SELECT * FROM disk_questions;', {})).rows
+      );
+      const res = await sqldb.queryAsync(
+        `
+      SELECT src.qid AS src_qid, src.uuid AS src_uuid, dest.id AS dest_id, dest.uuid AS dest_uuid, dest.qid AS dest_qid -- matched_rows cols have underscores
+        FROM disk_questions AS src LEFT JOIN questions AS dest ON (
+            dest.course_id = $course_id
+            AND (src.uuid = dest.uuid
+                 OR ((src.uuid IS NULL OR dest.uuid IS NULL)
+                     AND src.qid = dest.qid AND dest.deleted_at IS NULL)))`,
+        { course_id: 1 }
+      );
+      console.log(res.rows);
+
+      const res2 = await sqldb.queryAsync(
+        `
+        SELECT DISTINCT ON (src_qid) src.qid AS src_qid, src.uuid AS src_uuid, dest.id AS dest_id, dest.uuid AS dest_uuid, dest.qid AS dest_qid -- matched_rows cols have underscores
+        FROM disk_questions AS src LEFT JOIN questions AS dest ON (
+            dest.course_id = $course_id
+            AND (src.uuid = dest.uuid
+                 OR ((src.uuid IS NULL OR dest.uuid IS NULL)
+                     AND src.qid = dest.qid AND dest.deleted_at IS NULL)))
+        ORDER BY src_qid, (src.uuid = dest.uuid) DESC NULLS LAST
+                     `,
+        { course_id: 1 }
+      );
+      console.log(res2.rows);
+    });
+    try {
+      await util.overwriteAndSyncCourseData(courseData, courseDir);
+    } catch (err) {
+      console.log(err);
+      throw err;
+    }
+
+    const questions = await util.dumpTable('questions');
+
+    console.log(questions);
+
+    // Original question should not exist.
+    const originalQuestionRow = questions.find((q) => q.qid === 'templates/simple_randomized_mcq');
+    assert.isUndefined(originalQuestionRow);
+
+    // New questions should exist and have the correct UUIDs.
+    const newQuestionRow1 = questions.find(
+      (q) => q.qid === 'firas_templates/simple_randomized_mcq' && q.deleted_at === null
+    );
+    assert.isNull(newQuestionRow1.deleted_at);
+    assert.equal(newQuestionRow1.uuid, '0e8097aa-b554-4908-9eac-d46a78d6c249');
+    const newQuestionRow2 = questions.find(
+      (q) => q.qid === 'firas_test/modulo_variable' && q.deleted_at === null
+    );
+    assert.isNull(newQuestionRow2.deleted_at);
+    assert.equal(newQuestionRow2.uuid, '0e3097ba-b554-4908-9eac-d46a78d6c249');
   });
 });

--- a/tests/sync/util.js
+++ b/tests/sync/util.js
@@ -73,6 +73,16 @@ const syncFromDisk = require('../../sync/syncFromDisk');
  */
 
 /**
+ * @typedef {Object} GroupRole
+ * @property {string} name
+ * @property {number} [minimum]
+ * @property {number} [maximum]
+ * @property {boolean} [canAssignRolesAtStart]
+ * @property {boolean} [canAssignRolesDuringAssessment]
+ * @property {boolean} [canSubmitAssessment]
+ */
+
+/**
  * @typedef {Object} SEBConfig
  * @property {string} password
  * @property {string} quitPassword
@@ -81,50 +91,53 @@ const syncFromDisk = require('../../sync/syncFromDisk');
 
 /**
  * @typedef {Object} AssessmentAllowAccess
- * @property {"Public" | "Exam" | "SEB"} mode
- * @property {string} examUuid
- * @property {string[]} uids
- * @property {number} credit
- * @property {string} startDate
- * @property {string} endDate
- * @property {number} timeLimitMin
- * @property {string} password
- * @property {SEBConfig} SEBConfig
+ * @property {"Public" | "Exam" | "SEB"} [mode]
+ * @property {string} [examUuid]
+ * @property {string[]} [uids]
+ * @property {number} [credit]
+ * @property {string} [startDate]
+ * @property {string} [endDate]
+ * @property {number} [timeLimitMin]
+ * @property {string} [password]
+ * @property {SEBConfig} [SEBConfig]
+ * @property {boolean} [active]
  */
 
 /**
  * @typedef {Object} QuestionAlternative
- * @property {number | number[]} points
- * @property {number | number[]} autoPoints
- * @property {number} maxPoints
- * @property {number} maxAutoPoints
- * @property {number} manualPoints
- * @property {string} id
- * @property {boolean} forceMaxPoints
- * @property {number} triesPerVariant
+ * @property {number | number[]} [points]
+ * @property {number | number[]} [autoPoints]
+ * @property {number} [maxPoints]
+ * @property {number} [maxAutoPoints]
+ * @property {number} [manualPoints]
+ * @property {string} [id]
+ * @property {boolean} [forceMaxPoints]
+ * @property {number} [triesPerVariant]
  */
 
 /**
  * @typedef {Object} ZoneQuestion
- * @property {number | number[]} points
- * @property {number | number[]} autoPoints
- * @property {number} maxPoints
- * @property {number} maxAutoPoints
- * @property {number} manualPoints
- * @property {string} id
- * @property {boolean} forceMaxPoints
- * @property {QuestionAlternative[]} alternatives
- * @property {number} numberChoose
- * @property {number} triesPerVariant
+ * @property {number | number[]} [points]
+ * @property {number | number[]} [autoPoints]
+ * @property {number} [maxPoints]
+ * @property {number} [maxAutoPoints]
+ * @property {number} [manualPoints]
+ * @property {string} [id]
+ * @property {boolean} [forceMaxPoints]
+ * @property {QuestionAlternative[]} [alternatives]
+ * @property {number} [numberChoose]
+ * @property {number} [triesPerVariant]
+ * @property {string[]} [canSubmit]
+ * @property {string[]} [canView]
  */
 
 /**
  * @typedef {Object} Zone
- * @property {string} title
- * @property {number} maxPoints
- * @property {number} maxChoose
- * @property {number} bestQuestions
- * @property {ZoneQuestion[]} questions
+ * @property {string} [title]
+ * @property {number} [maxPoints]
+ * @property {number} [maxChoose]
+ * @property {number} [bestQuestions]
+ * @property {ZoneQuestion[]} [questions]
  */
 
 /**
@@ -135,6 +148,7 @@ const syncFromDisk = require('../../sync/syncFromDisk');
  * @property {string} set
  * @property {string} [module]
  * @property {string} number
+ * @property {GroupRole[]} [groupRoles]
  * @property {boolean} [allowIssueReporting]
  * @property {boolean} [allowRealTimeGrading]
  * @property {boolean} [requireHonorCode]

--- a/tests/sync/util.js
+++ b/tests/sync/util.js
@@ -269,6 +269,7 @@ module.exports.writeCourseToDirectory = async function (courseData, coursePath) 
 module.exports.QUESTION_ID = 'test';
 module.exports.ALTERNATIVE_QUESTION_ID = 'test2';
 module.exports.MANUAL_GRADING_QUESTION_ID = 'test_manual';
+module.exports.WORKSPACE_QUESTION_ID = 'workspace';
 module.exports.COURSE_INSTANCE_ID = 'Fa19';
 
 /** @type {Course} */


### PR DESCRIPTION
Fixes https://github.com/PrairieLearn/PrairieLearn/issues/6539. See inline comments for details on the fix itself! Since we use essentially the same syncing algorithm for questions, assessments, and course instances, I had to make the fix in all three places.