### PR TITLE
Add missing Latex package required by matplotlib

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -27,6 +27,7 @@ dnf -y install \
     tar \
     texlive \
     texlive-dvipng \
+    texlive-type1cm \
     tmux
 
 echo "installing node via nvm"


### PR DESCRIPTION
As discussed on Slack. The `texlive-type1cm` is required for matplotlib to work. It likely used to be a dependency of a package previously used in Amazon Linux 2, but the switch to Amazon Linux 2023 in #7363 caused this package to no longer be installed by default. This caused dynamic images created using matplotlib to fail in some cases, e.g., in the example course question `gallery/includeFigure/complex`.