### PR TITLE
Change issue badge link to show open issues only

### DIFF
--- a/pages/instructorQuestions/instructorQuestions.ejs
+++ b/pages/instructorQuestions/instructorQuestions.ejs
@@ -101,7 +101,7 @@
           }
           text += `<a class="formatter-data" href="<%= urlPrefix %>/question/${question.id}/">${_.escape(question.qid)}</a>`;
           if (question.open_issue_count > 0) {
-              text += `<a class="badge badge-pill badge-danger ml-1" href="<%= urlPrefix %>/course_admin/issues?q=qid%3A${_.escape(question.qid)}">${question.open_issue_count}</a>`;
+              text += `<a class="badge badge-pill badge-danger ml-1" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A${_.escape(question.qid)}">${question.open_issue_count}</a>`;
           }
           return text;
       }

--- a/pages/partials/issueBadge.ejs
+++ b/pages/partials/issueBadge.ejs
@@ -1,7 +1,7 @@
 <% if (count > 0) { %>
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
-            <a class="badge badge-pill badge-danger" href="<%= urlPrefix %>/course_admin/issues?q=qid%3A<%= issueQid %>">
+            <a class="badge badge-pill badge-danger" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
             <a class="badge badge-pill badge-danger" href="<%= urlPrefix %>/course_admin/issues">
         <% } %>


### PR DESCRIPTION
Fixes #7375. The badge shows the number of open issues, but was linking to a list of all issues (including closed).