### PR TITLE
Fix pint cache issue

### DIFF
--- a/python/prairielearn.py
+++ b/python/prairielearn.py
@@ -75,6 +75,7 @@ def get_unit_registry() -> UnitRegistry:
     """Get a unit registry using cache folder valid on production machines."""
     pid = os.getpid()
     cache_dir = f"/tmp/pint_{pid}"
+
     return UnitRegistry(cache_folder=cache_dir)
 
 

--- a/python/prairielearn.py
+++ b/python/prairielearn.py
@@ -73,8 +73,8 @@ class ElementTestData(QuestionData):
 
 def get_unit_registry() -> UnitRegistry:
     """Get a unit registry using cache folder valid on production machines."""
-
-    cache_dir = "/tmp/pint"
+    pid = os.getpid()
+    cache_dir = f"/tmp/pint_{pid}"
     return UnitRegistry(cache_folder=cache_dir)
 
 

--- a/python/prairielearn.py
+++ b/python/prairielearn.py
@@ -73,9 +73,9 @@ class ElementTestData(QuestionData):
 
 def get_unit_registry() -> UnitRegistry:
     """Get a unit registry using cache folder valid on production machines."""
+
     pid = os.getpid()
     cache_dir = f"/tmp/pint_{pid}"
-
     return UnitRegistry(cache_folder=cache_dir)
 
 


### PR DESCRIPTION
Fixes the pint cache issue, discussed on slack. Summary: If multiple `zygote.py` processes are running on the same server, then this creates a race condition with `pint` cache creation, where a process might try and read a cache file that's still being created. To solve this, we use a separate cache directory for each process, that way, the cache file creation won't interfere with other processes.