### PR TITLE
Drop legacy manual grading feature flag column

### DIFF
--- a/apps/prairielearn/src/migrations/20230526124740_courses__manual_grading_visible__drop.sql
+++ b/apps/prairielearn/src/migrations/20230526124740_courses__manual_grading_visible__drop.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pl_courses
+DROP COLUMN manual_grading_visible;

--- a/database/tables/pl_courses.pg
+++ b/database/tables/pl_courses.pg
@@ -7,7 +7,6 @@ columns
     grading_queue: text
     id: bigint not null default nextval('pl_courses_id_seq'::regclass)
     institution_id: bigint not null default 1
-    manual_grading_visible: boolean default false
     options: jsonb not null default '{}'::jsonb
     path: text
     repository: text


### PR DESCRIPTION
Resolves #7714. Given #6271 is deployed and #7507 removes the need for column-based feature flags, the column is no longer needed.