### PR TITLE
Convert lib/cache to TypeScript

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -193,6 +193,7 @@
     "@types/passport-azure-ad": "^4.3.1",
     "@types/pem": "^1.9.6",
     "@types/pg": "^8.6.6",
+    "@types/redis": "^2.8.32",
     "@types/tar": "^6.1.4",
     "@types/tmp": "^0.2.3",
     "@types/uuid": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,6 +3412,7 @@ __metadata:
     "@types/passport-azure-ad": ^4.3.1
     "@types/pem": ^1.9.6
     "@types/pg": ^8.6.6
+    "@types/redis": ^2.8.32
     "@types/tar": ^6.1.4
     "@types/tmp": ^0.2.3
     "@types/uuid": ^9.0.1
@@ -4610,6 +4611,15 @@ __metadata:
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
   checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
+  languageName: node
+  linkType: hard
+
+"@types/redis@npm:^2.8.32":
+  version: 2.8.32
+  resolution: "@types/redis@npm:2.8.32"
+  dependencies:
+    "@types/node": "*"
+  checksum: 2b12103e05977941870c9a248f6ea51f4b7ad7e0f16a7403799c2ed1b3e63b60f693c39f9186be0ea02776934c4595ddcd2a5bde41e530aaad42d26449f6a669
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a deliberately low-effort conversion; I'm doing a refactor of this file soon in another PR. I just want to get the `.js` -> `.ts` change done such that Git will track the file contents between them.