### PR TITLE
Remove unused commands and dependencies from postgres package

### DIFF
--- a/.changeset/clever-insects-bow.md
+++ b/.changeset/clever-insects-bow.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/postgres': patch
+---
+
+Remove unused `pg-describe`/`pg-diff` commands from `package.json`

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -2,40 +2,29 @@
   "name": "@prairielearn/postgres",
   "version": "1.6.0",
   "main": "./dist/index.js",
-  "bin": {
-    "pg-describe": "./dist/bin/pg-describe.js",
-    "pg-diff": "./dist/bin/pg-diff.js"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/PrairieLearn/PrairieLearn.git",
     "directory": "packages/postgres"
   },
   "scripts": {
-    "build": "tsc && tscp",
-    "dev": "tsc --watch --preserveWatchOutput & tscp --watch",
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
     "test": "mocha --no-config --require ts-node/register src/*.test.ts"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
-    "@types/diff": "^5.0.3",
-    "@types/fs-extra": "^11.0.1",
     "@types/mocha": "^10.0.1",
     "@types/multipipe": "^3.0.1",
     "@types/node": "^18.16.1",
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4",
-    "typescript-cp": "^0.1.7"
+    "typescript": "^5.0.4"
   },
   "dependencies": {
     "@types/debug": "^4.1.7",
     "@types/lodash": "^4.14.192",
     "@types/pg-cursor": "^2.7.0",
-    "chalk": "^4.1.2",
-    "diff": "^5.1.0",
-    "fs-extra": "^11.1.1",
-    "lodash": "^4.17.21",
     "multipipe": "^4.0.0",
     "pg": "^8.10.0",
     "pg-cursor": "^2.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,17 +2852,11 @@ __metadata:
   dependencies:
     "@prairielearn/tsconfig": "workspace:^"
     "@types/debug": ^4.1.7
-    "@types/diff": ^5.0.3
-    "@types/fs-extra": ^11.0.1
     "@types/lodash": ^4.14.192
     "@types/mocha": ^10.0.1
     "@types/multipipe": ^3.0.1
     "@types/node": ^18.16.1
     "@types/pg-cursor": ^2.7.0
-    chalk: ^4.1.2
-    diff: ^5.1.0
-    fs-extra: ^11.1.1
-    lodash: ^4.17.21
     mocha: ^10.2.0
     multipipe: ^4.0.0
     pg: ^8.10.0
@@ -2870,11 +2864,7 @@ __metadata:
     pg-pool: ^3.6.0
     ts-node: ^10.9.1
     typescript: ^5.0.4
-    typescript-cp: ^0.1.7
     zod: ^3.21.4
-  bin:
-    pg-describe: ./dist/bin/pg-describe.js
-    pg-diff: ./dist/bin/pg-diff.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I forgot to remove these in #7543. They were left over from a previous iteration when I put these commands inside the `@prairielearn/postgres` package instead of the separate `@prairielearn/postgres-tools` package where they ended up.