### PR TITLE
Improve performance of code caller output handling

### DIFF
--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -129,8 +129,8 @@ class CodeCallerContainer {
     this.options = options;
 
     // These will accumulate output from the container.
-    this.outputStdout = '';
-    this.outputStderr = '';
+    this.outputStdout = [];
+    this.outputStderr = [];
     this.outputBoth = '';
 
     // for error logging
@@ -230,8 +230,8 @@ class CodeCallerContainer {
     const callDataString = JSON.stringify(callData);
 
     // Reset output accumulators.
-    this.outputStdout = '';
-    this.outputStderr = '';
+    this.outputStdout = [];
+    this.outputStderr = [];
     this.outputBoth = '';
 
     const deferred = deferredPromise();
@@ -418,15 +418,15 @@ class CodeCallerContainer {
 
   _handleStdout(data) {
     this.debug('enter _handleStdout()');
-    this.outputStdout += data;
-    if (this.outputStdout.indexOf('\n') >= 0) {
+    this.outputStdout.push(data);
+    if (data.indexOf('\n') >= 0) {
       this._callIsFinished();
     }
     this.debug('exit _handleStdout()');
   }
   _handleStderr(data) {
     this.debug('enter _handleStderr()');
-    this.outputStderr += data;
+    this.outputStderr.push(data);
     this.debug('exit _handleStderr()');
   }
 
@@ -505,7 +505,7 @@ class CodeCallerContainer {
     let data = null;
     let err = null;
     try {
-      data = JSON.parse(this.outputStdout);
+      data = JSON.parse(this.outputStdout.join(''));
       if (data.error) {
         err = new Error(data.error);
         if (data.errorData && data.errorData.outputBoth) {

--- a/lib/code-caller/code-caller-container.js
+++ b/lib/code-caller/code-caller-container.js
@@ -129,7 +129,9 @@ class CodeCallerContainer {
     this.options = options;
 
     // These will accumulate output from the container.
+    /** @type {string[]} */
     this.outputStdout = [];
+    /** @type {string[]} */
     this.outputStderr = [];
     this.outputBoth = '';
 
@@ -401,6 +403,8 @@ class CodeCallerContainer {
     this.stderrStream = new MemoryStream();
     this.stdinStream.pipe(stream);
     this.container.modem.demuxStream(stream, this.stdoutStream, this.stderrStream);
+    this.stdoutStream.setEncoding('utf8');
+    this.stderrStream.setEncoding('utf8');
     this.stdoutStream.on('data', (data) => this._handleStdout(data));
     this.stderrStream.on('data', (data) => this._handleStderr(data));
 
@@ -416,6 +420,9 @@ class CodeCallerContainer {
     this.debug('exit _createAndAttachContainer');
   }
 
+  /**
+   * @param {string} data
+   */
   _handleStdout(data) {
     this.debug('enter _handleStdout()');
     this.outputStdout.push(data);
@@ -424,6 +431,10 @@ class CodeCallerContainer {
     }
     this.debug('exit _handleStdout()');
   }
+
+  /**
+   * @param {string} data
+   */
   _handleStderr(data) {
     this.debug('enter _handleStderr()');
     this.outputStderr.push(data);

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -109,10 +109,14 @@ class CodeCallerNative {
 
     this.options = options;
 
-    // variables to accumulate child output
+    // Accumulators for output from the child process.
+    /** @type {string[]} */
     this.outputStdout = [];
+    /** @type {string[]} */
     this.outputStderr = [];
+    /** @type {string[]} */
     this.outputBoth = [];
+    /** @type {string[]} */
     this.outputData = [];
     this.outputRestart = '';
 

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -110,10 +110,10 @@ class CodeCallerNative {
     this.options = options;
 
     // variables to accumulate child output
-    this.outputStdout = '';
-    this.outputStderr = '';
-    this.outputBoth = '';
-    this.outputData = '';
+    this.outputStdout = [];
+    this.outputStderr = [];
+    this.outputBoth = [];
+    this.outputData = [];
     this.outputRestart = '';
 
     // for error logging
@@ -195,10 +195,10 @@ class CodeCallerNative {
     this.timeoutID = setTimeout(this._timeout.bind(this), timeout);
 
     // Reset output accumulators.
-    this.outputStdout = '';
-    this.outputStderr = '';
-    this.outputBoth = '';
-    this.outputData = '';
+    this.outputStdout = [];
+    this.outputStderr = [];
+    this.outputBoth = [];
+    this.outputData = [];
     this.outputRestart = '';
 
     this.lastCallData = callData;
@@ -344,8 +344,8 @@ class CodeCallerNative {
     this.debug('enter _handleStdoutData()');
     this._checkState([IN_CALL, EXITING]);
     if (this.state === IN_CALL) {
-      this.outputStdout += data;
-      this.outputBoth += data;
+      this.outputStdout.push(data);
+      this.outputBoth.push(data);
     } else {
       this._logError(`Unexpected STDOUT data: ${data}`);
     }
@@ -357,8 +357,8 @@ class CodeCallerNative {
     this.debug(`_handleStderrData(), data: ${data}`);
     this._checkState([IN_CALL, EXITING, WAITING]);
     if (this.state === IN_CALL) {
-      this.outputStderr += data;
-      this.outputBoth += data;
+      this.outputStderr.push(data);
+      this.outputBoth.push(data);
     } else {
       this._logError(`Unexpected STDERR data: ${data}`);
     }
@@ -369,7 +369,7 @@ class CodeCallerNative {
     this.debug('enter _handleStdio3Data()');
     this._checkState([IN_CALL, EXITING]);
     if (this.state === IN_CALL) {
-      this.outputData += data;
+      this.outputData.push(data);
       // If `data` contains a newline, then `outputData` must contain a newline as well.
       // We avoid looking in `outputData` because it's a potentially very large string.
       if (data.indexOf('\n') >= 0) {
@@ -508,7 +508,7 @@ class CodeCallerNative {
     let data,
       err = null;
     try {
-      data = JSON.parse(this.outputData);
+      data = JSON.parse(this.outputData.join(''));
     } catch (e) {
       err = new Error('Error decoding CodeCallerNative JSON: ' + e.message);
     }
@@ -519,7 +519,7 @@ class CodeCallerNative {
     } else {
       this.state = WAITING;
       if (data.present) {
-        this._callCallback(null, data.val, this.outputBoth);
+        this._callCallback(null, data.val, this.outputBoth.join(''));
       } else {
         this._callCallback(new FunctionMissingError('Function not found in module'));
       }
@@ -566,6 +566,10 @@ class CodeCallerNative {
     this.debug('exit _restartIsFinished()');
   }
 
+  /**
+   *
+   * @returns {ErrorData}
+   */
   _errorData() {
     const errForStack = new Error();
     return {
@@ -573,10 +577,10 @@ class CodeCallerNative {
       childIsNull: this.child == null,
       callbackIsNull: this.callback == null,
       timeoutIDIsNull: this.timeoutID == null,
-      outputStdout: this.outputStdout,
-      outputStderr: this.outputStderr,
-      outputBoth: this.outputBoth,
-      outputData: this.outputData,
+      outputStdout: this.outputStdout.join(''),
+      outputStderr: this.outputStderr.join(''),
+      outputBoth: this.outputBoth.join(''),
+      outputData: this.outputData.join(''),
       stack: errForStack.stack,
       lastCallData: this.lastCallData,
     };

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
         "@types/fs-extra": "^11.0.1",
         "@types/lodash": "^4.14.191",
         "@types/loopbench": "^1.2.1",
+        "@types/memorystream": "^0.3.1",
         "@types/mime": "^3.0.1",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/memorystream@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@types/memorystream@npm:0.3.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: ee1d4cb6838bb772e4118aa0797bd0d8a3a471076f83cad3ff1fd539e5f63e9bd7b0374406f05de1e3d1fcd41a7e8d0e0d0ea49616c854a5c872fe3a0df84468
+  languageName: node
+  linkType: hard
+
 "@types/mime@npm:*, @types/mime@npm:^3.0.1":
   version: 3.0.1
   resolution: "@types/mime@npm:3.0.1"
@@ -3366,6 +3375,7 @@ __metadata:
     "@types/fs-extra": ^11.0.1
     "@types/lodash": ^4.14.191
     "@types/loopbench": ^1.2.1
+    "@types/memorystream": ^0.3.1
     "@types/mime": ^3.0.1
     "@types/mocha": ^10.0.1
     "@types/node": ^18.14.2


### PR DESCRIPTION
When I implemented similar changes in #6994, I neglected to make them for the container code caller. I also realized that we're doing a lot of unnecessary string allocation here, so I changed things to collect an array of data chunks and only join them all together at the end.