### PR TITLE
Disable lib checking in tsconfig.json

### DIFF
--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -9,6 +9,9 @@
     "module": "CommonJS",
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    // Checking the types for *all* our dependencies is unnecessarily slow in
+    // CI, so we'll only check the types our code actually refers to.
+    "skipLibCheck": true,
   }
 }

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -12,6 +12,6 @@
     "noUnusedParameters": true,
     // Checking the types for *all* our dependencies is unnecessarily slow in
     // CI, so we'll only check the types our code actually refers to.
-    "skipLibCheck": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Locally, this cut the time for a `yarn turbo build --force` in half from ~8 seconds to ~4 seconds. This should help a lot on CI where we have fewer CPUs to parallelize things.