### PR TITLE
Fix detection of missing docker images on courseSyncs page

### DIFF
--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
@@ -45,7 +45,7 @@ router.get('/', function (req, res, next) {
               repositoryName: repository.getRepository(),
             };
             ecr.describeImages(params, (err, data) => {
-              if (err && err.code === 'RepositoryNotFoundException') {
+              if (err && err.name === 'RepositoryNotFoundException') {
                 image.imageSyncNeeded = true;
                 return callback(null);
               } else if (ERR(err, callback)) {


### PR DESCRIPTION
I'm guessing that this was a change caused by the upgrade to v3 of the AWS SDK in #7735 but I couldn't find anything in [the docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-ecr/classes/ecr.html#describeimages.describeimages-2) about the format of `err`.

This fixes the problem reported by Abdu where visiting the course "Sync" page gave an error like:
```
The repository with name '<IMAGE_NAME>' does not exist in the registry with id '<REGISTRY_ID>'
```

I logged the error that `describedImages()` returns and it looks like:
```
{"name":"RepositoryNotFoundException","$fault":"client","$metadata":{"httpStatusCode":400,"requestId":"<REQUEST_UUID>","attempts":1,"totalRetryDelay":0},"__type":"RepositoryNotFoundException"}
```

I reproduced the error in staging and verified that the change in this PR does indeed fix it.