### PR TITLE
Remove references to highlight.js from pl-code

### DIFF
--- a/elements/pl-code/info.json
+++ b/elements/pl-code/info.json
@@ -1,9 +1,6 @@
 {
   "controller": "pl-code.py",
   "dependencies": {
-    "elementScripts": [
-      "pl-code.js"
-    ],
     "elementStyles": [
       "pl-code.css"
     ],

--- a/elements/pl-code/pl-code.js
+++ b/elements/pl-code/pl-code.js
@@ -1,7 +1,0 @@
-/* eslint-env browser,jquery */
-/* global hljs */
-$(document).ready(function () {
-  $('pre.pl-code code').each(function (i, block) {
-    hljs.highlightBlock(block);
-  });
-});


### PR DESCRIPTION
We're long since used Pygments to highlight code; this script is unnecessary.