### PR TITLE
Fix instructor file editor client code

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorFileEditorClient.js
+++ b/apps/prairielearn/assets/scripts/instructorFileEditorClient.js
@@ -1,4 +1,3 @@
-/* eslint-env browser,jquery */
 /* global ace */
 /* global CryptoJS */
 window.InstructorFileEditor = function (options) {

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -260,3 +260,11 @@ export function compiledScriptTag(sourceFile: string): HtmlSafeString {
 export function compiledStylesheetTag(sourceFile: string): HtmlSafeString {
   return compiledAssets.compiledStylesheetTag(sourceFile);
 }
+
+export function compiledScriptPath(sourceFile: string): string {
+  return compiledAssets.compiledScriptPath(sourceFile);
+}
+
+export function compiledStylesheetPath(sourceFile: string): string {
+  return compiledAssets.compiledStylesheetPath(sourceFile);
+}

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ejs
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ejs
@@ -5,8 +5,7 @@
     <%- include('../partials/head', {pageTitle: 'Edit ' + fileEdit.fileName}); %>
     <script src="<%= node_modules_asset_path('ace-builds/src-min-noconflict/ace.js') %>"></script>
     <script src="<%= node_modules_asset_path('crypto-js/crypto-js.js') %>"></script>
-    <script src="./file_edit?serve=client"></script>
-    <script src="<%= node_modules_asset_path('socket.io-client/dist/socket.io.min.js') %>"></script>
+    <script src="<%= compiled_script_path('instructorFileEditorClient.js') %>"></script>
 </head>
 
 <body>

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -47,20 +47,6 @@ router.get('/*', (req, res, next) => {
     return next(new Error(`No path`));
   }
 
-  // This is a hack because we do not have a standard for how to serve
-  // page-specific client-side code. I would normally have done this with
-  // a route parameter, but all routes are being mapped to file paths, so
-  // I am using a query string instead.
-  if (req.query.serve) {
-    if (req.query.serve === 'client') {
-      debug('Responding to request for /instructorFileEditorClient.js');
-      res.sendFile(path.join(__dirname, './instructorFileEditorClient.js'));
-      return;
-    } else {
-      return next(new Error(`Invalid query: serve=${req.query.serve}`));
-    }
-  }
-
   let fileEdit = {
     uuid: uuidv4(),
     userID: res.locals.user.user_id,

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -114,6 +114,8 @@ module.exports.initExpress = function () {
     res.locals.node_modules_asset_path = assets.nodeModulesAssetPath;
     res.locals.compiled_script_tag = assets.compiledScriptTag;
     res.locals.compiled_stylesheet_tag = assets.compiledStylesheetTag;
+    res.locals.compiled_script_path = assets.compiledScriptPath;
+    res.locals.compiled_stylesheet_path = assets.compiledStylesheetPath;
     next();
   });
   app.use(function (req, res, next) {


### PR DESCRIPTION
When testing this after deploying to our staging environment, I discovered that our new compilation process (reasonably) doesn't play well with the pattern used here: serving a client-side script located in the `pages` directory. Now that we have support for client-side code bundles, I can use that instead.

I deliberately did not do any work to convert this to TypeScript or actually include ace or `crypto-js` in the bundle; I'm doing the least amount of work possible now to unblock a production deployment.