### PR TITLE
Use path constants to construct paths

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 const { hashElement } = require('folder-hash');
+const { APP_ROOT_PATH } = require('./paths');
 
 let assetsHash = 'NOT_SET';
 let elementsHash = 'NOT_SET';
@@ -20,11 +21,11 @@ async function hashDirectory(dir) {
 }
 
 async function computeAssetsHash() {
-  assetsHash = await hashDirectory(path.join(__dirname, '..', 'public'));
+  assetsHash = await hashDirectory(path.join(APP_ROOT_PATH, 'public'));
 }
 
 async function computeElementsHash() {
-  elementsHash = await hashDirectory(path.join(__dirname, '..', 'elements'));
+  elementsHash = await hashDirectory(path.join(APP_ROOT_PATH, 'elements'));
 }
 
 function getPackageVersion(packageName) {

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -173,8 +173,7 @@ class CodeCallerNative {
       paths.push(path.join(this.coursePath, 'serverFilesCourse'));
     } else if (type === 'v2-question') {
       // v2 questions always use the root of the PrairieLearn repository as their
-      // working directory. This is necessary for the `config.questionDefaultsDir`
-      // config option to work correctly.
+      // working directory.
       cwd = REPOSITORY_ROOT_PATH;
     } else if (type === 'course-element') {
       if (!directory) throw new Error('Missing directory');

--- a/lib/code-caller/code-caller-native.js
+++ b/lib/code-caller/code-caller-native.js
@@ -8,6 +8,7 @@ const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'
 const { FunctionMissingError } = require('./code-caller-shared');
 const { logger } = require('@prairielearn/logger');
 const { deferredPromise } = require('../deferred');
+const { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } = require('../paths');
 
 const CREATED = Symbol('CREATED');
 const WAITING = Symbol('WAITING');
@@ -165,7 +166,7 @@ class CodeCallerNative {
     }
 
     let cwd;
-    const paths = [path.join(__dirname, '..', '..', 'python')];
+    const paths = [path.join(APP_ROOT_PATH, 'python')];
     if (type === 'question') {
       if (!directory) throw new Error('Missing directory');
       cwd = path.join(this.coursePath, 'questions', directory);
@@ -174,14 +175,14 @@ class CodeCallerNative {
       // v2 questions always use the root of the PrairieLearn repository as their
       // working directory. This is necessary for the `config.questionDefaultsDir`
       // config option to work correctly.
-      cwd = path.resolve(path.join(__dirname, '..', '..'));
+      cwd = REPOSITORY_ROOT_PATH;
     } else if (type === 'course-element') {
       if (!directory) throw new Error('Missing directory');
       cwd = path.join(this.coursePath, 'elements', directory);
       paths.push(path.join(this.coursePath, 'serverFilesCourse'));
     } else if (type === 'core-element') {
       if (!directory) throw new Error('Missing directory');
-      cwd = path.join(__dirname, '..', '..', 'elements', directory);
+      cwd = path.join(APP_ROOT_PATH, 'elements', directory);
     } else if (type === 'restart' || type === 'ping') {
       // Doesn't need a working directory
     } else {
@@ -309,7 +310,7 @@ class CodeCallerNative {
     this._checkState([CREATED]);
 
     const cmd = 'python3';
-    const pythonZygote = path.join(__dirname, '..', '..', 'python', 'zygote.py');
+    const pythonZygote = path.join(APP_ROOT_PATH, 'python', 'zygote.py');
     const args = ['-B', pythonZygote];
     const env = _.clone(process.env);
     // PYTHONIOENCODING might not be needed once we switch to Python 3.7

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,3 @@
-import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from './paths';
-
 // @ts-check
 const { z } = require('zod');
 const {
@@ -8,6 +6,8 @@ const {
   makeImdsConfigSource,
   makeSecretsManagerConfigSource,
 } = require('@prairielearn/config');
+
+const { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } = require('./paths');
 
 const ConfigSchema = z.object({
   startServer: z.boolean().default(true),
@@ -121,7 +121,6 @@ const ConfigSchema = z.object({
    */
   nodeMetricsIntervalSec: z.number().default(5),
   autoFinishAgeMins: z.number().default(6 * 60),
-  questionDefaultsDir: z.string().default('question-servers/default-calculation'),
   // TODO: tweak this value once we see the data from #2267
   questionTimeoutMilliseconds: z.number().default(10000),
   secretKey: z.string().default('THIS_IS_THE_SECRET_KEY'),

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,3 +1,5 @@
+import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from './paths';
+
 // @ts-check
 const { z } = require('zod');
 const {
@@ -28,8 +30,8 @@ const ConfigSchema = z.object({
       '/course7',
       '/course8',
       '/course9',
-      'exampleCourse',
-      'testCourse',
+      EXAMPLE_COURSE_PATH,
+      TEST_COURSE_PATH,
     ]),
   courseRepoDefaultBranch: z.string().default('master'),
   urlPrefix: z.string().default('/pl'),

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -17,6 +17,7 @@ const { v4: uuidv4 } = require('uuid');
 const sha256 = require('crypto-js/sha256');
 const util = require('util');
 const chunks = require('./chunks');
+const { EXAMPLE_COURSE_PATH } = require('./paths');
 const { escapeRegExp } = require('@prairielearn/sanitize');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -1177,14 +1178,7 @@ class QuestionAddEditor extends Editor {
           callback(null);
         },
         (callback) => {
-          const fromPath = path.join(
-            __dirname,
-            '..',
-            'exampleCourse',
-            'questions',
-            'demo',
-            'calculation'
-          );
+          const fromPath = path.join(EXAMPLE_COURSE_PATH, 'questions', 'demo', 'calculation');
           const toPath = this.questionPath;
           debug(`Copy template\n from ${fromPath}\n to ${toPath}`);
           fs.copy(fromPath, toPath, { overwrite: false, errorOnExist: true }, (err) => {

--- a/lib/file-paths.js
+++ b/lib/file-paths.js
@@ -4,8 +4,6 @@ const path = require('path');
 const error = require('@prairielearn/error');
 const sqldb = require('@prairielearn/postgres');
 
-const { config } = require('./config');
-
 const sql = sqldb.loadSqlEquiv(__filename);
 const QUESTION_DEFAULTS_PATH = path.resolve(
   __dirname,

--- a/lib/file-paths.js
+++ b/lib/file-paths.js
@@ -7,6 +7,12 @@ const sqldb = require('@prairielearn/postgres');
 const { config } = require('./config');
 
 const sql = sqldb.loadSqlEquiv(__filename);
+const QUESTION_DEFAULTS_PATH = path.resolve(
+  __dirname,
+  '..',
+  'question-servers',
+  'default-calculation'
+);
 
 /**
  * @typedef {Object} QuestionFilePathInfo
@@ -102,14 +108,14 @@ module.exports.questionFilePathAsync = async function (
       }
     } else {
       const defaultFilename = question.type + filenameToSuffix[filename];
-      const fullDefaultFilePath = path.join(config.questionDefaultsDir, defaultFilename);
+      const fullDefaultFilePath = path.join(QUESTION_DEFAULTS_PATH, defaultFilename);
 
       if (await fs.pathExists(fullDefaultFilePath)) {
         // Found a default file
         return {
           fullPath: fullDefaultFilePath,
           effectiveFilename: defaultFilename,
-          rootPath: config.questionDefaultsDir,
+          rootPath: QUESTION_DEFAULTS_PATH,
         };
       } else {
         // No default file, give up

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,0 +1,17 @@
+// @ts-check
+const path = require('node:path');
+
+const REPOSITORY_ROOT_PATH = path.resolve(__dirname, '..');
+
+const APP_ROOT_PATH = path.resolve(__dirname, '..');
+
+const EXAMPLE_COURSE_PATH = path.resolve(REPOSITORY_ROOT_PATH, 'exampleCourse');
+
+const TEST_COURSE_PATH = path.resolve(REPOSITORY_ROOT_PATH, 'testCourse');
+
+module.exports = {
+  REPOSITORY_ROOT_PATH,
+  APP_ROOT_PATH,
+  EXAMPLE_COURSE_PATH,
+  TEST_COURSE_PATH,
+};

--- a/pages/administratorQueries/administratorQueries.js
+++ b/pages/administratorQueries/administratorQueries.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 
 const jsonLoad = require('../../lib/json-load');
 
-const queriesDir = 'admin_queries';
+const queriesDir = path.resolve(__dirname, '..', '..', 'admin_queries');
 
 router.get(
   '/',

--- a/pages/administratorQuery/administratorQuery.js
+++ b/pages/administratorQuery/administratorQuery.js
@@ -12,8 +12,8 @@ const sqldb = require('@prairielearn/postgres');
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const queriesDir = 'admin_queries';
-const schemaFilename = 'schemas/schemas/adminQuery.json';
+const queriesDir = path.resolve(__dirname, '..', '..', 'admin_queries');
+const schemaFilename = path.resolve(__dirname, '..', '..', 'schemas', 'schemas', 'adminQuery.json');
 
 router.get(
   '/:query',

--- a/pages/elementFiles/elementFiles.js
+++ b/pages/elementFiles/elementFiles.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 
 const chunks = require('../../lib/chunks');
 const { config } = require('../../lib/config');
+const { APP_ROOT_PATH } = require('../../lib/paths');
 const ERR = require('async-stacktrace');
 
 /**
@@ -58,7 +59,7 @@ router.get('/*', function (req, res, next) {
       res.sendFile(filename, { root: elementFilesDir, ...sendFileOptions });
     });
   } else {
-    elementFilesDir = path.join(__dirname, '..', '..', 'elements');
+    elementFilesDir = path.join(APP_ROOT_PATH, 'elements');
     res.sendFile(filename, { root: elementFilesDir, ...sendFileOptions });
   }
 });

--- a/question-servers/freeform.js
+++ b/question-servers/freeform.js
@@ -20,6 +20,7 @@ const courseUtil = require('../lib/courseUtil');
 const markdown = require('../lib/markdown');
 const chunks = require('../lib/chunks');
 const assets = require('../lib/assets');
+const { APP_ROOT_PATH } = require('../lib/paths');
 
 // Maps core element names to element info
 let coreElementsCache = {};
@@ -80,7 +81,7 @@ module.exports = {
   async init() {
     // Populate the list of PrairieLearn elements
     coreElementsCache = await module.exports.loadElements(
-      path.join(__dirname, '..', 'elements'),
+      path.join(APP_ROOT_PATH, 'elements'),
       'core'
     );
   },

--- a/server.js
+++ b/server.js
@@ -64,6 +64,7 @@ const nodeMetrics = require('./lib/node-metrics');
 const { isEnterprise } = require('./lib/license');
 const { enrichSentryScope } = require('./lib/sentry');
 const lifecycleHooks = require('./lib/lifecycle-hooks');
+const { APP_ROOT_PATH } = require('./lib/paths');
 
 process.on('warning', (e) => console.warn(e));
 
@@ -2128,8 +2129,8 @@ if (config.startServer) {
       async () => {
         compiledAssets.init({
           dev: config.devMode,
-          sourceDirectory: path.resolve(__dirname, 'assets'),
-          buildDirectory: path.resolve(__dirname, 'public/build'),
+          sourceDirectory: path.resolve(APP_ROOT_PATH, 'assets'),
+          buildDirectory: path.resolve(APP_ROOT_PATH, 'public/build'),
           publicPath: '/build',
         });
       },

--- a/server.js
+++ b/server.js
@@ -357,8 +357,8 @@ module.exports.initExpress = function () {
   app.use(bodyParser.urlencoded({ extended: false, limit: 5 * 1536 * 1024 }));
   app.use(cookieParser());
   app.use(passport.initialize());
-  if (config.devMode) app.use(favicon(path.join(__dirname, 'public', 'favicon-dev.ico')));
-  else app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
+  if (config.devMode) app.use(favicon(path.join(APP_ROOT_PATH, 'public', 'favicon-dev.ico')));
+  else app.use(favicon(path.join(APP_ROOT_PATH, 'public', 'favicon.ico')));
 
   if ('localRootFilesDir' in config) {
     logger.info(`localRootFilesDir: Mapping ${config.localRootFilesDir} into /`);
@@ -372,7 +372,7 @@ module.exports.initExpress = function () {
   // implementation details.
   app.use(
     '/assets/:cachebuster',
-    express.static(path.join(__dirname, 'public'), {
+    express.static(path.join(APP_ROOT_PATH, 'public'), {
       // In dev mode, assets are likely to change while the server is running,
       // so we'll prevent them from being cached.
       maxAge: config.devMode ? 0 : '31536000s',
@@ -381,7 +381,7 @@ module.exports.initExpress = function () {
   );
   // This route is kept around for legacy reasons - new code should prefer the
   // "cacheable" route above.
-  app.use(express.static(path.join(__dirname, 'public')));
+  app.use(express.static(path.join(APP_ROOT_PATH, 'public')));
 
   app.use('/build/', compiledAssets.handler());
 

--- a/tests/assets.test.js
+++ b/tests/assets.test.js
@@ -6,11 +6,12 @@ const fetch = require('node-fetch').default;
 
 const { config } = require('../lib/config');
 const assets = require('../lib/assets');
+const { APP_ROOT_PATH } = require('../lib/paths');
 
 const helperServer = require('./helperServer');
 
 const SITE_URL = 'http://localhost:' + config.serverPort;
-const ELEMENTS_PATH = path.resolve(__dirname, '..', 'elements');
+const ELEMENTS_PATH = path.resolve(APP_ROOT_PATH, 'elements');
 
 /** @type {Record<string, any> | null} */
 let cachedElementsInfo = null;

--- a/tests/chunks.test.js
+++ b/tests/chunks.test.js
@@ -10,6 +10,7 @@ const sqldb = require('@prairielearn/postgres');
 const courseDB = require('../sync/course-db');
 const chunksLib = require('../lib/chunks');
 const { config } = require('../lib/config');
+const { TEST_COURSE_PATH } = require('../lib/paths');
 const logger = require('./dummyLogger');
 const sql = sqldb.loadSqlEquiv(__filename);
 
@@ -276,7 +277,7 @@ describe('chunks', () => {
       // We need to modify the test course - create a copy that we can
       // safely manipulate.
       tempTestCourseDir = await tmp.dir({ unsafeCleanup: true });
-      await fs.copy(path.resolve(__dirname, '..', 'testCourse'), tempTestCourseDir.path, {
+      await fs.copy(TEST_COURSE_PATH, tempTestCourseDir.path, {
         overwrite: true,
       });
 

--- a/tests/courseElementExtension.test.js
+++ b/tests/courseElementExtension.test.js
@@ -7,6 +7,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
 const _ = require('lodash');
 const path = require('path');
 const freeform = require('../question-servers/freeform.js');
+const { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } = require('../lib/paths');
 const { promisify } = require('util');
 
 const helperServer = require('./helperServer');
@@ -14,10 +15,9 @@ const helperClient = require('./helperClient');
 
 describe('Course element extensions', function () {
   this.timeout(60000);
-  const exampleCourseDir = path.join(__dirname, '..', 'exampleCourse');
 
   describe('Extensions can be loaded', function () {
-    const extDir = path.join(exampleCourseDir, 'elementExtensions');
+    const extDir = path.resolve(EXAMPLE_COURSE_PATH, 'elementExtensions');
     const element = 'extendable-element';
     const element_extensions = [
       'example-extension',
@@ -65,8 +65,8 @@ describe('Course element extensions', function () {
 
     it("shouldn't fail when there are no extensions to load", async () => {
       const extensions = await freeform.loadExtensions(
-        path.join(__dirname, '..', 'testCourse', 'elementExtensions'),
-        path.join(__dirname, '..', 'testCourse', 'elementExtensions')
+        path.join(TEST_COURSE_PATH, 'elementExtensions'),
+        path.join(TEST_COURSE_PATH, 'elementExtensions')
       );
       assert.isEmpty(
         extensions,
@@ -76,7 +76,7 @@ describe('Course element extensions', function () {
   });
 
   describe('Extensions can insert client-side assets into the page', function () {
-    before('set up testing server', helperServer.before(exampleCourseDir));
+    before('set up testing server', helperServer.before(EXAMPLE_COURSE_PATH));
     after('shut down testing server', helperServer.after);
 
     const locals = {};

--- a/tests/exampleCourseQuestions.test.js
+++ b/tests/exampleCourseQuestions.test.js
@@ -1,4 +1,5 @@
 const { config } = require('../lib/config');
+const { EXAMPLE_COURSE_PATH } = require('../lib/paths');
 const path = require('path');
 
 var helperServer = require('./helperServer');
@@ -13,9 +14,6 @@ locals.questionBaseUrl = locals.courseInstanceBaseUrl + '/question';
 locals.questionPreviewTabUrl = '/preview';
 locals.questionsUrl = locals.courseInstanceBaseUrl + '/questions';
 locals.isStudentPage = false;
-
-// Link against exampleCourseDir
-const exampleCourseDir = path.join(__dirname, '..', 'exampleCourse');
 
 const qidsExampleCourse = [
   // FIXME: 'demo/autograder/ansiOutput',
@@ -71,7 +69,7 @@ const qidsExampleCourse = [
 describe('Auto-test questions in exampleCourse', function () {
   this.timeout(60000);
 
-  before('set up testing server', helperServer.before(exampleCourseDir));
+  before('set up testing server', helperServer.before(EXAMPLE_COURSE_PATH));
   after('shut down testing server', helperServer.after);
 
   qidsExampleCourse.forEach((qid) => helperQuestion.autoTestQuestion(locals, qid));

--- a/tests/exampleCourseQuestions.test.js
+++ b/tests/exampleCourseQuestions.test.js
@@ -1,6 +1,5 @@
 const { config } = require('../lib/config');
 const { EXAMPLE_COURSE_PATH } = require('../lib/paths');
-const path = require('path');
 
 var helperServer = require('./helperServer');
 var helperQuestion = require('./helperQuestion');

--- a/tests/fileEditor.test.js
+++ b/tests/fileEditor.test.js
@@ -17,12 +17,10 @@ const helperServer = require('./helperServer');
 const { exec } = require('child_process');
 const b64Util = require('../lib/base64-util');
 const { encodePath } = require('../lib/uri-util');
+const { EXAMPLE_COURSE_PATH } = require('../lib/paths');
 
 const locals = {};
 let page, elemList;
-
-// Connect to the exampleCourse
-const courseDirExampleCourse = path.join(__dirname, '..', 'exampleCourse');
 
 // Uses course within tests/testFileEditor
 const courseTemplateDir = path.join(__dirname, 'testFileEditor', 'courseTemplate');
@@ -316,7 +314,7 @@ describe('test file editor', function () {
   });
 
   describe('the exampleCourse', function () {
-    before('set up testing server', helperServer.before(courseDirExampleCourse));
+    before('set up testing server', helperServer.before(EXAMPLE_COURSE_PATH));
 
     after('shut down testing server', helperServer.after);
 

--- a/tests/gradingMethods.test.js
+++ b/tests/gradingMethods.test.js
@@ -10,6 +10,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const io = require('socket.io-client');
 const { setUser, parseInstanceQuestionId, saveOrGrade } = require('./helperClient');
+const { TEST_COURSE_PATH } = require('../lib/paths');
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';
@@ -20,16 +21,7 @@ const defaultUser = {
 };
 
 const fibonacciSolution = fs.readFileSync(
-  path.resolve(
-    __dirname,
-    '..',
-    'testCourse',
-    'questions',
-    'externalGrade',
-    'codeUpload',
-    'tests',
-    'ans.py'
-  )
+  path.resolve(TEST_COURSE_PATH, 'questions', 'externalGrade', 'codeUpload', 'tests', 'ans.py')
 );
 
 const mockStudents = [

--- a/tests/groupGenerateAndDelete.test.js
+++ b/tests/groupGenerateAndDelete.test.js
@@ -1,17 +1,16 @@
 var ERR = require('async-stacktrace');
 var assert = require('chai').assert;
-var path = require('path');
 
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 var helperServer = require('./helperServer');
 var groupUpdate = require('../lib/group-update');
+var { TEST_COURSE_PATH } = require('../lib/paths');
 var locals = {};
-locals.courseDir = path.join(__dirname, '..', 'testCourse');
 
 describe('test auto group and delete groups', function () {
   this.timeout(20000);
-  before('set up testing server', helperServer.before(locals.courseDir));
+  before('set up testing server', helperServer.before(TEST_COURSE_PATH));
   after('shut down testing server', helperServer.after);
 
   it('get group-based homework assessment', (callback) => {

--- a/tests/groupScoreAndSync.test.js
+++ b/tests/groupScoreAndSync.test.js
@@ -3,7 +3,6 @@ var ERR = require('async-stacktrace');
 const { config } = require('../lib/config');
 const { TEST_COURSE_PATH } = require('../lib/paths');
 const _ = require('lodash');
-const path = require('path');
 var assert = require('chai').assert;
 var request = require('request');
 var cheerio = require('cheerio');

--- a/tests/groupScoreAndSync.test.js
+++ b/tests/groupScoreAndSync.test.js
@@ -1,6 +1,7 @@
 var ERR = require('async-stacktrace');
 
 const { config } = require('../lib/config');
+const { TEST_COURSE_PATH } = require('../lib/paths');
 const _ = require('lodash');
 const path = require('path');
 var assert = require('chai').assert;
@@ -11,7 +12,6 @@ var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 var page, form, elemList;
 const helperServer = require('./helperServer');
-const courseDir = path.join(__dirname, '..', 'testCourse');
 
 const locals = {};
 locals.helperClient = require('./helperClient');
@@ -36,7 +36,7 @@ describe('assessment instance group synchronization test', function () {
     Object.assign(config, storedConfig);
   });
 
-  before('set up testing server', helperServer.before(courseDir));
+  before('set up testing server', helperServer.before(TEST_COURSE_PATH));
   after('shut down testing server', helperServer.after);
   describe('1. database initialization', function () {
     it('get group-based homework assessment id', function (callback) {

--- a/tests/groupStudent.test.js
+++ b/tests/groupStudent.test.js
@@ -1,7 +1,6 @@
 const ERR = require('async-stacktrace');
 
 const { config } = require('../lib/config');
-const path = require('path');
 var assert = require('chai').assert;
 var request = require('request');
 var cheerio = require('cheerio');
@@ -11,6 +10,7 @@ var sql = sqldb.loadSqlEquiv(__filename);
 
 var helperServer = require('./helperServer');
 const { idsEqual } = require('../lib/id');
+const { TEST_COURSE_PATH } = require('../lib/paths');
 
 let page, elemList;
 const locals = {};
@@ -19,7 +19,6 @@ locals.siteUrl = 'http://localhost:' + config.serverPort;
 locals.baseUrl = locals.siteUrl + '/pl';
 locals.courseInstanceUrl = locals.baseUrl + '/course_instance/1';
 locals.assessmentsUrl = locals.courseInstanceUrl + '/assessments';
-locals.courseDir = path.join(__dirname, '..', 'testCourse');
 
 const storedConfig = {};
 
@@ -31,7 +30,7 @@ describe('Group based homework assess control on student side', function () {
     storedConfig.authUin = config.authUin;
     callback(null);
   });
-  before('set up testing server', helperServer.before(locals.courseDir));
+  before('set up testing server', helperServer.before(TEST_COURSE_PATH));
   after('shut down testing server', helperServer.after);
   after('unset authenticated user', function (callback) {
     Object.assign(config, storedConfig);

--- a/tests/helperDb.js
+++ b/tests/helperDb.js
@@ -62,12 +62,12 @@ async function runMigrationsAndSprocs(dbName, runMigrations) {
   // so we need to make sure the batched migration machinery is initialized.
   initBatchedMigrations({
     project: 'prairielearn',
-    directories: [path.join(__dirname, '..', 'batched-migrations')],
+    directories: [path.resolve(__dirname, '..', 'batched-migrations')],
   });
 
   if (runMigrations) {
     await initMigrations(
-      [path.join(__dirname, '..', 'migrations'), SCHEMA_MIGRATIONS_PATH],
+      [path.resolve(__dirname, '..', 'migrations'), SCHEMA_MIGRATIONS_PATH],
       'prairielearn'
     );
   }

--- a/tests/helperServer.js
+++ b/tests/helperServer.js
@@ -21,6 +21,7 @@ const localCache = require('../lib/local-cache');
 const codeCaller = require('../lib/code-caller');
 const externalGrader = require('../lib/externalGrader');
 const externalGradingSocket = require('../lib/externalGradingSocket');
+const { TEST_COURSE_PATH } = require('../lib/paths');
 
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -33,13 +34,10 @@ const server = require('../server');
 const logger = require('./dummyLogger');
 const helperDb = require('./helperDb');
 
-const courseDirDefault = path.join(__dirname, '..', 'testCourse');
-
 module.exports = {
   before: (courseDir) => {
-    if (typeof courseDir === 'undefined') {
-      courseDir = courseDirDefault;
-    }
+    courseDir ??= TEST_COURSE_PATH;
+
     return function (callback) {
       debug('before()');
       let httpServer;

--- a/tests/manualGrading.test.js
+++ b/tests/manualGrading.test.js
@@ -1,3 +1,5 @@
+import { TEST_COURSE_PATH } from '../lib/paths';
+
 // @ts-check
 const { assert } = require('chai');
 const cheerio = require('cheerio');
@@ -21,7 +23,7 @@ const defaultUser = {
 };
 
 const fibonacciSolution = fs.readFileSync(
-  path.resolve(__dirname, '../testCourse/questions/externalGrade/codeUpload/tests/ans.py')
+  path.resolve(TEST_COURSE_PATH, 'questions', 'externalGrade', 'codeUpload', 'tests', 'ans.py')
 );
 
 const mockStudents = [

--- a/tests/manualGrading.test.js
+++ b/tests/manualGrading.test.js
@@ -1,5 +1,3 @@
-import { TEST_COURSE_PATH } from '../lib/paths';
-
 // @ts-check
 const { assert } = require('chai');
 const cheerio = require('cheerio');
@@ -13,6 +11,7 @@ const helperServer = require('./helperServer');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const { setUser, parseInstanceQuestionId, saveOrGrade } = require('./helperClient');
+const { TEST_COURSE_PATH } = require('../lib/paths');
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';


### PR DESCRIPTION
This PR introduces a number of constants from which we can construct paths instead of sprinkling `path.resolve(__dirname, ...)` all over the project. This will minimize the number of changes we have to make when we move the PrairieLearn code to the `apps/prairielearn` directory.