### PR TITLE
Report cron errors to Sentry

### DIFF
--- a/apps/prairielearn/src/cron/index.js
+++ b/apps/prairielearn/src/cron/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const debug = require('debug')('prairielearn:cron');
 const { v4: uuidv4 } = require('uuid');
 const { trace, context, suppressTracing, SpanStatusCode } = require('@prairielearn/opentelemetry');
+const Sentry = require('@prairielearn/sentry');
 
 const { config } = require('../lib/config');
 const { isEnterprise } = require('../lib/license');
@@ -270,6 +271,13 @@ module.exports = {
                     stack: err.stack,
                     data: JSON.stringify(err.data),
                     cronUuid,
+                  });
+
+                  Sentry.captureException(err, {
+                    tags: {
+                      'cron.name': job.name,
+                      'cron.uuid': cronUuid,
+                    },
                   });
 
                   span.recordException(err);


### PR DESCRIPTION
This will give us additional visibility into when cron jobs aren't behaving as expected.