### PR TITLE
Add NOT NULL constraint to workspace_hosts.instance_id

### DIFF
--- a/apps/prairielearn/src/migrations/20230626194943_workspace_hosts__instance_id__set_not_null.sql
+++ b/apps/prairielearn/src/migrations/20230626194943_workspace_hosts__instance_id__set_not_null.sql
@@ -1,0 +1,3 @@
+ALTER TABLE workspace_hosts
+ALTER COLUMN instance_id
+SET NOT NULL;

--- a/database/tables/workspace_hosts.pg
+++ b/database/tables/workspace_hosts.pg
@@ -1,7 +1,7 @@
 columns
     hostname: text
     id: bigint not null default nextval('workspace_hosts_id_seq'::regclass)
-    instance_id: text
+    instance_id: text not null
     launched_at: timestamp with time zone
     load_count: integer default 0
     ready_at: timestamp with time zone


### PR DESCRIPTION
Doing this ahead of #7333 so I don't need to leak null-checking into application code. All the places we insert into `workspace_hosts` have an `instance_id`, and I manually checked our production databases to ensure that all existing rows satisfy this constraint (they do).