### PR TITLE
Improve query plan for course request jobs

### DIFF
--- a/database/tables/job_sequences.pg
+++ b/database/tables/job_sequences.pg
@@ -18,6 +18,7 @@ indexes
     job_sequences_course_id_number_key: UNIQUE (course_id, number) USING btree (course_id, number)
     job_sequences_assessment_id_idx: USING btree (assessment_id)
     job_sequences_course_id_idx: USING btree (course_id)
+    job_sequences_course_request_id_idx: USING btree (course_request_id)
 
 foreign-key constraints
     job_sequences_assessment_id_fkey: FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/migrations/20230331223233_job_sequences__course_request_id__add_index.sql
+++ b/migrations/20230331223233_job_sequences__course_request_id__add_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS job_sequences_course_request_id_idx ON job_sequences (course_request_id);

--- a/pages/administratorCourseRequests/administratorCourseRequests.sql
+++ b/pages/administratorCourseRequests/administratorCourseRequests.sql
@@ -23,8 +23,8 @@ WITH
         )
       ) AS jobs
     FROM
-      job_sequences AS js
-      LEFT JOIN course_requests AS cr ON cr.id = js.course_request_id
+      course_requests AS cr
+      JOIN job_sequences AS js ON cr.id = js.course_request_id
       LEFT JOIN users AS u ON js.authn_user_id = u.user_id
     GROUP BY
       cr.id

--- a/pages/administratorCourses/administratorCourses.sql
+++ b/pages/administratorCourses/administratorCourses.sql
@@ -23,8 +23,8 @@ WITH
         )
       ) AS jobs
     FROM
-      job_sequences AS js
-      LEFT JOIN course_requests AS cr ON cr.id = js.course_request_id
+      course_requests AS cr
+      JOIN job_sequences AS js ON cr.id = js.course_request_id
       LEFT JOIN users AS u ON js.authn_user_id = u.user_id
     GROUP BY
       cr.id


### PR DESCRIPTION
This PR speeds up the CTE queries for course request jobs by ~43x and reduces memory usage from 639MB to just 1MB. By using `course_requests` as the left table (instead of `job_sequences`), we avoid a very expensive `HashAggregate` on all 392,000 `job_sequences` rows.

Before:

```
 HashAggregate  (cost=25859.30..25864.85 rows=444 width=48) (actual time=4335.904..4401.829 rows=408 loops=1)
   Group Key: cr.id
   Batches: 77  Memory Usage: 639037kB  Disk Usage: 4592kB
   ->  Nested Loop Left Join  (cost=20.29..22026.90 rows=383240 width=64) (actual time=0.195..504.843 rows=392340 loops=1)
         ->  Hash Left Join  (cost=19.99..12176.41 rows=383240 width=48) (actual time=0.187..246.744 rows=392340 loops=1)
               Hash Cond: (js.course_request_id = cr.id)
               ->  Seq Scan on job_sequences js  (cost=0.00..11150.40 rows=383240 width=48) (actual time=0.007..162.296 rows=392340 loops=1)
               ->  Hash  (cost=14.44..14.44 rows=444 width=8) (actual time=0.176..0.177 rows=503 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 28kB
                     ->  Seq Scan on course_requests cr  (cost=0.00..14.44 rows=444 width=8) (actual time=0.004..0.107 rows=503 loops=1)
         ->  Memoize  (cost=0.30..0.34 rows=1 width=24) (actual time=0.000..0.000 rows=1 loops=392340)
               Cache Key: js.authn_user_id
               Cache Mode: logical
               Hits: 391066  Misses: 1274  Evictions: 0  Overflows: 0  Memory Usage: 159kB
               ->  Index Scan using users_pkey on users u  (cost=0.29..0.33 rows=1 width=24) (actual time=0.008..0.008 rows=1 loops=1274)
                     Index Cond: (user_id = js.authn_user_id)
 Planning Time: 0.325 ms
 Execution Time: 4403.112 ms
(18 rows)
```

After:

```
 HashAggregate  (cost=25859.30..25864.85 rows=444 width=48) (actual time=101.692..102.040 rows=407 loops=1)
   Group Key: cr.id
   Batches: 1  Memory Usage: 1053kB
   ->  Nested Loop Left Join  (cost=20.29..22026.90 rows=383240 width=64) (actual time=4.651..97.343 rows=413 loops=1)
         ->  Hash Join  (cost=19.99..12176.41 rows=383240 width=48) (actual time=4.626..96.360 rows=413 loops=1)
               Hash Cond: (js.course_request_id = cr.id)
               ->  Seq Scan on job_sequences js  (cost=0.00..11150.40 rows=383240 width=48) (actual time=0.007..76.273 rows=392340 loops=1)
               ->  Hash  (cost=14.44..14.44 rows=444 width=8) (actual time=0.191..0.192 rows=503 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 28kB
                     ->  Seq Scan on course_requests cr  (cost=0.00..14.44 rows=444 width=8) (actual time=0.004..0.109 rows=503 loops=1)
         ->  Memoize  (cost=0.30..0.34 rows=1 width=24) (actual time=0.002..0.002 rows=1 loops=413)
               Cache Key: js.authn_user_id
               Cache Mode: logical
               Hits: 335  Misses: 78  Evictions: 0  Overflows: 0  Memory Usage: 10kB
               ->  Index Scan using users_pkey on users u  (cost=0.29..0.33 rows=1 width=24) (actual time=0.006..0.006 rows=1 loops=78)
                     Index Cond: (user_id = js.authn_user_id)
 Planning Time: 0.306 ms
 Execution Time: 102.268 ms
(18 rows)
```