### PR TITLE
fix: navbar always show logout option

### DIFF
--- a/pages/partials/logout.ejs
+++ b/pages/partials/logout.ejs
@@ -1,5 +1,0 @@
-<% if (typeof authn_user != 'undefined') { %>
-   <a class="dropdown-item" href="<%= plainUrlPrefix %>/logout">Log out</a>
-<% } else { %>
-   <a class="dropdown-item disabled">Log out</a>
-<% } %>

--- a/pages/partials/navbar.ejs
+++ b/pages/partials/navbar.ejs
@@ -39,7 +39,7 @@
       <% } %>
     </ul>
 
-    <%# User and logout %> 
+    <%# User and logout %>
     <%
     let displayedName;
     if (locals.authz_data) {
@@ -307,7 +307,7 @@
             <% } %>
           </a>
 
-          <%- include('logout'); %>
+          <a class="dropdown-item" href="<%= plainUrlPrefix %>/logout">Log out</a>
 
         </div>
       </li>


### PR DESCRIPTION
This small change removes the conditional on showing the logout link in the navbar so that it is never disabled.

I ran into a case in development where my auth cookie was no longer valid and I noticed the error page didn't give me the logout link to easily remove the cookie. When I traced through the partials, I found I had a case for the only conditional in that partial (maybe there were originally more?), so I simplified it just to always show the link in `navbar.ejs`