### PR TITLE
Force Google auth to prompt user for account

### DIFF
--- a/pages/authLoginOAuth2/authLoginOAuth2.js
+++ b/pages/authLoginOAuth2/authLoginOAuth2.js
@@ -20,6 +20,7 @@ router.get('/', function (req, res, next) {
     url = oauth2Client.generateAuthUrl({
       access_type: 'online',
       scope: scopes,
+      prompt: 'select_account',
       // FIXME: should add some state here to avoid CSRF
     });
   } catch (err) {


### PR DESCRIPTION
Addresses part of https://github.com/PrairieLearn/PrairieTest-feedback/issues/20. The issue is that, when using Google Auth, often the user is already logged in to a single Google account (e.g., their Gmail), but they may need to login with an institution-specific account. Causing the account page to always be shown when logging in ensures the user is aware of which account is being used, even in the specific cases where the Gmail account (or whatever they're already logged in with) is the expected one.

Unfortunately I don't have the means to test this.