### PR TITLE
Fix spelling of PGHOST environment variable

### DIFF
--- a/docker/start_postgres.sh
+++ b/docker/start_postgres.sh
@@ -25,13 +25,13 @@ if [[ $? == 4 ]]; then
     ACTION=start
 fi
 
-# Only locally start postgres if we weren't given a PG_HOST environment variable
-if [[ -z "$PG_HOST" ]]; then
+# Only locally start postgres if we weren't given a PGHOST environment variable
+if [[ -z "$PGHOST" ]]; then
   su postgres -c "pg_ctl --silent --log=${PGDATA}/postgresql.log ${ACTION}"
 fi
 
 if [[ "$ACTION" == "start" ]]; then
-    # wait for postgres to start (local or PG_HOST)
+    # wait for postgres to start (local or PGHOST)
     until pg_isready -q ; do sleep 1 ; done
 fi
 


### PR DESCRIPTION
the postgres tools expect PG not PG_ in the names