### PR TITLE
Improve issue queries

### DIFF
--- a/lib/question.js
+++ b/lib/question.js
@@ -1709,7 +1709,6 @@ module.exports = {
           // page render. Specifically, we'll only load the "course data" if
           // the user has the appropriate permissions. This should match the
           // check used in `pages/partials/question.ejs`.
-          console.log(locals.devMode || locals.authz_data.has_course_permission_view);
           const result = await sqldb.queryAsync(sql.select_issues, {
             variant_id: locals.variant.id,
             load_course_data: locals.devMode || locals.authz_data.has_course_permission_view,

--- a/lib/question.js
+++ b/lib/question.js
@@ -1192,20 +1192,17 @@ module.exports = {
           }
           callback(null);
         },
-        (callback) => {
-          sqldb.query(sql.select_issues_for_variant, { variant_id: variant.id }, (err, result) => {
-            if (ERR(err, () => {})) {
-              return callback(err);
-            }
-
-            if (result.rowCount > 0) {
-              success = false;
-              logger.verbose(`ERROR: ${result.rowCount} issues encountered during test.`);
-            } else {
-              logger.verbose('Success: no issues during test');
-            }
-            callback(null);
+        async () => {
+          const result = await sqldb.queryOneRowAsync(sql.select_issue_count_for_variant, {
+            variant_id: variant.id,
           });
+
+          if (result.rows[0].count > 0) {
+            success = false;
+            logger.verbose(`ERROR: ${result.rowCount} issues encountered during test.`);
+          } else {
+            logger.verbose('Success: no issues during test');
+          }
         },
       ],
       (err) => {

--- a/lib/question.js
+++ b/lib/question.js
@@ -1702,16 +1702,19 @@ module.exports = {
             }
           );
         },
-        (callback) => {
-          // load issues last in case there are issues from rendering
-          const params = {
+        async () => {
+          // Load issues last in case there are issues from rendering.
+          //
+          // We'll only load the data that will be needed for this specific
+          // page render. Specifically, we'll only load the "course data" if
+          // the user has the appropriate permissions. This should match the
+          // check used in `pages/partials/question.ejs`.
+          console.log(locals.devMode || locals.authz_data.has_course_permission_view);
+          const result = await sqldb.queryAsync(sql.select_issues, {
             variant_id: locals.variant.id,
-          };
-          sqldb.query(sql.select_issues, params, (err, result) => {
-            if (ERR(err, callback)) return;
-            locals.issues = result.rows;
-            callback(null);
+            load_course_data: locals.devMode || locals.authz_data.has_course_permission_view,
           });
+          locals.issues = result.rows;
         },
         async () => {
           if (locals.question.type !== 'Freeform') {

--- a/lib/question.sql
+++ b/lib/question.sql
@@ -101,8 +101,8 @@ WHERE
 ORDER BY
    s.date DESC;
 
--- BLOCK select_issues_for_variant
-SELECT COUNT(*)
+-- BLOCK select_issue_count_for_variant
+SELECT COUNT(*)::int
 FROM issues AS i
 WHERE i.variant_id = $variant_id;
 

--- a/lib/question.sql
+++ b/lib/question.sql
@@ -49,7 +49,7 @@ ORDER BY
     s.date DESC;
 
 -- BLOCK select_issues_for_variant
-SELECT i.*
+SELECT COUNT(*)
 FROM issues AS i
 WHERE i.variant_id = $variant_id;
 

--- a/lib/question.sql
+++ b/lib/question.sql
@@ -1,6 +1,22 @@
 -- BLOCK select_issues
 SELECT
-    i.*,
+    i.assessment_id,
+    i.authn_user_id,
+    i.course_caused,
+    (CASE WHEN $load_course_data THEN i.course_data END) AS course_data,
+    i.course_id,
+    i.course_instance_id,
+    i.date,
+    i.id,
+    i.instance_question_id,
+    i.instructor_message,
+    i.manually_reported,
+    i.open,
+    i.question_id,
+    i.student_message,
+    i.system_data,
+    i.user_id,
+    i.variant_id,
     format_date_full(i.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,
     u.uid AS user_uid,
     u.name AS user_name


### PR DESCRIPTION
This PR makes two improvements to the issues queries used in `lib/question.js`:

- When only a count is needed, only load the count instead of all the data.
- If the `course_data` will not be displayed, don't load it.

These should both reduce load on the database and decrease memory consumption.