### PR TITLE
Don't store server job stdout/stderr separately

### DIFF
--- a/apps/prairielearn/src/lib/server-jobs.js
+++ b/apps/prairielearn/src/lib/server-jobs.js
@@ -21,11 +21,9 @@ const sql = sqldb.loadSqlEquiv(__filename);
   Room 'job-231' for job_id = 231 in DB.
 
   Receives messages:
-  'joinJob', arguments: job_id, returns: status, stderr, stdout, output
+  'joinJob', arguments: job_id, returns: status, output
 
   Sends messages:
-  'change:stderr', arguments: job_id, stderr
-  'change:stdout', arguments: job_id, stdout
   'change:output', arguments: job_id, output
   'update', arguments: job_id
 
@@ -43,8 +41,8 @@ const sql = sqldb.loadSqlEquiv(__filename);
   'update' events are sent for bulk changes to the object when
   there is no specific 'change' event available.
 
-  For example, an 'update' will not be sent when stderr changes
-  because the more specific 'change:stderr' event will be sent
+  For example, an 'update' will not be sent when output changes
+  because the more specific 'change:output' event will be sent
   instead.
 */
 
@@ -59,22 +57,10 @@ class Job {
   constructor(id, options) {
     this.id = id;
     this.options = options;
-    this.stderr = '';
-    this.stdout = '';
     this.output = '';
     this.finished = false;
   }
-  addToStderr(text) {
-    this.stderr += text;
-    this.output += text;
-    const ansiUp = new AnsiUp();
-    const ansifiedOutput = ansiUp.ansi_to_html(this.output);
-    socketServer.io
-      .to('job-' + this.id)
-      .emit('change:output', { job_id: this.id, output: ansifiedOutput });
-  }
-  addToStdout(text) {
-    this.stdout += text;
+  addToOutput(text) {
     this.output += text;
     const ansiUp = new AnsiUp();
     const ansifiedOutput = ansiUp.ansi_to_html(this.output);
@@ -83,16 +69,16 @@ class Job {
       .emit('change:output', { job_id: this.id, output: ansifiedOutput });
   }
   error(msg) {
-    this.addToStderr(msg + '\n');
+    this.addToOutput(msg + '\n');
   }
   warn(msg) {
-    this.addToStdout(msg + '\n');
+    this.addToOutput(msg + '\n');
   }
   info(msg) {
-    this.addToStdout(msg + '\n');
+    this.addToOutput(msg + '\n');
   }
   verbose(msg) {
-    this.addToStdout(msg + '\n');
+    this.addToOutput(msg + '\n');
   }
   debug(_msg) {
     // do nothing
@@ -104,8 +90,6 @@ class Job {
 
     const params = {
       job_id: this.id,
-      stderr: this.stderr,
-      stdout: this.stdout,
       output: this.output,
       exit_code: code,
       exit_signal: signal,
@@ -142,17 +126,15 @@ class Job {
     this.finished = true;
 
     var errMsg = err.toString();
-    this.addToStderr(errMsg);
+    this.addToOutput(errMsg);
     if (_.has(err, 'stack')) {
-      this.addToStderr('\n' + err.stack);
+      this.addToOutput('\n' + err.stack);
     }
     if (_.has(err, 'data')) {
-      this.addToStderr('\n' + JSON.stringify(err.data, null, '    '));
+      this.addToOutput('\n' + JSON.stringify(err.data, null, '    '));
     }
     const params = {
       job_id: this.id,
-      stderr: this.stderr,
-      stdout: this.stdout,
       output: this.output,
       error_message: errMsg,
     };
@@ -358,16 +340,16 @@ module.exports.spawnJob = function (options, callback) {
     job.proc.stderr.setEncoding('utf8');
     job.proc.stdout.setEncoding('utf8');
     job.proc.stderr.on('data', function (text) {
-      job.addToStderr(text);
+      job.addToOutput(text);
     });
     job.proc.stdout.on('data', function (text) {
-      job.addToStdout(text);
+      job.addToOutput(text);
     });
     job.proc.stderr.on('error', function (err) {
-      job.addToStderr('ERROR: ' + err.toString() + '\n');
+      job.addToOutput('ERROR: ' + err.toString() + '\n');
     });
     job.proc.stdout.on('error', function (err) {
-      job.addToStderr('ERROR: ' + err.toString() + '\n');
+      job.addToOutput('ERROR: ' + err.toString() + '\n');
     });
 
     // when a process exists, first 'exit' is fired with stdio
@@ -398,8 +380,6 @@ module.exports.errorAbandonedJobs = async function () {
     try {
       await sqldb.queryAsync(sql.update_job_on_error, {
         job_id: row.id,
-        stderr: null,
-        stdout: null,
         output: null,
         error_message: 'Job abandoned by server',
       });

--- a/apps/prairielearn/src/lib/server-jobs.sql
+++ b/apps/prairielearn/src/lib/server-jobs.sql
@@ -169,8 +169,6 @@ WITH
     SET
       finish_date = CURRENT_TIMESTAMP,
       status = 'Error'::enum_job_status,
-      stderr = $stderr,
-      stdout = $stdout,
       output = $output,
       error_message = $error_message
     WHERE

--- a/apps/prairielearn/src/lib/server-jobs.sql
+++ b/apps/prairielearn/src/lib/server-jobs.sql
@@ -124,8 +124,6 @@ WITH
         WHEN $exit_code = 0 THEN 'Success'::enum_job_status
         ELSE 'Error'::enum_job_status
       END,
-      stderr = $stderr,
-      stdout = $stdout,
       output = $output,
       exit_code = $exit_code,
       exit_signal = $exit_signal


### PR DESCRIPTION
We long since stopped doing anything with these columns; we use the unified `output` column instead. This PR removes all remaining code that writes to these columns; we can then remove the columns themselves once this has been deployed.

I'm doing this ahead of #6475 to reduce the number of things I have to account for in that PR.