### PR TITLE
Add configurable site-wide announcement

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -325,6 +325,17 @@ config.titleOverride = null;
 config.homepageFooterText = null;
 config.homepageFooterTextHref = null;
 
+/**
+ * HTML that will be displayed in a banner at the top of every page. Useful for
+ * announcing maintenance windows, etc.
+ */
+config.announcementText = null;
+/**
+ * A Bootstrap color (`primary`, `secondary`, `warning`, etc.) for the
+ * announcement banner.
+ */
+config.announcementColor = null;
+
 /** The name of the auto scaling group that this instance is attached to, if any. */
 config.autoScalingGroupName = null;
 /** The name of an ASG lifecycle hook name to complete when launching. */

--- a/pages/home/home.ejs
+++ b/pages/home/home.ejs
@@ -117,8 +117,6 @@
         </div><!-- card -->
         <% } %> <!-- devMode -->
 
-        <%- include('../partials/advertisement'); %>
-
         <% if (locals.instructor_courses && instructor_courses.length > 0) { %>
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">Courses with instructor access</div>

--- a/pages/partials/advertisement.ejs
+++ b/pages/partials/advertisement.ejs
@@ -1,6 +1,0 @@
-<% /* insert advertising banners like this:
-      <div class="alert alert-info my-4">
-      <img src="/images/hackillinois.png" class="mr-2" style="height: 22px; margin-top: -4px;"/>
-      <small>PrairieLearn will be at HackIllinois 2018 — <a href="/pl/hackillinois" target="_blank">check out our projects!</a></small>
-      </div>
-*/ %>

--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -9,6 +9,12 @@
   <span id="test_csrf_token" hidden><%= __csrf_token %></span>
 <% } %>
 
+<% if (config.announcementHtml) { %>
+  <div class="alert alert-<%= config.announcementColor ?? 'primary' %> mb-0 rounded-0 text-center">
+    <%- config.announcementHtml %>
+  </div>
+<% } %>
+
 <div class="mb-4">
 <nav class="navbar navbar-dark bg-dark navbar-expand-md">
   <a class="navbar-brand" href="<%= homeUrl %>">

--- a/pages/studentAssessments/studentAssessments.ejs
+++ b/pages/studentAssessments/studentAssessments.ejs
@@ -12,8 +12,6 @@
     <%- include('../partials/navbar', {navPage: 'assessments'}); %>
     <div id="content" class="container">
 
-      <%- include('../partials/advertisement'); %>
-
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">Assessments</div>
 

--- a/pages/studentGradebook/studentGradebook.ejs
+++ b/pages/studentGradebook/studentGradebook.ejs
@@ -12,8 +12,6 @@
     <%- include('../partials/navbar', {navPage: 'gradebook'}); %>
     <div id="content" class="container">
 
-      <%- include('../partials/advertisement'); %>
-
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">Gradebook</div>
 


### PR DESCRIPTION
This PR adds the ability to configure a site-wide announcement that will appear at the top of every page. This is primarily meant to be used to announce maintenance windows, including the upcoming downtime in January 2023.

<img width="1180" alt="Screenshot 2022-12-19 at 13 40 57" src="https://user-images.githubusercontent.com/1476544/208531579-9cb57cae-4544-4f3b-a7de-39ca76120b69.png">

This also removes the old "advertisement" code in favor of this new configurable announcement.