### PR TITLE
Unref code caller timeout to allow tests to exit

### DIFF
--- a/lib/code-caller/index.js
+++ b/lib/code-caller/index.js
@@ -56,7 +56,8 @@ function destroyUnhealthyCodeCallers() {
     });
   });
 
-  setTimeout(destroyUnhealthyCodeCallers, 100);
+  // Unref the timeout so that it doesn't keep the process alive.
+  setTimeout(destroyUnhealthyCodeCallers, 100).unref();
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes the issue reported by @jonatanschroeder on Slack where tests would hang after completing.