### PR TITLE
Improve workspace reconnection handling

### DIFF
--- a/jobs/workspaces/workspace-2-2/current/fibonacci.py
+++ b/jobs/workspaces/workspace-2-2/current/fibonacci.py
@@ -1,0 +1,2 @@
+def fib(n):
+    pass

--- a/jobs/workspaces/workspace-2-2/current/fibonacci.py
+++ b/jobs/workspaces/workspace-2-2/current/fibonacci.py
@@ -1,2 +1,0 @@
-def fib(n):
-    pass

--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -64,21 +64,22 @@ module.exports = {
         if (ERR(err, callback)) return;
         const workspace = result.rows[0];
 
-        // Immediately return the workspace state to the client, but continue
-        // starting the workspace in the background.
         callback({
           workspace_id,
           state: workspace.state,
         });
+      });
+    });
 
-        module.exports.startup(workspace_id, workspace.state).catch(async (err) => {
-          logger.error(`Error starting workspace ${workspace_id}`, err);
-          await module.exports.updateState(
-            workspace_id,
-            'stopped',
-            `Error! Click "Reboot" to try again. Detail: ${err}`
-          );
-        });
+    socket.on('startWorkspace', (msg) => {
+      const workspace_id = msg.workspace_id;
+      module.exports.startup(workspace_id).catch(async (err) => {
+        logger.error(`Error starting workspace ${workspace_id}`, err);
+        await module.exports.updateState(
+          workspace_id,
+          'stopped',
+          `Error! Click "Reboot" to try again. Detail: ${err}`
+        );
       });
     });
 
@@ -191,7 +192,10 @@ module.exports = {
     throw new Error(`Error from workspace host: ${json.message}`);
   },
 
-  async startup(workspace_id, state) {
+  async startup(workspace_id) {
+    const result = await sqldb.queryOneRowAsync(sql.select_workspace, { workspace_id });
+    const state = result.rows[0].state;
+
     if (state !== 'uninitialized' && state !== 'stopped') return;
 
     let useInitialZip = state === 'uninitialized';

--- a/pages/workspace/workspace.ejs
+++ b/pages/workspace/workspace.ejs
@@ -190,10 +190,14 @@
         setMessage(msg.message);
       });
 
-      socket.emit('joinWorkspace', {workspace_id: <%= workspace_id %>}, (msg) => {
-        console.log(`joinWorkspace, msg = ${JSON.stringify(msg)}`);
-        setState(msg.state);
+      socket.on('connect', () => {
+        socket.emit('joinWorkspace', {workspace_id: <%= workspace_id %>}, (msg) => {
+          console.log(`joinWorkspace, msg = ${JSON.stringify(msg)}`);
+          setState(msg.state);
+        });
       });
+
+      socket.emit('startWorkspace', {workspace_id: <%= workspace_id %>});
 
       setInterval(() => {
         socket.emit('heartbeat', {workspace_id: <%= workspace_id %>}, (msg) => {


### PR DESCRIPTION
Fixes #7023. The key change here is that we separate joining the socket room from actually starting the workspace. That allows us to rejoin the room when a client reconnects *without* also restarting the workspace.