### PR TITLE
Use tryWithLock when starting batched migrations

### DIFF
--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
@@ -204,7 +204,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
   }
 
   private async getOrStartMigration(): Promise<BatchedMigrationRow | null> {
-    return doWithLock(this.lockName, {}, async () => {
+    return tryWithLock(this.lockName, {}, async () => {
       let migration = await queryValidatedZeroOrOneRow(
         sql.select_running_migration,
         { project: this.options.project },


### PR DESCRIPTION
If we can't acquire a lock, we consider that to be a case where there's nothing to do; this function is already designed to return `null` if there isn't work to be done.