### PR TITLE
Capture detailed information after failed OAuth authentication

### DIFF
--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -34,10 +34,13 @@ router.get('/', function (req, res, next) {
   oauth2Client.getToken(code, function (err, tokens) {
     if (err?.response) {
       // This is probably a detailed error from the Google API client. We'll
-      // attach the full error object to the Sentry scope so that it will be
-      // included with the error event.
+      // pick off the useful bits and attach them to the Sentry scope so that
+      // they'll be included with the error event.
       Sentry.configureScope((scope) => {
-        scope.setContext('oauth', { ...err });
+        scope.setContext('OAuth', {
+          code: err.code,
+          data: err.response.data,
+        });
       });
     }
     if (ERR(err, next)) return;

--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -1,5 +1,6 @@
 const ERR = require('async-stacktrace');
 const assert = require('assert');
+const Sentry = require('@prairielearn/sentry');
 const express = require('express');
 const router = express.Router();
 
@@ -31,6 +32,14 @@ router.get('/', function (req, res, next) {
   }
   logger.verbose('Got Google auth with code: ' + code);
   oauth2Client.getToken(code, function (err, tokens) {
+    if (err?.response) {
+      // This is probably a detailed error from the Google API client. We'll
+      // attach the full error object to the Sentry scope so that it will be
+      // included with the error event.
+      Sentry.configureScope((scope) => {
+        scope.setContext('oauth', { ...err });
+      });
+    }
     if (ERR(err, next)) return;
     try {
       logger.verbose('Got Google auth tokens: ' + JSON.stringify(tokens));


### PR DESCRIPTION
This PR picks off some information from a Google OAuth error and sends it to Sentry so that we can investigate `invalid_grant` errors that we're occasionally seeing.