### PR TITLE
Use tmpfs filesystem for Postgres data in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,9 @@ jobs:
       # socket being available, as well as a specific volume mount and
       # environment variable. See the docs for more details:
       # https://prairielearn.readthedocs.io/en/latest/externalGrading/#running-locally-for-development
-      run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs --tmpfs=/var/postgres -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
+      #
+      # We put the Postgres data on a tmpfs volume, which should be much faster.
+      run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs --tmpfs=/var/docker-postgres -e PGDATA=/var/docker-postgres -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
     - name: Run the Python linter
       run: docker exec test_container /PrairieLearn/docker/lint_python.sh
     - name: Run the JavaScript linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       # https://prairielearn.readthedocs.io/en/latest/externalGrading/#running-locally-for-development
       #
       # We put the Postgres data on a tmpfs volume, which should be much faster.
-      run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs --tmpfs=/var/docker-postgres -e PGDATA=/var/docker-postgres -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
+      run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs --tmpfs=/var/postgres -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
     - name: Run the Python linter
       run: docker exec test_container /PrairieLearn/docker/lint_python.sh
     - name: Run the JavaScript linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       # socket being available, as well as a specific volume mount and
       # environment variable. See the docs for more details:
       # https://prairielearn.readthedocs.io/en/latest/externalGrading/#running-locally-for-development
-      run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
+      run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs --tmpfs=/var/postgres -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
     - name: Run the Python linter
       run: docker exec test_container /PrairieLearn/docker/lint_python.sh
     - name: Run the JavaScript linter

--- a/docker/start_postgres.sh
+++ b/docker/start_postgres.sh
@@ -15,11 +15,11 @@ if [[ "$ACTION" == "start" ]]; then
     fi
 fi
 
+mkdir -p $PGDATA
+chown -f postgres:postgres $PGDATA
 su postgres -c 'pg_ctl status' >/dev/null 2>&1
 if [[ $? == 4 ]]; then
     echo "Making new postgres database at ${PGDATA}"
-    mkdir -p $PGDATA
-    chown -f postgres:postgres $PGDATA
     su postgres -c "initdb" >/dev/null 2>&1
     INIT_RESOLVE=0
     ACTION=start


### PR DESCRIPTION
This made the Node tests run ~40s faster in CI. While this is not as much as a speedup as we'd hoped, it's still something! Bigger gains are likely to come from changes to tests themselves.