### PR TITLE
Truncate and conditionally load issue system data

### DIFF
--- a/lib/issues.js
+++ b/lib/issues.js
@@ -38,7 +38,9 @@ module.exports.insertIssue = async ({
   // if needed. The worst data is submission data, which can be very large;
   // this is stored on each individual submission.
   const truncatedCourseData = recursivelyTruncateStrings(courseData, 1000);
-  const truncatedSystemData = recursivelyTruncateStrings(systemData, 1000);
+  // Allow for a higher limit on the system data. This object contains output
+  // from the Python subprocess, which can be especially useful for debugging.
+  const truncatedSystemData = recursivelyTruncateStrings(systemData, 10000);
   await sqldb.callAsync('issues_insert_for_variant', [
     variantId,
     studentMessage,

--- a/lib/issues.js
+++ b/lib/issues.js
@@ -31,13 +31,14 @@ module.exports.insertIssue = async ({
   systemData,
   authnUserId,
 }) => {
-  // Truncate all strings in `courseData` to 1000 characters. This ensures
+  // Truncate all strings in the data objects to 1000 characters. This ensures
   // that we don't store too much unnecessary data. This data is here for
   // convenience, but it's not the source of truth: pretty much all of it
   // is also stored elsewhere in the database, so we can always retrieve it
   // if needed. The worst data is submission data, which can be very large;
   // this is stored on each individual submission.
   const truncatedCourseData = recursivelyTruncateStrings(courseData, 1000);
+  const truncatedSystemData = recursivelyTruncateStrings(systemData, 1000);
   await sqldb.callAsync('issues_insert_for_variant', [
     variantId,
     studentMessage,
@@ -45,7 +46,7 @@ module.exports.insertIssue = async ({
     manuallyReported,
     courseCaused,
     truncatedCourseData,
-    systemData,
+    truncatedSystemData,
     authnUserId,
   ]);
 };

--- a/lib/question.js
+++ b/lib/question.js
@@ -1725,10 +1725,11 @@ module.exports = {
           // We'll only load the data that will be needed for this specific
           // page render. The checks here should match those in
           // `pages/partials/question.ejs`.
+          const loadExtraData = locals.devMode || locals.authz_data.has_course_permission_view;
           const result = await sqldb.queryAsync(sql.select_issues, {
             variant_id: locals.variant.id,
-            load_course_data: locals.devMode || locals.authz_data.has_course_permission_view,
-            load_system_data: locals.is_administrator,
+            load_course_data: loadExtraData,
+            load_system_data: loadExtraData,
           });
           locals.issues = result.rows;
         },

--- a/lib/question.js
+++ b/lib/question.js
@@ -1723,12 +1723,12 @@ module.exports = {
           // Load issues last in case there are issues from rendering.
           //
           // We'll only load the data that will be needed for this specific
-          // page render. Specifically, we'll only load the "course data" if
-          // the user has the appropriate permissions. This should match the
-          // check used in `pages/partials/question.ejs`.
+          // page render. The checks here should match those in
+          // `pages/partials/question.ejs`.
           const result = await sqldb.queryAsync(sql.select_issues, {
             variant_id: locals.variant.id,
             load_course_data: locals.devMode || locals.authz_data.has_course_permission_view,
+            load_system_data: locals.is_administrator,
           });
           locals.issues = result.rows;
         },

--- a/lib/question.sql
+++ b/lib/question.sql
@@ -14,7 +14,7 @@ SELECT
     i.open,
     i.question_id,
     i.student_message,
-    i.system_data,
+    (CASE WHEN $load_system_data THEN i.system_data END) AS system_data,
     i.user_id,
     i.variant_id,
     format_date_full(i.date, coalesce(ci.display_timezone, c.display_timezone)) AS formatted_date,


### PR DESCRIPTION
Applies the same changes from #7112 and #7113 to the `system_data` of issues. This should further improve memory usage and performance in the average case when errors are encountered (that is, the user is a student).