### PR TITLE
Only fetch workspace logs from host if running

### DIFF
--- a/pages/workspaceLogs/workspaceLogs.js
+++ b/pages/workspaceLogs/workspaceLogs.js
@@ -83,7 +83,7 @@ async function loadLogsForWorkspaceVersion(workspaceId, version) {
   // If the current workspace version matches the requested version, we can
   // reach out to the workspace host directly to get the remaining logs. Otherwise,
   // they should have been flushed to S3 already.
-  if (workspace.state === 'running' && workspace.is_current_version) {
+  if (workspace.state === 'running' && workspace.is_current_version && workspace.hostname) {
     const res = await fetch(`http://${workspace.hostname}/`, {
       method: 'POST',
       body: JSON.stringify({ workspace_id: workspaceId, action: 'getLogs' }),

--- a/pages/workspaceLogs/workspaceLogs.js
+++ b/pages/workspaceLogs/workspaceLogs.js
@@ -88,6 +88,7 @@ async function loadLogsForWorkspaceVersion(workspaceId, version) {
       method: 'POST',
       body: JSON.stringify({ workspace_id: workspaceId, action: 'getLogs' }),
       headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(30_000),
     });
     if (res.ok) {
       logParts.push(await res.text());

--- a/pages/workspaceLogs/workspaceLogs.js
+++ b/pages/workspaceLogs/workspaceLogs.js
@@ -83,7 +83,7 @@ async function loadLogsForWorkspaceVersion(workspaceId, version) {
   // If the current workspace version matches the requested version, we can
   // reach out to the workspace host directly to get the remaining logs. Otherwise,
   // they should have been flushed to S3 already.
-  if (workspace.is_current_version) {
+  if (workspace.state === 'running' && workspace.is_current_version) {
     const res = await fetch(`http://${workspace.hostname}/`, {
       method: 'POST',
       body: JSON.stringify({ workspace_id: workspaceId, action: 'getLogs' }),

--- a/pages/workspaceLogs/workspaceLogs.sql
+++ b/pages/workspaceLogs/workspaceLogs.sql
@@ -1,6 +1,7 @@
 -- BLOCK select_workspace
 SELECT
   w.version,
+  w.state,
   wh.hostname,
   ($version = version) AS is_current_version
 FROM


### PR DESCRIPTION
Before this change, trying to get logs from a stopped workspace would cause an error:

<img width="1139" alt="Screenshot 2023-03-01 at 13 51 41" src="https://user-images.githubusercontent.com/1476544/222273336-0a28732e-4b3b-44bb-a29b-267948afd5fe.png">
