### PR TITLE
Fix instructor grading job pipelining

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.js
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 const express = require('express');
-const { pipeline } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
 const { S3, NoSuchKey } = require('@aws-sdk/client-s3');
 const error = require('@prairielearn/error');
 const sqldb = require('@prairielearn/postgres');


### PR DESCRIPTION
TypeScript treats the last (callback) argument to non-promise `pipeline` as optional, but the observable runtime behavior is that it is actually required! That's why this didn't get caught until I deployed to staging.