### PR TITLE
Allow interpolating BigInt values in @prairielearn/html

### DIFF
--- a/.changeset/friendly-colts-glow.md
+++ b/.changeset/friendly-colts-glow.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/html': minor
+---
+
+Support interpolating BigInt values

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -11,6 +11,14 @@ describe('html', () => {
     assert.equal(html`<p>${'cats'} and ${'dogs'}</p>`.toString(), '<p>cats and dogs</p>');
   });
 
+  it('interpolates a number', () => {
+    assert.equal(html`<p>${123}</p>`.toString(), '<p>123</p>');
+  });
+
+  it('interpolates a bigint', () => {
+    assert.equal(html`<p>${123n}</p>`.toString(), '<p>123</p>');
+  });
+
   it('escapes values when rendering array', () => {
     const arr = ['cats>', '<dogs'];
     assert.equal(

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -24,7 +24,7 @@ function escapeValue(value: unknown): string {
     return value.toString();
   } else if (Array.isArray(value)) {
     return value.map((val) => escapeValue(val)).join('');
-  } else if (typeof value === 'string' || typeof value === 'number') {
+  } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
     return escapeHtmlRaw(String(value));
   } else if (value == null) {
     // undefined or null -- render nothing
@@ -54,7 +54,15 @@ export class HtmlSafeString {
   }
 }
 
-export type HtmlValue = string | number | boolean | HtmlSafeString | undefined | null | HtmlValue[];
+export type HtmlValue =
+  | string
+  | number
+  | boolean
+  | bigint
+  | HtmlSafeString
+  | undefined
+  | null
+  | HtmlValue[];
 
 export function html(strings: TemplateStringsArray, ...values: HtmlValue[]): HtmlSafeString {
   return new HtmlSafeString(strings, values);


### PR DESCRIPTION
I'm making use of `BigInt` values over in #7292; this will allow me to easily interpolate them into HTML templates.