### PR TITLE
Fix default name of config.announcementHtml

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -328,7 +328,7 @@ config.homepageFooterTextHref = null;
  * HTML that will be displayed in a banner at the top of every page. Useful for
  * announcing maintenance windows, etc.
  */
-config.announcementText = null;
+config.announcementHtml = null;
 /**
  * A Bootstrap color (`primary`, `secondary`, `warning`, etc.) for the
  * announcement banner.


### PR DESCRIPTION
The code uses the variable name `config.announcementHtml` but in `config.js` we initialize a default value for `config.announcementText` (note `...Text` vs `...Html`). This PR fixes the `config.js` name to be `...Html`.