### PR TITLE
Depluralize significant figures in pl-number-input

### DIFF
--- a/elements/pl-number-input/pl-number-input.mustache
+++ b/elements/pl-number-input/pl-number-input.mustache
@@ -16,7 +16,7 @@
             <span class="input-group-text">{{{label}}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" class="form-control {{^display_append_span}}rounded-right{{/display_append_span}} pl-number-input-input" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
+        <input name="{{name}}" autocomplete="off" type="text" class="form-control {{^display_append_span}}rounded-right{{/display_append_span}} pl-number-input-input" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} aria-describedby="basic-addon1" placeholder="{{shortinfo}}" />
 
           <span class="input-group-append">
             {{#suffix}}<span class="input-group-text {{^show_info}}rounded-right{{/show_info}}">{{suffix}}</span>{{/suffix}}

--- a/elements/pl-number-input/pl-number-input.mustache
+++ b/elements/pl-number-input/pl-number-input.mustache
@@ -130,7 +130,7 @@ Your answer must be either a real number between <code>-1e308</code> and <code>1
 {{^allow_complex}}
 Your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number).
 {{/allow_complex}}
-No symbolic expressions (those that involve{{^allow_fractions}} fractions,{{/allow_fractions}} square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., <code>1.2e03</code>). {{#allow_fractions}} You may express your answer as a fraction of two numbers. {{/allow_fractions}} {{#relabs}}<p>Your answer must be accurate to within relative tolerance <code>{{rtol}}</code> and absolute tolerance <code>{{atol}}</code>.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figures. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digits after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
+No symbolic expressions (those that involve{{^allow_fractions}} fractions,{{/allow_fractions}} square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., <code>1.2e03</code>). {{#allow_fractions}} You may express your answer as a fraction of two numbers. {{/allow_fractions}} {{#relabs}}<p>Your answer must be accurate to within relative tolerance <code>{{rtol}}</code> and absolute tolerance <code>{{atol}}</code>.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
 {{/show_info}}
 {{#show_correct}}
 The correct answer used for grading is <samp>{{a_tru}}</samp>
@@ -138,7 +138,7 @@ The correct answer used for grading is <samp>{{a_tru}}</samp>
 {{/format}}
 
 {{#shortformat}}
-number {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figures){{/sigfig}}{{#decdig}}({{digits}} digits after decimal){{/decdig}}
+number {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
 {{/shortformat}}
 
 {{#format_error}}

--- a/elements/pl-number-input/pl-number-input.py
+++ b/elements/pl-number-input/pl-number-input.py
@@ -118,12 +118,12 @@ def render(element_html, data):
             digits = pl.get_integer_attrib(element, 'digits', DIGITS_DEFAULT)
             if (digits < 0):
                 raise ValueError('Attribute digits = {:d} must be non-negative'.format(digits))
-            info_params = {'format': True, 'sigfig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 1))}
+            info_params = {'format': True, 'sigfig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 1)), 'digits_plural': digits > 1}
         elif comparison == 'decdig':
             digits = pl.get_integer_attrib(element, 'digits', DIGITS_DEFAULT)
             if (digits < 0):
                 raise ValueError('Attribute digits = {:d} must be non-negative'.format(digits))
-            info_params = {'format': True, 'decdig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 0))}
+            info_params = {'format': True, 'decdig': True, 'digits': '{:d}'.format(digits), 'comparison_eps': 0.51 * (10**-(digits - 0)), 'digits_plural': digits > 1}
         else:
             raise ValueError('method of comparison "%s" is not valid (must be "relabs", "sigfig", or "decdig")' % comparison)
 


### PR DESCRIPTION
See description. Resolves https://github.com/PrairieLearn/PrairieLearn/issues/4260 and https://github.com/PrairieLearn/PrairieLearn/issues/2344 for the number input element.

Screenshot:
![Screenshot_20230103_175205](https://user-images.githubusercontent.com/1345068/210454986-da87c3ce-ebea-4139-92a5-adcb58e27d37.png)
