### PR TITLE
Tweak documentation page titles about local installation

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,4 +1,4 @@
-# Installing PL for local development
+# Installing and running for local course development
 
 This page describes the procedure to install and run your course locally within Docker. You can develop course content locally following the instructions below, or using the
 [in-browser tools](getStarted.md).

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -1,4 +1,4 @@
-# Installing with local source code
+# Running in Docker with local source
 
 This page describes the procedure to run PrairieLearn within Docker, but using a locally-installed version of the PrairieLearn source code. This is the recommended way to do PrairieLearn development. This is tested and supported on MacOS, Linux, and Windows.
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -1,4 +1,4 @@
-# Installing natively
+# Running natively
 
 _WARNING:_ The recommended setup for PrairieLearn development is [within Docker](installingLocal.md). The setup described on this page is not recommended or supported.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ nav:
   - 'Creating content in the browser': 'getStarted.md'
   - 'Workshop': 'workshop/index.md'
 - User Guide:
-  - 'Installing and running PL locally': 'installing.md'
+  - 'Installing and running locally': 'installing.md'
   - 'Syncing course content': 'sync.md'
   - 'Course configuration': 'course.md'
   - 'Course instance configuration': 'courseInstance.md'
@@ -47,8 +47,8 @@ nav:
   - 'API': 'api.md'  
 - Developer Guide:
   - 'Developer guide': 'dev-guide.md'
-  - 'Installing with local source': 'installingLocal.md'
-  - 'Installing natively': 'installingNative.md'
+  - 'Running in Docker with local source': 'installingLocal.md'
+  - 'Running natively': 'installingNative.md'
   - 'Server configuration': 'configJson.md'
   - 'Question element writing': 'devElements.md'
   - 'Element extensions': 'elementExtensions.md'


### PR DESCRIPTION
I didn't change the file names so as not to break existing links.

Closes #5030.