### PR TITLE
Capture Postgres pool metrics

### DIFF
--- a/.changeset/flat-ways-roll.md
+++ b/.changeset/flat-ways-roll.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/postgres': minor
+---
+
+Add `totalCount`, `idleCount`, and `waitingCount` properties to `PostgresPool`

--- a/.changeset/heavy-balloons-appear.md
+++ b/.changeset/heavy-balloons-appear.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/named-locks': minor
+---
+
+Export underlying Postgres client pool as `pool`

--- a/.changeset/poor-drinks-change.md
+++ b/.changeset/poor-drinks-change.md
@@ -2,4 +2,4 @@
 '@prairielearn/opentelemetry': minor
 ---
 
-Add `createObservableRangeGauge()` function
+Add `createObservableValueGauges()` function

--- a/.changeset/poor-drinks-change.md
+++ b/.changeset/poor-drinks-change.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/opentelemetry': minor
+---
+
+Add `createObservableRangeGauge()` function

--- a/graders/python/python_autograder/pl_result.py
+++ b/graders/python/python_autograder/pl_result.py
@@ -93,7 +93,7 @@ class PLTestResult(unittest.TestResult):
                 ipynb_key=Feedback.test.ipynb_key,
             )
         else:
-            tr_message = ''.join(traceback.format_exception(*err))
+            tr_message = "".join(traceback.format_exception(*err))
 
             if isinstance(test, unittest.suite._ErrorHolder):
                 # Error occurred outside of a test case, like in setup code for example

--- a/packages/named-locks/src/index.ts
+++ b/packages/named-locks/src/index.ts
@@ -63,7 +63,7 @@ type InternalLockOptions =
  * can lead to deadlocks.
  */
 
-const pool = new PostgresPool();
+export const pool = new PostgresPool();
 
 /**
  * Initializes a new {@link PostgresPool} that will be used to acquire named locks.

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -103,13 +103,13 @@ await instrumentedWithMetrics(meter, 'operation.name', async () => {
 });
 ```
 
-To capture statistics about a constantly changing value (for instance, the size of a database connection pool), you can use `createObservableRangeGauge`. This will "observe" your chosen value on a regular interval and collect the min/max/average of that value for each metrics collection interval.
+To capture statistics about a constantly changing value (for instance, the size of a database connection pool), you can use `createObservableValueGauges`. This will "observe" your chosen value on a regular interval and collect the min/max/average of that value for each metrics collection interval.
 
 ```ts
-import { metrics, createObservableRangeGauge } from '@prairielearn/opentelemetry';
+import { metrics, createObservableValueGauges } from '@prairielearn/opentelemetry';
 
 const meter = metrics.getMeter('meter-name');
-createObservableRangeGauge(
+createObservableValueGauges(
   meter,
   'db.pool.size',
   {

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -102,3 +102,20 @@ await instrumentedWithMetrics(meter, 'operation.name', async () => {
   }
 });
 ```
+
+To capture statistics about a constantly changing value (for instance, the size of a database connection pool), you can use `createObservableRangeGauge`. This will "observe" your chosen value on a regular interval and collect the min/max/average of that value for each metrics collection interval.
+
+```ts
+import { metrics, createObservableRangeGauge } from '@prairielearn/opentelemetry';
+
+const meter = metrics.getMeter('meter-name');
+createObservableRangeGauge(
+  meter,
+  'db.pool.size',
+  {
+    // The interval that your value will be observed, in milliseconds.
+    interval: 1000,
+  },
+  () => pool.size
+);
+```

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -11,4 +11,6 @@ export {
   getObservableCounter,
   getObservableUpDownCounter,
   getObservableGauge,
+  createObservableRangeGauge,
+  CreateObservableRangeGaugeOptions,
 } from './metrics';

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -11,6 +11,6 @@ export {
   getObservableCounter,
   getObservableUpDownCounter,
   getObservableGauge,
-  createObservableRangeGauge,
-  CreateObservableRangeGaugeOptions,
+  createObservableValueGauges,
+  createObservableValueGaugesOptions,
 } from './metrics';

--- a/packages/opentelemetry/src/metrics.ts
+++ b/packages/opentelemetry/src/metrics.ts
@@ -92,7 +92,7 @@ export async function instrumentedWithMetrics<T>(
   }
 }
 
-export interface CreateObservableRangeGaugeOptions extends MetricOptions {
+export interface createObservableValueGaugesOptions extends MetricOptions {
   interval: number;
 }
 
@@ -107,10 +107,10 @@ export interface CreateObservableRangeGaugeOptions extends MetricOptions {
  * - `${name}.max`
  * - `${name}.avg`
  */
-export async function createObservableRangeGauge(
+export async function createObservableValueGauges(
   meter: Meter,
   name: string,
-  options: CreateObservableRangeGaugeOptions,
+  options: createObservableValueGaugesOptions,
   observe: () => number
 ) {
   const { interval, ...metricOptions } = options;

--- a/packages/opentelemetry/src/metrics.ts
+++ b/packages/opentelemetry/src/metrics.ts
@@ -91,3 +91,73 @@ export async function instrumentedWithMetrics<T>(
     histogram.record(performance.now() - start);
   }
 }
+
+export interface CreateObservableRangeGaugeOptions extends MetricOptions {
+  interval: number;
+}
+
+/**
+ * Creates a set of gauges that track the min, max, and average of a value over
+ * time. The value is observed on a regular interval.
+ *
+ * The provided {@link name} is used as the base name for the three gauges. The
+ * names of the individual gauges are:
+ *
+ * - `${name}.min`
+ * - `${name}.max`
+ * - `${name}.avg`
+ */
+export async function createObservableRangeGauge(
+  meter: Meter,
+  name: string,
+  options: CreateObservableRangeGaugeOptions,
+  observe: () => number
+) {
+  const { interval, ...metricOptions } = options;
+
+  let min = 0;
+  let max = 0;
+  let sum = 0;
+  let count = 0;
+
+  // Observe the value on a regular interval. Black-hole any errors.
+  const intervalId = setInterval(() => {
+    Promise.resolve(observe())
+      .then((value) => {
+        min = Math.min(min, value);
+        max = Math.max(max, value);
+        sum += value;
+        count += 1;
+      })
+      .catch(() => {});
+  }, interval);
+
+  // Don't let this keep the process alive.
+  intervalId.unref();
+
+  const minGauge = getObservableGauge(meter, `${name}.min`, metricOptions);
+  const maxGauge = getObservableGauge(meter, `${name}.max`, metricOptions);
+  const averageGauge = getObservableGauge(meter, `${name}.avg`, metricOptions);
+
+  minGauge.addCallback((observableResult) => {
+    observableResult.observe(min);
+
+    min = 0;
+  });
+
+  maxGauge.addCallback((observableResult) => {
+    observableResult.observe(max);
+
+    max = 0;
+  });
+
+  averageGauge.addCallback((observableResult) => {
+    const avg = sum / count;
+    observableResult.observe(avg);
+
+    sum = 0;
+    count = 0;
+  });
+
+  return { minGauge, maxGauge, averageGauge, stop: () => clearInterval(intervalId) };
+}

--- a/packages/opentelemetry/src/metrics.ts
+++ b/packages/opentelemetry/src/metrics.ts
@@ -137,7 +137,11 @@ export async function createObservableRangeGauge(
 
   const minGauge = getObservableGauge(meter, `${name}.min`, metricOptions);
   const maxGauge = getObservableGauge(meter, `${name}.max`, metricOptions);
-  const averageGauge = getObservableGauge(meter, `${name}.avg`, metricOptions);
+  const averageGauge = getObservableGauge(meter, `${name}.avg`, {
+    ...metricOptions,
+    // Average is always a double, even if the observed value is an int.
+    valueType: ValueType.DOUBLE,
+  });
 
   minGauge.addCallback((observableResult) => {
     observableResult.observe(min);

--- a/packages/opentelemetry/src/metrics.ts
+++ b/packages/opentelemetry/src/metrics.ts
@@ -124,7 +124,7 @@ export async function createObservableRangeGauge(
   const intervalId = setInterval(() => {
     Promise.resolve(observe())
       .then((value) => {
-        min = Math.min(min, value);
+        min = (count == 0 ? value : Math.min(min, value));
         max = Math.max(max, value);
         sum += value;
         count += 1;

--- a/packages/opentelemetry/src/metrics.ts
+++ b/packages/opentelemetry/src/metrics.ts
@@ -124,7 +124,7 @@ export async function createObservableRangeGauge(
   const intervalId = setInterval(() => {
     Promise.resolve(observe())
       .then((value) => {
-        min = (count == 0 ? value : Math.min(min, value));
+        min = count == 0 ? value : Math.min(min, value);
         max = Math.max(max, value);
         sum += value;
         count += 1;

--- a/packages/postgres/src/default-pool.test.ts
+++ b/packages/postgres/src/default-pool.test.ts
@@ -3,35 +3,35 @@ import { PostgresPool } from './pool';
 import * as pgPool from './default-pool';
 
 /**
- * Returns true if the property on `PostgresPool` should be considered
- * hidden - that is, if it should be available on the module's exports.
+ * Properties on {@link PostgresPool} that should not be available on the default
+ * pool's exports.
  */
-function isHiddenProperty(property: string) {
-  switch (property) {
-    case 'pool':
-    case 'alsClient':
-    case 'searchSchema':
-      return true;
-    default:
-      return false;
-  }
-}
+const HIDDEN_PROPERTIES = new Set([
+  'pool',
+  'alsClient',
+  'searchSchema',
+  'totalCount',
+  'idleCount',
+  'waitingCount',
+]);
 
 describe('sqldb', () => {
   it('exports the full PostgresPool interface', () => {
     const pool = new PostgresPool();
 
     Object.getOwnPropertyNames(pool)
-      .filter((n) => !isHiddenProperty(n))
+      .filter((n) => !HIDDEN_PROPERTIES.has(n))
       .forEach((prop) => {
         assert.property(pgPool, prop);
         assert.ok((pgPool as any)[prop]);
       });
 
-    Object.getOwnPropertyNames(Object.getPrototypeOf(pool)).forEach((prop) => {
-      assert.property(pgPool, prop);
-      assert.ok((pgPool as any)[prop]);
-    });
+    Object.getOwnPropertyNames(Object.getPrototypeOf(pool))
+      .filter((n) => !HIDDEN_PROPERTIES.has(n))
+      .forEach((prop) => {
+        assert.property(pgPool, prop);
+        assert.ok((pgPool as any)[prop]);
+      });
   });
 
   it('should not have extra properties', () => {

--- a/packages/postgres/src/default-pool.test.ts
+++ b/packages/postgres/src/default-pool.test.ts
@@ -7,12 +7,16 @@ import * as pgPool from './default-pool';
  * pool's exports.
  */
 const HIDDEN_PROPERTIES = new Set([
+  // Private members
   'pool',
   'alsClient',
   'searchSchema',
+  '_queryCount',
+  // Getters
   'totalCount',
   'idleCount',
   'waitingCount',
+  'queryCount',
 ]);
 
 describe('sqldb', () => {

--- a/packages/postgres/src/default-pool.ts
+++ b/packages/postgres/src/default-pool.ts
@@ -1,6 +1,7 @@
 import { PostgresPool } from './pool';
 
 const defaultPool = new PostgresPool();
+export { defaultPool };
 
 // We re-expose all functions from the default pool here to account for the
 // default case of a shared global pool of clients. If someone want to create

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -882,4 +882,16 @@ export class PostgresPool {
    * Generate, set, and return a random schema name.
    */
   setRandomSearchSchema = callbackify(this.setRandomSearchSchemaAsync);
+
+  get totalCount() {
+    return this.pool?.totalCount ?? 0;
+  }
+
+  get idleCount() {
+    return this.pool?.idleCount ?? 0;
+  }
+
+  get waitingCount() {
+    return this.pool?.waitingCount ?? 0;
+  }
 }

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -125,6 +125,8 @@ export class PostgresPool {
    */
   private alsClient: AsyncLocalStorage<pg.PoolClient> = new AsyncLocalStorage();
   private searchSchema: string | null = null;
+  /** Tracks the total number of queries executed by this pool. */
+  private _queryCount = 0;
 
   /**
    * Creates a new connection pool and attempts to connect to the database.
@@ -262,6 +264,7 @@ export class PostgresPool {
     sql: string,
     params: Params
   ): Promise<pg.QueryResult> {
+    this._queryCount += 1;
     debug('queryWithClient()', 'sql:', debugString(sql));
     debug('queryWithClient()', 'params:', debugParams(params));
     const { processedSql, paramsArray } = paramsToArray(sql, params);
@@ -883,15 +886,23 @@ export class PostgresPool {
    */
   setRandomSearchSchema = callbackify(this.setRandomSearchSchemaAsync);
 
+  /** The number of established connections. */
   get totalCount() {
     return this.pool?.totalCount ?? 0;
   }
 
+  /** The number of idle connections. */
   get idleCount() {
     return this.pool?.idleCount ?? 0;
   }
 
+  /** The number of queries waiting for a connection to become available. */
   get waitingCount() {
     return this.pool?.waitingCount ?? 0;
+  }
+
+  /** The total number of queries that have been executed by this pool. */
+  get queryCount() {
+    return this._queryCount;
   }
 }

--- a/server.js
+++ b/server.js
@@ -1776,7 +1776,7 @@ module.exports.startServer = async () => {
   });
   server.on('connection', () => connectionCounter.add(1));
 
-  opentelemetry.createObservableRangeGauge(
+  opentelemetry.createObservableValueGauges(
     meter,
     'http.connections.active',
     {
@@ -2020,7 +2020,7 @@ if (config.startServer) {
         ];
 
         pools.forEach(({ name, pool }) => {
-          opentelemetry.createObservableRangeGauge(
+          opentelemetry.createObservableValueGauges(
             meter,
             `postgres.pool.${name}.total`,
             {
@@ -2030,7 +2030,7 @@ if (config.startServer) {
             () => pool.totalCount
           );
 
-          opentelemetry.createObservableRangeGauge(
+          opentelemetry.createObservableValueGauges(
             meter,
             `postgres.pool.${name}.idle`,
             {
@@ -2040,7 +2040,7 @@ if (config.startServer) {
             () => pool.idleCount
           );
 
-          opentelemetry.createObservableRangeGauge(
+          opentelemetry.createObservableValueGauges(
             meter,
             `postgres.pool.${name}.waiting`,
             {

--- a/server.js
+++ b/server.js
@@ -2049,6 +2049,17 @@ if (config.startServer) {
             },
             () => pool.waitingCount
           );
+
+          const queryCounter = opentelemetry.getObservableCounter(
+            meter,
+            `postgres.pool.${name}.query.count`,
+            {
+              valueType: opentelemetry.ValueType.INT,
+            }
+          );
+          queryCounter.addCallback((observableResult) => {
+            observableResult.observe(pool.queryCount);
+          });
         });
       },
       async () => {

--- a/server.js
+++ b/server.js
@@ -1772,7 +1772,7 @@ module.exports.startServer = async () => {
   const meter = opentelemetry.metrics.getMeter('prairielearn');
 
   const connectionCounter = opentelemetry.getCounter(meter, 'http.connections', {
-    unit: opentelemetry.ValueType.INT,
+    valueType: opentelemetry.ValueType.INT,
   });
   server.on('connection', () => connectionCounter.add(1));
 
@@ -1780,7 +1780,7 @@ module.exports.startServer = async () => {
     meter,
     'http.connections.active',
     {
-      unit: opentelemetry.ValueType.INT,
+      valueType: opentelemetry.ValueType.INT,
       interval: 1000,
     },
     () => {
@@ -2024,7 +2024,7 @@ if (config.startServer) {
             meter,
             `postgres.pool.${name}.total`,
             {
-              unit: opentelemetry.ValueType.INT,
+              valueType: opentelemetry.ValueType.INT,
               interval: 1000,
             },
             () => pool.totalCount
@@ -2034,7 +2034,7 @@ if (config.startServer) {
             meter,
             `postgres.pool.${name}.idle`,
             {
-              unit: opentelemetry.ValueType.INT,
+              valueType: opentelemetry.ValueType.INT,
               interval: 1000,
             },
             () => pool.idleCount
@@ -2044,7 +2044,7 @@ if (config.startServer) {
             meter,
             `postgres.pool.${name}.waiting`,
             {
-              unit: opentelemetry.ValueType.INT,
+              valueType: opentelemetry.ValueType.INT,
               interval: 1000,
             },
             () => pool.waitingCount


### PR DESCRIPTION
This should allow us to better understand how our queries are performing under load. Specifically, this will give us insight into how queries are queueing.

Here's what these look line on Honeycomb. Once I finally limited my local connection pool to 2 clients, you can see that we start measuring waiting clients!

<img width="1777" alt="Screenshot 2023-03-09 at 16 12 23" src="https://user-images.githubusercontent.com/1476544/224190170-129d6ff0-6455-4f08-bed0-6b1aee40cf63.png">
