### PR TITLE
Trigger response log on stream close

### DIFF
--- a/apps/prairielearn/src/middlewares/logResponse.js
+++ b/apps/prairielearn/src/middlewares/logResponse.js
@@ -25,26 +25,20 @@ module.exports = function (req, res, next) {
         params: req.params,
         body: req.body,
         finished: res.writableFinished,
-        authn_user_id: res.locals && res.locals.authn_user ? res.locals.authn_user.user_id : null,
-        authn_user_uid: res.locals && res.locals.authn_user ? res.locals.authn_user.uid : null,
-        user_id: res.locals && res.locals.user ? res.locals.user.user_id : null,
-        user_uid: res.locals && res.locals.user ? res.locals.user.uid : null,
-        course_id: res.locals && res.locals.course ? res.locals.course.id : null,
-        course_short_name: res.locals && res.locals.course ? res.locals.course.short_name : null,
-        course_instance_id:
-          res.locals && res.locals.course_instance ? res.locals.course_instance.id : null,
-        course_instance_short_name:
-          res.locals && res.locals.course_instance ? res.locals.course_instance.short_name : null,
-        assessment_id: res.locals && res.locals.assessment ? res.locals.assessment.id : null,
-        assessment_directory:
-          res.locals && res.locals.assessment ? res.locals.assessment.tid : null,
-        assessment_instance_id:
-          res.locals && res.locals.assessment_instance ? res.locals.assessment_instance.id : null,
-        question_id: res.locals && res.locals.question ? res.locals.question.id : null,
-        question_directory:
-          res.locals && res.locals.question ? res.locals.question.directory : null,
-        instance_question_id:
-          res.locals && res.locals.instance_question ? res.locals.instance_question.id : null,
+        authn_user_id: res.locals?.authn_user?.user_id ?? null,
+        authn_user_uid: res.locals?.authn_user?.uid ?? null,
+        user_id: res.locals?.user?.user_id ?? null,
+        user_uid: res.locals?.user?.uid ?? null,
+        course_id: res.locals?.course?.id ?? null,
+        course_short_name: res.locals?.course?.short_name ?? null,
+        course_instance_id: res.locals?.course_instance?.id ?? null,
+        course_instance_short_name: res.locals?.course_instance?.short_name ?? null,
+        assessment_id: res.locals?.assessment?.id ?? null,
+        assessment_directory: res.locals?.assessment?.tid ?? null,
+        assessment_instance_id: res.locals?.assessment_instance?.id ?? null,
+        question_id: res.locals?.question?.id ?? null,
+        question_directory: res.locals?.question?.directory ?? null,
+        instance_question_id: res.locals?.instance_question?.id ?? null,
       };
       logger.verbose('response', access);
     });

--- a/apps/prairielearn/src/middlewares/logResponse.js
+++ b/apps/prairielearn/src/middlewares/logResponse.js
@@ -41,6 +41,14 @@ module.exports = function (req, res, next) {
         instance_question_id: res.locals?.instance_question?.id ?? null,
       };
       logger.verbose('response', access);
+
+      // Print additional message in this case to simplify grepping logs for this scenario
+      if (!res.writableFinished) {
+        logger.verbose('request aborted by client', {
+          response_id: res.locals.response_id,
+          timestamp: new Date().toISOString(),
+        });
+      }
     });
   }
   next();

--- a/apps/prairielearn/src/middlewares/logResponse.js
+++ b/apps/prairielearn/src/middlewares/logResponse.js
@@ -17,7 +17,6 @@ module.exports = function (req, res, next) {
 
       var access = {
         response_id: res.locals.response_id,
-        timestamp: new Date().toISOString(),
         ip: req.ip,
         forwardedIP: req.headers['x-forwarded-for'],
         method: req.method,

--- a/apps/prairielearn/src/middlewares/logResponse.js
+++ b/apps/prairielearn/src/middlewares/logResponse.js
@@ -47,7 +47,6 @@ module.exports = function (req, res, next) {
           res.locals && res.locals.instance_question ? res.locals.instance_question.id : null,
       };
       logger.verbose('response', access);
-      res.locals.response_logged = true;
     });
   }
   next();

--- a/apps/prairielearn/src/middlewares/logResponse.js
+++ b/apps/prairielearn/src/middlewares/logResponse.js
@@ -46,7 +46,6 @@ module.exports = function (req, res, next) {
       if (!res.writableFinished) {
         logger.verbose('request aborted by client', {
           response_id: res.locals.response_id,
-          timestamp: new Date().toISOString(),
         });
       }
     });


### PR DESCRIPTION
If an HTTP client (browser, test, API, etc.) reads from a URL but closes the stream before it's completely sent, the log response is not being triggered. This is because the `finish` event only triggers when the stream is completely sent. This often happens for responses that cause a redirection (e.g., most POST responses), since in that case the client only needs the header to identify the next location. This PR changes the logging to happen on the `close` event, which is triggered even when the stream is closed.

I have no means to test how this affects production environment and sentry logs.