### PR TITLE
Fix counting of waiting Python callbacks

### DIFF
--- a/lib/code-caller/index.js
+++ b/lib/code-caller/index.js
@@ -188,10 +188,11 @@ module.exports = {
       // broken and dispose of it.
       unhealthyCodeCallers.add(codeCaller);
       throw err;
+    } finally {
+      load.endJob('python_callback_waiting', jobUuid);
     }
 
     debug(`getPythonCaller(): got ${codeCaller.uuid}`);
-    load.endJob('python_callback_waiting', jobUuid);
     load.endJob('python_worker_idle', codeCaller.uuid);
     load.startJob('python_worker_active', codeCaller.uuid);
 


### PR DESCRIPTION
If we error when configuring a code caller, we should unconditionally "end" the `python_callback_waiting` "job".