### PR TITLE
Shut down load estimators after server during tests

### DIFF
--- a/apps/prairielearn/src/tests/helperServer.js
+++ b/apps/prairielearn/src/tests/helperServer.js
@@ -138,16 +138,15 @@ module.exports = {
           await codeCaller.finish();
         },
         function (callback) {
-          debug('after(): close load estimators');
-          load.close();
-          callback(null);
-        },
-        function (callback) {
           debug('after(): stop server');
           server.stopServer(function (err) {
             if (ERR(err, callback)) return;
             callback(null);
           });
+        },
+        async () => {
+          debug('after(): close load estimators');
+          load.close();
         },
         async () => {
           debug('after(): stop cron');

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -131,30 +131,42 @@ describe('News items', function () {
 
   describe('News items page', () => {
     it('should load in course instructor level', async () => {
-      const res = await fetch(locals.baseUrl + '/course/1/news_items');
+      const res = await fetch(locals.baseUrl + '/course/1/news_items', {
+        method: 'HEAD',
+      });
       assert.isOk(res.ok);
     });
     it('should load in course instance instructor level', async () => {
-      const res = await fetch(locals.baseUrl + '/course_instance/1/instructor/news_items');
+      const res = await fetch(locals.baseUrl + '/course_instance/1/instructor/news_items', {
+        method: 'HEAD',
+      });
       assert.isOk(res.ok);
     });
     it('should load in course instance student level', async () => {
-      const res = await fetch(locals.baseUrl + '/course_instance/1/news_items');
+      const res = await fetch(locals.baseUrl + '/course_instance/1/news_items', {
+        method: 'HEAD',
+      });
       assert.isOk(res.ok);
     });
   });
 
   describe('Single news item page', () => {
     it('should load in course instructor level', async () => {
-      const res = await fetch(locals.baseUrl + '/course/1/news_item/1/');
+      const res = await fetch(locals.baseUrl + '/course/1/news_item/1/', {
+        method: 'HEAD',
+      });
       assert.isOk(res.ok);
     });
     it('should load in course instance instructor level', async () => {
-      const res = await fetch(locals.baseUrl + '/course_instance/1/instructor/news_item/1/');
+      const res = await fetch(locals.baseUrl + '/course_instance/1/instructor/news_item/1/', {
+        method: 'HEAD',
+      });
       assert.isOk(res.ok);
     });
     it('should load in course instance student level', async () => {
-      const res = await fetch(locals.baseUrl + '/course_instance/1/news_item/1/');
+      const res = await fetch(locals.baseUrl + '/course_instance/1/news_item/1/', {
+        method: 'HEAD',
+      });
       assert.isOk(res.ok);
     });
   });


### PR DESCRIPTION
I'm hoping that this will reduce the recent flakiness we've seen in some tests that looks like the following:

```
@prairielearn/prairielearn:test:        "after all" hook: shut down testing server in "News items":
@prairielearn/prairielearn:test:      Uncaught Error: endJob(): no such estimator: request
@prairielearn/prairielearn:test:       at Object.endJob (src/lib/load.js:151:44)
@prairielearn/prairielearn:test:       at /PrairieLearn/apps/prairielearn/src/server.js:432:12
@prairielearn/prairielearn:test:       at AsyncResource.runInAsyncScope (node:async_hooks:203:9)
@prairielearn/prairielearn:test:       at listener (/PrairieLearn/node_modules/on-finished/index.js:170:15)
@prairielearn/prairielearn:test:       at onFinish (/PrairieLearn/node_modules/on-finished/index.js:101:5)
@prairielearn/prairielearn:test:       at callback (/PrairieLearn/node_modules/ee-first/index.js:55:10)
@prairielearn/prairielearn:test:       at ServerResponse.onevent (/PrairieLearn/node_modules/ee-first/index.js:93:5)
@prairielearn/prairielearn:test:       at ServerResponse.emit (node:events:525:35)
@prairielearn/prairielearn:test:       at ServerResponse.emit (node:domain:489:12)
@prairielearn/prairielearn:test:       at onFinish (node:_http_outgoing:950:10)
@prairielearn/prairielearn:test:       at callback (node:internal/streams/writable:554:21)
@prairielearn/prairielearn:test:       at afterWrite (node:internal/streams/writable:499:5)
@prairielearn/prairielearn:test:       at afterWriteTick (node:internal/streams/writable:486:10)
@prairielearn/prairielearn:test:       at processTicksAndRejections (node:internal/process/task_queues:82:21)
```

By shutting down the load estimator after stopping the server, I hope we can avoid the situation where a request is still in progress after we've stopped the load estimator.

I also changed the news items tests to use `HEAD` instead of `GET`, which should ensure that requests aren't still in progress after the tests end.