### PR TITLE
Fix crash when getting Node metrics fails

### DIFF
--- a/lib/node-metrics.js
+++ b/lib/node-metrics.js
@@ -1,6 +1,7 @@
 // @ts-check
 const AWS = require('aws-sdk');
 const loopbench = require('loopbench')();
+const Sentry = require('@prairielearn/sentry');
 
 const logger = require('./logger');
 const config = require('./config');
@@ -89,6 +90,7 @@ async function emit() {
       .promise();
   } catch (err) {
     logger.error('Error reporting Node metrics', err);
+    Sentry.captureException(err);
   }
 }
 

--- a/lib/node-metrics.js
+++ b/lib/node-metrics.js
@@ -9,87 +9,87 @@ let intervalId;
 let cpuUsage = process.cpuUsage();
 let time = process.hrtime.bigint();
 
-function emit() {
-  const memoryStats = process.memoryUsage();
+async function emit() {
+  try {
+    const memoryStats = process.memoryUsage();
 
-  const elapsedCpuUsage = process.cpuUsage(cpuUsage);
-  // This delta is in nanoseconds.
-  const elapsedTime = process.hrtime.bigint() - time;
-  // This conversion should be safe, as `Number.MAX_SAFE_INTEGER` microseconds
-  // corresponds to about 258 years.
-  const elapsedMicroseconds = Number(elapsedTime / BigInt(1000));
+    const elapsedCpuUsage = process.cpuUsage(cpuUsage);
+    // This delta is in nanoseconds.
+    const elapsedTime = process.hrtime.bigint() - time;
+    // This conversion should be safe, as `Number.MAX_SAFE_INTEGER` microseconds
+    // corresponds to about 258 years.
+    const elapsedMicroseconds = Number(elapsedTime / BigInt(1000));
 
-  const userCpuPercent = (100 * elapsedCpuUsage.user) / elapsedMicroseconds;
-  const systemCpuPercent = (100 * elapsedCpuUsage.system) / elapsedMicroseconds;
-  const totalCpuPercent = userCpuPercent + systemCpuPercent;
+    const userCpuPercent = (100 * elapsedCpuUsage.user) / elapsedMicroseconds;
+    const systemCpuPercent = (100 * elapsedCpuUsage.system) / elapsedMicroseconds;
+    const totalCpuPercent = userCpuPercent + systemCpuPercent;
 
-  cpuUsage = process.cpuUsage();
-  time = process.hrtime.bigint();
+    cpuUsage = process.cpuUsage();
+    time = process.hrtime.bigint();
 
-  const metrics = [
-    {
-      MetricName: 'NodeEventLoopDelay',
-      Unit: 'Milliseconds',
-      Value: loopbench.delay,
-    },
-    {
-      MetricName: 'NodeMemoryRss',
-      Unit: 'Bytes',
-      Value: memoryStats.rss,
-    },
-    {
-      MetricName: 'NodeMemoryHeapTotal',
-      Unit: 'Bytes',
-      Value: memoryStats.heapTotal,
-    },
-    {
-      MetricName: 'NodeMemoryHeapUsed',
-      Unit: 'Bytes',
-      Value: memoryStats.heapUsed,
-    },
-    {
-      MetricName: 'NodeMemoryExternal',
-      Unit: 'Bytes',
-      Value: memoryStats.external,
-    },
-    {
-      MetricName: 'NodeCpuUser',
-      Unit: 'Percent',
-      Value: userCpuPercent,
-    },
-    {
-      MetricName: 'NodeCpuSystem',
-      Unit: 'Percent',
-      Value: systemCpuPercent,
-    },
-    {
-      MetricName: 'NodeCpuTotal',
-      Unit: 'Percent',
-      Value: totalCpuPercent,
-    },
-  ];
+    const metrics = [
+      {
+        MetricName: 'NodeEventLoopDelay',
+        Unit: 'Milliseconds',
+        Value: loopbench.delay,
+      },
+      {
+        MetricName: 'NodeMemoryRss',
+        Unit: 'Bytes',
+        Value: memoryStats.rss,
+      },
+      {
+        MetricName: 'NodeMemoryHeapTotal',
+        Unit: 'Bytes',
+        Value: memoryStats.heapTotal,
+      },
+      {
+        MetricName: 'NodeMemoryHeapUsed',
+        Unit: 'Bytes',
+        Value: memoryStats.heapUsed,
+      },
+      {
+        MetricName: 'NodeMemoryExternal',
+        Unit: 'Bytes',
+        Value: memoryStats.external,
+      },
+      {
+        MetricName: 'NodeCpuUser',
+        Unit: 'Percent',
+        Value: userCpuPercent,
+      },
+      {
+        MetricName: 'NodeCpuSystem',
+        Unit: 'Percent',
+        Value: systemCpuPercent,
+      },
+      {
+        MetricName: 'NodeCpuTotal',
+        Unit: 'Percent',
+        Value: totalCpuPercent,
+      },
+    ];
 
-  const cloudwatch = new AWS.CloudWatch(config.awsServiceGlobalOptions);
-  /** @type {import('aws-sdk').CloudWatch.Types.Dimensions} */
-  const dimensions = [
-    { Name: 'Server Group', Value: config.groupName },
-    { Name: 'InstanceId', Value: `${config.instanceId}:${config.serverPort}` },
-  ];
-  /** @type {import('aws-sdk').CloudWatch.Types.PutMetricDataInput} */
-  const params = {
-    Namespace: 'PrairieLearn',
-    MetricData: metrics.map((m) => ({
-      ...m,
-      StorageResolution: 1,
-      Timestamp: new Date(),
-      Dimensions: dimensions,
-    })),
-  };
-  cloudwatch.putMetricData(params, (err) => {
-    if (err) {
-      logger.error('Error reporting Node metrics to CloudWatch', err);
-    }
-  });
+    const cloudwatch = new AWS.CloudWatch(config.awsServiceGlobalOptions);
+    /** @type {import('aws-sdk').CloudWatch.Types.Dimensions} */
+    const dimensions = [
+      { Name: 'Server Group', Value: config.groupName },
+      { Name: 'InstanceId', Value: `${config.instanceId}:${config.serverPort}` },
+    ];
+    await cloudwatch
+      .putMetricData({
+        Namespace: 'PrairieLearn',
+        MetricData: metrics.map((m) => ({
+          ...m,
+          StorageResolution: 1,
+          Timestamp: new Date(),
+          Dimensions: dimensions,
+        })),
+      })
+      .promise();
+  } catch (err) {
+    logger.error('Error reporting Node metrics', err);
+  }
 }
 
 module.exports.init = () => {


### PR DESCRIPTION
This PR wraps the collection and reporting of Node metrics in a `try`/`catch` block to ensure that the process doesn't die if metrics collection fails.

It's recommended to review this PR with whitespace changes hidden.