### PR TITLE
Allow weight attribute for pl-matching element

### DIFF
--- a/elements/pl-matching/pl-matching.py
+++ b/elements/pl-matching/pl-matching.py
@@ -113,7 +113,7 @@ def prepare(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
 
     required_attribs = ['answers-name']
-    optional_attribs = ['fixed-order', 'number-statements', 'number-options', 'none-of-the-above', 'blank', 'counter-type', 'fixed-options-order']
+    optional_attribs = ['weight', 'fixed-order', 'number-statements', 'number-options', 'none-of-the-above', 'blank', 'counter-type', 'fixed-options-order']
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, 'answers-name')
     options, statements = categorize_matches(element, data)


### PR DESCRIPTION
This was reported on Slack: https://prairielearn.slack.com/archives/C266KEH9A/p1670371314582939. The element appears to already support `weight`, and the attribute is even documented; it just wasn't listed here when this element was implemented in #3670.