### PR TITLE
Run SQL migrations inside transactions

### DIFF
--- a/.changeset/fluffy-bottles-drive.md
+++ b/.changeset/fluffy-bottles-drive.md
@@ -1,0 +1,14 @@
+---
+'@prairielearn/migrations': major
+---
+
+SQL migrations are now run inside a transaction by default
+
+If you need to disable this behavior, you can add an annotation comment to the top of the migration file:
+
+```sql
+-- prairielearn:migrations NO TRANSACTION
+CREATE INDEX CONCURRENTLY ...
+```
+
+Note that migrations implemented as JavaScript are not run in transactions by default. Transactions should be manually used as appropriate.

--- a/apps/prairielearn/src/migrations/20221122001508_time_series__date__add_index.sql
+++ b/apps/prairielearn/src/migrations/20221122001508_time_series__date__add_index.sql
@@ -1,1 +1,2 @@
+-- prairielearn:migrations NO TRANSACTION
 CREATE INDEX CONCURRENTLY time_series_date_idx ON time_series (date);

--- a/apps/prairielearn/src/migrations/20230309222017_workspace_logs__workspace_id__create_index.sql
+++ b/apps/prairielearn/src/migrations/20230309222017_workspace_logs__workspace_id__create_index.sql
@@ -1,1 +1,2 @@
+-- prairielearn:migrations NO TRANSACTION
 CREATE INDEX CONCURRENTLY IF NOT EXISTS workspace_logs_workspace_id_idx ON workspace_logs (workspace_id);

--- a/apps/prairielearn/src/migrations/20230331223233_job_sequences__course_request_id__add_index.sql
+++ b/apps/prairielearn/src/migrations/20230331223233_job_sequences__course_request_id__add_index.sql
@@ -1,1 +1,2 @@
+-- prairielearn:migrations NO TRANSACTION
 CREATE INDEX CONCURRENTLY IF NOT EXISTS job_sequences_course_request_id_idx ON job_sequences (course_request_id);

--- a/packages/migrations/README.md
+++ b/packages/migrations/README.md
@@ -24,6 +24,17 @@ module.exports = async function () {
 };
 ```
 
+`.sql` migrations are run inside a transaction by default. If your migration cannot run inside a transaction (for instance, if it uses `CREATE INDEX CONCURRENTLY`), you can add a special annotation comment to the file:
+
+```sql
+-- prairielearn:migrations NO TRANSACTION
+CREATE INDEX CONCURRENTLY ...;
+```
+
+When running without a transaction, it is recommended that the migration only consist of a single statement so that the database isn't left in an inconsistent state.
+
+`.js`/`.ts` migrations are not automatically run inside a transaction. If transactional DDL is required, a transaction should be manually wrapped in a transaction.
+
 ### Batched migrations
 
 Batched migrations are useful for when one needs to make changes to many rows within a table, for instance backfilling a new column from existing data. While one could technically do this with the schema migrations machinery, that has a number of disadvantages:

--- a/packages/migrations/src/load-migrations.test.ts
+++ b/packages/migrations/src/load-migrations.test.ts
@@ -4,7 +4,11 @@ import path from 'path';
 import tmp from 'tmp-promise';
 import fs from 'fs-extra';
 
-import { readAndValidateMigrationsFromDirectory, sortMigrationFiles } from './load-migrations';
+import {
+  parseAnnotations,
+  readAndValidateMigrationsFromDirectory,
+  sortMigrationFiles,
+} from './load-migrations';
 
 chai.use(chaiAsPromised);
 
@@ -82,6 +86,19 @@ describe('load-migrations', () => {
           },
         ]
       );
+    });
+  });
+
+  describe('parseAnnotations', () => {
+    it('parses a NO TRANSACTION annotation', () => {
+      const annotations = parseAnnotations('-- prairielearn:migrations NO TRANSACTION');
+      assert.deepEqual(annotations, new Set(['NO TRANSACTION']));
+    });
+
+    it('throws an error for an invalid annotation', () => {
+      assert.throws(() => {
+        parseAnnotations('-- prairielearn:migrations INVALID');
+      });
     });
   });
 });


### PR DESCRIPTION
Now that we're running on Postgres 14, we're revisiting https://github.com/PrairieLearn/PrairieLearn/issues/5530. Virtually all of our migrations can now run successfully inside a transaction, with the exception of `CREATE INDEX CONCURRENTLY`. To handle that case, a special annotation comment (`-- prairielearn:migrations NO TRANSACTION`) can be added to migration files to run the migration outside of a transaction.