### PR TITLE
C Grader: Add option to invoke objcopy for student code

### DIFF
--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -124,6 +124,7 @@ class CGrader:
         return_objects=False,
         enable_asan=False,
         reject_symbols=None,
+        objcopy_args=None,
     ):
         cflags = flags
         if cflags and not isinstance(cflags, list):
@@ -199,6 +200,10 @@ class CGrader:
                         + "\033[0m"
                     )
                     os.unlink(obj_file)
+                if objcopy_args:
+                    self.run_command(
+                        ["objcopy", obj_file] + objcopy_args, sandboxed=False
+                    )
 
         if all(os.path.isfile(obj) for obj in std_obj_files):
             # Add new C files that maybe overwrite some existing functions.
@@ -311,14 +316,14 @@ class CGrader:
         ungradable_if_failed=True,
         enable_asan=False,
         reject_symbols=None,
+        objcopy_args=None,
     ):
         if not add_c_file:
             add_c_file = []
         elif not isinstance(add_c_file, list):
             add_c_file = [add_c_file]
-        if (
-            main_file
-        ):  # Kept for compatibility reasons, but could be set as an added file
+        # Kept for compatibility reasons, but could be set as an added file
+        if main_file:
             add_c_file.append(main_file)
 
         out, objects = self.compile_file(
@@ -333,6 +338,7 @@ class CGrader:
             return_objects=True,
             enable_asan=enable_asan,
             reject_symbols=reject_symbols,
+            objcopy_args=objcopy_args,
         )
         success = (
             os.path.isfile(exec_file)


### PR DESCRIPTION
While this was already possible with the separation of compiler and linker, the idea here is to simplify the use of this option.