### PR TITLE
Attempt to fix code caller memory leak

### DIFF
--- a/lib/code-caller/index.js
+++ b/lib/code-caller/index.js
@@ -12,6 +12,7 @@ const load = require('../load');
 const { CodeCallerContainer, init: initCodeCallerDocker } = require('./code-caller-container');
 const { CodeCallerNative } = require('./code-caller-native');
 const { FunctionMissingError } = require('./code-caller-shared');
+const { sleep } = require('../sleep');
 
 /**
  * This module maintains a pool of CodeCaller workers, which are used any
@@ -23,10 +24,40 @@ const { FunctionMissingError } = require('./code-caller-shared');
  * - python_callback_waiting: number of queued jobs/callbacks waiting for an available worker
  */
 
-/** @typedef {import('./code-caller-shared').CodeCaller} CodeCaller*/
+/** @typedef {import('./code-caller-shared').CodeCaller} CodeCaller */
 
 /** @type {import('generic-pool').Pool<CodeCaller> | null} */
 let pool = null;
+
+/** @type {Set<CodeCaller>} */
+let unhealthyCodeCallers = new Set();
+
+async function getHealthyCodeCaller() {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const codeCaller = await pool.acquire();
+    if (!unhealthyCodeCallers.has(codeCaller)) {
+      return codeCaller;
+    }
+    await pool.release(codeCaller);
+    await sleep(0);
+  }
+}
+
+function destroyUnhealthyCodeCallers() {
+  unhealthyCodeCallers.forEach((codeCaller) => {
+    // Delete from the set first. That way, if `pool.destroy()` is still running
+    // on the next tick of this `destroyUnhealthyCodeCallers()` function, we
+    // won't try to destroy it again.
+    unhealthyCodeCallers.delete(codeCaller);
+    pool.destroy(codeCaller).catch((err) => {
+      logger.error('Error destroying unhealthy Python worker', err);
+      Sentry.captureException(err);
+    });
+  });
+
+  setTimeout(destroyUnhealthyCodeCallers, 100);
+}
 
 module.exports = {
   async init() {
@@ -85,6 +116,24 @@ module.exports = {
       Sentry.captureException(err);
     });
 
+    // This is part of a huge kludge we use to work around the fact that Sentry
+    // uses domains. We need to ensure that new code callers are only created
+    // outside the context of the domain of a request. Otherwise, if a request
+    // has very large objects associated with it (e.g. `res.locals` for a large
+    // submission), those objects will be kept alive forever by the domain, which
+    // ends up being associated with the Docker HTTP client that survives for
+    // the lifetime of the container.
+    //
+    // To work around this, instead of calling `pool.destroy(codeCaller)`
+    // immediately after an error, we'll add the code caller to a set of
+    // unhealthy ones. This `destroyUnhealthyCodeCallers()` function will then
+    // execute at a regular interval and destroy any unhealthy code callers.
+    //
+    // See https://github.com/getsentry/sentry-javascript/issues/7031 for more
+    // details. If they ever switch to using AsyncLocalStorage, we can remove
+    // this and destroy code callers as soon as they become unhealthy.
+    destroyUnhealthyCodeCallers();
+
     // Ensure that the workers are ready; this will ensure that we're ready to
     // execute code as soon as we start processing requests.
     //
@@ -129,14 +178,14 @@ module.exports = {
     const jobUuid = uuidv4();
     load.startJob('python_callback_waiting', jobUuid);
 
-    const codeCaller = await pool.acquire();
+    const codeCaller = await getHealthyCodeCaller();
 
     try {
       await codeCaller.prepareForCourse(coursePath);
     } catch (err) {
       // If we fail to prepare for a course, assume that the code caller is
       // broken and dispose of it.
-      await pool.destroy(codeCaller);
+      unhealthyCodeCallers.add(codeCaller);
       throw err;
     }
 
@@ -174,7 +223,7 @@ module.exports = {
     load.startJob('python_worker_idle', codeCaller.uuid);
 
     if (needsFullRestart) {
-      await pool.destroy(codeCaller);
+      unhealthyCodeCallers.add(codeCaller);
     } else {
       await pool.release(codeCaller);
     }


### PR DESCRIPTION
This is a huge kludge to work around the issue described here: https://github.com/getsentry/sentry-javascript/issues/7031. Tl;dr: we need to ensure that code callers are created outside the ["domain"](https://nodejs.org/api/domain.html) of a request. Otherwise, that domain will indefinitely hold on to the Express `res` object, which in turn means that any large values in `res.locals` will be kept alive (prevented from being garbage-collected) for the lifespan of the worker.

I tested this in isolation on my reproduction repo: https://github.com/nwalters512/sentry-domain-memory-leak/pull/1. After refreshing 6 times, memory usage falls back to normal levels, so I believe this fix should work. However, it's difficult to test in PrairieLearn itself, as it's difficult to reproduce the failure condition. I think we'll just have to deploy it and ensure that it has the desired impact on memory usage.