### PR TITLE
Fix require of lru-cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const redis = require('redis');
 const redisLru = require('redis-lru');
-const { LRUCache } = require('lru-cache');
+const LRUCache = require('lru-cache').default;
 const util = require('util');
 
 const config = require('./config');


### PR DESCRIPTION
I broke this accidentally in #7428. TypeScript lied to me, so I didn't notice; see https://github.com/isaacs/node-lru-cache/issues/289.