### PR TITLE
Remove legacy login redirects

### DIFF
--- a/pages/authCallbackShib/authCallbackShib.js
+++ b/pages/authCallbackShib/authCallbackShib.js
@@ -6,7 +6,7 @@ var config = require('../../lib/config');
 var csrf = require('../../lib/csrf');
 var sqldb = require('../../prairielib/lib/sql-db');
 
-router.get('/:action?/:target(*)?', function (req, res, next) {
+router.get('/', function (req, res, next) {
   if (!config.hasShib) return next(new Error('Shibboleth login is not enabled'));
   var authUid = null;
   var authName = null;
@@ -34,7 +34,6 @@ router.get('/:action?/:target(*)?', function (req, res, next) {
       httpOnly: true,
       secure: true,
     });
-    if (req.params.action === 'redirect') return res.redirect('/' + req.params.target);
     var redirUrl = res.locals.homeUrl;
     if ('preAuthUrl' in req.cookies) {
       redirUrl = req.cookies.preAuthUrl;


### PR DESCRIPTION
#810 introduced support for URLs like https://pl-dev.engr.illinois.edu/pl/shibcallback/redirect/pl/course_instance/4/instructor/assessment/10/. #1057 improved this by storing the desired URL in a cookie and redirecting to it once auth is complete, so the `.../redirect/...` is no longer necessary.