### PR TITLE
Allow admins to override feature flags on a per-request basis

### DIFF
--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -1,5 +1,6 @@
 import { FeatureManager } from './manager';
+import { featuresMiddleware } from './middleware';
 
 const features = new FeatureManager(['manual-grading-rubrics']);
 
-export { features };
+export { features, featuresMiddleware };

--- a/apps/prairielearn/src/lib/features/middleware.ts
+++ b/apps/prairielearn/src/lib/features/middleware.ts
@@ -1,0 +1,45 @@
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+
+import { features } from './index';
+import { FeatureOverrides } from './manager';
+
+type AuthFunction = (req: Request, res: Response) => boolean;
+
+/**
+ * Middleware that allows per-request overriding of enabled features.
+ *
+ * Middleware that allows a special `_features` query parameter can be used to
+ * enable or disable specific features for the lifetime of a request.
+ *
+ * - `?_features=feature1,feature2` enables `feature1` and `feature2`
+ * - `?_features=!feature1,feature2` disables `feature1` and enables `feature2`
+ *
+ * The provided function is executed to determine whether the user for this
+ * request is allowed to override feature flags. This should generally be
+ * limited to administrators.
+ */
+export function featuresMiddleware(auth: AuthFunction) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!auth(req, res)) {
+      return next();
+    }
+
+    const rawFeatureOverrides = z
+      .string()
+      .parse(req.query._features ?? '')
+      .split(',')
+      .filter((f) => f.length > 0);
+
+    const featureOverrides: FeatureOverrides = {};
+    for (const featureOverride of rawFeatureOverrides) {
+      if (featureOverride.startsWith('!')) {
+        featureOverrides[featureOverride.slice(1)] = false;
+      } else {
+        featureOverrides[featureOverride] = true;
+      }
+    }
+
+    features.runWithOverrides(featureOverrides, next);
+  };
+}


### PR DESCRIPTION
I'm doing this so that I can easily test #7128 in production. Specifically, I want to be able to quickly flip this feature on and off in arbitrary courses so that I can compare performance and results.

I borrowed this idea from https://github.com/jnunemaker/flipper/issues/283#issuecomment-327898906. However, I didn't implement all the pattern-matching stuff that that example used. It's just simple on/off for specific flags.