### PR TITLE
Don't start nested transactions in runInTransactionAsync

### DIFF
--- a/.changeset/breezy-fishes-act.md
+++ b/.changeset/breezy-fishes-act.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/postgres': minor
+---
+
+Don't start nested transactions in `runInTransactionAsync`


### PR DESCRIPTION
Consider the following code:

```ts
await runInTransactionAsync(async () => {
  await runInTransactionAsync(async () => {
    queryAsync('SELECT ...', {});
  });
});
```

Before this change, that would have resulted in the following warnings from Postgres:

```
2023-03-27 01:08:49 UTC:10.0.49.218(39398):pdb@prairielearn:[4822]:WARNING:  there is already a transaction in progress
2023-03-27 01:08:50 UTC:10.0.49.218(39398):pdb@prairielearn:[4822]:WARNING:  there is no transaction in progress
```

The first one is fine, but the second one is potentially a problem, as it means we're prematurely committing a transaction.

With this change, any nested transactions won't execute `START TRANSACTION` and either `COMMIT` or `ROLLBACK`; only the root transaction will be able to do that.