### PR TITLE
Don't rely on fixed node_modules path for assets

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -6,7 +6,6 @@ const { hashElement } = require('folder-hash');
 
 let assetsHash = 'NOT_SET';
 let elementsHash = 'NOT_SET';
-const cachedPackageVersions = {};
 const cachedPackageVersionHashes = {};
 
 /**
@@ -26,6 +25,37 @@ async function computeAssetsHash() {
 
 async function computeElementsHash() {
   elementsHash = await hashDirectory(path.join(__dirname, '..', 'elements'));
+}
+
+function getPackageVersion(packageName) {
+  try {
+    return require(`${packageName}/package.json`).version;
+  } catch (e) {
+    if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      throw e;
+    }
+
+    // If we can't directly resolve the package's `package.json` file, we'll
+    // `require.resolve` the package itself, and then do a little manipulation
+    // to get the `package.json` path from there.
+
+    // Get the resolved path to the package entrypoint, which will look something
+    // like `/absolute/path/to/node_modules/package-name/index.js`.
+    const pkgPath = require.resolve(packageName);
+
+    // Strip off everything after the last `/node_modules/`, then append the
+    // package name.
+    const nodeModulesToken = '/node_modules/';
+    const lastNodeModulesIndex = pkgPath.lastIndexOf(nodeModulesToken);
+    const pkgJsonPath = path.resolve(
+      pkgPath.slice(0, lastNodeModulesIndex + nodeModulesToken.length),
+      packageName,
+      'package.json'
+    );
+
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    return pkgJson.version;
+  }
 }
 
 /**
@@ -61,43 +91,15 @@ module.exports.nodeModulesAssetPath = (assetPath) => {
     moduleName = maybeScope;
   }
 
-  // Reading files synchronously is relatively expensive; ensure we only do it
-  // once per module.
-  let version = cachedPackageVersions[moduleName];
-  if (version == null) {
-    // Packages containing an `exports` field may not declare their `package.json`
-    // file, so we'd get a `ERR_PACKAGE_PATH_NOT_EXPORTED` error if we tried to
-    // directly resolve the path of `package-name/package.json`. Instead, we'll
-    // `require.resolve` the package itself, and then do a little manipulation
-    // to get the `package.json` path from there.
-
-    // Get the resolved path to the package entrypoint, which will look something
-    // like `/absolute/path/to/node_modules/package-name/index.js`.
-    const pkgPath = require.resolve(moduleName);
-
-    // Strip off everything after the last `/node_modules/`, then append the
-    // package name.
-    const nodeModulesToken = '/node_modules/';
-    const lastNodeModulesIndex = pkgPath.lastIndexOf(nodeModulesToken);
-    const pkgJsonPath = path.resolve(
-      pkgPath.slice(0, lastNodeModulesIndex + nodeModulesToken.length),
-      '@octokit/rest',
-      moduleName,
-      'package.json'
-    );
-
-    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-    version = pkgJson.version;
-    cachedPackageVersions[moduleName] = version ?? '';
-  }
-
-  // Cryptography operations are potentially expensive, so we'll cache the
-  // hashed version info.
-  let hash = cachedPackageVersionHashes[version];
+  // Reading files synchronously and computing cryptographic hashes are both
+  // relatively expensive; cache the hashes for each package.
+  let hash = cachedPackageVersionHashes[moduleName];
   if (!hash) {
+    const version = getPackageVersion(moduleName);
     hash = crypto.createHash('sha256').update(version).digest('hex').slice(0, 16);
-    cachedPackageVersionHashes[version] = hash;
+    cachedPackageVersionHashes[moduleName] = hash;
   }
+
   return `/cacheable_node_modules/${hash}/${assetPath}`;
 };
 

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -65,7 +65,27 @@ module.exports.nodeModulesAssetPath = (assetPath) => {
   // once per module.
   let version = cachedPackageVersions[moduleName];
   if (version == null) {
-    const pkgJsonPath = path.resolve('node_modules', moduleName, 'package.json');
+    // Packages containing an `exports` field may not declare their `package.json`
+    // file, so we'd get a `ERR_PACKAGE_PATH_NOT_EXPORTED` error if we tried to
+    // directly resolve the path of `package-name/package.json`. Instead, we'll
+    // `require.resolve` the package itself, and then do a little manipulation
+    // to get the `package.json` path from there.
+
+    // Get the resolved path to the package entrypoint, which will look something
+    // like `/absolute/path/to/node_modules/package-name/index.js`.
+    const pkgPath = require.resolve(moduleName);
+
+    // Strip off everything after the last `/node_modules/`, then append the
+    // package name.
+    const nodeModulesToken = '/node_modules/';
+    const lastNodeModulesIndex = pkgPath.lastIndexOf(nodeModulesToken);
+    const pkgJsonPath = path.resolve(
+      pkgPath.slice(0, lastNodeModulesIndex + nodeModulesToken.length),
+      '@octokit/rest',
+      moduleName,
+      'package.json'
+    );
+
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
     version = pkgJson.version;
     cachedPackageVersions[moduleName] = version ?? '';

--- a/tests/assets.test.js
+++ b/tests/assets.test.js
@@ -1,0 +1,45 @@
+// @ts-check
+const { assert } = require('chai');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const fetch = require('node-fetch').default;
+
+const { config } = require('../lib/config');
+const assets = require('../lib/assets');
+
+const helperServer = require('./helperServer');
+
+const SITE_URL = 'http://localhost:' + config.serverPort;
+
+describe('Static assets', () => {
+  before(helperServer.before());
+  after(helperServer.after);
+
+  it('serves all element node_modules assets', async () => {
+    const elementsPath = path.resolve(__dirname, '..', 'elements');
+    const elements = await fs.readdir(elementsPath);
+    console.log(elements);
+
+    const elementAssets = new Set();
+    for (const element of elements) {
+      const elementInfoPath = path.join(elementsPath, element, 'info.json');
+      console.log(elementInfoPath);
+      const elementInfo = JSON.parse(await fs.readFile(elementInfoPath, 'utf-8'));
+      const nodeModulesScripts = elementInfo.dependencies?.nodeModulesScripts ?? [];
+      const nodeModulesStyles = elementInfo.dependencies?.nodeModulesStyles ?? [];
+      [...nodeModulesScripts, ...nodeModulesStyles].forEach((asset) => {
+        elementAssets.add(asset);
+      });
+    }
+
+    for (const elementAsset of elementAssets) {
+      const assetPath = assets.nodeModulesAssetPath(elementAsset);
+      const assetUrl = `${SITE_URL}${assetPath}`;
+      console.log(assetUrl);
+      const res = await fetch(assetUrl, { method: 'HEAD' });
+      if (!res.ok) {
+        assert.fail(`Failed to fetch ${assetUrl}: ${res.status} ${res.statusText}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Once we move the PrairieLearn code to `apps/prairielearn`, we won't be able to _necessarily_ rely on serving `node_modules` assets from exactly one of `node_modules` and `apps/prairielearn/node_modules` - Yarn could in theory place dependencies in either directory (though it will generally host them to the root `node_modules` directory).

This PR uses `require.resolve` to locate the correct version to serve. This is conceptually similar to what we used to do before #6330, except it's robust to the issue that caused us to change this in the first place.

Note that I'll be updating `app.use('/cacheable_node_modules/:cachebuster', ...)` in `server.js` in the PR that actually moves PrairieLearn. We'll need to serve from both `node_modules` directories to handle all cases.