### PR TITLE
pl-order-blocks: restore typechecking

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -1,14 +1,12 @@
-from typing import Mapping, Optional, Iterable
 import itertools
 from collections import Counter
 from copy import deepcopy
+from typing import Iterable, Mapping, Optional
 
 import networkx as nx
 
 
-def validate_grouping(
-    graph: Mapping[str, list[str]], group_belonging: Mapping[str, str]
-):
+def validate_grouping(graph: nx.DiGraph, group_belonging: Mapping[str, Optional[str]]):
     for node in graph:
         group_tag = group_belonging.get(node)
         if group_tag is None:
@@ -30,7 +28,7 @@ def validate_grouping(
 
 
 def solve_dag(
-    depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, str]
+    depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, Optional[str]]
 ):
     """Solve the given problem
     :param depends_graph: The dependency graph between blocks specified in the question
@@ -70,7 +68,7 @@ def check_topological_sorting(submission: list[str], graph: nx.DiGraph) -> int:
 
 
 def check_grouping(
-    submission: list[str], group_belonging: Mapping[str, Optional[int]]
+    submission: list[str], group_belonging: Mapping[str, Optional[str]]
 ) -> int:
     """
     :param submission: candidate solution
@@ -100,7 +98,7 @@ def check_grouping(
 
 
 def dag_to_nx(
-    depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, str]
+    depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, Optional[str]]
 ) -> nx.DiGraph:
     """Convert input graph format into NetworkX object to utilize their algorithms."""
     graph = nx.DiGraph()
@@ -120,7 +118,9 @@ def dag_to_nx(
     return graph
 
 
-def add_edges_for_groups(graph: nx.DiGraph, group_belonging: Mapping[str, str]):
+def add_edges_for_groups(
+    graph: nx.DiGraph, group_belonging: Mapping[str, Optional[str]]
+):
     groups = {
         group: [tag for tag in group_belonging if group_belonging[tag] == group]
         for group in set(group_belonging.values())
@@ -150,8 +150,8 @@ def add_edges_for_groups(graph: nx.DiGraph, group_belonging: Mapping[str, str]):
 def grade_dag(
     submission: list[str],
     depends_graph: Mapping[str, list[str]],
-    group_belonging: Mapping[str, Optional[int]],
-) -> int:
+    group_belonging: Mapping[str, Optional[str]],
+) -> tuple[int, int]:
     """In order for a student submission to a DAG graded question to be deemed correct, the student
     submission must be a topological sort of the DAG and blocks which are in the same pl-block-group
     as one another must all appear contiguously.
@@ -202,7 +202,7 @@ def lcs_partial_credit(
     :return: edit distance from the student submission to some correct solution
     """
     graph = dag_to_nx(depends_graph, group_belonging)
-    trans_clos = nx.algorithms.dag.transitive_closure(graph)
+    trans_clos = nx.algorithms.dag.transitive_closure(graph)  # type: ignore
     submission_no_distractors = [node for node in submission if node in depends_graph]
 
     # if node1 must occur before node2 in any correct solution, but node2 occurs before

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -1,3 +1,4 @@
+from typing import Mapping, Optional, Iterable
 import itertools
 from collections import Counter
 from copy import deepcopy
@@ -5,7 +6,9 @@ from copy import deepcopy
 import networkx as nx
 
 
-def validate_grouping(graph, group_belonging):
+def validate_grouping(
+    graph: Mapping[str, list[str]], group_belonging: Mapping[str, str]
+):
     for node in graph:
         group_tag = group_belonging.get(node)
         if group_tag is None:
@@ -26,7 +29,9 @@ def validate_grouping(graph, group_belonging):
     return True
 
 
-def solve_dag(depends_graph, group_belonging):
+def solve_dag(
+    depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, str]
+):
     """Solve the given problem
     :param depends_graph: The dependency graph between blocks specified in the question
     :param group_belonging: which pl-block-group each block belongs to, specified in the question
@@ -50,7 +55,7 @@ def solve_dag(depends_graph, group_belonging):
     return sort
 
 
-def check_topological_sorting(submission, graph):
+def check_topological_sorting(submission: list[str], graph: nx.DiGraph) -> int:
     """
     :param submission: candidate for topological sorting
     :param graph: graph to check topological sorting over
@@ -64,7 +69,9 @@ def check_topological_sorting(submission, graph):
     return len(submission)
 
 
-def check_grouping(submission, group_belonging):
+def check_grouping(
+    submission: list[str], group_belonging: Mapping[str, Optional[int]]
+) -> int:
     """
     :param submission: candidate solution
     :param group_belonging: group that each block belongs to
@@ -92,7 +99,9 @@ def check_grouping(submission, group_belonging):
     return len(submission)
 
 
-def dag_to_nx(depends_graph, group_belonging):
+def dag_to_nx(
+    depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, str]
+) -> nx.DiGraph:
     """Convert input graph format into NetworkX object to utilize their algorithms."""
     graph = nx.DiGraph()
     for node in depends_graph:
@@ -111,7 +120,7 @@ def dag_to_nx(depends_graph, group_belonging):
     return graph
 
 
-def add_edges_for_groups(graph, group_belonging):
+def add_edges_for_groups(graph: nx.DiGraph, group_belonging: Mapping[str, str]):
     groups = {
         group: [tag for tag in group_belonging if group_belonging[tag] == group]
         for group in set(group_belonging.values())
@@ -138,7 +147,11 @@ def add_edges_for_groups(graph, group_belonging):
         graph.remove_node(group_tag)
 
 
-def grade_dag(submission, depends_graph, group_belonging):
+def grade_dag(
+    submission: list[str],
+    depends_graph: Mapping[str, list[str]],
+    group_belonging: Mapping[str, Optional[int]],
+) -> int:
     """In order for a student submission to a DAG graded question to be deemed correct, the student
     submission must be a topological sort of the DAG and blocks which are in the same pl-block-group
     as one another must all appear contiguously.
@@ -156,7 +169,7 @@ def grade_dag(submission, depends_graph, group_belonging):
     return min(top_sort_correctness, grouping_correctness), graph.number_of_nodes()
 
 
-def is_vertex_cover(G, vertex_cover):
+def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable):
     """this function from
     https://docs.ocean.dwavesys.com/projects/dwave-networkx/en/latest/_modules/dwave_networkx/algorithms/cover.html#is_vertex_cover
     """
@@ -164,7 +177,11 @@ def is_vertex_cover(G, vertex_cover):
     return all(u in cover or v in cover for u, v in G.edges)
 
 
-def lcs_partial_credit(submission, depends_graph, group_belonging):
+def lcs_partial_credit(
+    submission: list[str],
+    depends_graph: Mapping[str, list[str]],
+    group_belonging: Mapping[str, str],
+) -> int:
     """Computes the number of edits required to change the student solution into a correct solution using
     largest common subsequence edit distance (allows only additions and deletions, not replacing).
     The naive solution would be to enumerate all topological sorts, then get the edit distance to each of them,

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -6,7 +6,9 @@ from typing import Iterable, Mapping, Optional
 import networkx as nx
 
 
-def validate_grouping(graph: nx.DiGraph, group_belonging: Mapping[str, Optional[str]]):
+def validate_grouping(
+    graph: nx.DiGraph, group_belonging: Mapping[str, Optional[str]]
+) -> bool:
     for node in graph:
         group_tag = group_belonging.get(node)
         if group_tag is None:
@@ -120,7 +122,7 @@ def dag_to_nx(
 
 def add_edges_for_groups(
     graph: nx.DiGraph, group_belonging: Mapping[str, Optional[str]]
-):
+) -> None:
     groups = {
         group: [tag for tag in group_belonging if group_belonging[tag] == group]
         for group in set(group_belonging.values())
@@ -180,7 +182,7 @@ def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable[str]) -> bool:
 def lcs_partial_credit(
     submission: list[str],
     depends_graph: Mapping[str, list[str]],
-    group_belonging: Mapping[str, str],
+    group_belonging: Mapping[str, Optional[str]],
 ) -> int:
     """Computes the number of edits required to change the student solution into a correct solution using
     largest common subsequence edit distance (allows only additions and deletions, not replacing).

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -31,7 +31,7 @@ def validate_grouping(
 
 def solve_dag(
     depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, Optional[str]]
-):
+) -> list[str]:
     """Solve the given problem
     :param depends_graph: The dependency graph between blocks specified in the question
     :param group_belonging: which pl-block-group each block belongs to, specified in the question

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -1,7 +1,7 @@
 import itertools
 from collections import Counter
 from copy import deepcopy
-from typing import Any, Iterable, Mapping, Optional
+from typing import Iterable, Mapping, Optional
 
 import networkx as nx
 

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -1,7 +1,7 @@
 import itertools
 from collections import Counter
 from copy import deepcopy
-from typing import Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import networkx as nx
 
@@ -169,7 +169,7 @@ def grade_dag(
     return min(top_sort_correctness, grouping_correctness), graph.number_of_nodes()
 
 
-def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable):
+def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable[str]) -> bool:
     """this function from
     https://docs.ocean.dwavesys.com/projects/dwave-networkx/en/latest/_modules/dwave_networkx/algorithms/cover.html#is_vertex_cover
     """
@@ -202,7 +202,7 @@ def lcs_partial_credit(
     :return: edit distance from the student submission to some correct solution
     """
     graph = dag_to_nx(depends_graph, group_belonging)
-    trans_clos = nx.algorithms.dag.transitive_closure(graph)  # type: ignore
+    trans_clos = nx.transitive_closure(graph)
     submission_no_distractors = [node for node in submission if node in depends_graph]
 
     # if node1 must occur before node2 in any correct solution, but node2 occurs before

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -804,11 +804,10 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
                         feedback += FIRST_WRONG_FEEDBACK["block-group"]
                     feedback += "</ul>"
 
-    data["partial_scores"][answer_name] = {  # type: ignore
+    data["partial_scores"][answer_name] = {
         "score": round(final_score, 2),
         "feedback": feedback,
-        "weight": answer_weight,
-        "first_wrong": first_wrong,
+        "weight": answer_weight
     }
 
 
@@ -839,11 +838,10 @@ def test(element_html: str, data: pl.ElementTestData) -> None:
             data["correct_answers"][answer_name], ["inner_html", "indent", "uuid"]
         )
         data["raw_submitted_answers"][answer_name_field] = json.dumps(answer)
-        data["partial_scores"][answer_name] = {  # type: ignore
+        data["partial_scores"][answer_name] = {
             "score": 1,
             "weight": weight,
-            "feedback": "",
-            "first_wrong": -1,
+            "feedback": ""
         }
 
     # TODO: The only wrong answer being tested is the correct answer with the first
@@ -886,11 +884,10 @@ def test(element_html: str, data: pl.ElementTestData) -> None:
             feedback = ""
 
         data["raw_submitted_answers"][answer_name_field] = json.dumps(answer)
-        data["partial_scores"][answer_name] = {  # type: ignore
+        data["partial_scores"][answer_name] = {
             "score": score,
             "weight": weight,
-            "feedback": feedback,
-            "first_wrong": first_wrong,
+            "feedback": feedback
         }
 
     else:

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -14,28 +14,6 @@ from dag_checker import grade_dag, lcs_partial_credit, solve_dag
 from lxml import etree
 from typing_extensions import NotRequired, assert_never
 
-PL_ANSWER_CORRECT_DEFAULT = True
-PL_ANSWER_INDENT_DEFAULT = -1
-ALLOW_BLANK_DEFAULT = False
-INDENTION_DEFAULT = False
-MAX_INDENTION_DEFAULT = 4
-SOURCE_HEADER_DEFAULT = "Drag from here:"
-SOLUTION_HEADER_DEFAULT = "Construct your solution here:"
-FILE_NAME_DEFAULT = "user_code.py"
-SOLUTION_PLACEMENT_DEFAULT = "right"
-WEIGHT_DEFAULT = 1
-TAB_SIZE_PX = 50
-
-FIRST_WRONG_FEEDBACK = {
-    "incomplete": "Your answer is correct so far, but it is incomplete.",
-    "wrong-at-block": r"""Your answer is incorrect starting at <span style="color:red;">block number {}</span>.
-        The problem is most likely one of the following:
-        <ul><li> This block is not a part of the correct solution </li>
-        <li>This block needs to come after a block that did not appear before it </li>""",
-    "indentation": r"""<li>This line is indented incorrectly </li>""",
-    "block-group": r"""<li> You have attempted to start a new section of the answer without finishing the previous section </li>""",
-}
-
 
 class GradingMethodType(Enum):
     UNORDERED = "unordered"
@@ -66,11 +44,6 @@ class FormatType(Enum):
     CODE = "code"
 
 
-GRADING_METHOD_DEFAULT = GradingMethodType.ORDERED
-SOURCE_BLOCKS_ORDER_DEFAULT = SourceBlocksOrderType.ALPHABETIZED
-FEEDBACK_DEFAULT = FeedbackType.NONE
-
-
 class GroupInfo(TypedDict):
     tag: Optional[str]
     depends: Optional[list[str]]
@@ -87,6 +60,31 @@ class OrderBlocksAnswerData(TypedDict):
     group_info: GroupInfo  # only used with DAG grader
     distractor_bin: NotRequired[str]
     uuid: str
+
+
+GRADING_METHOD_DEFAULT = GradingMethodType.ORDERED
+SOURCE_BLOCKS_ORDER_DEFAULT = SourceBlocksOrderType.ALPHABETIZED
+FEEDBACK_DEFAULT = FeedbackType.NONE
+PL_ANSWER_CORRECT_DEFAULT = True
+PL_ANSWER_INDENT_DEFAULT = -1
+ALLOW_BLANK_DEFAULT = False
+INDENTION_DEFAULT = False
+MAX_INDENTION_DEFAULT = 4
+SOURCE_HEADER_DEFAULT = "Drag from here:"
+SOLUTION_HEADER_DEFAULT = "Construct your solution here:"
+FILE_NAME_DEFAULT = "user_code.py"
+SOLUTION_PLACEMENT_DEFAULT = "right"
+WEIGHT_DEFAULT = 1
+TAB_SIZE_PX = 50
+FIRST_WRONG_FEEDBACK = {
+    "incomplete": "Your answer is correct so far, but it is incomplete.",
+    "wrong-at-block": r"""Your answer is incorrect starting at <span style="color:red;">block number {}</span>.
+        The problem is most likely one of the following:
+        <ul><li> This block is not a part of the correct solution </li>
+        <li>This block needs to come after a block that did not appear before it </li>""",
+    "indentation": r"""<li>This line is indented incorrectly </li>""",
+    "block-group": r"""<li> You have attempted to start a new section of the answer without finishing the previous section </li>""",
+}
 
 
 def filter_multiple_from_array(
@@ -198,7 +196,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
         raise Exception('code-language attribute may only be used with format="code"')
 
     correct_answers: list[OrderBlocksAnswerData] = []
-    incorrect_answers = []
+    incorrect_answers: list[OrderBlocksAnswerData] = []
     used_tags = set()
 
     def prepare_tag(

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -60,6 +60,7 @@ class PartialCreditType(Enum):
     NONE = "none"
     LCS = "lcs"
 
+
 class FormatType(Enum):
     DEFAULT = "default"
     CODE = "code"
@@ -419,7 +420,9 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     answer_name = pl.get_string_attrib(element, "answers-name")
     format = pl.get_string_attrib(element, "format", "default")
 
-    block_formatting = "pl-order-blocks-code" if format is FormatType.CODE else "list-group-item"
+    block_formatting = (
+        "pl-order-blocks-code" if format is FormatType.CODE else "list-group-item"
+    )
     grading_method = pl.get_enum_attrib(
         element, "grading-method", GradingMethodType, GRADING_METHOD_DEFAULT
     )
@@ -850,8 +853,10 @@ def test(element_html: str, data: pl.ElementTestData) -> None:
         answer.pop(0)
         score = 0
         if grading_method is GradingMethodType.UNORDERED or (
-            (grading_method is GradingMethodType.DAG
-            or grading_method is GradingMethodType.RANKING)
+            (
+                grading_method is GradingMethodType.DAG
+                or grading_method is GradingMethodType.RANKING
+            )
             and partial_credit_type is PartialCreditType.LCS
         ):
             score = round(float(len(answer)) / (len(answer) + 1), 2)

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -175,7 +175,8 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     if (
         grading_method is not GradingMethodType.DAG
         and grading_method is not GradingMethodType.RANKING
-        and pl.get_enum_attrib(element, "partial-credit", PartialCreditType) is not None
+        and pl.get_enum_attrib(element, "partial-credit", PartialCreditType, None)
+        is not None
     ):
         raise Exception(
             "You may only specify partial credit options in the DAG and ranking grading modes."

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -175,8 +175,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     if (
         grading_method is not GradingMethodType.DAG
         and grading_method is not GradingMethodType.RANKING
-        and pl.get_enum_attrib(element, "partial-credit", PartialCreditType, None)
-        is not None
+        and pl.has_attrib(element, "partial-credit")
     ):
         raise Exception(
             "You may only specify partial credit options in the DAG and ranking grading modes."

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -191,7 +191,9 @@ def get_enum_attrib(
     accepted_names = {member.name.replace("_", "-") for member in enum_type}
 
     if upper_enum_str not in accepted_names:
-        raise ValueError(f"{enum_val} is not a valid type")
+        raise ValueError(
+            f"{enum_val} is not a valid type, must be one of: {', '.join(str(member.value) for member in enum_type)}."
+        )
 
     return enum_type[upper_enum_str.replace("-", "_")]
 

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -172,11 +172,7 @@ def get_enum_attrib(
     provided, must be a member of the given enum.
     """
 
-    enum_val, is_default = (
-        _get_attrib(element, name)
-        if default is None
-        else _get_attrib(element, name, default)
-    )
+    enum_val, is_default = _get_attrib(element, name, default)
 
     # Default doesn't need to be converted, already a value of the enum
     if is_default:

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -160,7 +160,7 @@ def get_enum_attrib(
     element: lxml.html.HtmlElement,
     name: str,
     enum_type: Type[EnumT],
-    default: Optional[EnumT] = None,
+    *args,
 ) -> EnumT:
     """
     Returns the named attribute for the element parsed as an enum,
@@ -172,7 +172,7 @@ def get_enum_attrib(
     provided, must be a member of the given enum.
     """
 
-    enum_val, is_default = _get_attrib(element, name, default)
+    enum_val, is_default = _get_attrib(element, name, *args)
 
     # Default doesn't need to be converted, already a value of the enum
     if is_default:

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -183,7 +183,7 @@ def get_enum_attrib(
 
     if enum_val != enum_val.lower():
         raise ValueError(
-            f'Value "{enum_val}" assigned to "{name}" cannot have uppercase characters.'
+            f"{enum_val} is not a valid type, must be one of: {', '.join(member.name.lower().replace('_', '-') for member in enum_type)}."
         )
 
     upper_enum_str = enum_val.upper()

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -177,13 +177,14 @@ def get_enum_attrib(
         if default is None
         else _get_attrib(element, name, default)
     )
+
     # Default doesn't need to be converted, already a value of the enum
     if is_default:
         return enum_val
 
     if enum_val != enum_val.lower():
         raise ValueError(
-            f"{enum_val} is not a valid type, must be one of: {', '.join(member.name.lower().replace('_', '-') for member in enum_type)}."
+            f'Value "{enum_val}" assigned to "{name}" cannot have uppercase characters.'
         )
 
     upper_enum_str = enum_val.upper()
@@ -191,7 +192,7 @@ def get_enum_attrib(
 
     if upper_enum_str not in accepted_names:
         raise ValueError(
-            f"{enum_val} is not a valid type, must be one of: {', '.join(str(member.value) for member in enum_type)}."
+            f"{enum_val} is not a valid type, must be one of: {', '.join(member.name.lower().replace('_', '-') for member in enum_type)}."
         )
 
     return enum_type[upper_enum_str.replace("-", "_")]

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -160,7 +160,7 @@ def get_enum_attrib(
     element: lxml.html.HtmlElement,
     name: str,
     enum_type: Type[EnumT],
-    *args,
+    default: Optional[EnumT] = None,
 ) -> EnumT:
     """
     Returns the named attribute for the element parsed as an enum,
@@ -172,8 +172,11 @@ def get_enum_attrib(
     provided, must be a member of the given enum.
     """
 
-    enum_val, is_default = _get_attrib(element, name, *args)
-
+    enum_val, is_default = (
+        _get_attrib(element, name)
+        if default is None
+        else _get_attrib(element, name, default)
+    )
     # Default doesn't need to be converted, already a value of the enum
     if is_default:
         return enum_val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ include = [
     "./apps/prairielearn/elements/pl-matrix-latex",
     "./apps/prairielearn/elements/pl-manual-grading-only",
     "./apps/prairielearn/elements/pl-overlay",
+    "./apps/prairielearn/elements/pl-order-blocks",
     "./apps/prairielearn/elements/pl-python-variable",
     "./apps/prairielearn/elements/pl-question-panel",
     "./apps/prairielearn/elements/pl-submission-panel",


### PR DESCRIPTION
originally disabled in #5292

In addition to type checking and function annotations, a few of the option attributes were converted to Enums for better type safety.