### PR TITLE
Delete chunks even for deleted entities

### DIFF
--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -176,17 +176,14 @@ WITH
       JSON_ARRAY_ELEMENTS($chunks) AS cm
       LEFT JOIN questions AS q ON (
         q.qid = (cm ->> 'questionName')
-        AND q.deleted_at IS NULL
         AND q.course_id = $course_id
       )
       LEFT JOIN course_instances AS ci ON (
         ci.short_name = (cm ->> 'courseInstanceName')
-        AND ci.deleted_at IS NULL
         AND ci.course_id = $course_id
       )
       LEFT JOIN assessments AS a ON (
         a.tid = (cm ->> 'assessmentName')
-        AND a.deleted_at IS NULL
         AND a.course_instance_id = ci.id
       )
   ),

--- a/tests/chunks.test.js
+++ b/tests/chunks.test.js
@@ -4,6 +4,7 @@ const util = require('util');
 const tmp = require('tmp-promise');
 const fs = require('fs-extra');
 const path = require('path');
+const { z } = require('zod');
 const sqldb = require('@prairielearn/postgres');
 
 const courseDB = require('../sync/course-db');
@@ -40,6 +41,26 @@ const COURSE = {
     },
   },
 };
+
+function getAllChunksForCourse(course_id) {
+  return sqldb.queryValidatedRows(
+    sql.select_all_chunks,
+    {
+      course_id,
+    },
+    z.object({
+      id: z.string(),
+      uuid: z.string(),
+      type: z.string(),
+      course_id: z.string(),
+      course_instance_id: z.string().nullable(),
+      assessment_id: z.string().nullable(),
+      question_id: z.string().nullable(),
+    })
+  );
+}
+
+function syncAndReloadCourse() {}
 
 describe('chunks', () => {
   describe('identifyChunksFromChangedFiles', () => {
@@ -446,6 +467,9 @@ describe('chunks', () => {
       await fs.remove(path.join(courseDir, 'elements'));
       await fs.remove(path.join(courseDir, 'elementExtensions'));
 
+      // Sync course to DB.
+      await syncDiskToSqlAsync(courseDir, courseId, logger);
+
       // Regenerate chunks
       await chunksLib.updateChunksForCourse({
         coursePath: courseDir,
@@ -460,9 +484,49 @@ describe('chunks', () => {
       assert.isNotOk(await fs.pathExists(path.join(courseRuntimeDir, 'elements')));
       assert.isNotOk(await fs.pathExists(path.join(courseRuntimeDir, 'elementExtensions')));
 
+      // Assert that the chunks have been deleted from the database
+      let databaseChunks = await getAllChunksForCourse(courseId);
+      assert.isUndefined(databaseChunks.find((chunk) => chunk.type === 'elements'));
+      assert.isUndefined(databaseChunks.find((chunk) => chunk.type === 'elementExtensions'));
+
       // Also assert that the chunks for directories that do exist are still there
       assert.isOk(await fs.pathExists(path.join(courseRuntimeDir, 'serverFilesCourse')));
       assert.isOk(await fs.pathExists(path.join(courseRuntimeDir, 'clientFilesCourse')));
+      assert.isOk(
+        await fs.pathExists(
+          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance')
+        )
+      );
+      assert.isOk(
+        await fs.pathExists(
+          path.join(
+            courseRuntimeDir,
+            'courseInstances',
+            'Sp15',
+            'assessments',
+            'exam1-automaticTestSuite',
+            'clientFilesAssessment'
+          )
+        )
+      );
+      assert.isOk(await fs.pathExists(path.join(courseRuntimeDir, 'questions', 'addNumbers')));
+
+      // Also assert that the database still has chunks for directories that do exist
+      assert.isOk(databaseChunks.find((chunk) => chunk.type === 'serverFilesCourse'));
+      assert.isOk(databaseChunks.find((chunk) => chunk.type === 'clientFilesCourse'));
+      assert.isOk(
+        databaseChunks.find(
+          (chunk) =>
+            chunk.type === 'clientFilesCourseInstance' &&
+            chunk.course_instance_id === courseInstanceId
+        )
+      );
+      assert.isOk(
+        databaseChunks.find(
+          (chunk) => chunk.type === 'clientFilesAssessment' && chunk.assessment_id === assessmentId
+        )
+      );
+      assert.isOk(databaseChunks.find((chunk) => chunk.type === 'question' && chunk.question_id));
 
       // Remove remaining directories from the course
       await fs.remove(path.join(courseDir, 'serverFilesCourse'));
@@ -479,6 +543,9 @@ describe('chunks', () => {
         )
       );
       await fs.remove(path.join(courseDir, 'questions', 'addNumbers'));
+
+      // Sync course to DB.
+      await syncDiskToSqlAsync(courseDir, courseId, logger);
 
       // Regenerate chunks
       await chunksLib.updateChunksForCourse({
@@ -512,6 +579,28 @@ describe('chunks', () => {
       );
       assert.isNotOk(
         await fs.pathExists(path.join(courseRuntimeDir, 'questions', 'addNumbers', 'question.html'))
+      );
+
+      // Assert that the remaining chunks have been deleted from the database
+      databaseChunks = await getAllChunksForCourse(courseId);
+      assert.isUndefined(databaseChunks.find((chunk) => chunk.type === 'serverFilesCourse'));
+      assert.isUndefined(databaseChunks.find((chunk) => chunk.type === 'clientFilesCourse'));
+      assert.isUndefined(
+        databaseChunks.find(
+          (chunk) =>
+            chunk.type === 'clientFilesCourseInstance' &&
+            chunk.course_instance_id === courseInstanceId
+        )
+      );
+      assert.isUndefined(
+        databaseChunks.find(
+          (chunk) => chunk.type === 'clientFilesAssessment' && chunk.assessment_id === assessmentId
+        )
+      );
+      assert.isUndefined(
+        databaseChunks.find(
+          (chunk) => chunk.type === 'question' && chunk.question_id === questionId
+        )
       );
     });
   });

--- a/tests/chunks.test.sql
+++ b/tests/chunks.test.sql
@@ -32,3 +32,11 @@ FROM
 WHERE
   qid = $qid
   AND deleted_at IS NULL;
+
+-- BLOCK select_all_chunks
+SELECT
+  *
+FROM
+  chunks
+WHERE
+  course_id = $course_id;


### PR DESCRIPTION
We had previously been refusing to delete chunks for deleted questions/course instances/assessments. However, this means that once one of those was deleted, we would try again to delete those chunks every time the course was synced. These could build up into hundreds of chunks over time, slowing down syncs and crowding the sync logs.

We'll now delete chunks even for deleted entities. This should be completely safe, since we shouldn't ever try to do anything with deleted things.