### PR TITLE
Fix CodeCallerContainer state machine during child creation

### DIFF
--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -330,13 +330,16 @@ class CodeCallerContainer {
       await ensureImage();
       await this._createAndAttachContainer();
 
+      // Transition to the WAITING state before pinging the container, as we
+      // need to be in that state in order to make a call.
+      this.state = WAITING;
+
       // Give the child a reasonably long amount of time to start up. Under
       // periods of high load, it should be cheaper to wait for a child to
       // start slowly than it would be to time out too quickly and try to
       // launch a new one to replace it.
       await this.call('ping', null, null, 'ping', [], { timeout: 60 * 1000 });
 
-      this.state = WAITING;
       this._checkState();
       this.debug('exit _ensureChild()');
     });


### PR DESCRIPTION
Closes #6614. This makes the `CodeCallerContainer` state machine match that of `CodeCallerNative`, where we transition to `WAITING` as soon as we have a child, before we've actually health-checked it.