### PR TITLE
fix: Sort assessment instances by role

### DIFF
--- a/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
+++ b/pages/instructorAssessmentInstances/instructorAssessmentInstances.ejs
@@ -260,7 +260,6 @@
                   data-switchable="true">Name</th>
               <th data-field="role"
                   data-sortable="true"
-                  data-sorter="roleSorter"
                   data-class="text-center align-middle text-nowrap"
                   data-switchable="true">Role
                 <button class="btn btn-xs" type="button" title="Show roles help" data-toggle="modal" data-target="#role-help">


### PR DESCRIPTION
Fixes #7378. The sorting functionality was originally set when roles included a distinction between TA and instructor. The relevant function was removed in #3020, but the column still had a reference to the function. This change uses default sorting for the role.