### PR TITLE
Add support for CHECK constraints to database description tooling

### DIFF
--- a/database/tables/assessment_instances.pg
+++ b/database/tables/assessment_instances.pg
@@ -32,6 +32,9 @@ indexes
     assessment_instances_modified_at_key: USING btree (modified_at)
     assessment_instances_user_id_idx: USING btree (user_id)
 
+check constraints
+    user_group_xor: CHECK (user_id IS NOT NULL AND group_id IS NULL OR group_id IS NOT NULL AND user_id IS NULL)
+
 foreign-key constraints
     assessment_instances_assessment_id_fkey: FOREIGN KEY (assessment_id) REFERENCES assessments(id) ON UPDATE CASCADE ON DELETE CASCADE
     assessment_instances_auth_user_id_fkey: FOREIGN KEY (auth_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/last_accesses.pg
+++ b/database/tables/last_accesses.pg
@@ -9,6 +9,9 @@ indexes
     last_accesses_group_id_key: UNIQUE (group_id) USING btree (group_id)
     last_accesses_user_id_key: UNIQUE (user_id) USING btree (user_id)
 
+check constraints
+    user_group_xor: CHECK (user_id IS NOT NULL AND group_id IS NULL OR group_id IS NOT NULL AND user_id IS NULL)
+
 foreign-key constraints
     last_accesses_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     last_accesses_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/variants.pg
+++ b/database/tables/variants.pg
@@ -26,6 +26,9 @@ indexes
     variants_qiid_key: UNIQUE (qiid) USING btree (qiid)
     variants_workspace_id_key: USING btree (workspace_id)
 
+check constraints
+    user_group_xor: CHECK (user_id IS NOT NULL AND group_id IS NULL OR group_id IS NOT NULL AND user_id IS NULL)
+
 foreign-key constraints
     variants_authn_user_id_fkey: FOREIGN KEY (authn_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     variants_course_instance_id_fkey: FOREIGN KEY (course_instance_id) REFERENCES course_instances(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/lib/databaseDescribe.js
+++ b/lib/databaseDescribe.js
@@ -39,11 +39,18 @@ const sql = sqldb.loadSqlEquiv(__filename);
  */
 
 /**
+ * @typedef {Object} CheckConstraintDescription
+ * @property {string} name
+ * @property {string} def
+ */
+
+/**
  * @typedef {Object} TableDescription
  * @property {ColumnDescription[]} columns
  * @property {IndexDescription[]} indexes
  * @property {ForeignKeyConstraintDescription[]} foreignKeyConstraints
  * @property {ReferenceDescription[]} references
+ * @property {CheckConstraintDescription[]} checkConstraints
  */
 
 /**
@@ -70,6 +77,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
 module.exports.describe = async function (databaseName, options = {}) {
   var ignoreColumns = {};
 
+  /** @type {DatabaseDescription} */
   var output = {
     tables: {},
     enums: {},
@@ -97,8 +105,6 @@ module.exports.describe = async function (databaseName, options = {}) {
     tables = _.filter(tables, (table) => options.ignoreTables.indexOf(table.name) === -1);
   }
 
-  tables.forEach((table) => (output.tables[table.name] = {}));
-
   // Transform ignored columns into a map from table names to arrays
   // of column names
   if (options.ignoreColumns && _.isArray(options.ignoreColumns)) {
@@ -120,48 +126,48 @@ module.exports.describe = async function (databaseName, options = {}) {
 
   // Get column info for each table
   await async.each(tables, async (table) => {
-    await async.series([
-      async () => {
-        const results = await sqldb.queryAsync(sql.get_columns_for_table, {
-          oid: table.oid,
-        });
+    const columnResults = await sqldb.queryAsync(sql.get_columns_for_table, {
+      oid: table.oid,
+    });
 
-        const rows = _.filter(results.rows, (row) => {
-          return (ignoreColumns[table.name] || []).indexOf(row.name) === -1;
-        });
+    const columns = columnResults.rows.filter((row) => {
+      return (ignoreColumns[table.name] || []).indexOf(row.name) === -1;
+    });
 
-        output.tables[table.name].columns = rows;
-      },
-      async () => {
-        const results = await sqldb.queryAsync(sql.get_indexes_for_table, {
-          oid: table.oid,
-        });
+    const indexResults = await sqldb.queryAsync(sql.get_indexes_for_table, {
+      oid: table.oid,
+    });
 
-        output.tables[table.name].indexes = results.rows;
-      },
-      async () => {
-        const results = await sqldb.queryAsync(sql.get_foreign_key_constraints_for_table, {
-          oid: table.oid,
-        });
+    const foreignKeyConstraintResults = await sqldb.queryAsync(
+      sql.get_foreign_key_constraints_for_table,
+      {
+        oid: table.oid,
+      }
+    );
 
-        output.tables[table.name].foreignKeyConstraints = results.rows;
-      },
-      async () => {
-        const results = await sqldb.queryAsync(sql.get_references_for_table, {
-          oid: table.oid,
-        });
+    const referenceResults = await sqldb.queryAsync(sql.get_references_for_table, {
+      oid: table.oid,
+    });
 
-        // Filter out references from ignored tables
-        let rows = results.rows;
-        if (options.ignoreTables && _.isArray(options.ignoreTables)) {
-          rows = _.filter(results.rows, (row) => {
-            return options.ignoreTables.indexOf(row.table) === -1;
-          });
-        }
+    // Filter out references from ignored tables
+    let references = referenceResults.rows;
+    if (options.ignoreTables && _.isArray(options.ignoreTables)) {
+      references = referenceResults.rows.filter((row) => {
+        return options.ignoreTables.indexOf(row.table) === -1;
+      });
+    }
 
-        output.tables[table.name].references = rows;
-      },
-    ]);
+    const checkConstraintResults = await sqldb.queryAsync(sql.get_check_constraints_for_table, {
+      oid: table.oid,
+    });
+
+    output.tables[table.name] = {
+      columns: columns,
+      indexes: indexResults.rows,
+      foreignKeyConstraints: foreignKeyConstraintResults.rows,
+      references: references,
+      checkConstraints: checkConstraintResults.rows,
+    };
   });
 
   // Get all enums
@@ -243,7 +249,7 @@ module.exports.formatDescription = function (description, options = { coloredOut
           // capture that explicitly.
           if (row.isunique && !row.isprimary) {
             if (!row.constraintdef || row.constraintdef.indexOf('UNIQUE') === -1) {
-              // Some unique indexes don't incldue the UNIQUE constraint
+              // Some unique indexes don't include the UNIQUE constraint
               // as part of the constraint definition, so we need to capture
               // that manually.
               rowText += formatText(` UNIQUE`, chalk.green);
@@ -251,6 +257,20 @@ module.exports.formatDescription = function (description, options = { coloredOut
           }
           rowText += row.constraintdef ? formatText(` ${row.constraintdef}`, chalk.green) : '';
           rowText += using ? formatText(` ${using}`, chalk.green) : '';
+          return rowText;
+        })
+        .join('\n');
+    }
+
+    if (table.checkConstraints.length > 0) {
+      if (output.tables[tableName].length !== 0) {
+        output.tables[tableName] += '\n\n';
+      }
+      output.tables[tableName] += formatText('check constraints\n', chalk.underline);
+      output.tables[tableName] += table.checkConstraints
+        .map((row) => {
+          let rowText = formatText(`    ${row.name}:`, chalk.bold);
+          rowText += formatText(` ${row.def}`, chalk.green);
           return rowText;
         })
         .join('\n');

--- a/lib/databaseDescribe.sql
+++ b/lib/databaseDescribe.sql
@@ -93,6 +93,18 @@ WHERE
 ORDER BY
   1;
 
+-- BLOCK get_check_constraints_for_table
+SELECT
+  conname AS name,
+  pg_catalog.pg_get_constraintdef (r.oid, true) as def
+FROM
+  pg_catalog.pg_constraint r
+WHERE
+  r.conrelid = $oid
+  AND r.contype = 'c'
+ORDER BY
+  1;
+
 -- BLOCK get_enums
 SELECT
   t.typname AS name,


### PR DESCRIPTION
I discovered in #7292 that our tooling didn't support `CHECK` constraints in the descriptions it generates. This PR adds support for that. It turns out there were already some existing constraints that weren't captured yet!