### PR TITLE
Fix pl-code error message on invalid language

### DIFF
--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -128,11 +128,11 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     if language is not None:
         lexer = get_lexer_by_name(language)
         if lexer is None:
-            allowed_languages = map(
-                lambda tup: tup[1][0], pygments.lexers.get_all_lexers()
+            allowed_languages = (
+                l[1][0] for l in pygments.lexers.get_all_lexers() if l[1]
             )
             raise KeyError(
-                f'Unknown language: "{language}". Must be one of {", ".join(allowed_languages)}'
+                f'Unknown language: "{language}". Must be one of: {", ".join(allowed_languages)}'
             )
 
     style = pl.get_string_attrib(element, "style", STYLE_DEFAULT)

--- a/elements/pl-code/pl-code.py
+++ b/elements/pl-code/pl-code.py
@@ -128,11 +128,8 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     if language is not None:
         lexer = get_lexer_by_name(language)
         if lexer is None:
-            allowed_languages = (
-                l[1][0] for l in pygments.lexers.get_all_lexers() if l[1]
-            )
             raise KeyError(
-                f'Unknown language: "{language}". Must be one of: {", ".join(allowed_languages)}'
+                f'Unknown language: "{language}". Must be one of the alias listed in https://pygments.org/languages/.'
             )
 
     style = pl.get_string_attrib(element, "style", STYLE_DEFAULT)


### PR DESCRIPTION
The original code relied on `get_all_lexers` returning a list of available lexers where all items have at least one alias, but there are lexers that don't have an alias (e.g., JSONBareObject or RawToken), so this was causing an error. Given the list was so extensive that it made no sense to list all elements, this PR replaces the list of lexers with a link to the table of Pygments languages.