### PR TITLE
Expose types from browser-utils package

### DIFF
--- a/.changeset/plenty-dodos-return.md
+++ b/.changeset/plenty-dodos-return.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/browser-utils': patch
+---
+
+Add missing types field to exports in package.json

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -12,7 +12,8 @@
     "./package.json": "./package.json",
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
This change is necessary because `tsc` does not view `index.d.ts` as "adjacent" to `index.mjs` and thus can't automatically resolve the types.

Once PL is also using ESM, we can stop dual-publishing to CJS and ESM, which will simplify things a bit.