### PR TITLE
Use 400 HTTP status for missing issue description

### DIFF
--- a/pages/instructorQuestionPreview/instructorQuestionPreview.js
+++ b/pages/instructorQuestionPreview/instructorQuestionPreview.js
@@ -86,7 +86,7 @@ function processSubmission(req, res, callback) {
 async function processIssue(req, res, callback) {
   const description = req.body.description;
   if (!_.isString(description) || description.length === 0) {
-    return callback(new Error('A description of the issue must be provided'));
+    return callback(error.make(400, 'A description of the issue must be provided'));
   }
 
   const variantId = req.body.__variant_id;

--- a/pages/shared/studentInstanceQuestion.js
+++ b/pages/shared/studentInstanceQuestion.js
@@ -94,7 +94,7 @@ module.exports.processIssue = async (req, res) => {
   }
   const description = req.body.description;
   if (!_.isString(description) || description.length === 0) {
-    throw new Error('A description of the issue must be provided');
+    throw error.make(400, 'A description of the issue must be provided');
   }
 
   const variantId = await module.exports.getValidVariantId(req, res);


### PR DESCRIPTION
This ensures that these errors aren't reported to Sentry.