### PR TITLE
Fix workspace versions before publish

### DIFF
--- a/.changeset/early-colts-count.md
+++ b/.changeset/early-colts-count.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/config': patch
+---
+
+Fix dependency on `@prairielearn/aws-imds` package

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "node": ">=16.0.0"
     },
     "scripts": {
-        "release": "turbo run build && changeset publish",
+        "release": "turbo run build && node tools/fix-workspace-versions-before-publish.mjs && changeset publish",
         "version": "changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn"
     },
     "dependencies": {

--- a/tools/fix-workspace-versions-before-publish.mjs
+++ b/tools/fix-workspace-versions-before-publish.mjs
@@ -1,0 +1,62 @@
+// @ts-check
+
+// Changesets doesn't currently support workspace versions:
+// https://github.com/changesets/changesets/issues/432
+// https://github.com/changesets/action/issues/246
+// To work around that, we'll manually resolve any `workspace:` version ranges
+// with this tool prior to publishing. If/when changesets adds native support for
+// publishing with Yarn 3, we can remove this script.
+//
+// We'll only support the `workspace:^` range, which is the only one we
+// generally want to use.
+
+import cp from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import util from 'node:util';
+
+const DEPENDENCY_TYPES = ['dependencies', 'devDependencies', 'peerDependencies'];
+
+const exec = util.promisify(cp.exec);
+
+const rawWorkspaces = await exec('yarn workspaces list --json', { encoding: 'utf8' });
+const workspaces = rawWorkspaces.stdout
+  .trim()
+  .split('\n')
+  .map((line) => JSON.parse(line))
+  .filter((workspace) => workspace.location !== '.');
+
+// Get the version of each workspace package.
+const workspaceVersions = new Map();
+for (const workspace of workspaces) {
+  const packageJsonPath = path.join(workspace.location, 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+  workspaceVersions.set(workspace.name, packageJson.version);
+}
+
+// Replace any `workspace:^` version ranges with the actual version.
+for (const workspace of workspaces) {
+  const packageJsonPath = path.join(workspace.location, 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+
+  for (const dependencyType of DEPENDENCY_TYPES) {
+    const dependencies = Object.keys(packageJson[dependencyType] ?? {});
+    for (const dependency of dependencies) {
+      const dependencyVersion = packageJson[dependencyType][dependency];
+      if (dependencyVersion.startsWith('workspace:')) {
+        if (!dependencyVersion.startsWith('workspace:^')) {
+          throw new Error(`Unsupported workspace version range: ${dependencyVersion}`);
+        }
+
+        const realVersion = workspaceVersions.get(dependency);
+        if (!realVersion) {
+          throw new Error(`Could not find version for workspace ${dependency}`);
+        }
+
+        packageJson[dependencyType][dependency] = `^${realVersion}`;
+      }
+    }
+  }
+
+  await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,10 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
+    "module": "NodeNext",
+    // Corresponds to Node 16.x, which we currently run on.
+    // To check compatibility in the future, see https://node.green/.
+    "target": "ES2021",
   },
   // We don't actually use any TypeScript; we just use it to validate our
   // standard JavaScript with JSDoc comments.


### PR DESCRIPTION
Changesets unfortunately doesn't support publishing with Yarn, which means that `workspace:` version ranges aren't replaced prior to publishing:

* https://github.com/changesets/changesets/issues/432
* https://github.com/changesets/action/issues/246

This meant that packages were published to npm with literal `workspace:^` versions, which obviously broke when we tried to install them in another project.

This PR introduces a small script that will rewrite the versions for us.