### PR TITLE
Render booleans in html template strings

### DIFF
--- a/.changeset/serious-bugs-push.md
+++ b/.changeset/serious-bugs-push.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/html': major
+---
+
+Render booleans in templates

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -19,6 +19,10 @@ describe('html', () => {
     assert.equal(html`<p>${123n}</p>`.toString(), '<p>123</p>');
   });
 
+  it('interpolates a boolean', () => {
+    assert.equal(html`<p>${false}</p>`.toString(), '<p>false</p>');
+  });
+
   it('escapes values when rendering array', () => {
     const arr = ['cats>', '<dogs'];
     assert.equal(

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -50,10 +50,6 @@ describe('html', () => {
     );
   });
 
-  it('omits boolean values from template', () => {
-    assert.equal(html`<p>${true}${false}</p>`.toString(), '<p></p>');
-  });
-
   it('omits nullish values from template', () => {
     assert.equal(html`<p>${null}${undefined}</p>`.toString(), '<p></p>');
   });

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -20,6 +20,7 @@ describe('html', () => {
   });
 
   it('interpolates a boolean', () => {
+    assert.equal(html`<p>${true}</p>`.toString(), '<p>true</p>');
     assert.equal(html`<p>${false}</p>`.toString(), '<p>false</p>');
   });
 

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -24,7 +24,12 @@ function escapeValue(value: unknown): string {
     return value.toString();
   } else if (Array.isArray(value)) {
     return value.map((val) => escapeValue(val)).join('');
-  } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
+  } else if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'bigint' ||
+    typeof value === 'boolean'
+  ) {
     return escapeHtmlRaw(String(value));
   } else if (value == null) {
     // undefined or null -- render nothing
@@ -32,8 +37,10 @@ function escapeValue(value: unknown): string {
   } else if (typeof value === 'object') {
     throw new Error(`Cannot interpolate object in template: ${JSON.stringify(value)}`);
   } else {
-    // This is boolean - don't render anything here.
-    return '';
+    // There shouldn't be any other types
+    throw new Error(
+      `Unexpected type in template: ${typeof value} for value ${JSON.stringify(value)}`
+    );
   }
 }
 


### PR DESCRIPTION
Previously we silently discarded booleans in `html` template strings. This allowed the use of the pattern:
```
html`${bool_value && 'some string'}`
```
which would template in `some string` if `bool_value` was true and nothing otherwise. However, it also meant that it was easy to accidentally fail to render a boolean value when we actually wanted to do it. This PR fixes this, but it does mean that we'll need to replace the pattern above with:
```
html`${bool_value ? 'some string' : ''}`
```
I personally prefer the explicit nature of this anyway.