### PR TITLE
Update yarn.lock after changeset versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # We need to run `yarn` after `changeset version` to update `yarn.lock`
+          # https://github.com/changesets/action/issues/170
+          version: yarn changeset version && yarn
           # This invokes the `release` script in `package.json`, which will build
           # all the packages and then invoke `changeset publish`.
           publish: yarn release


### PR DESCRIPTION
A recent merge to master failed because `yarn.lock` wasn't in sync after running `changeset version` (https://github.com/changesets/action/issues/170). We now run `yarn` after `changeset version` to make any necessary changes to `yarn.lock` automatically.