### PR TITLE
Disable pl-order-blocks when new answers are no longer allowed

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
@@ -22,10 +22,18 @@ li.pl-order-blocks-code {
   margin-bottom: 0px !important;
 }
 
-ul.pl-order-blocks-connected-sortable li:hover{
+ul.pl-order-blocks-connected-sortable li:hover:not(.nodrag){
   cursor: move; /* For UX: The answer tiles shows a 'grab' cursor on mouse over */
   outline: 2px solid blue;
   outline-offset: -2px;
+}
+
+ul.pl-order-blocks-connected-sortable li.nodrag {
+  opacity: 0.6;
+}
+
+ul.pl-order-blocks-connected-sortable li.nodrag:hover {
+  cursor: not-allowed;
 }
 
 li.ui-state-highlight {

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
@@ -58,7 +58,7 @@ window.PLOrderBlocks = function (uuid, options) {
 
   let sortables = optionsElementId + ', ' + dropzoneElementId;
   $(sortables).sortable({
-    items: 'li:not(.info-fixed)',
+    items: 'li:not(.info-fixed):not(.nodrag)',
     // We add `a` to the default list of tags to account for help
     // popover triggers.
     cancel: 'input,textarea,button,select,option,a',

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache
@@ -15,7 +15,7 @@ $(function() {
             <div class="card-header pl-order-blocks-header list-group-item-primary">{{source-header}}</div>
             <ul id="order-blocks-options-{{uuid}}" name="{{answer_name}}" class="card-body list-group pl-order-blocks-connected-sortable {{inline}}">
                 {{#options}}
-                    <li class="{{block_formatting}} shadow" uuid="{{uuid}}" string="{{inner_html}}">{{{inner_html}}}</li>
+                    <li class="{{block_formatting}} shadow {{^editable}}nodrag{{/editable}}" uuid="{{uuid}}" string="{{inner_html}}">{{{inner_html}}}</li>
                 {{/options}}
             </ul>
         </div>
@@ -28,7 +28,7 @@ $(function() {
             </div>
             <ul id="order-blocks-dropzone-{{uuid}}" name="{{answer_name}}" class="card-body list-group pl-order-blocks-connected-sortable dropzone">
                 {{#submission_dict}}
-                    <li uuid="{{uuid}}" string="{{inner_html}}" style='margin-left: {{indent}}px;' class="{{block_formatting}} shadow">{{{inner_html}}}</li>
+                    <li uuid="{{uuid}}" string="{{inner_html}}" style='margin-left: {{indent}}px;' class="{{block_formatting}} shadow {{^editable}}nodrag{{/editable}}">{{{inner_html}}}</li>
                 {{/submission_dict}}
             </ul>
         </div>

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -324,6 +324,8 @@ def render(element_html, data):
     )
 
     if data["panel"] == "question":
+        editable = data["editable"]
+
         mcq_options = []
         student_previous_submission = []
         submission_indent = []
@@ -403,6 +405,7 @@ def render(element_html, data):
             "max_indent": max_indent,
             "uuid": uuid,
             "block_formatting": block_formatting,
+            "editable": editable,
         }
 
         with open("pl-order-blocks.mustache", "r", encoding="utf-8") as f:


### PR DESCRIPTION
As mentioned in #5540, `pl-order-blocks` does not become disabled when question submission is no longer allowed. 

This PR fixes the said defect by adding a `nodrag` class to `li` dragging blocks whenever the param `data['editable']` is set to `false`, and modifying the `sortable` dragging function within `pl-order-blocks.js` to ignore (and hence disallow) dragging of `li` items with the `nodrag` class. This is done to disable the dragging functionality as desired.

The CSS file (`pl-order-blocks.css`) has also been updated to show a `cursor: not-allowed` upon hovering over disabled elements, and disabled elements have opacity set to `0.6` to show that interaction is not allowed (see screencap below). This is done to show a visual cue to the user that dragging of the elements is not possible.

![image](https://github.com/PrairieLearn/PrairieLearn/assets/11191061/5105a51f-cdf4-46c3-a562-68c3ffa8ee45)
 