### PR TITLE
Fix pl-drawing HTML attribute escaping

### DIFF
--- a/elements/pl-drawing/pl-drawing.mustache
+++ b/elements/pl-drawing/pl-drawing.mustache
@@ -1,5 +1,5 @@
 {{#render_button}}
-<button type="button" name="{{button_class}}" class="btn btn-primary pl-drawing-button" opts='{{{ options }}}'><img /></button>
+<button type="button" name="{{button_class}}" class="btn btn-primary pl-drawing-button" opts="{{{ options }}}"><img /></button>
 {{/render_button}}
 
 {{#render_element}}

--- a/elements/pl-drawing/pl-drawing.py
+++ b/elements/pl-drawing/pl-drawing.py
@@ -1,3 +1,4 @@
+import html
 import json
 import warnings
 
@@ -203,7 +204,7 @@ def render_controls(template, elem):
                 {
                     "render_button": True,
                     "button_class": elem.attrib.get("type", ""),
-                    "options": json.dumps(opts),
+                    "options": html.escape(json.dumps(opts), quote=True),
                 },
             ).strip()
     elif elem.tag == "pl-controls-group":


### PR DESCRIPTION
While comparing the rendered HTML from #7128, I observed that it was behaving differently for questions using `<pl-drawing>`. While this ultimately ended up being a bug in the new rendering code, I think it's still worth changing this code to use double-quoted attributes and explicitly escape any quote characters in the JSON.