### PR TITLE
Optimize Python calls with large amounts of data

### DIFF
--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -366,9 +366,8 @@ class CodeCallerNative {
     this._checkState([IN_CALL, EXITING]);
     if (this.state === IN_CALL) {
       this.outputData += data;
-      // We check for a newline in `data` instead of `outputData` to avoid an
-      // O(n) operation on a potentially very large string. If `data` contains
-      // a newline, then we know that `outputData` contains a newline as well.
+      // If `data` contains a newline, then `outputData` must contain a newline as well.
+      // We avoid looking in `outputData` because it's a potentially very large string.
       if (data.indexOf('\n') >= 0) {
         this._callIsFinished();
       }

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -366,7 +366,10 @@ class CodeCallerNative {
     this._checkState([IN_CALL, EXITING]);
     if (this.state === IN_CALL) {
       this.outputData += data;
-      if (this.outputData.indexOf('\n') >= 0) {
+      // We check for a newline in `data` instead of `outputData` to avoid an
+      // O(n) operation on a potentially very large string. If `data` contains
+      // a newline, then we know that `outputData` contains a newline as well.
+      if (data.indexOf('\n') >= 0) {
         this._callIsFinished();
       }
     }


### PR DESCRIPTION
This reduces a Python call from ~3s to about 200ms 🎉 

This was especially bad because Node feeds us data in chunks of 8kB. For elements that output megabytes of data, we'd do the `indexOf` operation 100s or 1000s of times. Each check only took a few milliseconds, but that was really expensive across so many operations. If I recall from undergrad correctly, that would make this $O(n^2)$ on the length of the data 😭 