### PR TITLE
Reformat exampleCourse documentation comments

### DIFF
--- a/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/question.html
@@ -62,8 +62,7 @@ of this triangle?</p>
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this example question includes the introduction of a concept with corresponding short quiz questions. Read more  <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md" target="_blank">here</a>.</small>
         <pl-github-link></pl-github-link>

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/question.html
@@ -50,8 +50,7 @@ to this question using the workspace below. Click the button to open a JupyterLa
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this example question includes the introduction of a concept with corresponding short quiz questions. Read more  <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md" target="_blank">here</a>.</small>
         <pl-github-link></pl-github-link>

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
@@ -90,8 +90,7 @@ The <pl-dropdown answers-name="geo" weight="1">
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this example summarizes the concepts introduced in the previous questions. Read more  <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md" target="_blank">here</a>.</small>
         <pl-github-link></pl-github-link>

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/question.html
@@ -29,8 +29,7 @@
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of a question including JupyterLab for a collaborative learning activity.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/question.html
@@ -27,8 +27,7 @@
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of a question including JupyterLab for a collaborative learning activity.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/question.html
@@ -27,8 +27,7 @@
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of a question including JupyterLab for a collaborative learning activity.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/engBeamStress/question.html
+++ b/exampleCourse/questions/demo/annotated/engBeamStress/question.html
@@ -56,8 +56,7 @@ For the beam designations indicated below, determine the maximum normal stress $
 </p>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>repeated variant</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/engBinary/question.html
+++ b/exampleCourse/questions/demo/annotated/engBinary/question.html
@@ -13,8 +13,7 @@ represent the same integer number).
 </p>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>drilling for mastery</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/engCircuit/question.html
+++ b/exampleCourse/questions/demo/annotated/engCircuit/question.html
@@ -21,8 +21,7 @@
 </p>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">retry attempts for partial credit.</a>

--- a/exampleCourse/questions/demo/annotated/engMarkovBrewing/question.html
+++ b/exampleCourse/questions/demo/annotated/engMarkovBrewing/question.html
@@ -45,8 +45,7 @@
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>fixed variant</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/engVectorDrawing/question.html
+++ b/exampleCourse/questions/demo/annotated/engVectorDrawing/question.html
@@ -33,8 +33,7 @@
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>repeated variant</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/graphAdjacencyMatrix/question.html
+++ b/exampleCourse/questions/demo/annotated/graphAdjacencyMatrix/question.html
@@ -8,8 +8,7 @@
 <pl-matrix-component-input label="$\mathbf{A} = $" answers-name="mat" allow-blank="true" allow-partial-credit="true"></pl-matrix-component-input>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">retry attempts for partial credit.</a>

--- a/exampleCourse/questions/demo/annotated/mathFunctionDerivative/question.html
+++ b/exampleCourse/questions/demo/annotated/mathFunctionDerivative/question.html
@@ -16,8 +16,7 @@ $\qquad\dfrac{df(x)}{dx}$ = <pl-symbolic-input answers-name="df" variables="{{pa
 </p>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>drilling for mastery</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/mathMatrixMult/question.html
+++ b/exampleCourse/questions/demo/annotated/mathMatrixMult/question.html
@@ -14,8 +14,7 @@ Find the product of these two matrices:
 <pl-matrix-input answers-name="C" comparison="sigfig" digits="3" label="$AB=$"></pl-matrix-input>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">retry attempts for partial credit.</a>

--- a/exampleCourse/questions/demo/annotated/mathMatrixMultT/question.html
+++ b/exampleCourse/questions/demo/annotated/mathMatrixMultT/question.html
@@ -21,8 +21,7 @@ What is the matrix ${\bf B} = {\bf A}{\bf A}^T$?
 <pl-matrix-input answers-name="B" comparison="sigfig" digits={{params.sigfigs}} label="${\bf B} =$"></pl-matrix-input>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">retry attempts for partial credit.</a>

--- a/exampleCourse/questions/demo/annotated/mathNumberInput/question.html
+++ b/exampleCourse/questions/demo/annotated/mathNumberInput/question.html
@@ -9,8 +9,7 @@ Given two numbers $a = {{params.a}}$ and $b = {{params.b}}$, what is $c = {{para
 </p>
 
 <pl-question-panel>
-   This is not part of the question, and is included for documentation purposes
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">retry attempts for partial credit.</a>

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-all/question.html
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-all/question.html
@@ -10,8 +10,7 @@
 
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>drilling for mastery</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">here</a>.</small>

--- a/exampleCourse/questions/demo/annotated/mathOuterProduct/question.html
+++ b/exampleCourse/questions/demo/annotated/mathOuterProduct/question.html
@@ -15,8 +15,7 @@ compute the outer product ${\bf w} = \textrm{a} {\bf u} \otimes \textrm{b} {\bf 
 <pl-matrix-input answers-name="w" label="${\bf w} = $" comparison="sigfig" digits={{params.d2}}></pl-matrix-input>
 
 <pl-question-panel>
-  <!-- This is not part of the question, and is included for documentation purposes-->
-  <p></p>
+  <!-- This is not part of the question, and is included for documentation purposes -->
   <div class="alert alert-info p-2" role="alert">
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank">retry attempts for partial credit.</a>


### PR DESCRIPTION
While reviewing another PR, I noticed that the documentation note in `exampleCourse/questions/demo/annotated/mathNumberInput/question.html` wasn't actually a comment. I changed that and took the opportunity to find/replace to remove an unnecessary `<p>` tag.