### PR TITLE
feat: user settings page: add user info, mathjax reset button

### DIFF
--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -51,10 +51,14 @@
           Browser configuration
         </div>
         <div class="card-body">
-          <p>This section will let you reset browser settings related to technology inside PrairieLearn.</p>
-           <p>
+          <p>
+            This section will let you reset browser settings related to technology inside PrairieLearn.
+          </p>
+          <p>
             If math formulas shows up as code like <strong>$ x = \frac {-b \pm \sqrt {b^2 - 4ac}}{2a} $</strong>
-            <br>
+            resetting the MathJax menu settings might help.
+          </p>
+          <p>
             <button class="btn btn-md btn-info"
               onClick="localStorage.removeItem('MathJax-Menu-Settings');alert('MathJax menu settings have been reset');">
               Reset MathJax menu settings

--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -15,6 +15,59 @@
 
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex align-items-center">
+          Logged-in user profile information
+          <a href="/pl/logout" class="btn btn-danger btn-sm ml-auto">Logout</a>
+        </div>
+          <table class="table table-sm two-column-description">
+            <tbody>
+              <tr>
+                <th>User ID (UID)</th>
+                <td>
+                  <%= authn_user.uid %>
+                </td>
+              </tr>
+              <tr>
+                <th>User Name</th>
+                <td><%= authn_user.name %></td>
+              </tr>
+              <tr>
+                <th>Unique Id Number (UIN)</th>
+                <td><%= authn_user.uin %></td>
+              </tr>
+              <tr>
+                <th>Institution</th>
+                <td><%= authn_institution.long_name %> (<%= authn_institution.short_name %>)</td>
+              </tr>
+              <tr>
+                <th>Authentication method</th>
+                <td>
+                  <%= authn_provider_name %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white d-flex">
+          Browser configuration
+        </div>
+        <div class="card-body">
+          <p>These options will let you reset some browser settings related to technology inside PrairieLearn.
+            Use these buttons to reset things if things are broken for you.
+          </p>
+          <p>
+          <button class="btn btn-md btn-info"
+            onClick="localStorage.removeItem('MathJax-Menu-Settings');alert('MathJax menu settings have been reset');">
+            Reset MathJax menu settings
+          </button> Can be helpful if your math shows up as
+          <strong>$ x = \frac {-b \pm \sqrt {b^2 - 4ac}}{2a} $</strong>
+          </p>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header bg-primary text-white d-flex align-items-center">
           Personal Access Tokens
           <button id="generateTokenButton"
             type="button" class="btn btn-light btn-sm ml-auto"

--- a/pages/userSettings/userSettings.ejs
+++ b/pages/userSettings/userSettings.ejs
@@ -12,40 +12,38 @@
     <%- include('../partials/navbar', {navPage: 'user_settings'}); %>
     <div id="content" class="container">
       <h1 class="mb-4">Settings</h1>
-
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex align-items-center">
-          Logged-in user profile information
-          <a href="/pl/logout" class="btn btn-danger btn-sm ml-auto">Logout</a>
+          User Profile
         </div>
           <table class="table table-sm two-column-description">
-            <tbody>
-              <tr>
-                <th>User ID (UID)</th>
-                <td>
-                  <%= authn_user.uid %>
-                </td>
-              </tr>
-              <tr>
-                <th>User Name</th>
-                <td><%= authn_user.name %></td>
-              </tr>
-              <tr>
-                <th>Unique Id Number (UIN)</th>
-                <td><%= authn_user.uin %></td>
-              </tr>
-              <tr>
-                <th>Institution</th>
-                <td><%= authn_institution.long_name %> (<%= authn_institution.short_name %>)</td>
-              </tr>
-              <tr>
-                <th>Authentication method</th>
-                <td>
-                  <%= authn_provider_name %>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <tbody>
+            <tr>
+              <th>User ID (UID)</th>
+              <td>
+                <%= authn_user.uid %>
+              </td>
+            </tr>
+            <tr>
+              <th>User Name</th>
+              <td><%= authn_user.name %></td>
+            </tr>
+            <tr>
+              <th>Unique Identifier (UIN)</th>
+              <td><%= authn_user.uin %></td>
+            </tr>
+            <tr>
+              <th>Institution</th>
+              <td><%= authn_institution.long_name %> (<%= authn_institution.short_name %>)</td>
+            </tr>
+            <tr>
+              <th>Authentication method</th>
+              <td>
+                <%= authn_provider_name %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
 
       <div class="card mb-4">
@@ -53,15 +51,14 @@
           Browser configuration
         </div>
         <div class="card-body">
-          <p>These options will let you reset some browser settings related to technology inside PrairieLearn.
-            Use these buttons to reset things if things are broken for you.
-          </p>
-          <p>
-          <button class="btn btn-md btn-info"
-            onClick="localStorage.removeItem('MathJax-Menu-Settings');alert('MathJax menu settings have been reset');">
-            Reset MathJax menu settings
-          </button> Can be helpful if your math shows up as
-          <strong>$ x = \frac {-b \pm \sqrt {b^2 - 4ac}}{2a} $</strong>
+          <p>This section will let you reset browser settings related to technology inside PrairieLearn.</p>
+           <p>
+            If math formulas shows up as code like <strong>$ x = \frac {-b \pm \sqrt {b^2 - 4ac}}{2a} $</strong>
+            <br>
+            <button class="btn btn-md btn-info"
+              onClick="localStorage.removeItem('MathJax-Menu-Settings');alert('MathJax menu settings have been reset');">
+              Reset MathJax menu settings
+            </button>
           </p>
         </div>
       </div>


### PR DESCRIPTION
Closes #7189 
Part of the effort to resolve the Mathjax rendering complexities and support, issues, and PRs

Also adds some logged-in user data (like institution and authentication source) readonly to the user settings page. We don't show that information anywhere and it could be helpful for LTI development