### PR TITLE
Add `pl-card` element

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -65,6 +65,7 @@ images, files, and code display. The following **decorative** elements are avail
 - [`pl-overlay`](#pl-overlay-element): Allows layering existing elements on top of one another in specified positions.
 - [`pl-external-grader-variables`](#pl-external-grader-variables-element): Displays expected and given variables for externally graded questions.
 - [`pl-xss-safe`](#pl-xss-safe-element): Removes potentially unsafe code from HTML code.
+* [`pl-card`](#pl-card): Displays content within a card container.
 
 **Conditional** elements are meant to improve the feedback and question structure.
 These elements conditionally render their content depending on the question state.
@@ -1889,6 +1890,39 @@ Note that only one of the attributes `source-file-name`, `submitted-file-name` o
 #### See also
 
 - [`pl-file-editor` to provide an in-browser code environment](#pl-file-editor-element)
+
+### `pl-card` element
+
+Displays question content inside a card component. Optionally displays content in a header, footer, or image caps via tag attributes.
+
+#### Sample element
+
+```html
+<pl-card header="Header" title="Title" width="50%" img-bottom-src="https://picsum.photos/536/354">
+  <pl-question-panel>
+    This card is 50% width and has a bottom image cap.
+  </pl-question-panel>
+</pl-card>
+```
+
+#### Customizations
+
+| Attribute             | Type   | Default | Description                             |
+| --------------------- | ------ | ------- | --------------------------------------- |
+| `header`              | string | -       | Contents of the card header             |
+| `title`               | string | -       | Contents of the card title              |
+| `subtitle`            | string | -       | Contents of the card subtitle           |
+| `contents`            | string | -       | Raw contents of the card body           |
+| `footer`              | string | -       | Contents of the card footer             |
+| `img-top-src`         | string | -       | Source URL for the top image cap        |
+| `img-bottom-src`      | string | -       | Source URL for the bottom image cap     |
+| `width`               | string | auto    | Width of the card (25%, 50%, 75%, auto) |
+
+These `pl-card` attributes mirror the options of [Bootstrap 4 cards](https://getbootstrap.com/docs/4.6/components/card/).
+
+#### Example implementations
+
+- [element/card]
 
 ---
 

--- a/elements/pl-card/info.json
+++ b/elements/pl-card/info.json
@@ -1,0 +1,3 @@
+{
+    "controller": "pl-card.py"
+}

--- a/elements/pl-card/pl-card.mustache
+++ b/elements/pl-card/pl-card.mustache
@@ -1,0 +1,31 @@
+<div class="card w-{{width}} my-4">
+  {{#img-top-src}}
+  <img src="{{img-top-src}}" class="card-img-top">
+  {{/img-top-src}}
+  {{#header}}
+  <div class="card-header">
+    {{header}}
+  </div>
+  {{/header}}
+  <div class="card-body">
+    {{#title}}
+    <p class="h5 card-title">
+      {{title}}
+    </p>
+    {{/title}}
+    {{#subtitle}}
+    <p class="h6 card-subtitle mb-2 text-muted">{{subtitle}}</h6>
+    {{/subtitle}}
+    <div class="card-text">
+      {{{content}}}
+    </div>
+  </div>
+  {{#img-bottom-src}}
+  <img src="{{img-bottom-src}}" class="card-img-bottom">
+  {{/img-bottom-src}}
+  {{#footer}}
+  <div class="card-footer">
+    {{footer}}
+  </div>
+  {{/footer}}
+</div>

--- a/elements/pl-card/pl-card.py
+++ b/elements/pl-card/pl-card.py
@@ -1,0 +1,56 @@
+import chevron
+import lxml.html
+import prairielearn as pl
+
+
+HEADER_DEFAULT = ""
+TITLE_DEFAULT = ""
+SUBTITLE_DEFAULT = ""
+FOOTER_DEFAULT = ""
+IMG_TOP_SRC_DEFAULT = ""
+IMG_BOTTOM_SRC_DEFAULT = ""
+WIDTH_DEFAULT = "auto"
+
+
+def prepare(element_html: str, data: pl.QuestionData) -> None:
+    element = lxml.html.fragment_fromstring(element_html)
+    required_attribs = []
+    optional_attribs = [
+        "header",
+        "title",
+        "subtitle",
+        "footer",
+        "img-top-src",
+        "img-bottom-src",
+        "width",
+    ]
+    pl.check_attribs(element, required_attribs, optional_attribs)
+
+
+def render(element_html: str, data: pl.QuestionData) -> str:
+    element = lxml.html.fragment_fromstring(element_html)
+
+    header = pl.get_string_attrib(element, "header", HEADER_DEFAULT)
+    title = pl.get_string_attrib(element, "title", TITLE_DEFAULT)
+    subtitle = pl.get_string_attrib(element, "subtitle", SUBTITLE_DEFAULT)
+    footer = pl.get_string_attrib(element, "footer", FOOTER_DEFAULT)
+    img_top_src = pl.get_string_attrib(element, "img-top-src", IMG_TOP_SRC_DEFAULT)
+    img_bottom_src = pl.get_string_attrib(element, "img-bottom-src", IMG_BOTTOM_SRC_DEFAULT)
+    width = pl.get_string_attrib(element, "width", WIDTH_DEFAULT)
+
+    content = pl.inner_html(element)
+
+    html_params = {
+        "header": header,
+        "title": lambda x, render: render(x, {"title": title}),
+        "subtitle": subtitle,
+        "footer": footer,
+        "img-top-src": img_top_src,
+        "img-bottom-src": img_bottom_src,
+        "width": width.strip("%"),
+        "content": content,
+    }
+    with open("pl-card.mustache", "r", encoding="utf-8") as f:
+        html = chevron.render(f, html_params).strip()
+
+    return html

--- a/exampleCourse/questions/element/card/info.json
+++ b/exampleCourse/questions/element/card/info.json
@@ -1,0 +1,10 @@
+{
+    "uuid": "9a20c3a0-2f08-4efc-a4f5-4e1cdc2026b4",
+    "title": "Element pl-card: Display content within card component",
+    "topic": "Element",
+    "tags": [
+        "tyang15",
+        "balamut2"
+    ],
+    "type": "v3"
+}

--- a/exampleCourse/questions/element/card/question.html
+++ b/exampleCourse/questions/element/card/question.html
@@ -1,0 +1,17 @@
+<pl-card header="Header" title="Title" subtitle="Subtitle" footer="Footer">
+  <pl-question-panel>
+    This is a full-width card with all options except for image caps.
+  </pl-question-panel>
+</pl-card>
+
+<pl-card header="Header" title="Title" img-bottom-src="https://via.placeholder.com/720x480" width="50%">
+  <pl-question-panel>
+    This is a 50%-width card with a header and a bottom image cap.
+  </pl-question-panel>
+</pl-card>
+
+<pl-card img-top-src="https://via.placeholder.com/1920x1080" title="Title" footer="Footer" width="75%">
+  <pl-question-panel>
+    This is a 75%-width card with a top image cap and a footer.
+  </pl-question-panel>
+</pl-card>


### PR DESCRIPTION
Adds a `pl-card` element with tag attributes that map to Bootstrap 4 card classes, e.g.:

```
<pl-card header="Header" title="Title" subtitle="Subtitle" footer="Footer">
  <pl-question-panel>
    This is a full-width card with all options except for image caps.
  </pl-question-panel>
</pl-card>

<pl-card title="Title" subtitle="Subtitle" img-top-src="https://via.placeholder.com/720x480" width="50%">
  <pl-question-panel>
    This is a 50%-width card with a title and a top image cap.
  </pl-question-panel>
</pl-card>
```

<a href="https://user-images.githubusercontent.com/2503508/213844950-e717e495-2678-4e0c-b703-e5e6b6e6fa3c.png"><img src="https://user-images.githubusercontent.com/2503508/213844950-e717e495-2678-4e0c-b703-e5e6b6e6fa3c.png" width="450"><a>

resolves #6971
cc @coatless 