### PR TITLE
Review use of MathJax promises

### DIFF
--- a/apps/prairielearn/assets/scripts/mathjax.js
+++ b/apps/prairielearn/assets/scripts/mathjax.js
@@ -3,49 +3,64 @@
 // Default to SVG, as lines were sometimes disappearing when using the CHTML renderer.
 const outputComponent = 'output/svg';
 
-window.MathJax = {
-  tex: {
-    inlineMath: [
-      ['$', '$'],
-      ['\\(', '\\)'],
-    ],
-  },
-  svg: {
-    // Using local instead of global prevents a MathJax bug if the user
-    // tries to switch the renderer with the pop-up menu. The bug will
-    // supposedly be fixed in MathJax 4, and then this could be changed
-    // back to global.
-    // Refer to issues on MathJax:
-    // https://github.com/mathjax/MathJax/issues/2924
-    // https://github.com/mathjax/MathJax/issues/2956
-    // This PR was merged but won't be released until MathJax v4:
-    // https://github.com/mathjax/MathJax-src/pull/859
-    fontCache: 'local',
-  },
-  loader: {
-    load: ['input/tex', 'ui/menu', outputComponent],
-  },
-  // Register a callback to be run when MathJax is loaded, use MathJax.config.onReady().
-  readyQueue: [],
-  onReady: (cb) => {
-    window.MathJax.config.readyQueue.push(cb);
-  },
-  startup: {
-    ready: () => {
-      window.MathJax.startup.defaultReady();
-      window.MathJax.Hub = {
-        Queue: function () {
-          console.warn(
-            'MathJax.Hub.Queue() has been deprecated in 3.0, please use MathJax.typeset() or MathJax.typesetPromise()'
-          );
-          window.MathJax.typesetPromise();
-        },
-      };
+window.safeMathjaxPromise = new Promise((resolve, _reject) => {
+  window.MathJax = {
+    tex: {
+      inlineMath: [
+        ['$', '$'],
+        ['\\(', '\\)'],
+      ],
     },
-    pageReady: () => {
-      window.MathJax.startup.defaultPageReady();
-      window.MathJax.config.onReady = (cb) => cb();
-      window.MathJax.config.readyQueue.forEach((cb) => cb());
+    svg: {
+      // Using local instead of global prevents a MathJax bug if the user
+      // tries to switch the renderer with the pop-up menu. The bug will
+      // supposedly be fixed in MathJax 4, and then this could be changed
+      // back to global.
+      // Refer to issues on MathJax:
+      // https://github.com/mathjax/MathJax/issues/2924
+      // https://github.com/mathjax/MathJax/issues/2956
+      // This PR was merged but won't be released until MathJax v4:
+      // https://github.com/mathjax/MathJax-src/pull/859
+      fontCache: 'local',
     },
-  },
+    loader: {
+      load: ['input/tex', 'ui/menu', outputComponent],
+    },
+    // Kept for compatibility reasons.
+    onReady: (cb) => {
+      window.safeMathjaxPromise.then(cb);
+    },
+    startup: {
+      ready: () => {
+        window.MathJax.startup.defaultReady();
+        window.MathJax.Hub = {
+          Queue: function () {
+            console.warn(
+              'MathJax.Hub.Queue() has been deprecated in 3.0, please use MathJax.typeset() or MathJax.typesetPromise()'
+            );
+            window.MathJax.typesetPromise();
+          },
+        };
+      },
+      pageReady: () => {
+        window.MathJax.startup.defaultPageReady();
+        resolve();
+      },
+    },
+  };
+});
+
+window.mathjaxTypeset = async () => {
+  await window.safeMathjaxPromise;
+  return window.MathJax.typesetPromise();
+};
+
+window.mathjaxConvert = async (value) => {
+  await window.safeMathjaxPromise;
+  return (window.MathJax.tex2chtmlPromise || window.MathJax.tex2svgPromise)(value);
+};
+
+module.exports = {
+  mathjaxTypeset: window.mathjaxTypeset,
+  mathjaxConvert: window.mathjaxConvert,
 };

--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -1,11 +1,5 @@
 import { io } from 'socket.io-client';
-import './mathjax';
-
-declare global {
-  interface Window {
-    MathJax: any;
-  }
-}
+import { mathjaxTypeset } from './mathjax';
 
 document.addEventListener('DOMContentLoaded', () => {
   const { gradingMethod } = (document.querySelector('.question-container') as HTMLElement).dataset;
@@ -114,9 +108,7 @@ function fetchResults(socket, submissionId) {
       }
       if (msg.submissionPanel) {
         document.getElementById('submission-' + submissionId).outerHTML = msg.submissionPanel;
-        window.MathJax.startup.promise.then(async () => {
-          window.MathJax.typesetPromise();
-        });
+        mathjaxTypeset();
         // Restore modal state if need be
         if (wasModalOpen) {
           $('#submissionInfoModal-' + submissionId).modal('show');

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -1,5 +1,5 @@
 /* eslint-env browser,jquery */
-/* global Quill,he, MathJax, QuillMarkdown, showdown */
+/* global Quill, he, QuillMarkdown, showdown */
 
 window.PLRTE = function (uuid, options) {
   if (!options.modules) options.modules = {};
@@ -62,12 +62,10 @@ class MathFormula extends Embed {
   }
 
   static updateNode(node, value) {
-    MathJax.startup.promise.then(async () => {
-      const html = await (MathJax.tex2chtmlPromise || MathJax.tex2svgPromise)(value);
+    window.mathjaxConvert(value).then(async (html) => {
       const formatted = html.innerHTML;
       // Without trailing whitespace, cursor will not appear at end of text if LaTeX is at end
       node.innerHTML = formatted + '&#8201;';
-      await MathJax.typesetPromise();
       node.contentEditable = 'false';
       node.setAttribute('data-value', value);
     });


### PR DESCRIPTION
`MathJax` has some of its components loaded asynchronously, so a safe way to request a typeset requires waiting for it to load. Traditionally this has been done with a custom function `MathJax.config.onReady`, but this is not fully safe, as `MathJax.config` is only available once the mathjax script is partially loaded. Using `MathJax.onReady` is also not safe. Similarly, `MathJax.startup.promise` is only available when the script is partially loaded.

This PR introduces a promise that resolves when the script is fully loaded and ready for typeset to be called. It also introduces helper functions that wait for this promise and call typical calls like `typesetPromise` and `tex2svgPromise`.