### PR TITLE
Fix correct answer not showing up in the question template/numberInput

### DIFF
--- a/exampleCourse/questions/template/numberInput/question.html
+++ b/exampleCourse/questions/template/numberInput/question.html
@@ -4,4 +4,4 @@ Given two numbers $a = {{params.a}}$ and $b = {{params.b}}$. What is $c = \sqrt{
 </p>
 </pl-question-panel>
 
-<pl-number-input answers-name="ans" label="$c =$"></pl-number-input>
+<pl-number-input answers-name="c" label="$c =$"></pl-number-input>

--- a/exampleCourse/questions/template/numberInput/server.py
+++ b/exampleCourse/questions/template/numberInput/server.py
@@ -16,5 +16,5 @@ def generate(data):
     # Compute the product of these two numbers
     c = math.sqrt(a**2 + b**2)
 
-    # Put the product into data['params']
-    data["params"]["correct_answer"] = c
+    # Put the correct answer into data['correct_answers']
+    data["correct_answers"]["c"] = c


### PR DESCRIPTION
While working on `pl-number-input` and using the template question `template/numberInput` for testing, I found a small bug where the correct answer wasn't showing up or used for grading for the question. This is caused by a minor typo in the question code, and this PR fixes the typo in the question code.