### PR TITLE
Use correct function to update course commit hash

### DIFF
--- a/lib/editors.js
+++ b/lib/editors.js
@@ -311,7 +311,7 @@ class Editor {
               }
 
               const updateCourseCommitHash = () => {
-                courseUtil.getOrUpdateCourseCommitHash(this.course, (err) => {
+                courseUtil.updateCourseCommitHash(this.course, (err) => {
                   if (err) {
                     job.fail(err);
                   } else {

--- a/pages/shared/syncHelpers.js
+++ b/pages/shared/syncHelpers.js
@@ -190,7 +190,7 @@ module.exports.pullAndUpdate = function (locals, callback) {
             }
 
             const updateCourseCommitHash = () => {
-              courseUtil.getOrUpdateCourseCommitHash(locals.course, (err) => {
+              courseUtil.updateCourseCommitHash(locals.course, (err) => {
                 if (err) {
                   job.fail(err);
                 } else {


### PR DESCRIPTION
If the course object passed to `getOrUpdateCourseCommitHash` already has a `hash` property, it would be returned immediately. However, we don't want that behavior in these two cases: we always want to force a new hash to be computed and persisted to the database.