### PR TITLE
Allow none-of-the-above to always be incorrect in multiple choice element

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -115,21 +115,31 @@ incorrect answers and displays them in a random order as radio buttons.
 
 #### Customizations
 
-| Attribute                     | Type    | Default | Description                                                                                                                                                      |
-| ----------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `answers-name`                | string  | —       | Variable name to store data in.                                                                                                                                  |
-| `weight`                      | integer | 1       | Weight to use when computing a weighted average score over elements.                                                                                             |
-| `inline`                      | boolean | false   | List answer choices on a single line instead of as separate paragraphs.                                                                                          |
-| `number-answers`              | integer | special | The total number of answer choices to display. Defaults to displaying one correct answer and all incorrect answers.                                              |
-| `fixed-order`                 | boolean | false   | Disable the randomization of answer order.                                                                                                                       |
-| `hide-letter-keys`            | boolean | false   | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.                                                                                               |
-| `all-of-the-above`            | boolean | false   | Add "All of the above" choice below all answer choices, but above "None of the above" if enabled. Bounded by `number-answers` and not affected by `fixed-order`. |
-| `none-of-the-above`           | boolean | false   | Add "None of the above" choice below all answer choices regardless of `fixed-order`, and is bounded by `number-answers`.                                         |
-| `all-of-the-above-feedback`   | string  | —       | Helper text to be displayed to the student next to the `all-of-the-above` option after question is graded if this option has been selected by the student.       |
-| `none-of-the-above-feedback`  | string  | —       | Helper text to be displayed to the student next to the `none-of-the-above` option after question is graded if this option has been selected by the student.      |
-| `external-json`               | string  | special | Optional path to a JSON file to load external answer choices from. Answer choices are stored as lists under "correct" and "incorrect" key names.                 |
-| `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                       |
-| `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                     |
+| Attribute                     | Type    | Default | Description                                                                                                                                                 |
+| ----------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `answers-name`                | string  | —       | Variable name to store data in.                                                                                                                             |
+| `weight`                      | integer | 1       | Weight to use when computing a weighted average score over elements.                                                                                        |
+| `inline`                      | boolean | false   | List answer choices on a single line instead of as separate paragraphs.                                                                                     |
+| `number-answers`              | integer | special | The total number of answer choices to display. Defaults to displaying one correct answer and all incorrect answers.                                         |
+| `fixed-order`                 | boolean | false   | Disable the randomization of answer order.                                                                                                                  |
+| `hide-letter-keys`            | boolean | false   | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.                                                                                          |
+| `all-of-the-above`            | string  | `false` | Add "All of the above" choice. See below for details.                                                                                                       |
+| `none-of-the-above`           | string  | `false` | Add "None of the above" choice. See below for details.                                                                                                      |
+| `all-of-the-above-feedback`   | string  | —       | Helper text to be displayed to the student next to the `all-of-the-above` option after question is graded if this option has been selected by the student.  |
+| `none-of-the-above-feedback`  | string  | —       | Helper text to be displayed to the student next to the `none-of-the-above` option after question is graded if this option has been selected by the student. |
+| `external-json`               | string  | special | Optional path to a JSON file to load external answer choices from. Answer choices are stored as lists under "correct" and "incorrect" key names.            |
+| `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                  |
+| `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                |
+
+The attributes `none-of-the-above` and `all-of-the-above` can be set to one of these values:
+
+- `false`: the corresponding choice will not be shown in the list of choices. This is the default.
+- `random`: the corresponding choice will always be shown, and will be randomly correct, with probability proportional to the total number of correct choices. In other words, if there are `N` possible correct choices in total, this choice will be correct with probability `1/N`.
+- `correct`: the corresponding choice will always be shown and will always be the correct answer.
+- `incorrect`: the corresponding choice will always be shown and will always be an incorrect answer (i.e., a distractor).
+- `true`: same as `random`, accepted for backwards compatibility.
+
+Note that "All of the above" and "None of the above", if set, are bounded by the `number-answers` value above. Also, these two values are always shown as the last choices, regardless of the setting for `fixed-order`. If both choices are shown, then "All of the above" will be listed before "None of the above".
 
 Inside the `pl-multiple-choice` element, each choice must be specified with
 a `pl-answer` that has attributes:

--- a/exampleCourse/questions/element/multipleChoice/question.html
+++ b/exampleCourse/questions/element/multipleChoice/question.html
@@ -125,14 +125,21 @@
     <div class="card-body">
 
         <pl-question-panel>
-            <p>Here, the <code>pl-multiple-choice</code> element displays "All of the above" and "None of the above" as options below the correct and incorrect options provided.
-                Both of these options could be correct with the same probability as all of the individual correct options. The number of options displayed is also consistent across
-                all variants, and is determined automatically if <code>number-answers</code> is not set.</p>
+            <p>Here, the <code>pl-multiple-choice</code> element
+              displays "All of the above" and "None of the above" as
+              options below the correct and incorrect options
+              provided.  By setting these options
+              to <code>"random"</code>, they options could be correct
+              with the same probability as all of the individual
+              correct options. The number of options displayed is also
+              consistent across all variants, and is determined
+              automatically if <code>number-answers</code> is not
+              set.</p>
 
             <p> What is the color of the sky? </p>
         </pl-question-panel>
 
-        <pl-multiple-choice answers-name="sky-color5" none-of-the-above="true" all-of-the-above="true">
+        <pl-multiple-choice answers-name="sky-color5" none-of-the-above="random" all-of-the-above="random">
           <pl-answer correct="true">Blue</pl-answer>
           <pl-answer correct="true">Dark Blue</pl-answer>
           <pl-answer correct="true">Light Blue</pl-answer>
@@ -156,15 +163,22 @@
     <div class="card-body">
 
         <pl-question-panel>
-            <p>Here, the <code>pl-multiple-choice</code> element does not contain any <code>pl-answer</code> inner tag; instead, it pulls the correct and incorrect choices, if they exist,
-                from <code>sky-color.json</code> file inside <code>serverFilesQuestion/</code> directory. By default, the external json file should have <code>"correct"</code>
-                and <code>"incorrect"</code> attributes of type list to store choices, these attribute names can be overridden with <code>"external-json-correct-key"</code>
-                and <code>"external-json-incorrect-key"</code>.</p>
+          <p>The options for "All of the above" and "None of the above" can also be set to always be incorrect (i.e., a distractor).</p>
 
             <p> What is the color of the sky? </p>
         </pl-question-panel>
 
-        <pl-multiple-choice answers-name="sky-color6" external-json="serverFilesQuestion/sky-color.json" external-json-incorrect-key="incorrect_choices">
+        <pl-multiple-choice answers-name="sky-color6" none-of-the-above="incorrect" all-of-the-above="incorrect">
+          <pl-answer correct="true">Blue</pl-answer>
+          <pl-answer correct="true">Dark Blue</pl-answer>
+          <pl-answer correct="true">Light Blue</pl-answer>
+          <pl-answer correct="true">Clear Blue</pl-answer>
+          <pl-answer>Pink</pl-answer>
+          <pl-answer>Purple</pl-answer>
+          <pl-answer>Orange</pl-answer>
+          <pl-answer>Yellow</pl-answer>
+          <pl-answer>Brown</pl-answer>
+          <pl-answer>Red</pl-answer>
         </pl-multiple-choice>
 
     </div>
@@ -178,13 +192,35 @@
     <div class="card-body">
 
         <pl-question-panel>
+            <p>Here, the <code>pl-multiple-choice</code> element does not contain any <code>pl-answer</code> inner tag; instead, it pulls the correct and incorrect choices, if they exist,
+                from <code>sky-color.json</code> file inside <code>serverFilesQuestion/</code> directory. By default, the external json file should have <code>"correct"</code>
+                and <code>"incorrect"</code> attributes of type list to store choices, these attribute names can be overridden with <code>"external-json-correct-key"</code>
+                and <code>"external-json-incorrect-key"</code>.</p>
+
+            <p> What is the color of the sky? </p>
+        </pl-question-panel>
+
+        <pl-multiple-choice answers-name="sky-color7" external-json="serverFilesQuestion/sky-color.json" external-json-incorrect-key="incorrect_choices">
+        </pl-multiple-choice>
+
+    </div>
+</div>
+
+<div class="card my-2">
+    <div class="card-header">
+        Part 8
+    </div>
+
+    <div class="card-body">
+
+        <pl-question-panel>
             <p>Here, you can observe the behavior of the <code>feedback</code> attribute in <code>pl-answer</code>. Feedback is expected to convey a small piece of information that explains why an
                 answer is correct or incorrect. When an answer with a feedback setting is selected and graded, a small box containing the feedback is displayed next to the answer.</p>
 
             <p> What is the color of the sky? </p>
         </pl-question-panel>
 
-        <pl-multiple-choice answers-name="sky-color7">
+        <pl-multiple-choice answers-name="sky-color8">
             <pl-answer correct="true" feedback="Correct! The sky is indeed blue.">Blue</pl-answer>
             <pl-answer feedback="Incorrect. The sky is not pink.">Pink</pl-answer>
             <pl-answer feedback="Incorrect. The sky is not purple.">Purple</pl-answer>
@@ -199,7 +235,7 @@
 
 <div class="card my-2">
     <div class="card-header">
-        Part 8
+        Part 9
     </div>
 
     <div class="card-body">
@@ -212,7 +248,7 @@
             <p> What is the color of the sky? </p>
         </pl-question-panel>
 
-        <pl-multiple-choice answers-name="sky-color8">
+        <pl-multiple-choice answers-name="sky-color9">
             <pl-answer correct="true" feedback="Correct! The sky is indeed blue.">Blue</pl-answer>
             <pl-answer>Pink</pl-answer>
             <pl-answer score=0.5>Purple</pl-answer>


### PR DESCRIPTION
Resolves #3380. This is implemented by replacing how `none-of-the-above` (and `all-of-the-above`) are read as attributes, from boolean to string. Each can receive four values: `false` (the current default), `random` (the current behaviour for true), `correct` (always correct) and `incorrect` (always incorrect). True-like values still default to `random` for backwards-compatibility.

Note that the `none-of-the-above="correct"` behaviour could still be achieved before by having it set to `true` and no correct answers, which would cause the randomization of this option to always be true, however the option was added for completeness. The same is true for `all-of-the-above="correct"` and no incorrect answers.