### PR TITLE
Don't version private packages with Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,9 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.6.4/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "access": "public",
   "baseBranch": "master",
-  "updateInternalDependencies": "minor"
+  "updateInternalDependencies": "minor",
+  "privatePackages": false
 }


### PR DESCRIPTION
See https://github.com/PrairieLearn/PrairieLearn/pull/7373/commits/60e276ddcbe468670b8134c0bebe4cd3ce85f34c - we don't want the private `@prairielearn/workspace-utils` package to be versioned when one of its internal dependencies changes.