### PR TITLE
Block file attachment submission if no file selected

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -25,7 +25,7 @@ module.exports.storageTypes = Object.freeze({
  * @param {number} user_id - The current user performing the update.
  * @param {number} authn_user_id - The current authenticated user.
  * @param {string} storage_type - AWS 'S3' or 'FileSystem' storage options.
- * @return {number} The file_id of the newly created file.
+ * @return {Promise<number>} The file_id of the newly created file.
  */
 module.exports.upload = async (
   display_filename,

--- a/pages/partials/attachFilePanel.ejs
+++ b/pages/partials/attachFilePanel.ejs
@@ -51,52 +51,67 @@
     </div>
     <% } else { /* assessment_instance is open and authorized_edit is true */ %>
     <!-- UPLOAD FILE -->
-    <button class="btn btn-xs btn-secondary" type="button" data-toggle="collapse" data-target="#attachFileCollapse" aria-expanded="false" aria-controls="attachFileCollapse">
-      Attach a file <i class="far fa-caret-square-down"></i>
-    </button>
-    <div class="collapse" id="attachFileCollapse">
-      <form class="attach-file-form" name="attach-file-form" method="POST" enctype="multipart/form-data" class="mb-3">
-        <p class="small mt-3">
-          Attached files will be saved here for your reference.
-        </p>
-        <div class="form-group">
-          <div class="custom-file">
-            <input type="file" name="file" class="custom-file-input" id="attachFileInput">
-            <label class="custom-file-label" for="attachFileInput">Choose file</label>
-            <small id="emailHelp" class="form-text text-muted">Max file size: <%= config.fileUploadMaxBytesFormatted %></small>
+    <div>
+      <button class="btn btn-xs btn-secondary" type="button" data-toggle="collapse" data-target="#attachFileCollapse" aria-expanded="false" aria-controls="attachFileCollapse">
+        Attach a file <i class="far fa-caret-square-down"></i>
+      </button>
+      <div class="collapse" id="attachFileCollapse">
+        <form class="attach-file-form mb-3" name="attach-file-form" method="POST" enctype="multipart/form-data">
+          <p class="small mt-3">
+            Attached files will be saved here for your reference.
+          </p>
+          <div class="form-group">
+            <div class="custom-file">
+              <input type="file" name="file" class="custom-file-input" id="attachFileInput">
+              <label class="custom-file-label" for="attachFileInput">Choose file</label>
+              <small id="emailHelp" class="form-text text-muted">Max file size: <%= config.fileUploadMaxBytesFormatted %></small>
+            </div>
           </div>
-        </div>
-        <div class="form-group mb-0">
-          <input type="hidden" name="__action" value="attach_file">
+          <div class="form-group mb-0">
+            <input type="hidden" name="__action" value="attach_file">
+            <% if (typeof variant != 'undefined') { %>
+            <input type="hidden" name="__variant_id" value="<%= variant.id %>">
+            <% } %>
+            <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+            <button type="submit" class="btn btn-primary" disabled>Attach file</button>
+          </div>
+        </form>
+
+        <script>
+          $(() => {
+            // Only enable the "submit" button if a file is selected.
+            const form = document.querySelector('form.attach-file-form');
+            const fileInput = form.querySelector('#attachFileInput');
+            const submitButton = form.querySelector('button[type="submit"]');
+            fileInput.addEventListener('change', (e) => {
+              submitButton.disabled = (fileInput.files.length === 0);
+            })
+          });
+        </script>
+      </div>
+    </div>
+
+    <!-- UPLOAD TEXT -->
+    <div>
+      <button class="btn btn-xs btn-secondary" type="button" data-toggle="collapse" data-target="#attachTextCollapse" aria-expanded="false" aria-controls="attachTextCollapse">
+        Attach text <i class="far fa-caret-square-down"></i>
+      </button>
+      <div class="collapse" id="attachTextCollapse">
+        <form method="POST" class="attach-text-form">
+          <p class="small mt-3">
+            Attached text will be saved here for your reference.
+          </p>
+          <input class="form-control" aria-label="Text filename" name="filename" value="notes.txt">
+          <div class="form-group">
+            <textarea class="form-control" rows="5" aria-label="Text contents" name="contents" placeholder="Type or paste text here"></textarea>
+          </div>
           <% if (typeof variant != 'undefined') { %>
           <input type="hidden" name="__variant_id" value="<%= variant.id %>">
           <% } %>
           <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
-          <button type="submit" class="btn btn-primary">Attach file</button>
-        </div>
-      </form>
-    </div>
-
-    <!-- UPLOAD TEXT -->
-    <br>
-    <button class="btn btn-xs btn-secondary" type="button" data-toggle="collapse" data-target="#attachTextCollapse" aria-expanded="false" aria-controls="attachTextCollapse">
-      Attach text <i class="far fa-caret-square-down"></i>
-    </button>
-    <div class="collapse" id="attachTextCollapse">
-      <form method="POST" class="attach-text-form">
-        <p class="small mt-3">
-          Attached text will be saved here for your reference.
-        </p>
-        <input class="form-control" aria-label="Text filename" name="filename" value="notes.txt">
-        <div class="form-group">
-          <textarea class="form-control" rows="5" aria-label="Text contents" name="contents" placeholder="Type or paste text here"></textarea>
-        </div>
-        <% if (typeof variant != 'undefined') { %>
-        <input type="hidden" name="__variant_id" value="<%= variant.id %>">
-        <% } %>
-        <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
-        <button class="btn btn-small btn-primary" name="__action" value="attach_text">Attach text</button>
-      </form>
+          <button class="btn btn-small btn-primary" name="__action" value="attach_text">Attach text</button>
+        </form>
+      </div>
     </div>
     <!-- END OF FILES -->
     <% } %>

--- a/pages/shared/studentInstanceQuestion.js
+++ b/pages/shared/studentInstanceQuestion.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const sqldb = require('../../prairielib/lib/sql-db');
+const error = require('../../prairielib/lib/error');
 
 const fileStore = require('../../lib/file-store');
 const { idsEqual } = require('../../lib/id');
@@ -30,6 +31,9 @@ module.exports.processFileUpload = async (req, res) => {
   if (!res.locals.assessment_instance.open) throw new Error(`Assessment is not open`);
   if (!res.locals.authz_result.active) {
     throw new Error(`This assessment is not accepting submissions at this time.`);
+  }
+  if (!req.file) {
+    throw error.make(400, 'No file uploaded');
   }
   await fileStore.upload(
     req.file.originalname,


### PR DESCRIPTION
This PR solves the following Sentry error: https://sentry.io/organizations/prairielearn-inc/issues/3581270096/?project=6704263

The specific error is `Cannot read properties of undefined (reading 'originalname')`, coming from here:

https://github.com/PrairieLearn/PrairieLearn/blob/f2ee0e4280da6a83e36f271df6db5342c3154408/pages/shared/studentInstanceQuestion.js#L35

For good measure, I'm validating both on the client (don't allow submission if a file hasn't been selected) and on the server (respond with a 400 if no file was attached).