### PR TITLE
Use typescript-cp instead of copyfiles

### DIFF
--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -8,8 +8,8 @@
     "directory": "packages/migrations"
   },
   "scripts": {
-    "build": "tsc && copyfiles -u 1 \"./src/**/*.sql\" dist",
-    "dev": "tsc --watch --preserveWatchOutput",
+    "build": "tsc && tscp",
+    "dev": "tsc --watch --preserveWatchOutput & tscp --watch",
     "test": "mocha --no-config --require ts-node/register src/**/*.test.ts"
   },
   "devDependencies": {
@@ -17,10 +17,10 @@
     "@types/fs-extra": "^11.0.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.15.11",
-    "copyfiles": "^2.4.1",
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "typescript-cp": "^0.1.7"
   },
   "dependencies": {
     "@prairielearn/error": "workspace:^",

--- a/packages/postgres-tools/package.json
+++ b/packages/postgres-tools/package.json
@@ -12,16 +12,16 @@
     "directory": "packages/postgres-tools"
   },
   "scripts": {
-    "build": "tsc && copyfiles -u 1 \"./src/**/*.sql\" dist",
-    "dev": "tsc --watch --preserveWatchOutput"
+    "build": "tsc && tscp",
+    "dev": "tsc --watch --preserveWatchOutput & tscp --watch"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
     "@types/diff": "^5.0.3",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.15.11",
-    "copyfiles": "^2.4.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "typescript-cp": "^0.1.7"
   },
   "dependencies": {
     "@prairielearn/postgres": "workspace:^",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -12,8 +12,8 @@
     "directory": "packages/postgres"
   },
   "scripts": {
-    "build": "tsc && copyfiles -u 1 \"./src/**/*.sql\" dist",
-    "dev": "tsc --watch --preserveWatchOutput",
+    "build": "tsc && tscp",
+    "dev": "tsc --watch --preserveWatchOutput & tscp --watch",
     "test": "mocha --no-config --require ts-node/register src/*.test.ts"
   },
   "devDependencies": {
@@ -23,10 +23,10 @@
     "@types/mocha": "^10.0.1",
     "@types/multipipe": "^3.0.1",
     "@types/node": "^18.15.11",
-    "copyfiles": "^2.4.1",
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "typescript-cp": "^0.1.7"
   },
   "dependencies": {
     "@types/debug": "^4.1.7",

--- a/packages/workspace-utils/package.json
+++ b/packages/workspace-utils/package.json
@@ -9,14 +9,14 @@
     "directory": "packages/workspace-utils"
   },
   "scripts": {
-    "build": "rm -rf dist/ && tsc && copyfiles -u 1 \"./src/**/*.sql\" dist",
-    "dev": "tsc --watch --preserveWatchOutput"
+    "build": "tsc && tscp",
+    "dev": "tsc --watch --preserveWatchOutput & tscp --watch"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^18.15.11",
-    "copyfiles": "^2.4.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "typescript-cp": "^0.1.7"
   },
   "dependencies": {
     "@prairielearn/path-utils": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,12 +2714,12 @@ __metadata:
     "@types/fs-extra": ^11.0.1
     "@types/mocha": ^10.0.1
     "@types/node": ^18.15.11
-    copyfiles: ^2.4.1
     fs-extra: ^11.1.1
     mocha: ^10.2.0
     serialize-error: ^8.1.0
     ts-node: ^10.9.1
     typescript: ^4.9.5
+    typescript-cp: ^0.1.7
     zod: ^3.21.4
   languageName: unknown
   linkType: soft
@@ -2797,11 +2797,11 @@ __metadata:
     "@types/lodash": ^4.14.192
     "@types/node": ^18.15.11
     chalk: ^4.1.2
-    copyfiles: ^2.4.1
     diff: ^5.1.0
     fs-extra: ^11.1.1
     lodash: ^4.17.21
     typescript: ^4.9.4
+    typescript-cp: ^0.1.7
   bin:
     pg-describe: ./dist/bin/pg-describe.js
     pg-diff: ./dist/bin/pg-diff.js
@@ -2822,7 +2822,6 @@ __metadata:
     "@types/node": ^18.15.11
     "@types/pg-cursor": ^2.7.0
     chalk: ^4.1.2
-    copyfiles: ^2.4.1
     diff: ^5.1.0
     fs-extra: ^11.1.1
     lodash: ^4.17.21
@@ -2833,6 +2832,7 @@ __metadata:
     pg-pool: ^3.6.0
     ts-node: ^10.9.1
     typescript: ^4.9.4
+    typescript-cp: ^0.1.7
     zod: ^3.21.4
   bin:
     pg-describe: ./dist/bin/pg-describe.js
@@ -2906,10 +2906,10 @@ __metadata:
     "@prairielearn/postgres": "workspace:^"
     "@prairielearn/tsconfig": "workspace:^"
     "@types/node": ^18.15.11
-    copyfiles: ^2.4.1
     fast-glob: ^3.2.12
     filesize: ^10.0.7
     typescript: ^4.9.4
+    typescript-cp: ^0.1.7
   languageName: unknown
   linkType: soft
 
@@ -3544,6 +3544,13 @@ __metadata:
   version: 3.0.2
   resolution: "@types/object-hash@npm:3.0.2"
   checksum: 0332e59074e7df2e74c093a7419c05c1e1c5ae1e12d3779f3240b3031835ff045b4ac591362be0b411ace24d3b5e760386b434761c33af25904f7a3645cb3785
+  languageName: node
+  linkType: hard
+
+"@types/parse-json@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@types/parse-json@npm:4.0.0"
+  checksum: fd6bce2b674b6efc3db4c7c3d336bd70c90838e8439de639b909ce22f3720d21344f52427f1d9e57b265fcb7f6c018699b99e5e0c208a1a4823014269a6bf35b
   languageName: node
   linkType: hard
 
@@ -5301,7 +5308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:3.5.3, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
+"chokidar@npm:3.5.3, chokidar@npm:^3.5.1, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -5528,6 +5535,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^8.1.0":
+  version: 8.3.0
+  resolution: "commander@npm:8.3.0"
+  checksum: 0f82321821fc27b83bd409510bb9deeebcfa799ff0bf5d102128b500b7af22872c0c92cb6a0ebc5a4cf19c6b550fba9cedfa7329d18c6442a625f851377bacf0
+  languageName: node
+  linkType: hard
+
 "commander@npm:^9.0.0, commander@npm:^9.1.0":
   version: 9.5.0
   resolution: "commander@npm:9.5.0"
@@ -5651,24 +5665,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copyfiles@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "copyfiles@npm:2.4.1"
-  dependencies:
-    glob: ^7.0.5
-    minimatch: ^3.0.3
-    mkdirp: ^1.0.4
-    noms: 0.0.0
-    through2: ^2.0.1
-    untildify: ^4.0.0
-    yargs: ^16.1.0
-  bin:
-    copyfiles: copyfiles
-    copyup: copyfiles
-  checksum: aea69873bb99cc5f553967660cbfb70e4eeda198f572a36fb0f748b36877ff2c90fd906c58b1d540adbad8afa8ee82820172f1c18e69736f7ab52792c12745a7
-  languageName: node
-  linkType: hard
-
 "core-js@npm:^3.23.5":
   version: 3.26.1
   resolution: "core-js@npm:3.26.1"
@@ -5697,6 +5693,19 @@ __metadata:
     object-assign: ^4
     vary: ^1
   checksum: ced838404ccd184f61ab4fdc5847035b681c90db7ac17e428f3d81d69e2989d2b680cc254da0e2554f5ed4f8a341820a1ce3d1c16b499f6e2f47a1b9b07b5006
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "cosmiconfig@npm:7.1.0"
+  dependencies:
+    "@types/parse-json": ^4.0.0
+    import-fresh: ^3.2.1
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+    yaml: ^1.10.0
+  checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
   languageName: node
   linkType: hard
 
@@ -7838,6 +7847,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "fs-extra@npm:10.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^11.1.1":
   version: 11.1.1
   resolution: "fs-extra@npm:11.1.1"
@@ -8137,7 +8157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.5, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
+"glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -8194,7 +8214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.0, globby@npm:^11.1.0":
+"globby@npm:^11.0.0, globby@npm:^11.0.3, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -8837,7 +8857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -10690,7 +10710,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:2 || 3, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:2 || 3, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -11164,16 +11184,6 @@ __metadata:
   bin:
     nodemon: bin/nodemon.js
   checksum: 9c987e139748f5b5c480c6c9080bdc97304ee7d29172b7b3da1a7db590b1323ad57b96346304e9b522b0e445c336dc393ccd3f9f45c73b20d476d2347890dcd0
-  languageName: node
-  linkType: hard
-
-"noms@npm:0.0.0":
-  version: 0.0.0
-  resolution: "noms@npm:0.0.0"
-  dependencies:
-    inherits: ^2.0.1
-    readable-stream: ~1.0.31
-  checksum: a05f056dabf764c86472b6b5aad10455f3adcb6971f366cdf36a72b559b29310a940e316bca30802f2804fdd41707941366224f4cba80c4f53071512245bf200
   languageName: node
   linkType: hard
 
@@ -12444,18 +12454,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:~1.0.31":
-  version: 1.0.34
-  resolution: "readable-stream@npm:1.0.34"
-  dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: 0.0.1
-    string_decoder: ~0.10.x
-  checksum: 85042c537e4f067daa1448a7e257a201070bfec3dd2706abdbd8ebc7f3418eb4d3ed4b8e5af63e2544d69f88ab09c28d5da3c0b77dc76185fddd189a59863b60
-  languageName: node
-  linkType: hard
-
 "readable-web-to-node-stream@npm:^3.0.0":
   version: 3.0.2
   resolution: "readable-web-to-node-stream@npm:3.0.2"
@@ -13654,13 +13652,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:~0.10.x":
-  version: 0.10.31
-  resolution: "string_decoder@npm:0.10.31"
-  checksum: fe00f8e303647e5db919948ccb5ce0da7dea209ab54702894dd0c664edd98e5d4df4b80d6fabf7b9e92b237359d21136c95bf068b2f7760b772ca974ba970202
-  languageName: node
-  linkType: hard
-
 "string_decoder@npm:~1.1.1":
   version: 1.1.1
   resolution: "string_decoder@npm:1.1.1"
@@ -13861,7 +13852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.11, tar@npm:^6.1.13, tar@npm:^6.1.2":
+"tar@npm:^6.1.0, tar@npm:^6.1.11, tar@npm:^6.1.13, tar@npm:^6.1.2":
   version: 6.1.13
   resolution: "tar@npm:6.1.13"
   dependencies:
@@ -13924,16 +13915,6 @@ __metadata:
   bin:
     thrift2json: ./thrift2json.js
   checksum: fc03374131a713f5c5eca712a4092abf48282d985d23542f3ef7c92d222af52716e7037c446d5734708cc514d8fad42674f82dd6a9c59b8807beba0a1169b539
-  languageName: node
-  linkType: hard
-
-"through2@npm:^2.0.1":
-  version: 2.0.5
-  resolution: "through2@npm:2.0.5"
-  dependencies:
-    readable-stream: ~2.3.6
-    xtend: ~4.0.1
-  checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
   languageName: node
   linkType: hard
 
@@ -14362,6 +14343,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-cp@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "typescript-cp@npm:0.1.7"
+  dependencies:
+    chokidar: ^3.5.1
+    commander: ^8.1.0
+    cosmiconfig: ^7.0.0
+    fs-extra: ^10.0.0
+    globby: ^11.0.3
+    lodash: ^4.17.21
+    pify: ^5.0.0
+    rimraf: ^3.0.2
+    tar: ^6.1.0
+  peerDependencies:
+    typescript: ^4.2.3
+  bin:
+    tscp: dist/bin/tscp.js
+  checksum: ff73a7fab0492e7a574792458a0fd38c6b426eac012ffcb459e4cda358d8e38930f34ca6dafb76b1b381915096cb7e2632668ee953fce0803e8354a3360c4b1d
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^4.9.4, typescript@npm:^4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
@@ -14544,13 +14546,6 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
-  languageName: node
-  linkType: hard
-
-"untildify@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "untildify@npm:4.0.0"
-  checksum: 39ced9c418a74f73f0a56e1ba4634b4d959422dff61f4c72a8e39f60b99380c1b45ed776fbaa0a4101b157e4310d873ad7d114e8534ca02609b4916bb4187fb9
   languageName: node
   linkType: hard
 
@@ -15156,7 +15151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:~4.0.0, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0, xtend@npm:~4.0.0":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
@@ -15188,6 +15183,13 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^1.10.0":
+  version: 1.10.2
+  resolution: "yaml@npm:1.10.2"
+  checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
   languageName: node
   linkType: hard
 
@@ -15234,7 +15236,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:16.2.0, yargs@npm:^16.1.0, yargs@npm:^16.2.0":
+"yargs@npm:16.2.0, yargs@npm:^16.2.0":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:


### PR DESCRIPTION
This requires slightly less fiddling with exactly which extensions we want to copy - it'll just copy everything that isn't already being transformed by TypeScript.

I'm once again wishing `tsc --copy-files` was a thing! Alas, https://github.com/microsoft/TypeScript/issues/30835.