### PR TITLE
Improve course image syncing

### DIFF
--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ejs
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ejs
@@ -79,7 +79,14 @@
               <tbody>
               <% images.forEach((image) => { %>
                 <tr>
-                  <td><%= image.image %></td>
+                  <td>
+                    <div class="d-flex flex-row align-items-center">
+                      <span class="mr-2"><%= image.image %></span>
+                      <% if (image.invalid) { %>
+                        <span class="badge badge-danger">Invalid image name</span>
+                      <% } %>
+                    </div>
+                  </td>
                   <td><%= image.tag %></td>
                   <td><pre class="mb-0" title="<%= image.digest_full %>"><%= image.digest %></pre></td>
                   <td><%= image.size ? image.size.toFixed(2) + ' MB' : ''; %></td>

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ejs
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ejs
@@ -62,85 +62,84 @@
           Docker images
         </div>
 
-        <div class="table-responsive">
-          <table class="table table-sm">
-            <thead>
-              <tr>
-                  <th>Image name</th>
-                  <th>Tag</th>
-                  <th>Digest</th>
-                  <th>Image size</th>
-                  <th>Last sync</th>
-                  <th>Actions</th>
-                  <th>Used by</th>
-              </tr>
-            </thead>
-            <tbody>
-            <% images.forEach((image) => { %>
-              <tr>
-                <td><%= image.image %></td>
-                <td><%= image.tag %></td>
-                <td><pre class="mb-0" title="<%= image.digest_full %>"><%= image.digest %></pre></td>
-                <td><%= image.size ? image.size.toFixed(2) + ' MB' : ''; %></td>
-                <td>
-                  <% if (image.imageSyncNeeded) { %>
-                  <span class="text-warning">Not found in PL registry</span>
-                  <% } else { %>
-                  <%= image.pushed_at_formatted %>
-                  <% } %>
-                </td>
-                <td>
-                  <% if (config.cacheImageRegistry) { %>
-                    <form method="POST">
-                        <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
-                        <input type="hidden" name="__action" value="syncImages">
-                        <input type="hidden" name="single_image" value="<%= image.image %>">
-                        <button type="submit" class="btn btn-xs btn-primary">
-                          <i class="fa fa-sync" aria-hidden="true"></i> Sync
-                        </button>
-                    </form>
-                  <% } %>
-                </td>
-                <td>
-                  <% if (image.questions.length > 0) { %>
-                  <%= image.questions.length %> question<% if (image.questions.length > 1) { %>s<% } %>
+        <% if (images.length > 0) { %>
+          <div class="table-responsive">
+            <table class="table table-sm">
+              <thead>
+                <tr>
+                    <th>Image name</th>
+                    <th>Tag</th>
+                    <th>Digest</th>
+                    <th>Image size</th>
+                    <th>Last sync</th>
+                    <th>Actions</th>
+                    <th>Used by</th>
+                </tr>
+              </thead>
+              <tbody>
+              <% images.forEach((image) => { %>
+                <tr>
+                  <td><%= image.image %></td>
+                  <td><%= image.tag %></td>
+                  <td><pre class="mb-0" title="<%= image.digest_full %>"><%= image.digest %></pre></td>
+                  <td><%= image.size ? image.size.toFixed(2) + ' MB' : ''; %></td>
+                  <td>
+                    <% if (image.imageSyncNeeded) { %>
+                    <span class="text-warning">Not found in PL registry</span>
+                    <% } else { %>
+                    <%= image.pushed_at_formatted %>
+                    <% } %>
+                  </td>
+                  <td>
+                    <% if (config.cacheImageRegistry) { %>
+                      <form method="POST">
+                          <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+                          <input type="hidden" name="__action" value="syncImages">
+                          <input type="hidden" name="single_image" value="<%= image.image %>">
+                          <button type="submit" class="btn btn-xs btn-primary">
+                            <i class="fa fa-sync" aria-hidden="true"></i> Sync
+                          </button>
+                      </form>
+                    <% } %>
+                  </td>
+                  <td>
+                    <% if (image.questions.length > 0) { %>
+                    <%= image.questions.length %> question<% if (image.questions.length > 1) { %>s<% } %>
 
-                  <a class="btn btn-xs btn-secondary" role="button"
-                   tabindex="0" data-toggle="popover" data-html="true"
-                   title="Questions using <%= image.image %>"
-                   data-content="<%= include('listQuestionsPopover', {image}); %>"
-                   data-trigger="focus" href="#">
-                    Show
-                  </a>
-                  <% } else { %>
-                  No questions
-                  <% } %>
-                </td>
-              </tr>
-            <% }); %>
-            </tbody>
-            <tfoot>
-              <tr>
-                <td colspan=10>
-                  <% if (images.length == 0) { %>
-                    <em>No questions are using docker images.</em>
-                  <% } else if (config.cacheImageRegistry) { %>
-                    <form name="confirm-form" method="POST">
-                      <input type="hidden" name="__action" value="syncImages">
-                      <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
-                      <button type="submit" class="btn btn-sm btn-primary">
-                        <i class="fa fa-sync" aria-hidden="true"></i>
-                        Sync all images from Docker Hub to PrairieLearn
-                      </button>
-                    </form>
-                  <% } else { %>
-                      Local image repository not configured
-                  <% } %>
-                </td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+                    <a class="btn btn-xs btn-secondary" role="button"
+                    tabindex="0" data-toggle="popover" data-html="true"
+                    title="Questions using <%= image.image %>"
+                    data-content="<%= include('listQuestionsPopover', {image}); %>"
+                    data-trigger="focus" href="#">
+                      Show
+                    </a>
+                    <% } else { %>
+                    No questions
+                    <% } %>
+                  </td>
+                </tr>
+              <% }); %>
+              </tbody>
+            </table>
+          </div>
+        <% } else { %>
+          <div class="card-body">
+            <em>No questions are using Docker images.</em>
+          </div>
+        <% } %>
+
+        <% if (config.cacheImageRegistry) { %>
+          <div class="card-footer">
+            <form name="confirm-form" method="POST">
+              <input type="hidden" name="__action" value="syncImages">
+              <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+              <button type="submit" class="btn btn-sm btn-primary">
+                <i class="fa fa-sync" aria-hidden="true"></i>
+                Sync all images from Docker Hub to PrairieLearn
+              </button>
+            </form>
+          </div>
+        <% } %>
       </div>
 
       <%# Sync history %> 

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
@@ -41,15 +41,21 @@ router.get('/', function (req, res, next) {
             // Default to get overwritten later
             image.pushed_at = null;
             image.imageSyncNeeded = false;
+            image.invalid = false;
             var params = {
               repositoryName: repository.getRepository(),
             };
             ecr.describeImages(params, (err, data) => {
-              if (err && err.name === 'RepositoryNotFoundException') {
-                image.imageSyncNeeded = true;
-                return callback(null);
-              } else if (ERR(err, callback)) {
-                return;
+              if (err) {
+                if (err.name === 'InvalidParameterException') {
+                  image.invalid = true;
+                  return callback(null);
+                } else if (err.name === 'RepositoryNotFoundException') {
+                  image.imageSyncNeeded = true;
+                  return callback(null);
+                } else if (ERR(err, callback)) {
+                  return;
+                }
               }
               res.locals.ecrInfo = {};
               data.imageDetails.forEach((imageDetails) => {


### PR DESCRIPTION
If someone accidentally used an invalid image name in one of their questions, the sync page would fail to load because ECR would error out (see #7980). This PR fixes that by handling the error appropriately and displaying an "Invalid image name" badge:

<img width="695" alt="Screenshot 2023-06-23 at 10 08 03" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/b4a83f24-386a-4f5f-9adb-8b9859ce382b">

I also tweaked the table itself:

- The empty state now does not display the table headers.
- If a cache image registry is not configured, there is no message displayed communicating that (it's never clear to the end user what a "local image repository" is).

Closes #7980.