### PR TITLE
Fix handling of empty groups

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs
@@ -287,7 +287,9 @@
             <tr>
               <td><%= row.name %></td>
               <td class="text-center"><%= row.size %></td>
-              <td class="text-center" style ="word-break:break-all;"><small><%= row.uid_list %></small></td>
+              <td class="text-center" style="word-break:break-all;">
+                <small><%= row.uid_list.length > 0 ? row.uid_list : '(empty)' %></small>
+              </td>
               <% if (authz_data.has_course_instance_permission_edit) { %>
               <td class="text-center">
                 <div class="dropdown">

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
@@ -130,12 +130,19 @@ router.post(
       const assessment_id = res.locals.assessment.id;
       const group_name = req.body.group_name;
       if (!group_name || String(group_name).length < 1) {
-        flash('error', 'Group name cannot be empty');
+        flash('error', 'Group name cannot be empty.');
         res.redirect(req.originalUrl);
         return;
       }
+
       const uids = req.body.uids;
-      const uidlist = uids.split(/[ ,]+/);
+      const uidlist = uids.split(/[ ,]+/).filter((uid) => !!uid);
+      if (uidlist.length === 0) {
+        flash('error', 'Group must be created with at least one user.');
+        res.redirect(req.originalUrl);
+        return;
+      }
+
       let updateList = [];
       uidlist.forEach((uid) => {
         updateList.push([group_name, uid]);
@@ -144,7 +151,6 @@ router.post(
       const result = await sqldb.callAsync('assessment_groups_update', params);
 
       const notExist = result.rows[0].not_exist_user;
-      console.log(notExist);
       if (notExist) {
         flash(
           'error',
@@ -165,7 +171,7 @@ router.post(
       const assessment_id = res.locals.assessment.id;
       const group_id = req.body.group_id;
       const uids = req.body.add_member_uids;
-      const uidlist = uids.split(/[ ,]+/);
+      const uidlist = uids.split(/[ ,]+/).filter((uid) => !!uid);
       let failedUids = [];
       for (const uid of uidlist) {
         let params = [assessment_id, group_id, uid, res.locals.authn_user.user_id];
@@ -187,7 +193,7 @@ router.post(
       const assessment_id = res.locals.assessment.id;
       const group_id = req.body.group_id;
       const uids = req.body.delete_member_uids;
-      const uidlist = uids.split(/[ ,]+/);
+      const uidlist = uids.split(/[ ,]+/).filter((uid) => !!uid);
       let failedUids = [];
       for (const uid of uidlist) {
         let params = [assessment_id, group_id, uid, res.locals.authn_user.user_id];


### PR DESCRIPTION
This was a regression introduced in #7907. Our query ended up with `uid_list = '{NULL}'` for empty groups, which we didn't handle correctly.