### PR TITLE
Use correct protocol for student links

### DIFF
--- a/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
+++ b/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
@@ -40,15 +40,15 @@ router.get('/', function (req, res, next) {
     ],
     function (err) {
       if (ERR(err, next)) return;
-      debug('render page');
-      let host = config.serverCanonicalHost || 'https://' + req.headers.host;
-      res.locals.studentLink =
-        host +
+      const host = config.serverCanonicalHost || `${req.protocol}://${req.headers.host}`;
+      res.locals.studentLink = new URL(
         res.locals.plainUrlPrefix +
-        '/course_instance/' +
-        res.locals.course_instance.id +
-        '/assessment/' +
-        res.locals.assessment.id;
+          '/course_instance/' +
+          res.locals.course_instance.id +
+          '/assessment/' +
+          res.locals.assessment.id,
+        host
+      ).href;
       res.locals.studentLinkQRCode = new QR({
         content: res.locals.studentLink,
         width: 512,

--- a/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
+++ b/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
@@ -36,10 +36,11 @@ router.get('/', function (req, res, next) {
     ],
     function (err) {
       if (ERR(err, next)) return;
-      debug('render page');
-      let host = config.serverCanonicalHost || 'https://' + req.headers.host;
-      res.locals.studentLink =
-        host + res.locals.plainUrlPrefix + '/course_instance/' + res.locals.course_instance.id;
+      const host = config.serverCanonicalHost || `${req.protocol}://${req.headers.host}`;
+      res.locals.studentLink = new URL(
+        res.locals.plainUrlPrefix + '/course_instance/' + res.locals.course_instance.id,
+        host
+      ).href;
       res.locals.studentLinkQRCode = new QR({
         content: res.locals.studentLink,
         width: 512,


### PR DESCRIPTION
Fixes #6628. Because we set [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) to 1 when running behind a load balancer, it will respect the value of `X-Forwarded-Proto` and use it for `req.protocol`.