### PR TITLE
Force Yarn to mutate lockfile in version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "release": "turbo run build && changeset publish",
-        "version": "changeset version && yarn install --mode=update-lockfile"
+        "version": "changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn"
     },
     "dependencies": {
         "@aws-sdk/client-auto-scaling": "^3.304.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "release": "turbo run build && changeset publish",
-        "version": "changeset version && yarn"
+        "version": "changeset version && yarn install --mode=update-lockfile"
     },
     "dependencies": {
         "@aws-sdk/client-auto-scaling": "^3.304.0",


### PR DESCRIPTION
The `yarn version` command run during our "Release" workflow recently started failing:

```
  ➤ YN0000: │ @@ -2884,9 +2884,9 @@
  ➤ YN0000: │    version: 0.0.0-use.local
  ➤ YN0000: │    resolution: "@prairielearn/migrations@workspace:packages/migrations"
  ➤ YN0000: │    dependencies:
  ➤ YN0000: │      "@prairielearn/error": ^1.0.0
  ➤ YN0028: │ -    "@prairielearn/named-locks": ^1.0.0
  ➤ YN0028: │ +    "@prairielearn/named-locks": ^1.2.0
  ➤ YN0000: │      "@prairielearn/postgres": ^1.2.0
  ➤ YN0000: │      "@prairielearn/tsconfig": "*"
  ➤ YN0000: │      "@types/fs-extra": ^11.0.1
  ➤ YN0000: │      "@types/mocha": ^10.0.1
  ➤ YN0000: │ @@ -2898,9 +2898,9 @@
  ➤ YN0000: │      typescript: ^4.9.5
  ➤ YN0000: │    languageName: unknown
  ➤ YN0000: │    linkType: soft
  ➤ YN0000: │  
  ➤ YN0028: │ -"@prairielearn/named-locks@^1.0.0, @prairielearn/named-locks@workspace:packages/named-locks":
  ➤ YN0028: │ +"@prairielearn/named-locks@^1.0.0, @prairielearn/named-locks@^1.2.0, @prairielearn/named-locks@workspace:packages/named-locks":
  ➤ YN0000: │    version: 0.0.0-use.local
  ➤ YN0000: │    resolution: "@prairielearn/named-locks@workspace:packages/named-locks"
  ➤ YN0000: │    dependencies:
  ➤ YN0000: │      "@prairielearn/postgres": ^1.3.0
  ➤ YN0000: │ 
  ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```

I don't know *why* this only just started happening, but it's happening because Yarn 3 defaults to immutable installs if it detects it's in CI. As noted in Yarn's changelog, we can use `YARN_ENABLE_IMMUTABLE_INSTALLS=false` to specifically allow lockfile mutations.