### PR TITLE
Allow redisUrl to be null

### DIFF
--- a/schemas/schemas/serverConfig.json
+++ b/schemas/schemas/serverConfig.json
@@ -34,7 +34,7 @@
         },
         "redisUrl": {
             "description": "The url for connecting to Redis.",
-            "type": "string"
+            "type": ["string", "null"]
         },
         "logFilename": {
             "description": "Filename to use for server logging.",


### PR DESCRIPTION
We've assigned a meaning to `redisUrl: null`:

https://github.com/PrairieLearn/PrairieLearn/blob/310ff716139f576b20280456a64b3b5fb34f5a93/lib/redis.js#L16

This PR ensures that the JSON schema for our config allows Redis to be disabled.