### PR TITLE
fix: pl-drawing MathJax reference to objects not yet in DOM

### DIFF
--- a/elements/pl-drawing/mechanicsObjects.js
+++ b/elements/pl-drawing/mechanicsObjects.js
@@ -891,7 +891,7 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
       .each((_, use) => {
         // Find and create a new copy to link to
         let refLink = use.getAttribute('xlink:href');
-        let refElement = $(refLink)[0];
+        let refElement = $(svg).find(refLink)[0];
         let replacement = $(refElement.outerHTML)[0];
 
         // Copy over any attributes on the link


### PR DESCRIPTION
This seems to have been an issue that may have been introduced indirectly by #6974 (works in 1e4140495, does not work in 0e9b51088). In essence this approach is likely better anyway.

At the moment the element is referenced, it is not yet part of the document's DOM, so it would not be found. Looks for the specific object ID inside the SVG reference instead of in the whole document.

Before the change:

<img width="163" alt="image" src="https://user-images.githubusercontent.com/1004907/223170084-ba3443a9-8954-401a-9646-9ae3456ab6a1.png">

After the change:

<img width="172" alt="image" src="https://user-images.githubusercontent.com/1004907/223169887-c37b7654-120a-4159-a1e2-b6ca2f5ec727.png">
