### PR TITLE
`pl-symbolic-input` return type fix

### DIFF
--- a/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -324,7 +324,7 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
                 a_sub, allow_complex=allow_complex, allow_trig_functions=True
             )
 
-        return a_tru_sympy.equals(a_sub_sympy), None
+        return a_tru_sympy.equals(a_sub_sympy) is True, None
 
     pl.grade_answer_parameterized(data, name, grade_function, weight=weight)
 


### PR DESCRIPTION
For some unequal expressions, the sympy `equals` function will return `None`, which raises an assertion failure in the grader code (which expected `equals` to return to return a boolean). Unfortunately, tooling didn't catch this because Sympy doesn't have type annotations.