### PR TITLE
Fix Azure callback error handling

### DIFF
--- a/ee/auth/azure/callback.js
+++ b/ee/auth/azure/callback.js
@@ -2,30 +2,39 @@
 const passport = require('passport');
 const express = require('express');
 const asyncHandler = require('express-async-handler');
-const util = require('util');
 
 const authnLib = require('../../../lib/authn');
 
 const router = express.Router();
 
+function authenticate(req, res) {
+  return new Promise((resolve, reject) => {
+    passport.authenticate(
+      'azuread-openidconnect',
+      {
+        failureRedirect: '/pl',
+        session: false,
+      },
+      (err, user) => {
+        if (err) {
+          reject(err);
+        } else if (!user) {
+          reject(new Error('Login failed'));
+        } else {
+          resolve(user);
+        }
+      }
+    )(req, res);
+  });
+}
+
 router.post(
   '/',
   asyncHandler(async (req, res) => {
-    // This will write the resolved user to `req.user`.
-    await util.promisify(
-      passport.authenticate('azuread-openidconnect', {
-        failureRedirect: '/pl',
-        session: false,
-      })
-    )(req, res);
-
-    const user = req.user;
-    if (!user) throw new Error('Login failed');
+    const user = await authenticate(req, res);
 
     const authnParams = {
-      // @ts-expect-error `upn` is not defined on the type.
       uid: user.upn,
-      // @ts-expect-error `displayName` is not defined on the type.
       name: user.displayName,
       uin: null,
       provider: 'Azure',

--- a/ee/auth/azure/callback.js
+++ b/ee/auth/azure/callback.js
@@ -17,7 +17,7 @@ router.post(
         failureRedirect: '/pl',
         session: false,
       })
-    )(res, res);
+    )(req, res);
 
     const user = req.user;
     if (!user) throw new Error('Login failed');

--- a/ee/auth/azure/login.js
+++ b/ee/auth/azure/login.js
@@ -6,12 +6,10 @@ const router = express.Router();
 router.get(
   '/',
   function (req, res, next) {
-    const authData = {
-      response: res,
+    passport.authenticate('azuread-openidconnect', {
       failureRedirect: '/pl',
       session: false,
-    };
-    passport.authenticate('azuread-openidconnect', authData)(req, res, next);
+    })(req, res, next);
   },
   function (req, res) {
     res.redirect('/pl');

--- a/ee/auth/saml/router.js
+++ b/ee/auth/saml/router.js
@@ -3,7 +3,6 @@ const ERR = require('async-stacktrace');
 const asyncHandler = require('express-async-handler');
 const { Router } = require('express');
 const passport = require('passport');
-const util = require('util');
 
 const authnLib = require('../../../lib/authn');
 

--- a/ee/auth/saml/router.js
+++ b/ee/auth/saml/router.js
@@ -30,16 +30,31 @@ router.get('/login', (req, res, next) => {
   })(req, res, next);
 });
 
+function authenticate(req, res) {
+  return new Promise((resolve, reject) => {
+    passport.authenticate(
+      'saml',
+      {
+        failureRedirect: '/pl',
+        session: false,
+      },
+      (err, user) => {
+        if (err) {
+          reject(err);
+        } else if (!user) {
+          reject(new Error('Login failed'));
+        } else {
+          resolve(user);
+        }
+      }
+    )(req, res);
+  });
+}
+
 router.post(
   '/callback',
   asyncHandler(async (req, res) => {
-    // This will write the resolved user to `req.user`.
-    await util.promisify(
-      passport.authenticate('saml', {
-        failureRedirect: '/pl',
-        session: false,
-      })
-    )(req, res);
+    const user = await authenticate(req, res);
 
     // Fetch this institution's attribute mappings.
     const institutionId = req.params.institution_id;
@@ -49,12 +64,9 @@ router.post(
     const nameAttribute = institutionSamlProvider.name_attribute;
 
     // Read the appropriate attributes.
-    // @ts-expect-error `attributes` is not defined on the type.
-    const authnUid = req.user.attributes[uidAttribute];
-    // @ts-expect-error `attributes` is not defined on the type.
-    const authnUin = req.user.attributes[uinAttribute];
-    // @ts-expect-error `attributes` is not defined on the type.
-    const authnName = req.user.attributes[nameAttribute];
+    const authnUid = user.attributes[uidAttribute];
+    const authnUin = user.attributes[uinAttribute];
+    const authnName = user.attributes[nameAttribute];
 
     if (req.body.RelayState === 'test') {
       res.send(
@@ -65,8 +77,7 @@ router.post(
           uidAttribute,
           uinAttribute,
           nameAttribute,
-          // @ts-expect-error `attributes` is not defined on the type.
-          attributes: req.user.attributes,
+          attributes: user.attributes,
           resLocals: res.locals,
         })
       );


### PR DESCRIPTION
Looks like this was a regression from #7094. The callback to `passport.authenticate` isn't meant to be an async function. If one is passed, errors won't be handled correctly, resulting in a server crash.