### PR TITLE
Add support for dynamic files in workspaces

### DIFF
--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -22,16 +22,21 @@ const sqlLoader = require('../prairielib/lib/sql-loader');
 const ERR = require('async-stacktrace');
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
-const zipDirectory = async function (source, zip) {
+const zipDirectory = async function (source, dynamic, zip) {
   const stream = fs.createWriteStream(zip);
   const archive = archiver('zip');
 
   await new Promise((resolve, reject) => {
     stream
-      .on('open', () => {
+      .on('open', async () => {
         archive.pipe(stream);
         if (source) {
           archive.directory(source, false);
+        }
+        if (dynamic) {
+          async.eachSeries(dynamic, ({ name, contents }) => {
+            archive.append(Buffer.from(contents, 'base64'), { name });
+          });
         }
         archive.on('error', (err) => {
           throw err;
@@ -327,7 +332,7 @@ module.exports = {
    * @returns {Promise<InitializeResult | null>}
    */
   async initialize(workspace_id) {
-    const { workspace, question, course } = (
+    const { workspace, variant, question, course } = (
       await sqldb.queryOneRowAsync(sql.select_workspace_data, { workspace_id })
     ).rows[0];
     const course_path = chunks.getRuntimeDirectoryForCourse(course);
@@ -368,16 +373,31 @@ module.exports = {
     } catch (err) {
       localPathExists = false;
     }
+    const paramsFilesExist = Array.isArray(variant.params?._files);
 
     // upload files to s3/efs depending on how the workspace is configured
     if (workspace.homedir_location === 'S3') {
-      await zipDirectory(localPathExists ? localPath : null, localZipPath);
+      await zipDirectory(localPathExists ? localPath : null, variant.params?._files, localZipPath);
       const remoteZipPath = `${remoteDirName}/initial.zip`;
       await awsHelper.uploadToS3Async(config.workspaceS3Bucket, remoteZipPath, localZipPath, false);
 
       if (localPathExists) {
         debug(`Syncing ${localPath} to ${remotePath}`);
         await awsHelper.uploadDirectoryToS3Async(config.workspaceS3Bucket, remotePath, localPath);
+      }
+
+      if (paramsFilesExist) {
+        async.eachSeries(variant.params._files, async ({ name, contents }) => {
+          // TODO Handle errors or incorrect format
+          const buffer = Buffer.from(contents, 'base64');
+          const result = await awsHelper.uploadToS3Async(
+            config.workspaceS3Bucket,
+            path.join(remotePath, name),
+            false, // localPath
+            false, // isDirectory
+            buffer
+          );
+        });
       }
 
       return null;
@@ -396,7 +416,17 @@ module.exports = {
       if (localPathExists) {
         debug(`Syncing ${localPath} to ${remotePath}`);
         await fse.copy(localPath, sourcePath);
+      }
 
+      if (paramsFilesExist) {
+        async.eachSeries(variant.params._files, async ({ name, contents }) => {
+          // TODO Handle errors or incorrect format
+          const buffer = Buffer.from(contents, 'base64');
+          const result = await fse.writeFile(path.join(sourcePath, name), buffer);
+        });
+      }
+
+      if (localPathExists || paramsFilesExist) {
         // Update permissions so that the directory and all contents are owned by the workspace user
         for await (const file of klaw(sourcePath)) {
           await fsPromises.chown(

--- a/lib/workspace.sql
+++ b/lib/workspace.sql
@@ -19,6 +19,7 @@ FOR UPDATE;
 -- BLOCK select_workspace_data
 SELECT
     to_jsonb(w.*) AS workspace,
+    to_jsonb(v.*) AS variant,
     to_jsonb(q.*) AS question,
     to_jsonb(c.*) AS course
 FROM


### PR DESCRIPTION
Allows questions using workspaces to have dynamic files. Files are created in `data['params']['_files']` using the same format as `data['submitted_answers']['_files']`, i.e., an array of objects where each object has a name and a base64-encoded content.

I have no way of testing the S3 component of this implementation, so I'd appreciate it if someone could work on it for me.

* [x] Basic implementation
* [ ] Error handling (e.g., incorrect format for the parameter)
* [ ] Example course question
* [ ] Tests
* [ ] Documentation