### PR TITLE
Fix termination sequence

### DIFF
--- a/lib/socket-server.js
+++ b/lib/socket-server.js
@@ -33,7 +33,9 @@ module.exports.close = async function () {
 
   // Note that we don't use `io.close()` here, as that actually tries to close
   // the underlying HTTP server. In our desired shutdown sequence, we first
-  // close the HTTP server and then later disconnect all sockets.
+  // close the HTTP server and then later disconnect all sockets. There's some
+  // discussion about this behavior here:
+  // https://github.com/socketio/socket.io/discussions/4002#discussioncomment-4080748
   //
   // Note the use of `io.local`, which prevents the server from attempting to
   // broadcast the disconnect to other servers via Redis.

--- a/server.js
+++ b/server.js
@@ -24,7 +24,6 @@ const multer = require('multer');
 const filesize = require('filesize');
 const url = require('url');
 const { createProxyMiddleware } = require('http-proxy-middleware');
-const util = require('util');
 const Sentry = require('@prairielearn/sentry');
 
 const logger = require('./lib/logger');

--- a/server.js
+++ b/server.js
@@ -2058,8 +2058,8 @@ if (config.startServer) {
             // shut down, even if some of them fail.
             await Promise.allSettled([
               externalGraderResults.stop(),
-              serverJobs.stop(),
               cron.stop(),
+              serverJobs.stop(),
             ]);
           } catch (err) {
             logger.error('Error while terminating', err);

--- a/server.js
+++ b/server.js
@@ -2047,6 +2047,10 @@ if (config.startServer) {
         const prepareForTermination = async () => {
           logger.info('Preparing for termination...');
 
+          // By this point, we should no longer be attached to the load balancer,
+          // so there's no point shutting down the HTTP server or the socket.io
+          // server.
+          //
           // We want to proceed with termination even if something goes wrong,
           // so don't allow this function to throw.
           try {

--- a/server.js
+++ b/server.js
@@ -2046,25 +2046,19 @@ if (config.startServer) {
 
         const prepareForTermination = async () => {
           logger.info('Preparing for termination...');
+
           // We want to proceed with termination even if something goes wrong,
           // so don't allow this function to throw.
           try {
-            // By this point, we should have already been detached from the
-            // load balancer, so the following should be no-ops. However, we
-            // still do to ensure that we don't get any more traffic as we're
-            // shutting everything down.
-            await util.promisify(server.close).call(server);
-            await socketServer.close();
-
             // We use `allSettled()` here to ensure that all tasks can gracefully
             // shut down, even if some of them fail.
             await Promise.allSettled([
               externalGraderResults.stop(),
-              cron.stop(),
               serverJobs.stop(),
+              cron.stop(),
             ]);
           } catch (err) {
-            logger.error('Error while shutting down server', err);
+            logger.error('Error while terminating', err);
             Sentry.captureException(err);
           }
         };


### PR DESCRIPTION
Closes #6619. There should never be a need for us to "gracefully" shut down the HTTP or socket.io servers. If they still have connections when we start terminating, something else has gone wrong and we can allow those connections to die unceremoniously.