### PR TITLE
Fix test suite failures caused by chalk

### DIFF
--- a/lib/databaseDescribe.js
+++ b/lib/databaseDescribe.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const async = require('async');
 const pgArray = require('pg').types.arrayParser;
-const chalk = require('chalk').default;
+const chalk = require('chalk');
 const _ = require('lodash');
 
 const sqldb = require('../prairielib/lib/sql-db');

--- a/lib/databaseDiff.js
+++ b/lib/databaseDiff.js
@@ -3,7 +3,7 @@ const ERR = require('async-stacktrace');
 const async = require('async');
 const fs = require('fs-extra');
 const path = require('path');
-const chalk = require('chalk').default;
+const chalk = require('chalk');
 const _ = require('lodash');
 const jsdiff = require('diff');
 

--- a/tools/pg-describe.js
+++ b/tools/pg-describe.js
@@ -3,7 +3,7 @@
 
 const async = require('async');
 const ERR = require('async-stacktrace');
-const chalk = require('chalk').default;
+const chalk = require('chalk');
 const fs = require('fs-extra');
 const _ = require('lodash');
 const path = require('path');


### PR DESCRIPTION
For unknown reasons, these issues appear to have not been caught by Mocha, and in fact made Mocha skip much of our test suite and exit 0. They also weren't caught by TypeScript somehow?