### PR TITLE
Make auth_user_uid nullable for assessment logs

### DIFF
--- a/lib/assessment.js
+++ b/lib/assessment.js
@@ -23,7 +23,7 @@ const InstanceLogSchema = z.object({
   event_name: z.string(),
   event_color: z.string(),
   event_date: z.date(),
-  auth_user_uid: z.string(),
+  auth_user_uid: z.string().nullable(),
   qid: z.string().nullable(),
   question_id: z.string().nullable(),
   instance_question_id: z.string().nullable(),


### PR DESCRIPTION
This was introduced in #7194. The `LEFT JOIN`s on `users` in this query make it pretty clear that that we might not have a user. ~I don't know exactly why.~ The auto-close event doesn't have an associated user.

