### PR TITLE
Improved documentation of local installation on Windows

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,44 +1,70 @@
 # Installing and running for local course development
 
-This page describes the procedure to install and run your course locally within Docker. You can develop course content locally following the instructions below, or using the
-[in-browser tools](getStarted.md).
+This page describes the procedure to install and run your course locally within Docker. You can develop course content locally following the instructions below, or using the [in-browser tools](getStarted.md).
 
-- Step 1: Install [Docker Community Edition](https://www.docker.com/community-edition). It's free.
+## Installation instructions
 
-  - On Linux and MacOS this is straightforward. [Download from here](https://store.docker.com/search?type=edition&offering=community).
-  - On Windows the best version is [Docker Community Edition for Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows), which requires Windows 10 Pro/Edu.
-    - UIUC students and staff can download Windows 10 from [the WebStore](https://webstore.illinois.edu/shop/product.aspx?zpid=2899).
-    - Docker Toolbox is no longer supported.
+Regardless of which operating system you are using, you will need to install the appropriate version of [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
-- Step 2: Run PrairieLearn using the example course with:
+If you are using Windows, you are strongly encouraged to use WSL 2 to run PrairieLearn. WSL 2 provides a Linux environment that runs alongside Windows, and makes better use of modern CPU virtualization features. It has been found to provide better performance for running PrairieLearn compared to running Docker directly on top of Windows.
+
+Here are the instructions to enable WSL 2 integration:
+
+- Install WSL 2. For current instructions, [follow the Microsoft documentation](https://learn.microsoft.com/en-us/windows/wsl/install).
+- Enable the Docker Desktop WSL 2 backend. For current instructions, [follow the Docker documentation](https://docs.docker.com/desktop/windows/wsl/).
+- On the shell of your WSL 2 instance, make sure the instance has the `docker` command installed. The installation process may depend on your distribution, but most distributions provide a `docker` package. For example, if you are using Debian, Ubuntu or similar distributions, you may install it with:
+
+```sh
+sudo apt install docker
+```
+
+If you are using Windows without WSL 2 then you will need to first give Docker permission to access the C: drive (or whichever drive your course directory is on). This can be done by right-clicking on the Docker "whale" icon in the taskbar, choosing "Settings", and granting shared access to the C: drive. This step is not necessary if you are using WSL 2 integration.
+
+## Cloning your course repository
+
+If you are running PrairieLearn with the example course only, you may skip this section.
+
+When you request your course, you will typically receive a GitHub repository URL to your course's content. You may use [Git](https://git-scm.com/) to clone (make a local copy of) this course content in your own computer. Make note of the directory you are cloning your course to. If you are working with multiple courses, you will need to store each course in a separate directory.
+
+If you are using Windows with WSL 2, you have two options to store your course repository(ies):
+
+- Store your course content inside the WSL instance. This option typically provides the best performance when running PrairieLearn locally. You can clone the repository [using git commands](https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository) inside your WSL shell. Note that, in this case, you will need to either update your files using WSL tools and editors, or access the files using the Linux file systems. [Instructions to do so are listed here](https://learn.microsoft.com/en-us/windows/wsl/filesystems). In this case, keep track of the path used by your course inside WSL (e.g., `$HOME/pl-tam212`)
+
+- Store your course content in the Windows file system itself (e.g., in your Documents or Desktop folder, or elsewhere inside the C:\ drive). If you are using this option, you will need to translate the Windows path into the WSL mounted path in `/mnt`. For example, if your course is stored in `C:\Users\mwest\Documents\pl-tam212`, then the directory you will use is `/mnt/c/Users/Documents/pl-tam212` (note the change of prefix and the replacement of backslashes with forward slashes).
+
+## Running instructions
+
+To run PrairieLearn using the example course only, open a terminal window and type the command:
 
 ```sh
 docker run -it --rm -p 3000:3000 prairielearn/prairielearn
 ```
 
-- Step 3: Open a web browser and connect to [http://localhost:3000/pl](http://localhost:3000/pl)
-
-- Step 4: When you are finished with PrairieLearn, type Control-C on the commandline where you ran the server to stop it.
-
-- Step 5: To use your own course, use the `-v` flag to bind the Docker `/course` directory with your own course directory (replace the precise path with your own) on Windows:
-
-```sh
-docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course prairielearn/prairielearn
-```
-
-or on MacOS/Linux:
+To use your own course, use the `-v` flag to bind the Docker `/course` directory with your own course directory. For example, if your course is stored in `/Users/mwest/git/pl-tam212`, the command is:
 
 ```sh
 docker run -it --rm -p 3000:3000 -v /Users/mwest/git/pl-tam212:/course prairielearn/prairielearn
 ```
 
-If you are using Docker for Windows then you will need to first give Docker permission to access the C: drive (or whichever drive your course directory is on). This can be done by right-clicking on the Docker "whale" icon in the taskbar, choosing "Settings", and granting shared access to the C: drive.
+Make sure to replace the course path with your own course directory. To use multiple courses, add additional `-v` flags (e.g., `-v /path/to/course1:/course -v /path/to/course2:course2`). You may use up to nine courses through this method, using the mount points: `/course`, `/course2`, `/course3`, ..., `/course9`.
 
-To use multiple courses, add additional `-v` flags (e.g., `-v /path/to/course:/course -v /path/to/course2:course2`). There are nine available mount points in the Docker: `/course`, `/course2`, `/course3`, ..., `/course9`.
+If you are running on Windows with WSL 2, run the command above in a WSL 2 shell, not on PowerShell or the Command Prompt. If you are using Windows without support for WSL 2, use the Windows path for your course, e.g.:
 
-If you're in the root of your course directory already, you can substitute `%cd%` (on Windows) or `$PWD` (Linux and MacOS) for `/path/to/course`.
+```sh
+docker run -it --rm -p 3000:3000 -v C:\GitHub\pl-tam212:/course prairielearn/prairielearn
+```
 
-If you plan on running externally graded questions in local development, please see [this section](../externalGrading/#running-locally-on-docker) for a slightly different docker launch command.
+If you plan on running externally graded questions or workspaces in local development, please see [this section](../externalGrading/#running-locally-on-docker) for additional options required to handle these features.
+
+After running the command above, you should see a message that says:
+
+```console
+PrairieLearn server ready, press Control-C to quit
+```
+
+Once that message shows up, open a web browser and connect to [http://localhost:3000/pl](http://localhost:3000/pl).
+
+When you are finished with PrairieLearn, type Control-C on the terminal where you ran the server to stop it.
 
 **NOTE**: On MacOS with "Apple Silicon" (ARM64) hardware, the use of R is not currently supported.
 
@@ -67,24 +93,3 @@ docker run -it --rm -p 3000:3000 --pull=always [other args] prairielearn/prairie
 Note that the command above uses the `--pull=always` option, which will update the local version of the image every time the docker command is restarted. If you keep a long-running container locally, make sure to restart the container when updates in the production servers are announced in the [PrairieLearn GitHub Discussions page](https://github.com/PrairieLearn/PrairieLearn/discussions/categories/announcements).
 
 Additional tags are available for older versions. The list of available versions is viewable on the [Docker Hub build page](https://hub.docker.com/r/prairielearn/prairielearn/builds/).
-
-## Running PrairieLearn from a WSL2 instance
-
-If you are using Windows with WSL2, you should be able to run Docker from another WSL2 instance. In order to that, you need to follow these instructions:
-
-- Open the Docker Dashboard, and click on Settings (the gear button at the top of the interface).
-
-  - Under General, ensure the "Use the WSL2 based engine" option is selected.
-  - Then, under Resources, select "WSL integration", and enable the option "Enable integration with my default WSL distro".
-  - Also enable integration with any listed distros that you want to access docker from.
-  - Click on "Apply & Restart" for the settings to apply.
-
-- On the shell of your WSL2 instance, make sure the instance has the `docker` command installed. The installation process may depend on your distribution, but most distributions provide a `docker` package.
-
-- Now you should be able to start PrairieLearn with the following command (assuming your course is stored under `/mnt/c/Users/yourname/git/pl-tam212`):
-
-```sh
-docker run -it --rm -p 3000:3000 -v /mnt/c/Users/yourname/git/pl-tam212:/course prairielearn/prairielearn
-```
-
-If you plan on running externally graded questions or workspaces in local development, please see the [docker section in the external grading docs](../externalGrading/#running-locally-on-docker) for a slightly different docker launch command.

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -227,82 +227,13 @@ If you're using your own editor, you must ensure that it frequently autosaves an
 
 ## Running locally (on Docker)
 
-- First, create an empty directory to use to share job data between containers.
-
-  - This can live anywhere, but needs to be created first and referenced in the `docker run` command.
-  - This command is copy-pastable for Windows PowerShell, MacOS, and Linux.
-  - **If you already created an external grader jobs directory, you can reuse the same one.**
-
-```sh
-mkdir "$HOME/pl_ag_jobs"
-```
-
-- Then, use one of the following `docker run` commands based on your platform.
-
-In MacOS, `cd` to your course directory and copy-paste the following command:
-
-```sh
-docker run -it --rm -p 3000:3000 \
-  -v "$PWD":/course \
-  -v "$HOME/pl_ag_jobs:/jobs" \
-  -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  prairielearn/prairielearn
-```
-
-In Linux, `cd` to your course directory and copy-paste the following command (same as the MacOS command but add the `--add-host` option):
-
-```sh
-docker run -it --rm -p 3000:3000 \
-  -v "$PWD":/course \
-  -v "$HOME/pl_ag_jobs:/jobs" \
-  -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  --add-host=host.docker.internal:172.17.0.1 `# this line is new vs MacOS` \
-  prairielearn/prairielearn
-```
-
-In Windows 10/11 (PowerShell), `cd` to your course directory and copy the following command **but with your own username in `HOST_JOBS_DIR`**:
-
-```powershell
-docker run -it --rm -p 3000:3000 `
-  -v "$PWD":/course `
-  -v $HOME\pl_ag_jobs:/jobs `
-  -e HOST_JOBS_DIR=/c/Users/Tim/pl_ag_jobs `
-  -v /var/run/docker.sock:/var/run/docker.sock `
-  prairielearn/prairielearn
-```
-
-- **Note** the following about `HOST_JOBS_DIR` in PowerShell:
-
-  - Use Unix-style paths (i.e., use `/c/Users/Tim/pl_ag_jobs`, not `C:\Users\Tim\pl_ag_jobs`).
-  - Use the full path rather than `$HOME` (i.e., use `/c/Users/Tim/pl_ag_jobs`, not `$HOME/pl_ag_jobs`).
-
-- **Note** that `C:` must have shared access between Windows and Docker:
-
-  - Right-click the Docker "whale" icon in the taskbar
-  - Click "Settings"
-  - Ensure `C:` is checked
-
-If you are calling docker [from a WSL2 container](../installing/#running-prairielearn-from-a-wsl2-instance), you can use the following command:
-
-```sh
-docker run -it --rm -p 3000:3000 \
-    -v "$PWD":/course \
-    -v $HOME/pl_ag_jobs:/jobs \
-    -e HOST_JOBS_DIR=$HOME/pl_ag_jobs \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    --add-host=host.docker.internal:172.17.0.1 \
-    prairielearn/prairielearn
-```
-
-Note that in this case, the `$HOME/pl_ag_jobs` folder is created inside the WSL2 instance, not on the host. This can mitigate issues with mode/permissions in external grader instances, as the jobs are created in a Linux environment that allows non-executable files.
+In production, PrairieLearn runs workspaces on a distributed system that uses a variety of AWS services to efficiently run many jobs in parallel. When developing questions locally, you won't have access to this infrastructure, but PrairieLearn allows you to still workspaces locally with a few workarounds. This infrastructure is similar to the one used for external graders. To enable workspace functionality in your local environment, follow the [instructions provided in the external grader page](../externalGrading.md#running-locally-for-development).
 
 ## Developing with workspaces (in Docker)
 
 For development, run the docker container as described in [Installing with local source code](../installingLocal.md) but also add the workspace-specific arguments described above to the docker command line. Inside the container, run:
 
-```
+```sh
 make dev-workspace-host
 make dev
 ```


### PR DESCRIPTION
The documentation currently lists WSL2 as an alternative on Windows, however this provides better performance, better functionality for jobs (particularly for permissions) and better use of local file systems (see #7928).

This PR updates the documentation to list WSL2 as the main option on Windows. It also reorganizes the installation documentation for clarity, and includes a brief description of the steps to clone the course directory locally. Some minor updates in related documentation are also included.