### PR TITLE
Remove whitespace around instructor QID link

### DIFF
--- a/pages/partials/instructorInfoPanel.ejs
+++ b/pages/partials/instructorInfoPanel.ejs
@@ -44,12 +44,10 @@
     <div class="pr-1">QID:</div>
     <div>
       <% if (locals.course_instance) { %>
-      <a href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/question/<%= question.id %>?variant_seed=<%= variant.variant_seed %>">
+      <a href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/question/<%= question.id %>?variant_seed=<%= variant.variant_seed %>"><%= question.qid %></a>
       <% } else { %>
-      <a href="<%= plainUrlPrefix %>/course/<%= course.id %>/question/<%= question.id %>?variant_seed=<%= variant.variant_seed %>">
+      <a href="<%= plainUrlPrefix %>/course/<%= course.id %>/question/<%= question.id %>?variant_seed=<%= variant.variant_seed %>"><%= question.qid %></a>
       <% } %>
-        <%= question.qid %>
-      </a>
     </div>
   </div>
     <div class="d-flex flex-wrap">


### PR DESCRIPTION
The extra whitespace around the QID text can result in Firefox incorrectly selecting the QID on double-click, as reported by @daviddalpiaz. This is apparently a Firefox bug, as @nwalters512 found (https://bugzilla.mozilla.org/show_bug.cgi?id=1043118) but this PR should work around it.