### PR TITLE
Improve ts-node config for Mocha

### DIFF
--- a/apps/prairielearn/.mocharc.js
+++ b/apps/prairielearn/.mocharc.js
@@ -1,5 +1,13 @@
 module.exports = {
-  require: ['ts-node/register', './src/tests/mocha-hooks.mjs'],
+  require: [
+    // Set up `TS_NODE_*` environment variables. This must be loaded before
+    // `ts-node/register`. Environment variables are implemented here instead
+    // of via `ENV=...` so that they're used even when executing Mocha directly,
+    // e.g. `yarn mocha path/to/file.ts`.
+    './src/tests/mocha-env.mjs',
+    'ts-node/register',
+    './src/tests/mocha-hooks.mjs',
+  ],
   timeout: '30000', // in milliseconds
   'watch-files': ['.'],
 };

--- a/apps/prairielearn/src/tests/mocha-env.mjs
+++ b/apps/prairielearn/src/tests/mocha-env.mjs
@@ -1,0 +1,11 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Don't perform typechecking, just transpile to keep tests fast.
+process.env.TS_NODE_TRANSPILE_ONLY = 'true';
+
+// Always use the tsconfig.json file in the `src` directory, not the one in the
+// application root. `ts-node` doesn't seem to like our usage of project references.
+process.env.TS_NODE_PROJECT = path.resolve(__dirname, '..', 'tsconfig.json');

--- a/apps/prairielearn/src/tsconfig.json
+++ b/apps/prairielearn/src/tsconfig.json
@@ -4,5 +4,8 @@
     "rootDir": "./",
     "outDir": "../dist"
   },
-  "include": ["**/*"]
+  "include": ["**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }

--- a/apps/prairielearn/src/tsconfig.json
+++ b/apps/prairielearn/src/tsconfig.json
@@ -4,8 +4,5 @@
     "rootDir": "./",
     "outDir": "../dist"
   },
-  "include": ["**/*"],
-  "ts-node": {
-    "transpileOnly": true
-  }
+  "include": ["**/*"]
 }

--- a/apps/prairielearn/tsconfig.json
+++ b/apps/prairielearn/tsconfig.json
@@ -4,5 +4,8 @@
   "references": [
     { "path": "./src/tsconfig.json" },
     { "path": "./assets/scripts/tsconfig.json" }
-  ]
+  ],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }

--- a/apps/prairielearn/tsconfig.json
+++ b/apps/prairielearn/tsconfig.json
@@ -4,5 +4,5 @@
   "references": [
     { "path": "./src/tsconfig.json" },
     { "path": "./assets/scripts/tsconfig.json" }
-  ],
+  ]
 }

--- a/apps/prairielearn/tsconfig.json
+++ b/apps/prairielearn/tsconfig.json
@@ -5,7 +5,4 @@
     { "path": "./src/tsconfig.json" },
     { "path": "./assets/scripts/tsconfig.json" }
   ],
-  "ts-node": {
-    "transpileOnly": true
-  }
 }


### PR DESCRIPTION
This keeps `ts-node` happy when running things like `yarn mocha src/tests/assets.test.js`.