### PR TITLE
Allow unmounting errors to propagate up

### DIFF
--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -154,8 +154,6 @@ class CodeCallerContainer {
   }
 
   /**
-   * Wrapper around `createBindMount` that includes instance-specific logs.
-   *
    * @param {string} directory
    * @param {string} mountpoint
    */
@@ -175,7 +173,9 @@ class CodeCallerContainer {
    *
    * @param {string} mountpoint
    */
-  async removeBindMount(mountpoint) {
+  async removeBindMountIfNeeded(mountpoint) {
+    if (!this.hasBindMount) return;
+
     this.debug(`removing bind mount at ${mountpoint}`);
     await instrumented('removeBindMount', async (span) => {
       span.setAttribute('mountpoint', mountpoint);
@@ -198,10 +198,7 @@ class CodeCallerContainer {
 
     this.coursePath = coursePath;
 
-    if (this.hasBindMount) {
-      await this.removeBindMount(this.hostDirectory.path);
-    }
-
+    await this.removeBindMountIfNeeded(this.hostDirectory.path);
     await this.createBindMount(coursePath, this.hostDirectory.path);
   }
 
@@ -560,7 +557,7 @@ class CodeCallerContainer {
     // Note that we can't safely do any of this until the container is actually dead
     if (this.hostDirectory) {
       try {
-        await this.removeBindMount(this.hostDirectory.path);
+        await this.removeBindMountIfNeeded(this.hostDirectory.path);
       } catch (e) {
         logger.error('Error unmounting host directory', e);
       }

--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -562,7 +562,6 @@ class CodeCallerContainer {
       try {
         await this.removeBindMount(this.hostDirectory.path);
       } catch (e) {
-        // Probably not mounted; swallow error.
         logger.error('Error unmounting host directory', e);
       }
       try {

--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -180,6 +180,7 @@ class CodeCallerContainer {
     await instrumented('removeBindMount', async (span) => {
       span.setAttribute('mountpoint', mountpoint);
       await bindMount.umount(mountpoint);
+      this.hasBindMount = false;
     });
     this.debug(`removed bind mount at ${mountpoint}`);
   }

--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -124,6 +124,7 @@ class CodeCallerContainer {
     this.timeoutID = null;
     this.callCount = 0;
     this.ensureChildMutex = new Mutex();
+    this.hasBindMount = false;
 
     this.options = options;
 
@@ -162,7 +163,9 @@ class CodeCallerContainer {
     this.debug(`creating bind mount for ${directory} at ${mountpoint}`);
     await instrumented('createBindMount', async (span) => {
       span.setAttribute('mountpoint', mountpoint);
+      span.setAttribute('directory', directory);
       await bindMount.mount(directory, mountpoint);
+      this.hasBindMount = true;
     });
     this.debug(`created bind mount for ${directory} at ${mountpoint}`);
   }
@@ -195,17 +198,10 @@ class CodeCallerContainer {
 
     this.coursePath = coursePath;
 
-    // If this Docker code caller was used before, we might have an existing
-    // bind mount that we need to remove first. This should have been cleaned
-    // up before, but if it wasn't, we'll do so here to avoid a
-    // `mount point XXX is itself on a OSXFUSE volume` error.
-    try {
+    if (this.hasBindMount) {
       await this.removeBindMount(this.hostDirectory.path);
-    } catch (e) {
-      // If the above command failed, assume it because a mount point didn't
-      // already exist and proceed as normal. If something is really messed
-      // up, the next command will likely fail anyways.
     }
+
     await this.createBindMount(coursePath, this.hostDirectory.path);
   }
 
@@ -566,7 +562,8 @@ class CodeCallerContainer {
       try {
         await this.removeBindMount(this.hostDirectory.path);
       } catch (e) {
-        // Probably not mounted; swallow error
+        // Probably not mounted; swallow error.
+        logger.error('Error unmounting host directory', e);
       }
       try {
         await this.hostDirectory.cleanup();


### PR DESCRIPTION
I made two bad assumptions when writing this code:

1. Unmounting will only ever fail if the directory wasn't already mounted.
2. If an error occurred while unmounting, we could safely proceed with the subsequent mount.

In practice, we seem to have a really weird failure case where transient issues outside our control result in a bind mount being unable to be removed (e.g. `EBUSY` errors). If we try to re-mount on top of an existing mount, weird things that I don't fully understand happen, and the kernel locks up for a while.

It's vastly preferable for us to fail to grade/render a question (this can be retried by the student) than it is to get stuck in a state where the kernel is unhappy, so I'm changing this code so that we'll only try to remove a bind mount if we know we created one before, and if it errors, we'll allow that error to bubble up and kill this particular worker as a whole.