### PR TITLE
Don't track render cache stats in the database

### DIFF
--- a/middlewares/logPageView.js
+++ b/middlewares/logPageView.js
@@ -15,10 +15,6 @@ module.exports = function (pageType) {
 
     const user_id = res.locals.user ? res.locals.user.user_id : res.locals.authn_user.user_id;
 
-    // If this page view required a v3 question render, these properties
-    // will be defined
-    const { panel_render_count = null, panel_render_cache_hit_count = null } = res.locals;
-
     // Originally, we opted to only record page views for assessments if
     // the authn'ed user is also the owner of the assessment instance.
     // However, we now track all page views, so be sure to filter by
@@ -37,8 +33,6 @@ module.exports = function (pageType) {
       variant_id: res.locals.variant ? res.locals.variant.id : null,
       page_type: pageType,
       path: req.originalUrl,
-      panel_render_count,
-      panel_render_cache_hit_count,
     };
 
     sqldb.queryOneRow(sql.log_page_view, params, function (err, result) {

--- a/middlewares/logPageView.sql
+++ b/middlewares/logPageView.sql
@@ -2,12 +2,10 @@
 WITH log_result AS (
     INSERT INTO page_view_logs
         (user_id, authn_user_id, course_instance_id, assessment_id,
-        assessment_instance_id, question_id, variant_id, page_type, path,
-        panel_render_count, panel_render_cache_hit_count)
+        assessment_instance_id, question_id, variant_id, page_type, path)
     VALUES
         ($user_id, $authn_user_id, $course_instance_id, $assessment_id,
-        $assessment_instance_id, $question_id, $variant_id, $page_type, $path,
-        $panel_render_count, $panel_render_cache_hit_count)
+        $assessment_instance_id, $question_id, $variant_id, $page_type, $path)
     RETURNING id
 ), current_page_result AS (
     INSERT INTO current_pages

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "bowser": "^2.11.0",
         "byline": "^5.0.0",
         "chalk": "^4.1.2",
-        "chart.js": "^4.1.2",
         "cheerio": "^0.22.0",
         "chokidar": "^3.5.3",
         "clipboard": "^2.0.11",

--- a/pages/administratorOverview/administratorOverview.ejs
+++ b/pages/administratorOverview/administratorOverview.ejs
@@ -2,29 +2,6 @@
 <html lang="en">
   <head>
     <%- include('../partials/head'); %>
-    <script src="<%= node_modules_asset_path('chart.js/dist/chart.umd.js') %>"></script>
-    <style>
-    canvas {
-      border: none;
-      width: 100%;
-      height: 100%;
-      display: block;
-    }
-    .chart-container {
-      width: 100%;
-    }
-    .chart-container:not(:last-child) {
-      margin-bottom: 2rem;
-    }
-    @media (min-width: 768px) {
-      .chart-container {
-        width: 50%;
-      }
-      .chart-container:not(:last-child) {
-        margin-bottom: 0;
-      }
-    }
-    </style>
   </head>
   <body>
     <script>
@@ -44,6 +21,7 @@
               <tr>
                 <th>Key</th>
                 <th>Value</th>
+              </tr>
             </thead>
             <tbody>
               <% configs.forEach(function(config, i) { %>
@@ -85,6 +63,7 @@
                 <th>UID</th>
                 <th>Name</th>
                 <th></th>
+              </tr>
             </thead>
             <tbody>
               <% administrator_users.forEach(function(administrator_user, i) { %>
@@ -129,6 +108,7 @@
                 <th>End date</th>
                 <th>Location</th>
                 <th>Purpose</th>
+              </tr>
             </thead>
             <tbody>
               <% networks.forEach(function(network, i) { %>
@@ -164,6 +144,7 @@
                 <th>Long name</th>
                 <th>UID regexp</th>
                 <th>Authn providers</th>
+              </tr>
             </thead>
             <tbody>
               <% institutions.forEach(function(inst, i) { %>
@@ -232,6 +213,7 @@
                 <th>Repository</th>
                 <th>Branch</th>
                 <th></th>
+              </tr>
             </thead>
             <tbody>
               <% courses.forEach(function(course, i) { %>
@@ -279,18 +261,6 @@
           Question render cache
         </div>
         <div class="card-body">
-          <div class="h4 mb-0">Cache hit rates</div>
-          <div class="small text-muted">For last 24 hours</div>
-          <div class="charts mt-2">
-            <div class="chart-container d-inline-flex flex-column align-items-center">
-              <canvas id="question-cache-hit-rate-chart"></canvas>
-              <span class="mt-2">Average hit rate per question<span>
-            </div><div class="chart-container d-inline-flex flex-column align-items-center">
-              <canvas id="panel-cache-hit-rate-chart"></canvas>
-              <span class="mt-2">Total panel hit rate</span>
-            </div>
-          </div>
-          <hr>
           <p>
             Each panel rendered for a question is cached by default.
             This button will invalidate all entries in the cache.
@@ -305,63 +275,8 @@
               <button id="cancel-invalidate-render-cache" type="button" class="btn btn-secondary">Cancel</button>
             </div>
           </form>
-          <script>
-          $(function() {
-            var invalidateButton = $('#invalidate-render-cache');
-            var confirmInvalidateContainer = $('#confirm-invalidate-cache-container');
-            var cancelInvalidateButton = $('#cancel-invalidate-render-cache');
-            invalidateButton.click(function() {
-              confirmInvalidateContainer.show();
-              invalidateButton.hide();
-            });
-            cancelInvalidateButton.click(function() {
-              invalidateButton.show();
-              confirmInvalidateContainer.hide();
-            });
-            var questionCacheHitRate = <%= question_render_cache_stats.question_cache_hit_rate ? question_render_cache_stats.question_cache_hit_rate : 0 %>;
-            var panelCacheHitRate = <%= question_render_cache_stats.panel_cache_hit_rate ? question_render_cache_stats.panel_cache_hit_rate : 0 %>;
-            // This draws the percentage in the middle of the pie
-            Chart.register({
-              id: 'draw-percentage',
-              beforeDraw: function(chart) {
-                var { width, height, ctx } = chart;
-                ctx.restore();
-                var fontSize = (height / 160).toFixed(2);
-                ctx.font = fontSize + "em sans-serif";
-                ctx.textBaseline = "middle";
-                var text = Number(chart.config.data.datasets[0].data[0]).toFixed(2) + '%',
-                textX = Math.round((width - ctx.measureText(text).width) / 2),
-                textY = height / 2;
-                ctx.fillText(text, textX, textY);
-                ctx.save();
-              }
-            });
-            function buildChart(ctx, hitRate) {
-              var roundedHitRate = Math.round(hitRate * 10000) / 100;
-              return new Chart(ctx, {
-                type: 'doughnut',
-                data: {
-                  datasets: [{
-                    data: [roundedHitRate, 100 - roundedHitRate],
-                    backgroundColor: ['green', 'red'],
-                  }],
-                  labels: ['Cache hit %', 'Cache miss %'],
-                },
-                options: {
-                  cutout: '70%',
-                  legend: {
-                    display: false,
-                  },
-                }
-              });
-            };
-            buildChart($("#question-cache-hit-rate-chart"), questionCacheHitRate);
-            buildChart($("#panel-cache-hit-rate-chart"), panelCacheHitRate);
-          });
-          </script>
         </div>
       </div>
-
     </div>
   </body>
 </html>

--- a/pages/administratorOverview/administratorOverview.sql
+++ b/pages/administratorOverview/administratorOverview.sql
@@ -88,17 +88,6 @@ select_config AS (
     FROM
         config AS c
 ),
-select_question_render_cache_stats AS (
-    SELECT
-        jsonb_build_object(
-            'question_cache_hit_rate', AVG(pvl.panel_render_cache_hit_count / pvl.panel_render_count),
-            'panel_cache_hit_rate', (CAST(SUM(pvl.panel_render_cache_hit_count) AS FLOAT) / SUM(pvl.panel_render_count))
-        ) AS question_render_cache_stats
-    FROM
-        page_view_logs AS pvl
-    WHERE
-        pvl.date > now() - interval '1 day'
-),
 select_institutions_with_authn_providers AS (
     SELECT
         i.*,
@@ -127,7 +116,6 @@ SELECT
     courses,
     networks,
     configs,
-    question_render_cache_stats,
     institutions
 FROM
     select_administrator_users,
@@ -135,7 +123,6 @@ FROM
     select_courses,
     select_networks,
     select_config,
-    select_question_render_cache_stats,
     select_institutions;
 
 -- BLOCK select_course

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1246,8 +1246,6 @@ module.exports = {
       };
       let allRenderedElementNames = [];
       const courseIssues = [];
-      let panelCount = 0,
-        cacheHitCount = 0;
       const context = await module.exports.getContext(question, course);
 
       return withCodeCaller(context.course_dir_host, async (codeCaller) => {
@@ -1260,7 +1258,6 @@ module.exports = {
               courseIssues: newCourseIssues,
               html,
               renderedElementNames,
-              cacheHit,
             } = await module.exports.renderPanelInstrumented(
               'question',
               codeCaller,
@@ -1274,8 +1271,6 @@ module.exports = {
 
             courseIssues.push(...newCourseIssues);
             htmls.questionHtml = html;
-            panelCount++;
-            if (cacheHit) cacheHitCount++;
             allRenderedElementNames = _.union(allRenderedElementNames, renderedElementNames);
           },
           async () => {
@@ -1286,7 +1281,6 @@ module.exports = {
                 courseIssues: newCourseIssues,
                 html,
                 renderedElementNames,
-                cacheHit,
               } = await module.exports.renderPanelInstrumented(
                 'submission',
                 codeCaller,
@@ -1299,8 +1293,6 @@ module.exports = {
               );
 
               courseIssues.push(...newCourseIssues);
-              panelCount++;
-              if (cacheHit) cacheHitCount++;
               allRenderedElementNames = _.union(allRenderedElementNames, renderedElementNames);
               return html;
             });
@@ -1328,9 +1320,6 @@ module.exports = {
             allRenderedElementNames = _.union(allRenderedElementNames, renderedElementNames);
           },
           async () => {
-            span.setAttribute('panel_count', panelCount);
-            span.setAttribute('cache_hit_count', cacheHitCount);
-
             const extensions = context.course_element_extensions;
             const dependencies = {
               coreStyles: [],

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1326,8 +1326,6 @@ module.exports = {
 
             courseIssues.push(...newCourseIssues);
             htmls.answerHtml = html;
-            panelCount++;
-            if (cacheHit) cacheHitCount++;
             allRenderedElementNames = _.union(allRenderedElementNames, renderedElementNames);
           },
           async () => {

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1236,7 +1236,7 @@ module.exports = {
     course_instance,
     locals
   ) {
-    return instrumented('freeform.render', async (span) => {
+    return instrumented('freeform.render', async () => {
       debug('render()');
       const htmls = {
         extraHeadersHtml: '',

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -1312,7 +1312,6 @@ module.exports = {
               courseIssues: newCourseIssues,
               html,
               renderedElementNames,
-              cacheHit,
             } = await module.exports.renderPanelInstrumented(
               'answer',
               codeCaller,
@@ -1329,11 +1328,6 @@ module.exports = {
             allRenderedElementNames = _.union(allRenderedElementNames, renderedElementNames);
           },
           async () => {
-            // The logPageView middleware knows to write this to the DB
-            // when we log the page view - sorry for mutable object hell
-            locals.panel_render_count = panelCount;
-            locals.panel_render_cache_hit_count = cacheHitCount;
-
             span.setAttribute('panel_count', panelCount);
             span.setAttribute('cache_hit_count', cacheHitCount);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,13 +2124,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kurkle/color@npm:^0.3.0":
-  version: 0.3.2
-  resolution: "@kurkle/color@npm:0.3.2"
-  checksum: 79e97b31f8f6efb28c69d373f94b0c7480226fe8ec95221f518ac998e156444a496727ce47de6d728eb5c3369288e794cba82cae34253deb0d472d3bfe080e49
-  languageName: node
-  linkType: hard
-
 "@manypkg/find-root@npm:^1.1.0":
   version: 1.1.0
   resolution: "@manypkg/find-root@npm:1.1.0"
@@ -3714,7 +3707,6 @@ __metadata:
     chai: ^4.3.7
     chai-as-promised: ^7.1.1
     chalk: ^4.1.2
-    chart.js: ^4.1.2
     cheerio: ^0.22.0
     chokidar: ^3.5.3
     clipboard: ^2.0.11
@@ -5109,15 +5101,6 @@ __metadata:
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
   checksum: 81dcadbe57e861d527faf6dd3855dc857395a1c4d6781f4847288ab23cffb7b3ee80d57c15bba7252ffe3e5e8019db767757ee7975663ad2ca0939bb8fcaf2e5
-  languageName: node
-  linkType: hard
-
-"chart.js@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chart.js@npm:4.1.2"
-  dependencies:
-    "@kurkle/color": ^0.3.0
-  checksum: 938ac88baf04eb8d784a8d89064696375bc12545421186f5ec9b69ba9b6f7b7da960754f351b59b1df2b1c314dfa848aab44267076888e664d5253bc6a4059dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
These stats are better tracked by Honeycomb and CloudWatch.

I've left the `panel_render_cache_hit_count` and `panel_render_count` columns in the DB so that we can safely deploy this. Once we've done that, I'll remove them: #6958