### PR TITLE
Install latest compatible version of chalk

### DIFF
--- a/lib/chalk.js
+++ b/lib/chalk.js
@@ -1,6 +1,6 @@
 // @ts-check
-const { default: chalkDefault } = require('chalk');
-const chalk = new chalkDefault.constructor({ enabled: true, level: 3 });
+const chalkLib = require('chalk');
+const chalk = new chalkLib.Instance({ level: 3 });
 
 module.exports.chalk = chalk;
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "bootstrap-table": "^1.21.2",
         "bowser": "^2.11.0",
         "byline": "^5.0.0",
-        "chalk": "^2.4.2",
+        "chalk": "^4.1.2",
         "chart.js": "^2.9.4",
         "cheerio": "^0.22.0",
         "chokidar": "^3.5.3",

--- a/sync/course-db.js
+++ b/sync/course-db.js
@@ -7,14 +7,12 @@ const jju = require('jju');
 const Ajv = require('ajv').default;
 const betterAjvErrors = require('better-ajv-errors').default;
 const { parseISO, isValid, isAfter, isFuture } = require('date-fns');
-const { default: chalkDefault } = require('chalk');
+const { chalk } = require('../lib/chalk');
 
 const schemas = require('../schemas');
 const infofile = require('./infofile');
 const jsonLoad = require('../lib/json-load');
 const perf = require('./performance')('course-db');
-
-const chalk = new chalkDefault.constructor({ enabled: true, level: 3 });
 
 // We use a single global instance so that schemas aren't recompiled every time they're used
 const ajv = new Ajv({ allErrors: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,7 +3697,7 @@ __metadata:
     byline: ^5.0.0
     chai: ^4.3.7
     chai-as-promised: ^7.1.1
-    chalk: ^2.4.2
+    chalk: ^4.1.2
     chart.js: ^2.9.4
     cheerio: ^0.22.0
     chokidar: ^3.5.3


### PR DESCRIPTION
Note that we can't yet use chalk 5+, as we can't yet use EMS-only packages.