### PR TITLE
C Grader: add option to reject symbols in student code

### DIFF
--- a/docs/c-grader/index.md
+++ b/docs/c-grader/index.md
@@ -161,6 +161,18 @@ self.link_object_files(["student_file1_nomain.o", "student_file2.o"],
 
 The `link_object_files` also accepts arguments like `flags`, `pkg_config_flags`, `add_warning_result_msg=False` and `ungradable_if_failed=False`, as described above.
 
+For questions where students are not allowed to use a specific set of functions or global variables (e.g., students are not allowed to use the `system` library call), it is possible to reject a specific set of symbols. This option will cause an error similar to a compilation error if any of these symbols is referenced in the code. Only student files are checked against this list of symbols, so they can still be used in instructor code.
+
+```python
+self.compile_file(
+    ["student_file1.c", "student_file2.c"],
+    "executable",
+    add_c_file=["/grade/tests/question_file1.c", "/grade/tests/question_file2.c"],
+    flags=["-I/grade/tests", "-I/grade/student", "-lrt"],
+    reject_symbols=["system", "vfork", "clone", "clone3", "posix_spawn", "posix_spawnp"],
+)
+```
+
 For `self.test_compile_file()`, the results of the compilation will show up as a test named "Compilation", worth one point. To change the name and/or points, set the `name` or `points` argument as follows:
 
 ```python

--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -123,6 +123,7 @@ class CGrader:
         ungradable_if_failed=True,
         return_objects=False,
         enable_asan=False,
+        reject_symbols=None,
     ):
         cflags = flags
         if cflags and not isinstance(cflags, list):
@@ -170,7 +171,7 @@ class CGrader:
                     }
                 if found_primitives:
                     out += (
-                        "\n\033[31mThe following unauthorized primitives were found in the provided code:\n\t"
+                        "\n\033[31mThe following unauthorized primitives were found in the submitted code:\n\t"
                         + ", ".join(found_primitives)
                         + "\033[0m"
                     )
@@ -181,10 +182,12 @@ class CGrader:
                 symbols = self.run_command(
                     ["nm", "-j", obj_file], sandboxed=False
                 ).splitlines()
-                found_symbols = INVALID_SYMBOLS & set(symbols)
+                found_symbols = (INVALID_SYMBOLS | set(reject_symbols or {})) & set(
+                    symbols
+                )
                 if found_symbols:
                     out += (
-                        "\n\033[31mThe following unauthorized function(s) and/or variable(s) were found in the provided code:\n\t"
+                        "\n\033[31mThe following unauthorized function(s) and/or variable(s) were found in the submitted code:\n\t"
                         + ", ".join(found_symbols)
                         + "\033[0m"
                     )
@@ -300,6 +303,7 @@ class CGrader:
         add_warning_result_msg=True,
         ungradable_if_failed=True,
         enable_asan=False,
+        reject_symbols=None,
     ):
         if not add_c_file:
             add_c_file = []
@@ -321,6 +325,7 @@ class CGrader:
             ungradable_if_failed=ungradable_if_failed,
             return_objects=True,
             enable_asan=enable_asan,
+            reject_symbols=reject_symbols,
         )
         success = (
             os.path.isfile(exec_file)


### PR DESCRIPTION
Extend the work in #7342 by allowing question code to determine additional rejected symbols.

Given the commit in #7342 also did not cause the image push CI to run, this PR is also intended to update the image on Docker Hub.