### PR TITLE
Replace showdown with remark in manual feedback rendering

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -79,7 +79,7 @@ const makeHandler = (visitor) => {
 const handleCode = makeHandler(visitCodeBlock);
 const handleMath = makeHandler(visitMathBlock);
 
-const regularProcessor = unified()
+const defaultProcessor = unified()
   .use(markdown)
   .use(math)
   .use(handleMath)
@@ -110,6 +110,6 @@ module.exports.processQuestion = function (html) {
   });
 };
 
-module.exports.processContent = function (original) {
-  return regularProcessor.processSync(original).contents;
+module.exports.processContent = async function (original) {
+  return (await defaultProcessor.process(original)).contents;
 };

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -79,7 +79,17 @@ const makeHandler = (visitor) => {
 const handleCode = makeHandler(visitCodeBlock);
 const handleMath = makeHandler(visitMathBlock);
 
-const processor = unified()
+const regularProcessor = unified()
+  .use(markdown)
+  .use(math)
+  .use(handleMath)
+  .use(gfm)
+  .use(remark2rehype, { allowDangerousHtml: true })
+  .use(raw)
+  .use(stringify);
+
+// The question processor also includes the use of pl-code instead of pre
+const questionProcessor = unified()
   .use(markdown)
   .use(math)
   .use(handleCode)
@@ -95,7 +105,11 @@ module.exports.processQuestion = function (html) {
     const decodedContents = originalContents.replace(escapeRegex, (match, prefix, hashes) => {
       return `${prefix}${'#'.repeat(hashes.length - 1)}>`;
     });
-    const res = processor.processSync(decodedContents);
+    const res = questionProcessor.processSync(decodedContents);
     return res.contents;
   });
+};
+
+module.exports.processContent = function (original) {
+  return regularProcessor.processSync(original).contents;
 };

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -5,6 +5,7 @@ const gfm = require('remark-gfm');
 const remark2rehype = require('remark-rehype');
 const math = require('remark-math');
 const stringify = require('rehype-stringify');
+const sanitize = require('rehype-sanitize');
 const visit = require('unist-util-visit');
 
 const regex = /<markdown>(.+?)<\/markdown>/gms;
@@ -86,9 +87,11 @@ const defaultProcessor = unified()
   .use(gfm)
   .use(remark2rehype, { allowDangerousHtml: true })
   .use(raw)
+  .use(sanitize)
   .use(stringify);
 
-// The question processor also includes the use of pl-code instead of pre
+// The question processor also includes the use of pl-code instead of pre,
+// and does not sanitize scripts
 const questionProcessor = unified()
   .use(markdown)
   .use(math)

--- a/lib/question.js
+++ b/lib/question.js
@@ -10,7 +10,6 @@ const moment = require('moment');
 const util = require('util');
 const fs = require('fs');
 const unzipper = require('unzipper');
-const xss = require('xss');
 
 const markdown = require('./markdown');
 const config = require('./config');
@@ -1653,10 +1652,11 @@ module.exports = {
               ...s,
             }));
             await async.each(locals.submissions, async (s) => {
-              if (s.feedback?.manual)
-                s.feedback_manual_html = xss(
-                  await markdown.processContent(s.feedback.manual.toString() || '')
+              if (s.feedback?.manual) {
+                s.feedback_manual_html = await markdown.processContent(
+                  s.feedback.manual.toString() || ''
                 );
+              }
             });
             locals.submission = locals.submissions[0]; // most recent submission
 

--- a/lib/question.js
+++ b/lib/question.js
@@ -10,8 +10,9 @@ const moment = require('moment');
 const util = require('util');
 const fs = require('fs');
 const unzipper = require('unzipper');
-const showdown = require('showdown');
+const xss = require('xss');
 
+const markdown = require('./markdown');
 const config = require('./config');
 const csrf = require('./csrf');
 const externalGrader = require('./externalGrader');
@@ -1647,15 +1648,12 @@ module.exports = {
           sqldb.query(sql.select_submissions, params, (err, result) => {
             if (ERR(err, callback)) return;
             if (result.rowCount >= 1) {
-              const renderer = new showdown.Converter({
-                literalMidWordUnderscores: true,
-                literalMidWordAsterisks: true,
-              });
-
               locals.submissions = result.rows.map((s, idx) => ({
                 grading_job_stats: module.exports._buildGradingJobStats(s.grading_job),
                 submission_number: result.rowCount - idx,
-                feedback_manual_html: renderer.makeHtml(s.feedback?.manual?.toString() || ''),
+                feedback_manual_html: xss(
+                  markdown.processContent(s.feedback?.manual?.toString() || '')
+                ),
                 ...s,
               }));
               locals.submission = locals.submissions[0]; // most recent submission

--- a/lib/question.js
+++ b/lib/question.js
@@ -1640,33 +1640,33 @@ module.exports = {
             locals.showTrueAnswer = true;
           }
         },
-        (callback) => {
+        async () => {
           var params = {
             variant_id: locals.variant.id,
             req_date: locals.req_date,
           };
-          sqldb.query(sql.select_submissions, params, (err, result) => {
-            if (ERR(err, callback)) return;
-            if (result.rowCount >= 1) {
-              locals.submissions = result.rows.map((s, idx) => ({
-                grading_job_stats: module.exports._buildGradingJobStats(s.grading_job),
-                submission_number: result.rowCount - idx,
-                feedback_manual_html: xss(
-                  markdown.processContent(s.feedback?.manual?.toString() || '')
-                ),
-                ...s,
-              }));
-              locals.submission = locals.submissions[0]; // most recent submission
+          const result = await sqldb.queryAsync(sql.select_submissions, params);
+          if (result.rowCount >= 1) {
+            locals.submissions = result.rows.map((s, idx) => ({
+              grading_job_stats: module.exports._buildGradingJobStats(s.grading_job),
+              submission_number: result.rowCount - idx,
+              ...s,
+            }));
+            await async.each(locals.submissions, async (s) => {
+              if (s.feedback?.manual)
+                s.feedback_manual_html = xss(
+                  await markdown.processContent(s.feedback.manual.toString() || '')
+                );
+            });
+            locals.submission = locals.submissions[0]; // most recent submission
 
-              locals.showSubmissions = true;
-              if (!locals.assessment && locals.question.show_correct_answer) {
-                // instructor question pages, only show if true answer is
-                // allowed by this question
-                locals.showTrueAnswer = true;
-              }
+            locals.showSubmissions = true;
+            if (!locals.assessment && locals.question.show_correct_answer) {
+              // instructor question pages, only show if true answer is
+              // allowed by this question
+              locals.showTrueAnswer = true;
             }
-            callback(null);
-          });
+          }
         },
         (callback) => {
           questionServers.getEffectiveQuestionType(locals.question.type, (err, eqt) => {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
         "redis": "^3.1.2",
         "redis-lru": "^0.6.0",
         "rehype-raw": "^5.1.0",
+        "rehype-sanitize": "4.0.0",
         "rehype-stringify": "^8.0.0",
         "remark-gfm": "^1.0.0",
         "remark-math": "^4.0.0",

--- a/tests/markdown.test.js
+++ b/tests/markdown.test.js
@@ -1,99 +1,149 @@
 const markdown = require('../lib/markdown');
 const assert = require('chai').assert;
 
-const testMarkdown = (question, expected) => {
+const testMarkdownQuestion = (question, expected) => {
   const actual = markdown.processQuestion(question);
   assert.equal(actual, expected);
 };
 
+const testMarkdown = async (original, expected, testQuestion) => {
+  const actual = await markdown.processContent(original);
+  assert.equal(actual, expected);
+  if (testQuestion) {
+    testMarkdownQuestion(`<markdown>${original}</markdown>`, expected);
+  }
+};
+
 describe('Markdown processing', () => {
-  it('renders basic markdown correctly', () => {
-    const question = '<markdown>\n# Hello, world!\nThis **works**.\n</markdown>';
+  it('renders basic markdown correctly', async () => {
+    const question = '\n# Hello, world!\nThis **works**.\n';
     const expected = '<h1>Hello, world!</h1>\n<p>This <strong>works</strong>.</p>';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles multiple <markdown> tags', () => {
+  it('handles multiple <markdown> tags', async () => {
     const question = '<markdown>`nice`</markdown><markdown>`also nice`</markdown>';
     const expected = '<p><code>nice</code></p><p><code>also nice</code></p>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks', () => {
+  it('handles code blocks', async () => {
     const question = '<markdown>\n```\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code no-highlight="true">int a = 12;</pl-code>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks with language', () => {
+  it('handles code blocks with language', async () => {
     const question = '<markdown>\n```cpp\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code language="cpp">int a = 12;</pl-code>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks with highlighted lines', () => {
+  it('handles code blocks with highlighted lines', async () => {
     const question = '<markdown>\n```{1,2-3}\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code no-highlight="true" highlight-lines="1,2-3">int a = 12;</pl-code>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks with language and highlighted lines', () => {
+  it('handles code blocks with language and highlighted lines', async () => {
     const question = '<markdown>\n```cpp{1,2-3}\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code language="cpp" highlight-lines="1,2-3">int a = 12;</pl-code>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles escaped <markdown> tags', () => {
+  it('handles escaped <markdown> tags', async () => {
     const question = '<markdown>```html\n<markdown#></markdown#>\n```</markdown>';
     const expected = '<pl-code language="html">&#x3C;markdown>&#x3C;/markdown></pl-code>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles weird escaped <markdown> tags', () => {
+  it('handles weird escaped <markdown> tags', async () => {
     const question = '<markdown>```html\n<markdown###></markdown###>\n```</markdown>';
     const expected = '<pl-code language="html">&#x3C;markdown##>&#x3C;/markdown##></pl-code>';
-    testMarkdown(question, expected);
+    testMarkdownQuestion(question, expected);
   });
 
-  it('handles inline latex with underscores', () => {
-    const question = '<markdown>$a _{1_ 2}$</markdown>';
+  it('handles inline latex with underscores', async () => {
+    const question = '$a _{1_ 2}$';
     const expected = '<p>$a _{1_ 2}$</p>';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles inline latex', () => {
-    const question = '<markdown>$a_1 + a_2 = a_3$</markdown>';
+  it('handles inline latex', async () => {
+    const question = '$a_1 + a_2 = a_3$';
     const expected = '<p>$a_1 + a_2 = a_3$</p>';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles multiple lines of inline latex', () => {
-    const question = '<markdown>$a_{ 1 } = 3$ and\n$a_{ 2 } = 4$</markdown>';
+  it('handles multiple lines of inline latex', async () => {
+    const question = '$a_{ 1 } = 3$ and\n$a_{ 2 } = 4$';
     const expected = '<p>$a_{ 1 } = 3$ and\n$a_{ 2 } = 4$</p>';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles block latex', () => {
-    const question = '<markdown>\n$$\na^2 + b^2 = c^2\n$$</markdown>';
+  it('handles block latex', async () => {
+    const question = '\n$$\na^2 + b^2 = c^2\n$$';
     const expected = '$$\na^2 + b^2 = c^2\n$$';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles block latex with asterisks', () => {
-    const question = '<markdown>$$\na **b** c\n$$</markdown>';
+  it('handles block latex with asterisks', async () => {
+    const question = '$$\na **b** c\n$$';
     const expected = '$$\na **b** c\n$$';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles two consecutive latex blocks', () => {
-    const question = '<markdown>$$\na **b** c\n$$\n$$\na+b=c\n$$</markdown>';
+  it('handles two consecutive latex blocks', async () => {
+    const question = '$$\na **b** c\n$$\n$$\na+b=c\n$$';
     const expected = '$$\na **b** c\n$$\n$$\na+b=c\n$$';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
   });
 
-  it('handles block latex with asterisks and surrouding text', () => {
-    const question = '<markdown>testing\n$$\na **b** c\n$$\ntesting</markdown>';
+  it('handles block latex with asterisks and surrouding text', async () => {
+    const question = 'testing\n$$\na **b** c\n$$\ntesting';
     const expected = '<p>testing</p>\n$$\na **b** c\n$$\n<p>testing</p>';
-    testMarkdown(question, expected);
+    await testMarkdown(question, expected, true);
+  });
+
+  it('handles HTML tags', async () => {
+    const question = 'testing with <strong>bold</strong> and <em>italics</em> words';
+    const expected = '<p>testing with <strong>bold</strong> and <em>italics</em> words</p>';
+    await testMarkdown(question, expected, true);
+  });
+
+  it('handles HTML tags that do not close properly', async () => {
+    const question = 'testing with <strong>bold</strong> and <em>italics words';
+    const expected = '<p>testing with <strong>bold</strong> and <em>italics words</em></p>';
+    await testMarkdown(question, expected, true);
+  });
+
+  it('handles HTML paragraphs that do not close properly', async () => {
+    const question = 'first paragraph<p>second paragraph<p>third paragraph';
+    const expected = '<p>first paragraph</p><p>second paragraph</p><p>third paragraph</p>';
+    await testMarkdown(question, expected, true);
+  });
+
+  it('handles HTML closing tags that do not open properly', async () => {
+    const question = 'testing with </div><p>new line';
+    const expected = '<p>testing with </p><p>new line</p>';
+    await testMarkdown(question, expected, true);
+  });
+
+  it('sanitizes HTML script tags (default processor only)', async () => {
+    const question = 'testing<script>alert("XSS")</script>';
+    const expected = '<p>testing</p>';
+    await testMarkdown(question, expected, false);
+  });
+
+  it('sanitizes HTML javascript event tags (default processor only)', async () => {
+    const question = 'testing<img src="x" onerror="alert(\'XSS\')">';
+    const expected = '<p>testing<img src="x"></p>';
+    await testMarkdown(question, expected, false);
+  });
+
+  it('sanitizes HTML javascript iframes (default processor only)', async () => {
+    const question = 'testing<iframe src="javascript:alert(\'delta\')"></iframe>';
+    const expected = '<p>testing</p>';
+    await testMarkdown(question, expected, false);
   });
 });

--- a/tests/markdown.test.js
+++ b/tests/markdown.test.js
@@ -3,20 +3,20 @@ const assert = require('chai').assert;
 
 const testMarkdownQuestion = (question, expected) => {
   const actual = markdown.processQuestion(question);
-  assert.equal(actual, expected);
+  assert.equal(actual?.trim(), expected);
 };
 
 const testMarkdown = async (original, expected, testQuestion) => {
   const actual = await markdown.processContent(original);
-  assert.equal(actual, expected);
+  assert.equal(actual?.trim(), expected);
   if (testQuestion) {
-    testMarkdownQuestion(`<markdown>${original}</markdown>`, expected);
+    testMarkdownQuestion(`<markdown>\n${original}\n</markdown>`, expected);
   }
 };
 
 describe('Markdown processing', () => {
   it('renders basic markdown correctly', async () => {
-    const question = '\n# Hello, world!\nThis **works**.\n';
+    const question = '# Hello, world!\nThis **works**.';
     const expected = '<h1>Hello, world!</h1>\n<p>This <strong>works</strong>.</p>';
     await testMarkdown(question, expected, true);
   });
@@ -82,7 +82,7 @@ describe('Markdown processing', () => {
   });
 
   it('handles block latex', async () => {
-    const question = '\n$$\na^2 + b^2 = c^2\n$$';
+    const question = '$$\na^2 + b^2 = c^2\n$$';
     const expected = '$$\na^2 + b^2 = c^2\n$$';
     await testMarkdown(question, expected, true);
   });
@@ -102,6 +102,13 @@ describe('Markdown processing', () => {
   it('handles block latex with asterisks and surrouding text', async () => {
     const question = 'testing\n$$\na **b** c\n$$\ntesting';
     const expected = '<p>testing</p>\n$$\na **b** c\n$$\n<p>testing</p>';
+    await testMarkdown(question, expected, true);
+  });
+
+  it('handles GFM extension for tables', async () => {
+    const question = '| foo | bar |\n| --- | --- |\n| baz | bim |';
+    const expected =
+      '<table><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>baz</td><td>bim</td></tr></tbody></table>';
     await testMarkdown(question, expected, true);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5706,6 +5706,13 @@ hast-util-raw@^6.1.0:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
+hast-util-sanitize@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-3.0.2.tgz#b0b783220af528ba8fe6999f092d138908678520"
+  integrity sha512-+2I0x2ZCAyiZOO/sb4yNLFmdwPBnyJ4PBkVTUMKMqBwYNA+lXSgOmoRXlJFazoyid9QPogRRKgKhVEodv181sA==
+  dependencies:
+    xtend "^4.0.0"
+
 hast-util-to-html@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-7.1.2.tgz#db677f0ee483658cea0eecc9dec30aba42b67111"
@@ -9080,6 +9087,13 @@ rehype-raw@^5.1.0:
   integrity sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==
   dependencies:
     hast-util-raw "^6.1.0"
+
+rehype-sanitize@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-sanitize/-/rehype-sanitize-4.0.0.tgz#b5241cf66bcedc49cd4e924a5f7a252f00a151ad"
+  integrity sha512-ZCr/iQRr4JeqPjun5i9CHHILVY7i45VnLu1CkkibDrSyFQ7dTLSvw8OIQpHhS4RSh9h/9GidxFw1bRb0LOxIag==
+  dependencies:
+    hast-util-sanitize "^3.0.0"
 
 rehype-stringify@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
Fixes #6600. Remark (via remark-raw) is better suited to handle badly formatted html.