### PR TITLE
Tag prairielearn/prairielearn Docker image with commit SHA

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -46,7 +46,7 @@ jobs:
           platforms: linux/amd64
           push: true
           no-cache: true
-          tags: prairielearn/prairielearn:latest
+          tags: prairielearn/prairielearn:latest,prairielearn/prairielearn:${{ github.sha }}
 
       ######################################################################################################
       # grader-c


### PR DESCRIPTION
We've heard from folks that doing local course dev against `prairielearn/prairielearn:latest` can result in using features that aren't available in the deployed version yet. This change will make it possible to reference the SHA in a deploy announcement and pull the image that corresponds with that exact version.