### PR TITLE
Add built assets to .prettierignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,6 +39,7 @@
 !packages/
 !prairielib/
 !public/
+public/build/
 !python/
 !question-servers/
 !requirements.txt

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,9 @@ coverage/
 # Transpiled files
 packages/*/dist
 
+# Built assets
+public/build/scripts/
+
 # The `public/localscripts/calculationQuestion` directory unfortunately
 # contains a mixture of first-party and vendored third-party scripts. We want
 # to format our own scripts, but we should avoid formatting anything that was

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,7 @@ coverage/
 packages/*/dist
 
 # Built assets
-public/build/scripts/
+public/build/
 
 # The `public/localscripts/calculationQuestion` directory unfortunately
 # contains a mixture of first-party and vendored third-party scripts. We want


### PR DESCRIPTION
This has no effect on Github CI but can give warnings when running the linter locally. Also adds it to .dockerignore for consistency.