### PR TITLE
Drop columns for points and score in grading

### DIFF
--- a/database/tables/assessment_instances.pg
+++ b/database/tables/assessment_instances.pg
@@ -17,10 +17,8 @@ columns
     obj: jsonb
     open: boolean default true
     points: double precision default 0
-    points_in_grading: double precision default 0
     qids: jsonb
     score_perc: double precision default 0
-    score_perc_in_grading: double precision default 0
     tiid: text
     user_id: bigint
 

--- a/database/tables/assessment_score_logs.pg
+++ b/database/tables/assessment_score_logs.pg
@@ -5,9 +5,7 @@ columns
     id: bigint not null default nextval('assessment_score_logs_id_seq'::regclass)
     max_points: double precision
     points: double precision
-    points_in_grading: double precision
     score_perc: double precision
-    score_perc_in_grading: double precision
 
 indexes
     assessment_score_logs_pkey: PRIMARY KEY (id) USING btree (id)

--- a/database/tables/instance_questions.pg
+++ b/database/tables/instance_questions.pg
@@ -24,12 +24,10 @@ columns
     open: boolean default true
     order_by: integer default floor((random() * (1000000)::double precision))
     points: double precision default 0
-    points_in_grading: double precision default 0
     points_list: double precision[]
     points_list_original: double precision[]
     requires_manual_grading: boolean not null default false
     score_perc: double precision default 0
-    score_perc_in_grading: double precision default 0
     some_nonzero_submission: boolean
     some_perfect_submission: boolean
     some_submission: boolean

--- a/migrations/20230119091410_points_in_grading__drop.sql
+++ b/migrations/20230119091410_points_in_grading__drop.sql
@@ -1,0 +1,6 @@
+ALTER TABLE assessment_instances DROP COLUMN IF EXISTS points_in_grading;
+ALTER TABLE assessment_instances DROP COLUMN IF EXISTS score_perc_in_grading;
+ALTER TABLE assessment_score_logs DROP COLUMN IF EXISTS points_in_grading;
+ALTER TABLE assessment_score_logs DROP COLUMN IF EXISTS score_perc_in_grading;
+ALTER TABLE instance_questions DROP COLUMN IF EXISTS points_in_grading;
+ALTER TABLE instance_questions DROP COLUMN IF EXISTS score_perc_in_grading;


### PR DESCRIPTION
Resolves #5911. These columns are not used anywhere in the code, and #5909 removed all remaining instances of these columns being updated (they were not used before that point even).