### PR TITLE
Java grader: fully disable Java management module

### DIFF
--- a/graders/java/Dockerfile
+++ b/graders/java/Dockerfile
@@ -20,5 +20,8 @@ RUN echo "kernel.yama.ptrace_scope = 3" > cat /etc/sysctl.d/10-ptrace.conf
 
 RUN javac -cp '/javagrader:/javagrader/libs:/javagrader/libs/*' -d /javagrader /javagrader/JUnitAutograder.java /javagrader/AutograderInfo.java
 
+# Delete all java.management files to hinder student's ability to retrieve information from the grader
+RUN rm -rf /usr/lib/jvm/java-18-openjdk-amd64/lib/libmanagement.so /usr/lib/jvm/java-18-openjdk-amd64/lib/libmanagement_agent.so /usr/lib/jvm/java-18-openjdk-amd64/lib/libmanagement_ext.so
+
 COPY autograder.sh /bin
 RUN chmod 700 /bin/autograder.sh

--- a/graders/java/autograder.sh
+++ b/graders/java/autograder.sh
@@ -61,8 +61,7 @@ chmod 777 /grade/params
 chmod 777 /grade/params/params.json
 
 # Disable Java management options to hinder student's ability to dump
-# the heap. The port is not a valid int on purpose, to trigger an
-# error on attempt to launch it.
+# the heap.
 DISABLE_JAVA_MANAGEMENT="-XX:+DisableAttachMechanism -Djavax.management.builder.initial=DISABLED"
 
 su - sbuser <<EOF


### PR DESCRIPTION
Continuation of #7154. This will cause any attempt to use classes in `java.lang.management` and related classes to fail with:

```
java.lang.UnsatisfiedLinkError: no management in system library path: /usr/lib/jvm/java-18-openjdk-amd64/lib
```