### PR TITLE
Support redirect after logout

### DIFF
--- a/pages/authLogout/authLogout.js
+++ b/pages/authLogout/authLogout.js
@@ -4,7 +4,11 @@ var router = express.Router();
 router.get('/', function (req, res, _next) {
   res.clearCookie('pl_authn');
   res.clearCookie('pl_assessmentpw');
-  if (res.locals.authn_provider_name === 'Shibboleth') {
+
+  const redirect = req.query.redirect;
+  if (redirect) {
+    res.redirect(decodeURIComponent(redirect));
+  } else if (res.locals.authn_provider_name === 'Shibboleth') {
     res.redirect('/Shibboleth.sso/Logout');
   } else {
     res.redirect('/');


### PR DESCRIPTION
After this change, http://localhost:3000/pl/logout?redirect=https://google.com will redirect to google.com after clearing the cookies.