### PR TITLE
Move database testing utilities into @prairielearn/postgres

### DIFF
--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -4,3 +4,5 @@ export { loadSql, loadSqlEquiv } from './loader';
 export { PostgresPool } from './pool';
 
 export * from './default-pool';
+
+export { makePostgresTestUtils, PostgresTestUtils, PostgresTestUtilsOptions } from './test-utils';

--- a/packages/postgres/src/test-utils.ts
+++ b/packages/postgres/src/test-utils.ts
@@ -16,8 +16,9 @@ export interface PostgresTestUtilsOptions {
 
 interface CreateDatabaseOptions {
   dropExistingDatabase?: boolean;
-  configurePool?: boolean;
+  database?: string;
   templateDatabase?: string;
+  configurePool?: boolean;
   prepare?: (client: pg.Client) => Promise<void>;
 }
 
@@ -41,7 +42,7 @@ async function createDatabase(
   await client.connect();
 
   const escapedDatabase = client.escapeIdentifier(
-    getDatabaseNameForCurrentMochaWorker(options.database)
+    createOptions.database ?? getDatabaseNameForCurrentMochaWorker(options.database)
   );
   if (dropExistingDatabase ?? true) {
     await client.query(`DROP DATABASE IF EXISTS ${escapedDatabase}`);

--- a/packages/postgres/src/test-utils.ts
+++ b/packages/postgres/src/test-utils.ts
@@ -1,0 +1,144 @@
+import pg from 'pg';
+
+import * as defaultPool from './default-pool';
+
+const POSTGRES_USER = 'postgres';
+const POSTGRES_HOST = 'localhost';
+const POSTGRES_DATABASE = 'postgres';
+
+export interface PostgresTestUtilsOptions {
+  user?: string;
+  host?: string;
+  defaultDatabase?: string;
+  database: string;
+  prepareAfterReset?: (client: pg.Client) => Promise<void>;
+}
+
+interface CreateDatabaseOptions {
+  dropExistingDatabase?: boolean;
+  configurePool?: boolean;
+  templateDatabase?: string;
+  prepare?: () => Promise<void>;
+}
+
+interface DropDatabaseOptions {
+  database?: string;
+  force?: boolean;
+}
+
+async function createDatabase(
+  options: PostgresTestUtilsOptions,
+  createOptions: CreateDatabaseOptions
+): Promise<void> {
+  const dropExistingDatabase = createOptions.dropExistingDatabase ?? true;
+  const configurePool = createOptions.configurePool ?? true;
+
+  const client = new pg.Client({
+    user: options.user ?? POSTGRES_USER,
+    host: options.host ?? POSTGRES_HOST,
+    database: options.defaultDatabase ?? POSTGRES_DATABASE,
+  });
+  await client.connect();
+
+  if (dropExistingDatabase ?? true) {
+    await client.query(`DROP DATABASE IF EXISTS ${client.escapeIdentifier(options.database)}`);
+  }
+
+  const escapedDatabase = client.escapeIdentifier(options.database);
+  if (createOptions.templateDatabase) {
+    const escapedTemplateDatabase = client.escapeIdentifier(createOptions.templateDatabase);
+    await client.query(`CREATE DATABASE ${escapedDatabase} TEMPLATE ${escapedTemplateDatabase}`);
+  } else {
+    await client.query(`CREATE DATABASE ${escapedDatabase}`);
+  }
+
+  await client.end();
+
+  await createOptions.prepare?.();
+
+  if (configurePool) {
+    await defaultPool.initAsync(
+      {
+        user: options.user ?? POSTGRES_USER,
+        host: options.host ?? POSTGRES_HOST,
+        database: getDatabaseNameForCurrentMochaWorker(options.database),
+        // TODO: make these configurable?
+        max: 10,
+        idleTimeoutMillis: 30000,
+      },
+      (err) => {
+        throw err;
+      }
+    );
+  }
+}
+
+async function resetDatabase(options: PostgresTestUtilsOptions): Promise<void> {
+  const client = new pg.Client(getPoolConfig(options));
+  await client.connect();
+  await client.query(`
+    DO
+    $func$
+    BEGIN
+      EXECUTE (
+        SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' RESTART IDENTITY CASCADE'
+          FROM pg_class
+          WHERE relkind = 'r'
+          AND relnamespace = 'public'::regnamespace
+      );
+    END
+    $func$;
+  `);
+  await options.prepareAfterReset?.(client);
+  await client.end();
+}
+
+async function dropDatabase(
+  options: PostgresTestUtilsOptions,
+  dropOptions: DropDatabaseOptions = {}
+): Promise<void> {
+  await defaultPool.closeAsync();
+
+  const database = dropOptions.database ?? getDatabaseNameForCurrentMochaWorker(options.database);
+  if ('PL_KEEP_TEST_DB' in process.env && !(dropOptions.force ?? false)) {
+    console.log(`PL_KEEP_TEST_DB enviroment variable set, not dropping database ${database}`);
+    return;
+  }
+
+  const client = new pg.Client(getPoolConfig(options));
+  await client.connect();
+  await client.query('DROP DATABASE IF EXISTS ' + database + ';');
+  await client.end();
+}
+
+function getDatabaseNameForCurrentMochaWorker(namespace: string): string {
+  return `${namespace}_${process.env.MOCHA_WORKER_ID}`;
+}
+
+function getPoolConfig(options: PostgresTestUtilsOptions): pg.PoolConfig {
+  return {
+    user: options.user ?? POSTGRES_USER,
+    host: options.host ?? POSTGRES_HOST,
+    database: getDatabaseNameForCurrentMochaWorker(POSTGRES_DATABASE),
+  };
+}
+
+export interface PostgresTestUtils {
+  createDatabase: (options: CreateDatabaseOptions) => Promise<void>;
+  resetDatabase: () => Promise<void>;
+  dropDatabase: (options?: DropDatabaseOptions) => Promise<void>;
+  getDatabaseNameForCurrentMochaWorker: () => string;
+  getPoolConfig: () => pg.PoolConfig;
+}
+
+export function makePostgresTestUtils(options: PostgresTestUtilsOptions): PostgresTestUtils {
+  return {
+    createDatabase: (createOptions: CreateDatabaseOptions) =>
+      createDatabase(options, createOptions),
+    resetDatabase: () => resetDatabase(options),
+    dropDatabase: (dropOptions?: DropDatabaseOptions) => dropDatabase(options, dropOptions),
+    getDatabaseNameForCurrentMochaWorker: () =>
+      getDatabaseNameForCurrentMochaWorker(options.database),
+    getPoolConfig: () => getPoolConfig(options),
+  };
+}

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -16,8 +16,27 @@ const POSTGRES_INIT_CONNECTION_STRING = 'postgres://postgres@localhost/postgres'
 const POSTGRES_DATABASE = 'pltest';
 const POSTGRES_DATABASE_TEMPLATE = 'pltest_template';
 
-async function runMigrationsAndSprocs(dbName, mochaThis, runMigrations) {
-  mochaThis.timeout?.(20000);
+const postgresTestUtils = sqldb.makePostgresTestUtils({
+  user: POSTGRES_USER,
+  host: POSTGRES_HOST,
+  defaultDatabase: 'postgres',
+  database: POSTGRES_DATABASE,
+  prepareAfterReset: async (client) => {
+    // This is the sole piece of database state that's actually created in a
+    // migration (`153_institutions__create`) - when we TRUNCATE the `institutions`
+    // table above, we lose the default institution, so we add it back here.
+    await client.query(
+      "INSERT INTO institutions (id, long_name, short_name) VALUES (1, 'Default', 'Default') ON CONFLICT DO NOTHING;"
+    );
+  },
+});
+
+/**
+ *
+ * @param {string} dbName
+ * @param {boolean} runMigrations
+ */
+async function runMigrationsAndSprocs(dbName, runMigrations) {
   const pgConfig = {
     user: POSTGRES_USER,
     database: dbName,
@@ -45,72 +64,32 @@ async function runMigrationsAndSprocs(dbName, mochaThis, runMigrations) {
   await sqldb.closeAsync();
 }
 
-async function createFullDatabase(dbName, dropFirst, mochaThis) {
-  // long timeout because DROP DATABASE might take a long time to error
-  // if other processes have an open connection to that database
-  mochaThis.timeout?.(20000);
-
-  const client = new pg.Client(POSTGRES_INIT_CONNECTION_STRING);
-  await client.connect();
-  if (dropFirst) {
-    await client.query('DROP DATABASE IF EXISTS ' + dbName + ';');
-  }
-  await client.query('CREATE DATABASE ' + dbName + ';');
-  await client.end();
-  await runMigrationsAndSprocs(dbName, mochaThis, true);
+async function createFullDatabase(dbName, dropFirst) {
+  await postgresTestUtils.createDatabase({
+    dropExistingDatabase: dropFirst,
+    configurePool: true,
+    prepare: () => runMigrationsAndSprocs(dbName, true),
+  });
 }
 
-async function createFromTemplate(dbName, dbTemplateName, dropFirst, mochaThis) {
-  // long timeout because DROP DATABASE might take a long time to error
-  // if other processes have an open connection to that database
-  mochaThis.timeout?.(20000);
-  const client = new pg.Client(POSTGRES_INIT_CONNECTION_STRING);
-  await client.connect();
-  if (dropFirst) {
-    await client.query('DROP DATABASE IF EXISTS ' + dbName + ';');
-  }
-  await client.query(`CREATE DATABASE ${dbName} TEMPLATE ${dbTemplateName};`);
-  await client.end();
-  await runMigrationsAndSprocs(dbName, mochaThis, false);
-}
-
-async function establishSql(dbName) {
-  const pgConfig = {
-    user: POSTGRES_USER,
-    database: dbName,
-    host: POSTGRES_HOST,
-    max: 10,
-    idleTimeoutMillis: 30000,
-  };
-  function idleErrorHandler(err) {
-    throw err;
-  }
-  await sqldb.initAsync(pgConfig, idleErrorHandler);
-
-  // Ideally this would happen only over in `helperServer`, but we need to use
-  // the same database details, so this is a convenient place to do it.
-  await namedLocks.init(pgConfig, idleErrorHandler);
+/**
+ *
+ * @param {string} dbName
+ * @param {string} dbTemplateName
+ * @param {boolean} dropFirst
+ */
+async function createFromTemplate(dbName, dbTemplateName, dropFirst) {
+  await postgresTestUtils.createDatabase({
+    dropExistingDatabase: dropFirst,
+    templateDatabase: dbTemplateName,
+    configurePool: true,
+    prepare: () => runMigrationsAndSprocs(dbName, false),
+  });
 }
 
 async function closeSql() {
   await namedLocks.close();
   await sqldb.closeAsync();
-}
-
-async function dropDatabase(dbName, mochaThis, forceDrop = false) {
-  if (_.has(process.env, 'PL_KEEP_TEST_DB') && !forceDrop) {
-    console.log(`PL_KEEP_TEST_DB enviroment variable set, not dropping database ${dbName}`);
-    return;
-  }
-
-  // long timeout because DROP DATABASE might take a long time to error
-  // if other processes have an open connection to that database
-  mochaThis.timeout?.(20000);
-
-  const client = new pg.Client(POSTGRES_INIT_CONNECTION_STRING);
-  await client.connect();
-  await client.query('DROP DATABASE IF EXISTS ' + dbName + ';');
-  await client.end();
 }
 
 async function databaseExists(dbName) {
@@ -124,90 +103,77 @@ async function databaseExists(dbName) {
   return existsResult;
 }
 
-async function setupDatabases(mochaThis) {
+async function setupDatabases() {
   const templateExists = await databaseExists(POSTGRES_DATABASE_TEMPLATE);
   const dbName = module.exports.getDatabaseNameForCurrentWorker();
   if (templateExists) {
-    await createFromTemplate(dbName, POSTGRES_DATABASE_TEMPLATE, true, mochaThis);
+    await createFromTemplate(dbName, POSTGRES_DATABASE_TEMPLATE, true);
   } else {
-    await module.exports.createTemplate(mochaThis);
-    await createFromTemplate(dbName, POSTGRES_DATABASE_TEMPLATE, true, mochaThis);
+    await module.exports.createTemplate();
+    await createFromTemplate(dbName, POSTGRES_DATABASE_TEMPLATE, true);
   }
-  await establishSql(dbName);
+
+  // Ideally this would happen only over in `helperServer`, but we need to use
+  // the same database details, so this is a convenient place to do it.
+  await namedLocks.init(postgresTestUtils.getPoolConfig(), (err) => {
+    throw err;
+  });
 }
 
+/**
+ * @this {import('mocha').Context}
+ */
 module.exports.before = async function before() {
-  var that = this;
-  await setupDatabases(that);
+  // long timeout because DROP DATABASE might take a long time to error
+  // if other processes have an open connection to that database
+  this.timeout?.(20000);
+  await setupDatabases();
 };
 
-// This version will only (re)create the database with migrations; it will
-// then close the connection in sqldb. This is necessary for database
-// schema verification, where databaseDiff will set up a connection to the
-// desired database.
+/**
+ * This version will only (re)create the database with migrations; it will
+ * then close the connection in sqldb. This is necessary for database
+ * schema verification, where databaseDiff will set up a connection to the
+ * desired database.
+ *
+ * @this {import('mocha').Context}
+ */
 module.exports.beforeOnlyCreate = async function beforeOnlyCreate() {
-  var that = this;
-  await setupDatabases(that);
+  // long timeout because DROP DATABASE might take a long time to error
+  // if other processes have an open connection to that database
+  this.timeout?.(20000);
+  await setupDatabases();
   await closeSql();
 };
 
+/**
+ * @this {import('mocha').Context}
+ */
 module.exports.after = async function after() {
-  var that = this;
+  // long timeout because DROP DATABASE might take a long time to error
+  // if other processes have an open connection to that database
+  this.timeout?.(20000);
   await closeSql();
-  const dbName = module.exports.getDatabaseNameForCurrentWorker();
-  await dropDatabase(dbName, that);
+  await postgresTestUtils.dropDatabase();
 };
 
-module.exports.createTemplate = async function createTemplate(mochaThis) {
-  await createFullDatabase(POSTGRES_DATABASE_TEMPLATE, true, mochaThis);
+module.exports.createTemplate = async function createTemplate() {
+  await createFullDatabase(POSTGRES_DATABASE_TEMPLATE, true);
 };
 
 module.exports.dropTemplate = async function dropTemplate() {
-  var that = this;
   await closeSql();
-  await dropDatabase(
-    POSTGRES_DATABASE_TEMPLATE,
-    that,
+  await postgresTestUtils.dropDatabase({
+    database: POSTGRES_DATABASE_TEMPLATE,
     // Always drop the template regardless of PL_KEEP_TEST_DB env
-    true
-  );
+    force: true,
+  });
 };
 
 module.exports.resetDatabase = async function resetDatabase() {
-  const client = new pg.Client({
-    user: POSTGRES_USER,
-    database: module.exports.getDatabaseNameForCurrentWorker(),
-    host: POSTGRES_HOST,
-  });
-  await client.connect();
-  await client.query(`
-      DO
-      $func$
-      BEGIN
-        EXECUTE (
-          SELECT 'TRUNCATE TABLE ' || string_agg(oid::regclass::text, ', ') || ' RESTART IDENTITY CASCADE'
-            FROM pg_class
-            WHERE relkind = 'r'
-            AND relnamespace = 'public'::regnamespace
-        );
-      END
-      $func$;
-    `);
-
-  // This is the sole piece of database state that's actually created in a
-  // migration (`153_institutions__create`) - when we TRUNCATE the `institutions`
-  // table above, we lose the default institution, so we add it back here.
-  await client.query(
-    "INSERT INTO institutions (id, long_name, short_name) VALUES (1, 'Default', 'Default') ON CONFLICT DO NOTHING;"
-  );
-
-  await client.end();
-};
-
-module.exports.getDatabaseNameForWorker = function getDatabaseNameForWorker(workerId = '1') {
-  return `${POSTGRES_DATABASE}_${workerId}`;
+  await postgresTestUtils.resetDatabase();
 };
 
 module.exports.getDatabaseNameForCurrentWorker = function getDatabaseNameForCurrentWorker() {
-  return module.exports.getDatabaseNameForWorker(process.env.MOCHA_WORKER_ID);
+  return postgresTestUtils.getDatabaseNameForCurrentMochaWorker();
 };

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -1,7 +1,6 @@
 // @ts-check
 const pg = require('pg');
 const path = require('path');
-const _ = require('lodash');
 const util = require('util');
 
 const sqldb = require('@prairielearn/postgres');

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -161,7 +161,13 @@ module.exports.createTemplate = async function createTemplate() {
   await createFullDatabase(POSTGRES_DATABASE_TEMPLATE, true);
 };
 
+/**
+ * @this {import('mocha').Context}
+ */
 module.exports.dropTemplate = async function dropTemplate() {
+  // long timeout because DROP DATABASE might take a long time to error
+  // if other processes have an open connection to that database
+  this.timeout?.(20000);
   await closeSql();
   await postgresTestUtils.dropDatabase({
     database: POSTGRES_DATABASE_TEMPLATE,

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -64,14 +64,6 @@ async function runMigrationsAndSprocs(dbName, runMigrations) {
   await sqldb.closeAsync();
 }
 
-async function createFullDatabase(dbName, dropFirst) {
-  await postgresTestUtils.createDatabase({
-    dropExistingDatabase: dropFirst,
-    configurePool: true,
-    prepare: () => runMigrationsAndSprocs(dbName, true),
-  });
-}
-
 /**
  *
  * @param {string} dbName
@@ -81,6 +73,7 @@ async function createFullDatabase(dbName, dropFirst) {
 async function createFromTemplate(dbName, dbTemplateName, dropFirst) {
   await postgresTestUtils.createDatabase({
     dropExistingDatabase: dropFirst,
+    database: dbName,
     templateDatabase: dbTemplateName,
     configurePool: true,
     prepare: () => runMigrationsAndSprocs(dbName, false),
@@ -158,7 +151,12 @@ module.exports.after = async function after() {
 };
 
 module.exports.createTemplate = async function createTemplate() {
-  await createFullDatabase(POSTGRES_DATABASE_TEMPLATE, true);
+  await postgresTestUtils.createDatabase({
+    dropExistingDatabase: true,
+    database: POSTGRES_DATABASE_TEMPLATE,
+    configurePool: false,
+    prepare: () => runMigrationsAndSprocs(POSTGRES_DATABASE_TEMPLATE, true),
+  });
 };
 
 /**

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -23,7 +23,8 @@ const postgresTestUtils = sqldb.makePostgresTestUtils({
   prepareAfterReset: async (client) => {
     // This is the sole piece of database state that's actually created in a
     // migration (`153_institutions__create`) - when we TRUNCATE the `institutions`
-    // table above, we lose the default institution, so we add it back here.
+    // table when resetting the database, we lose the default institution, so we
+    // add it back here.
     await client.query(
       "INSERT INTO institutions (id, long_name, short_name) VALUES (1, 'Default', 'Default') ON CONFLICT DO NOTHING;"
     );

--- a/tests/mocha-hooks.mjs
+++ b/tests/mocha-hooks.mjs
@@ -4,7 +4,7 @@ import { createTemplate, dropTemplate } from './helperDb.js';
 export async function mochaGlobalSetup() {
   // Create a global instance of our template database, dropping the existing
   // template database first if needed.
-  await createTemplate(this);
+  await createTemplate();
 }
 
 export async function mochaGlobalTeardown() {

--- a/tests/sync/questionsSync.test.js
+++ b/tests/sync/questionsSync.test.js
@@ -37,8 +37,6 @@ async function findSyncedUndeletedQuestion(qid) {
 }
 
 describe('Question syncing', () => {
-  // Uncomment whenever you change relevant sprocs or migrations
-  // before('remove the template database', helperDb.dropTemplate);
   before('set up testing database', helperDb.before);
   after('tear down testing database', helperDb.after);
 


### PR DESCRIPTION
This allows us to reuse our utilities for spinning up and tearing down test databases across packages, including in `@prairielearn/postgres` itself.

Once sproc handling is moved into a shared package, I plan to introduce a package like `@prairielearn/server-test-utils` that encapsulates migrations and sproc creation as well; we can then reuse that across PrairieLearn and PrairieTest (and any other servers we end up with in the future).