### PR TITLE
Fix bug when loading missing element extensions

### DIFF
--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -197,8 +197,8 @@ module.exports = {
       elementFolders = await fs.readdir(sourceDir);
     } catch (err) {
       if (err.code === 'ENOENT') {
-        // We don't really care if there are no extensions, just return an empty array.
-        return [];
+        // We don't really care if there are no extensions, just return an empty object.
+        return {};
       }
 
       throw err;

--- a/tests/courseElementExtension.test.js
+++ b/tests/courseElementExtension.test.js
@@ -68,8 +68,8 @@ describe('Course element extensions', function () {
         path.join(__dirname, '..', 'testCourse', 'elementExtensions'),
         path.join(__dirname, '..', 'testCourse', 'elementExtensions')
       );
-      assert(
-        extensions.length === 0,
+      assert.isEmpty(
+        extensions,
         'non-zero number of extensions were loaded from a course without extensions'
       );
     });


### PR DESCRIPTION
Another fix I'm lifting out of #7128. I don't think this would have actually manifested as an error in practice, but it'll pose a problem with the experimental renderer.