### PR TITLE
Improve performance of workspace logs parsing

### DIFF
--- a/workspace_host/interface.js
+++ b/workspace_host/interface.js
@@ -957,7 +957,13 @@ async function sendLogs(workspaceId, res) {
   try {
     const workspace = await _getWorkspaceAsync(workspaceId);
     const container = await _getDockerContainerByLaunchUuid(workspace.launch_uuid);
-    const logs = await container.logs({ stdout: true, stderr: true, timestamps: true });
+    const logs = await container.logs({
+      stdout: true,
+      stderr: true,
+      timestamps: true,
+      // This should give us a reasonable bound on the worst-case performance.
+      tail: 50000,
+    });
     const parsedLogs = parseDockerLogs(logs);
     res.status(200).send(parsedLogs);
   } catch (err) {
@@ -991,7 +997,13 @@ async function flushLogsToS3(container) {
   // date for ordering of logs from different versions.
   const startedAt = containerInfo.State.StartedAt;
 
-  const logs = await container.logs({ stdout: true, stderr: true, timestamps: true });
+  const logs = await container.logs({
+    stdout: true,
+    stderr: true,
+    timestamps: true,
+    // This should give us a reasonable bound on the worst-case performance.
+    tail: 50000,
+  });
   const parsedLogs = parseDockerLogs(logs);
 
   const key = `${workspaceId}/${version}/${startedAt}.log`;

--- a/workspace_host/lib/docker.js
+++ b/workspace_host/lib/docker.js
@@ -11,7 +11,7 @@
  * @returns {Buffer}
  */
 function parseDockerLogs(buffer) {
-  let output = Buffer.from([]);
+  let outputChunks = [];
 
   while (buffer.length > 0) {
     // Ensure that we gracefully handle the case where we have a partial header.
@@ -25,7 +25,7 @@ function parseDockerLogs(buffer) {
     const dataLength = header.readUInt32BE(4);
 
     const content = bufferSlice(dataLength);
-    output = Buffer.concat([output, content]);
+    outputChunks.push(content);
   }
 
   function bufferSlice(end) {
@@ -34,7 +34,7 @@ function parseDockerLogs(buffer) {
     return out;
   }
 
-  return output;
+  return Buffer.concat(outputChunks);
 }
 
 module.exports = {


### PR DESCRIPTION
This PR improves the performance of workspace logs parsing by avoiding the allocation of a new `Buffer` on each iteration of the loop. For an artificial log with 100000 "chunks", this improved performance from ~14 seconds to ~100ms.

This also changes the log handling to read at most 50k lines of logs, which should also help ensure that we don't process/transmit/store ridiculous amounts of information.