### PR TITLE
Create infrastructure for batched migrations

### DIFF
--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@prairielearn/migrations",
+  "version": "1.0.0",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "*",
+    "@types/node": "^18.14.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "@prairielearn/postgres": "^1.2.0",
+    "zod": "^3.20.6"
+  }
+}

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -4,11 +4,14 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch --preserveWatchOutput"
+    "dev": "tsc --watch --preserveWatchOutput",
+    "test": "mocha --no-config --require ts-node/register src/*.test.ts"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "*",
+    "@types/mocha": "^10.0.1",
     "@types/node": "^18.14.2",
+    "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },

--- a/packages/migrations/schema-migrations/20230303193423_batched_migrations__create.sql
+++ b/packages/migrations/schema-migrations/20230303193423_batched_migrations__create.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS batched_migrations (
+  current BIGINT NOT NULL,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  id BIGSERIAL PRIMARY KEY,
+  max BIGINT NOT NULL,
+  min BIGINT NOT NULL,
+  name TEXT,
+  project TEXT DEFAULT 'prairielearn',
+  started_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  timestamp TEXT,
+  UNIQUE (project, timestamp)
+)

--- a/packages/migrations/src/batched-migration.test.ts
+++ b/packages/migrations/src/batched-migration.test.ts
@@ -1,0 +1,7 @@
+import { assert } from 'chai';
+
+describe('BatchedMigrationExecutor', () => {
+  it('works', () => {
+    assert.equal(true, true);
+  });
+});

--- a/packages/migrations/src/batched-migration.test.ts
+++ b/packages/migrations/src/batched-migration.test.ts
@@ -23,7 +23,6 @@ async function makeTestDatabase() {
   await client.query(`CREATE DATABASE ${POSTGRES_DATABASE};`);
   await client.end();
 
-  console.log('here');
   await sqldb.initAsync(
     {
       user: POSTGRES_USER,
@@ -36,7 +35,6 @@ async function makeTestDatabase() {
       throw err;
     }
   );
-  console.log('now here');
 
   // Run local migrations to set up the database. Once the real migration-running
   // code is lifted into this package, we can use that instead.
@@ -71,9 +69,7 @@ class TestBatchMigration extends BatchedMigration {
     return '10000';
   }
 
-  async execute(start: BigInt, end: BigInt) {
-    console.log('running for range', start, end);
-  }
+  async execute(_start: BigInt, _end: BigInt) {}
 }
 
 async function getBatchedMigrationState() {

--- a/packages/migrations/src/batched-migration.test.ts
+++ b/packages/migrations/src/batched-migration.test.ts
@@ -1,7 +1,90 @@
 import { assert } from 'chai';
+import * as sqldb from '@prairielearn/postgres';
+import pg from 'pg';
+import fs from 'fs';
+import path from 'path';
+
+import { BatchedMigration, BatchedMigrationExecutor } from './batched-migration';
+import { SCHEMA_MIGRATIONS_PATH } from './index';
+
+const WORKER_ID = process.env.MOCHA_WORKER_ID || '1';
+const POSTGRES_DATABASE = `prairielearn_migrations_${WORKER_ID}`;
+const POSTGRES_INIT_CONNECTION_STRING = 'postgres://postgres@localhost/postgres';
+
+// This was borrowed from `tests/helperDb.js` in the main database. When that's
+// moved to a shared package, we should be able to reuse that functionality.
+async function makeTestDatabase() {
+  const POSTGRES_USER = 'postgres';
+  const POSTGRES_HOST = 'localhost';
+
+  const client = new pg.Client(POSTGRES_INIT_CONNECTION_STRING);
+  await client.connect();
+  await client.query(`DROP DATABASE IF EXISTS ${POSTGRES_DATABASE};`);
+  await client.query(`CREATE DATABASE ${POSTGRES_DATABASE};`);
+  await client.end();
+
+  console.log('here');
+  await sqldb.initAsync(
+    {
+      user: POSTGRES_USER,
+      database: POSTGRES_DATABASE,
+      host: POSTGRES_HOST,
+      max: 10,
+      idleTimeoutMillis: 30000,
+    },
+    (err) => {
+      throw err;
+    }
+  );
+  console.log('now here');
+
+  // Run local migrations to set up the database. Once the real migration-running
+  // code is lifted into this package, we can use that instead.
+  const migrations = fs.readdirSync(SCHEMA_MIGRATIONS_PATH);
+  const sortedMigrations = migrations.sort((a, b) => {
+    const aTimestamp = parseInt(a.split('_')[0]);
+    const bTimestamp = parseInt(b.split('_')[0]);
+    return aTimestamp - bTimestamp;
+  });
+  for (const migrationName of sortedMigrations) {
+    const migrationPath = path.join(SCHEMA_MIGRATIONS_PATH, migrationName);
+    const migration = fs.readFileSync(migrationPath, 'utf8');
+    await sqldb.queryAsync(migration, {});
+  }
+}
+
+async function destroyTestDatabase() {
+  await sqldb.closeAsync();
+
+  const client = new pg.Client(POSTGRES_INIT_CONNECTION_STRING);
+  await client.connect();
+  await client.query(`DROP DATABASE IF EXISTS ${POSTGRES_DATABASE}`);
+  await client.end();
+}
+
+class TestBatchMigration extends BatchedMigration {
+  async getMin() {
+    return '0';
+  }
+
+  async getMax() {
+    return '0';
+  }
+
+  async execute(start: BigInt, end: BigInt) {
+    console.log('running for range', start, end);
+  }
+}
 
 describe('BatchedMigrationExecutor', () => {
-  it('works', () => {
+  beforeEach(async () => makeTestDatabase());
+  afterEach(async () => destroyTestDatabase());
+
+  it('works', async () => {
     assert.equal(true, true);
+
+    const migration = new TestBatchMigration();
+    const executor = new BatchedMigrationExecutor('test_batch_migration', migration);
+    await executor.run();
   });
 });

--- a/packages/migrations/src/batched-migration.ts
+++ b/packages/migrations/src/batched-migration.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+import {
+  queryAsync,
+  queryValidatedOneRow,
+  queryValidatedZeroOrOneRow,
+} from '@prairielearn/postgres';
+
+const BatchedMigrationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  min: z.bigint({ coerce: true }),
+  max: z.bigint({ coerce: true }),
+  current: z.bigint({ coerce: true }),
+});
+type BatchedMigrationRow = z.infer<typeof BatchedMigrationSchema>;
+
+/**
+ * A batched migration operates on a range of IDs in batches. It's designed
+ * for migrations that are too large to run in a single transaction.
+ *
+ * Migrations should be idempotent, as they may be run multiple times in case
+ * of unexpected failure.
+ */
+export abstract class BatchedMigration {
+  public async getMin(): Promise<string> {
+    return '0';
+  }
+  public abstract getMax(): Promise<string>;
+  public abstract execute(start: BigInt, end: BigInt): Promise<void>;
+}
+
+export class BatchedMigrationExecutor {
+  private name: string;
+  private migration: BatchedMigration;
+
+  constructor(name: string, migration: BatchedMigration) {
+    this.name = name;
+    this.migration = migration;
+  }
+
+  private async getMigrationState(): Promise<BatchedMigrationRow> {
+    const migration = await queryValidatedZeroOrOneRow(
+      'SELECT * FROM batched_migrations WHERE name = $name;',
+      { name: this.name },
+      BatchedMigrationSchema
+    );
+    if (migration) return migration;
+
+    return this.createMigrationState();
+  }
+
+  private async createMigrationState(): Promise<BatchedMigrationRow> {
+    const min = await this.migration.getMin();
+    const max = await this.migration.getMax();
+    return await queryValidatedOneRow(
+      'INSERT INTO batched_migrations (name, min, max, current) VALUES ($name, $min, $max, $min) ON CONFLICT DO NOTHING RETURNING *;',
+      { name: this.name, min, max },
+      BatchedMigrationSchema
+    );
+  }
+
+  private async updateMigrationState(current: BigInt): Promise<void> {
+    await queryAsync('UPDATE batched_migrations SET current = $current WHERE name = $name;', {
+      name: this.name,
+      current,
+    });
+  }
+
+  /**
+   * Should be used when the migration is being run with a short-lived lock
+   * held. Allows the migration to be picked up by different machines and
+   * be automatically restarted in case of failure.
+   *
+   * @param duration How many seconds to execute for.
+   */
+  async runForDuration(duration: number): Promise<void> {
+    await this.run({ signal: AbortSignal.timeout(duration * 1000) });
+  }
+
+  async run({ signal }: { signal?: AbortSignal }): Promise<void> {
+    const migrationState = await this.getMigrationState();
+
+    let current = migrationState.current;
+    while (!signal?.aborted && current < migrationState.max) {
+      let min = current;
+      let max = current + 1000n;
+
+      this.migration.execute(min, max);
+
+      current = max;
+      await this.updateMigrationState(current);
+    }
+  }
+}

--- a/packages/migrations/src/batched-migration.ts
+++ b/packages/migrations/src/batched-migration.ts
@@ -77,12 +77,13 @@ export class BatchedMigrationExecutor {
     await this.run({ signal: AbortSignal.timeout(duration * 1000) });
   }
 
-  async run({ signal }: { signal?: AbortSignal }): Promise<void> {
+  async run({ signal }: { signal?: AbortSignal } = {}): Promise<void> {
     const migrationState = await this.getMigrationState();
 
     let current = migrationState.current;
-    while (!signal?.aborted && current < migrationState.max) {
+    while (!signal?.aborted && current <= migrationState.max) {
       let min = current;
+      // TODO: configurable batch size
       let max = current + 1000n;
 
       this.migration.execute(min, max);

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,1 +1,1 @@
-export { BatchedMigration } from './batched-migration';
+export { BatchedMigration, BatchedMigrationExecutor } from './batched-migration';

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,1 +1,5 @@
+import path from 'path';
+
 export { BatchedMigration, BatchedMigrationExecutor } from './batched-migration';
+
+export const SCHEMA_MIGRATIONS_PATH = path.resolve(__dirname, '..', 'schema-migrations');

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,0 +1,1 @@
+export { BatchedMigration } from './batched-migration';

--- a/packages/migrations/tsconfig.json
+++ b/packages/migrations/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@prairielearn/tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"],
+  }
+}

--- a/packages/migrations/tsconfig.json
+++ b/packages/migrations/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "types": ["node"],
+    "types": ["node", "mocha"],
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,7 +2481,9 @@ __metadata:
   dependencies:
     "@prairielearn/postgres": ^1.2.0
     "@prairielearn/tsconfig": "*"
+    "@types/mocha": ^10.0.1
     "@types/node": ^18.14.2
+    mocha: ^10.2.0
     ts-node: ^10.9.1
     typescript: ^4.9.5
     zod: ^3.20.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -2475,6 +2475,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@prairielearn/migrations@workspace:packages/migrations":
+  version: 0.0.0-use.local
+  resolution: "@prairielearn/migrations@workspace:packages/migrations"
+  dependencies:
+    "@prairielearn/postgres": ^1.2.0
+    "@prairielearn/tsconfig": "*"
+    "@types/node": ^18.14.2
+    ts-node: ^10.9.1
+    typescript: ^4.9.5
+    zod: ^3.20.6
+  languageName: unknown
+  linkType: soft
+
 "@prairielearn/opentelemetry@^1.0.0, @prairielearn/opentelemetry@workspace:packages/opentelemetry":
   version: 0.0.0-use.local
   resolution: "@prairielearn/opentelemetry@workspace:packages/opentelemetry"
@@ -2511,7 +2524,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@prairielearn/postgres@^1.0.0, @prairielearn/postgres@workspace:packages/postgres":
+"@prairielearn/postgres@^1.0.0, @prairielearn/postgres@^1.2.0, @prairielearn/postgres@workspace:packages/postgres":
   version: 0.0.0-use.local
   resolution: "@prairielearn/postgres@workspace:packages/postgres"
   dependencies:


### PR DESCRIPTION
This PR creates infrastructure for running batched migrations, which are migrations that execute in small chunks of a table's ID space to avoid locking every row in the table.