### PR TITLE
Disable Dependabot rebasing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -14,6 +15,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: docker
   directory: "/"
   schedule:
@@ -21,6 +23,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: pip
   directory: "/graders/python"
   schedule:
@@ -28,6 +31,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: docker
   directory: "/graders/python"
   schedule:
@@ -35,6 +39,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: npm
   directory: "/grader_host"
   schedule:
@@ -42,13 +47,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
-- package-ecosystem: npm
-  directory: "/prairielib"
-  schedule:
-    interval: monthly
-    time: "06:00"
-    timezone: America/Chicago
-  open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: docker
   directory: "/images/plbase"
   schedule:
@@ -56,6 +55,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: pip
   directory: "/images/plbase"
   schedule:
@@ -63,6 +63,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: docker
   directory: "/workspaces/jupyterlab"
   schedule:
@@ -70,6 +71,7 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled
 - package-ecosystem: docker
   directory: "/workspaces/xtermjs"
   schedule:
@@ -77,3 +79,4 @@ updates:
     time: "06:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  rebase-strategy: disabled


### PR DESCRIPTION
When merging a PR forces all Dependabot PRs to be rebased, the subsequent GitHub Actions run queue prevents new jobs from running for hours. This PR disables the automatic rebasing behavior to avoid this.

I've taken to manually applying and grouping JS dependency updates into a single PR (see e.g. https://github.com/PrairieLearn/PrairieLearn/pull/6893), so having automatic rebasing is less important. Fingers crossed that GitHub will implement grouped dependency updates soon: https://github.com/dependabot/dependabot-core/issues/1190.