### PR TITLE
Add missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
         "@types/jest": "^29.2.3",
         "@types/loopbench": "^1.2.1",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^18.11.10",
+        "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.2",
         "@types/passport": "^1.0.11",
         "@types/passport-azure-ad": "^4.3.1",

--- a/packages/compiled-assets/package.json
+++ b/packages/compiled-assets/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "*",
+    "@types/node": "^18.11.18",
     "chai": "^4.3.7",
     "get-port": "^5.1.1",
     "mocha": "^10.1.0",

--- a/packages/html-ejs/package.json
+++ b/packages/html-ejs/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@prairielearn/tsconfig": "*",
     "@types/ejs": "^3.1.1",
+    "@types/node": "^18.11.18",
     "mocha": "^10.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "*",
+    "@types/node": "^18.11.18",
     "mocha": "^10.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "*",
+    "@types/node": "^18.11.18",
     "mocha": "^10.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "*",
+    "@types/node": "^18.11.18",
     "mocha": "^10.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,18 +1242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.19.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3":
-  version: 7.20.5
-  resolution: "@babel/types@npm:7.20.5"
-  dependencies:
-    "@babel/helper-string-parser": ^7.19.4
-    "@babel/helper-validator-identifier": ^7.19.1
-    to-fast-properties: ^2.0.0
-  checksum: 773f0a1ad9f6ca5c5beaf751d1d8d81b9130de87689d1321fc911d73c3b1167326d66f0ae086a27fb5bfc8b4ee3ffebf1339be50d3b4d8015719692468c31f2d
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.19.0, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.5, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
   version: 7.20.7
   resolution: "@babel/types@npm:7.20.7"
   dependencies:
@@ -2619,6 +2608,7 @@ __metadata:
   dependencies:
     "@prairielearn/html": ^2.1.1
     "@prairielearn/tsconfig": "*"
+    "@types/node": ^18.11.18
     chai: ^4.3.7
     commander: ^9.4.1
     esbuild: ^0.15.16
@@ -2645,6 +2635,7 @@ __metadata:
     "@prairielearn/html": ^2.0.0
     "@prairielearn/tsconfig": "*"
     "@types/ejs": ^3.1.1
+    "@types/node": ^18.11.18
     ejs: ^3.1.8
     mocha: ^10.1.0
     ts-node: ^10.9.1
@@ -2657,6 +2648,7 @@ __metadata:
   resolution: "@prairielearn/html@workspace:packages/html"
   dependencies:
     "@prairielearn/tsconfig": "*"
+    "@types/node": ^18.11.18
     mocha: ^10.1.0
     ts-node: ^10.9.1
     typescript: ^4.9.3
@@ -2686,6 +2678,7 @@ __metadata:
     "@opentelemetry/sdk-trace-node": ^1.8.0
     "@opentelemetry/semantic-conventions": ^1.8.0
     "@prairielearn/tsconfig": "*"
+    "@types/node": ^18.11.18
     mocha: ^10.1.0
     ts-node: ^10.9.1
     typescript: ^4.9.3
@@ -2698,6 +2691,7 @@ __metadata:
   dependencies:
     "@prairielearn/tsconfig": "*"
     "@sentry/node": ^7.23.0
+    "@types/node": ^18.11.18
     execa: ^5.1.1
     mocha: ^10.1.0
     ts-node: ^10.9.1
@@ -3279,10 +3273,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^18.11.10":
-  version: 18.11.10
-  resolution: "@types/node@npm:18.11.10"
-  checksum: 0f60cb090b2ee91fcd3dc4311bc1ed7889b92f14644c0069f100776f86474c12eebbcc6c75bc0d7d96b975a103b4d5d6b3c22b4e88bea6e7f4e2b1bb0daf5ea8
+"@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^18.11.18":
+  version: 18.11.18
+  resolution: "@types/node@npm:18.11.18"
+  checksum: 03f17f9480f8d775c8a72da5ea7e9383db5f6d85aa5fefde90dd953a1449bd5e4ffde376f139da4f3744b4c83942166d2a7603969a6f8ea826edfb16e6e3b49d
   languageName: node
   linkType: hard
 
@@ -3497,7 +3491,7 @@ __metadata:
     "@types/jest": ^29.2.3
     "@types/loopbench": ^1.2.1
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.11.10
+    "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.2
     "@types/passport": ^1.0.11
     "@types/passport-azure-ad": ^4.3.1
@@ -13994,21 +13988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.11, tar@npm:^6.1.12":
-  version: 6.1.12
-  resolution: "tar@npm:6.1.12"
-  dependencies:
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    minipass: ^3.0.0
-    minizlib: ^2.1.1
-    mkdirp: ^1.0.3
-    yallist: ^4.0.0
-  checksum: 49d72e4420944e7ede2782d6b0826a6ede6cdab23c7de63470917e7a78166bc4d5b1a96279d3d79a85f1ba5a17cd37c0acbb3cbff19a07447691445b8b051c55
-  languageName: node
-  linkType: hard
-
-"tar@npm:^6.1.2":
+"tar@npm:^6.1.11, tar@npm:^6.1.12, tar@npm:^6.1.2":
   version: 6.1.13
   resolution: "tar@npm:6.1.13"
   dependencies:


### PR DESCRIPTION
This PR fixes the following warnings that would appear when running `yarn` in a project:

```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ @prairielearn/compiled-assets@workspace:packages/compiled-assets doesn't provide @types/node (p790b8), requested by ts-node
➤ YN0002: │ @prairielearn/html-ejs@workspace:packages/html-ejs doesn't provide @types/node (p82ca1), requested by ts-node
➤ YN0002: │ @prairielearn/html@workspace:packages/html doesn't provide @types/node (p312bc), requested by ts-node
➤ YN0002: │ @prairielearn/opentelemetry@workspace:packages/opentelemetry doesn't provide @types/node (pe8f1a), requested by ts-node
➤ YN0002: │ @prairielearn/sentry@workspace:packages/sentry doesn't provide @types/node (pd6f60), requested by ts-node
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
```