### PR TITLE
Limit height of output/message in external grader results

### DIFF
--- a/elements/pl-external-grader-results/pl-external-grader-results.css
+++ b/elements/pl-external-grader-results/pl-external-grader-results.css
@@ -10,8 +10,6 @@
   transform: rotateX(180deg);
 }
 
-.pl-external-grader-results .output {
-  background-color: black;
-  line-height: 1.2;
-  overflow-wrap: normal;
+.pl-external-grader-results pre {
+  max-height: 40vh;
 }


### PR DESCRIPTION
When external grader results include long messages or outputs, the output boxes can cause the scrolling of results to become overwhelming. This is particularly a problem when the message provides the expected value, and the output provides the obtained value, and the student may have issues trying to compare the results.

The change here causes these boxes to use at most 40% of the screen height, introducing scrollbars if necessary. This makes the boxes easier to navigate overall.

An existing CSS rule for an `.output` class was removed as well, since there is no element with such a class in the mustache template.