### PR TITLE
Bail to prevent silent failures with mocha --parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ start-s3rver:
 test: test-js test-python
 test-js: test-prairielearn test-prairielib test-grader-host test-workspace-host test-packages
 test-prairielearn: start-support
-	@yarn mocha --bail --parallel "tests/**/*.test.{js,mjs}"
+	@yarn mocha --bail --parallel "tests/**/*.test.{js,mjs}" || { echo "Mocha failed. Repeating for full diagnostics." ; yarn mocha --parallel "tests/**/*.test.{js,mjs}" ; false ; }
 test-prairielearn-serial: start-support
 	@yarn mocha "tests/**/*.test.{js,mjs}"
 test-prairielib:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ start-s3rver:
 test: test-js test-python
 test-js: test-prairielearn test-prairielib test-grader-host test-workspace-host test-packages
 test-prairielearn: start-support
-	@yarn mocha --parallel "tests/**/*.test.{js,mjs}"
+	@yarn mocha --bail --parallel "tests/**/*.test.{js,mjs}"
 test-prairielearn-serial: start-support
 	@yarn mocha "tests/**/*.test.{js,mjs}"
 test-prairielib:


### PR DESCRIPTION
Fixes #6940 

Adding `--bail` seems to help prevent `mocha --parallel` from failing silently, but I'm not sure if this is appropriate based on how CI is expected to behave on the server.