### PR TITLE
Writing csv-stringified data to http res stream instead of buffering

### DIFF
--- a/lib/csv-maker.js
+++ b/lib/csv-maker.js
@@ -1,14 +1,22 @@
 const ERR = require('async-stacktrace');
-const util = require('util');
 const _ = require('lodash');
 const csvStringify = require('../lib/nonblocking-csv-stringify');
+const { nonblockingStringifyAsync } = require('../lib/nonblocking-csv-stringify');
 
 module.exports = {};
+
+function computeData(rows, columns) {
+  var headers = _.map(columns, (c) => c[0]);
+  var properties = _.map(columns, (c) => c[1]);
+  var data = _.map(rows, (row) => _.map(properties, (p) => (p == null ? '' : row[p])));
+  data.splice(0, 0, headers);
+  return data;
+}
 
 /*
   Example:
 
-  rows = [
+  var rows = [
       {col1: 50, col2: 'X'},
       {col1: 70, col2: 'Y'},
   ];
@@ -16,11 +24,11 @@ module.exports = {};
       ['Column 1', 'col1'],
       ['Column 2', 'col2'],
   ];
-  rowsToCsv(rows, columns, function(err, csv) {
+  rowsToCsv(rows, columns, function(err, chunk) {
       ...
   });
 
-  to produce:
+  where chunk is some number of rows of:
 
   Column 1,Column 2
   50,X
@@ -28,31 +36,38 @@ module.exports = {};
 
   which is returned as:
 
-  csv = 'Column 1,Column 2\n50,X\n70,Y\n'
+  'Column 1,Column 2\n50,X\n70,Y\n'
 */
 module.exports.rowsToCsv = function (rows, columns, callback) {
-  var headers = _.map(columns, (c) => c[0]);
-  var properties = _.map(columns, (c) => c[1]);
-  var data = _.map(rows, (row) => _.map(properties, (p) => (p == null ? '' : row[p])));
-  data.splice(0, 0, headers);
-  csvStringify(data, function (err, csv) {
-    if (ERR(err, callback)) return;
-    callback(null, csv);
+  const data = computeData(rows, columns);
+  csvStringify(data, function (err, chunk) {
+    if (ERR(err, callback)) {
+      return;
+    } else if (chunk) {
+      callback(null, chunk);
+    } else {
+      callback(null, null);
+    }
   });
 };
-module.exports.rowsToCsvAsync = util.promisify(module.exports.rowsToCsv);
+
+module.exports.rowsToCsvAsync = async function (rows, columns, callback) {
+  const data = computeData(rows, columns);
+  return nonblockingStringifyAsync(data, callback);
+};
 
 /*
   Example:
 
   const result = {columns: ['a', 'b'], rows: [{a: 1, b: 2}, {a: 5, b: 6}]};
-  const csv = await resultToCsvAsync(result);
+  await resultToCsvAsync(result, (chunk) => { // do something with chunk });
 */
 module.exports.resultToCsv = function (result, callback) {
   const columns = _.map(result.columns, (c) => [c, c]);
-  module.exports.rowsToCsv(result.rows, columns, (err, csv) => {
-    if (ERR(err, callback)) return;
-    callback(null, csv);
-  });
+  module.exports.rowsToCsv(result.rows, columns, callback);
 };
-module.exports.resultToCsvAsync = util.promisify(module.exports.resultToCsv);
+
+module.exports.resultToCsvAsync = async function (result, callback) {
+  const columns = _.map(result.columns, (c) => [c, c]);
+  return module.exports.rowsToCsvAsync(result.rows, columns, callback);
+};

--- a/lib/nonblocking-csv-stringify.js
+++ b/lib/nonblocking-csv-stringify.js
@@ -30,18 +30,18 @@ function nonblockingStringify(data, callback, options) {
     }
     loop();
   });
-  let chunks = [];
+  
   stringifier.on('readable', function () {
     let chunk;
     while ((chunk = stringifier.read()) !== null) {
-      chunks.push(chunk);
+      callback(null, chunk);
     }
   });
   stringifier.on('error', function (err) {
     return callback(err);
   });
   stringifier.on('end', function () {
-    return callback(null, chunks.join(''));
+    return callback(null, null);
   });
 }
 

--- a/lib/nonblocking-csv-stringify.js
+++ b/lib/nonblocking-csv-stringify.js
@@ -30,7 +30,7 @@ function nonblockingStringify(data, callback, options) {
     }
     loop();
   });
-  
+
   stringifier.on('readable', function () {
     let chunk;
     while ((chunk = stringifier.read()) !== null) {
@@ -45,13 +45,18 @@ function nonblockingStringify(data, callback, options) {
   });
 }
 
-function nonblockingStringifyAsync(data, options) {
+function nonblockingStringifyAsync(data, callback, options) {
   return new Promise((resolve, reject) => {
     nonblockingStringify(
       data,
-      (err, csv) => {
-        if (err) return reject(err);
-        return resolve(csv);
+      (err, chunk) => {
+        if (err) {
+          return reject(err);
+        } else if (chunk) {
+          callback(chunk);
+        } else {
+          return resolve();
+        }
       },
       options
     );

--- a/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -68,10 +68,15 @@ var sendInstancesCsv = function (res, req, columns, options, callback) {
     if (ERR(err, callback)) return;
 
     var rows = result.rows;
-    csvMaker.rowsToCsv(rows, columns, function (err, csv) {
-      if (ERR(err, callback)) return;
-      res.attachment(req.params.filename);
-      res.send(csv);
+    res.attachment(req.params.filename);
+    csvMaker.rowsToCsv(rows, columns, function (err, chunk) {
+      if (ERR(err, callback)) {
+        return;
+      } else if (chunk) {
+        res.write(chunk);
+      } else {
+        res.end();
+      }
     });
   });
 };
@@ -208,10 +213,15 @@ router.get('/:filename', function (req, res, next) {
         ['Assigned manual grader', 'assigned_grader'],
         ['Last manual grader', 'last_grader'],
       ]);
-      csvMaker.rowsToCsv(result.rows, columns, function (err, csv) {
-        if (ERR(err, next)) return;
-        res.attachment(req.params.filename);
-        res.send(csv);
+      res.attachment(req.params.filename);
+      csvMaker.rowsToCsv(result.rows, columns, function (err, chunk) {
+        if (ERR(err, next)) {
+          return;
+        } else if (chunk) {
+          res.write(chunk);
+        } else {
+          res.end();
+        }
       });
     });
   } else if (req.params.filename === res.locals.submissionsForManualGradingCsvFilename) {
@@ -240,10 +250,15 @@ router.get('/:filename', function (req, res, next) {
         ['score_perc', null],
         ['feedback', null],
       ]);
-      csvMaker.rowsToCsv(result.rows, columns, function (err, csv) {
-        if (ERR(err, next)) return;
-        res.attachment(req.params.filename);
-        res.send(csv);
+      res.attachment(req.params.filename);
+      csvMaker.rowsToCsv(result.rows, columns, function (err, chunk) {
+        if (ERR(err, next)) {
+          return;
+        } else if (chunk) {
+          res.write(chunk);
+        } else {
+          res.end();
+        }
       });
     });
   } else if (
@@ -299,10 +314,15 @@ router.get('/:filename', function (req, res, next) {
         ['Manual points', 'manual_points'],
         ['Max manual points', 'max_manual_points'],
       ]);
-      csvMaker.rowsToCsv(result.rows, columns, function (err, csv) {
-        if (ERR(err, next)) return;
-        res.attachment(req.params.filename);
-        res.send(csv);
+      res.attachment(req.params.filename);
+      csvMaker.rowsToCsv(result.rows, columns, function (err, chunk) {
+        if (ERR(err, next)) {
+          return;
+        } else if (chunk) {
+          res.write(chunk);
+        } else {
+          res.end();
+        }
       });
     });
   } else if (req.params.filename === res.locals.filesForManualGradingZipFilename) {
@@ -383,10 +403,15 @@ router.get('/:filename', function (req, res, next) {
         ['groupName', 'name'],
         ['UID', 'uid'],
       ];
-      csvMaker.rowsToCsv(result.rows, columns, function (err, csv) {
-        if (ERR(err, next)) return;
-        res.attachment(req.params.filename);
-        res.send(csv);
+      res.attachment(req.params.filename);
+      csvMaker.rowsToCsv(result.rows, columns, function (err, chunk) {
+        if (ERR(err, next)) {
+          return;
+        } else if (chunk) {
+          res.write(chunk);
+        } else {
+          res.end();
+        }
       });
     });
   } else if (req.params.filename === res.locals.scoresGroupCsvFilename) {

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -92,13 +92,13 @@ router.get('/:filename', (req, res, next) => {
         ];
       });
       csvData.splice(0, 0, csvHeaders);
-      csvStringify(csvData, (err, csv) => {
+      res.attachment(req.params.filename);
+      csvStringify(csvData, function (err, chunk) {
         if (err) {
           throw Error('Error formatting CSV', err);
-        } else if (csv) {
-          res.write(csv);
+        } else if (chunk) {
+          res.write(chunk);
         } else {
-          res.attachment(req.params.filename);
           res.end();
         }
       });

--- a/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -93,9 +93,14 @@ router.get('/:filename', (req, res, next) => {
       });
       csvData.splice(0, 0, csvHeaders);
       csvStringify(csvData, (err, csv) => {
-        if (err) throw Error('Error formatting CSV', err);
-        res.attachment(req.params.filename);
-        res.send(csv);
+        if (err) {
+          throw Error('Error formatting CSV', err);
+        } else if (csv) {
+          res.write(csv);
+        } else {
+          res.attachment(req.params.filename);
+          res.end();
+        }
       });
     });
   } else {

--- a/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
+++ b/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
@@ -122,10 +122,15 @@ router.get(
 
         csvData.push(questionStatsData);
       });
-      const csv = await nonblockingStringifyAsync(csvData);
-
-      res.attachment(req.params.filename);
-      res.send(csv);
+      try {
+        res.attachment(req.params.filename);
+        await nonblockingStringifyAsync(csvData, (chunk) => {
+          res.write(chunk);
+        });
+        res.end();
+      } catch (err) {
+        throw Error('Error formatting CSV', err);
+      }
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }

--- a/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
+++ b/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
@@ -121,9 +121,15 @@ router.get(
         csvData[0].push(count);
       });
       csvData.unshift(csvHeaders);
-      const csv = await nonblockingStringifyAsync(csvData);
-      res.attachment(req.params.filename);
-      res.send(csv);
+      try {
+        res.attachment(req.params.filename);
+        await nonblockingStringifyAsync(csvData, (chunk) => {
+          res.write(chunk);
+        });
+        res.end();
+      } catch (err) {
+        throw Error('Error formatting CSV', err);
+      }
     } else if (req.params.filename === res.locals.durationStatsCsvFilename) {
       // get formatted duration statistics
       const durationStatsResult = await sqldb.queryOneRowAsync(sql.select_duration_stats, {
@@ -168,9 +174,15 @@ router.get(
         csvData[0].push(count);
       });
       csvData.unshift(csvHeaders);
-      const csv = await nonblockingStringifyAsync(csvData);
-      res.attachment(req.params.filename);
-      res.send(csv);
+      try {
+        res.attachment(req.params.filename);
+        await nonblockingStringifyAsync(csvData, (chunk) => {
+          res.write(chunk);
+        });
+        res.end();
+      } catch (err) {
+        throw Error('Error formatting CSV', err);
+      }
     } else if (req.params.filename === res.locals.statsByDateCsvFilename) {
       const histByDateResult = await sqldb.queryAsync(sql.assessment_score_histogram_by_date, {
         assessment_id: res.locals.assessment.id,
@@ -207,9 +219,15 @@ router.get(
         csvData.push(groupData);
       }
       csvData.splice(0, 0, csvHeaders);
-      const csv = await nonblockingStringifyAsync(csvData);
-      res.attachment(req.params.filename);
-      res.send(csv);
+      try {
+        res.attachment(req.params.filename);
+        await nonblockingStringifyAsync(csvData, (chunk) => {
+          res.write(chunk);
+        });
+        res.end();
+      } catch (err) {
+        throw Error('Error formatting CSV', err);
+      }
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }

--- a/pages/instructorAssessments/instructorAssessments.js
+++ b/pages/instructorAssessments/instructorAssessments.js
@@ -166,9 +166,14 @@ router.get(
       });
       csvData.splice(0, 0, csvHeaders);
       csvStringify(csvData, function (err, csv) {
-        if (err) throw Error('Error formatting CSV', err);
-        res.attachment(req.params.filename);
-        res.send(csv);
+        if (err) {
+          throw Error('Error formatting CSV', err);
+        } else if (csv) {
+          res.write(csv);
+        } else {
+          res.attachment(req.params.filename);
+          res.end();
+        }
       });
     } else if (req.params.filename === fileSubmissionsFilename(res.locals)) {
       if (!res.locals.authz_data.has_course_instance_permission_view) {

--- a/pages/instructorAssessments/instructorAssessments.js
+++ b/pages/instructorAssessments/instructorAssessments.js
@@ -165,13 +165,13 @@ router.get(
         csvData.push(csvRow);
       });
       csvData.splice(0, 0, csvHeaders);
-      csvStringify(csvData, function (err, csv) {
+      res.attachment(req.params.filename);
+      csvStringify(csvData, function (err, chunk) {
         if (err) {
           throw Error('Error formatting CSV', err);
-        } else if (csv) {
-          res.write(csv);
+        } else if (chunk) {
+          res.write(chunk);
         } else {
-          res.attachment(req.params.filename);
           res.end();
         }
       });

--- a/pages/instructorGradebook/instructorGradebook.js
+++ b/pages/instructorGradebook/instructorGradebook.js
@@ -100,10 +100,15 @@ router.get('/:filename', function (req, res, next) {
           return [row.uid, row.uin, row.user_name, row.role].concat(score_percs);
         });
         csvData.splice(0, 0, csvHeaders);
-        csvStringify(csvData, function (err, csv) {
-          if (ERR(err, next)) return;
-          res.attachment(req.params.filename);
-          res.send(csv);
+        res.attachment(req.params.filename);
+        csvStringify(csvData, function (err, chunk) {
+          if (err) {
+            throw Error('Error formatting CSV', err);
+          } else if (chunk) {
+            res.write(chunk);
+          } else {
+            res.end();
+          }
         });
       });
     });

--- a/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
+++ b/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
@@ -125,10 +125,15 @@ router.get('/:filename', function (req, res, next) {
           csvData.push(questionStatsData);
         });
 
-        csvStringify(csvData, function (err, csv) {
-          if (ERR(err, next)) return;
-          res.attachment(req.params.filename);
-          res.send(csv);
+        res.attachment(req.params.filename);
+        csvStringify(csvData, function (err, chunk) {
+          if (err) {
+            throw Error('Error formatting CSV', err);
+          } else if (chunk) {
+            res.write(chunk);
+          } else {
+            res.end();
+          }
         });
       }
     );

--- a/tests/lib/csv-maker.test.js
+++ b/tests/lib/csv-maker.test.js
@@ -1,0 +1,103 @@
+const assert = require('chai').assert;
+const csvMaker = require('../../lib/csv-maker');
+
+describe('csv-maker', async function () {
+  const NUM_ROWS = 30;
+
+  describe('rowsToCsv', async function () {
+    const generateTestData = (numRows = NUM_ROWS) => {
+      const columns = [
+        ['Column 1', 'col1'],
+        ['Column 2', 'col2'],
+      ];
+
+      let rows = [];
+      for (let i = 0; i < numRows; i++) {
+        let row = {};
+        columns.forEach(([_header, col]) => (row = { ...row, [col]: `row${i}_${col}` }));
+        rows.push(row);
+      }
+
+      return { rows, columns };
+    };
+
+    const { rows, columns } = generateTestData();
+    const EXPECTED_CSV_STRING =
+      columns.map(([header, _col]) => header).join(',') +
+      '\n' +
+      rows.map((row) => Object.values(row).join(',')).join('\n') +
+      '\n';
+
+    it('should stringify small number of columns and rows to CSV format callback-style', function () {
+      let chunks = [];
+      csvMaker.rowsToCsv(rows, columns, (err, chunk) => {
+        if (err) {
+          throw Error('Error formatting CSV', err);
+        } else if (chunk) {
+          chunks.push(chunk);
+        } else {
+          assert.equal(chunks.join(''), EXPECTED_CSV_STRING);
+        }
+      });
+    });
+
+    it('should stringify small number of columns and rows to CSV format async', async function () {
+      try {
+        let chunks = [];
+        await csvMaker.rowsToCsvAsync(rows, columns, (chunk) => {
+          chunks.push(chunk);
+        });
+        assert(chunks.join(''), EXPECTED_CSV_STRING);
+      } catch (err) {
+        throw Error('Error formatting CSV', err);
+      }
+    });
+  });
+
+  describe('resultToCsv', async function () {
+    const generateTestData = (numRows = NUM_ROWS) => {
+      const columns = ['col1', 'col2'];
+
+      let rows = [];
+      for (let i = 0; i < numRows; i++) {
+        let row = {};
+        columns.forEach((col) => (row = { ...row, [col]: `row${i}_${col}` }));
+        rows.push(row);
+      }
+
+      return { rows, columns };
+    };
+
+    const result = generateTestData();
+    const EXPECTED_CSV_STRING =
+      result.columns.join(',') +
+      '\n' +
+      result.rows.map((row) => Object.values(row).join(',')).join('\n') +
+      '\n';
+
+    it('should stringify small result to CSV format callback-style', function () {
+      let chunks = [];
+      csvMaker.resultToCsv(result, (err, chunk) => {
+        if (err) {
+          throw Error('Error formatting CSV', err);
+        } else if (chunk) {
+          chunks.push(chunk);
+        } else {
+          assert.equal(chunks.join(''), EXPECTED_CSV_STRING);
+        }
+      });
+    });
+
+    it('should stringify small result to CSV format async', async function () {
+      try {
+        let chunks = [];
+        await csvMaker.resultToCsvAsync(result, (chunk) => {
+          chunks.push(chunk);
+        });
+        assert.equal(chunks.join(''), EXPECTED_CSV_STRING);
+      } catch (err) {
+        throw Error('Error formatting CSV', err);
+      }
+    });
+  });
+});

--- a/tests/lib/nonblocking-csv-stringify.test.js
+++ b/tests/lib/nonblocking-csv-stringify.test.js
@@ -1,0 +1,28 @@
+const { describe } = require('../../lib/databaseDescribe');
+
+const assert = require('chai').assert;
+const csvStringify = require('../../lib/nonblocking-csv-stringify');
+
+/**
+ * Run test: mocha tests/lib/nonblocking-csv-stringify.test.js
+ */
+describe('nonblocking-csv-stringify', () => {
+  it('should stringify data to CSV format', () => {
+    const data = [
+      ['col1', 'col2', 'col3'],
+      ['row1_v1', 'row1_v2', 'row1_v3'],
+      ['row2_v1', 'row2_v2', 'row2_v3'],
+      ['row3_v1', 'row3_v2', 'row3_v3'],
+    ];
+
+    const expected = "col1,col2,col3\nrow1_v1,row1_v2,row1_v3\nrow2_v1,row2_v2,row2_v3\nrow3_v1,row3_v2,row3_v3\n";
+
+    const callback = (err, csv) => {
+      if (err) return err;
+      const actual = csv;
+      assert.equal(actual, expected);
+    };
+
+    csvStringify(data, callback);
+  });
+});


### PR DESCRIPTION
#### Issue
#6523 

#### Description
Partially addressed #6523 by piping `stringifier` stream in `lib/nonblocking-csv-stringify` directly to the Express response. This should fix the issue of buffered csv strings hitting the 1GB Node string limit. 
TODO after this PR: use Cursor or pagination when reading from db.

#### Tests
- New sanity unit tests for `lib/nonblocking-csv-stringify` and the dependent `lib/csv-maker` to ensure existing functionalities weren't broken
- Manual tests
- Existing [`tests/instructorAssessmentDownloads.test.js`](https://github.com/PrairieLearn/PrairieLearn/blob/master/tests/instructorAssessmentDownloads.test.js) should already cover the changes too
