### PR TITLE
Exclude all node_modules directories from Black formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ max-line-length = 88
 extend-ignore = ["E203", "W503"]
 
 [tool.black]
-exclude = '^\/tools\/.*\.py$|^\/exampleCourse\/.*\.py$|^\/testCourse\/.*\.py$|\/node_modules\/.*\.pyi?$'
+exclude = '^\/tools\/|^\/exampleCourse\/|^\/testCourse\/|\/node_modules\/$'
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ max-line-length = 88
 extend-ignore = ["E203", "W503"]
 
 [tool.black]
-exclude = '^\/tools\/.*\.py$|^\/exampleCourse\/.*\.py$|^\/testCourse\/.*\.py$|^\/node_modules\/.*\.pyi?$'
+exclude = '^\/tools\/.*\.py$|^\/exampleCourse\/.*\.py$|^\/testCourse\/.*\.py$|\/node_modules\/.*\.pyi?$'
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Running `make format` locally produced some false positive errors:

```
error: cannot format workspaces/xtermjs/src/node_modules/node-pty/deps/winpty/misc/DumpLines.py: Cannot parse: 5:10:     print i, "X" * 78
Python 2 support was removed in version 22.0.
error: cannot format workspaces/xtermjs/src/node_modules/node-pty/deps/winpty/ship/common_ship.py: Cannot parse: 23:22:                 print "+ rm -r " + path
Python 2 support was removed in version 22.0.
error: cannot format workspaces/xtermjs/src/node_modules/node-pty/deps/winpty/ship/ship.py: Cannot parse: 48:6: print "Determining Cygwin/MSYS2 DLL versions..."
Python 2 support was removed in version 22.0.

Oh no! 💥 💔 💥
118 files left unchanged, 3 files failed to reformat.
```

These don't show up in CI because we don't install the deps in `workspaces/xtermjs` there. Regardless, the new regex better matches our intentions (don't process anything inside a `node_modules` directory).

I also took the opportunity to improve the overall `exclude` regex. By only using a directory name instead of a trailing `.py` extension, Black can avoid descending into a lot of directories where nothing should *ever* be formatted. This reduced the duration of `make format-python` from 6 seconds to just 1.5 seconds on my machine.