### PR TITLE
Make chai-as-promised available in all tests

### DIFF
--- a/apps/prairielearn/src/tests/mocha-hooks.mjs
+++ b/apps/prairielearn/src/tests/mocha-hooks.mjs
@@ -32,5 +32,13 @@ export const mochaHooks = {
     const { config } = await import('../lib/config.js');
     config.workersCount = 2; // explicitly use 2 workers to test parallelism
     config.fileEditorUseGit = true; // test use of git in file editor
+
+    // Allow using `chai-as-promised` in all tests.
+    const chai = await import('chai');
+    const chaiAsPromised = await import('chai-as-promised');
+    // @ts-expect-error -- Dynamic imports do have a `.default` property, but
+    // `allowSyntheticDefaultImports` is disabled at the time of writing, so
+    // TypeScript doesn't know about it.
+    chai.use(chaiAsPromised.default);
   },
 };

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -1,13 +1,9 @@
 // @ts-check
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+const { assert } = require('chai');
 const { step } = require('mocha-steps');
 
 const sqldb = require('@prairielearn/postgres');
 const helperDb = require('../helperDb');
-
-chai.use(chaiAsPromised);
-const { assert } = chai;
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -1,7 +1,5 @@
 // @ts-check
-const chaiAsPromised = require('chai-as-promised');
-const chai = require('chai');
-chai.use(chaiAsPromised);
+const { assert } = require('chai');
 const fs = require('fs-extra');
 const path = require('path');
 const sqldb = require('@prairielearn/postgres');
@@ -11,7 +9,6 @@ const util = require('./util');
 const helperDb = require('../helperDb');
 
 const sql = sqldb.loadSqlEquiv(__filename);
-const { assert } = chai;
 
 /**
  * Makes an empty assessment.

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -1,14 +1,10 @@
 // @ts-check
-const chaiAsPromised = require('chai-as-promised');
-const chai = require('chai');
-chai.use(chaiAsPromised);
+const { assert } = require('chai');
 const fs = require('fs-extra');
 const path = require('path');
 const util = require('./util');
 const helperDb = require('../helperDb');
 const { idsEqual } = require('../../lib/id');
-
-const { assert } = chai;
 
 /**
  * Makes an empty course instance.

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -1,15 +1,11 @@
 // @ts-check
-const chaiAsPromised = require('chai-as-promised');
-const chai = require('chai');
-chai.use(chaiAsPromised);
+const { assert } = require('chai');
 const fs = require('fs-extra');
 const path = require('path');
 
 const util = require('./util');
 const helperDb = require('../helperDb');
 const { idsEqual } = require('../../lib/id');
-
-const { assert } = chai;
 
 /**
  * Makes an empty question.

--- a/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
@@ -1,11 +1,7 @@
 // @ts-check
-const chaiAsPromised = require('chai-as-promised');
-const chai = require('chai');
-chai.use(chaiAsPromised);
+const { assert } = require('chai');
 const util = require('./util');
 const helperDb = require('../helperDb');
-
-const { assert } = chai;
 
 /**
  * Topics and tags are currently almost identical, so we test them together


### PR DESCRIPTION
This removes the `chai-as-promised` boilerplate from all tests in favor of declaring it once in a Mocha root hook.