### PR TITLE
Only perform ECR auth if cache registry is configured

### DIFF
--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.js
@@ -78,7 +78,9 @@ async function ensureImage() {
     if (e.statusCode === 404) {
       logger.info('Image not found, pulling from registry');
       const start = Date.now();
-      const dockerAuth = await setupDockerAuthAsync(config.awsRegion);
+      const dockerAuth = config.cacheImageRegistry
+        ? await setupDockerAuthAsync(config.awsRegion)
+        : null;
       const stream = await docker.createImage(dockerAuth, { fromImage: imageName });
       await new Promise((resolve, reject) => {
         docker.modem.followProgress(

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -544,7 +544,10 @@ async function _pullImage(workspace) {
   await workspaceUtils.updateWorkspaceMessage(workspace.id, 'Checking image');
   const workspace_image = workspace.settings.workspace_image;
   logger.info(`Pulling docker image: ${workspace_image}`);
-  const auth = await setupDockerAuthAsync(config.awsRegion);
+
+  // We only auth if a specific ECR registry is configured. Otherwise, we'll
+  // assume we're pulling from the public Docker Hub registry.
+  const auth = config.cacheImageRegistry ? await setupDockerAuthAsync(config.awsRegion) : null;
 
   let percentDisplayed = false;
   let stream;


### PR DESCRIPTION
Fixes an issue [reported on Slack](https://prairielearn.slack.com/archives/C266KEH9A/p1685241582002019) where workspace images couldn't be pulled in local development. This was a regression introduced by https://github.com/PrairieLearn/PrairieLearn/pull/7731.