### PR TITLE
Remove aws-sdk dependency from workspace-host

### DIFF
--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -22,7 +22,6 @@
     "async": "^3.2.4",
     "async-mutex": "^0.4.0",
     "async-stacktrace": "^0.0.2",
-    "aws-sdk": "^2.1369.0",
     "body-parser": "^1.20.2",
     "debug": "^4.3.4",
     "dockerode": "^3.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3621,7 +3621,6 @@ __metadata:
     async: ^3.2.4
     async-mutex: ^0.4.0
     async-stacktrace: ^0.0.2
-    aws-sdk: ^2.1369.0
     body-parser: ^1.20.2
     chai: ^4.3.7
     debug: ^4.3.4
@@ -5217,7 +5216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.1369.0, aws-sdk@npm:^2.293.0":
+"aws-sdk@npm:^2.293.0":
   version: 2.1369.0
   resolution: "aws-sdk@npm:2.1369.0"
   dependencies:


### PR DESCRIPTION
The remaining usage of `aws-sdk` is via `winston-aws-cloudwatch`, which I intend to replace with logging to CloudWatch via the CloudWatch agent on our hosts.