### PR TITLE
C Grader: create results directory if it does not exist

### DIFF
--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -478,6 +478,7 @@ class CGrader:
         print(out)  # Printing so it shows in the grading job log
 
         # Copy log file to results directory so it becomes available to the instructor after execution
+        out = self.run_command(["mkdir", "-p", "/grade/results"], sandboxed=False)
         out = self.run_command(
             ["cp", log_file, "/grade/results/check_log.xml", "--backup=numbered"],
             sandboxed=False,


### PR DESCRIPTION
In #5910, the check-based functionality of the C grader implemented a copy of the XML log to the `/grade/results` directory so it could be investigated if needed. The problem is that this directory may not exist at that point.