### PR TITLE
Only update course commit hash after successful sync

### DIFF
--- a/lib/editors.js
+++ b/lib/editors.js
@@ -260,16 +260,16 @@ class Editor {
           arguments: ['push'],
           working_directory: this.course.path,
           env: gitEnv,
-          on_success: _updateCommitHash,
+          on_success: _getEndCommitHash,
           on_error: _cleanupAfterCommit,
           no_job_sequence_update: true,
         };
         serverJobs.spawnJob(jobOptions);
       };
 
-      const _updateCommitHash = () => {
+      const _getEndCommitHash = () => {
         debug(`${job_sequence_id}: _updateCommitHash`);
-        courseUtil.updateCourseCommitHash(this.course, (err, hash) => {
+        courseUtil.getCommitHash(this.course.path, (err, hash) => {
           ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
           endGitHash = hash;
 
@@ -298,6 +298,7 @@ class Editor {
             _finishWithFailure();
             return;
           }
+
           syncFromDisk._syncDiskToSqlWithLock(
             this.course.path,
             this.course.id,
@@ -306,28 +307,47 @@ class Editor {
               if (ERR(err, (e) => logger.error('Error in _syncDiskToSqlWithLock()', e))) {
                 debug('_syncDiskToSqlWithLock(): failure');
                 job.fail(err);
-              } else {
-                if (config.chunksGenerator) {
-                  util.callbackify(chunks.updateChunksForCourse)(
-                    {
-                      coursePath: this.course.path,
-                      courseId: this.course.id,
-                      courseData: result.courseData,
-                      oldHash: startGitHash,
-                      newHash: endGitHash,
-                    },
-                    (err, chunkChanges) => {
-                      if (err) {
-                        job.fail(err);
-                        return;
-                      }
-                      chunks.logChunkChangesToJob(chunkChanges, job);
-                      job.succeed();
-                    }
-                  );
+                return;
+              }
+
+              const updateCourseCommitHash = () => {
+                courseUtil.getOrUpdateCourseCommitHash(this.course, (err) => {
+                  if (err) {
+                    job.fail(err);
+                  } else {
+                    checkJsonErrors();
+                  }
+                });
+              };
+
+              const checkJsonErrors = () => {
+                if (result.hadJsonErrors) {
+                  job.fail('One or more JSON files contained errors and were unable to be synced');
                 } else {
                   job.succeed();
                 }
+              };
+
+              if (config.chunksGenerator) {
+                util.callbackify(chunks.updateChunksForCourse)(
+                  {
+                    coursePath: this.course.path,
+                    courseId: this.course.id,
+                    courseData: result.courseData,
+                    oldHash: startGitHash,
+                    newHash: endGitHash,
+                  },
+                  (err, chunkChanges) => {
+                    if (err) {
+                      job.fail(err);
+                      return;
+                    }
+                    chunks.logChunkChangesToJob(chunkChanges, job);
+                    updateCourseCommitHash();
+                  }
+                );
+              } else {
+                updateCourseCommitHash();
               }
             }
           );

--- a/lib/github.js
+++ b/lib/github.js
@@ -443,17 +443,6 @@ module.exports = {
         job_sequence_id,
         authn_user.user_id
       );
-      await module.exports._runJobAsync(
-        {
-          type: 'update_commit_hash',
-          description: 'Update course commit hash',
-        },
-        job_sequence_id,
-        authn_user.user_id,
-        async () => {
-          await courseUtil.updateCourseCommitHashAsync(inserted_course);
-        }
-      );
       let sync_result;
       await module.exports._runJobAsync(
         {
@@ -492,6 +481,18 @@ module.exports = {
           }
         );
       }
+
+      await module.exports._runJobAsync(
+        {
+          type: 'update_commit_hash',
+          description: 'Update course commit hash',
+        },
+        job_sequence_id,
+        authn_user.user_id,
+        async () => {
+          await courseUtil.updateCourseCommitHashAsync(inserted_course);
+        }
+      );
     };
 
     // Create a server job to wrap the course creation process

--- a/pages/shared/syncHelpers.js
+++ b/pages/shared/syncHelpers.js
@@ -147,10 +147,13 @@ module.exports.pullAndUpdate = function (locals, callback) {
       serverJobs.spawnJob(jobOptions);
     };
 
-    // After either cloning or fetching and resetting from Git, we'll need
-    // to load and store the current commit hash in the database
+    // After either cloning or fetching and resetting from Git, we'll load the
+    // current commit hash. Note that we don't commit this to the database until
+    // after we've synced the changes to the database and generated chunks. This
+    // ensures that if the sync fails, we'll sync from the same starting commit
+    // hash next time.
     const syncStage2 = () => {
-      courseUtil.updateCourseCommitHash(locals.course, (err, hash) => {
+      courseUtil.updateCourseCommitHash(locals.course.path, (err, hash) => {
         ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
         endGitHash = hash;
         syncStage3();
@@ -183,6 +186,16 @@ module.exports.pullAndUpdate = function (locals, callback) {
               return;
             }
 
+            const updateCourseCommitHash = () => {
+              courseUtil.getOrUpdateCourseCommitHash(locals.course, (err) => {
+                if (err) {
+                  job.fail(err);
+                } else {
+                  checkJsonErrors();
+                }
+              });
+            };
+
             const checkJsonErrors = () => {
               if (result.hadJsonErrors) {
                 job.fail('One or more JSON files contained errors and were unable to be synced');
@@ -205,12 +218,12 @@ module.exports.pullAndUpdate = function (locals, callback) {
                     job.fail(err);
                   } else {
                     chunks.logChunkChangesToJob(chunkChanges, job);
-                    checkJsonErrors();
+                    updateCourseCommitHash();
                   }
                 }
               );
             } else {
-              checkJsonErrors();
+              updateCourseCommitHash();
             }
           }
         );

--- a/pages/shared/syncHelpers.js
+++ b/pages/shared/syncHelpers.js
@@ -153,7 +153,7 @@ module.exports.pullAndUpdate = function (locals, callback) {
     // ensures that if the sync fails, we'll sync from the same starting commit
     // hash next time.
     const syncStage2 = () => {
-      courseUtil.updateCourseCommitHash(locals.course.path, (err, hash) => {
+      courseUtil.getCommitHash(locals.course.path, (err, hash) => {
         ERR(err, (e) => logger.error('Error in updateCourseCommitHash()', e));
         endGitHash = hash;
         syncStage3();


### PR DESCRIPTION
This fixes a syncing issue that came up recently. If a sync failed before chunks could be generated, we'd be left with new course code on disk and the latest commit hash in the DB. However, on the next sync, we'd use that new commit hash when deciding what chunks to regenerate, which means we'd "lose" any changes that had been made in the last sync. This same kind of issue could occur if a server died in the middle of performing a sync.

By only updating the commit hash in the database _after_ chunks have been generated, we ensure that a future successful sync will include the previous changes.

This change has a potential side effect: the fact that we now don't update the hash means that the question render cache may serve state entries until a successful sync occurs. I think this is fine; we don't guarantee that things will behave sensibly after a failed sync. If we want things to behave more predictably, we could change the "pull and sync" processes to reset the on-disk revision to the previous revision if a sync fails.