### PR TITLE
Fix use of percentage-based input in manual grading

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -123,7 +123,7 @@ function resetInstructorGradingPanel() {
     .forEach((item) => item.addEventListener('change', computePointsFromRubric));
   document
     .querySelectorAll('.js-grading-score-input')
-    .forEach((input) => input.addEventListener('input', computePointsFromRubric));
+    .forEach((input) => input.addEventListener('input', () => computePointsFromRubric(input)));
 
   document.querySelectorAll('.js-adjust-points-enable').forEach((link) =>
     link.addEventListener('click', function () {
@@ -390,7 +390,7 @@ function updatePointsView(sourceInput) {
   });
 }
 
-function computePointsFromRubric() {
+function computePointsFromRubric(sourceInput = null) {
   document.querySelectorAll('form[name=manual-grading-form]').forEach((form) => {
     if (form.dataset.rubricActive === 'true') {
       const manualInput = form.querySelector('.js-manual-score-value-input-points');
@@ -414,7 +414,7 @@ function computePointsFromRubric() {
       manualInput.value = manualPoints;
     }
   });
-  updatePointsView(this);
+  updatePointsView(sourceInput);
 }
 
 function enableRubricItemLongTextField(event) {

--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -76,7 +76,7 @@ function resetInstructorGradingPanel() {
         element.style.display = use_percentage ? '' : 'none';
       });
       window.localStorage.manual_grading_score_use = use_percentage ? 'percentage' : 'points';
-      updatePointsView();
+      updatePointsView(null);
     });
     toggle.checked = window.localStorage.manual_grading_score_use === 'percentage';
     toggle.dispatchEvent(new Event('change'));
@@ -345,7 +345,7 @@ function roundPoints(points) {
   return Math.round(Number(points) * 100) / 100;
 }
 
-function updatePointsView() {
+function updatePointsView(sourceInput) {
   document.querySelectorAll('form[name=manual-grading-form]').forEach((form) => {
     const max_auto_points = Number(form.dataset.maxAutoPoints);
     const max_manual_points = Number(form.dataset.maxManualPoints);
@@ -353,14 +353,14 @@ function updatePointsView() {
 
     const auto_points =
       roundPoints(
-        this.name === 'score_auto_percent'
-          ? (this.value * max_auto_points) / 100
+        sourceInput?.name === 'score_auto_percent'
+          ? (sourceInput?.value * max_auto_points) / 100
           : form.querySelector('[name=score_auto_points]')?.value
       ) || 0;
     const manual_points =
       roundPoints(
-        this.name === 'score_manual_percent'
-          ? (this.value * max_manual_points) / 100
+        sourceInput?.name === 'score_manual_percent'
+          ? (sourceInput?.value * max_manual_points) / 100
           : form.querySelector('[name=score_manual_points]')?.value
       ) || 0;
     const points = roundPoints(auto_points + manual_points);
@@ -368,16 +368,16 @@ function updatePointsView() {
     const manual_perc = roundPoints((manual_points * 100) / (max_manual_points || max_points));
     const total_perc = roundPoints((points * 100) / max_points);
 
-    if (this.name !== 'score_auto_points') {
+    if (sourceInput?.name !== 'score_auto_points') {
       updateQueryObjects(form, '[name=score_auto_points]', { value: auto_points });
     }
-    if (this.name !== 'score_auto_percent') {
+    if (sourceInput?.name !== 'score_auto_percent') {
       updateQueryObjects(form, '[name=score_auto_percent]', { value: auto_perc });
     }
-    if (this.name !== 'score_manual_points') {
+    if (sourceInput?.name !== 'score_manual_points') {
       updateQueryObjects(form, '[name=score_manual_points]', { value: manual_points });
     }
-    if (this.name !== 'score_manual_percent') {
+    if (sourceInput?.name !== 'score_manual_percent') {
       updateQueryObjects(form, '[name=score_manual_percent]', { value: manual_perc });
     }
 
@@ -414,7 +414,7 @@ function computePointsFromRubric() {
       manualInput.value = manualPoints;
     }
   });
-  updatePointsView();
+  updatePointsView(this);
 }
 
 function enableRubricItemLongTextField(event) {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.ejs
@@ -11,6 +11,8 @@
   <input type="hidden" name="modified_at" value="<%= instance_question.modified_at %>">
   <input type="hidden" name="submission_id" value="<%= submission.id %>">
   <ul class="list-group list-group-flush">
+    <%# Percentage-based grading is only suitable if the question has points %>
+    <% if (assessment_question.max_points) { %>
     <li class="list-group-item">
       <div class="form-group row justify-content-center">
         <label class="custom-control-inline col-auto mx-0">
@@ -23,6 +25,7 @@
         </label>
       </div>
     </li>
+    <% } %>
     <% if (!assessment_question.max_auto_points && !(locals.auto_points ?? instance_question.auto_points)) { %>
     <li class="list-group-item">
       <%- include('manualPointsSection'); %>
@@ -51,12 +54,14 @@
           <%= assessment_question.max_points %>
         </span>
       </div>
+      <% if (assessment_question.max_points) { %>
       <div class="form-group js-manual-grading-percentage w-100">
         Total Score:
         <span class="float-right">
           <span class="js-value-total-percentage"><%= Math.round(100 * (locals.score_perc ?? instance_question.score_perc)) / 100 %></span>%
         </span>
       </div>
+      <% } %>
       <% if (locals.rubric_data?.replace_auto_points) { %><%- include('rubricInputSection'); %><% } %>
     </li>
     <% } %>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.ejs
@@ -58,7 +58,7 @@
       <div class="form-group js-manual-grading-percentage w-100">
         Total Score:
         <span class="float-right">
-          <span class="js-value-total-percentage"><%= Math.round(100 * (locals.score_perc ?? instance_question.score_perc)) / 100 %></span>%
+          <span class="js-value-total-percentage"></span>%
         </span>
       </div>
       <% } %>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.ejs
@@ -10,12 +10,12 @@
       <% if (!show_input) { %>
         <span class="js-manual-grading-points">
           <span class="js-<%= type %>-score-value-info">
-            <span class="js-value-<%= type %>-points"><%= Math.round(points * 100) / 100 %></span> / <%= max_points %>
+            <span class="js-value-<%= type %>-points"></span> / <%= max_points %>
           </span>
         </span>
         <span class="js-manual-grading-percentage">
           <span class="js-<%= type %>-score-value-info">
-            <span class="js-value-<%= type %>-percentage"><%= Math.round(points * 10000 / (max_points || assessment_question.max_points)) / 100 %></span>%
+            <span class="js-value-<%= type %>-percentage"></span>%
           </span>
         </span>
       <% } %>
@@ -53,7 +53,6 @@
              id="js-<%= type %>-score-value-input-percentage-<%= context %>"
              class="form-control js-grading-score-input js-<%= type %>-score-value-input-percentage"
              name="score_<%= type %>_percent"
-             value="<%= Math.round(points * 10000 / (max_points || assessment_question.max_points)) / 100 %>"
       <% if (locals.disable || !authz_data.has_course_instance_permission_edit) { %>disabled<% } %> />
       <span class="input-group-append">
         <span class="input-group-text">%</span>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.ejs
@@ -3,9 +3,11 @@
     <label for="js-<%= type %>-score-value-input-points-<%= context %>" class="js-manual-grading-points">
       <%= type_label %> Points:
     </label>
+    <% if (assessment_question.max_points) { %>
     <label for="js-<%= type %>-score-value-input-percentage-<%= context %>" class="js-manual-grading-percentage">
       <%= type_label %> Score:
     </label>
+    <% } %>
     <span class="float-right">
       <% if (!show_input) { %>
         <span class="js-manual-grading-points">
@@ -13,11 +15,13 @@
             <span class="js-value-<%= type %>-points"></span> / <%= max_points %>
           </span>
         </span>
+        <% if (assessment_question.max_points) { %>
         <span class="js-manual-grading-percentage">
           <span class="js-<%= type %>-score-value-info">
             <span class="js-value-<%= type %>-percentage"></span>%
           </span>
         </span>
+        <% } %>
       <% } %>
       <div class="btn-group btn-group-sm" role="group">
         <% if (show_input_edit && authz_data.has_course_instance_permission_edit) { %>
@@ -47,6 +51,7 @@
       </span>
     </div>
   </div>
+  <% if (assessment_question.max_points) { %>
   <div class="js-manual-grading-percentage">
     <div class="input-group js-<%= type %>-score-value-input <% if (!show_input) { %> d-none<% } %>">
       <input type="number" step="any" required
@@ -59,4 +64,5 @@
       </span>
     </div>
   </div>
+  <% } %>
 </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.ejs
@@ -12,7 +12,7 @@
       <% if (!show_input) { %>
         <span class="js-manual-grading-points">
           <span class="js-<%= type %>-score-value-info">
-            <span class="js-value-<%= type %>-points"></span> / <%= max_points %>
+            <span class="js-value-<%= type %>-points"><%= Math.round(points * 100) / 100 %></span> / <%= max_points %>
           </span>
         </span>
         <% if (assessment_question.max_points) { %>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.ejs
@@ -28,9 +28,11 @@
             <span class="js-manual-grading-points" data-testid="rubric-item-points">
               [<%= (item.points >= 0 ? '+' : '') + (Math.round(item.points * 100) / 100) %>]
             </span>
+            <% if (assessment_question.max_points) { %>
             <span class="js-manual-grading-percentage">
               [<%= (item.points >= 0 ? '+' : '') + (Math.round(item.points * 10000 / (assessment_question.max_manual_points || assessment_question.max_points)) / 100) %>%]
             </span>
+            <% } %>
           </strong>
         </span>
         <span>
@@ -64,6 +66,7 @@
             <% if (locals.disable || !authz_data.has_course_instance_permission_edit) { %>disabled<% } %> />
           </div>
         </div>
+        <% if (assessment_question.max_points) { %>
         <div class="js-manual-grading-percentage">
           <div class="input-group input-group-sm">
             <input type="number" step="any"
@@ -77,6 +80,7 @@
             </span>
           </div>
         </div>
+        <% } %>
       </label>
     </div>
   </div>

--- a/apps/prairielearn/src/pages/partials/submissionStatus.ejs
+++ b/apps/prairielearn/src/pages/partials/submissionStatus.ejs
@@ -1,5 +1,4 @@
 <% let auto_submission_status_prefix = ''; %>
-<% const manual_percentage = assessment_question.max_points ? Math.floor(instance_question.manual_points * 100 / (assessment_question.max_manual_points || assessment_question.max_points)) + '%' : `${instance_question.manual_points > 0 ? '+' : ''}${instance_question.manual_points} ${Math.abs(instance_question.manual_points > 1) ? 'pts' : 'pt'}`; %>
 <% if (locals.assessment_question ? (assessment_question.max_manual_points || instance_question.manual_points || instance_question.requires_manual_grading) : question.grading_method == 'Manual') { %>
     <% auto_submission_status_prefix = 'auto-grading: '; %>
     <%# The manual grading status only applies to the latest submission %>
@@ -10,12 +9,17 @@
             <% } else { %>
                 <span class="badge badge-secondary">manual grading: waiting for grading</span><br/>
             <% } %>
-        <% } else if (instance_question.manual_points <= 0) { %>
+        <% } else { %>
+        <% const manual_percentage = assessment_question.max_points
+           ? Math.floor(instance_question.manual_points * 100 / (assessment_question.max_manual_points || assessment_question.max_points)) + '%'
+           : ((instance_question.manual_points > 0 ? '+' : '') + instance_question.manual_points + (Math.abs(instance_question.manual_points) > 1 ? ' pts' : ' pt')); %>
+        <% if (instance_question.manual_points <= 0) { %>
             <span class="badge badge-danger">manual grading: <%= manual_percentage %></span><br/>
         <% } else if (instance_question.manual_points >= assessment_question.max_manual_points) { %>
             <span class="badge badge-success">manual grading: <%= manual_percentage %></span><br/>
         <% } else { %>
             <span class="badge badge-warning">manual grading: <%= manual_percentage %></span><br/>
+        <% } %>
         <% } %>
     <% } %>
 <% } %>

--- a/apps/prairielearn/src/pages/partials/submissionStatus.ejs
+++ b/apps/prairielearn/src/pages/partials/submissionStatus.ejs
@@ -1,4 +1,5 @@
 <% let auto_submission_status_prefix = ''; %>
+<% const manual_percentage = assessment_question.max_points ? Math.floor(instance_question.manual_points * 100 / (assessment_question.max_manual_points || assessment_question.max_points)) + '%' : `${instance_question.manual_points > 0 ? '+' : ''}${instance_question.manual_points} ${Math.abs(instance_question.manual_points > 1) ? 'pts' : 'pt'}`; %>
 <% if (locals.assessment_question ? (assessment_question.max_manual_points || instance_question.manual_points || instance_question.requires_manual_grading) : question.grading_method == 'Manual') { %>
     <% auto_submission_status_prefix = 'auto-grading: '; %>
     <%# The manual grading status only applies to the latest submission %>
@@ -10,11 +11,11 @@
                 <span class="badge badge-secondary">manual grading: waiting for grading</span><br/>
             <% } %>
         <% } else if (instance_question.manual_points <= 0) { %>
-            <span class="badge badge-danger">manual grading: <%= Math.floor(instance_question.manual_points * 100 / (assessment_question.max_manual_points || assessment_question.max_points)) %>%</span><br/>
+            <span class="badge badge-danger">manual grading: <%= manual_percentage %></span><br/>
         <% } else if (instance_question.manual_points >= assessment_question.max_manual_points) { %>
-            <span class="badge badge-success">manual grading: <%= Math.floor(instance_question.manual_points * 100 /(assessment_question.max_manual_points || assessment_question.max_points)) %>%</span><br/>
+            <span class="badge badge-success">manual grading: <%= manual_percentage %></span><br/>
         <% } else { %>
-            <span class="badge badge-warning">manual grading: <%= Math.floor(instance_question.manual_points * 100 /(assessment_question.max_manual_points || assessment_question.max_points)) %>%</span><br/>
+            <span class="badge badge-warning">manual grading: <%= manual_percentage %></span><br/>
         <% } %>
     <% } %>
 <% } %>

--- a/apps/prairielearn/src/tests/manualGrading.test.js
+++ b/apps/prairielearn/src/tests/manualGrading.test.js
@@ -128,7 +128,8 @@ const checkGradingResults = (assigned_grader, grader) => {
     const manualGradingIQPage = await (await fetch(manualGradingIQUrl)).text();
     const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
     const form = $manualGradingIQPage('form[name=manual-grading-form]');
-    assert.equal(form.find('input[name=score_manual_percent]').val(), score_percent);
+    // The percentage input is not checked because its value is updated via client-side JS, which is
+    // currently not supported by the test suite
     assert.equal(form.find('input[name=score_manual_points]').val(), score_points);
     assert.equal(form.find('textarea').text(), feedback_note);
 


### PR DESCRIPTION
Based on issue mentioned on Slack. Resolves two issues:

* Recent rubrics update broke the way manual input of points (particularly percentage) is handled, since the function relies on `this`, for which the function is no longer bound to. For safety and clarity this was replaced with an explicit argument.
* Resolves #7791, i.e., properly handles manual grading cases when the question is worth zero in total (i.e., no manual or auto points).