### PR TITLE
Don't update workspaces.homedir_location column

### DIFF
--- a/lib/workspace.js
+++ b/lib/workspace.js
@@ -302,12 +302,6 @@ module.exports = {
       questionId: question.id,
     });
 
-    // TODO: remove this code once nothing is reading from the `homedir_location` columns.
-    await sqldb.queryOneRowAsync(sql.update_workspace_homedir_location, {
-      workspace_id,
-      homedir_location: 'FileSystem',
-    });
-
     // local workspace files
     const questionBasePath = path.join(course_path, 'questions', question.qid);
     const localPath = path.join(questionBasePath, 'workspace');

--- a/lib/workspace.sql
+++ b/lib/workspace.sql
@@ -74,13 +74,6 @@ WHERE
 RETURNING
   heartbeat_at;
 
--- BLOCK update_workspace_homedir_location
-UPDATE workspaces AS W
-SET
-  homedir_location = $homedir_location
-WHERE
-  w.id = $workspace_id;
-
 -- BLOCK update_workspace_state
 WITH
   old_workspace AS (


### PR DESCRIPTION
No code is reading this column anymore, so we can avoid writing to it.