### PR TITLE
Add migration to remove invalid group_users

### DIFF
--- a/apps/prairielearn/src/migrations/20230609223157_group_users__remove_invalid_rows.sql
+++ b/apps/prairielearn/src/migrations/20230609223157_group_users__remove_invalid_rows.sql
@@ -1,0 +1,4 @@
+DELETE FROM group_users AS gu USING groups AS g
+WHERE
+  gu.group_id = g.id
+  AND g.deleted_at IS NOT NULL;


### PR DESCRIPTION
Resolves #7924.

I used the following query to estimate the impact of this migration against our US production data:

```sql
SELECT
  *
FROM
  group_users AS gu
  JOIN groups AS g ON (gu.group_id = g.id)
WHERE
  g.deleted_at IS NOT NULL;
```

This revealed ~19000 rows!