### PR TITLE
Add recommended extensions for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,11 @@ docker-compose.override.yml
 ### JetBrains
 /.idea/
 
-.vscode
+### VSCode
+.vscode/*
+!.vscode/extensions.json
+
+### tmux
 .tmux.conf
 
 ## Backup files

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "Tobermory.es6-string-html",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}


### PR DESCRIPTION
This should improve the experience for folks who are new to PrairieLearn. It'll also be valuable for existing folks: as we shift from EJS to `@prairielearn/html`, the `Tobermory.es6-string-html` extension will be especially helpful.