### PR TITLE
Fix response on unsuccessful group creation

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessmentExam/studentAssessmentExam.js
+++ b/apps/prairielearn/src/pages/studentAssessmentExam/studentAssessmentExam.js
@@ -166,7 +166,7 @@ router.post(
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,
-        function (err, succeeded, uniqueGroupName, invalidGroupName, permissions) {
+        function (err, succeeded, uniqueGroupName, invalidGroupName, groupConfig) {
           if (ERR(err, next)) return;
           if (succeeded) {
             res.redirect(req.originalUrl);
@@ -176,8 +176,9 @@ router.post(
             } else {
               res.locals.uniqueGroupName = uniqueGroupName;
             }
-            res.locals.permissions = permissions;
-            res.locals.groupsize = 0;
+            res.locals.notInGroup = true;
+            res.locals.groupConfig = groupConfig;
+            res.locals.groupSize = 0;
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
           }
         }


### PR DESCRIPTION
## Problem

<img width="500" alt="Attempting to create a group with an existing name" src="https://github.com/PrairieLearn/PrairieLearn/assets/55109467/6ff53343-afd5-4970-bb7d-7ef70cad82f0">

A small bug related to group exams was introduced in #6109, which can be reproduced with the following steps:

- Create a group in a group work exam assessment
- As another user, create a group with the same name

These steps result in the following error:

<img width="500" alt="Error showing the local variable notInGroup is undefined" src="https://github.com/PrairieLearn/PrairieLearn/assets/55109467/00991e23-7e48-4ca6-b8c3-cf2d2ab8639a">

## Solution

In #6109, we changed the local variables returned in the response to POST requests with the `create_group` action when users create groups in group **homework** assessments. However, we neglected to make the proper changes for group **exam** assessments - this PR implements those changes. The correct response looks like the following:

<img width="500" alt="Correct error message when creating a group with name that already exists" src="https://github.com/PrairieLearn/PrairieLearn/assets/55109467/21530b02-897a-400c-9d87-dacbff7f73bd">
