### PR TITLE
Force rebuild of plbase image

### DIFF
--- a/images/plbase/Dockerfile
+++ b/images/plbase/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux:2023
 
-# plbase-install.sh       - script to install everything (also used by production builds)
-# python-requirements.txt - list of python packages to be installed by pip
+# plbase-install.sh: script to install all needed packages and dependencies
+# python-requirements.txt: list of python packages to be installed by pip
 COPY plbase-install.sh python-requirements.txt /
 
 RUN /bin/bash /plbase-install.sh


### PR DESCRIPTION
Changing `.github/workflows/images.yml` in #7931 didn't actually trigger a rebuild of `prairielearn/plbase`. This PR makes a few trivial changes to force the image to rebuild.