### PR TITLE
Java grader: fix handling of disabled Java management

### DIFF
--- a/graders/java/autograder.sh
+++ b/graders/java/autograder.sh
@@ -63,7 +63,7 @@ chmod 777 /grade/params/params.json
 # Disable Java management options to hinder student's ability to dump
 # the heap. The port is not a valid int on purpose, to trigger an
 # error on attempt to launch it.
-DISABLE_JAVA_MANAGEMENT="-XX:+DisableAttachMechanism -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=x"
+DISABLE_JAVA_MANAGEMENT="-XX:+DisableAttachMechanism -Djavax.management.builder.initial=DISABLED"
 
 su - sbuser <<EOF
 java -cp "$CLASSPATH" $DISABLE_JAVA_MANAGEMENT JUnitAutograder


### PR DESCRIPTION
Previous fix actually made the autograder stop working altogether.