### PR TITLE
Improve Yarn config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       # ensure that the tests fail more quickly so that people can fix them.
       timeout-minutes: 30
     - name: Install dependencies on host
-      run: yarn install --frozen-lockfile
+      run: yarn install --immutable
     - name: Build executor image
       run: ./tools/executor/build.js
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: 16.x
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --immutable
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,6 @@
 nodeLinker: node-modules
+enableGlobalCache: true
+preferAggregateCacheInfo: true
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY packages/ /PrairieLearn/packages/
 COPY .yarn/ /PrairieLearn/.yarn/
 COPY package.json yarn.lock .yarnrc.yml /PrairieLearn/
 RUN cd /PrairieLearn \
-    && yarn install --frozen-lockfile \
+    && yarn install --immutable \
     && yarn cache clean
 
 # NOTE: Modify .dockerignore to allowlist files/directories to copy.


### PR DESCRIPTION
This PR makes a few changes to how we use Yarn:

- Enables the global cache. This makes our host-based deploys faster, as we can reuse cached downloads between different revisions.
- Enables the `preferAggregateCacheInfo` option. This makes Yarn print a single-line message for missing cache entries (e.g. `29 packages were already cached, 1517 had to be fetched`) instead of one line per package.
- Replaces the now-deprecated `--frozen-lockfile` option with `--immutable`.