### PR TITLE
Drop unused enum_log_level type

### DIFF
--- a/database/enums/enum_log_level.pg
+++ b/database/enums/enum_log_level.pg
@@ -1,1 +1,0 @@
-error, warn, info, debug

--- a/migrations/20230421225700_enum_log_level__drop.sql
+++ b/migrations/20230421225700_enum_log_level__drop.sql
@@ -1,0 +1,1 @@
+DROP TYPE IF EXISTS enum_log_level;


### PR DESCRIPTION
This type has long been unused. I lifted this out of #7333 since it wasn't really related to the changes there.