### PR TITLE
fix: Initialization of socket server in workspace host

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -217,6 +217,12 @@ async.series(
         callback(null);
       });
     },
+    (callback) => {
+      server = http.createServer(app);
+      server.listen(workspace_server_settings.port);
+      logger.info(`Workspace server listening on port ${workspace_server_settings.port}`);
+      callback(null);
+    },
     async () => {
       socketServer.init(server);
     },
@@ -225,12 +231,6 @@ async.series(
         if (ERR(err, callback)) return;
         callback(null);
       });
-    },
-    (callback) => {
-      server = http.createServer(app);
-      server.listen(workspace_server_settings.port);
-      logger.verbose(`Workspace server listening on port ${workspace_server_settings.port}`);
-      callback(null);
     },
     async () => {
       // Set up file watching with chokidar

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -218,10 +218,8 @@ async.series(
       });
     },
     (callback) => {
-      socketServer.init(server, function (err) {
-        if (ERR(err, callback)) return;
-        callback(null);
-      });
+      socketServer.init(server);
+      callback(null);
     },
     (callback) => {
       util.callbackify(workspaceHelper.init)((err) => {

--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -217,9 +217,8 @@ async.series(
         callback(null);
       });
     },
-    (callback) => {
+    async () => {
       socketServer.init(server);
-      callback(null);
     },
     (callback) => {
       util.callbackify(workspaceHelper.init)((err) => {


### PR DESCRIPTION
#6381 changed the interface to initialize a socket server, but a reference to this interface was not updated in the workspace host call. This caused the workspace host not to be initialized properly, as a callback function that was expected to run was indeed not running anymore.