### PR TITLE
Fix xterm workspace CSS

### DIFF
--- a/workspaces/xtermjs/src/index.html
+++ b/workspaces/xtermjs/src/index.html
@@ -5,13 +5,13 @@
         <script src="xterm/lib/xterm.js"></script>
         <script src="xterm-fit/lib/xterm-addon-fit.js"></script>
         <style>
-         div.terminal {
-             position: absolute;
-             left: 0;
-             right: 0;
-             top: 0;
-             bottom: 0;
-         }
+          #terminal {
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 0;
+            bottom: 0;
+          }
         </style>
     </head>
     <body>


### PR DESCRIPTION
The element with id `terminal` was recently changed from a `div` to a `main` for accessibility reasons, but the CSS wasn't updated to account for that change. This PR changes the CSS selector to just be `#terminal`, which should be resilient to future changes.