### PR TITLE
Add `make deps` target for Node/python/transpile tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 	@node packages/compiled-assets/dist/cli.js build ./assets ./public/build
 deps:
 	@yarn
-	@pip3 install -qr images/plbase/python-requirements.txt
+	@pip3 install -qr images/plbase/python-requirements.txt --root-user-action=ignore
 	@make build
 
 dev:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 build:
 	@yarn turbo run build
 	@node packages/compiled-assets/dist/cli.js build ./assets ./public/build
+deps:
+	@yarn
+	@pip3 install -qr images/plbase/python-requirements.txt
+	@make build
 
 dev:
 	@yarn turbo run dev

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -21,9 +21,10 @@ docker run -it --rm -p 3000:3000 -w /PrairieLearn -v /path/to/PrairieLearn:/Prai
 # Repeat after switching branches or pulling new code.
 yarn
 
-# Transpile code in the `packages/` directory.
-# Repeat after switching branches, pulling new code, or editing JS/TS in `packages/`.
-make build
+# Install Node packages and Pythong dependencies, and transpile code in the `packages/` directory.
+# Repeat after switching branches, pulling new code, or editing Python dependencies in `plbase` image.
+# If editing JS/TS in `packages/`, you should also repeat either this command or `make build`.
+make deps
 
 # Run the PrairieLearn server.
 make start

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -52,6 +52,9 @@ python3.6 --version   # should return "Python 3.6" or higher
 ```sh
 cd PrairieLearn/images/plbase
 python3 -m pip install -r python-requirements.txt
+
+# Alternatively, use the following command to transpile packages and update Node/Python libraries:
+make deps
 ```
 
 - Create the database (one time only):
@@ -103,6 +106,6 @@ cd PrairieLearn
 node server
 ```
 
-This should end with `PrairieLearn server ready` and will remain running in the foreground, so this terminal can't be used for anything else. Stopping or restarting the server can be done with `Crtl-C`.
+This should end with `PrairieLearn server ready` and will remain running in the foreground, so this terminal can't be used for anything else. Stopping or restarting the server can be done with `Ctrl-C`.
 
 - In a web-browswer go to [http://localhost:3000](http://localhost:3000)


### PR DESCRIPTION
Resolves #7301 by adding a `deps` target in Makefile that calls `yarn`, `make build` and update Python dependencies. Also creates a separate target only for Python dependencies (`python-deps`). I haven't added yum requirements as they would be quite time-consuming and are unlikely to change frequently anyway.