### PR TITLE
Add binary attribute to .yarn files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,6 @@
 
 # Treat all files inside .yarn/ as binary files. This ensures they do
 # not make a mess in results for git grep or git diff. See
-# https://stackoverflow.com/a/51564689
-.yarn/**/* binary
+# https://stackoverflow.com/a/51564689 and
+# https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+.yarn/** binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 * text=auto
 
 *.sh text eol=lf
+
+# Treat all files inside .yarn/ as binary files. This ensures they do
+# not make a mess in results for git grep or git diff. See
+# https://stackoverflow.com/a/51564689
+.yarn/**/* binary


### PR DESCRIPTION
This is to ensure files in `.yarn` are not included in results of `git grep` or `git diff`.