### PR TITLE
Use FOR NO KEY UPDATE instead of FOR UPDATE

### DIFF
--- a/lib/assessment.sql
+++ b/lib/assessment.sql
@@ -81,7 +81,7 @@ FROM
   assessments AS a
 WHERE
   a.id = $assessment_id
-FOR UPDATE;
+FOR NO KEY UPDATE;
 
 -- BLOCK select_assessment_needs_statisics_update
 SELECT

--- a/lib/workspace.sql
+++ b/lib/workspace.sql
@@ -22,7 +22,7 @@ FROM
   workspaces
 WHERE
   id = $workspace_id
-FOR UPDATE;
+FOR NO KEY UPDATE;
 
 -- BLOCK select_workspace_data
 SELECT

--- a/sprocs/assessment_groups_add_member.sql
+++ b/sprocs/assessment_groups_add_member.sql
@@ -20,7 +20,7 @@ BEGIN
         gc.assessment_id = assessment_groups_add_member.assessment_id
         AND g.id = arg_group_id
         AND g.deleted_at IS NULL
-    FOR UPDATE of g;
+    FOR NO KEY UPDATE of g;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'The group does not belong to the assessment';

--- a/sprocs/assessment_groups_delete_group.sql
+++ b/sprocs/assessment_groups_delete_group.sql
@@ -17,7 +17,7 @@ BEGIN
         gc.assessment_id = assessment_groups_delete_group.assessment_id
         AND g.id = arg_group_id
         AND g.deleted_at IS NULL
-    FOR UPDATE of g;
+    FOR NO KEY UPDATE of g;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'The user does not belong to the assessment';

--- a/sprocs/assessment_groups_delete_member.sql
+++ b/sprocs/assessment_groups_delete_member.sql
@@ -20,7 +20,7 @@ BEGIN
         gc.assessment_id = assessment_groups_delete_member.assessment_id
         AND g.id = arg_group_id
         AND g.deleted_at IS NULL
-    FOR UPDATE of g;
+    FOR NO KEY UPDATE of g;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'The user does not belong to the assessment';

--- a/sprocs/assessment_instances_lock.sql
+++ b/sprocs/assessment_instances_lock.sql
@@ -7,7 +7,7 @@ BEGIN
     PERFORM ai.id
     FROM assessment_instances AS ai
     WHERE ai.id = assessment_instance_id
-    FOR UPDATE OF ai;
+    FOR NO KEY UPDATE OF ai;
 
     IF NOT FOUND THEN RAISE EXCEPTION 'no such assessment_instance_id: %', assessment_instance_id; END IF;
 END;

--- a/sprocs/courses_update_column.sql
+++ b/sprocs/courses_update_column.sql
@@ -15,7 +15,7 @@ BEGIN
         pl_courses AS c
     WHERE
         c.id = course_id
-    FOR UPDATE;
+    FOR NO KEY UPDATE;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'no such course, id: %', course_id;

--- a/sprocs/grading_jobs_lock.sql
+++ b/sprocs/grading_jobs_lock.sql
@@ -24,13 +24,13 @@ BEGIN
         PERFORM ai.id
         FROM assessment_instances AS ai
         WHERE ai.id = assessment_instance_id
-        FOR UPDATE OF ai;
+        FOR NO KEY UPDATE OF ai;
     ELSE
         -- lock the variant
         PERFORM v.id
         FROM variants AS v
         WHERE v.id = variant_id
-        FOR UPDATE OF v;
+        FOR NO KEY UPDATE OF v;
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/group_users_insert.sql
+++ b/sprocs/group_users_insert.sql
@@ -36,7 +36,7 @@ BEGIN
     PERFORM g.id
     FROM groups AS g
     WHERE g.id = arg_group_id
-    FOR UPDATE OF g;
+    FOR NO KEY UPDATE OF g;
 
     -- count the group size and compare with the max size
     SELECT

--- a/sprocs/instance_questions_lock.sql
+++ b/sprocs/instance_questions_lock.sql
@@ -18,6 +18,6 @@ BEGIN
     PERFORM ai.id
     FROM assessment_instances AS ai
     WHERE ai.id = assessment_instance_id
-    FOR UPDATE OF ai;
+    FOR NO KEY UPDATE OF ai;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/submissions_lock.sql
+++ b/sprocs/submissions_lock.sql
@@ -23,13 +23,13 @@ BEGIN
         PERFORM ai.id
         FROM assessment_instances AS ai
         WHERE ai.id = assessment_instance_id
-        FOR UPDATE OF ai;
+        FOR NO KEY UPDATE OF ai;
     ELSE
         -- lock the variant
         PERFORM v.id
         FROM variants AS v
         WHERE v.id = variant_id
-        FOR UPDATE OF v;
+        FOR NO KEY UPDATE OF v;
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/sprocs/variants_lock.sql
+++ b/sprocs/variants_lock.sql
@@ -20,13 +20,13 @@ BEGIN
         PERFORM ai.id
         FROM assessment_instances AS ai
         WHERE ai.id = assessment_instance_id
-        FOR UPDATE OF ai;
+        FOR NO KEY UPDATE OF ai;
     ELSE
         -- lock the variant
         PERFORM v.id
         FROM variants AS v
         WHERE v.id = variant_id
-        FOR UPDATE OF v;
+        FOR NO KEY UPDATE OF v;
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
This should help reduce lock contention by allowing `page_view_logs` to insert records even when locks are held on referenced tables.

Though this is probably only necessary for `assessment`/`assessment_instance`/`variant` tables, I opted to make the change for all tables. This should be safe, as we're neither deleting a row or changing its primary key after acquiring a lock on it.

Closes https://github.com/PrairieLearnInc/sysconf/issues/870.