### PR TITLE
Fix workspace logs when course instance not present

### DIFF
--- a/pages/workspaceLogs/workspaceLogs.js
+++ b/pages/workspaceLogs/workspaceLogs.js
@@ -119,7 +119,7 @@ router.get(
       workspace_id: res.locals.workspace_id,
       workspace_version: null,
       display_timezone:
-        res.locals.course_instance.display_timezone ?? res.locals.course.display_timezone,
+        res.locals.course_instance?.display_timezone ?? res.locals.course.display_timezone,
     });
     res.send(WorkspaceLogs({ workspaceLogs: workspaceLogs.rows, resLocals: res.locals }));
   })
@@ -134,7 +134,7 @@ router.get(
       workspace_id: res.locals.workspace_id,
       workspace_version: req.params.version,
       display_timezone:
-        res.locals.course_instance.display_timezone ?? res.locals.course.display_timezone,
+        res.locals.course_instance?.display_timezone ?? res.locals.course.display_timezone,
     });
     const containerLogsEnabled = areContainerLogsEnabled();
     const containerLogsExpired = areContainerLogsExpired(workspaceLogs.rows);


### PR DESCRIPTION
If a workspace is created from a question preview without a course instance in the URL (e.g. `pl/course/1/question/87/preview`), the workspace won't have an associated course instance.