### PR TITLE
feat: make ci  shortcut

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,5 @@ typecheck-python:
 
 changeset:
 	@yarn changeset
+
+ci: lint typecheck test


### PR DESCRIPTION
Tiny change to add `make ci` to the makefile to mimic what the CI tests do on GitHub (without the docker checks). Locally I kept forgetting to run a typecheck or lint, thinking that test did all of them. This takes it down to one command.