### PR TITLE
Mark sync_warnings as nullable

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -18,7 +18,7 @@ export const CourseSchema = z.object({
   short_name: z.string().nullable(),
   sync_errors: z.string().nullable(),
   sync_job_sequence_id: IdSchema.nullable(),
-  sync_warnings: z.string(),
+  sync_warnings: z.string().nullable(),
   title: z.string().nullable(),
 });
 export type Course = z.infer<typeof CourseSchema>;
@@ -36,7 +36,7 @@ export const CourseInstanceSchema = z.object({
   short_name: z.string().nullable(),
   sync_errors: z.string().nullable(),
   sync_job_sequence_id: IdSchema.nullable(),
-  sync_warnings: z.string(),
+  sync_warnings: z.string().nullable(),
   uuid: z.string().nullable(),
 });
 export type CourseInstance = z.infer<typeof CourseInstanceSchema>;


### PR DESCRIPTION
I considered marking the columns themselves as `NOT NULL`, but in this case I think it's actually reasonable for them to be nullable - that just indicates a lack of warnings!