### PR TITLE
Configure GitHub Actions workflows for the merge queue

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,7 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
+  merge_group:
 
 jobs:
   cla-assistant:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 concurrency:
   # Ensure that we only run one concurrent job for Pull Requests. This ensures


### PR DESCRIPTION
Per https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue, we need this to trigger workflow runs.