### PR TITLE
Add missing yargs types to postgres-tools package

### DIFF
--- a/packages/postgres-tools/package.json
+++ b/packages/postgres-tools/package.json
@@ -19,13 +19,14 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@types/diff": "^5.0.3",
     "@types/fs-extra": "^11.0.1",
+    "@types/lodash": "^4.14.192",
     "@types/node": "^18.16.1",
+    "@types/yargs": "^17.0.24",
     "typescript": "^5.0.4",
     "typescript-cp": "^0.1.7"
   },
   "dependencies": {
     "@prairielearn/postgres": "workspace:^",
-    "@types/lodash": "^4.14.192",
     "chalk": "^4.1.2",
     "diff": "^5.1.0",
     "fs-extra": "^11.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,6 +2595,7 @@ __metadata:
     "@types/fs-extra": ^11.0.1
     "@types/lodash": ^4.14.192
     "@types/node": ^18.16.1
+    "@types/yargs": ^17.0.24
     chalk: ^4.1.2
     diff: ^5.1.0
     fs-extra: ^11.1.1


### PR DESCRIPTION
I discovered this while working on the move to `apps/prairielearn` in another branch.