### PR TITLE
Print sync warnings/errors after writing to database

### DIFF
--- a/sync/syncFromDisk.js
+++ b/sync/syncFromDisk.js
@@ -45,10 +45,6 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
   const courseData = await perf.timedAsync('loadCourseData', () =>
     courseDB.loadFullCourse(courseDir)
   );
-  // Write any errors and warnings to sync log
-  courseDB.writeErrorsAndWarningsForCourseData(courseId, courseData, (line) =>
-    logger.info(line || '')
-  );
   logger.info('Syncing info to database');
   await perf.timedAsync('syncCourseInfo', () => syncCourseInfo.sync(courseData, courseId));
   const courseInstanceIds = await perf.timedAsync('syncCourseInstances', () =>
@@ -93,6 +89,10 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
   } else {
     logger.info(chalk.green('✓ Course sync successful'));
   }
+  courseDB.writeErrorsAndWarningsForCourseData(courseId, courseData, (line) =>
+    logger.info(line || '')
+  );
+
   perf.end('sync');
   return {
     hadJsonErrors: courseDataHasErrors,

--- a/sync/syncFromDisk.js
+++ b/sync/syncFromDisk.js
@@ -89,6 +89,11 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
   } else {
     logger.info(chalk.green('✓ Course sync successful'));
   }
+
+  // Note that we deliberately log warnings/errors after syncing to the database
+  // since in some cases we actually discover new warnings/errors during the
+  // sync process. For instance, we don't actually validate exam UUIDs until
+  // the database sync step.
   courseDB.writeErrorsAndWarningsForCourseData(courseId, courseData, (line) =>
     logger.info(line || '')
   );


### PR DESCRIPTION
Fixes #6546. Note that if writing to the database itself fails, we won't print warnings and errors because an error will have been thrown. I think this is acceptable, as syncing is designed to be extremely resilient and shouldn't ever actually fail. If it does (like in #6540), we have a bigger problem.

Here's how the syncing output looks now:

<img width="658" alt="Screenshot 2022-11-02 at 16 25 11" src="https://user-images.githubusercontent.com/1476544/199621658-f013cf41-2a19-4f35-87e9-7cff36339c47.png">
