### PR TITLE
Cause external grader errors to tag submission as not gradable

### DIFF
--- a/lib/externalGrader.js
+++ b/lib/externalGrader.js
@@ -121,7 +121,7 @@ function handleGraderError(jobId, err) {
       startTime: null,
       endTime: null,
       feedback: {
-        results: { succeeded: false },
+        results: { succeeded: false, gradable: false },
         message: err.toString(),
       },
     },


### PR DESCRIPTION
Currently if there is an unknown error in the external grader (e.g., a disk full error), the external grader provides an error message to the student, but still keeps the submission as gradable. For questions with limited attempts (either exam questions, or homework questions with limited tries per attempt), this causes the student to lose an attempt at the question through no fault of their own. This PR changes that behaviour to tag the question as not gradable, which is the same behaviour used for other errors like formatting errors, blank answers or compilation errors in the external grader.