### PR TITLE
Define fallback timezones for effective user page

### DIFF
--- a/database/tables/institutions.pg
+++ b/database/tables/institutions.pg
@@ -1,5 +1,6 @@
 columns
     default_authn_provider_id: bigint
+    display_timezone: text not null default 'America/Chicago'::text
     id: bigint not null default nextval('institutions_id_seq'::regclass)
     long_name: text not null
     short_name: text not null

--- a/migrations/20230331212027_institutions__display_timezone__add.sql
+++ b/migrations/20230331212027_institutions__display_timezone__add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE institutions
+ADD COLUMN IF NOT EXISTS display_timezone TEXT NOT NULL DEFAULT 'America/Chicago';

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -47,11 +47,12 @@ router.get('/', function (req, res, next) {
 
     // This page can be mounted under `/pl/course/...`, in which case we won't
     // have a course instance to get a display timezone from. In that case, we'll
-    // fall back to the course, and then to `UTC`. Note that in some other places
-    // we fall back to `America/Chicago` if neither the course nor the course
-    // instance has a timezone; UTC seems to make more sense here.
+    // fall back to the course, and then to the institution. All institutions must
+    // have a display timezone, so we're always guaranteed to have one.
     const displayTimezone =
-      res.locals.course_instance?.display_timezone ?? res.locals.course.display_timezone ?? 'UTC';
+      res.locals.course_instance?.display_timezone ??
+      res.locals.course.display_timezone ??
+      res.locals.institution.display_timezone;
 
     res.locals.true_req_date_for_display = format(
       utcToZonedTime(res.locals.true_req_date, displayTimezone),

--- a/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -44,18 +44,27 @@ router.get('/', function (req, res, next) {
     if (res.locals.ipaddress.substr(0, 7) === '::ffff:') {
       res.locals.ipaddress = res.locals.ipaddress.substr(7);
     }
+
+    // This page can be mounted under `/pl/course/...`, in which case we won't
+    // have a course instance to get a display timezone from. In that case, we'll
+    // fall back to the course, and then to `UTC`. Note that in some other places
+    // we fall back to `America/Chicago` if neither the course nor the course
+    // instance has a timezone; UTC seems to make more sense here.
+    const displayTimezone =
+      res.locals.course_instance?.display_timezone ?? res.locals.course.display_timezone ?? 'UTC';
+
     res.locals.true_req_date_for_display = format(
-      utcToZonedTime(res.locals.true_req_date, res.locals.course_instance.display_timezone),
+      utcToZonedTime(res.locals.true_req_date, displayTimezone),
       "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
       {
-        timeZone: res.locals.course_instance.display_timezone,
+        timeZone: displayTimezone,
       }
     );
     res.locals.req_date_for_display = format(
-      utcToZonedTime(res.locals.req_date, res.locals.course_instance.display_timezone),
+      utcToZonedTime(res.locals.req_date, displayTimezone),
       "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
       {
-        timeZone: res.locals.course_instance.display_timezone,
+        timeZone: displayTimezone,
       }
     );
 


### PR DESCRIPTION
#7340 didn't account for the fact that the effective user page is also mounted to `/pl/course/...`, where we won't have access to a course instance from which we can fetch a timezone.