### PR TITLE
Java grader: better handling of exceptions in test factories

### DIFF
--- a/graders/java/JUnitAutograder.java
+++ b/graders/java/JUnitAutograder.java
@@ -160,7 +160,15 @@ public class JUnitAutograder implements TestExecutionListener {
     @Override
     public synchronized void executionFinished(TestIdentifier test, TestExecutionResult result) {
 
-        if (!test.isTest()) return;
+        if (!test.isTest()) {
+            if (!result.getStatus().equals(TestExecutionResult.Status.SUCCESSFUL)) {
+                this.points = 0;
+                this.gradable = false;
+                this.message = "A test factory or value source failed to produce tests. Consult your instructor.";
+                result.getThrowable().ifPresent(t -> t.printStackTrace());
+            }
+            return;
+        }
         AutograderTest autograderTest = tests.get(test);
         if (autograderTest == null) {
             // This shouldn't happen


### PR DESCRIPTION
Resolves #7718. In essence, if an exception happens in a test factory (including value sources and other methods that generate dynamic tests), the question is tagged as ungradable. Instructors should be able to identify the proper error in the grading job log.

For a technical explanation: the `executionFinished` listener method is called when any test or test container finishes executing. Typically for non-test (i.e., containers) the result would not affect the tests themselves and would not cause any changes in the autograder results, but in this case the container itself fails to generate dynamic tests. Since presumably the test containers are based on instructor code, not student code, the details of the error are shown only in the grading log, so that the instructor can check it while testing or debugging, but the student is not confused with errors that are not related to their code.