### PR TITLE
Fix query cursor stream closing

### DIFF
--- a/packages/postgres/src/pool.test.ts
+++ b/packages/postgres/src/pool.test.ts
@@ -17,7 +17,7 @@ const postgresTestUtils = makePostgresTestUtils({
 describe('@prairielearn/postgres', function () {
   before(async () => {
     await postgresTestUtils.createDatabase();
-    await queryAsync('CREATE TABLE workspaces (id BIGSERIAL PRIMARY KEY, state TEXT);', {});
+    await queryAsync('CREATE TABLE workspaces (id BIGSERIAL PRIMARY KEY);', {});
     await queryAsync('INSERT INTO workspaces (id) SELECT s FROM generate_series(1, 100) AS s', {});
   });
 


### PR DESCRIPTION
This PR fixes a pub where a Postgres cursor+client would remain indefinitely it a client did not fully consume all of the cursor's rows. This lead to queries that remained active for multiple days until they were manually killed.

Closes https://github.com/PrairieLearnInc/sysconf/issues/983.