### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The PrairieLearn team takes the security of our products and services seriously.
 
 ## Reporting a vulnerability
 
-If you believe you have found a vulnerability in any PrairieLearn software, please report it to us via coordinated disclosure. **Do not report suspected vulnerabilities publicly, including through GiHub issues or public Slack channels.** Instead, please send an email to security@prairielearn.com with as much relevant information as possible, including:
+If you believe you have found a vulnerability in any PrairieLearn software, please report it to us via coordinated disclosure. **Do not report suspected vulnerabilities publicly, including through GitHub issues or Slack.** Instead, please send an email to security@prairielearn.com with as much relevant information as possible, including:
 
 - The type of issue (e.g. SQL injection or cross-site scripting)
 - Any special configuration required to reproduce the issue

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security
+
+The PrairieLearn team takes the security of our products and services seriously. Thanks for helping to make PrairieLearn secure for everyone.
+
+## Reporting a vulnerability
+
+If you believe you have found a vulnerability in any PrairieLearn software, please report it to us via coordinated disclosure. **Do not report suspected vulnerabilities publicly, including through GiHub issues or public Slack channels.** Instead, please send an email to security@prairielearn.com with as much relevant information as possible, including:
+
+- The type of issue (e.g. SQL injection or cross-site scripting)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Impact of issue, including how an attacker might exploit the issue
+
+The PrairieLearn security team will triage your report and respond according to its impact on PrairieLearn users and systems.


### PR DESCRIPTION
Provides information on how to responsibly disclose suspected vulnerabilities to the PrairieLearn team.