### PR TITLE
Fix handling of empty files in external grader

### DIFF
--- a/lib/externalGraderCommon.js
+++ b/lib/externalGraderCommon.js
@@ -123,7 +123,7 @@ module.exports.buildDirectory = function (dir, submission, variant, question, co
               if (!file.name) {
                 return callback(new Error("File was missing 'name' property."));
               }
-              if (!file.contents) {
+              if (file.contents == null) {
                 return callback(new Error("File was missing 'contents' property."));
               }
 


### PR DESCRIPTION
Empty files will have a blank contents attribute, which is treated as falsy. This should be allowed.