### PR TITLE
Simplify top-level tsconfig.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,10 @@ jobs:
       run: make lint-links
     - name: Run the Python typechecker
       run: docker exec test_container /PrairieLearn/docker/typecheck_python.sh
+    # The rest of our code is typechecked in the `build` Makefile target, which
+    # is run when the Docker image is built.
+    - name: Run the TypeScript typechecker for tools
+      run: docker exec test_container /PrairieLearn/docker/typecheck_tools.sh
     - name: Run the Python tests
       run: docker exec test_container /PrairieLearn/docker/test_python.sh
       timeout-minutes: 5

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ typecheck: typecheck-js typecheck-python
 # as a side-effect.
 # TODO: Do we want to have a separate typecheck command for all packages/apps?
 # Maybe using TypeScript project references?
+typecheck-tools:
+	@yarn tsc
 typecheck-js:
 	@yarn turbo run build
 typecheck-python:

--- a/docker/typecheck_tools.sh
+++ b/docker/typecheck_tools.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make -s -C /PrairieLearn typecheck-tools

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prettier": "2.8.8",
     "pyright": "^1.1.305",
     "s3rver": "^3.7.1",
-    "turbo": "^1.9.3"
+    "turbo": "^1.9.3",
+    "typescript": "^5.0.4"
   },
   "workspaces": [
     "apps/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,17 +3,11 @@
   "compilerOptions": {
     "noEmit": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
   },
-  // We don't actually use any TypeScript; we just use it to validate our
-  // standard JavaScript with JSDoc comments.
-  // Adding new code? Consider opting in to type checking!
+  // Individual apps/packages have their own `tsconfig.json` files. This
+  // top-level one is only used to typecheck the `tools/` directory.
   "include": [
-    "tests/**/*",
-    "sync/**/*",
-    "lib/**/*",
     "tools/**/*",
-    "ee/**/*",
-    "api/**/*",
-    "question-servers/**/*",
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12573,6 +12573,7 @@ __metadata:
     pyright: ^1.1.305
     s3rver: ^3.7.1
     turbo: ^1.9.3
+    typescript: ^5.0.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The top-level `tsconfig.json` file referenced paths that no longer exist. This PR removes them. It also re-adds CI type checking for the `tools/` directory, which was inadvertently lost during the recent repo reorganization.

Closes #7720.