### PR TITLE
feat: Customizable placeholder text for pl-symbolic-input and pl-big-o-input elements

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -588,20 +588,21 @@ def generate(data):
 
 #### Customizations
 
-| Attribute                    | Type                | Default  | Description                                                                                                                                                                                                       |
-| ---------------------------- | ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `answers-name`               | string              | —        | Variable name to store data in. If the correct answer `ans` is a `sympy` object, you should use `import prairielearn as pl` and `data["correct_answers"][answers-name] = pl.to_json(ans)`.                        |
-| `weight`                     | integer             | 1        | Weight to use when computing a weighted average score over elements.                                                                                                                                              |
-| `correct-answer`             | float               | special  | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.                                                                                                                                  |
-| `label`                      | text                | —        | A prefix to display before the input box (e.g., `label="$F =$"`).                                                                                                                                                 |
-| `display`                    | "block" or "inline" | "inline" | How to display the input field.                                                                                                                                                                                   |
-| `variables`                  | string              | —        | A comma-delimited list of symbols that can be used in the symbolic expression.                                                                                                                                    |
-| `allow-complex`              | boolean             | false    | Whether complex numbers (expressions with `i` or `j` as the imaginary unit) are allowed.                                                                                                                          |
-| `imaginary-unit-for-display` | string              | `i`      | The imaginary unit that is used for display. It must be either `i` or `j`. Again, this is _only_ for display. Both `i` and `j` can be used by the student in their submitted answer, when `allow-complex="true"`. |
-| `allow-blank`                | boolean             | false    | Whether or not an empty input box is allowed. By default, an empty input box will not be graded (invalid format).                                                                                                 |
-| `blank-value`                | string              | 0 (zero) | Expression to be used as an answer if the answer is left blank. Only applied if `allow-blank` is `true`. Must follow the same format as an expected user input (e.g., same variables, etc.).                      |
-| `size`                       | integer             | 35       | Size of the input box.                                                                                                                                                                                            |
-| `show-help-text`             | boolean             | true     | Show the question mark at the end of the input displaying required input parameters.                                                                                                                              |
+| Attribute                    | Type                | Default               | Description                                                                                                                                                                                                       |
+| ---------------------------- | ------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `answers-name`               | string              | —                     | Variable name to store data in. If the correct answer `ans` is a `sympy` object, you should use `import prairielearn as pl` and `data["correct_answers"][answers-name] = pl.to_json(ans)`.                        |
+| `weight`                     | integer             | 1                     | Weight to use when computing a weighted average score over elements.                                                                                                                                              |
+| `correct-answer`             | float               | special               | Correct answer for grading. Defaults to `data["correct_answers"][answers-name]`.                                                                                                                                  |
+| `label`                      | text                | —                     | A prefix to display before the input box (e.g., `label="$F =$"`).                                                                                                                                                 |
+| `display`                    | "block" or "inline" | "inline"              | How to display the input field.                                                                                                                                                                                   |
+| `variables`                  | string              | —                     | A comma-delimited list of symbols that can be used in the symbolic expression.                                                                                                                                    |
+| `allow-complex`              | boolean             | false                 | Whether complex numbers (expressions with `i` or `j` as the imaginary unit) are allowed.                                                                                                                          |
+| `imaginary-unit-for-display` | string              | `i`                   | The imaginary unit that is used for display. It must be either `i` or `j`. Again, this is _only_ for display. Both `i` and `j` can be used by the student in their submitted answer, when `allow-complex="true"`. |
+| `allow-blank`                | boolean             | false                 | Whether or not an empty input box is allowed. By default, an empty input box will not be graded (invalid format).                                                                                                 |
+| `blank-value`                | string              | 0 (zero)              | Expression to be used as an answer if the answer is left blank. Only applied if `allow-blank` is `true`. Must follow the same format as an expected user input (e.g., same variables, etc.).                      |
+| `size`                       | integer             | 35                    | Size of the input box.                                                                                                                                                                                            |
+| `show-help-text`             | boolean             | true                  | Show the question mark at the end of the input displaying required input parameters.                                                                                                                              |
+| `placeholder`                | string              | "symbolic expression" | Hint displayed inside the input box describing the expected type of input.                                                                                                                                        |
 
 #### Details
 
@@ -636,16 +637,17 @@ Gives automated feedback in the case of improper asymptotic input.
 
 #### Customizations
 
-| Attribute        | Type                                                  | Default  | Description                                                                          |
-| ---------------- | ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
-| `answers-name`   | string                                                | —        | Variable name to store data in.                                                      |
-| `type`           | "big-o", "theta", "omega", "little-o", "little-omega" | "big-o"  | Type of asymptotic answer required.                                                  |
-| `weight`         | integer                                               | 1        | Weight to use when computing a weighted average score over elements.                 |
-| `correct-answer` | string                                                | -        | Correct answer for grading.                                                          |
-| `display`        | "block" or "inline"                                   | "inline" | How to display the input field.                                                      |
-| `variable`       | string                                                | —        | A symbol for use in the symbolic expression. Only one variable supported.            |
-| `size`           | integer                                               | 35       | Size of the input box.                                                               |
-| `show-help-text` | boolean                                               | true     | Show the question mark at the end of the input displaying required input parameters. |
+| Attribute        | Type                                                  | Default                 | Description                                                                          |
+| ---------------- | ----------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
+| `answers-name`   | string                                                | —                       | Variable name to store data in.                                                      |
+| `type`           | "big-o", "theta", "omega", "little-o", "little-omega" | "big-o"                 | Type of asymptotic answer required.                                                  |
+| `weight`         | integer                                               | 1                       | Weight to use when computing a weighted average score over elements.                 |
+| `correct-answer` | string                                                | -                       | Correct answer for grading.                                                          |
+| `display`        | "block" or "inline"                                   | "inline"                | How to display the input field.                                                      |
+| `variable`       | string                                                | —                       | A symbol for use in the symbolic expression. Only one variable supported.            |
+| `size`           | integer                                               | 35                      | Size of the input box.                                                               |
+| `show-help-text` | boolean                                               | true                    | Show the question mark at the end of the input displaying required input parameters. |
+| `placeholder`    | string                                                | "asymptotic expression" | Hint displayed inside the input box describing the expected type of input.           |
 
 #### Details
 

--- a/elements/pl-big-o-input/pl-big-o-input.mustache
+++ b/elements/pl-big-o-input/pl-big-o-input.mustache
@@ -19,7 +19,7 @@
                 <span class="input-group-prepend">
                     <span class="input-group-text">${{type}}($</span>
                 </span>
-                <input name="{{name}}" type="text" autocomplete="off" class="form-control big-o-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{placeholder}}"{{/show_placeholder}} />
+                <input name="{{name}}" type="text" autocomplete="off" class="form-control big-o-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{placeholder}}"/>
                 <span class="input-group-append">
                     <span class="input-group-text">$)$</span>
                     {{#show_info}}

--- a/elements/pl-big-o-input/pl-big-o-input.mustache
+++ b/elements/pl-big-o-input/pl-big-o-input.mustache
@@ -19,7 +19,7 @@
                 <span class="input-group-prepend">
                     <span class="input-group-text">${{type}}($</span>
                 </span>
-                <input name="{{name}}" type="text" autocomplete="off" class="form-control big-o-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{shortinfo}}"{{/show_placeholder}} />
+                <input name="{{name}}" type="text" autocomplete="off" class="form-control big-o-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{placeholder}}"{{/show_placeholder}} />
                 <span class="input-group-append">
                     <span class="input-group-text">$)$</span>
                     {{#show_info}}

--- a/elements/pl-big-o-input/pl-big-o-input.py
+++ b/elements/pl-big-o-input/pl-big-o-input.py
@@ -35,7 +35,6 @@ GRADE_FUNCTION_DICT: Dict[BigOType, bou.BigOGradingFunctionT] = {
 
 VARIABLES_DEFAULT = ""
 SIZE_DEFAULT = 35
-PLACEHOLDER_TEXT_THRESHOLD = 20
 SHOW_HELP_TEXT_DEFAULT = True
 WEIGHT_DEFAULT = 1
 DISPLAY_DEFAULT = DisplayType.INLINE
@@ -133,7 +132,6 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             ),
             "uuid": pl.get_uuid(),
             display.value: True,
-            "show_placeholder": size >= PLACEHOLDER_TEXT_THRESHOLD,
             "placeholder": placeholder,
             "raw_submitted_answer": raw_submitted_answer,
             "type": bigo_type,

--- a/elements/pl-big-o-input/pl-big-o-input.py
+++ b/elements/pl-big-o-input/pl-big-o-input.py
@@ -40,6 +40,8 @@ SHOW_HELP_TEXT_DEFAULT = True
 WEIGHT_DEFAULT = 1
 DISPLAY_DEFAULT = DisplayType.INLINE
 BIG_O_TYPE_DEFAULT = BigOType.BIG_O
+PLACEHOLDER_DEFAULT = "asymptotic expression"
+BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME = "pl-big-o-input.mustache"
 
 
 def prepare(element_html: str, data: pl.QuestionData) -> None:
@@ -53,6 +55,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
         "display",
         "show-help-text",
         "type",
+        "placeholder",
     ]
     pl.check_attribs(element, required_attribs, optional_attribs)
 
@@ -90,6 +93,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     size = pl.get_integer_attrib(element, "size", SIZE_DEFAULT)
 
     bigo_type = pl.get_enum_attrib(element, "type", BigOType, BIG_O_TYPE_DEFAULT).value
+    placeholder = pl.get_string_attrib(element, "placeholder", PLACEHOLDER_DEFAULT)
 
     constants_class = phs._Constants()
 
@@ -112,7 +116,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         editable = data["editable"]
         raw_submitted_answer = data["raw_submitted_answers"].get(name)
 
-        with open("pl-big-o-input.mustache", "r", encoding="utf-8") as f:
+        with open(BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             info = chevron.render(f, info_params).strip()
 
         if raw_submitted_answer is not None:
@@ -130,6 +134,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             "uuid": pl.get_uuid(),
             display.value: True,
             "show_placeholder": size >= PLACEHOLDER_TEXT_THRESHOLD,
+            "placeholder": placeholder,
             "raw_submitted_answer": raw_submitted_answer,
             "type": bigo_type,
         }
@@ -138,7 +143,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             score_type, score_value = pl.determine_score_params(score)
             html_params[score_type] = score_value
 
-        with open("pl-big-o-input.mustache", "r", encoding="utf-8") as f:
+        with open(BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             return chevron.render(f, html_params).strip()
 
     elif data["panel"] == "submission":
@@ -160,13 +165,15 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         else:
 
             # Use the existing format text in the invalid popup.
-            with open("pl-big-o-input.mustache", "r", encoding="utf-8") as f:
+            with open(BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
                 info = chevron.render(f, info_params).strip()
 
             # Render invalid popup
             raw_submitted_answer = data["raw_submitted_answers"].get(name)
             if isinstance(parse_error, str):
-                with open("pl-big-o-input.mustache", "r", encoding="utf-8") as f:
+                with open(
+                    BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8"
+                ) as f:
                     parse_error += chevron.render(
                         f, {"format_error": True, "format_string": info}
                     ).strip()
@@ -189,7 +196,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             score_type, score_value = pl.determine_score_params(score)
             html_params[score_type] = score_value
 
-        with open("pl-big-o-input.mustache", "r", encoding="utf-8") as f:
+        with open(BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             return chevron.render(f, html_params).strip()
 
     # Display the correct answer.
@@ -205,7 +212,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             "a_tru": sympy.latex(a_tru),
             "type": bigo_type,
         }
-        with open("pl-big-o-input.mustache", "r", encoding="utf-8") as f:
+        with open(BIG_O_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             return chevron.render(f, html_params).strip()
 
     assert_never(data["panel"])

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -16,7 +16,7 @@
             <span class="input-group-text">{{{label}}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" autocomplete="off" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{placeholder}}"{{/show_placeholder}} />
+        <input name="{{name}}" type="text" autocomplete="off" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{placeholder}}"/>
         <span class="input-group-append">
 
             {{#show_info}}

--- a/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -16,7 +16,7 @@
             <span class="input-group-text">{{{label}}}</span>
         </span>
         {{/label}}
-        <input name="{{name}}" type="text" autocomplete="off" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{shortinfo}}"{{/show_placeholder}} />
+        <input name="{{name}}" type="text" autocomplete="off" class="form-control pl-symbolic-input-input {{^show_info}}rounded-right{{/show_info}}" size="{{size}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} {{#show_placeholder}}placeholder="{{placeholder}}"{{/show_placeholder}} />
         <span class="input-group-append">
 
             {{#show_info}}
@@ -115,10 +115,6 @@ ${{a_tru}}$
 
 <p>Note that either <code class="user-output">^</code> or <code class="user-output">**</code> can be used for exponentiation.</p>
 {{/format}}
-
-{{#shortformat}}
-symbolic expression
-{{/shortformat}}
 
 {{#format_error}}
     <hr>

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -28,6 +28,8 @@ SHOW_HELP_TEXT_DEFAULT = True
 PLACEHOLDER_TEXT_THRESHOLD = 15  # Minimum size to show the placeholder text
 ALLOW_BLANK_DEFAULT = False
 BLANK_VALUE_DEFAULT = "0"
+PLACEHOLDER_DEFAULT = "symbolic expression"
+SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME = "pl-symbolic-input.mustache"
 
 
 def prepare(element_html: str, data: pl.QuestionData) -> None:
@@ -45,6 +47,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
         "show-help-text",
         "allow-blank",
         "blank-value",
+        "placeholder",
     ]
     pl.check_attribs(element, required_attribs, optional_attribs)
     name = pl.get_string_attrib(element, "answers-name")
@@ -78,6 +81,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         element, "imaginary-unit-for-display", IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT
     )
     size = pl.get_integer_attrib(element, "size", SIZE_DEFAULT)
+    placeholder = pl.get_string_attrib(element, "placeholder", PLACEHOLDER_DEFAULT)
 
     constants_class = phs._Constants()
     operators = ["( )", "+", "-", "*", "/", "^", "**"]
@@ -98,12 +102,8 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             "constants": constants,
             "allow_complex": allow_complex,
         }
-        with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
+        with open(SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             info = chevron.render(f, info_params).strip()
-        with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
-            info_params.pop("format", None)
-            info_params["shortformat"] = True
-            shortinfo = chevron.render(f, info_params).strip()
 
         html_params = {
             "question": True,
@@ -111,7 +111,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             "label": label,
             "editable": editable,
             "info": info,
-            "shortinfo": shortinfo,
+            "placeholder": placeholder,
             "size": size,
             "show_info": pl.get_boolean_attrib(
                 element, "show-help-text", SHOW_HELP_TEXT_DEFAULT
@@ -132,7 +132,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         if raw_submitted_answer is not None:
             html_params["raw_submitted_answer"] = escape(raw_submitted_answer)
 
-        with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
+        with open(SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             return chevron.render(f, html_params).strip()
 
     elif data["panel"] == "submission":
@@ -168,12 +168,16 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 "constants": constants,
                 "allow_complex": allow_complex,
             }
-            with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
+            with open(
+                SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8"
+            ) as f:
                 info = chevron.render(f, info_params).strip()
 
             # Render invalid popup
             raw_submitted_answer = data["raw_submitted_answers"].get(name, None)
-            with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
+            with open(
+                SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8"
+            ) as f:
                 parse_error += chevron.render(
                     f, {"format_error": True, "format_string": info}
                 ).strip()
@@ -196,7 +200,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             "missing_input", False
         )
 
-        with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
+        with open(SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8") as f:
             return chevron.render(f, html_params).strip()
 
     elif data["panel"] == "answer":
@@ -211,7 +215,9 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 a_tru = phs.json_to_sympy(a_tru, allow_complex=allow_complex)
             a_tru = a_tru.subs(sympy.I, sympy.Symbol(imaginary_unit))
             html_params = {"answer": True, "label": label, "a_tru": sympy.latex(a_tru)}
-            with open("pl-symbolic-input.mustache", "r", encoding="utf-8") as f:
+            with open(
+                SYMBOLIC_INPUT_MUSTACHE_TEMPLATE_NAME, "r", encoding="utf-8"
+            ) as f:
                 return chevron.render(f, html_params).strip()
         else:
             return ""

--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -25,7 +25,6 @@ ALLOW_COMPLEX_DEFAULT = False
 IMAGINARY_UNIT_FOR_DISPLAY_DEFAULT = "i"
 SIZE_DEFAULT = 35
 SHOW_HELP_TEXT_DEFAULT = True
-PLACEHOLDER_TEXT_THRESHOLD = 15  # Minimum size to show the placeholder text
 ALLOW_BLANK_DEFAULT = False
 BLANK_VALUE_DEFAULT = "0"
 PLACEHOLDER_DEFAULT = "symbolic expression"
@@ -118,7 +117,6 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             ),
             "uuid": pl.get_uuid(),
             "allow_complex": allow_complex,
-            "show_placeholder": size >= PLACEHOLDER_TEXT_THRESHOLD,
         }
 
         score = data["partial_scores"].get(name, {"score": None}).get("score", None)

--- a/exampleCourse/courseInstances/SectionA/assessments/gallery/elements/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/gallery/elements/infoAssessment.json
@@ -15,6 +15,7 @@
                 {"id": "element/orderBlocks",              "points": 2, "maxPoints": 10},
                 {"id": "element/integerInput",             "points": 2, "maxPoints": 10},
                 {"id": "element/symbolicInput",            "points": 2, "maxPoints": 10},
+                {"id": "element/bigOInput",                "points": 2, "maxPoints": 10},
                 {"id": "element/stringInput",              "points": 2, "maxPoints": 10},
                 {"id": "element/matching",                 "points": 2, "maxPoints": 10},
                 {"id": "element/matrixComponentInput",     "points": 2, "maxPoints": 10},
@@ -31,6 +32,7 @@
             "questions": [
                 {"id": "element/code",                     "points": 2, "maxPoints": 10},
                 {"id": "element/pythonVariable",           "points": 2, "maxPoints": 10},
+                {"id": "element/dataframe",                "points": 2, "maxPoints": 10},
                 {"id": "element/figure",                   "points": 2, "maxPoints": 10},
                 {"id": "element/fileDownload",             "points": 2, "maxPoints": 10},
                 {"id": "element/variableOutput",           "points": 2, "maxPoints": 10},

--- a/exampleCourse/questions/element/bigOInput/question.html
+++ b/exampleCourse/questions/element/bigOInput/question.html
@@ -26,15 +26,20 @@
         <pl-question-panel>
             <p>Submit $O(\log m)$.</p>
         </pl-question-panel>
-        <pl-big-o-input answers-name="q2" variable="m" correct-answer="log(m)"></pl-big-o-input>
+        <pl-big-o-input answers-name="q2" variable="m" correct-answer="log(m)"
+            placeholder="expression in terms of m"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="s2" variable="m" correct-answer="log(m)" type="theta"></pl-big-o-input>
+        <pl-big-o-input answers-name="s2" variable="m" correct-answer="log(m)" type="theta"
+            placeholder="expression in terms of m"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="t2" variable="m" correct-answer="log(m)" type="omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="t2" variable="m" correct-answer="log(m)" type="omega"
+            placeholder="expression in terms of m"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="r2" variable="m" correct-answer="log(m)" type="little-o"></pl-big-o-input>
+        <pl-big-o-input answers-name="r2" variable="m" correct-answer="log(m)" type="little-o"
+            placeholder="expression in terms of m"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="m2" variable="m" correct-answer="log(m)" type="little-omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="m2" variable="m" correct-answer="log(m)" type="little-omega"
+            placeholder="expression in terms of m"></pl-big-o-input>
     </div>
 </div>
 
@@ -72,9 +77,11 @@
         <br><br>
         <pl-big-o-input answers-name="t4" variable="n" correct-answer="n * (log(n)**2)" type="omega"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="r4" variable="n" correct-answer="n * (log(n)**2)" type="little-o"></pl-big-o-input>
+        <pl-big-o-input answers-name="r4" variable="n" correct-answer="n * (log(n)**2)"
+            type="little-o"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="m4" variable="n" correct-answer="n * (log(n)**2)" type="little-omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="m4" variable="n" correct-answer="n * (log(n)**2)"
+            type="little-omega"></pl-big-o-input>
     </div>
 </div>
 
@@ -134,6 +141,7 @@
         <br><br>
         <pl-big-o-input answers-name="r7" variable="n" correct-answer="factorial(n)" type="little-o"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="m7" variable="n" correct-answer="factorial(n)" type="little-omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="m7" variable="n" correct-answer="factorial(n)"
+            type="little-omega"></pl-big-o-input>
     </div>
 </div>

--- a/exampleCourse/questions/element/bigOInput/question.html
+++ b/exampleCourse/questions/element/bigOInput/question.html
@@ -1,6 +1,6 @@
 <div class="card my-2">
     <div class="card-header">
-        An example with constant complextiy.
+        An example with constant complexity.
     </div>
     <div class="card-body">
         <pl-question-panel>
@@ -20,11 +20,12 @@
 
 <div class="card my-2">
     <div class="card-header">
-        An example with logarithmic complextiy. Uses $m$ as the input variable.
+        An example with logarithmic complexity. Uses $m$ as the input variable.
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Submit $O(\log m)$.</p>
+            <p>Submit $O(\log m)$. We've set <code>placeholder="expression in terms of m"</code> to change the
+                placeholder text.</p>
         </pl-question-panel>
         <pl-big-o-input answers-name="q2" variable="m" correct-answer="log(m)"
             placeholder="expression in terms of m"></pl-big-o-input>
@@ -45,69 +46,80 @@
 
 <div class="card my-2">
     <div class="card-header">
-        An example with linear complextiy.
+        An example with linear complexity.
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Submit $O(n)$.</p>
+            <p>Submit $O(n)$. Here, we've set <code>display="block"</code> to widen the input box.</p>
         </pl-question-panel>
-        <pl-big-o-input answers-name="q3" variable="n" correct-answer="n"></pl-big-o-input>
+        <pl-big-o-input answers-name="q3" variable="n" correct-answer="n" display="block"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="s3" variable="n" correct-answer="n" type="theta"></pl-big-o-input>
+        <pl-big-o-input answers-name="s3" variable="n" correct-answer="n" type="theta" display="block"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="t3" variable="n" correct-answer="n" type="omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="t3" variable="n" correct-answer="n" type="omega" display="block"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="r3" variable="n" correct-answer="n" type="little-o"></pl-big-o-input>
+        <pl-big-o-input answers-name="r3" variable="n" correct-answer="n" type="little-o"
+            display="block"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="m3" variable="n" correct-answer="n" type="little-omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="m3" variable="n" correct-answer="n" type="little-omega"
+            display="block"></pl-big-o-input>
     </div>
 </div>
 
 <div class="card my-2">
     <div class="card-header">
-        An example with nearly linear complextiy.
+        An example with nearly linear complexity.
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Submit $O(n \log^2 n)$.</p>
+            <p>Submit $O(n \log^2 n)$. Here, we've set <code>size="5"</code> to shrink the input box and
+                <code>placeholder=""</code> to hide the placeholder text.
+            </p>
         </pl-question-panel>
-        <pl-big-o-input answers-name="q4" variable="n" correct-answer="n * (log(n)**2)"></pl-big-o-input>
+        <pl-big-o-input answers-name="q4" variable="n" correct-answer="n * (log(n)**2)" size="5"
+            placeholder=""></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="s4" variable="n" correct-answer="n * (log(n)**2)" type="theta"></pl-big-o-input>
+        <pl-big-o-input answers-name="s4" variable="n" correct-answer="n * (log(n)**2)" type="theta" size="5"
+            placeholder=""></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="t4" variable="n" correct-answer="n * (log(n)**2)" type="omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="t4" variable="n" correct-answer="n * (log(n)**2)" type="omega" size="5"
+            placeholder=""></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="r4" variable="n" correct-answer="n * (log(n)**2)"
-            type="little-o"></pl-big-o-input>
+        <pl-big-o-input answers-name="r4" variable="n" correct-answer="n * (log(n)**2)" type="little-o" size="5"
+            placeholder=""></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="m4" variable="n" correct-answer="n * (log(n)**2)"
-            type="little-omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="m4" variable="n" correct-answer="n * (log(n)**2)" type="little-omega" size="5"
+            placeholder=""></pl-big-o-input>
     </div>
 </div>
 
 <div class="card my-2">
     <div class="card-header">
-        An example with polynomial complextiy.
+        An example with polynomial complexity.
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Submit $O(n^2)$.</p>
+            <p>Submit $O(n^2)$. Here we've set <code>show-help-text="false"</code> to hide the help popup.</p>
         </pl-question-panel>
-        <pl-big-o-input answers-name="q5" variable="n" correct-answer="n**2"></pl-big-o-input>
+        <pl-big-o-input answers-name="q5" variable="n" correct-answer="n**2" show-help-text="false"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="s5" variable="n" correct-answer="n**2" type="theta"></pl-big-o-input>
+        <pl-big-o-input answers-name="s5" variable="n" correct-answer="n**2" type="theta"
+            show-help-text="false"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="t5" variable="n" correct-answer="n**2" type="omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="t5" variable="n" correct-answer="n**2" type="omega"
+            show-help-text="false"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="r5" variable="n" correct-answer="n**2" type="little-o"></pl-big-o-input>
+        <pl-big-o-input answers-name="r5" variable="n" correct-answer="n**2" type="little-o"
+            show-help-text="false"></pl-big-o-input>
         <br><br>
-        <pl-big-o-input answers-name="m5" variable="n" correct-answer="n**2" type="little-omega"></pl-big-o-input>
+        <pl-big-o-input answers-name="m5" variable="n" correct-answer="n**2" type="little-omega"
+            show-help-text="false"></pl-big-o-input>
     </div>
 </div>
 
 <div class="card my-2">
     <div class="card-header">
-        An example with exponential complextiy.
+        An example with exponential complexity.
     </div>
     <div class="card-body">
         <pl-question-panel>
@@ -127,7 +139,7 @@
 
 <div class="card my-2">
     <div class="card-header">
-        An example with factorial complextiy.
+        An example with factorial complexity.
     </div>
     <div class="card-body">
         <pl-question-panel>

--- a/exampleCourse/questions/element/symbolicInput/question.html
+++ b/exampleCourse/questions/element/symbolicInput/question.html
@@ -16,7 +16,8 @@
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Write an expression for the complex number $z$ whose argument is $a$ (in radians) and whose modulus is $m$.</p>
+            <p>Write an expression for the complex number $z$ whose argument is $a$ (in radians) and whose modulus is
+                $m$.</p>
         </pl-question-panel>
         <pl-symbolic-input answers-name="z" variables="a, m" allow-complex="true" label="$z=$"></pl-symbolic-input>
     </div>
@@ -28,7 +29,8 @@
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Write an expression for the current $I$ in a resistor if the voltage is $V$ and the resistance is $R$.</p>
+            <p>Write an expression for the current $I$ in a resistor if the voltage is $V$ and the resistance is $R$.
+            </p>
         </pl-question-panel>
         <pl-symbolic-input answers-name="I" variables="V, R" label="$I=$"></pl-symbolic-input>
     </div>
@@ -36,13 +38,16 @@
 
 <div class="card my-2">
     <div class="card-header">
-        An example in which we specify a different imaginary unit for display (<code>imaginary-unit-for-display="j"</code>)
+        An example in which we specify a different imaginary unit for display
+        (<code>imaginary-unit-for-display="j"</code>)
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>Write an expression for the complex number $c$ whose real part is $a$ and whose imaginary part is $b$.</p>
+            <p>Write an expression for the complex number $c$ whose real part is $a$ and whose imaginary part is $b$.
+            </p>
         </pl-question-panel>
-        <pl-symbolic-input answers-name="c" variables="a, b" allow-complex="true" imaginary-unit-for-display="j" label="$c=$"></pl-symbolic-input>
+        <pl-symbolic-input answers-name="c" variables="a, b" allow-complex="true" imaginary-unit-for-display="j"
+            label="$c=$"></pl-symbolic-input>
     </div>
 </div>
 
@@ -52,10 +57,14 @@
     </div>
     <div class="card-body">
         <pl-question-panel>
-            <p>The size of the input box can be set with the attribute <code>size</code>, and the attribute <code>show-help-text="false"</code> removes the button for the help popup.  This box below has <code>size=5</code> instead of the default <code>size=35</code>.</p>
+            <p>The size of the input box can be set with the attribute <code>size</code>, and the attribute
+                <code>show-help-text="false"</code> removes the button for the help popup. This box below has
+                <code>size=5</code> instead of the default <code>size=35</code>.
+            </p>
             <p>Write an expression for the first derivative of $\frac{1}{2} x^2$.</p>
         </pl-question-panel>
-        <pl-symbolic-input answers-name="dx" variables="x" size="5" show-help-text="false" label="$\dfrac{d}{dx} \frac{1}{2}x^2 =$"></pl-symbolic-input>
+        <pl-symbolic-input answers-name="dx" variables="x" size="5" show-help-text="false"
+            label="$\dfrac{d}{dx} \frac{1}{2}x^2 =$"></pl-symbolic-input>
     </div>
 </div>
 
@@ -64,10 +73,14 @@
         An example in which we allow a blank answer.
     </div>
     <div class="card-body">
-      <pl-question-panel>
-        <p>The <code>allow-blank</code> attribute allows an expression to be left blank by the user and still be considered valid. By default a blank expression is equivalent to the expression <code>0</code>, unless the <code>blank-value</code> is used.</p>
-        <p>Simplify the expression $x^2+x+1$, or leave it blank if the expression cannot be simplified further.</p>
-      </pl-question-panel>
-      <pl-symbolic-input answers-name="simplify" variables="x" allow-blank="true" blank-value="x^2+x+1"></pl-symbolic-input>
+        <pl-question-panel>
+            <p>The <code>allow-blank</code> attribute allows an expression to be left blank by the user and still be
+                considered valid. By default a blank expression is equivalent to the expression <code>0</code>, unless
+                the <code>blank-value</code> is used. The <code>placeholder</code> attribute allows setting custom
+                placeholder text.</p>
+            <p>Simplify the expression $x^2+x+1$, or leave it blank if the expression cannot be simplified further.</p>
+        </pl-question-panel>
+        <pl-symbolic-input answers-name="simplify" variables="x" allow-blank="true" blank-value="x^2+x+1"
+            placeholder="symbolic expression (blank is allowed)"></pl-symbolic-input>
     </div>
 </div>

--- a/exampleCourse/questions/element/symbolicInput/question.html
+++ b/exampleCourse/questions/element/symbolicInput/question.html
@@ -58,12 +58,13 @@
     <div class="card-body">
         <pl-question-panel>
             <p>The size of the input box can be set with the attribute <code>size</code>, and the attribute
-                <code>show-help-text="false"</code> removes the button for the help popup. This box below has
+                <code>show-help-text="false"</code> removes the button for the help popup.
+                The attribute <code>placeholder</code> can be used to set the placeholder text. This box below has
                 <code>size=5</code> instead of the default <code>size=35</code>.
             </p>
             <p>Write an expression for the first derivative of $\frac{1}{2} x^2$.</p>
         </pl-question-panel>
-        <pl-symbolic-input answers-name="dx" variables="x" size="5" show-help-text="false"
+        <pl-symbolic-input answers-name="dx" variables="x" size="5" show-help-text="false" placeholder=""
             label="$\dfrac{d}{dx} \frac{1}{2}x^2 =$"></pl-symbolic-input>
     </div>
 </div>


### PR DESCRIPTION
See title, in relation to https://github.com/PrairieLearn/PrairieLearn/issues/6968. Also cleans up mustache templates and adds a variable to reduce duplication of string literal name of the mustache template.