### PR TITLE
Update path to assets scripts in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,7 +90,7 @@ module.exports = {
       },
     },
     {
-      files: ['assets/scripts/*.js'],
+      files: ['apps/prairielearn/assets/scripts/**/*'],
       env: {
         browser: true,
         jquery: true,


### PR DESCRIPTION
We don't have any files in `apps/prairielearn/assets/scripts` on master, so this wasn't caught until Jonatan pulled the recent changes into his manual grading rubrics branch.