### PR TITLE
Use NULLS NOT DISTINCT for feature_grants unique index

### DIFF
--- a/apps/prairielearn/src/migrations/20230612162858_feature_grants__unique_nulls_not_distinct.sql
+++ b/apps/prairielearn/src/migrations/20230612162858_feature_grants__unique_nulls_not_distinct.sql
@@ -1,0 +1,27 @@
+-- Remove any duplicate rows that might exist.
+DELETE FROM feature_grants AS fg USING feature_grants AS fg_duplicates
+WHERE
+  fg.id > fg_duplicates.id
+  AND fg.name IS NOT DISTINCT FROM fg_duplicates.name
+  AND fg.institution_id IS NOT DISTINCT FROM fg_duplicates.institution_id
+  AND fg.course_id IS NOT DISTINCT FROM fg_duplicates.course_id
+  AND fg.course_instance_id IS NOT DISTINCT FROM fg_duplicates.course_instance_id
+  AND fg.user_id IS NOT DISTINCT FROM fg_duplicates.user_id;
+
+-- Rename the old constraint.
+ALTER INDEX feature_grants_by_name_idx
+RENAME TO feature_grants_by_name_idx_old;
+
+-- Create a new constraint using `NULLS NOT DISTINCT` to prevent duplicates.
+ALTER TABLE feature_grants
+ADD CONSTRAINT feature_grants_by_name_idx UNIQUE NULLS NOT DISTINCT (
+  name,
+  institution_id,
+  course_id,
+  course_instance_id,
+  user_id
+);
+
+-- Drop the old constraint.
+ALTER TABLE feature_grants
+DROP CONSTRAINT feature_grants_by_name_idx_old;

--- a/database/tables/feature_grants.pg
+++ b/database/tables/feature_grants.pg
@@ -10,7 +10,7 @@ columns
 
 indexes
     feature_grants_pkey: PRIMARY KEY (id) USING btree (id)
-    feature_grants_by_name_idx: UNIQUE (name, institution_id, course_id, course_instance_id, user_id) USING btree (name, institution_id, course_id, course_instance_id, user_id)
+    feature_grants_by_name_idx: UNIQUE NULLS NOT DISTINCT (name, institution_id, course_id, course_instance_id, user_id) USING btree (name, institution_id, course_id, course_instance_id, user_id) NULLS NOT DISTINCT
     feature_grants_by_entity_idx: USING btree (institution_id, course_id, course_instance_id, user_id, name)
     feature_grants_name_user_id_idx: USING btree (name, user_id)
     feature_grants_user_id_name_idx: USING btree (user_id, name)


### PR DESCRIPTION
This ensures that we don't end up with duplicate rows for the same institution/course/instance/user combination where one or more of those entities is null.