### PR TITLE
Cache Yarn dependencies in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,8 @@ jobs:
       # spinning until it eventually times out. This shorter timeout helps
       # ensure that the tests fail more quickly so that people can fix them.
       timeout-minutes: 30
-    - name: Set up Node on the host
+
+    - name: Set up Node and install dependencies
       uses: actions/setup-node@v3
       with:
         node-version: '16'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,8 +85,11 @@ jobs:
       # spinning until it eventually times out. This shorter timeout helps
       # ensure that the tests fail more quickly so that people can fix them.
       timeout-minutes: 30
-    - name: Install dependencies on host
-      run: yarn install --immutable
+    - name: Set up Node on the host
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+        cache: 'yarn'
     - name: Build executor image
       run: ./tools/executor/build.js
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,11 +86,13 @@ jobs:
       # ensure that the tests fail more quickly so that people can fix them.
       timeout-minutes: 30
 
-    - name: Set up Node and install dependencies
+    - name: Set up Node
       uses: actions/setup-node@v3
       with:
         node-version: '16'
         cache: 'yarn'
+    - name: Install dependencies
+      run: yarn install --immutable
     - name: Build executor image
       run: ./tools/executor/build.js
 


### PR DESCRIPTION
This PR caches the Yarn dependencies that are installed on the GitHub Actions host and used to build and publish the executor image. Note that this doesn't have any impact on the dependencies installed in the `prairielearn/prairielearn` Docker image itself.