### PR TITLE
Improve formatting of CHECK constraints in database descriptions

### DIFF
--- a/lib/databaseDescribe.js
+++ b/lib/databaseDescribe.js
@@ -263,8 +263,19 @@ module.exports.formatDescription = function (description, options = { coloredOut
       output.tables[tableName] += formatText('check constraints\n', chalk.underline);
       output.tables[tableName] += table.checkConstraints
         .map((row) => {
+          // Particularly long constraints are formatted as multiple lines.
+          // We'll collapse them into a single line for better appearance in
+          // the resulting file.
+          //
+          // The first replace handles lines that end with a parenthesis: we
+          // want to avoid spaces between the parenthesis and the next token.
+          //
+          // The second replace handles all other lines: we want to collapse
+          // all leading whitespace into a single space.
+          const def = row.def.replace(/\(\n/g, '(').replace(/\n\s*/g, ' ');
+
           let rowText = formatText(`    ${row.name}:`, chalk.bold);
-          rowText += formatText(` ${row.def}`, chalk.green);
+          rowText += formatText(` ${def}`, chalk.green);
           return rowText;
         })
         .join('\n');


### PR DESCRIPTION
This doesn't impact PL, but it improves the formatting in PT where we have some kinda gnarly constraints:

```diff
 check constraints
-    course_or_center: CHECK ((
-CASE
-    WHEN course_staff_id IS NOT NULL THEN 1
-    ELSE 0
-END +
-CASE
-    WHEN center_staff_id IS NOT NULL THEN 1
-    ELSE 0
-END) = 1)
+    course_or_center: CHECK ((CASE WHEN course_staff_id IS NOT NULL THEN 1 ELSE 0 END + CASE WHEN center_staff_id IS NOT NULL THEN 1 ELSE 0 END) = 1)
```