### PR TITLE
Don't treat external grader results JSON as binary-encoded

### DIFF
--- a/grader_host/index.js
+++ b/grader_host/index.js
@@ -622,7 +622,7 @@ function uploadResults(info, callback) {
         const params = {
           Bucket: s3Bucket,
           Key: `${s3RootKey}/results.json`,
-          Body: Buffer.from(JSON.stringify(results, null, '  '), 'binary'),
+          Body: Buffer.from(JSON.stringify(results, null, 2)),
         };
         s3.putObject(params, (err) => {
           if (ERR(err, callback)) return;


### PR DESCRIPTION
Closes #6605.

This explains why I'm unable to reproduce the error in #6605, and why the issue was fixed for the author when they reduced the amount of output: the data is now small enough to fix in the SQS results message, so we now never try to read this file in PL. When the results file was originally larger, it *didn't* fit in the SQS results, so we had to read it from S3. We don't use this code locally, which explains why it can't be reproduced locally either. This *also* explains why this particular error went away

The `'binary'` has been present for as long as the external grader host code has existed. I don't know why I used that in the first place, but I can't see any reason why we should use it - everything should be UTF8.