### PR TITLE
Only complete ASG lifecycle actions if instance is in wait state

### DIFF
--- a/lib/lifecycle-hooks.js
+++ b/lib/lifecycle-hooks.js
@@ -2,10 +2,27 @@
 const {
   AutoScalingClient,
   CompleteLifecycleActionCommand,
+  DescribeAutoScalingInstancesCommand,
 } = require('@aws-sdk/client-auto-scaling');
 
 const config = require('./config');
 const logger = require('./logger');
+
+/**
+ * Gets the lifecycle state of the current EC2 instance.
+ *
+ * @param {AutoScalingClient} client
+ * @returns {Promise<string>}
+ */
+async function getInstanceLifecycleState(client) {
+  const res = await client.send(
+    new DescribeAutoScalingInstancesCommand({
+      InstanceIds: [config.instanceId],
+    })
+  );
+
+  return res.AutoScalingInstances[0]?.LifecycleState;
+}
 
 module.exports.completeInstanceLaunch = async function () {
   if (
@@ -17,8 +34,17 @@ module.exports.completeInstanceLaunch = async function () {
     return;
   }
 
-  logger.info('Completing Auto Scaling lifecycle action for instance launch...');
   const client = new AutoScalingClient({ region: config.awsRegion, maxAttempts: 3 });
+
+  // If we're starting outside the context of an Auto Scaling lifecycle change
+  // (e.g. a restart after a process crash), there won't be a lifecycle action
+  // to complete.
+  const lifecycleState = await getInstanceLifecycleState(client);
+  if (lifecycleState !== 'Pending:Wait' && lifecycleState !== 'Warmed:Pending:Wait') {
+    return;
+  }
+
+  logger.info('Completing Auto Scaling lifecycle action for instance launch...');
   await client.send(
     new CompleteLifecycleActionCommand({
       LifecycleActionResult: 'CONTINUE',
@@ -40,8 +66,16 @@ module.exports.completeInstanceTermination = async function () {
     return;
   }
 
-  logger.info('Completing Auto Scaling lifecycle action for instance termination...');
   const client = new AutoScalingClient({ region: config.awsRegion, maxAttempts: 3 });
+
+  // If we're terminating outside the context of an Auto Scaling lifecycle change
+  // (e.g. via `systemctl stop`), there won't be a lifecycle action to complete.
+  const lifecycleState = await getInstanceLifecycleState(client);
+  if (lifecycleState !== 'Terminating:Wait' && lifecycleState !== 'Warmed:Terminating:Wait') {
+    return;
+  }
+
+  logger.info('Completing Auto Scaling lifecycle action for instance termination...');
   await client.send(
     new CompleteLifecycleActionCommand({
       LifecycleActionResult: 'CONTINUE',


### PR DESCRIPTION
This PR avoids errors if we try to start up or shut down outside the context of an ASG lifecycle change. See inline comments for more details.

Closes https://github.com/PrairieLearnInc/sysconf/issues/547.