### PR TITLE
Fix strict mode warning on question JSON schema

### DIFF
--- a/schemas/schemas/infoQuestion.json
+++ b/schemas/schemas/infoQuestion.json
@@ -228,6 +228,7 @@
             "description": "Options for workspace questions.",
             "type": "object",
             "additionalProperties": {
+                "type": "object",
                 "properties": {
                     "syncIgnore": {
                         "description": "(deprecated) The list of files or directories that will be excluded from sync.",


### PR DESCRIPTION
@jonatanschroeder reported seeing the following error when running tests:

```
strict mode: missing type "object" for keyword "properties" at "#/properties/workspaceOptions/additionalProperties" (strictTypes)
```

This PR should fix that.