### PR TITLE
pl-order-blocks: fix code formatting

### DIFF
--- a/elements/pl-order-blocks/pl-order-blocks.css
+++ b/elements/pl-order-blocks/pl-order-blocks.css
@@ -16,7 +16,8 @@ li.pl-order-blocks-code {
   list-style-type: none;
 }
 
-.pl-order-blocks-code > .pl-code:only-child div {
+.pl-order-blocks-code > .pl-code,
+.pl-order-blocks-code > .pl-code div {
   /* override margins on code block to ensure code is centered properly */
   margin-bottom: 0px !important;
 }


### PR DESCRIPTION
Recent changes to `pl-code` (#7366) broke the formatting hack that allows `pl-order-blocks` to display code nicely using `pl-code`. This fixes the issue. 

Good: 
![image](https://user-images.githubusercontent.com/25016959/232919586-f23b29a5-48e3-47cb-8639-66c3c951dd26.png)

Bad:
![image](https://user-images.githubusercontent.com/25016959/232919664-16cb4e12-7de3-4c5f-bcea-aeeec4c3c252.png)
