### PR TITLE
Optimize chunk deletion query

### DIFF
--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -240,11 +240,11 @@ WITH
       JOIN chunks_metadata AS cm ON (cm.type = chunks.type)
     WHERE
       chunks.course_id = $course_id
-      AND (
-        cm.type = 'elements'
-        OR cm.type = 'elementExtensions'
-        OR cm.type = 'clientFilesCourse'
-        OR cm.type = 'serverFilesCourse'
+      AND cm.type IN (
+        'elements',
+        'elementExtensions',
+        'clientFilesCourse',
+        'serverFilesCourse'
       )
   ),
   chunks_to_delete AS (

--- a/lib/chunks.sql
+++ b/lib/chunks.sql
@@ -199,12 +199,12 @@ WITH
     FROM
       chunks
       JOIN chunks_metadata AS cm ON (
-        chunks.course_id = $course_id
-        AND chunks.type = cm.type
+        cm.type = chunks.type
         AND cm.question_id = chunks.question_id
       )
     WHERE
-      chunks.type = 'question'
+      chunks.course_id = $course_id
+      AND chunks.type = 'question'
   ),
   client_files_course_instance_chunks_to_delete AS (
     SELECT
@@ -212,12 +212,12 @@ WITH
     FROM
       chunks
       JOIN chunks_metadata AS cm ON (
-        chunks.course_id = $course_id
-        AND chunks.type = cm.type
+        cm.type = chunks.type
         AND cm.course_instance_id = chunks.course_instance_id
       )
     WHERE
-      chunks.type = 'clientFilesCourseInstance'
+      chunks.course_id = $course_id
+      AND chunks.type = 'clientFilesCourseInstance'
   ),
   client_files_assessment_chunks_to_delete AS (
     SELECT
@@ -225,27 +225,27 @@ WITH
     FROM
       chunks
       JOIN chunks_metadata AS cm ON (
-        chunks.course_id = $course_id
-        AND chunks.type = cm.type
+        cm.type = chunks.type
         AND cm.assessment_id = chunks.assessment_id
       )
     WHERE
-      chunks.type = 'clientFilesAssessment'
+      chunks.course_id = $course_id
+      AND chunks.type = 'clientFilesAssessment'
   ),
   other_chunks_to_delete AS (
     SELECT
       id
     FROM
       chunks
-      JOIN chunks_metadata AS cm ON (
-        chunks.course_id = $course_id
-        AND chunks.type = cm.type
-      )
+      JOIN chunks_metadata AS cm ON (cm.type = chunks.type)
     WHERE
-      cm.type = 'elements'
-      OR cm.type = 'elementExtensions'
-      OR cm.type = 'clientFilesCourse'
-      OR cm.type = 'serverFilesCourse'
+      chunks.course_id = $course_id
+      AND (
+        cm.type = 'elements'
+        OR cm.type = 'elementExtensions'
+        OR cm.type = 'clientFilesCourse'
+        OR cm.type = 'serverFilesCourse'
+      )
   ),
   chunks_to_delete AS (
     SELECT


### PR DESCRIPTION
For a query that tries to delete 1000 question chunks, this PR reduces the execution time from ~18 seconds to 10 milliseconds.

Postgres was choking on the `chunks.type = cm.type` condition of the `chunks_to_delete` CTE. The execution order it took was to do that join first, and only *then* filter out rows where the type/IDs were mismatched. This resulted in essentially a cross product between the deleted questions and *all* questions, which was millions of rows. By using separate CTEs, we allow Postgres to work much more efficiently.

The only reason we were attempting to delete this many chunks on a regular basis is that we weren't *actually* deleting chunks for deleted questions/assessments/etc, meaning the number of questions we tried to delete each sync just increased over time. This will be resolved by #7531.