### PR TITLE
Fix ts-node config for dev mode

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc --build --incremental && tscp -b && compiled-assets build ./assets ./public/build",
-    "dev:no-watch": "ts-node src/server.js",
+    "dev:no-watch": "ts-node --project src/tsconfig.json src/server.js",
     "dev": "nodemon --exec \"yarn dev:no-watch\" --",
     "start-executor": "node dist/executor.js",
     "start": "node dist/server.js",

--- a/apps/prairielearn/src/tests/mocha-env.mjs
+++ b/apps/prairielearn/src/tests/mocha-env.mjs
@@ -3,9 +3,6 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Don't perform typechecking, just transpile to keep tests fast.
-process.env.TS_NODE_TRANSPILE_ONLY = 'true';
-
 // Always use the tsconfig.json file in the `src` directory, not the one in the
-// application root. `ts-node` doesn't seem to like our usage of project references.
+// application root. `ts-node` doesn't seem to understand our usage of project references.
 process.env.TS_NODE_PROJECT = path.resolve(__dirname, '..', 'tsconfig.json');

--- a/apps/prairielearn/src/tsconfig.json
+++ b/apps/prairielearn/src/tsconfig.json
@@ -4,5 +4,8 @@
     "rootDir": "./",
     "outDir": "../dist"
   },
-  "include": ["**/*"]
+  "include": ["**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }


### PR DESCRIPTION
I accidentally broke `make dev`/`yarn dev` in #7723. This should get everything back into a good working state. I tested the following commands and they all work!

- `make dev` from repo root
- `yarn dev` from app root
- `yarn test` from app root
- `yarn mocha src/tests/assets.test.js` from app root