### PR TITLE
Don't duplicate file contents in pl-file-preview HTML

### DIFF
--- a/elements/pl-file-preview/pl-file-preview.mustache
+++ b/elements/pl-file-preview/pl-file-preview.mustache
@@ -8,7 +8,7 @@
       {{#has_files}}
       <ul class="list-group list-group-flush">
         {{#files}}
-        <li class="list-group-item" data-file="{{name}}" data-contents="{{contentsb64}}" data-decode-error="{{decode_error}}">
+        <li class="list-group-item" data-name="{{name}}" data-contents="{{contentsb64}}" data-decode-error="{{decode_error}}">
           <div class="file-status-container has-preview collapsed" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}">
             <div class="file-status-container-left">
               <i class="file-status-icon fa fa-check-circle" style="color: #4CAF50;" aria-hidden="true"></i>
@@ -16,14 +16,10 @@
               <p class="file-status">uploaded</p>
             </div>
             <div class="file-status-container-right">
-              <a
-                download="{{name}}"
-                class="btn btn-outline-secondary btn-sm file-preview-download"
-                onclick="event.stopPropagation();"
-              >
+              <button type="button" class="btn btn-outline-secondary btn-sm file-preview-download" disabled>
                 Download
-              </a>
-              <button type="button" class="btn btn-outline-secondary btn-sm file-preview-button" aria-expanded="false" aria-controls="file-preview-contents-{{uuid}}-{{index}}">
+              </button>
+              <button type="button" class="btn btn-outline-secondary btn-sm file-preview-button" aria-expanded="false" aria-controls="file-preview-contents-{{uuid}}-{{index}}" disabled>
                 <i class="file-preview-icon fa fa-angle-down"></i>
               </button>
             </div>
@@ -47,18 +43,31 @@
 <script>
 $(() => {
   function decodeBase64(str) {
-    return decodeURIComponent(Array.prototype.map.call(atob(str), c => {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), (c) => {
       return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
     }).join(''));
   }
 
+  function downloadFile(name, contents) {
+    const aElement = document.createElement('a');
+    aElement.setAttribute('href', 'data:application/octet-stream;base64,' + contents);
+    aElement.setAttribute('download', name);
+    aElement.setAttribute('target', '_blank');
+    aElement.click();
+  }
+
   document.querySelectorAll('#file-preview-{{uuid}}').forEach((el) => {
     el.querySelectorAll('.list-group-item').forEach((li) => {
+      const name = li.getAttribute('data-name');
       const contents = li.getAttribute('data-contents')
       const hasDecodeError = li.getAttribute('data-decode-error') === 'true';
 
-      const downloadButton = li.querySelector('a.file-preview-download');
-      downloadButton.setAttribute('href', 'data:application/octet-stream;base64,' + contents);
+      const downloadButton = li.querySelector('button.file-preview-download');
+      downloadButton.addEventListener('click', (e) => {
+        e.stopPropagation();
+        downloadFile(name, contents);
+      });
+      downloadButton.removeAttribute('disabled');
 
       const image = li.querySelector('img');
       image.setAttribute('src', 'data:application/octet-stream;base64,' + contents);
@@ -69,6 +78,9 @@ $(() => {
       } else {
         code.innerText = 'Content preview is not available for this type of file.';
       }
+
+      const collapseButton = li.querySelector('button.file-preview-button');
+      collapseButton.removeAttribute('disabled');
     })
   })
 });

--- a/elements/pl-file-preview/pl-file-preview.mustache
+++ b/elements/pl-file-preview/pl-file-preview.mustache
@@ -8,7 +8,7 @@
       {{#has_files}}
       <ul class="list-group list-group-flush">
         {{#files}}
-        <li class="list-group-item" data-file="{{name}}">
+        <li class="list-group-item" data-file="{{name}}" data-contents="{{contentsb64}}" data-decode-error="{{decode_error}}">
           <div class="file-status-container has-preview collapsed" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}">
             <div class="file-status-container-left">
               <i class="file-status-icon fa fa-check-circle" style="color: #4CAF50;" aria-hidden="true"></i>
@@ -16,18 +16,20 @@
               <p class="file-status">uploaded</p>
             </div>
             <div class="file-status-container-right">
-              <a download="{{name}}" class="btn btn-outline-secondary btn-sm"
-                 onclick="event.stopPropagation();"
-                 href="data:application/octet-stream;base64,{{contentsb64}}">
-                 Download
+              <a
+                download="{{name}}"
+                class="btn btn-outline-secondary btn-sm file-preview-download"
+                onclick="event.stopPropagation();"
+              >
+                Download
               </a>
-              <button type="button" class="btn btn-outline-secondary btn-sm file-preview-button">
+              <button type="button" class="btn btn-outline-secondary btn-sm file-preview-button" aria-expanded="false" aria-controls="file-preview-contents-{{uuid}}-{{index}}">
                 <i class="file-preview-icon fa fa-angle-down"></i>
               </button>
             </div>
           </div>
           <div class="file-preview collapse" id="file-preview-contents-{{uuid}}-{{index}}">
-            <pre class="bg-dark text-white rounded p-3 mb-0"><img class="w-100" src="data:application/octet-stream;base64,{{contentsb64}}" onerror="$(this).hide();$(this).parent().find('code').removeClass('d-none');"><code class="d-none">{{contents}}</code></pre>
+            <pre class="bg-dark text-white rounded p-3 mb-0"><img class="w-100" onerror="$(this).hide();$(this).parent().find('code').removeClass('d-none');"><code class="d-none"></code></pre>
           </div>
         </li>
         {{/files}}
@@ -41,3 +43,33 @@
     </div>
   </div>
 </div>
+
+<script>
+$(() => {
+  function decodeBase64(str) {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), c => {
+      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    }).join(''));
+  }
+
+  document.querySelectorAll('#file-preview-{{uuid}}').forEach((el) => {
+    el.querySelectorAll('.list-group-item').forEach((li) => {
+      const contents = li.getAttribute('data-contents')
+      const hasDecodeError = li.getAttribute('data-decode-error') === 'true';
+
+      const downloadButton = li.querySelector('a.file-preview-download');
+      downloadButton.setAttribute('href', `data:application/octet-stream;base64,${contents}`);
+
+      const image = li.querySelector('img');
+      image.setAttribute('src', `data:application/octet-stream;base64,${contents}`);
+
+      const code = li.querySelector('code');
+      if (!hasDecodeError) {
+        code.innerText = decodeBase64(contents);
+      } else {
+        code.innerText = 'Content preview is not available for this type of file.';
+      }
+    })
+  })
+});
+</script>

--- a/elements/pl-file-preview/pl-file-preview.mustache
+++ b/elements/pl-file-preview/pl-file-preview.mustache
@@ -58,10 +58,10 @@ $(() => {
       const hasDecodeError = li.getAttribute('data-decode-error') === 'true';
 
       const downloadButton = li.querySelector('a.file-preview-download');
-      downloadButton.setAttribute('href', `data:application/octet-stream;base64,${contents}`);
+      downloadButton.setAttribute('href', 'data:application/octet-stream;base64,' + contents);
 
       const image = li.querySelector('img');
-      image.setAttribute('src', `data:application/octet-stream;base64,${contents}`);
+      image.setAttribute('src', 'data:application/octet-stream;base64,' + contents);
 
       const code = li.querySelector('code');
       if (!hasDecodeError) {

--- a/elements/pl-file-preview/pl-file-preview.py
+++ b/elements/pl-file-preview/pl-file-preview.py
@@ -34,14 +34,15 @@ def render(element_html, data):
         for idx, file in enumerate(submitted_files):
             b64contents = file["contents"] or ""
             try:
-                contents = base64.b64decode(b64contents).decode()
+                base64.b64decode(b64contents).decode()
+                decode_error = False
             except UnicodeDecodeError:
-                contents = "Content preview is not available for this type of file."
+                decode_error = True
             files.append(
                 {
                     "name": file["name"],
-                    "contents": contents,
                     "contentsb64": b64contents,
+                    "decode_error": "true" if decode_error else "false",
                     "index": idx,
                 }
             )


### PR DESCRIPTION
Previously, we were including the contents of each submitted file three times in the HTML: two base-64-encoded strings, and one decoded one. For questions where students submit especially large files, this make page renders and loads unnecessarily slow because of all the extra bytes we had to push around.

This PR changes it to use a single base-64-encoded `data-contents` attribute with the contents. This is then decoded on the client.