### PR TITLE
Use google-auth-library instead of googleapis

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -183,6 +183,9 @@ config.shibLinkColors = {
 };
 config.hasAzure = false;
 config.hasOauth = false;
+config.googleClientId = null;
+config.googleClientSecret = null;
+config.googleRedirectUrl = null;
 config.syncExamIdAccessRules = false;
 config.ptHost = 'http://localhost:4000';
 config.checkAccessRulesExamUuid = false;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "folder-hash": "^4.0.4",
         "fs-extra": "^11.1.0",
         "generic-pool": "^3.9.0",
-        "googleapis": "^110.0.0",
+        "google-auth-library": "^8.7.0",
         "he": "^1.2.0",
         "highlight.js": "^11.7.0",
         "http-proxy-middleware": "^2.0.6",

--- a/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -1,3 +1,4 @@
+// @ts-check
 const ERR = require('async-stacktrace');
 const assert = require('assert');
 const Sentry = require('@prairielearn/sentry');
@@ -9,19 +10,20 @@ const config = require('../../lib/config');
 const csrf = require('../../lib/csrf');
 const sqldb = require('@prairielearn/postgres');
 
-const { google } = require('googleapis');
-const OAuth2 = google.auth.OAuth2;
+const { OAuth2Client } = require('google-auth-library');
 
 router.get('/', function (req, res, next) {
   if (!config.hasOauth) return next(new Error('Google login is not enabled'));
   const code = req.query.code;
   if (code == null) {
     return next(new Error('No "code" query parameter for authCallbackOAuth2'));
+  } else if (typeof code !== 'string') {
+    return next(new Error(`Invalid "code" query parameter for authCallbackOAuth2: ${code}`));
   }
   // FIXME: should check req.query.state to avoid CSRF
   let oauth2Client, identity;
   try {
-    oauth2Client = new OAuth2(
+    oauth2Client = new OAuth2Client(
       config.googleClientId,
       config.googleClientSecret,
       config.googleRedirectUrl

--- a/pages/authLoginOAuth2/authLoginOAuth2.js
+++ b/pages/authLoginOAuth2/authLoginOAuth2.js
@@ -1,3 +1,4 @@
+// @ts-check
 const ERR = require('async-stacktrace');
 const express = require('express');
 const router = express.Router();
@@ -5,13 +6,13 @@ const router = express.Router();
 const logger = require('../../lib/logger');
 const config = require('../../lib/config');
 
-const { google } = require('googleapis');
+const { OAuth2Client } = require('google-auth-library');
 
 router.get('/', function (req, res, next) {
   if (!config.hasOauth) return next(new Error('Google login is not enabled'));
   let url;
   try {
-    const oauth2Client = new google.auth.OAuth2(
+    const oauth2Client = new OAuth2Client(
       config.googleClientId,
       config.googleClientSecret,
       config.googleRedirectUrl

--- a/yarn.lock
+++ b/yarn.lock
@@ -3784,7 +3784,7 @@ __metadata:
     folder-hash: ^4.0.4
     fs-extra: ^11.1.0
     generic-pool: ^3.9.0
-    googleapis: ^110.0.0
+    google-auth-library: ^8.7.0
     he: ^1.2.0
     highlight.js: ^11.7.0
     htmlhint: ^1.1.4
@@ -8074,7 +8074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-auth-library@npm:^8.0.2":
+"google-auth-library@npm:^8.7.0":
   version: 8.7.0
   resolution: "google-auth-library@npm:8.7.0"
   dependencies:
@@ -8099,30 +8099,6 @@ __metadata:
   bin:
     gp12-pem: build/src/bin/gp12-pem.js
   checksum: 59a5026331ea67455672e83770da29f09d979f02e06cb2227ea5916f8cca437887c2d3869f2602a686dc84437886ae9d2ac010780803cbe8e5f161c2d02d8efd
-  languageName: node
-  linkType: hard
-
-"googleapis-common@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "googleapis-common@npm:6.0.3"
-  dependencies:
-    extend: ^3.0.2
-    gaxios: ^5.0.1
-    google-auth-library: ^8.0.2
-    qs: ^6.7.0
-    url-template: ^2.0.8
-    uuid: ^9.0.0
-  checksum: 72b3f2f4018d96d6e5bcc08096c693e393ba1ae59be243ac409e8876d941f918aad556a62d828709956552a5940295360674b9681b7871a1b3be54ea8a588f3f
-  languageName: node
-  linkType: hard
-
-"googleapis@npm:^110.0.0":
-  version: 110.0.0
-  resolution: "googleapis@npm:110.0.0"
-  dependencies:
-    google-auth-library: ^8.0.2
-    googleapis-common: ^6.0.0
-  checksum: 4cfa66d007ecca350e9df240a476792654385e878c76d3ca755a5df3898c97cd3256134b788c4765513bca393062f9e033f746245eba45ae189769918d1ccd98
   languageName: node
   linkType: hard
 
@@ -12466,7 +12442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.11.0, qs@npm:^6.7.0":
+"qs@npm:6.11.0":
   version: 6.11.0
   resolution: "qs@npm:6.11.0"
   dependencies:
@@ -14712,13 +14688,6 @@ __metadata:
   dependencies:
     punycode: ^2.1.0
   checksum: 7167432de6817fe8e9e0c9684f1d2de2bb688c94388f7569f7dbdb1587c9f4ca2a77962f134ec90be0cc4d004c939ff0d05acc9f34a0db39a3c797dada262633
-  languageName: node
-  linkType: hard
-
-"url-template@npm:^2.0.8":
-  version: 2.0.8
-  resolution: "url-template@npm:2.0.8"
-  checksum: 4183fccd74e3591e4154134d4443dccecba9c455c15c7df774f1f1e3fa340fd9bffb903b5beec347196d15ce49c34edf6dec0634a95d170ad6e78c0467d6e13e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`googleapis` is a massive package, weighing in at ~120MB and taking ~250ms to load on my machine. `google-auth-library` is comparably much smaller: it's only 680kB and takes ~20ms to load on my machine.

This change should decrease the size of our Docker image, decrease application boot time, and make our production AMI builds complete more quickly.