### PR TITLE
Remove download of all course instance files

### DIFF
--- a/pages/instructorAssessments/instructorAssessments.ejs
+++ b/pages/instructorAssessments/instructorAssessments.ejs
@@ -137,12 +137,6 @@
             Download <a href="<%= urlPrefix %>/instance_admin/assessments/file/<%= csvFilename %>"><%= csvFilename %></a>
             (includes more statistics columns than displayed above)
           </p>
-          <% if (authz_data.has_course_instance_permission_view) { %>
-          <p class="mb-0">
-            Download <a href="<%= urlPrefix %>/instance_admin/assessments/file/<%= fileSubmissionsFilename %>"><%= fileSubmissionsFilename %></a>
-            (includes all files ever submitted for this course instance)
-          </p>
-          <% } %>
         </div>
 
       </div>


### PR DESCRIPTION
This PR removes the download of all files ever submitted for a course instance. The query puts an incredible amount of stress on our database and will almost always exceed the 60 second timeout at the load balancer, meaning the data can't be accessed anyways. If course staff really wants all this data, they can fetch each individual submission from the API. In the vast majority of cases, they should be able to use the assessment-specific download links.