### PR TITLE
Allow lastCallData to be quickly garbage collected

### DIFF
--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -221,6 +221,9 @@ class CodeCallerContainer {
     this.debug(`enter call(${type}, ${directory}, ${file}, ${fcn})`);
     this.callCount += 1;
 
+    // Reset this so that we don't include old data if the checks below fail.
+    this.lastCallData = null;
+
     if (!this._checkState([WAITING])) {
       throw new Error('invalid CodeCallerContainer state');
     }
@@ -528,6 +531,11 @@ class CodeCallerContainer {
         this._callCallback(null, data.data, data.output);
       }
     }
+
+    // This is potentially quite a large object. Drop our reference to it to
+    // allow this memory to be quickly garbage collected.
+    this.lastCallData = null;
+
     this.debug('exit _callIsFinished()');
   }
 

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -152,6 +152,10 @@ class CodeCallerNative {
    */
   async call(type, directory, file, fcn, args) {
     this.debug('enter call()');
+
+    // Reset this so that we don't include old data if the checks below fail.
+    this.lastCallData = null;
+
     if (!this._checkState([WAITING])) {
       throw new Error(`Invalid CodeCallerNative state: ${String(this.state)}`);
     }
@@ -520,6 +524,11 @@ class CodeCallerNative {
         this._callCallback(new FunctionMissingError('Function not found in module'));
       }
     }
+
+    // This is potentially quite a large object. Drop our reference to it to
+    // allow this memory to be quickly garbage collected.
+    this.lastCallData = null;
+
     this.debug('exit _callIsFinished()');
   }
 


### PR DESCRIPTION
After spending some time with the Node inspector, I think this may have been contributing to our memory issues. We'd be holding this object in memory until `this.lastCallData` gets reassigned in the next `call()` call. If we get unlucky and have a lot of failed calls in a row *and* have a low request rate (read: we're not cycling through the Python code callers very quickly), we might have a lot of these objects hanging around in memory. By dropping the reference to it, we allow it to be garbage collected ASAP.