### PR TITLE
Improve formatting of postgres-tools diff

### DIFF
--- a/.changeset/rude-books-suffer.md
+++ b/.changeset/rude-books-suffer.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/postgres-tools': minor
+---
+
+Improve formatting of database diffs

--- a/packages/postgres-tools/src/diff.ts
+++ b/packages/postgres-tools/src/diff.ts
@@ -88,7 +88,6 @@ async function diff(db1: DiffTarget, db2: DiffTarget, options: DiffOptions): Pro
     result += formatText(`Differences in ${boldTable} table\n`, chalk.underline);
 
     patch.hunks.forEach((hunk, index) => {
-      console.log(hunk);
       if (index !== 0) {
         result += formatText('...\n', chalk.gray);
       }


### PR DESCRIPTION
Before:

<img width="1028" alt="Screenshot 2023-05-03 at 12 09 23" src="https://user-images.githubusercontent.com/1476544/236019667-51d0d7c8-fb14-4c1e-9391-6a6a133f7aa0.png">

After:

<img width="1028" alt="Screenshot 2023-05-03 at 12 08 32" src="https://user-images.githubusercontent.com/1476544/236019678-f298f7ea-9355-4923-9e84-587f43e3e855.png">

The key change is that this shows context instead of just added/removed lines. I could have used the patch format directly, but this is a bit more concise and skips over info that (IMO) is unnecessary, like file names (which may not even be defined for a diff) and line numbers.