### PR TITLE
pl-order-blocks: raise exception if question has non-unique tags

### DIFF
--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -134,7 +134,7 @@ def prepare(element_html, data):
             tag = str(index)
 
         if tag in used_tags:
-            raise Exception('tag "' + tag + '" used on multiple <pl-answer>. The tag attribute for each <pl-answer> must be unique.')
+                raise Exception(f'Tag "{tag}" used in multiple places. The tag attribute for each <pl-answer> and <pl-block-group> must be unique.')
         else:
             used_tags.add(tag)
 
@@ -166,6 +166,11 @@ def prepare(element_html, data):
                 raise Exception('Block groups only supported in the "dag" grading mode.')
 
             group_tag, group_depends = get_graph_info(html_tags)
+            if group_tag in used_tags:
+                raise Exception(f'Tag "{group_tag}" used in multiple places. The tag attribute for each <pl-answer> and <pl-block-group> must be unique.')
+            else:
+                used_tags.add(group_tag)
+
             for grouped_tag in html_tags:
                 if html_tags.tag is etree.Comment:
                     continue

--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -134,7 +134,7 @@ def prepare(element_html, data):
             tag = str(index)
 
         if tag in used_tags:
-                raise Exception(f'Tag "{tag}" used in multiple places. The tag attribute for each <pl-answer> and <pl-block-group> must be unique.')
+            raise Exception(f'Tag "{tag}" used in multiple places. The tag attribute for each <pl-answer> and <pl-block-group> must be unique.')
         else:
             used_tags.add(tag)
 

--- a/elements/pl-order-blocks/pl-order-blocks.py
+++ b/elements/pl-order-blocks/pl-order-blocks.py
@@ -108,6 +108,7 @@ def prepare(element_html, data):
 
     correct_answers = []
     incorrect_answers = []
+    used_tags = set()
 
     def prepare_tag(html_tags, index, group_info={'tag': None, 'depends': None}):
         if html_tags.tag != 'pl-answer':
@@ -131,6 +132,11 @@ def prepare(element_html, data):
         tag, depends = get_graph_info(html_tags)
         if grading_method == 'ranking':
             tag = str(index)
+
+        if tag in used_tags:
+            raise Exception('tag "' + tag + '" used on multiple <pl-answer>. The tag attribute for each <pl-answer> must be unique.')
+        else:
+            used_tags.add(tag)
 
         if check_indentation is False and answer_indent is not None:
             raise Exception('<pl-answer> should not specify indentation if indentation is disabled.')


### PR DESCRIPTION
We've had a few people confused why problems aren't being graded properly, when they shouldn't be using duplicate tags.

Throw an error so the question won't even render.

This could potentially break some questions in the wild. Though arguably they are already broken if they are using duplicate tags. Making them break loudly might be better than having them be broken silently, which is what currently happens.