### PR TITLE
Wait for code callers to boot up before sending calls to them

### DIFF
--- a/executor.js
+++ b/executor.js
@@ -98,55 +98,42 @@ async function handleInput(line, codeCaller) {
   };
 }
 
-// Our overall loop looks like this: read a line of input from stdin, spin
-// off a python worker to handle it, and write the results back to stdout.
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-  terminal: false,
-});
-
 let questionTimeoutMilliseconds = Number.parseInt(process.env.QUESTION_TIMEOUT_MILLISECONDS);
 if (Number.isNaN(questionTimeoutMilliseconds)) {
   questionTimeoutMilliseconds = 10000;
 }
 
-let codeCaller = new CodeCallerNative({
-  dropPrivileges: true,
-  questionTimeoutMilliseconds,
-  errorLogger: console.error,
-});
-codeCaller.ensureChild();
+(async () => {
+  let codeCaller = new CodeCallerNative({
+    dropPrivileges: true,
+    questionTimeoutMilliseconds,
+    errorLogger: console.error,
+  });
+  await codeCaller.ensureChild();
 
-// Safety check: if we receive more input while handling another request,
-// discard it.
-let processingRequest = false;
-rl.on('line', (line) => {
-  if (processingRequest) {
-    // Someone else messed up - fail fast.
-    process.exit(1);
+  // Our overall loop looks like this: read a line of input from stdin, spin
+  // off a python worker to handle it, and write the results back to stdout.
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+
+  // Once the readline interface closes, we can't get any more input; die
+  // immediately to allow our container to be removed.
+  rl.on('close', () => process.exit(0));
+
+  for await (const line of rl) {
+    const results = await handleInput(line, codeCaller);
+    const { needsFullRestart, ...rest } = results;
+    console.log(JSON.stringify(rest));
+    if (needsFullRestart) {
+      codeCaller.done();
+      codeCaller = new CodeCallerNative();
+      await codeCaller.ensureChild();
+    }
   }
-
-  processingRequest = true;
-  handleInput(line, codeCaller)
-    .then((results) => {
-      const { needsFullRestart, ...rest } = results;
-      if (needsFullRestart) {
-        codeCaller.done();
-        codeCaller = new CodeCallerNative();
-        codeCaller.ensureChild();
-      }
-      console.log(JSON.stringify(rest));
-      processingRequest = false;
-    })
-    .catch((err) => {
-      console.error(err);
-      processingRequest = false;
-    });
-});
-
-rl.on('close', () => {
-  // We can't get any more input; die immediately to allow our container
-  // to be removed.
-  process.exit(0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });

--- a/lib/code-caller/README.md
+++ b/lib/code-caller/README.md
@@ -1,0 +1,21 @@
+# Code Callers
+
+A "code caller" is an abstraction for invoking some piece of code in a Python subprocess. The code could be either user-provided or provided by PrairieLearn.
+
+## Usage
+
+You can obtain and use a code caller with the `withCodeCaller()` function
+
+```js
+const { withCodeCaller } = require('./index.js');
+
+await withCodeCaller('/path/to/course', async (codeCaller) => {
+  await codeCaller.call(...);
+});
+```
+
+## Implementation
+
+A pool of code callers is maintained via the `generic-pool` package. `withCodeCaller()` obtains a code caller from the pool and automatically releases it back to the pool once it's no longer needed.
+
+The individual classes (`CodeCallerContainer` and `CodeCallerNative`) should generally not be used on their own, independent of the pool. The pool does important lifecycle tracking to ensure that code callers are started correctly, restarted after use, and destroyed if they enter a bad state.

--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -195,7 +195,6 @@ class CodeCallerContainer {
 
     this.coursePath = coursePath;
 
-    await this._ensureChild();
     // If this Docker code caller was used before, we might have an existing
     // bind mount that we need to remove first. This should have been cleaned
     // up before, but if it wasn't, we'll do so here to avoid a
@@ -222,7 +221,7 @@ class CodeCallerContainer {
   async call(type, directory, file, fcn, args, options = {}) {
     this.debug(`enter call(${type}, ${directory}, ${file}, ${fcn})`);
     this.callCount += 1;
-    await this._ensureChild();
+
     if (!this._checkState([WAITING])) {
       throw new Error('invalid CodeCallerContainer state');
     }
@@ -316,25 +315,6 @@ class CodeCallerContainer {
     this.debug('enter ensureChild()');
     this._checkState();
 
-    await this._ensureChild();
-
-    // Give the child a reasonably long amount of time to start up. Under
-    // periods of high load, it should be cheaper to wait for a child to
-    // start slowly than it would be to time out too quickly and try to
-    // launch a new one to replace it.
-    await this.call('ping', null, null, 'ping', [], { timeout: 60 * 1000 });
-
-    this._checkState();
-    this.debug('exit ensureChild()');
-  }
-
-  /**
-   * Ensures that this code caller has a container.
-   */
-  async _ensureChild() {
-    this.debug('enter _ensureChild()');
-    this._checkState();
-
     // Since container creation is async, it's possible that ensureChild()
     // could be called again while it's already executing. For instance, we
     // could be inside a call that was made to warm up this worker, but then
@@ -349,10 +329,20 @@ class CodeCallerContainer {
       this.hostDirectory = await tmp.dir({ unsafeCleanup: true, prefix: MOUNT_DIRECTORY_PREFIX });
       await ensureImage();
       await this._createAndAttachContainer();
+
+      // Give the child a reasonably long amount of time to start up. Under
+      // periods of high load, it should be cheaper to wait for a child to
+      // start slowly than it would be to time out too quickly and try to
+      // launch a new one to replace it.
+      await this.call('ping', null, null, 'ping', [], { timeout: 60 * 1000 });
+
       this.state = WAITING;
       this._checkState();
       this.debug('exit _ensureChild()');
     });
+
+    this._checkState();
+    this.debug('exit ensureChild()');
   }
 
   /**

--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -195,23 +195,19 @@ class CodeCallerContainer {
 
     this.coursePath = coursePath;
 
-    if (config.workersExecutionMode === 'container') {
-      await this.ensureChild();
-      // If this Docker code caller was used before, we might have an existing
-      // bind mount that we need to remove first. This should have been cleaned
-      // up before, but if it wasn't, we'll do so here to avoid a
-      // `mount point XXX is itself on a OSXFUSE volume` error.
-      try {
-        await this.removeBindMount(this.hostDirectory.path);
-      } catch (e) {
-        // If the above command failed, assume it because a mount point didn't
-        // already exist and proceed as normal. If something is really messed
-        // up, the next command will likely fail anyways.
-      }
-      await this.createBindMount(coursePath, this.hostDirectory.path);
-    } else {
-      throw new Error(`Unexpected worker execution mode "${config.workersExecutionMode}"`);
+    await this._ensureChild();
+    // If this Docker code caller was used before, we might have an existing
+    // bind mount that we need to remove first. This should have been cleaned
+    // up before, but if it wasn't, we'll do so here to avoid a
+    // `mount point XXX is itself on a OSXFUSE volume` error.
+    try {
+      await this.removeBindMount(this.hostDirectory.path);
+    } catch (e) {
+      // If the above command failed, assume it because a mount point didn't
+      // already exist and proceed as normal. If something is really messed
+      // up, the next command will likely fail anyways.
     }
+    await this.createBindMount(coursePath, this.hostDirectory.path);
   }
 
   /**
@@ -220,12 +216,13 @@ class CodeCallerContainer {
    * @param {string} file
    * @param {string} fcn
    * @param {any[]} args
+   * @param {{ timeout?: number }} [options]
    * @returns {Promise<{ result: any, output: string }>}
    */
-  async call(type, directory, file, fcn, args) {
+  async call(type, directory, file, fcn, args, options = {}) {
     this.debug(`enter call(${type}, ${directory}, ${file}, ${fcn})`);
     this.callCount += 1;
-    await this.ensureChild();
+    await this._ensureChild();
     if (!this._checkState([WAITING])) {
       throw new Error('invalid CodeCallerContainer state');
     }
@@ -256,7 +253,7 @@ class CodeCallerContainer {
     // is and use that as the timeout for the Docker container to minimize the
     // likelihood of the container being killed when user code times out. This
     // should still ensure the container is killed when it's truly unresponsive.
-    const containerTimeout = this.options.questionTimeoutMilliseconds + 5000;
+    const containerTimeout = (options.timeout ?? this.options.questionTimeoutMilliseconds) + 5000;
     this.timeoutID = setTimeout(this._handleTimeout.bind(this), containerTimeout);
 
     this.lastCallData = callData;
@@ -319,6 +316,25 @@ class CodeCallerContainer {
     this.debug('enter ensureChild()');
     this._checkState();
 
+    await this._ensureChild();
+
+    // Give the child a reasonably long amount of time to start up. Under
+    // periods of high load, it should be cheaper to wait for a child to
+    // start slowly than it would be to time out too quickly and try to
+    // launch a new one to replace it.
+    await this.call('ping', null, null, 'ping', [], { timeout: 60 * 1000 });
+
+    this._checkState();
+    this.debug('exit ensureChild()');
+  }
+
+  /**
+   * Ensures that this code caller has a container.
+   */
+  async _ensureChild() {
+    this.debug('enter _ensureChild()');
+    this._checkState();
+
     // Since container creation is async, it's possible that ensureChild()
     // could be called again while it's already executing. For instance, we
     // could be inside a call that was made to warm up this worker, but then
@@ -335,7 +351,7 @@ class CodeCallerContainer {
       await this._createAndAttachContainer();
       this.state = WAITING;
       this._checkState();
-      this.debug('exit ensureChild()');
+      this.debug('exit _ensureChild()');
     });
   }
 

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -281,13 +281,13 @@ class CodeCallerNative {
 
     if (this.state === CREATED) {
       this._startChild();
-    }
 
-    // Give the child a reasonably long amount of time to start up. Under
-    // periods of high load, it should be cheaper to wait for a child to
-    // start slowly than it would be to time out too quickly and try to
-    // launch a new one to replace it.
-    await this.call('ping', null, null, 'ping', [], { timeout: 30 * 1000 });
+      // Give the child a reasonably long amount of time to start up. Under
+      // periods of high load, it should be cheaper to wait for a child to
+      // start slowly than it would be to time out too quickly and try to
+      // launch a new one to replace it.
+      await this.call('ping', null, null, 'ping', [], { timeout: 30 * 1000 });
+    }
 
     this._checkState();
     this.debug('exit ensureChild()');

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -70,7 +70,7 @@ const EXITED = Symbol('EXITED');
 */
 
 /** @typedef {import('./code-caller-shared').CodeCaller} CodeCaller */
-/** @typedef {import('./code-caller-shared').CallType | "ping"} CallType */
+/** @typedef {import('./code-caller-shared').CallType} CallType */
 
 /**
  * @implements {CodeCaller}
@@ -146,7 +146,7 @@ class CodeCallerNative {
    * @param {string} file
    * @param {string} fcn
    * @param {any[]} args
-   * @param {{ timeout?: number }} options
+   * @param {{ timeout?: number }} [options]
    * @returns {Promise<{ result: any, output: string }>}
    */
   async call(type, directory, file, fcn, args, options = {}) {
@@ -283,14 +283,11 @@ class CodeCallerNative {
       this._startChild();
     }
 
-    this.debug('pinging child');
-    const start = Date.now();
     // Give the child a reasonably long amount of time to start up. Under
     // periods of high load, it should be cheaper to wait for a child to
     // start slowly than it would be to time out too quickly and try to
     // launch a new one to replace it.
     await this.call('ping', null, null, 'ping', [], { timeout: 30 * 1000 });
-    this.debug(`child ready after ${Date.now() - start}ms`);
 
     this._checkState();
     this.debug('exit ensureChild()');

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -151,12 +151,8 @@ class CodeCallerNative {
    */
   async call(type, directory, file, fcn, args, options = {}) {
     this.debug('enter call()');
-    if (!this._checkState([CREATED, WAITING])) {
-      throw new Error('invalid CodeCallerNative state');
-    }
-
-    if (this.state === CREATED) {
-      this._startChild();
+    if (!this._checkState([WAITING])) {
+      throw new Error(`Invalid CodeCallerNative state: ${String(this.state)}`);
     }
 
     let cwd;
@@ -257,7 +253,7 @@ class CodeCallerNative {
       return false;
     } else {
       this.debug('exit restart()');
-      throw new Error(`invalid state ${String(this.state)}`);
+      throw new Error(`Invalid CodeCallerNative state: ${String(this.state)}`);
     }
   }
 

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -70,7 +70,7 @@ const EXITED = Symbol('EXITED');
 */
 
 /** @typedef {import('./code-caller-shared').CodeCaller} CodeCaller */
-/** @typedef {import('./code-caller-shared').CallType} CallType */
+/** @typedef {import('./code-caller-shared').CallType | "ping"} CallType */
 
 /**
  * @implements {CodeCaller}
@@ -146,9 +146,10 @@ class CodeCallerNative {
    * @param {string} file
    * @param {string} fcn
    * @param {any[]} args
+   * @param {{ timeout?: number }} options
    * @returns {Promise<{ result: any, output: string }>}
    */
-  call(type, directory, file, fcn, args) {
+  async call(type, directory, file, fcn, args, options = {}) {
     this.debug('enter call()');
     if (!this._checkState([CREATED, WAITING])) {
       throw new Error('invalid CodeCallerNative state');
@@ -168,7 +169,7 @@ class CodeCallerNative {
       paths.push(path.join(this.coursePath, 'serverFilesCourse'));
     } else if (type === 'core-element') {
       cwd = path.join(__dirname, '..', '..', 'elements', directory);
-    } else if (type === 'restart') {
+    } else if (type === 'restart' || type === 'ping') {
       // Doesn't need a working directory
     } else {
       throw new Error(`Unknown function call type: ${type}`);
@@ -185,7 +186,9 @@ class CodeCallerNative {
         deferred.resolve({ result: data, output });
       }
     };
-    this.timeoutID = setTimeout(this._timeout.bind(this), this.options.questionTimeoutMilliseconds);
+
+    const timeout = options?.timeout ?? this.options.questionTimeoutMilliseconds;
+    this.timeoutID = setTimeout(this._timeout.bind(this), timeout);
 
     // Reset output accumulators.
     this.outputStdout = '';
@@ -279,6 +282,15 @@ class CodeCallerNative {
     if (this.state === CREATED) {
       this._startChild();
     }
+
+    this.debug('pinging child');
+    const start = Date.now();
+    // Give the child a reasonably long amount of time to start up. Under
+    // periods of high load, it should be cheaper to wait for a child to
+    // start slowly than it would be to time out too quickly and try to
+    // launch a new one to replace it.
+    await this.call('ping', null, null, 'ping', [], { timeout: 30 * 1000 });
+    this.debug(`child ready after ${Date.now() - start}ms`);
 
     this._checkState();
     this.debug('exit ensureChild()');

--- a/lib/code-caller/code-caller-shared.js
+++ b/lib/code-caller/code-caller-shared.js
@@ -7,7 +7,7 @@ class FunctionMissingError extends Error {
 
 module.exports.FunctionMissingError = FunctionMissingError;
 
-/** @typedef {"question" | "course-element" | "core-element" | "restart"} CallType */
+/** @typedef {"question" | "course-element" | "core-element" | "ping" | "restart"} CallType */
 
 /**
  * @typedef {Object} CodeCaller

--- a/lib/code-caller/index.js
+++ b/lib/code-caller/index.js
@@ -75,15 +75,22 @@ module.exports = {
     );
 
     pool.on('factoryCreateError', (err) => {
+      logger.error('Error creating Python worker', err);
       Sentry.captureException(err);
     });
 
     pool.on('factoryDestroyError', (err) => {
+      logger.error('Error destroying Python worker', err);
       Sentry.captureException(err);
     });
 
     // Ensure that the workers are ready; this will ensure that we're ready to
     // execute code as soon as we start processing requests.
+    //
+    // Note: if resource creation fails for any reason, this will never resolve
+    // or reject. This is unfortunate, but we'll still log and report the error
+    // above, so it won't fail totally silently. If we fail to create workers,
+    // we have a bigger problem.
     await pool.ready();
   },
 

--- a/lib/code-caller/index.js
+++ b/lib/code-caller/index.js
@@ -166,7 +166,7 @@ module.exports = {
     } catch (err) {
       restartErr = err;
       debug('returnPythonCaller(): restart returned error: ${err}');
-      logger.error(`Error restarting pythonCaller: ${err}`);
+      logger.error('Error restarting pythonCaller', err);
       needsFullRestart = true;
     }
 

--- a/python/zygote.py
+++ b/python/zygote.py
@@ -79,12 +79,20 @@ def worker_loop():
             cwd = inp.get('cwd', None)
             paths = inp.get('paths', None)
 
+            # "ping" is a special fake function name that the parent process
+            # will use to check if the worker is active and able to respond to
+            # calls. We just reply with "pong" to indicate that we're alive.
+            if file == None and fcn == 'ping':
+                json.dump({"present": True, "val": "pong"}, outf)
+                outf.write("\n");
+                outf.flush()
+                continue
+
             # "restart" is a special fake function name that causes
             # the forked worker to exit, returning control to the
             # zygote parent process
             if file == None and fcn == 'restart':
-                json_outp = try_dumps({"present": True, "val": "success"}, allow_nan=False)
-                outf.write(json_outp)
+                json.dump({"present": True, "val": "success"}, outf)
                 outf.write("\n");
                 outf.flush()
 


### PR DESCRIPTION
We've observed intermittent timeouts under periods of high load. When a timeout occurs, we kill the child process and start a new one. However, because we preload a number of large Python libraries, starting a new worker can take a long time. Previously, our calling code wasn't aware of this. We believe this was capable of causing cascading failures where we'd send a call to a worker while it was still booting up, and that call would time out, leading to another restart, and so on.

This PR allows the host process to "ping" the child when it's booting up for the first time to ensure that it's ready to accept calls. This ping is modeled as a normal call; this means that when a worker is able to respond to a ping, it'll be able to respond to question/element calls too.

I originally started going down the path of having the worker reach out when it finished initializing, but getting that working with our current state machine turned out to be really complex. By modeling this check as a call into the worker, we reuse all the existing code, and it ends up being a very simple implementation!