### PR TITLE
Remove ASG lifecycle state polling

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -297,11 +297,6 @@ config.autoScalingGroupName = null;
 config.autoScalingLaunchingLifecycleHookName = null;
 /** The name of an ASG lifecycle hook name to complete when terminating. */
 config.autoScalingTerminatingLifecycleHookName = null;
-/**
- * How often to poll the ASG API for the current instance's state. If set to a
- * falsy value, polling is disabled.
- */
-config.autoScalingLifecycleStatePollIntervalSec = 10;
 
 config.serverJobHeartbeatIntervalSec = 10;
 /**

--- a/lib/lifecycle-hooks.js
+++ b/lib/lifecycle-hooks.js
@@ -1,47 +1,11 @@
 // @ts-check
 const {
   AutoScalingClient,
-  DescribeAutoScalingInstancesCommand,
   CompleteLifecycleActionCommand,
 } = require('@aws-sdk/client-auto-scaling');
 
 const config = require('./config');
 const logger = require('./logger');
-const { sleep } = require('./sleep');
-
-/**
- * Polls the Auto Scaling API until the instance is in the given lifecycle state.
- * Ideally this would be event-driven instead, but there's no good way to receive
- * events straight to an EC2 instance; it's really designed to be used with
- * something like SNS, SQS, or Lambda.
- *
- * @param {import('@aws-sdk/client-auto-scaling').AutoScalingClient} client
- * @param {string} instanceId
- * @param {string} lifecycleState
- */
-async function waitForLifecycleState(client, instanceId, lifecycleState) {
-  // We use a loop + "sleeps" instead of `setInterval` because we've configured
-  // the ASG client to automatically retry with exponential backoff. We don't
-  // want to have multiple overlapping calls in progress, which would be possible
-  // if automatic retries were happening in parallel with our `setInterval`.
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    try {
-      const instances = await client.send(
-        new DescribeAutoScalingInstancesCommand({ InstanceIds: [instanceId] })
-      );
-      if (instances.AutoScalingInstances.length === 0) return;
-      const instance = instances.AutoScalingInstances[0];
-      if (instance.LifecycleState === lifecycleState) {
-        return;
-      }
-    } catch (err) {
-      // Hopefully a transient error; keep trying to fetch instance state.
-    }
-
-    await sleep(config.autoScalingLifecycleStatePollIntervalSec * 1000);
-  }
-}
 
 module.exports.completeInstanceLaunch = async function () {
   if (
@@ -87,24 +51,4 @@ module.exports.completeInstanceTermination = async function () {
     })
   );
   logger.info('Completed Auto Scaling lifecycle action for instance termination');
-};
-
-/**
- * Resolves once the instance has entered the `Terminating:Wait` state. If
- * not running in EC2, or not configured with an ASG or lifecycle hook name,
- * or with a falsy poll interval, returns a promise that never settles.
- */
-module.exports.waitForInstanceTermination = async function () {
-  if (
-    !config.runningInEc2 ||
-    !config.autoScalingGroupName ||
-    !config.autoScalingTerminatingLifecycleHookName ||
-    !config.autoScalingLifecycleStatePollIntervalSec
-  ) {
-    // Return a Promise that never settles.
-    return new Promise(() => {});
-  }
-
-  const client = new AutoScalingClient({ region: config.awsRegion, maxAttempts: 3 });
-  await waitForLifecycleState(client, config.instanceId, 'Terminating:Wait');
 };

--- a/server.js
+++ b/server.js
@@ -2093,14 +2093,6 @@ if (config.startServer) {
             process.exit(0);
           }
         });
-
-        // If we're running in EC2 auto scaling, this will wait for our instance
-        // to enter the `Terminating:Wait` state. If we're not running in EC2,
-        // this will be a no-op.
-        lifecycleHooks.waitForInstanceTermination().then(() => {
-          logger.info('Terminating server due to lifecycle state change');
-          process.kill(process.pid, 'SIGTERM');
-        });
       }
     }
   );


### PR DESCRIPTION
This PR removes the code that polls for the ASG instance lifecycle state. Automated termination should now be handled with the webhook that was added in https://github.com/PrairieLearn/PrairieLearn/pull/6608.