### PR TITLE
Remove turbo dev and make dev scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ deps:
 	@yarn
 	@make python-deps build
 
-dev:
-	@yarn turbo run dev
-
 start: start-support
 	@node server.js
 start-nodemon: start-support

--- a/turbo.json
+++ b/turbo.json
@@ -5,9 +5,6 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/"]
     },
-    "dev": {
-      "cache": false
-    },
     "test": {
       "outputs": []
     }


### PR DESCRIPTION
`make dev` / `yarn turbo dev` do not currently work as expected. `dev` scripts by design don't finish, and because Turbo treats tasks as a DAG, it will never start the `dev` tasks for packages that depend on other packages. This limitation is discussed in more detail here: https://github.com/vercel/turbo/issues/986.

In general, this script wasn't used much anyways, as folks are rarely working on more than one package at once. I think the best workflow here is to just run `yarn workspace @prairirelearn/PKG run dev` for whatever packages are currently being worked on.

I'm removing this primarily with the goal of making `make dev` run PrairieLearn in "dev" mode, which will become more relevant once we're running PrairieLearn code through a build tool and we need to differentiate between essentially `node dist/server.js` and `ts-node src/server.js`.