### PR TITLE
Add middleware for serving static files from node_modules

### DIFF
--- a/middlewares/staticNodeModules.js
+++ b/middlewares/staticNodeModules.js
@@ -1,0 +1,33 @@
+// @ts-check
+const express = require('express');
+const path = require('node:path');
+
+const { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } = require('../lib/paths');
+
+const NODE_MODULES_PATHS = [
+  path.resolve(APP_ROOT_PATH, 'node_modules'),
+  path.resolve(REPOSITORY_ROOT_PATH, 'node_modules'),
+];
+
+/**
+ * Allows serving static files from multiple `node_modules` directories.
+ * Multiple directories are supported to account for the fact that PrairieLearn
+ * is in a monorepo and dependencies might be located in either `node_modules`
+ * or `apps/prairielearn/node_modules`.
+ *
+ * The first argument is a path within `node_modules` to serve. This can be '.'
+ * to serve all files, or a subdirectory like `mathjax/es5`.
+ *
+ * @param {string} servePath
+ * @param {import('serve-static').ServeStaticOptions} options
+ */
+module.exports = function (servePath, options) {
+  const router = express.Router();
+
+  NODE_MODULES_PATHS.forEach((p) => {
+    const resolvedServePath = path.resolve(p, servePath);
+    router.use(express.static(resolvedServePath, options));
+  });
+
+  return router;
+};

--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ const nodeMetrics = require('./lib/node-metrics');
 const { isEnterprise } = require('./lib/license');
 const { enrichSentryScope } = require('./lib/sentry');
 const lifecycleHooks = require('./lib/lifecycle-hooks');
-const { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } = require('./lib/paths');
+const { APP_ROOT_PATH } = require('./lib/paths');
 const staticNodeModules = require('./middlewares/staticNodeModules');
 
 process.on('warning', (e) => console.warn(e));

--- a/server.js
+++ b/server.js
@@ -64,7 +64,8 @@ const nodeMetrics = require('./lib/node-metrics');
 const { isEnterprise } = require('./lib/license');
 const { enrichSentryScope } = require('./lib/sentry');
 const lifecycleHooks = require('./lib/lifecycle-hooks');
-const { APP_ROOT_PATH } = require('./lib/paths');
+const { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } = require('./lib/paths');
+const staticNodeModules = require('./middlewares/staticNodeModules');
 
 process.on('warning', (e) => console.warn(e));
 
@@ -390,28 +391,26 @@ module.exports.initExpress = function () {
   // us to treat those files as immutable and cache them essentially forever.
   app.use(
     '/cacheable_node_modules/:cachebuster',
-    express.static(path.join(__dirname, 'node_modules'), {
+    staticNodeModules('.', {
       maxAge: '31536000s',
       immutable: true,
     })
   );
+
   // This is included for backwards-compatibility with pages that might still
   // expect to be able to load files from the `/node_modules` route.
-  app.use('/node_modules', express.static(path.join(__dirname, 'node_modules')));
+  app.use('/node_modules', staticNodeModules('.'));
 
   // Included for backwards-compatibility; new code should load MathJax from
   // `/cacheable_node_modules` instead.
-  app.use('/MathJax', express.static(path.join(__dirname, 'node_modules', 'mathjax', 'es5')));
+  app.use('/MathJax', staticNodeModules(path.join('mathjax', 'es5')));
 
   // Support legacy use of ace by v2 questions
   app.use(
     '/localscripts/calculationQuestion/ace',
-    express.static(path.join(__dirname, 'node_modules/ace-builds/src-min-noconflict'))
+    staticNodeModules(path.join('ace-builds', 'src-min-noconflict'))
   );
-  app.use(
-    '/javascripts/ace',
-    express.static(path.join(__dirname, 'node_modules/ace-builds/src-min-noconflict'))
-  );
+  app.use('/javascripts/ace', staticNodeModules(path.join('ace-builds', 'src-min-noconflict')));
 
   // Middleware for all requests
   // response_id is logged on request, response, and error to link them together


### PR DESCRIPTION
Lifting this out of #7640. See the JSDoc comment on the middleware for more details. This abstraction exists so we don't have to repeat each `express.static` middleware twice for each `node_modules` directory.