### PR TITLE
Disallow user from changing the MathJax renderer

### DIFF
--- a/pages/partials/mathjax.ejs
+++ b/pages/partials/mathjax.ejs
@@ -38,6 +38,11 @@ var MathJax = {
                     MathJax.typesetPromise();
                 }
             };
+
+            // Disallow the user from changing the MathJax renderer. This often
+            // lead to bugs in the past.
+            const renderer = window.MathJax.startup.document.menu.menu.find('Renderer');
+            if (renderer) renderer.disable();
         },
         pageReady: () => {
             MathJax.startup.defaultPageReady();


### PR DESCRIPTION
This should help resolve #6495. It might mean we don't have to implement #7189 (cc @trombonekenny). If we have a snippet of JS that can clear the user settings, I wouldn't mind adding that here and just making it always automatically run on every page load.