### PR TITLE
Load only rendered submissions from database

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -26,9 +26,10 @@ const error = require('../prairielib/lib/error');
 const sql = sqlLoader.loadSqlEquiv(__filename);
 
 /**
- * Question module.
- * @module question
+ * To improve performance, we'll only render at most three submissions on page
+ * load. If the user requests more, we'll render them on the fly.
  */
+const MAX_RECENT_SUBMISSIONS = 3;
 
 /**
  * Internal error type for tracking lack of submission.
@@ -1641,16 +1642,43 @@ module.exports = {
           }
         },
         async () => {
-          var params = {
+          // We only fully render a small number of submissions on initial page
+          // load; the rest only require basic information like timestamps. As
+          // such, we'll load submissions in two passes: we'll load basic
+          // information for all submissions to this variant, and then we'll
+          // load the full submission for only the submissions that we'll
+          // actually render.
+          const result = await sqldb.queryAsync(sql.select_basic_submissions, {
             variant_id: locals.variant.id,
             req_date: locals.req_date,
-          };
-          const result = await sqldb.queryAsync(sql.select_submissions, params);
+          });
+
           if (result.rowCount >= 1) {
+            // Load detailed information for the submissions that we'll render.
+            // Note that for non-Freeform questions, we unfortunately have to
+            // eagerly load detailed data for all submissions, as that ends up
+            // being serialized in the HTML. v2 questions don't have any easy
+            // way to support async rendering of submissions.
+            const needsAllSubmissions = locals.question.type !== 'Freeform';
+            const submissionsToRender = needsAllSubmissions
+              ? result.rows
+              : result.rows.slice(0, MAX_RECENT_SUBMISSIONS);
+            const detailedSubmissionResult = await sqldb.queryAsync(
+              sql.select_detailed_submissions,
+              {
+                submission_ids: submissionsToRender.map((s) => s.id),
+              }
+            );
+
             locals.submissions = result.rows.map((s, idx) => ({
               grading_job_stats: module.exports._buildGradingJobStats(s.grading_job),
               submission_number: result.rowCount - idx,
               ...s,
+              // Both queries order results consistently, so we can just use
+              // the array index to match up the basic and detailed results.
+              ...(idx < detailedSubmissionResult.rowCount
+                ? detailedSubmissionResult.rows[idx]
+                : {}),
             }));
             await async.each(locals.submissions, async (s) => {
               if (s.feedback?.manual) {
@@ -1688,7 +1716,7 @@ module.exports = {
             locals.variant,
             locals.question,
             locals.submission,
-            locals.submissions.slice(0, 3), // Only first three submissions are rendered initially
+            locals.submissions.slice(0, MAX_RECENT_SUBMISSIONS),
             locals.course,
             locals.course_instance,
             locals,

--- a/lib/question.sql
+++ b/lib/question.sql
@@ -15,9 +15,29 @@ WHERE
 ORDER BY
     i.date;
 
--- BLOCK select_submissions
+-- BLOCK select_basic_submissions
 SELECT
-    s.*,
+    -- This includes every `submissions` column EXCEPT for jsonb columns.
+    -- Those can be quite large in size, so we'll only load them for specific
+    -- submissions in the `select_detailed_submissions` query below.
+    s.auth_user_id,
+    s.broken,
+    s.correct,
+    s.credit,
+    s.date,
+    s.duration,
+    s.gradable,
+    s.graded_at,
+    s.grading_method,
+    s.grading_requested_at,
+    s.id,
+    s.mode,
+    s.override_score,
+    s.regradable,
+    s.score,
+    s.sid,
+    s.v2_score,
+    s.variant_id,
     to_jsonb(gj) AS grading_job,
     -- These are separate for historical reasons
     gj.id AS grading_job_id,
@@ -47,6 +67,23 @@ WHERE
     v.id = $variant_id
 ORDER BY
     s.date DESC;
+
+-- BLOCK select_detailed_submissions
+SELECT
+    -- This includes ONLY the jsonb columns from `submissions`.
+    s.feedback,
+    s.format_errors,
+    s.params,
+    s.partial_scores,
+    s.raw_submitted_answer,
+    s.submitted_answer,
+    s.true_answer
+FROM
+    submissions AS s
+WHERE
+    s.id IN (SELECT UNNEST($submission_ids::bigint[]))
+ORDER BY
+   s.date DESC;
 
 -- BLOCK select_issues_for_variant
 SELECT i.*

--- a/pages/partials/submission.ejs
+++ b/pages/partials/submission.ejs
@@ -43,7 +43,7 @@
     </button>
   </div>
 
-  <div class="collapse js-submission-body <% if (submission.submission_number == submissionCount || locals.expanded) { %>show<% } %> <% if (submissionHtml === undefined) { %>render-pending<% } %>" data-submission-id="<%= submission.id %>" id="submission-<%= submission.id %>-body">
+  <div class="collapse js-submission-body <% if (submission.submission_number == submissionCount || locals.expanded) { %>show<% } %> <% if (submissionHtml === undefined && question.type === 'Freeform') { %>render-pending<% } %>" data-submission-id="<%= submission.id %>" id="submission-<%= submission.id %>-body">
     <div class="card-body submission-body" >
       <%- submissionHtml %>
       <% if (submissionHtml === undefined) { %>


### PR DESCRIPTION
#6375 changed v3/Freeform questions to lazily render all old submissions when their panels are expanded. However, we were still actually loading all the data for *every* submission to a variant, which could be quite a lot. We believe this is partially responsible for some memory issues we've been seeing in production recently.

This PR changes that to only load the detailed information (the JSONB columns) for the submissions that will actually be rendered. This does mean that we'll need 2 database round-trips instead of just one, but the cost of that should be low.