### PR TITLE
Fix graphviz fontconfig warnings

### DIFF
--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -31,15 +31,21 @@ saved_path = copy.copy(sys.path)
 
 drop_privileges = os.environ.get("DROP_PRIVILEGES", False)
 
-# If we're configured to drop privileges, matplotlib won't be able to write to
-# its default config/cache dir. To keep it fast, we'll create a cache dir for
-# it and provide it with config via the `MPLCONFIGDIR` environment variable.
+# If we're configured to drop privileges (that is, if we're running in a
+# Docker container), various tools like matplotlib and fontconfig will be
+# unable to write to their default config/cache directories. This is because
+# the `$HOME` environment variable still points to `/root`, which is not
+# writable by the `executor` user.
+#
+# To work around this, we create a directory on `/tmp` and set `$XDG_CONFIG_HOME`
+# to point to it. matplotlib and fontconfig will respect this; other tools
+# should as well. If they don't, special cases can be added below.
 if drop_privileges:
-    config_dir_path = "/tmp/matplotlib"
+    config_home_path = "/tmp/xdg_config"
     oldmask = os.umask(000)
-    os.makedirs(config_dir_path, mode=0o777, exist_ok=True)
+    os.makedirs(config_home_path, mode=0o777, exist_ok=True)
     os.umask(oldmask)
-    os.environ["MPLCONFIGDIR"] = config_dir_path
+    os.environ["XDG_CONFIG_HOME"] = config_home_path
 
 # Silence matplotlib's FontManager logs; these can cause trouble with our
 # expectation that code execution doesn't log anything to stdout/stderr.

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -37,15 +37,23 @@ drop_privileges = os.environ.get("DROP_PRIVILEGES", False)
 # the `$HOME` environment variable still points to `/root`, which is not
 # writable by the `executor` user.
 #
-# To work around this, we create a directory on `/tmp` and set `$XDG_CONFIG_HOME`
-# to point to it. matplotlib and fontconfig will respect this; other tools
-# should as well. If they don't, special cases can be added below.
+# To work around this, we'll set `$XDG_CONFIG_HOME` and `$XDG_CACHE_HOME` to
+# directories created in `/tmp` that are world-writable. matplotlib and
+# fontconfig should respect these environment variables; other tools should as
+# well. If they don't, special cases can be added below.
 if drop_privileges:
     config_home_path = "/tmp/xdg_config"
+    cache_home_path = "/tmp/xdg_cache"
+
     oldmask = os.umask(000)
+
     os.makedirs(config_home_path, mode=0o777, exist_ok=True)
+    os.makedirs(cache_home_path, mode=0o777, exist_ok=True)
+
     os.umask(oldmask)
+
     os.environ["XDG_CONFIG_HOME"] = config_home_path
+    os.environ["XDG_CACHE_HOME"] = cache_home_path
 
 # Silence matplotlib's FontManager logs; these can cause trouble with our
 # expectation that code execution doesn't log anything to stdout/stderr.


### PR DESCRIPTION
The following error was reported on Slack:

![image](https://github.com/PrairieLearn/PrairieLearn/assets/1476544/617f8afd-e58a-42df-a48c-e4c746506120)

I don't know why exactly this error occured, or why it didn't occur consistently. However, it's reproducible on multiple environments. See inline comment for more details. This is similar to an issue we've faced before with matplotlib. The new fix should be generic enough to handle both that and the fontconfig warning.