### PR TITLE
Speed up watch restarts

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -42,7 +42,6 @@
     "@pyroscope/nodejs": "^0.2.5",
     "@sentry/profiling-node": "^0.3.0",
     "@sentry/tracing": "^7.50.0",
-    "@swc/core": "^1.3.60",
     "ace-builds": "^1.18.0",
     "ace-code": "^1.18.0",
     "ajv": "^8.12.0",
@@ -167,6 +166,7 @@
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
     "@sa11y/format": "^4.1.5",
+    "@swc/core": "^1.3.60",
     "@types/async": "^3.2.20",
     "@types/body-parser": "^1.19.2",
     "@types/bootstrap": "^5.2.6",

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "tsc --build --incremental && tscp -b && compiled-assets build ./assets ./public/build",
-    "dev:no-watch": "ts-node --project src/tsconfig.json src/server.js",
+    "dev:no-watch": "ts-node --project src/tsconfig.json --swc src/server.js",
     "dev": "nodemon --exec \"yarn dev:no-watch\" --",
     "start-executor": "node dist/executor.js",
     "start": "node dist/server.js",
@@ -42,6 +42,7 @@
     "@pyroscope/nodejs": "^0.2.5",
     "@sentry/profiling-node": "^0.3.0",
     "@sentry/tracing": "^7.50.0",
+    "@swc/core": "^1.3.60",
     "ace-builds": "^1.18.0",
     "ace-code": "^1.18.0",
     "ajv": "^8.12.0",

--- a/apps/prairielearn/src/lib/code-caller/index.js
+++ b/apps/prairielearn/src/lib/code-caller/index.js
@@ -144,11 +144,17 @@ module.exports = {
     // Ensure that the workers are ready; this will ensure that we're ready to
     // execute code as soon as we start processing requests.
     //
+    // We skip this if we're running in dev mode, as we want to prioritize the
+    // speed of starting up the server to ensure running in watch mode is as
+    // fast as possible.
+    //
     // Note: if resource creation fails for any reason, this will never resolve
     // or reject. This is unfortunate, but we'll still log and report the error
     // above, so it won't fail totally silently. If we fail to create workers,
     // we have a bigger problem.
-    await pool.ready();
+    if (!config.devMode) {
+      await pool.ready();
+    }
   },
 
   async finish() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,7 @@ __metadata:
     "@sa11y/format": ^4.1.5
     "@sentry/profiling-node": ^0.3.0
     "@sentry/tracing": ^7.50.0
+    "@swc/core": ^1.3.60
     "@types/async": ^3.2.20
     "@types/body-parser": ^1.19.2
     "@types/bootstrap": ^5.2.6
@@ -3950,6 +3951,120 @@ __metadata:
   version: 3.1.0
   resolution: "@socket.io/component-emitter@npm:3.1.0"
   checksum: db069d95425b419de1514dffe945cc439795f6a8ef5b9465715acf5b8b50798e2c91b8719cbf5434b3fe7de179d6cdcd503c277b7871cb3dd03febb69bdd50fa
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-arm64@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-darwin-arm64@npm:1.3.60"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-darwin-x64@npm:1.3.60"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm-gnueabihf@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.60"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.60"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-musl@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-linux-arm64-musl@npm:1.3.60"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-linux-x64-gnu@npm:1.3.60"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-musl@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-linux-x64-musl@npm:1.3.60"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.60"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-ia32-msvc@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.60"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core-win32-x64-msvc@npm:1.3.60"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.3.60":
+  version: 1.3.60
+  resolution: "@swc/core@npm:1.3.60"
+  dependencies:
+    "@swc/core-darwin-arm64": 1.3.60
+    "@swc/core-darwin-x64": 1.3.60
+    "@swc/core-linux-arm-gnueabihf": 1.3.60
+    "@swc/core-linux-arm64-gnu": 1.3.60
+    "@swc/core-linux-arm64-musl": 1.3.60
+    "@swc/core-linux-x64-gnu": 1.3.60
+    "@swc/core-linux-x64-musl": 1.3.60
+    "@swc/core-win32-arm64-msvc": 1.3.60
+    "@swc/core-win32-ia32-msvc": 1.3.60
+    "@swc/core-win32-x64-msvc": 1.3.60
+  peerDependencies:
+    "@swc/helpers": ^0.5.0
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: f123571f90783a5b7c4569c88ed6679c3c462b8a19b6d039cffcab7e367e3a972e776cfb4ffef6904f5b2002c7859057385996ae1158278b765ab55de1d69393
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes two key changes to shave ~3 seconds off application booting in development:

- Uses `swc` to transpile TypeScript instead of `tsc`. See https://typestrong.org/ts-node/docs/swc/. I can't wait for https://tc39.es/proposal-type-annotations/ to become accepted and for Node to implement it so we don't have to pay any tax at all for using TypeScript!
- Don't wait for the code callers to boot up in dev mode, where we don't particularly care if the code callers are ready by the time the application starts accepting requests.

After these changes, on my machine, it takes ~3.4 seconds to completely boot up the server in watch mode, down from ~6.2.