### PR TITLE
Add manual grader columns for assessment downloads

### DIFF
--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -205,8 +205,8 @@ router.get('/:filename', function (req, res, next) {
         ['Last submission score', 'last_submission_score'],
         ['Number attempts', 'number_attempts'],
         ['Duration seconds', 'duration_seconds'],
-        ['Assigned manual grader', 'assigned_grader_name'],
-        ['Last manual grader', 'last_grader_name'],
+        ['Assigned manual grader', 'assigned_grader'],
+        ['Last manual grader', 'last_grader'],
       ]);
       csvMaker.rowsToCsv(result.rows, columns, function (err, csv) {
         if (ERR(err, next)) return;
@@ -286,8 +286,8 @@ router.get('/:filename', function (req, res, next) {
         ['Mode', 'mode'],
         ['Grading requested date', 'grading_requested_at_formatted'],
         ['Grading date', 'graded_at_formatted'],
-        ['Assigned manual grader', 'assigned_grader_name'],
-        ['Last manual grader', 'last_grader_name'],
+        ['Assigned manual grader', 'assigned_grader'],
+        ['Last manual grader', 'last_grader'],
         ['Score', 'score'],
         ['Correct', 'correct'],
         ['Feedback', 'feedback'],

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -205,6 +205,8 @@ router.get('/:filename', function (req, res, next) {
         ['Last submission score', 'last_submission_score'],
         ['Number attempts', 'number_attempts'],
         ['Duration seconds', 'duration_seconds'],
+        ['Assigned manual grader', 'assigned_grader_name'],
+        ['Last manual grader', 'last_grader_name'],
       ]);
       csvMaker.rowsToCsv(result.rows, columns, function (err, csv) {
         if (ERR(err, next)) return;
@@ -284,6 +286,8 @@ router.get('/:filename', function (req, res, next) {
         ['Mode', 'mode'],
         ['Grading requested date', 'grading_requested_at_formatted'],
         ['Grading date', 'graded_at_formatted'],
+        ['Assigned manual grader', 'assigned_grader_name'],
+        ['Last manual grader', 'last_grader_name'],
         ['Score', 'score'],
         ['Correct', 'correct'],
         ['Feedback', 'feedback'],

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -66,8 +66,8 @@ SELECT
     DATE_PART('epoch', iq.duration) AS duration_seconds,
     g.name AS group_name,
     groups_uid_list(g.id) AS uid_list,
-    COALESCE(agu.name, agu.uid) AS assigned_grader_name,
-    COALESCE(lgu.name, lgu.uid) AS last_grader_name
+    agu.uid AS assigned_grader,
+    lgu.uid AS last_grader
 FROM
     instance_questions AS iq
     JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
@@ -173,8 +173,8 @@ WITH all_submissions AS (
         g.name AS group_name,
         groups_uid_list(g.id) AS uid_list,
         su.uid AS submission_user,
-        COALESCE(agu.name, agu.uid) AS assigned_grader_name,
-        COALESCE(lgu.name, lgu.uid) AS last_grader_name
+        agu.uid AS assigned_grader,
+        lgu.uid AS last_grader
     FROM
         assessments AS a
         JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -65,7 +65,9 @@ SELECT
     iq.number_attempts,
     DATE_PART('epoch', iq.duration) AS duration_seconds,
     g.name AS group_name,
-    groups_uid_list(g.id) AS uid_list
+    groups_uid_list(g.id) AS uid_list,
+    COALESCE(agu.name, agu.uid) AS assigned_grader_name,
+    COALESCE(lgu.name, lgu.uid) AS last_grader_name
 FROM
     instance_questions AS iq
     JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
@@ -77,6 +79,8 @@ FROM
     LEFT JOIN group_configs AS gc ON (gc.assessment_id = a.id)
     LEFT JOIN groups AS g ON (g.id = ai.group_id AND g.group_config_id = gc.id)
     LEFT JOIN users AS u ON (u.user_id = ai.user_id)
+    LEFT JOIN users AS agu ON (agu.user_id = iq.assigned_grader)
+    LEFT JOIN users AS lgu ON (lgu.user_id = iq.last_grader)
 WHERE
     a.id = $assessment_id
 ORDER BY
@@ -168,7 +172,9 @@ WITH all_submissions AS (
         (row_number() OVER (PARTITION BY v.id ORDER BY s.score DESC NULLS LAST, s.date DESC, s.id DESC)) = 1 AS best_submission_per_variant,
         g.name AS group_name,
         groups_uid_list(g.id) AS uid_list,
-        su.uid AS submission_user
+        su.uid AS submission_user,
+        COALESCE(agu.name, agu.uid) AS assigned_grader_name,
+        COALESCE(lgu.name, lgu.uid) AS last_grader_name
     FROM
         assessments AS a
         JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
@@ -183,6 +189,8 @@ WITH all_submissions AS (
         JOIN variants AS v ON (v.instance_question_id = iq.id)
         JOIN submissions AS s ON (s.variant_id = v.id)
         LEFT JOIN users AS su ON (su.user_id = s.auth_user_id)
+        LEFT JOIN users AS agu ON (agu.user_id = iq.assigned_grader)
+        LEFT JOIN users AS lgu ON (lgu.user_id = iq.last_grader)
     WHERE
         a.id = $assessment_id
 )


### PR DESCRIPTION
Resolves #6623. Adds columns for assigned grader and last grader to the CSV downloads for instance questions and submissions (all/best/last).

#6623 refers to a column for when the assessment was last graded. This column already exists as "Grading date" in the submissions files.