### PR TITLE
Use LRUCache named export from lru-cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const redis = require('redis');
 const redisLru = require('redis-lru');
-const LRUCache = require('lru-cache').default;
+const { LRUCache } = require('lru-cache');
 const util = require('util');
 
 const config = require('./config');

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "lodash": "^4.17.21",
         "logform": "^2.4.2",
         "loopbench": "^2.0.0",
-        "lru-cache": "^8.0.4",
+        "lru-cache": "^8.0.5",
         "mathjax": "^3.2.2",
         "memorystream": "^0.3.1",
         "mersenne": "0.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,7 +3940,7 @@ __metadata:
     lodash: ^4.17.21
     logform: ^2.4.2
     loopbench: ^2.0.0
-    lru-cache: ^8.0.4
+    lru-cache: ^8.0.5
     mathjax: ^3.2.2
     memorystream: ^0.3.1
     mersenne: 0.0.4
@@ -10571,10 +10571,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^8.0.4":
-  version: 8.0.4
-  resolution: "lru-cache@npm:8.0.4"
-  checksum: dee2b905a8cd688c5847faa46ba3cfeaa0766283b244bfd6177420e04e9d923fc901a9a578fc3963d70959631595240ead37abaf43e21968bb9805bbd9519856
+"lru-cache@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "lru-cache@npm:8.0.5"
+  checksum: 87d72196d8f46e8299c4ab576ed2ec8a07e3cbef517dc9874399c0b2470bd9bf62aacec3b67f84ed6d74aaa1ef31636d048edf996f76248fd17db72bfb631609
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Followup to #7480; the named export is more elegant than tacking a `.default` on the end. The change from https://github.com/isaacs/node-lru-cache/commit/798fef3902e4a1a9d7ba106b285394bd93476022 allows us to do this!