### PR TITLE
Fix syncing of course that is not at course repo root

### DIFF
--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -18,6 +18,7 @@ import { createServerJob, ServerJob } from './server-jobs';
 import courseDB = require('../sync/course-db');
 import type { CourseData } from '../sync/course-db';
 import { config } from './config';
+import { contains } from '@prairielearn/path-utils';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
@@ -258,11 +259,39 @@ export async function identifyChangedFiles(
   oldHash: string,
   newHash: string
 ): Promise<string[]> {
-  const { stdout } = await util.promisify(child_process.exec)(
+  // In some specific scenarios, the course directory and the root of the course
+  // repository might be different. For example, the example course is usually
+  // manually cloned in production environments, and then the course is added
+  // with the path set to the absolute path of the repo _plus_ `exampleCourse/`.
+  //
+  // In these cases, we need to make sure that the paths we're returning from
+  // this function are relative to the course directory, not the root of the
+  // repository. To do this, we query git itself for the root of the repository,
+  // construct an absolute path for each file, and then trim off the course path.
+  const { stdout: topLevelStdout } = await util.promisify(child_process.exec)(
+    `git rev-parse --show-toplevel`,
+    { cwd: coursePath }
+  );
+  const topLevel = topLevelStdout.trim();
+
+  const { stdout: diffStdout } = await util.promisify(child_process.exec)(
     `git diff --name-only ${oldHash}..${newHash}`,
     { cwd: coursePath }
   );
-  return stdout.trim().split('\n');
+  const changedFiles = diffStdout.trim().split('\n');
+
+  // Construct absolute path to all changed files.
+  const absoluteChangedFiles = changedFiles.map((changedFile) => path.join(topLevel, changedFile));
+
+  // Exclude any changed files that aren't in the course directory.
+  const courseChangedFiles = absoluteChangedFiles.filter((absoluteChangedFile) =>
+    contains(coursePath, absoluteChangedFile)
+  );
+
+  // Convert all absolute paths back into relative paths.
+  return courseChangedFiles.map((absoluteChangedFile) =>
+    path.relative(coursePath, absoluteChangedFile)
+  );
 }
 
 /**


### PR DESCRIPTION
See inline comment for a description of this change.

To test this change, I added the following lines to `apps/prairielearn/src/tests/chunks.test.ts`:

```ts
describe.only('example course syncing', () => {
  it('works', async () => {
    const courseData = await courseDB.loadFullCourse(EXAMPLE_COURSE_PATH);
    const changedFiles = await chunksLib.identifyChangedFiles(
      EXAMPLE_COURSE_PATH,
      '92e03fb6f',
      '65aae01ac'
    );
    console.log('changedFiles', changedFiles);
    const changedChunks = chunksLib.identifyChunksFromChangedFiles(changedFiles, courseData);
    console.log('changedChunks', changedChunks);
  });
});
```

Before this PR, no changes were reported:

```ts
changedFiles [
  '.changeset/proud-moose-glow.md',
  '.github/workflows/images.yml',
  '.gitignore',
  'apps/prairielearn/assets/scripts/mathjax.js',
  'apps/prairielearn/assets/scripts/question.ts',
  'apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.py',
  'apps/prairielearn/elements/pl-checkbox/pl-checkbox.py',
  'apps/prairielearn/elements/pl-dropdown/pl-dropdown.py',
  'apps/prairielearn/elements/pl-integer-input/pl-integer-input.py',
  'apps/prairielearn/elements/pl-matching/pl-matching.py',
  'apps/prairielearn/elements/pl-matrix-component-input/pl-matrix-component-input.py',
  'apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.py',
  'apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py',
  'apps/prairielearn/elements/pl-number-input/pl-number-input.py',
  'apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css',
  'apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js',
  'apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache',
  'apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py',
  'apps/prairielearn/elements/pl-string-input/pl-string-input.py',
  'apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.py',
  'apps/prairielearn/elements/pl-threejs/pl-threejs.py',
  'apps/prairielearn/elements/pl-units-input/pl-units-input.py',
  'apps/prairielearn/package.json',
  'apps/prairielearn/python/check_data.py',
  'apps/prairielearn/python/check_data_test.py',
  'apps/prairielearn/python/conftest.py',
  'apps/prairielearn/python/prairielearn.py',
  'apps/prairielearn/python/question_phases.py',
  'apps/prairielearn/python/traverse.py',
  'apps/prairielearn/python/traverse_test.py',
  'apps/prairielearn/python/zygote.py',
  'apps/prairielearn/src/lib/assessment.js',
  'apps/prairielearn/src/lib/authn.js',
  'apps/prairielearn/src/lib/authn.sql',
  'apps/prairielearn/src/lib/db-types.ts',
  'apps/prairielearn/src/lib/editors.js',
  'apps/prairielearn/src/lib/externalGrader.sql',
  'apps/prairielearn/src/lib/externalGradingSocket.js',
  'apps/prairielearn/src/lib/features/index.ts',
  'apps/prairielearn/src/lib/features/manager.ts',
  'apps/prairielearn/src/lib/features/middleware.ts',
  'apps/prairielearn/src/lib/group-update.js',
  'apps/prairielearn/src/lib/group-update.sql',
  'apps/prairielearn/src/lib/groups.js',
  'apps/prairielearn/src/lib/groups.sql',
  'apps/prairielearn/src/lib/question.js',
  'apps/prairielearn/src/lib/question.sql',
  'apps/prairielearn/src/middlewares/authzWorkspace.sql',
  'apps/prairielearn/src/middlewares/selectAndAuthzInstructorQuestion.sql',
  'apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.sql',
  'apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ejs',
  'apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js',
  'apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.sql',
  'apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ejs',
  'apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.sql',
  'apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.sql',
  'apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ejs',
  'apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js',
  'apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs',
  'apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.sql',
  'apps/prairielearn/src/pages/partials/externalGradingLiveUpdate.ejs',
  'apps/prairielearn/src/pages/partials/mathjax.ejs',
  'apps/prairielearn/src/pages/partials/navbar.ejs',
  'apps/prairielearn/src/pages/partials/question.ejs',
  'apps/prairielearn/src/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.ejs',
  'apps/prairielearn/src/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js',
  'apps/prairielearn/src/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.ejs',
  'apps/prairielearn/src/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js',
  'apps/prairielearn/src/question-servers/calculation-inprocess.js',
  'apps/prairielearn/src/question-servers/calculation-subprocess.js',
  'apps/prairielearn/src/question-servers/freeform.js',
  'apps/prairielearn/src/server.js',
  'apps/prairielearn/src/sprocs/assessment_groups_delete_all.sql',
  'apps/prairielearn/src/sprocs/assessment_groups_delete_group.sql',
  'apps/prairielearn/src/sprocs/index.js',
  'apps/prairielearn/src/sprocs/issues_insert_for_variant.sql',
  'apps/prairielearn/src/sprocs/variants_select.sql',
  'apps/prairielearn/src/sprocs/variants_select_for_assessment_instance_grading.sql',
  'apps/prairielearn/src/sync/course-db.js',
  'apps/prairielearn/src/tests/accessibility/index.test.js',
  'apps/prairielearn/src/tests/gradingMethods.test.js',
  'apps/prairielearn/src/tests/groupGenerateAndDelete.test.js',
  'apps/prairielearn/src/tests/sync/assessmentsSync.test.js',
  'apps/workspace-host/src/interface.sql',
  'docker/start_redis.sh',
  'docs/elements.md',
  'docs/externalGrading.md',
  'docs/installing.md',
  'docs/installingLocal.md',
  'docs/question.md',
  'docs/workspaces/index.md',
  'exampleCourse/courseInstances/SectionA/assessments/demo/externalGrading/infoAssessment.json',
  'exampleCourse/questions/demo/autograder/python/randomFunctionName/info.json',
  'exampleCourse/questions/demo/autograder/python/randomFunctionName/question.html',
  'exampleCourse/questions/demo/autograder/python/randomFunctionName/server.py',
  'exampleCourse/questions/demo/autograder/python/randomFunctionName/tests/ans.py',
  'exampleCourse/questions/demo/autograder/python/randomFunctionName/tests/setup_code.py',
  'exampleCourse/questions/demo/autograder/python/randomFunctionName/tests/test.py',
  'exampleCourse/questions/element/bigOInput/question.html',
  'exampleCourse/questions/element/orderBlocks/question.html',
  ... 55 more items
]
changedChunks {
  elements: false,
  elementExtensions: false,
  clientFilesCourse: false,
  serverFilesCourse: false,
  courseInstances: {},
  questions: Set(0) {}
}
```

After this change, it correctly identified that four questions had changed (note that `changedFiles` does not include a leading `exampleCourse/`:

```ts
changedFiles [
  'courseInstances/SectionA/assessments/demo/externalGrading/infoAssessment.json',
  'questions/demo/autograder/python/randomFunctionName/info.json',
  'questions/demo/autograder/python/randomFunctionName/question.html',
  'questions/demo/autograder/python/randomFunctionName/server.py',
  'questions/demo/autograder/python/randomFunctionName/tests/ans.py',
  'questions/demo/autograder/python/randomFunctionName/tests/setup_code.py',
  'questions/demo/autograder/python/randomFunctionName/tests/test.py',
  'questions/element/bigOInput/question.html',
  'questions/element/orderBlocks/question.html',
  'questions/template/numberInput/question.html',
  'questions/template/numberInput/server.py'
]
changedChunks {
  elements: false,
  elementExtensions: false,
  clientFilesCourse: false,
  serverFilesCourse: false,
  courseInstances: {},
  questions: Set(4) {
    'demo/autograder/python/randomFunctionName',
    'element/bigOInput',
    'element/orderBlocks',
    'template/numberInput'
  }
}
```