### PR TITLE
Upgrade to Prettier 3

### DIFF
--- a/.changeset/heavy-hounds-hide.md
+++ b/.changeset/heavy-hounds-hide.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/prettier-plugin-sql': patch
+---
+
+Remove usage of deprecated API

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "plugins": ["@prairielearn/prettier-plugin-sql"]
 }

--- a/apps/grader-host/src/index.js
+++ b/apps/grader-host/src/index.js
@@ -77,7 +77,7 @@ async.series(
       }
 
       globalLogger.info(
-        'Connecting to database ' + pgConfig.user + '@' + pgConfig.host + ':' + pgConfig.database
+        'Connecting to database ' + pgConfig.user + '@' + pgConfig.host + ':' + pgConfig.database,
       );
       await sqldb.initAsync(pgConfig, idleErrorHandler);
       globalLogger.info('Successfully connected to database');
@@ -138,7 +138,7 @@ async.series(
               if (ERR(err, (err) => globalLogger.error('receive error:', err)));
               globalLogger.info('Completed full request cycle');
               next();
-            }
+            },
           );
         });
       }
@@ -156,7 +156,7 @@ async.series(
         process.exit(1);
       }, 1000);
     });
-  }
+  },
 );
 
 function isJobCanceled(job, callback) {
@@ -168,7 +168,7 @@ function isJobCanceled(job, callback) {
     (err, result) => {
       if (ERR(err, callback)) return;
       callback(null, result.rows[0].canceled);
-    }
+    },
   );
 }
 
@@ -220,7 +220,7 @@ function handleJob(job, done) {
       if (ERR(err, done)) return;
       logger.info('Successfully completed handleJob()');
       done(null);
-    }
+    },
   );
 }
 
@@ -255,7 +255,7 @@ async function reportReceived(info) {
       new SendMessageCommand({
         QueueUrl: config.resultsQueueUrl,
         MessageBody: JSON.stringify(messageBody),
-      })
+      }),
     );
   } catch (err) {
     // We don't want to fail the job if this notification fails
@@ -317,7 +317,7 @@ function initDocker(info, callback) {
             },
             (output) => {
               logger.info('docker output:', output);
-            }
+            },
           );
         });
       },
@@ -325,7 +325,7 @@ function initDocker(info, callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 
@@ -364,7 +364,7 @@ function initFiles(info, callback) {
             files.tempDir = dir;
             files.tempDirCleanup = cleanup;
             callback(null);
-          }
+          },
         );
       },
       async () => {
@@ -397,7 +397,7 @@ function initFiles(info, callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null, files);
-    }
+    },
   );
 }
 
@@ -467,7 +467,7 @@ function runJob(info, callback) {
           (err, container) => {
             if (ERR(err, callback)) return;
             callback(null, container);
-          }
+          },
         );
       },
       (container, callback) => {
@@ -484,7 +484,7 @@ function runJob(info, callback) {
               logger.info(`container> ${line.toString('utf8')}`);
             });
             callback(null, container);
-          }
+          },
         );
       },
       (container, callback) => {
@@ -540,7 +540,7 @@ function runJob(info, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null);
-          }
+          },
         );
       },
       (callback) => {
@@ -615,7 +615,7 @@ function runJob(info, callback) {
       } else {
         return callback(null, results);
       }
-    }
+    },
   );
 }
 
@@ -664,14 +664,14 @@ function uploadResults(info, callback) {
           new SendMessageCommand({
             QueueUrl: config.resultsQueueUrl,
             MessageBody: JSON.stringify(messageBody),
-          })
+          }),
         );
       },
     ],
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 
@@ -721,6 +721,6 @@ function uploadArchive(results, callback) {
       if (ERR(err, callback)) return;
       tempArchiveCleanup && tempArchiveCleanup();
       callback(null);
-    }
+    },
   );
 }

--- a/apps/grader-host/src/lib/logger.js
+++ b/apps/grader-host/src/lib/logger.js
@@ -30,7 +30,7 @@ logger.initCloudWatchLogging = function (groupName, streamName) {
       awsConfig: {
         region: config.awsRegion,
       },
-    })
+    }),
   );
 };
 

--- a/apps/grader-host/src/lib/pullImages.js
+++ b/apps/grader-host/src/lib/pullImages.js
@@ -46,7 +46,7 @@ module.exports = function (callback) {
               logger.info(
                 `Pulling latest version of "${image}" image from ${
                   config.cacheImageRegistry || 'default registry'
-                }`
+                }`,
               );
               var repository = new DockerName(image);
               if (config.cacheImageRegistry) {
@@ -69,7 +69,7 @@ module.exports = function (callback) {
                   },
                   (output) => {
                     logger.info('docker output:', output);
-                  }
+                  },
                 );
               });
             })((err) => {
@@ -81,13 +81,13 @@ module.exports = function (callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null);
-          }
+          },
         );
       },
     ],
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 };

--- a/apps/grader-host/src/lib/receiveFromQueue.js
+++ b/apps/grader-host/src/lib/receiveFromQueue.js
@@ -35,7 +35,7 @@ module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
                 MaxNumberOfMessages: 1,
                 QueueUrl: queueUrl,
                 WaitTimeSeconds: 20,
-              })
+              }),
             );
             const message = data.Messages?.[0];
             if (!message || !message.Body) return null;
@@ -50,7 +50,7 @@ module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null);
-          }
+          },
         );
       },
       (callback) => {
@@ -86,7 +86,7 @@ module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
             QueueUrl: queueUrl,
             ReceiptHandle: receiptHandle,
             VisibilityTimeout: newTimeout,
-          })
+          }),
         );
       },
       (callback) => {
@@ -99,7 +99,7 @@ module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
           () => {
             globalLogger.info(`Job ${parsedMessage.jobId} finished successfully.`);
             callback(null);
-          }
+          },
         );
       },
       async () => {
@@ -107,13 +107,13 @@ module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
           new DeleteMessageCommand({
             QueueUrl: queueUrl,
             ReceiptHandle: receiptHandle,
-          })
+          }),
         );
       },
     ],
     (err) => {
       if (ERR(err, doneCallback)) return;
       doneCallback(null);
-    }
+    },
   );
 };

--- a/apps/grader-host/src/tests/receiveFromQueue.test.js
+++ b/apps/grader-host/src/tests/receiveFromQueue.test.js
@@ -95,7 +95,7 @@ describe('queueReceiver', () => {
         assert.isNull(err);
         assert.equal(sqs.receiveMessage.args[0][0].input.QueueUrl, 'helloworld');
         done();
-      }
+      },
     );
   });
 
@@ -112,7 +112,7 @@ describe('queueReceiver', () => {
         assert.isNull(err);
         assert.equal(sqs.receiveMessage.callCount, 2);
         done();
-      }
+      },
     );
   });
 
@@ -129,7 +129,7 @@ describe('queueReceiver', () => {
         assert.isNotNull(err);
         assert.equal(sqs.deleteMessage.callCount, 0);
         done();
-      }
+      },
     );
   });
 
@@ -149,7 +149,7 @@ describe('queueReceiver', () => {
         assert.isNotNull(err);
         assert.equal(sqs.deleteMessage.callCount, 0);
         done();
-      }
+      },
     );
   });
 
@@ -170,7 +170,7 @@ describe('queueReceiver', () => {
         const params = sqs.changeMessageVisibility.args[0][0].input;
         assert.equal(params.VisibilityTimeout, 10 + TIMEOUT_OVERHEAD);
         done();
-      }
+      },
     );
   });
 
@@ -185,7 +185,7 @@ describe('queueReceiver', () => {
         assert.isNotNull(err);
         assert.equal(sqs.deleteMessage.callCount, 0);
         done();
-      }
+      },
     );
   });
 
@@ -202,7 +202,7 @@ describe('queueReceiver', () => {
         assert.equal(sqs.deleteMessage.args[0][0].input.QueueUrl, 'goodbyeworld');
         assert.equal(sqs.deleteMessage.args[0][0].input.ReceiptHandle, sqs.receiptHandle);
         done();
-      }
+      },
     );
   });
 });

--- a/apps/prairielearn/assets/scripts/examTimeLimitCountdown.ts
+++ b/apps/prairielearn/assets/scripts/examTimeLimitCountdown.ts
@@ -27,7 +27,7 @@ onDocumentReady(() => {
           html`<form method="POST">
             <input type="hidden" name="__action" value="timeLimitFinish" />
             <input type="hidden" name="__csrf_token" value="${timeLimitData.csrfToken}" />
-          </form>`
+          </form>`,
         ) as HTMLFormElement;
         document.body.append(form);
         form.submit();

--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -15,7 +15,7 @@ $(() => {
     ) {
       document
         .querySelectorAll(
-          `.js-selectable-rubric-item[data-key-binding="${event.key}"]:not(:disabled)`
+          `.js-selectable-rubric-item[data-key-binding="${event.key}"]:not(:disabled)`,
         )
         .forEach((item) => item.dispatchEvent(new MouseEvent('click')));
     }
@@ -46,7 +46,7 @@ function resetInstructorGradingPanel() {
           { backgroundColor: '#000', color: '#fff', offset: 0.5 },
           { backgroundColor: '', color: '', offset: 1 },
         ],
-        500
+        500,
       );
       $(e.trigger)
         .popover({
@@ -115,7 +115,7 @@ function resetInstructorGradingPanel() {
   document.querySelectorAll('.js-show-rubric-settings-button').forEach((button) =>
     button.addEventListener('click', function () {
       $('.js-rubric-settings-modal').modal('show');
-    })
+    }),
   );
 
   document
@@ -129,26 +129,26 @@ function resetInstructorGradingPanel() {
     link.addEventListener('click', function () {
       this.style.display = 'none';
       const input = this.closest('.js-adjust-points').querySelector(
-        '.js-adjust-points-input-container'
+        '.js-adjust-points-input-container',
       );
       input.style.display = '';
       input.classList.remove('d-none');
       input.querySelector('input').focus();
-    })
+    }),
   );
   document.querySelectorAll('.js-adjust-points-points').forEach((input) =>
     input.addEventListener('input', function () {
       this.closest('.js-adjust-points').querySelector('.js-adjust-points-percentage').value =
         (this.value * 100) / this.dataset.maxPoints;
       computePointsFromRubric();
-    })
+    }),
   );
   document.querySelectorAll('.js-adjust-points-percentage').forEach((input) =>
     input.addEventListener('input', function () {
       this.closest('.js-adjust-points').querySelector('.js-adjust-points-points').value =
         (this.value * this.dataset.maxPoints) / 100;
       computePointsFromRubric();
-    })
+    }),
   );
 
   document
@@ -168,8 +168,8 @@ function resetInstructorGradingPanel() {
     .querySelectorAll('.js-disable-rubric-button')
     .forEach((button) =>
       button.addEventListener('click', (e) =>
-        submitSettings.bind(button.closest('form'))(e, 'false')
-      )
+        submitSettings.bind(button.closest('form'))(e, 'false'),
+      ),
     );
 
   resetRubricItemRowsListeners();
@@ -205,7 +205,7 @@ function checkRubricItemTotals() {
     .map((input) => Number(input.value))
     .reduce(
       ([pos, neg], value) => (value > 0 ? [pos + value, neg] : [pos, neg + value]),
-      [startingPoints, startingPoints]
+      [startingPoints, startingPoints],
     );
   const minPoints = Number(form.querySelector('[name="min_points"]').value);
   const maxPoints =
@@ -219,7 +219,7 @@ function checkRubricItemTotals() {
       `Rubric item points reach at most ${totalPositive} points. ${
         maxPoints - totalPositive
       } left to reach maximum.`,
-      ['alert-warning']
+      ['alert-warning'],
     );
   }
 
@@ -227,7 +227,7 @@ function checkRubricItemTotals() {
     addAlert(
       form.querySelector('.js-settings-points-warning-placeholder'),
       `Minimum grade from rubric item penalties is ${totalNegative} points.`,
-      ['alert-warning']
+      ['alert-warning'],
     );
   }
 }
@@ -236,7 +236,7 @@ function submitSettings(e, use_rubric) {
   e.preventDefault();
   const modal = this.closest('.modal');
   const gradingForm = document.querySelector(
-    '.js-main-grading-panel form[name=manual-grading-form]'
+    '.js-main-grading-panel form[name=manual-grading-form]',
   );
   // Save values in grading rubric so they can be re-applied once the form is re-created.
   const rubricFormData = Array.from(new FormData(gradingForm).entries());
@@ -269,7 +269,7 @@ function submitSettings(e, use_rubric) {
 
         // Restore any values that had been set before the settings were configured.
         const newRubricForm = document.querySelector(
-          '.js-main-grading-panel form[name=manual-grading-form]'
+          '.js-main-grading-panel form[name=manual-grading-form]',
         );
         newRubricForm.querySelectorAll('input[type="checkbox"]').forEach((input) => {
           input.checked = false;
@@ -355,13 +355,13 @@ function updatePointsView(sourceInput) {
       roundPoints(
         sourceInput?.name === 'score_auto_percent'
           ? (sourceInput?.value * max_auto_points) / 100
-          : form.querySelector('[name=score_auto_points]')?.value
+          : form.querySelector('[name=score_auto_points]')?.value,
       ) || 0;
     const manual_points =
       roundPoints(
         sourceInput?.name === 'score_manual_percent'
           ? (sourceInput?.value * max_manual_points) / 100
-          : form.querySelector('[name=score_manual_points]')?.value
+          : form.querySelector('[name=score_manual_points]')?.value,
       ) || 0;
     const points = roundPoints(auto_points + manual_points);
     const auto_perc = roundPoints((auto_points * 100) / (max_auto_points || max_points));
@@ -403,7 +403,7 @@ function computePointsFromRubric(sourceInput = null) {
         Math.min(
           Math.max(Math.round(itemsSum * 100) / 100, Number(form.dataset.rubricMinPoints)),
           Number(replaceAutoPoints ? form.dataset.maxPoints : form.dataset.maxManualPoints) +
-            Number(form.dataset.rubricMaxExtraPoints)
+            Number(form.dataset.rubricMaxExtraPoints),
         ) + Number(form.querySelector('input[name="score_manual_adjust_points"]')?.value || 0);
       const manualPoints =
         rubricValue -
@@ -499,10 +499,10 @@ function addRubricItemRow() {
   row.querySelector('.js-rubric-item-points').value = points;
   row.querySelector('.js-rubric-item-description').name = `rubric_item[new${next_id}][description]`;
   row.querySelector(
-    '.js-rubric-item-explanation'
+    '.js-rubric-item-explanation',
   ).dataset.inputName = `rubric_item[new${next_id}][explanation]`;
   row.querySelector(
-    '.js-rubric-item-grader-note'
+    '.js-rubric-item-grader-note',
   ).dataset.inputName = `rubric_item[new${next_id}][grader_note]`;
 
   row.querySelector('.js-rubric-item-points').focus();

--- a/apps/prairielearn/assets/scripts/instructorFileEditorClient.js
+++ b/apps/prairielearn/assets/scripts/instructorFileEditorClient.js
@@ -60,7 +60,7 @@ window.InstructorFileEditor = function (options) {
 
         // Allow the editor to resize itself, filling the whole container
         this.editor.resize();
-      }.bind(this)
+      }.bind(this),
     );
   }
 
@@ -115,7 +115,7 @@ window.InstructorFileEditor.prototype.b64DecodeUnicode = function (str) {
       .map((c) => {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
       })
-      .join('')
+      .join(''),
   );
 };
 
@@ -126,7 +126,7 @@ window.InstructorFileEditor.prototype.b64EncodeUnicode = function (str) {
   return btoa(
     encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => {
       return String.fromCharCode('0x' + p1);
-    })
+    }),
   );
 };
 

--- a/apps/prairielearn/assets/scripts/mathjax.js
+++ b/apps/prairielearn/assets/scripts/mathjax.js
@@ -36,7 +36,7 @@ window.MathJax = {
       window.MathJax.Hub = {
         Queue: function () {
           console.warn(
-            'MathJax.Hub.Queue() has been deprecated in 3.0, please use MathJax.typeset() or MathJax.typesetPromise()'
+            'MathJax.Hub.Queue() has been deprecated in 3.0, please use MathJax.typeset() or MathJax.typesetPromise()',
           );
           window.MathJax.typesetPromise();
         },

--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -142,7 +142,7 @@ function fetchResults(socket, submissionId) {
         document.getElementById('question-nav-next').outerHTML = msg.questionNavNextButton;
       }
       setupDynamicObjects();
-    }
+    },
   );
 }
 

--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -21,12 +21,12 @@ $(function () {
   const heartbeatIntervalSec = getNumericalAttribute(
     document.body,
     'data-heartbeat-interval-sec',
-    60
+    60,
   );
   const visibilityTimeoutSec = getNumericalAttribute(
     document.body,
     'data-visibility-timeout-sec',
-    30 * 60
+    30 * 60,
   );
 
   const socket = io('/workspace');

--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -139,7 +139,7 @@ mechanicsObjects.Coil = fabric.util.createClass(fabric.Object, {
     let R = 0.5 * R2;
     let offsetAngle = (50 * Math.PI) / 180;
     let n = Math.floor(
-      (len - 3 * R - 2 * R * Math.cos(offsetAngle)) / (2 * R * Math.cos(offsetAngle))
+      (len - 3 * R - 2 * R * Math.cos(offsetAngle)) / (2 * R * Math.cos(offsetAngle)),
     );
     let l2 = len / 2;
 
@@ -1008,7 +1008,7 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
           this['canvas'].renderAll();
         }
       },
-      options
+      options,
     );
   },
   initialize: function (text, options) {
@@ -1420,7 +1420,7 @@ mechanicsObjects.makeCoordinates = function (options) {
     {
       angle: options.angle - 90,
     },
-    options
+    options,
   );
 
   let obj2 = new mechanicsObjects.Arrow(options2);
@@ -1433,7 +1433,7 @@ mechanicsObjects.makeCoordinates = function (options) {
       originY: 'center',
       fill: options.stroke,
     },
-    options
+    options,
   );
 
   let obj3 = new fabric.Circle(options3);
@@ -1608,7 +1608,7 @@ mechanicsObjects.byType['pl-rod'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c2);
           canvas.remove(obj);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.x1 = c1.left;
@@ -1630,7 +1630,7 @@ mechanicsObjects.byType['pl-rod'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c1);
           canvas.remove(obj);
-        }
+        },
       );
       c2.on('moving', function () {
         obj.x2 = c2.left;
@@ -1695,7 +1695,7 @@ mechanicsObjects.byType['pl-collar-rod'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c2);
           canvas.remove(obj);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.x1 = c1.left;
@@ -1717,7 +1717,7 @@ mechanicsObjects.byType['pl-collar-rod'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c1);
           canvas.remove(obj);
-        }
+        },
       );
       c2.on('moving', function () {
         obj.x2 = c2.left;
@@ -1784,7 +1784,7 @@ mechanicsObjects.byType['pl-3pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c2);
           canvas.remove(c3);
           canvas.remove(obj);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.x1 = c1.left;
@@ -1807,7 +1807,7 @@ mechanicsObjects.byType['pl-3pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c1);
           canvas.remove(c3);
           canvas.remove(obj);
-        }
+        },
       );
       c2.on('moving', function () {
         obj.x2 = c2.left;
@@ -1830,7 +1830,7 @@ mechanicsObjects.byType['pl-3pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c1);
           canvas.remove(c2);
           canvas.remove(obj);
-        }
+        },
       );
       c3.on('moving', function () {
         obj.x3 = c3.left;
@@ -1899,7 +1899,7 @@ mechanicsObjects.byType['pl-4pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c3);
           canvas.remove(c4);
           canvas.remove(obj);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.x1 = c1.left;
@@ -1923,7 +1923,7 @@ mechanicsObjects.byType['pl-4pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c3);
           canvas.remove(c4);
           canvas.remove(obj);
-        }
+        },
       );
       c2.on('moving', function () {
         obj.x2 = c2.left;
@@ -1947,7 +1947,7 @@ mechanicsObjects.byType['pl-4pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c2);
           canvas.remove(c4);
           canvas.remove(obj);
-        }
+        },
       );
       c3.on('moving', function () {
         obj.x3 = c3.left;
@@ -1971,7 +1971,7 @@ mechanicsObjects.byType['pl-4pointrod'] = class extends PLDrawingBaseElement {
           canvas.remove(c2);
           canvas.remove(c3);
           canvas.remove(obj);
-        }
+        },
       );
       c4.on('moving', function () {
         obj.x4 = c4.left;
@@ -2333,7 +2333,7 @@ mechanicsObjects.byType['pl-line'] = class extends PLDrawingBaseElement {
   static generate(canvas, options, submittedAnswer) {
     let obj = new fabric.Line(
       [options.x1, options.y1, options.x2, options.y2],
-      _.omit(options, 'left', 'top')
+      _.omit(options, 'left', 'top'),
     );
     obj.setControlVisible('bl', false);
     obj.setControlVisible('tl', false);
@@ -2379,7 +2379,7 @@ mechanicsObjects.byType['pl-line'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c2);
           canvas.remove(obj);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.set({ x1: c1.left, y1: c1.top });
@@ -2399,7 +2399,7 @@ mechanicsObjects.byType['pl-line'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c1);
           canvas.remove(obj);
-        }
+        },
       );
       c2.on('moving', function () {
         obj.set({ x2: c2.left, y2: c2.top });
@@ -2517,7 +2517,7 @@ mechanicsObjects.byType['pl-axes'] = class extends PLDrawingBaseElement {
         arrowheadWidthRatio: 1.5,
         arrowheadOffsetRatio: 1.5,
       },
-      options
+      options,
     );
     let obj1 = new mechanicsObjects.Arrow(options_axis_1);
     obj.addWithUpdate(obj1);
@@ -2533,7 +2533,7 @@ mechanicsObjects.byType['pl-axes'] = class extends PLDrawingBaseElement {
         arrowheadWidthRatio: 1.5,
         arrowheadOffsetRatio: 1.5,
       },
-      options
+      options,
     );
     let obj2 = new mechanicsObjects.Arrow(options_axis_2);
     obj.addWithUpdate(obj2);
@@ -2665,7 +2665,7 @@ mechanicsObjects.byType['pl-arc'] = class extends PLDrawingBaseElement {
           canvas.remove(c3);
           canvas.remove(obj);
           this.removeSubmittedAnswerObj(submittedAnswer, subObj);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.left = c1.left;
@@ -2700,7 +2700,7 @@ mechanicsObjects.byType['pl-arc'] = class extends PLDrawingBaseElement {
           canvas.remove(c3);
           canvas.remove(obj);
           submittedAnswer.deleteObject(subObj);
-        }
+        },
       );
       c2.on('moving', function () {
         const dy = c2.top - obj.top;
@@ -2733,7 +2733,7 @@ mechanicsObjects.byType['pl-arc'] = class extends PLDrawingBaseElement {
           canvas.remove(c2);
           canvas.remove(obj);
           submittedAnswer.deleteObject(subObj);
-        }
+        },
       );
       c3.on('moving', function () {
         const dy = c3.top - obj.top;
@@ -2789,7 +2789,7 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c1);
           canvas.remove(c2);
-        }
+        },
       );
       cc.on('moving', function () {
         obj.set({ x1: cc.left, y1: cc.top });
@@ -2810,7 +2810,7 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(cc);
           canvas.remove(c2);
-        }
+        },
       );
       c1.on('moving', function () {
         obj.set({ x2: c1.left, y2: c1.top });
@@ -2831,7 +2831,7 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(cc);
           canvas.remove(c1);
-        }
+        },
       );
       c2.on('moving', function () {
         obj.set({ x3: c2.left, y3: c2.top });
@@ -3137,7 +3137,7 @@ mechanicsObjects.byType['pl-paired-vector'] = class extends PLDrawingBaseElement
       function () {
         canvas.remove(obj1);
         canvas.remove(obj2);
-      }
+      },
     );
 
     mechanicsObjects.attachHandlersNoClone(
@@ -3152,7 +3152,7 @@ mechanicsObjects.byType['pl-paired-vector'] = class extends PLDrawingBaseElement
       function () {
         canvas.remove(obj1);
         canvas.remove(obj2);
-      }
+      },
     );
 
     return [obj1, obj2];
@@ -3459,19 +3459,19 @@ mechanicsObjects.byType['pl-controlled-line'] = class extends PLDrawingBaseEleme
       options.y1,
       options.x2,
       options.y2,
-      options
+      options,
     );
     var c1 = mechanicsObjects.makeControlHandle(
       options.x1,
       options.y1,
       options.handleRadius,
-      options.strokeWidth / 2
+      options.strokeWidth / 2,
     );
     var c2 = mechanicsObjects.makeControlHandle(
       options.x2,
       options.y2,
       options.handleRadius,
-      options.strokeWidth / 2
+      options.strokeWidth / 2,
     );
     canvas.add(line, c1, c2);
 
@@ -3517,7 +3517,7 @@ mechanicsObjects.byType['pl-controlled-line'] = class extends PLDrawingBaseEleme
         // Removed
         canvas.remove(c2);
         canvas.remove(line);
-      }
+      },
     );
     c1.on('moving', function () {
       line.set({ x1: c1.left, y1: c1.top });
@@ -3537,7 +3537,7 @@ mechanicsObjects.byType['pl-controlled-line'] = class extends PLDrawingBaseEleme
         // Removed
         canvas.remove(c1);
         canvas.remove(line);
-      }
+      },
     );
     c2.on('moving', function () {
       line.set({ x2: c2.left, y2: c2.top });
@@ -3560,26 +3560,26 @@ mechanicsObjects.byType['pl-controlled-curved-line'] = class extends PLDrawingBa
       options.y2,
       options.x3,
       options.y3,
-      options
+      options,
     );
     line.objectCaching = false;
     var c1 = mechanicsObjects.makeControlHandle(
       options.x1,
       options.y1,
       options.handleRadius,
-      options.strokeWidth / 2
+      options.strokeWidth / 2,
     );
     var c2 = mechanicsObjects.makeControlHandle(
       options.x2,
       options.y2,
       options.handleRadius,
-      options.strokeWidth / 2
+      options.strokeWidth / 2,
     );
     var c3 = mechanicsObjects.makeControlHandle(
       options.x3,
       options.y3,
       options.handleRadius,
-      options.strokeWidth / 2
+      options.strokeWidth / 2,
     );
 
     // c1 and c3 are the end points of the quadratic curve
@@ -3639,7 +3639,7 @@ mechanicsObjects.byType['pl-controlled-curved-line'] = class extends PLDrawingBa
         canvas.remove(c2);
         canvas.remove(c3);
         canvas.remove(line);
-      }
+      },
     );
     c1.on('moving', function () {
       line.path[0][1] = c1.left;
@@ -3661,7 +3661,7 @@ mechanicsObjects.byType['pl-controlled-curved-line'] = class extends PLDrawingBa
         canvas.remove(c1);
         canvas.remove(c3);
         canvas.remove(line);
-      }
+      },
     );
     c2.on('moving', function () {
       line.path[1][1] = c2.left;
@@ -3683,7 +3683,7 @@ mechanicsObjects.byType['pl-controlled-curved-line'] = class extends PLDrawingBa
         canvas.remove(c1);
         canvas.remove(c2);
         canvas.remove(line);
-      }
+      },
     );
     c3.on('moving', function () {
       line.path[1][3] = c3.left;
@@ -3947,7 +3947,7 @@ mechanicsObjects.byType['pl-resistor'] = class extends PLDrawingBaseElement {
         y2: options.y1 + ((d + 1.06 * gap) / 2) * Math.sin(theta),
         dx: gap / 10,
       },
-      options
+      options,
     );
     let resistorSpring = new mechanicsObjects.Spring(springOptions);
     if (!('id' in resistorSpring)) {
@@ -4024,7 +4024,7 @@ mechanicsObjects.byType['pl-inductor'] = class extends PLDrawingBaseElement {
         x2: options.x1 + ((d + 1.06 * gap) / 2) * Math.cos(theta),
         y2: options.y1 + ((d + 1.06 * gap) / 2) * Math.sin(theta),
       },
-      options
+      options,
     );
     let inductorCoil = new mechanicsObjects.Coil(coilOptions);
     if (!('id' in inductorCoil)) {
@@ -4097,7 +4097,7 @@ mechanicsObjects.byType['pl-switch'] = class extends PLDrawingBaseElement {
           left: xm1,
           top: ym1,
         },
-        options
+        options,
       );
       let objPin1 = new fabric.Circle(circleOptions);
       if (!('id' in objPin1)) {
@@ -4108,7 +4108,7 @@ mechanicsObjects.byType['pl-switch'] = class extends PLDrawingBaseElement {
           left: xm2,
           top: ym2,
         },
-        circleOptions
+        circleOptions,
       );
       let objPin2 = new fabric.Circle(circleOptions2);
       if (!('id' in objPin2)) {
@@ -4164,7 +4164,7 @@ mechanicsObjects.attachHandlersNoClone = function (
   reference,
   submittedAnswer,
   modifyHandler,
-  removeHandler
+  removeHandler,
 ) {
   submittedAnswer.updateObject(subObj);
   reference.on('modified', function () {
@@ -4196,7 +4196,7 @@ mechanicsObjects.createObjectHandlers = function (
   reference,
   submittedAnswer,
   modifyHandler,
-  removeHandler
+  removeHandler,
 ) {
   var subObj = mechanicsObjects.cloneMechanicsObject(type, options);
   mechanicsObjects.attachHandlersNoClone(
@@ -4204,7 +4204,7 @@ mechanicsObjects.createObjectHandlers = function (
     reference,
     submittedAnswer,
     modifyHandler,
-    removeHandler
+    removeHandler,
   );
 };
 

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -211,7 +211,7 @@ window.PLDrawingApi = {
         canvas,
         canvas_width,
         canvas_height,
-        elem_options.grid_size
+        elem_options.grid_size,
       );
     }
 
@@ -292,7 +292,7 @@ class PLDrawingAnswerState {
         console.trace(
           `Trying to set id ${object.id} from type ${this._answerData[object.id].type} to ${
             object.type
-          }`
+          }`,
         );
         console.warn('Existing', this._answerData[object.id]);
         console.warn('New', object);

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -150,7 +150,7 @@ window.PLFileEditor.prototype.initSettingsButton = function (uuid) {
             value: theme,
             text: caption,
             selected: localStorage.getItem('pl-file-editor-theme') === theme,
-          })
+          }),
         );
       }
 
@@ -163,7 +163,7 @@ window.PLFileEditor.prototype.initSettingsButton = function (uuid) {
             value: fontSizeList[entries],
             text: fontSizeList[entries],
             selected: localStorage.getItem('pl-file-editor-fontsize') === fontSizeList[entries],
-          })
+          }),
         );
       }
 
@@ -178,7 +178,7 @@ window.PLFileEditor.prototype.initSettingsButton = function (uuid) {
             value: keyboardHandler,
             text: keyboardHandlerList[index],
             selected: localStorage.getItem('pl-file-editor-keyboardHandler') === keyboardHandler,
-          })
+          }),
         );
       }
     });
@@ -188,7 +188,7 @@ window.PLFileEditor.prototype.initSettingsButton = function (uuid) {
     if (localStorage.getItem('pl-file-editor-keyboardHandler')) {
       sessionStorage.setItem(
         'pl-file-editor-keyboardHandler-current',
-        localStorage.getItem('pl-file-editor-keyboardHandler')
+        localStorage.getItem('pl-file-editor-keyboardHandler'),
       );
     }
 
@@ -230,7 +230,7 @@ window.PLFileEditor.prototype.initSettingsButton = function (uuid) {
     this.editor.setTheme(sessionStorage.getItem('pl-file-editor-theme-current'));
     this.editor.setFontSize(sessionStorage.getItem('pl-file-editor-fontsize-current'));
     this.editor.setKeyboardHandler(
-      sessionStorage.getItem('pl-file-editor-keyboardHandler-current')
+      sessionStorage.getItem('pl-file-editor-keyboardHandler-current'),
     );
 
     sessionStorage.removeItem('pl-file-editor-theme-current');
@@ -278,7 +278,7 @@ window.PLFileEditor.prototype.b64DecodeUnicode = function (str) {
       .map(function (c) {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
       })
-      .join('')
+      .join(''),
   );
 };
 
@@ -289,6 +289,6 @@ window.PLFileEditor.prototype.b64EncodeUnicode = function (str) {
   return btoa(
     encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(match, p1) {
       return String.fromCharCode('0x' + p1);
-    })
+    }),
   );
 };

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -65,7 +65,7 @@
           } catch (e) {
             console.error(e);
           }
-        })
+        }),
       );
     }
 
@@ -94,7 +94,7 @@
               '<strong>' +
                 file.name +
                 '</strong>' +
-                ' did not match any accepted file for this question.'
+                ' did not match any accepted file for this question.',
             );
             return;
           }
@@ -210,7 +210,7 @@
             uuid +
             '-' +
             index +
-            '"></div>'
+            '"></div>',
         );
         if (isExpanded) {
           $fileStatusContainer.removeClass('collapsed');
@@ -223,29 +223,29 @@
         $fileStatusContainer.append($fileStatusContainerLeft);
         if (this.pendingFileDownloads.has(fileName)) {
           $fileStatusContainerLeft.append(
-            '<i class="file-status-icon fas fa-spinner fa-spin" aria-hidden="true"></i>'
+            '<i class="file-status-icon fas fa-spinner fa-spin" aria-hidden="true"></i>',
           );
         } else if (this.failedFileDownloads.has(fileName)) {
           $fileStatusContainerLeft.append(
-            '<i class="file-status-icon fas fa-circle-exclamation text-danger" aria-hidden="true"></i>'
+            '<i class="file-status-icon fas fa-circle-exclamation text-danger" aria-hidden="true"></i>',
           );
         } else if (fileData) {
           $fileStatusContainerLeft.append(
-            '<i class="file-status-icon fa fa-check-circle text-success" aria-hidden="true"></i>'
+            '<i class="file-status-icon fa fa-check-circle text-success" aria-hidden="true"></i>',
           );
         } else {
           $fileStatusContainerLeft.append(
-            '<i class="file-status-icon far fa-circle" aria-hidden="true"></i>'
+            '<i class="file-status-icon far fa-circle" aria-hidden="true"></i>',
           );
         }
         $fileStatusContainerLeft.append(fileName);
         if (this.pendingFileDownloads.has(fileName)) {
           $fileStatusContainerLeft.append(
-            '<p class="file-status">fetching previous submission...</p>'
+            '<p class="file-status">fetching previous submission...</p>',
           );
         } else if (this.failedFileDownloads.has(fileName)) {
           $fileStatusContainerLeft.append(
-            '<p class="file-status">failed to fetch previous submission; upload this file again</p>'
+            '<p class="file-status">failed to fetch previous submission; upload this file again</p>',
           );
         } else if (!fileData) {
           $fileStatusContainerLeft.append('<p class="file-status">not uploaded</p>');
@@ -261,7 +261,11 @@
             '">Download</a>';
 
           var $preview = $(
-            '<div class="file-preview collapse" id="file-preview-' + uuid + '-' + index + '"></div>'
+            '<div class="file-preview collapse" id="file-preview-' +
+              uuid +
+              '-' +
+              index +
+              '"></div>',
           );
 
           var $error = $('<div class="alert alert-danger mt-2 d-none" role="alert"></div>');
@@ -271,7 +275,7 @@
           $preview.append($imgPreview);
 
           var $codePreview = $(
-            '<pre class="bg-dark text-white rounded p-3 mt-2 mb-0 d-none"><code></code></pre>'
+            '<pre class="bg-dark text-white rounded p-3 mt-2 mb-0 d-none"><code></code></pre>',
           );
           $preview.append($codePreview);
 
@@ -302,7 +306,7 @@
           $fileStatusContainer.append(
             '<div class="align-self-center">' +
               download +
-              '<button type="button" class="btn btn-outline-secondary btn-sm file-preview-button"><span class="file-preview-icon fa fa-angle-down"></span></button></div>'
+              '<button type="button" class="btn btn-outline-secondary btn-sm file-preview-button"><span class="file-preview-icon fa fa-angle-down"></span></button></div>',
           );
         }
 
@@ -312,7 +316,7 @@
 
     addWarningMessage(message) {
       var $alert = $(
-        '<div class="alert alert-warning alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
+        '<div class="alert alert-warning alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
       );
       $alert.append(message);
       this.element.find('.messages').append($alert);
@@ -348,7 +352,7 @@
           .map(function (c) {
             return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
           })
-          .join('')
+          .join(''),
       );
     }
   }

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
@@ -80,7 +80,7 @@ window.PLOrderBlocks = function (uuid, options) {
   function placePairingIndicators() {
     let answerObjs = Array.from($(optionsElementId)[0].getElementsByClassName('pl-order-block'));
     let allAns = answerObjs.concat(
-      Array.from($(dropzoneElementId)[0].getElementsByClassName('pl-order-block'))
+      Array.from($(dropzoneElementId)[0].getElementsByClassName('pl-order-block')),
     );
 
     let getDistractorBin = (block) => block.getAttribute('data-distractor-bin');
@@ -113,7 +113,7 @@ window.PLOrderBlocks = function (uuid, options) {
       containingIndicator.insertAdjacentElement('afterend', block);
     } else if (binUuid !== containingIndicatorUuid) {
       let properIndicatorList = getOrCreateIndicator(binUuid, block).getElementsByClassName(
-        'inner-list'
+        'inner-list',
       )[0];
       properIndicatorList.insertAdjacentElement('beforeend', block);
     }
@@ -128,7 +128,7 @@ window.PLOrderBlocks = function (uuid, options) {
       { length: maxIndent + 1 },
       (_, index) => {
         return `${+$(dropzoneElementId).css('padding-left').slice(0, -2) + TABWIDTH * index}px 0`;
-      }
+      },
     ).join(', ');
   }
 

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -42,8 +42,8 @@ window.PLRTE = function (uuid, options) {
         he.encode(contents, {
           allowUnsafeSymbols: true, // HTML tags should be kept
           useNamedReferences: true,
-        })
-      )
+        }),
+      ),
     );
   });
 };

--- a/apps/prairielearn/elements/pl-threejs/OrbitControls.js
+++ b/apps/prairielearn/elements/pl-threejs/OrbitControls.js
@@ -202,7 +202,7 @@ class OrbitControls extends THREE.EventDispatcher {
         // restrict radius to be between desired limits
         spherical.radius = Math.max(
           scope.minDistance,
-          Math.min(scope.maxDistance, spherical.radius)
+          Math.min(scope.maxDistance, spherical.radius),
         );
 
         // move target to panned location
@@ -389,18 +389,18 @@ class OrbitControls extends THREE.EventDispatcher {
             (deltaX * (scope.object.right - scope.object.left)) /
               scope.object.zoom /
               element.clientWidth,
-            scope.object.matrix
+            scope.object.matrix,
           );
           panUp(
             (deltaY * (scope.object.top - scope.object.bottom)) /
               scope.object.zoom /
               element.clientHeight,
-            scope.object.matrix
+            scope.object.matrix,
           );
         } else {
           // camera neither orthographic nor perspective
           console.warn(
-            'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.'
+            'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.',
           );
           scope.enablePan = false;
         }
@@ -413,13 +413,13 @@ class OrbitControls extends THREE.EventDispatcher {
       } else if (scope.object.isOrthographicCamera) {
         scope.object.zoom = Math.max(
           scope.minZoom,
-          Math.min(scope.maxZoom, scope.object.zoom * dollyScale)
+          Math.min(scope.maxZoom, scope.object.zoom * dollyScale),
         );
         scope.object.updateProjectionMatrix();
         zoomChanged = true;
       } else {
         console.warn(
-          'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.'
+          'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.',
         );
         scope.enableZoom = false;
       }
@@ -431,13 +431,13 @@ class OrbitControls extends THREE.EventDispatcher {
       } else if (scope.object.isOrthographicCamera) {
         scope.object.zoom = Math.max(
           scope.minZoom,
-          Math.min(scope.maxZoom, scope.object.zoom / dollyScale)
+          Math.min(scope.maxZoom, scope.object.zoom / dollyScale),
         );
         scope.object.updateProjectionMatrix();
         zoomChanged = true;
       } else {
         console.warn(
-          'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.'
+          'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.',
         );
         scope.enableZoom = false;
       }

--- a/apps/prairielearn/elements/pl-threejs/STLLoader.js
+++ b/apps/prairielearn/elements/pl-threejs/STLLoader.js
@@ -81,7 +81,7 @@ class STLLoader extends THREE.Loader {
         }
       },
       onProgress,
-      onError
+      onError,
     );
   }
 
@@ -271,7 +271,8 @@ class STLLoader extends THREE.Loader {
 
           if (normalCountPerFace !== 1) {
             console.error(
-              "THREE.STLLoader: Something isn't right with the normal of face number " + faceCounter
+              "THREE.STLLoader: Something isn't right with the normal of face number " +
+                faceCounter,
             );
           }
 
@@ -280,7 +281,7 @@ class STLLoader extends THREE.Loader {
           if (vertexCountPerFace !== 3) {
             console.error(
               "THREE.STLLoader: Something isn't right with the vertices of face number " +
-                faceCounter
+                faceCounter,
             );
           }
 

--- a/apps/prairielearn/elements/pl-threejs/pl-threejs.js
+++ b/apps/prairielearn/elements/pl-threejs/pl-threejs.js
@@ -126,7 +126,7 @@ function PLThreeJS(options) {
           if (onLoad) onLoad(font);
         },
         onProgress,
-        onError
+        onError,
       );
     }
 
@@ -195,7 +195,7 @@ function PLThreeJS(options) {
           char +
           '" does not exists in font family ' +
           data.familyName +
-          '.'
+          '.',
       );
 
       return;
@@ -266,7 +266,7 @@ function PLThreeJS(options) {
           function (font) {
             this.font = font;
             callback(null);
-          }.bind(this)
+          }.bind(this),
         );
       }.bind(this),
       // Load each stl
@@ -286,7 +286,7 @@ function PLThreeJS(options) {
                   });
                   var mesh = new THREE.Mesh(
                     geometry.scale(obj.scale, obj.scale, obj.scale),
-                    material
+                    material,
                   );
                   mesh.castShadow = true;
                   mesh.receiveShadow = true;
@@ -299,7 +299,7 @@ function PLThreeJS(options) {
                   }
                   // objects_to_drag.push(mesh);
                   callback(null);
-                }.bind(this)
+                }.bind(this),
               );
             } else if (obj.type === 'txt') {
               var geometry = new TextGeometry(obj.text, {
@@ -337,7 +337,7 @@ function PLThreeJS(options) {
           }.bind(this),
           function (err) {
             callback(err);
-          }
+          },
         );
       }.bind(this),
       function (callback) {
@@ -366,7 +366,7 @@ function PLThreeJS(options) {
 
         // buttons to toggle between camera and body motion
         $('#toggle-type-of-motion-' + uuid).change(
-          PLThreeJS.prototype.toggleTypeOfMotion.bind(this)
+          PLThreeJS.prototype.toggleTypeOfMotion.bind(this),
         );
 
         // mouse control of body pose
@@ -401,16 +401,16 @@ function PLThreeJS(options) {
 
         // buttons to toggle visibility
         $('#pl-threejs-button-bodyobjectsvisible-' + uuid).click(
-          PLThreeJS.prototype.toggleBodyObjectsVisible.bind(this)
+          PLThreeJS.prototype.toggleBodyObjectsVisible.bind(this),
         );
         $('#pl-threejs-button-spaceobjectsvisible-' + uuid).click(
-          PLThreeJS.prototype.toggleSpaceObjectsVisible.bind(this)
+          PLThreeJS.prototype.toggleSpaceObjectsVisible.bind(this),
         );
         $('#pl-threejs-button-framevisible-' + uuid).click(
-          PLThreeJS.prototype.toggleFrameVisible.bind(this)
+          PLThreeJS.prototype.toggleFrameVisible.bind(this),
         );
         $('#pl-threejs-button-shadowvisible-' + uuid).click(
-          PLThreeJS.prototype.toggleShadowVisible.bind(this)
+          PLThreeJS.prototype.toggleShadowVisible.bind(this),
         );
 
         // reset button
@@ -421,7 +421,7 @@ function PLThreeJS(options) {
             this.camera.position.fromArray(this.resetPose.camera_position);
             this.camera.lookAt(0, 0, 0);
             this.render();
-          }.bind(this)
+          }.bind(this),
         );
 
         // resize with window
@@ -433,7 +433,7 @@ function PLThreeJS(options) {
     function (_err, _results) {
       // Do nothing
       return;
-    }
+    },
   );
 }
 
@@ -686,7 +686,7 @@ PLThreeJS.prototype.onmousedown = function (event) {
     // - state for translation
     this.translatePlane.setFromNormalAndCoplanarPoint(
       this.camera.getWorldDirection(this.translatePlane.normal),
-      this.bodyGroup.position
+      this.bodyGroup.position,
     );
     if (this.raycaster.ray.intersectPlane(this.translatePlane, this.translateIntersection)) {
       this.translateOffset.copy(this.translateIntersection).sub(this.bodyGroup.position);
@@ -716,7 +716,7 @@ PLThreeJS.prototype.onmousemove = function (e) {
       var qCamera = this.camera.quaternion.clone();
       // Rotation to be applied by mouse motion (in camera frame)
       var qMotion = new THREE.Quaternion().setFromEuler(
-        new THREE.Euler(deltaMove.y * (Math.PI / 180), deltaMove.x * (Math.PI / 180), 0, 'XYZ')
+        new THREE.Euler(deltaMove.y * (Math.PI / 180), deltaMove.x * (Math.PI / 180), 0, 'XYZ'),
       );
       // Rotation to be applied by mouse motion (in world frame) - note that
       // ".inverse()" modifies qCamera in place, so the order here matters

--- a/apps/prairielearn/public/javascripts/PrairieDraw.js
+++ b/apps/prairielearn/public/javascripts/PrairieDraw.js
@@ -48,7 +48,7 @@
           Matrix.I(4),
           this._initViewAngleX3D,
           this._initViewAngleY3D,
-          this._initViewAngleZ3D
+          this._initViewAngleZ3D,
         );
         this._trans3DStack = [];
 
@@ -331,24 +331,24 @@
       this._viewAngleX3D = PrairieGeom.clip(
         this._viewAngleX3D,
         this._props.viewAngleXMin,
-        this._props.viewAngleXMax
+        this._props.viewAngleXMax,
       );
       this._viewAngleY3D = PrairieGeom.clip(
         this._viewAngleY3D,
         this._props.viewAngleYMin,
-        this._props.viewAngleYMax
+        this._props.viewAngleYMax,
       );
       this._viewAngleZ3D = PrairieGeom.clip(
         this._viewAngleZ3D,
         this._props.viewAngleZMin,
-        this._props.viewAngleZMax
+        this._props.viewAngleZMax,
       );
     }
     this._trans3D = PrairieGeom.rotateTransform3D(
       Matrix.I(4),
       this._viewAngleX3D,
       this._viewAngleY3D,
-      this._viewAngleZ3D
+      this._viewAngleZ3D,
     );
     if (redraw) {
       this.redraw();
@@ -365,7 +365,7 @@
       this._initViewAngleY3D,
       this._initViewAngleZ3D,
       undefined,
-      redraw
+      redraw,
     );
   };
 
@@ -381,7 +381,7 @@
       this._viewAngleX3D + deltaAngleX,
       this._viewAngleY3D + deltaAngleY,
       this._viewAngleZ3D + deltaAngleZ,
-      clip
+      clip,
     );
   };
 
@@ -1118,7 +1118,7 @@
     centerAngleDw,
     extentAngleDw,
     type,
-    fixedRad
+    fixedRad,
   ) {
     var startAngleDw = centerAngleDw - extentAngleDw / 2;
     var endAngleDw = centerAngleDw + extentAngleDw / 2;
@@ -1142,7 +1142,7 @@
     endAngleDw,
     type,
     fixedRad,
-    idealSegmentSize
+    idealSegmentSize,
   ) {
     this.save();
     this._ctx.lineWidth = this._props.arrowLineWidthPx;
@@ -1166,14 +1166,14 @@
       startAnglePx,
       startAnglePx,
       endAnglePx,
-      fixedRad
+      fixedRad,
     );
     var endRadiusPx = this._circleArrowRadius(
       radiusPx,
       endAnglePx,
       startAnglePx,
       endAnglePx,
-      fixedRad
+      fixedRad,
     );
     var arrowLengthPx = radiusPx * Math.abs(endAnglePx - startAnglePx);
     var arrowheadMaxLengthPx = this._props.arrowheadLengthRatio * this._props.arrowLineWidthPx;
@@ -1209,11 +1209,11 @@
       arrowBaseAnglePx,
       startAnglePx,
       endAnglePx,
-      fixedRad
+      fixedRad,
     );
     var arrowPosPx = posPx.add(PrairieGeom.vector2DAtAngle(endAnglePx).x(endRadiusPx));
     var arrowBasePosPx = posPx.add(
-      PrairieGeom.vector2DAtAngle(arrowBaseAnglePx).x(arrowBaseRadiusPx)
+      PrairieGeom.vector2DAtAngle(arrowBaseAnglePx).x(arrowBaseRadiusPx),
     );
     var arrowDirPx = arrowPosPx.subtract(arrowBasePosPx);
     var arrowPosDw = this.pos2Dw(arrowPosPx);
@@ -1237,7 +1237,7 @@
     anglePx,
     startAnglePx,
     endAnglePx,
-    fixedRad
+    fixedRad,
   ) {
     if (fixedRad !== undefined && fixedRad === true) {
       return midRadPx;
@@ -1281,7 +1281,7 @@
     refDw,
     startAngleDw,
     endAngleDw,
-    options
+    options,
   ) {
     posDw = this.pos2To3(posDw);
     normDw = normDw === undefined ? Vector.k : normDw;
@@ -1333,7 +1333,7 @@
     startAngleDw,
     endAngleDw,
     type,
-    options
+    options,
   ) {
     posDw = this.pos2To3(posDw);
     normDw = normDw || Vector.k;
@@ -1377,7 +1377,7 @@
     normDw,
     refDw,
     startAngleDw,
-    endAngleDw
+    endAngleDw,
   ) {
     if (labelText === undefined) {
       return;
@@ -1447,7 +1447,7 @@
     drawFront,
     refDw,
     startAngleDw,
-    endAngleDw
+    endAngleDw,
   ) {
     var cRDwSq = radDw * radDw - distDw * distDw;
     if (cRDwSq <= 0) {
@@ -1519,7 +1519,7 @@
           } else {
             intersections = PrairieGeom.intersectAngleRanges(
               [theta1, theta2],
-              [startAngleDw, endAngleDw]
+              [startAngleDw, endAngleDw],
             );
             for (i = 0; i < intersections.length; i++) {
               range = intersections[i];
@@ -1535,7 +1535,7 @@
         } else {
           intersections = PrairieGeom.intersectAngleRanges(
             [theta2, theta1 + 2 * Math.PI],
-            [startAngleDw, endAngleDw]
+            [startAngleDw, endAngleDw],
           );
           for (i = 0; i < intersections.length; i++) {
             range = intersections[i];
@@ -1687,7 +1687,7 @@
           pointsPx[i] = PrairieGeom.linearInterpVector(
             pointsPx[i],
             pointsPx[i - 1],
-            lengthToRemovePx / segmentLengthPx
+            lengthToRemovePx / segmentLengthPx,
           );
           break;
         }
@@ -1789,7 +1789,7 @@
     labelStart,
     labelEnd,
     arrowToLine,
-    arrowDown
+    arrowDown,
   ) {
     var LengthDw = endDw.subtract(startDw);
     var L = LengthDw.modulus();
@@ -1822,17 +1822,17 @@
       for (i = 0; i <= nSpaces; i++) {
         this.arrow(
           startArrow.add($V([inc, (inc * (sizeEndDwSign - sizeStartDwSign)) / L])),
-          endArrow.add($V([inc, 0]))
+          endArrow.add($V([inc, 0])),
         );
         inc = inc + spacing;
       }
       this.text(startArrow, $V([2, 0]), labelStart);
       this.text(
         startArrow.add(
-          $V([inc - spacing, ((inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L])
+          $V([inc - spacing, ((inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L]),
         ),
         $V([-2, 0]),
-        labelEnd
+        labelEnd,
       );
     } else {
       this.line(startDw, endDw);
@@ -1841,17 +1841,17 @@
       for (i = 0; i <= nSpaces; i++) {
         this.arrow(
           startArrow.add($V([inc, 0])),
-          endArrow.add($V([inc, (-inc * (sizeEndDwSign - sizeStartDwSign)) / L]))
+          endArrow.add($V([inc, (-inc * (sizeEndDwSign - sizeStartDwSign)) / L])),
         );
         inc = inc + spacing;
       }
       this.text(endArrow, $V([2, 0]), labelStart);
       this.text(
         endArrow.add(
-          $V([inc - spacing, (-(inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L])
+          $V([inc - spacing, (-(inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L]),
         ),
         $V([-2, 0]),
-        labelEnd
+        labelEnd,
       );
     }
 
@@ -2283,7 +2283,7 @@
       radiusPx + groundOffsetPx,
       -startAngle,
       -endAngle,
-      true
+      true,
     );
     this._ctx.fillStyle = this._props.groundInsideColor;
     this._ctx.fill();
@@ -2485,7 +2485,7 @@
             xPx - offsetPx.e(1) - textBorderPx,
             yPx + offsetPx.e(2) - textBorderPx,
             img.width + 2 * textBorderPx,
-            img.height + 2 * textBorderPx
+            img.height + 2 * textBorderPx,
           );
           this._ctx.restore();
         }
@@ -2601,7 +2601,7 @@
     endAngleDw,
     pos,
     text,
-    fixedRad
+    fixedRad,
   ) {
     // convert to Px coordinates
     var startOffsetDw = PrairieGeom.vector2DAtAngle(startAngleDw).x(radDw);
@@ -2795,14 +2795,14 @@
     timeOffset,
     yLabel,
     data,
-    type
+    type,
   ) {
     var scale = $V([sizeDw.e(1) / sizeData.e(1), sizeDw.e(2) / sizeData.e(2)]);
     var lastTime = data[data.length - 1][0];
     var offset = $V([timeOffset - lastTime, 0]);
     var plotData = PrairieGeom.scalePoints(
       PrairieGeom.translatePoints(this.pairsToVectors(data), offset),
-      scale
+      scale,
     );
 
     this.save();
@@ -3283,7 +3283,7 @@
     holdTimes,
     interps,
     names,
-    t
+    t,
   ) {
     var seq = this._sequences[name];
     if (seq === undefined) {
@@ -3339,7 +3339,7 @@
             states[nextIndex],
             interps,
             endTime,
-            endTime
+            endTime,
           );
           seq.lastState.inTransition = false;
           seq.lastState.index = nextIndex;
@@ -3545,7 +3545,7 @@
     var numDecPlaces = 2;
     /* jshint laxbreak: true */
     console.log(
-      '$V([' + posDw.e(1).toFixed(numDecPlaces) + ', ' + posDw.e(2).toFixed(numDecPlaces) + ']),'
+      '$V([' + posDw.e(1).toFixed(numDecPlaces) + ', ' + posDw.e(2).toFixed(numDecPlaces) + ']),',
     );
   };
 
@@ -3686,7 +3686,7 @@
     drawPoint,
     pointLabel,
     pointAnchor,
-    options
+    options,
   ) {
     drawAxes = drawAxes === undefined ? true : drawAxes;
     drawPoint = drawPoint === undefined ? true : drawPoint;
@@ -3724,7 +3724,7 @@
           originData.e(1) + sizeData.e(1),
           0,
           sizeDw.e(1),
-          i * dXGrid
+          i * dXGrid,
         );
         this.line($V([x, y0]), $V([x, y1]), 'grid');
       }
@@ -3736,7 +3736,7 @@
           originData.e(2) + sizeData.e(2),
           0,
           sizeDw.e(2),
-          i * dYGrid
+          i * dYGrid,
         );
         this.line($V([x0, y]), $V([x1, y]), 'grid');
       }
@@ -3749,7 +3749,7 @@
           originData.e(1) + sizeData.e(1),
           0,
           sizeDw.e(1),
-          i * dXGrid
+          i * dXGrid,
         );
         label = String(i * dXGrid);
         this.text($V([x, y0]), $V([0, 1]), label);
@@ -3762,7 +3762,7 @@
           originData.e(2) + sizeData.e(2),
           0,
           sizeDw.e(2),
-          i * dYGrid
+          i * dYGrid,
         );
         label = String(i * dYGrid);
         this.text($V([x0, y]), $V([1, 0]), label);
@@ -3781,7 +3781,7 @@
         originData.e(1) + sizeData.e(1),
         0,
         sizeDw.e(1),
-        vertAxisPos
+        vertAxisPos,
       );
     }
     if (horizAxisPos === 'bottom') {
@@ -3794,7 +3794,7 @@
         originData.e(2) + sizeData.e(2),
         0,
         sizeDw.e(2),
-        horizAxisPos
+        horizAxisPos,
       );
     }
     if (drawAxes) {

--- a/apps/prairielearn/public/javascripts/PrairieGeom.js
+++ b/apps/prairielearn/public/javascripts/PrairieGeom.js
@@ -740,7 +740,7 @@
         [factor.e(1), 0, 0],
         [0, factor.e(2), 0],
         [0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -756,7 +756,7 @@
         [1, 0, offset.e(1)],
         [0, 1, offset.e(2)],
         [0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -845,7 +845,7 @@
         [0, factor, 0, 0],
         [0, 0, factor, 0],
         [0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -862,7 +862,7 @@
         [0, 1, 0, offset.e(2)],
         [0, 0, 1, offset.e(3)],
         [0, 0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -923,7 +923,7 @@
   PrairieGeom.prototype.rotateTransform3D = function (transform, angleX, angleY, angleZ) {
     return this.rotateTransform3DZ(
       this.rotateTransform3DY(this.rotateTransform3DX(transform, angleX), angleY),
-      angleZ
+      angleZ,
     );
   };
 
@@ -1391,7 +1391,7 @@
           points[i].e(1).toFixed(numDecPlaces) +
           ', ' +
           points[i].e(2).toFixed(numDecPlaces) +
-          ']),'
+          ']),',
       );
     }
     console.log('],');
@@ -1783,7 +1783,7 @@
       return numeric.norm2(
         _(val).map(function (v) {
           return that.norm(v);
-        })
+        }),
       );
     } else if (val instanceof Sylvester.Vector) {
       return val.modulus();
@@ -1792,7 +1792,7 @@
       return numeric.norm2(
         _(val).map(function (v) {
           return that.norm(v);
-        })
+        }),
       );
     } else {
       return Infinity;
@@ -1825,7 +1825,7 @@
       return numeric.norm2(
         _(_.zip(trueVal, submittedVal)).map(function (v) {
           return that.absError(v[0], v[1]);
-        })
+        }),
       );
     } else if (trueVal instanceof Sylvester.Vector) {
       subVal = submittedVal;
@@ -1837,7 +1837,7 @@
       return numeric.norm2(
         _(trueVal).map(function (val, key) {
           return that.absError(val, submittedVal[key]);
-        })
+        }),
       );
     } else {
       return Infinity;

--- a/apps/prairielearn/public/localscripts/calculationQuestion/CBQServer.js
+++ b/apps/prairielearn/public/localscripts/calculationQuestion/CBQServer.js
@@ -21,7 +21,7 @@ define(['underscore', 'QServer', 'PrairieRandom'], function (_, QServer, Prairie
     // we need to choose at least this many correct answers to ensure we can make the total number
     var minNumberCorrect = Math.max(
       options.minCorrectAnswers,
-      options.numberAnswers - options.incorrectAnswers.length
+      options.numberAnswers - options.incorrectAnswers.length,
     );
 
     // but we must have minNumber <= maxNumber

--- a/apps/prairielearn/public/localscripts/calculationQuestion/PrairieDraw.js
+++ b/apps/prairielearn/public/localscripts/calculationQuestion/PrairieDraw.js
@@ -45,7 +45,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           Matrix.I(4),
           this._initViewAngleX3D,
           this._initViewAngleY3D,
-          this._initViewAngleZ3D
+          this._initViewAngleZ3D,
         );
         this._trans3DStack = [];
 
@@ -328,24 +328,24 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       this._viewAngleX3D = PrairieGeom.clip(
         this._viewAngleX3D,
         this._props.viewAngleXMin,
-        this._props.viewAngleXMax
+        this._props.viewAngleXMax,
       );
       this._viewAngleY3D = PrairieGeom.clip(
         this._viewAngleY3D,
         this._props.viewAngleYMin,
-        this._props.viewAngleYMax
+        this._props.viewAngleYMax,
       );
       this._viewAngleZ3D = PrairieGeom.clip(
         this._viewAngleZ3D,
         this._props.viewAngleZMin,
-        this._props.viewAngleZMax
+        this._props.viewAngleZMax,
       );
     }
     this._trans3D = PrairieGeom.rotateTransform3D(
       Matrix.I(4),
       this._viewAngleX3D,
       this._viewAngleY3D,
-      this._viewAngleZ3D
+      this._viewAngleZ3D,
     );
     if (redraw) {
       this.redraw();
@@ -362,7 +362,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       this._initViewAngleY3D,
       this._initViewAngleZ3D,
       undefined,
-      redraw
+      redraw,
     );
   };
 
@@ -378,7 +378,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       this._viewAngleX3D + deltaAngleX,
       this._viewAngleY3D + deltaAngleY,
       this._viewAngleZ3D + deltaAngleZ,
-      clip
+      clip,
     );
   };
 
@@ -1115,7 +1115,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     centerAngleDw,
     extentAngleDw,
     type,
-    fixedRad
+    fixedRad,
   ) {
     var startAngleDw = centerAngleDw - extentAngleDw / 2;
     var endAngleDw = centerAngleDw + extentAngleDw / 2;
@@ -1139,7 +1139,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     endAngleDw,
     type,
     fixedRad,
-    idealSegmentSize
+    idealSegmentSize,
   ) {
     this.save();
     this._ctx.lineWidth = this._props.arrowLineWidthPx;
@@ -1163,14 +1163,14 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       startAnglePx,
       startAnglePx,
       endAnglePx,
-      fixedRad
+      fixedRad,
     );
     var endRadiusPx = this._circleArrowRadius(
       radiusPx,
       endAnglePx,
       startAnglePx,
       endAnglePx,
-      fixedRad
+      fixedRad,
     );
     var arrowLengthPx = radiusPx * Math.abs(endAnglePx - startAnglePx);
     var arrowheadMaxLengthPx = this._props.arrowheadLengthRatio * this._props.arrowLineWidthPx;
@@ -1206,11 +1206,11 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       arrowBaseAnglePx,
       startAnglePx,
       endAnglePx,
-      fixedRad
+      fixedRad,
     );
     var arrowPosPx = posPx.add(PrairieGeom.vector2DAtAngle(endAnglePx).x(endRadiusPx));
     var arrowBasePosPx = posPx.add(
-      PrairieGeom.vector2DAtAngle(arrowBaseAnglePx).x(arrowBaseRadiusPx)
+      PrairieGeom.vector2DAtAngle(arrowBaseAnglePx).x(arrowBaseRadiusPx),
     );
     var arrowDirPx = arrowPosPx.subtract(arrowBasePosPx);
     var arrowPosDw = this.pos2Dw(arrowPosPx);
@@ -1234,7 +1234,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     anglePx,
     startAnglePx,
     endAnglePx,
-    fixedRad
+    fixedRad,
   ) {
     if (fixedRad !== undefined && fixedRad === true) {
       return midRadPx;
@@ -1278,7 +1278,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     refDw,
     startAngleDw,
     endAngleDw,
-    options
+    options,
   ) {
     posDw = this.pos2To3(posDw);
     normDw = normDw === undefined ? Vector.k : normDw;
@@ -1330,7 +1330,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     startAngleDw,
     endAngleDw,
     type,
-    options
+    options,
   ) {
     posDw = this.pos2To3(posDw);
     normDw = normDw || Vector.k;
@@ -1374,7 +1374,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     normDw,
     refDw,
     startAngleDw,
-    endAngleDw
+    endAngleDw,
   ) {
     if (labelText === undefined) {
       return;
@@ -1444,7 +1444,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     drawFront,
     refDw,
     startAngleDw,
-    endAngleDw
+    endAngleDw,
   ) {
     var cRDwSq = radDw * radDw - distDw * distDw;
     if (cRDwSq <= 0) {
@@ -1516,7 +1516,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           } else {
             intersections = PrairieGeom.intersectAngleRanges(
               [theta1, theta2],
-              [startAngleDw, endAngleDw]
+              [startAngleDw, endAngleDw],
             );
             for (i = 0; i < intersections.length; i++) {
               range = intersections[i];
@@ -1532,7 +1532,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
         } else {
           intersections = PrairieGeom.intersectAngleRanges(
             [theta2, theta1 + 2 * Math.PI],
-            [startAngleDw, endAngleDw]
+            [startAngleDw, endAngleDw],
           );
           for (i = 0; i < intersections.length; i++) {
             range = intersections[i];
@@ -1684,7 +1684,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           pointsPx[i] = PrairieGeom.linearInterpVector(
             pointsPx[i],
             pointsPx[i - 1],
-            lengthToRemovePx / segmentLengthPx
+            lengthToRemovePx / segmentLengthPx,
           );
           break;
         }
@@ -1786,7 +1786,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     labelStart,
     labelEnd,
     arrowToLine,
-    arrowDown
+    arrowDown,
   ) {
     var LengthDw = endDw.subtract(startDw);
     var L = LengthDw.modulus();
@@ -1813,17 +1813,17 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       for (i = 0; i <= nSpaces; i++) {
         this.arrow(
           startArrow.add($V([inc, (inc * (sizeEndDwSign - sizeStartDwSign)) / L])),
-          endArrow.add($V([inc, 0]))
+          endArrow.add($V([inc, 0])),
         );
         inc = inc + spacing;
       }
       this.text(startArrow, $V([2, 0]), labelStart);
       this.text(
         startArrow.add(
-          $V([inc - spacing, ((inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L])
+          $V([inc - spacing, ((inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L]),
         ),
         $V([-2, 0]),
-        labelEnd
+        labelEnd,
       );
     } else {
       this.line(startDw, endDw);
@@ -1832,17 +1832,17 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       for (i = 0; i <= nSpaces; i++) {
         this.arrow(
           startArrow.add($V([inc, 0])),
-          endArrow.add($V([inc, (-inc * (sizeEndDwSign - sizeStartDwSign)) / L]))
+          endArrow.add($V([inc, (-inc * (sizeEndDwSign - sizeStartDwSign)) / L])),
         );
         inc = inc + spacing;
       }
       this.text(endArrow, $V([2, 0]), labelStart);
       this.text(
         endArrow.add(
-          $V([inc - spacing, (-(inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L])
+          $V([inc - spacing, (-(inc - spacing) * (sizeEndDwSign - sizeStartDwSign)) / L]),
         ),
         $V([-2, 0]),
-        labelEnd
+        labelEnd,
       );
     }
 
@@ -2274,7 +2274,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
       radiusPx + groundOffsetPx,
       -startAngle,
       -endAngle,
-      true
+      true,
     );
     this._ctx.fillStyle = this._props.groundInsideColor;
     this._ctx.fill();
@@ -2476,7 +2476,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
             xPx - offsetPx.e(1) - textBorderPx,
             yPx + offsetPx.e(2) - textBorderPx,
             img.width + 2 * textBorderPx,
-            img.height + 2 * textBorderPx
+            img.height + 2 * textBorderPx,
           );
           this._ctx.restore();
         }
@@ -2592,7 +2592,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     endAngleDw,
     pos,
     text,
-    fixedRad
+    fixedRad,
   ) {
     // convert to Px coordinates
     var startOffsetDw = PrairieGeom.vector2DAtAngle(startAngleDw).x(radDw);
@@ -2786,14 +2786,14 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     timeOffset,
     yLabel,
     data,
-    type
+    type,
   ) {
     var scale = $V([sizeDw.e(1) / sizeData.e(1), sizeDw.e(2) / sizeData.e(2)]);
     var lastTime = data[data.length - 1][0];
     var offset = $V([timeOffset - lastTime, 0]);
     var plotData = PrairieGeom.scalePoints(
       PrairieGeom.translatePoints(this.pairsToVectors(data), offset),
-      scale
+      scale,
     );
 
     this.save();
@@ -3274,7 +3274,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     holdTimes,
     interps,
     names,
-    t
+    t,
   ) {
     var seq = this._sequences[name];
     if (seq === undefined) {
@@ -3330,7 +3330,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
             states[nextIndex],
             interps,
             endTime,
-            endTime
+            endTime,
           );
           seq.lastState.inTransition = false;
           seq.lastState.index = nextIndex;
@@ -3536,7 +3536,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     var numDecPlaces = 2;
     /* jshint laxbreak: true */
     console.log(
-      '$V([' + posDw.e(1).toFixed(numDecPlaces) + ', ' + posDw.e(2).toFixed(numDecPlaces) + ']),'
+      '$V([' + posDw.e(1).toFixed(numDecPlaces) + ', ' + posDw.e(2).toFixed(numDecPlaces) + ']),',
     );
   };
 
@@ -3677,7 +3677,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
     drawPoint,
     pointLabel,
     pointAnchor,
-    options
+    options,
   ) {
     drawAxes = drawAxes === undefined ? true : drawAxes;
     drawPoint = drawPoint === undefined ? true : drawPoint;
@@ -3715,7 +3715,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           originData.e(1) + sizeData.e(1),
           0,
           sizeDw.e(1),
-          i * dXGrid
+          i * dXGrid,
         );
         this.line($V([x, y0]), $V([x, y1]), 'grid');
       }
@@ -3727,7 +3727,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           originData.e(2) + sizeData.e(2),
           0,
           sizeDw.e(2),
-          i * dYGrid
+          i * dYGrid,
         );
         this.line($V([x0, y]), $V([x1, y]), 'grid');
       }
@@ -3740,7 +3740,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           originData.e(1) + sizeData.e(1),
           0,
           sizeDw.e(1),
-          i * dXGrid
+          i * dXGrid,
         );
         label = String(i * dXGrid);
         this.text($V([x, y0]), $V([0, 1]), label);
@@ -3753,7 +3753,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
           originData.e(2) + sizeData.e(2),
           0,
           sizeDw.e(2),
-          i * dYGrid
+          i * dYGrid,
         );
         label = String(i * dYGrid);
         this.text($V([x0, y]), $V([1, 0]), label);
@@ -3772,7 +3772,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
         originData.e(1) + sizeData.e(1),
         0,
         sizeDw.e(1),
-        vertAxisPos
+        vertAxisPos,
       );
     }
     if (horizAxisPos === 'bottom') {
@@ -3785,7 +3785,7 @@ define(['sylvester', 'sha1', 'PrairieGeom'], function (Sylvester, Sha1, PrairieG
         originData.e(2) + sizeData.e(2),
         0,
         sizeDw.e(2),
-        horizAxisPos
+        horizAxisPos,
       );
     }
     if (drawAxes) {

--- a/apps/prairielearn/public/localscripts/calculationQuestion/PrairieGeom.js
+++ b/apps/prairielearn/public/localscripts/calculationQuestion/PrairieGeom.js
@@ -738,7 +738,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
         [factor.e(1), 0, 0],
         [0, factor.e(2), 0],
         [0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -754,7 +754,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
         [1, 0, offset.e(1)],
         [0, 1, offset.e(2)],
         [0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -843,7 +843,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
         [0, factor, 0, 0],
         [0, 0, factor, 0],
         [0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -860,7 +860,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
         [0, 1, 0, offset.e(2)],
         [0, 0, 1, offset.e(3)],
         [0, 0, 0, 1],
-      ])
+      ]),
     );
   };
 
@@ -921,7 +921,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
   PrairieGeom.prototype.rotateTransform3D = function (transform, angleX, angleY, angleZ) {
     return this.rotateTransform3DZ(
       this.rotateTransform3DY(this.rotateTransform3DX(transform, angleX), angleY),
-      angleZ
+      angleZ,
     );
   };
 
@@ -1389,7 +1389,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
           points[i].e(1).toFixed(numDecPlaces) +
           ', ' +
           points[i].e(2).toFixed(numDecPlaces) +
-          ']),'
+          ']),',
       );
     }
     console.log('],');
@@ -1781,7 +1781,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
       return numeric.norm2(
         _(val).map(function (v) {
           return that.norm(v);
-        })
+        }),
       );
     } else if (val instanceof Sylvester.Vector) {
       return val.modulus();
@@ -1790,7 +1790,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
       return numeric.norm2(
         _(val).map(function (v) {
           return that.norm(v);
-        })
+        }),
       );
     } else {
       return Infinity;
@@ -1823,7 +1823,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
       return numeric.norm2(
         _(_.zip(trueVal, submittedVal)).map(function (v) {
           return that.absError(v[0], v[1]);
-        })
+        }),
       );
     } else if (trueVal instanceof Sylvester.Vector) {
       subVal = submittedVal;
@@ -1835,7 +1835,7 @@ define(['sylvester', 'underscore', 'numeric'], function (Sylvester, _, numeric) 
       return numeric.norm2(
         _(trueVal).map(function (val, key) {
           return that.absError(val, submittedVal[key]);
-        })
+        }),
       );
     } else {
       return Infinity;

--- a/apps/prairielearn/public/localscripts/calculationQuestion/SimpleClient.js
+++ b/apps/prairielearn/public/localscripts/calculationQuestion/SimpleClient.js
@@ -3,7 +3,7 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
   _,
   Backbone,
   rivets,
-  PrairieTemplate
+  PrairieTemplate,
 ) {
   rivets.configure({
     templateDelimiters: ['{{', '}}'],
@@ -127,14 +127,14 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
         this.template,
         templateData,
         this.questionDataModel,
-        this.appModel
+        this.appModel,
       );
       if (this.options.templateTwice) {
         templatedHTML = PrairieTemplate.template(
           templatedHTML,
           {},
           this.questionDataModel,
-          this.appModel
+          this.appModel,
         );
       }
       this.$el.html(templatedHTML);
@@ -154,12 +154,12 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
               _.filter(this.rivetsView.bindings, function (binding) {
                 return binding.key === 'submittedAnswer' && binding.type === 'checkedoptional';
               }),
-              'keypath'
-            )
+              'keypath',
+            ),
           ),
           function (kp) {
             if (!that.submittedAnswer.has(kp)) that.submittedAnswer.set(kp, false);
-          }
+          },
         );
         _.each(
           _.uniq(
@@ -167,10 +167,10 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
               _.filter(this.rivetsView.bindings, function (binding) {
                 return binding.key === 'submittedAnswer';
               }),
-              'keypath'
-            )
+              'keypath',
+            ),
           ),
-          this.addAnswer.bind(this)
+          this.addAnswer.bind(this),
         );
       }
       this.checkSubmittable();
@@ -224,7 +224,7 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
       for (i = 0; i < this.answerAttributes.length; i++) {
         if (this.submittedAnswer.has(this.answerAttributes[i].name)) {
           answerData[this.answerAttributes[i].name] = this.submittedAnswer.get(
-            this.answerAttributes[i].name
+            this.answerAttributes[i].name,
           );
         }
       }
@@ -260,14 +260,14 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
         this.template,
         templateData,
         this.questionDataModel,
-        this.appModel
+        this.appModel,
       );
       if (this.options.templateTwice) {
         templatedHTML = PrairieTemplate.template(
           templatedHTML,
           {},
           this.questionDataModel,
-          this.appModel
+          this.appModel,
         );
       }
       this.$el.html(templatedHTML);
@@ -315,14 +315,14 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
         this.template,
         templateData,
         this.questionDataModel,
-        this.appModel
+        this.appModel,
       );
       if (this.options.templateTwice) {
         templatedHTML = PrairieTemplate.template(
           templatedHTML,
           {},
           this.questionDataModel,
-          this.appModel
+          this.appModel,
         );
       }
       this.$el.html(templatedHTML);
@@ -372,7 +372,7 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
     questionDivID,
     changeCallback,
     questionDataModel,
-    appModel
+    appModel,
   ) {
     var that = this;
     //this.listenTo(this.model, "answerChanged", changeCallback);
@@ -422,7 +422,7 @@ define(['jquery', 'underscore', 'backbone', 'rivets', 'PrairieTemplate'], functi
     appModel,
     submittedAnswer,
     feedback,
-    submissionIndex
+    submissionIndex,
   ) {
     var that = this;
     feedback = feedback || {};

--- a/apps/prairielearn/public/localscripts/calculationQuestion/renderer.js
+++ b/apps/prairielearn/public/localscripts/calculationQuestion/renderer.js
@@ -69,7 +69,7 @@ define(function () {
     toolTipTexts,
     placement,
     showCounts,
-    percentages
+    percentages,
   ) {
     var total = counts.success + counts.warning + counts.danger;
     total = Math.max(1, total);

--- a/apps/prairielearn/public/localscripts/questionCalculation.js
+++ b/apps/prairielearn/public/localscripts/questionCalculation.js
@@ -66,7 +66,7 @@ CalculationClient.prototype.initialize = function (questionData, callback) {
       that.questionDataModel.set('questionFilePath', questionData.questionFilePath);
       that.questionDataModel.set(
         'questionGeneratedFilePath',
-        questionData.questionGeneratedFilePath
+        questionData.questionGeneratedFilePath,
       );
       that.appModel = new Backbone.Model();
       that.qClient = qc;
@@ -96,7 +96,7 @@ CalculationClient.prototype.renderSubmission = function (container, questionData
     this.appModel,
     questionData.submissions[submissionIndex].submitted_answer,
     questionData.submissions[submissionIndex].feedback,
-    submissionIndex
+    submissionIndex,
   );
 };
 

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAccessRules/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAccessRules/index.js
@@ -15,7 +15,7 @@ router.get(
       course_instance_id: res.locals.course_instance.id,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
@@ -25,7 +25,7 @@ router.get(
     } else {
       res.status(200).send(data[0]);
     }
-  })
+  }),
 );
 
 router.get(
@@ -36,7 +36,7 @@ router.get(
       unsafe_assessment_instance_id: req.params.unsafe_assessment_instance_id,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 router.get(
@@ -48,7 +48,7 @@ router.get(
       unsafe_submission_id: null,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 router.get(
@@ -67,10 +67,10 @@ router.get(
 
     const logs = await assessment.selectAssessmentInstanceLog(
       result.rows[0].assessment_instance_id,
-      true
+      true,
     );
     res.status(200).send(logs);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessments/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessments/index.js
@@ -16,7 +16,7 @@ router.get(
       unsafe_assessment_id: null,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 router.get(
@@ -34,7 +34,7 @@ router.get(
     } else {
       res.status(200).send(data[0]);
     }
-  })
+  }),
 );
 
 router.get(
@@ -46,7 +46,7 @@ router.get(
       unsafe_assessment_instance_id: null,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 router.get(
@@ -57,7 +57,7 @@ router.get(
       unsafe_assessment_id: req.params.unsafe_assessment_id,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.js
@@ -14,7 +14,7 @@ router.get(
       course_instance_id: res.locals.course_instance.id,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceInfo/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceInfo/index.js
@@ -15,7 +15,7 @@ router.get(
       course_instance_id: res.locals.course_instance.id,
     });
     res.status(200).send(result.rows[0].item);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceSubmissions/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceSubmissions/index.js
@@ -23,7 +23,7 @@ router.get(
     } else {
       res.status(200).send(data[0]);
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/api/v1/index.js
+++ b/apps/prairielearn/src/api/v1/index.js
@@ -14,7 +14,7 @@ function authzHasCourseInstanceView(req, res, next) {
     return next(
       error.make(403, 'Requires student data view access', {
         locals: res.locals,
-      })
+      }),
     );
   }
   next();
@@ -37,26 +37,26 @@ router.use('/course_instances/:course_instance_id', [
 // ROUTES
 router.use(
   '/course_instances/:course_instance_id/assessments',
-  require('./endpoints/courseInstanceAssessments')
+  require('./endpoints/courseInstanceAssessments'),
 );
 router.use(
   '/course_instances/:course_instance_id/assessment_instances',
   authzHasCourseInstanceView,
-  require('./endpoints/courseInstanceAssessmentInstances')
+  require('./endpoints/courseInstanceAssessmentInstances'),
 );
 router.use(
   '/course_instances/:course_instance_id/submissions',
   authzHasCourseInstanceView,
-  require('./endpoints/courseInstanceSubmissions')
+  require('./endpoints/courseInstanceSubmissions'),
 );
 router.use(
   '/course_instances/:course_instance_id/gradebook',
   authzHasCourseInstanceView,
-  require('./endpoints/courseInstanceGradebook')
+  require('./endpoints/courseInstanceGradebook'),
 );
 router.use(
   '/course_instances/:course_instance_id/course_instance_access_rules',
-  require('./endpoints/courseInstanceAccessRules')
+  require('./endpoints/courseInstanceAccessRules'),
 );
 
 // If no earlier routes matched, 404 the route

--- a/apps/prairielearn/src/batched-migrations/20230418190511_variants_course_id.ts
+++ b/apps/prairielearn/src/batched-migrations/20230418190511_variants_course_id.ts
@@ -24,7 +24,7 @@ export default makeBatchedMigration({
         v.question_id = q.id AND
         v.id >= $start AND
         v.id <= $end`,
-      { start, end }
+      { start, end },
     );
   },
 });

--- a/apps/prairielearn/src/cron/autoFinishExams.ts
+++ b/apps/prairielearn/src/cron/autoFinishExams.ts
@@ -45,13 +45,13 @@ export function run(callback: (err?: Error | null) => void): void {
               logger.error('Error finishing exam', error.addData(err, { examItem }));
             }
             callback(null);
-          }
+          },
         );
       },
       function (err) {
         if (ERR(err, callback)) return;
         callback(null);
-      }
+      },
     );
   });
 }

--- a/apps/prairielearn/src/cron/calculateAssessmentQuestionStats.js
+++ b/apps/prairielearn/src/cron/calculateAssessmentQuestionStats.js
@@ -13,7 +13,7 @@ module.exports.run = function (callback) {
     const assessments = result.rows;
     for (const assessment of assessments) {
       logger.verbose(
-        `calculateAssessmentQuestionStats: processing assessment_id = ${assessment.id}`
+        `calculateAssessmentQuestionStats: processing assessment_id = ${assessment.id}`,
       );
       await sqldb.callAsync('assessment_questions_calculate_stats_for_assessment', [assessment.id]);
     }

--- a/apps/prairielearn/src/cron/index.js
+++ b/apps/prairielearn/src/cron/index.js
@@ -157,7 +157,7 @@ module.exports = {
 
     logger.verbose(
       'initializing cron',
-      _.map(module.exports.jobs, (j) => _.pick(j, ['name', 'intervalSec']))
+      _.map(module.exports.jobs, (j) => _.pick(j, ['name', 'intervalSec'])),
     );
 
     const jobsByPeriodSec = _.groupBy(module.exports.jobs, 'intervalSec');
@@ -307,7 +307,7 @@ module.exports = {
         debug(`runJobs(): done`);
         logger.verbose('cron: jobs finished', { cronUuid });
         callback(null);
-      }
+      },
     );
   },
 

--- a/apps/prairielearn/src/cron/sendExternalGraderDeadLetters.js
+++ b/apps/prairielearn/src/cron/sendExternalGraderDeadLetters.js
@@ -43,7 +43,7 @@ module.exports.run = (callback) => {
           if (res.statusCode !== 200) {
             logger.error(
               `Error posting external grading dead letters to slack [status code ${res.statusCode}]`,
-              body
+              body,
             );
           }
           callback(null);
@@ -53,7 +53,7 @@ module.exports.run = (callback) => {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 };
 
@@ -101,7 +101,7 @@ async function drainQueue(sqs, queueName) {
           MaxNumberOfMessages: 10,
           QueueUrl: QUEUE_URLS[queueName],
           WaitTimeSeconds: 20,
-        })
+        }),
       );
       if (!data.Messages) {
         // stop with message collection
@@ -116,14 +116,14 @@ async function drainQueue(sqs, queueName) {
           new DeleteMessageCommand({
             QueueUrl: QUEUE_URLS[queueName],
             ReceiptHandle: receiptHandle,
-          })
+          }),
         );
       });
 
       // keep getting messages if we got some this time
       return true;
     },
-    async (keepGoing) => keepGoing
+    async (keepGoing) => keepGoing,
   );
   return messages;
 }

--- a/apps/prairielearn/src/cron/sendExternalGraderStats.js
+++ b/apps/prairielearn/src/cron/sendExternalGraderStats.js
@@ -53,7 +53,7 @@ module.exports.run = (callback) => {
       if (res.statusCode !== 200) {
         logger.error(
           `Error posting external grading stats to slack [status code ${res.statusCode}]`,
-          body
+          body,
         );
       }
       callback(null);

--- a/apps/prairielearn/src/cron/workspaceHostTransitions.ts
+++ b/apps/prairielearn/src/cron/workspaceHostTransitions.ts
@@ -59,8 +59,8 @@ async function checkDBConsistency() {
 
   const db_hosts_nonterminated = new Set(
     (await sqldb.queryAsync(sql.select_nonterminated_workspace_hosts, [])).rows.map(
-      (instance) => instance.instance_id
-    )
+      (instance) => instance.instance_id,
+    ),
   );
 
   // Kill off any host that is running but not in the db

--- a/apps/prairielearn/src/cron/workspaceTimeoutStop.ts
+++ b/apps/prairielearn/src/cron/workspaceTimeoutStop.ts
@@ -23,8 +23,8 @@ async function stopLaunchedTimeoutWorkspaces() {
       workspace.id,
       'stopped',
       `Maximum run time of ${Math.round(
-        config.workspaceLaunchedTimeoutSec / 3600
-      )} hours exceeded. Click "Reboot" to keep working.`
+        config.workspaceLaunchedTimeoutSec / 3600,
+      )} hours exceeded. Click "Reboot" to keep working.`,
     );
     launchedTimeoutCounter.add(1);
   }
@@ -45,8 +45,8 @@ async function stopHeartbeatTimeoutWorkspaces() {
       workspace.id,
       'stopped',
       `Connection was lost for more than ${Math.round(
-        config.workspaceHeartbeatTimeoutSec / 60
-      )} min. Click "Reboot" to keep working.`
+        config.workspaceHeartbeatTimeoutSec / 60,
+      )} min. Click "Reboot" to keep working.`,
     );
     visibilityTimeoutCounter.add(1);
   }
@@ -70,8 +70,8 @@ async function stopInLaunchingTimeoutWorkspaces() {
       workspace.id,
       'stopped',
       `Maximum launching time of ${Math.round(
-        config.workspaceInLaunchingTimeoutSec / 60
-      )} min exceeded. Click "Reboot" to keep working.`
+        config.workspaceInLaunchingTimeoutSec / 60,
+      )} min exceeded. Click "Reboot" to keep working.`,
     );
     launchingTimeoutCounter.add(1);
   }

--- a/apps/prairielearn/src/cron/workspaceTimeoutWarn.js
+++ b/apps/prairielearn/src/cron/workspaceTimeoutWarn.js
@@ -21,7 +21,7 @@ module.exports.runAsync = async () => {
     const time_to_timeout_min = Math.ceil(workspace.time_to_timeout_sec / 60);
     await workspaceUtils.updateWorkspaceMessage(
       workspace.id,
-      `WARNING: This workspace will stop in < ${time_to_timeout_min} min. Click "Reboot" to keep working.`
+      `WARNING: This workspace will stop in < ${time_to_timeout_min} min. Click "Reboot" to keep working.`,
     );
   }
 };

--- a/apps/prairielearn/src/ee/auth/azure/callback.ts
+++ b/apps/prairielearn/src/ee/auth/azure/callback.ts
@@ -22,7 +22,7 @@ function authenticate(req, res): Promise<any> {
         } else {
           resolve(user);
         }
-      }
+      },
     )(req, res);
   });
 }
@@ -43,7 +43,7 @@ router.post(
       redirect: true,
       pl_authn_cookie: true,
     });
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/auth/azure/index.ts
+++ b/apps/prairielearn/src/ee/auth/azure/index.ts
@@ -22,6 +22,6 @@ export function getAzureStrategy() {
     },
     function (iss, sub, profile, accessToken, refreshToken, done) {
       return done(null, profile);
-    }
+    },
   );
 }

--- a/apps/prairielearn/src/ee/auth/azure/login.ts
+++ b/apps/prairielearn/src/ee/auth/azure/login.ts
@@ -13,7 +13,7 @@ router.get(
   },
   function (req, res) {
     res.redirect('/pl');
-  }
+  },
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/auth/prairietest.html.ts
+++ b/apps/prairielearn/src/ee/auth/prairietest.html.ts
@@ -3,7 +3,7 @@ import { renderEjs } from '@prairielearn/html-ejs';
 
 export const AuthPrairieTest = ({ jwt, prairieTestCallback, resLocals }) => {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../pages/partials/head') %>", resLocals)}

--- a/apps/prairielearn/src/ee/auth/prairietest.ts
+++ b/apps/prairielearn/src/ee/auth/prairietest.ts
@@ -30,9 +30,9 @@ router.get(
         jwt,
         prairieTestCallback: `${config.ptHost}/pt/auth/prairielearn/callback`,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -36,5 +36,5 @@ export const strategy = new MultiSamlStrategy(
   },
   function (req, profile, done) {
     done(null, profile ?? undefined);
-  }
+  },
 );

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -45,7 +45,7 @@ function authenticate(req, res): Promise<any> {
         } else {
           resolve(user);
         }
-      }
+      },
     )(req, res);
   });
 }
@@ -82,7 +82,7 @@ router.post(
           nameAttribute,
           attributes: user.attributes,
           resLocals: res.locals,
-        })
+        }),
       );
       return;
     }
@@ -106,7 +106,7 @@ router.post(
       pl_authn_cookie: true,
       redirect: true,
     });
-  })
+  }),
 );
 
 router.get(
@@ -125,9 +125,9 @@ router.get(
         if (ERR(err, next)) return;
         res.type('application/xml');
         res.send(metadata);
-      }
+      },
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/cron/chunksHostAutoScaling.ts
+++ b/apps/prairielearn/src/ee/cron/chunksHostAutoScaling.ts
@@ -92,13 +92,13 @@ export const run = callbackify(async () => {
   });
 
   const pageViewsPerSecondMetric = metrics.MetricDataResults?.find(
-    (m) => m.Id === PAGE_VIEWS_PER_SECOND
+    (m) => m.Id === PAGE_VIEWS_PER_SECOND,
   );
   const activeWorkersPerSecondMetric = metrics.MetricDataResults?.find(
-    (m) => m.Id === ACTIVE_WORKERS_PER_SECOND
+    (m) => m.Id === ACTIVE_WORKERS_PER_SECOND,
   );
   const loadBalancerRequestsPerMinuteMetric = metrics.MetricDataResults?.find(
-    (m) => m.Id === LOAD_BALANCER_REQUESTS_PER_MINUTE
+    (m) => m.Id === LOAD_BALANCER_REQUESTS_PER_MINUTE,
   );
 
   const maxPageViewsPerSecond = _.max(pageViewsPerSecondMetric?.Values) ?? 0;
@@ -116,8 +116,8 @@ export const run = callbackify(async () => {
       desiredInstancesByPageViews,
       desiredInstancesByActiveWorkers,
       desiredInstancesByLoadBalancerRequests,
-      1
-    )
+      1,
+    ),
   );
 
   const dimensions: Dimension[] = [{ Name: 'Server Group', Value: config.groupName }];

--- a/apps/prairielearn/src/ee/lib/institution.ts
+++ b/apps/prairielearn/src/ee/lib/institution.ts
@@ -17,22 +17,22 @@ export async function getInstitution(institution_id: string): Promise<Institutio
 }
 
 export async function getInstitutionSamlProvider(
-  institution_id: string
+  institution_id: string,
 ): Promise<SamlProvider | null> {
   return await queryOptionalRow(
     sql.select_institution_saml_provider,
     { institution_id },
-    SamlProviderSchema
+    SamlProviderSchema,
   );
 }
 
 export async function getInstitutionAuthenticationProviders(
-  institution_id: string
+  institution_id: string,
 ): Promise<AuthnProvider[]> {
   return await queryRows(
     sql.select_institution_authn_providers,
     { institution_id },
-    AuthnProviderSchema
+    AuthnProviderSchema,
   );
 }
 

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourse/institutionAdminCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourse/institutionAdminCourse.html.ts
@@ -14,7 +14,7 @@ export function InstitutionAdminCourse({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../../pages/partials/head')%>", {

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourse/institutionAdminCourse.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourse/institutionAdminCourse.ts
@@ -18,7 +18,7 @@ router.get(
         institution_id: req.params.institution_id,
         course_id: req.params.course_id,
       },
-      CourseSchema
+      CourseSchema,
     );
     const courseInstances = await queryRows(
       sql.select_course_instances,
@@ -26,7 +26,7 @@ router.get(
         institution_id: req.params.institution_id,
         course_id: req.params.course_id,
       },
-      CourseInstanceSchema
+      CourseInstanceSchema,
     );
     res.send(
       InstitutionAdminCourse({
@@ -34,9 +34,9 @@ router.get(
         course,
         course_instances: courseInstances,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.html.ts
@@ -14,7 +14,7 @@ export function InstitutionAdminCourseInstance({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../../pages/partials/head')%>", {

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.ts
@@ -24,7 +24,7 @@ router.get(
       z.object({
         course: CourseSchema,
         course_instance: CourseInstanceSchema,
-      })
+      }),
     );
     res.send(
       InstitutionAdminCourseInstance({
@@ -32,9 +32,9 @@ router.get(
         course,
         course_instance,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 router.post(
@@ -50,7 +50,7 @@ router.post(
     } else {
       throw error.make(400, 'Unknown action');
     }
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.html.ts
@@ -12,7 +12,7 @@ export function InstitutionAdminCourses({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../../pages/partials/head')%>", {

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.ts
@@ -15,10 +15,10 @@ router.get(
     const courses = await queryRows(
       sql.select_courses,
       { institution_id: req.params.institution_id },
-      CourseSchema
+      CourseSchema,
     );
     res.send(InstitutionAdminCourses({ institution, courses, resLocals: res.locals }));
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/pages/institutionAdminGeneral/institutionAdminGeneral.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminGeneral/institutionAdminGeneral.html.ts
@@ -20,7 +20,7 @@ export function InstitutionAdminGeneral({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../../pages/partials/head')%>", {

--- a/apps/prairielearn/src/ee/pages/institutionAdminGeneral/institutionAdminGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminGeneral/institutionAdminGeneral.ts
@@ -19,16 +19,16 @@ router.get(
     const statistics = await queryRow(
       sql.select_institution_statistics,
       { institution_id: req.params.institution_id },
-      InstitutionStatisticsSchema
+      InstitutionStatisticsSchema,
     );
     res.send(
       InstitutionAdminGeneral({
         institution,
         statistics,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 router.post(
@@ -44,7 +44,7 @@ router.post(
     } else {
       throw error.make(400, `Unknown action: ${req.body.__action}`);
     }
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.html.ts
@@ -27,7 +27,7 @@ export const InstitutionAdminSaml = ({
   const testSamlUrl = `https://${host}/pl/auth/institution/${institution.id}/saml/login?RelayState=test`;
 
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../../pages/partials/head')%>", {

--- a/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.ts
@@ -16,7 +16,7 @@ const sql = loadSqlEquiv(__filename);
 const router = Router({ mergeParams: true });
 
 function createCertificate(
-  options: pem.CertificateCreationOptions
+  options: pem.CertificateCreationOptions,
 ): Promise<pem.CertificateCreationResult> {
   return new Promise((resolve, reject) => {
     pem.createCertificate(options, (err, keys) => {
@@ -83,7 +83,7 @@ router.post(
     }
 
     res.redirect(req.originalUrl);
-  })
+  }),
 );
 
 router.get(
@@ -92,7 +92,7 @@ router.get(
     const institution = await getInstitution(req.params.institution_id);
     const samlProvider = await getInstitutionSamlProvider(req.params.institution_id);
     const institutionAuthenticationProviders = await getInstitutionAuthenticationProviders(
-      req.params.institution_id
+      req.params.institution_id,
     );
 
     res.send(
@@ -102,9 +102,9 @@ router.get(
         institutionAuthenticationProviders,
         host: z.string().parse(req.headers.host),
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/ee/pages/institutionAdminSso/institutionAdminSso.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminSso/institutionAdminSso.html.ts
@@ -18,7 +18,7 @@ export const InstitutionAdminSso = ({
   const hasSamlProvider = !!institutionSamlProvider;
   // TODO: only show authentication providers that were enabled in `config.json`.
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../../pages/partials/head')%>", {
@@ -42,7 +42,7 @@ export const InstitutionAdminSso = ({
               <h2 class="h4">Enabled single sign-on providers</h2>
               ${supportedAuthenticationProviders.map((provider) => {
                 const isEnabled = institutionAuthenticationProviders.some(
-                  (p) => p.id === provider.id
+                  (p) => p.id === provider.id,
                 );
                 return html`
                   <div class="form-check">

--- a/apps/prairielearn/src/ee/pages/institutionAdminSso/institutionAdminSso.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminSso/institutionAdminSso.ts
@@ -29,7 +29,7 @@ router.post(
   asyncHandler(async (req, res) => {
     const supportedAuthenticationProviders = await getSupportedAuthenticationProviders();
     const supportedAuthenticationProviderIds = new Set(
-      supportedAuthenticationProviders.map((p) => p.id)
+      supportedAuthenticationProviders.map((p) => p.id),
     );
 
     const rawEnabledAuthnProviderIds = ensureArray(req.body.enabled_authn_provider_ids ?? []);
@@ -52,7 +52,7 @@ router.post(
     });
 
     res.redirect(req.originalUrl);
-  })
+  }),
 );
 
 router.get(
@@ -63,7 +63,7 @@ router.get(
     const institution = await getInstitution(req.params.institution_id);
     const institutionSamlProvider = await getInstitutionSamlProvider(req.params.institution_id);
     const institutionAuthenticationProviders = await getInstitutionAuthenticationProviders(
-      req.params.institution_id
+      req.params.institution_id,
     );
 
     res.send(
@@ -73,9 +73,9 @@ router.get(
         institutionSamlProvider,
         institutionAuthenticationProviders,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/executor.js
+++ b/apps/prairielearn/src/executor.js
@@ -79,7 +79,7 @@ async function handleInput(line, codeCaller) {
       request.directory,
       request.file,
       request.fcn,
-      request.args
+      request.args,
     ));
   } catch (err) {
     callErr = err;

--- a/apps/prairielearn/src/lib/assessment.js
+++ b/apps/prairielearn/src/lib/assessment.js
@@ -97,7 +97,7 @@ module.exports = {
     mode,
     time_limit_min,
     date,
-    callback
+    callback,
   ) {
     var params = [assessment_id, user_id, group_work, authn_user_id, mode, time_limit_min, date];
     sqldb.callOneRow('assessment_instances_insert', params, (err, result) => {
@@ -154,7 +154,7 @@ module.exports = {
       (err) => {
         if (ERR(err, callback)) return;
         callback(null, updated);
-      }
+      },
     );
   },
 
@@ -178,7 +178,7 @@ module.exports = {
     requireOpen,
     close,
     overrideGradeRate,
-    callback
+    callback,
   ) {
     debug('gradeAssessmentInstance()');
     let rows;
@@ -214,7 +214,7 @@ module.exports = {
               rows = result.rows;
               debug('gradeAssessmentInstance()', 'selected variants', 'count:', rows.length);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -236,14 +236,14 @@ module.exports = {
                     externalGradingJobIds.push(gradingJobId);
                   }
                   callback(null);
-                }
+                },
               );
             },
             (err) => {
               if (ERR(err, callback)) return;
               debug('gradeAssessmentInstance()', 'finished grading');
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -283,7 +283,7 @@ module.exports = {
         if (ERR(err, callback)) return;
         debug('gradeAssessmentInstance()', 'success');
         callback(null);
-      }
+      },
     );
   },
 
@@ -301,7 +301,7 @@ module.exports = {
     user_id,
     authn_user_id,
     close,
-    overrideGradeRate
+    overrideGradeRate,
   ) {
     debug('gradeAllAssessmentInstances()');
     const assessmentInfo = await sqldb.queryOneRowAsync(sql.select_assessment_info, {
@@ -339,7 +339,7 @@ module.exports = {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null);
-          }
+          },
         );
       });
     });
@@ -363,7 +363,7 @@ module.exports = {
             return callback(
               error.makeWithData('invalid grading.feedback', {
                 content: content,
-              })
+              }),
             );
           }
 
@@ -436,7 +436,7 @@ module.exports = {
                 if (ERR(err, callback)) return;
                 callback(null);
               });
-            }
+            },
           );
         },
       ]);
@@ -495,7 +495,7 @@ module.exports = {
     return sqldb.queryValidatedRows(
       sql.assessment_instance_log,
       { assessment_instance_id, include_files },
-      InstanceLogSchema
+      InstanceLogSchema,
     );
   },
 
@@ -503,7 +503,7 @@ module.exports = {
     return sqldb.queryValidatedCursor(
       sql.assessment_instance_log,
       { assessment_instance_id, include_files },
-      InstanceLogSchema
+      InstanceLogSchema,
     );
   },
 };

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -87,7 +87,7 @@ function getPackageVersion(packageName: string): string {
     const pkgJsonPath = path.resolve(
       pkgPath.slice(0, lastNodeModulesIndex + nodeModulesToken.length),
       packageName,
-      'package.json'
+      'package.json',
     );
 
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
@@ -163,7 +163,7 @@ export function applyMiddleware(app: express.Application) {
       // is running, so we'll enable long-term caching.
       maxAge: '1y',
       immutable: true,
-    })
+    }),
   );
   router.use(
     '/public/:cachebuster',
@@ -172,7 +172,7 @@ export function applyMiddleware(app: express.Application) {
       // so we'll prevent them from being cached.
       maxAge: config.devMode ? 0 : '1y',
       immutable: !config.devMode,
-    })
+    }),
   );
   router.use('/elements/:cachebuster', elementFiles);
 
@@ -221,7 +221,7 @@ export function coreElementAssetPath(assetPath: string): string {
 export function courseElementAssetPath(
   courseHash: string,
   urlPrefix: string,
-  assetPath: string
+  assetPath: string,
 ): string {
   if (!courseHash) {
     // If for some reason we don't have a course hash, fall back to the
@@ -241,7 +241,7 @@ export function courseElementAssetPath(
 export function courseElementExtensionAssetPath(
   courseHash: string,
   urlPrefix: string,
-  assetPath: string
+  assetPath: string,
 ): string {
   if (!courseHash) {
     // If for some reason we don't have a course hash, fall back to the

--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -50,7 +50,7 @@ module.exports.loadUser = async (req, res, authnParams, optionsParams = {}) => {
       is_administrator: z.boolean(),
       is_instructor: z.boolean(),
       news_item_notification_count: z.number(),
-    })
+    }),
   );
 
   if (!selectedUser) {

--- a/apps/prairielearn/src/lib/aws.js
+++ b/apps/prairielearn/src/lib/aws.js
@@ -59,7 +59,7 @@ module.exports.uploadToS3Async = async function (
   s3Path,
   localPath,
   isDirectory = false,
-  buffer = null
+  buffer = null,
 ) {
   const s3 = new S3(module.exports.makeS3ClientConfig());
 
@@ -108,7 +108,7 @@ module.exports.uploadDirectoryToS3Async = async function (
   s3Bucket,
   s3Path,
   localPath,
-  ignoreList = []
+  ignoreList = [],
 ) {
   const s3 = new S3(module.exports.makeS3ClientConfig());
   const ignoreSet = new Set(ignoreList);
@@ -138,7 +138,7 @@ module.exports.uploadDirectoryToS3Async = async function (
           logger.verbose(`Uploaded file ${localFilePath} to s3://${s3Bucket}/${s3FilePath}`);
         } catch (err) {
           logger.verbose(
-            `Did not sync file ${localFilePath} to $s3://${s3Bucket}/${s3FilePath}: ${err}`
+            `Did not sync file ${localFilePath} to $s3://${s3Bucket}/${s3FilePath}: ${err}`,
           );
         }
       } else if (stat.isDirectory()) {
@@ -152,7 +152,7 @@ module.exports.uploadDirectoryToS3Async = async function (
           logger.verbose(`Uploaded directory ${localFilePath} to s3://${s3Bucket}/${s3DirPath}`);
         } catch (err) {
           logger.verbose(
-            `Did not sync directory ${localFilePath} to $s3://${s3Bucket}/${s3DirPath}: ${err}`
+            `Did not sync directory ${localFilePath} to $s3://${s3Bucket}/${s3DirPath}: ${err}`,
           );
         }
         await walkDirectory(relFilePath);

--- a/apps/prairielearn/src/lib/base64-util.js
+++ b/apps/prairielearn/src/lib/base64-util.js
@@ -11,7 +11,7 @@ module.exports.b64EncodeUnicode = function (str) {
     return btoa(
       encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (match, p1) => {
         return String.fromCharCode('0x' + p1);
-      })
+      }),
     );
   } catch (e) {
     logger.error(`b64EncodeUnicode: returning empty string because failed to encode ${str}`);
@@ -28,7 +28,7 @@ module.exports.b64DecodeUnicode = function (str) {
         .map((c) => {
           return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
         })
-        .join('')
+        .join(''),
     );
   } catch (e) {
     logger.error(`b64DecodeUnicode: returning empty string because failed to decode ${str}`);

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -225,7 +225,7 @@ export function pathForChunk(chunkMetadata: ChunkMetadata): string {
       return path.join(
         'courseInstances',
         chunkMetadata.courseInstanceName,
-        'clientFilesCourseInstance'
+        'clientFilesCourseInstance',
       );
     case 'clientFilesAssessment':
       return path.join(
@@ -233,7 +233,7 @@ export function pathForChunk(chunkMetadata: ChunkMetadata): string {
         chunkMetadata.courseInstanceName,
         'assessments',
         chunkMetadata.assessmentName,
-        'clientFilesAssessment'
+        'clientFilesAssessment',
       );
   }
 }
@@ -257,7 +257,7 @@ export function coursePathForChunk(coursePath: string, chunkMetadata: ChunkMetad
 export async function identifyChangedFiles(
   coursePath: string,
   oldHash: string,
-  newHash: string
+  newHash: string,
 ): Promise<string[]> {
   // In some specific scenarios, the course directory and the root of the course
   // repository might be different. For example, the example course is usually
@@ -270,13 +270,13 @@ export async function identifyChangedFiles(
   // construct an absolute path for each file, and then trim off the course path.
   const { stdout: topLevelStdout } = await util.promisify(child_process.exec)(
     `git rev-parse --show-toplevel`,
-    { cwd: coursePath }
+    { cwd: coursePath },
   );
   const topLevel = topLevelStdout.trim();
 
   const { stdout: diffStdout } = await util.promisify(child_process.exec)(
     `git diff --name-only ${oldHash}..${newHash}`,
-    { cwd: coursePath }
+    { cwd: coursePath },
   );
   const changedFiles = diffStdout.trim().split('\n');
 
@@ -285,12 +285,12 @@ export async function identifyChangedFiles(
 
   // Exclude any changed files that aren't in the course directory.
   const courseChangedFiles = absoluteChangedFiles.filter((absoluteChangedFile) =>
-    contains(coursePath, absoluteChangedFile)
+    contains(coursePath, absoluteChangedFile),
   );
 
   // Convert all absolute paths back into relative paths.
   return courseChangedFiles.map((absoluteChangedFile) =>
-    path.relative(coursePath, absoluteChangedFile)
+    path.relative(coursePath, absoluteChangedFile),
   );
 }
 
@@ -304,7 +304,7 @@ export async function identifyChangedFiles(
  */
 export function identifyChunksFromChangedFiles(
   changedFiles: string[],
-  courseData: CourseData
+  courseData: CourseData,
 ): CourseChunks {
   const courseChunks: CourseChunks = {
     elements: false,
@@ -362,7 +362,7 @@ export function identifyChunksFromChangedFiles(
         // Let's validate that the preceeding path components correspond
         // to an actual course instance
         const courseInstanceId = path.join(
-          ...pathComponents.slice(0, clientFilesCourseInstanceIndex)
+          ...pathComponents.slice(0, clientFilesCourseInstanceIndex),
         );
         if (courseData.courseInstances[courseInstanceId]) {
           if (!courseChunks.courseInstances[courseInstanceId]) {
@@ -389,7 +389,7 @@ export function identifyChunksFromChangedFiles(
         // to course instance IDs and assessment IDs.
         const courseInstanceId = path.join(...pathComponents.slice(0, assessmentsIndex));
         const assessmentId = path.join(
-          ...pathComponents.slice(assessmentsIndex + 1, clientFilesAssessmentIndex)
+          ...pathComponents.slice(assessmentsIndex + 1, clientFilesAssessmentIndex),
         );
 
         if (
@@ -541,7 +541,7 @@ export async function diffChunks({
     Object.entries(courseData.courseInstances),
     async ([ciid, courseInstanceInfo]) => {
       const hasClientFilesCourseInstanceDirectory = await fs.pathExists(
-        path.join(coursePath, 'courseInstances', ciid, 'clientFilesCourseInstance')
+        path.join(coursePath, 'courseInstances', ciid, 'clientFilesCourseInstance'),
       );
       if (
         hasClientFilesCourseInstanceDirectory &&
@@ -562,8 +562,8 @@ export async function diffChunks({
             ciid,
             'assessments',
             tid,
-            'clientFilesAssessment'
-          )
+            'clientFilesAssessment',
+          ),
         );
         if (
           hasClientFilesAssessmentDirectory &&
@@ -577,7 +577,7 @@ export async function diffChunks({
           });
         }
       });
-    }
+    },
   );
 
   // Check for any deleted course instances or their assessments.
@@ -585,7 +585,7 @@ export async function diffChunks({
     Object.entries(existingCourseChunks.courseInstances).map(async ([ciid, courseInstanceInfo]) => {
       const courseInstanceExists = !!courseData.courseInstances[ciid];
       const clientFilesCourseInstanceExists = await fs.pathExists(
-        path.join(coursePath, 'courseInstances', ciid, 'clientFilesCourseInstance')
+        path.join(coursePath, 'courseInstances', ciid, 'clientFilesCourseInstance'),
       );
       if (!courseInstanceExists || !clientFilesCourseInstanceExists) {
         deletedChunks.push({
@@ -604,8 +604,8 @@ export async function diffChunks({
               ciid,
               'assessments',
               tid,
-              'clientFilesAssessment'
-            )
+              'clientFilesAssessment',
+            ),
           );
           if (!courseInstanceExists || !assessmentExists || !clientFilesAssessmentExists) {
             deletedChunks.push({
@@ -614,9 +614,9 @@ export async function diffChunks({
               assessmentName: tid,
             });
           }
-        })
+        }),
       );
-    })
+    }),
   );
 
   return { updatedChunks, deletedChunks };
@@ -625,7 +625,7 @@ export async function diffChunks({
 export async function createAndUploadChunks(
   coursePath: string,
   courseId: string,
-  chunksToGenerate: ChunkMetadata[]
+  chunksToGenerate: ChunkMetadata[],
 ) {
   const generatedChunks: (ChunkMetadata & { uuid: string })[] = [];
 
@@ -647,7 +647,7 @@ export async function createAndUploadChunks(
         gzip: true,
         cwd: chunkDirectory,
       },
-      ['.']
+      ['.'],
     );
 
     const passthrough = new PassThroughStream();
@@ -860,7 +860,7 @@ const ensureChunk = async (courseId: string, chunk: DatabaseChunk) => {
       relativeTargetPath = path.join(
         'courseInstances',
         chunk.course_instance_name,
-        'clientFilesCourseInstance'
+        'clientFilesCourseInstance',
       );
       break;
     case 'clientFilesAssessment':
@@ -875,7 +875,7 @@ const ensureChunk = async (courseId: string, chunk: DatabaseChunk) => {
         chunk.course_instance_name,
         'assessments',
         chunk.assessment_name,
-        'clientFilesAssessment'
+        'clientFilesAssessment',
       );
       break;
     case 'question':
@@ -1040,7 +1040,7 @@ export async function ensureChunksForCourseAsync(courseId: string, chunks: Chunk
       // will silently no-op.
       const chunkMetadata = chunkMetadataFromDatabaseChunk(chunk);
       await fs.remove(coursePathForChunk(courseChunksDirs.course, chunkMetadata));
-    })
+    }),
   );
 }
 export const ensureChunksForCourse = util.callbackify(ensureChunksForCourseAsync);
@@ -1057,7 +1057,7 @@ interface QuestionWithTemplateDirectory {
  * @returns Array of question IDs that are (recursive) templates for the given question (may be an empty array).
  */
 export async function getTemplateQuestionIdsAsync(
-  question: QuestionWithTemplateDirectory
+  question: QuestionWithTemplateDirectory,
 ): Promise<string[]> {
   if (!question.template_directory) return [];
   const result = await sqldb.queryAsync(sql.select_template_question_ids, {
@@ -1073,7 +1073,7 @@ export const getTemplateQuestionIds = util.callbackify(getTemplateQuestionIdsAsy
  */
 export function logChunkChangesToJob(
   { updatedChunks, deletedChunks }: ChunksDiff,
-  job: Pick<ServerJob, 'verbose'>
+  job: Pick<ServerJob, 'verbose'>,
 ) {
   if (updatedChunks.length === 0 && deletedChunks.length === 0) {
     job.verbose('No chunks changed.');

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.js
@@ -97,7 +97,7 @@ async function ensureImage() {
           },
           (output) => {
             logger.info('Docker output', output);
-          }
+          },
         );
       });
     } else {
@@ -480,8 +480,8 @@ class CodeCallerContainer {
     if (this.state === WAITING) {
       this._logError(
         `CodeCallerContainer container exited while in state = WAITING, code = ${JSON.stringify(
-          code
-        )}, err = ${err}`
+          code,
+        )}, err = ${err}`,
       );
       this.container = null;
       this.state = EXITED;
@@ -492,9 +492,9 @@ class CodeCallerContainer {
       this._callCallback(
         new Error(
           `CodeCallerContainer container exited unexpectedly, code = ${JSON.stringify(
-            code
-          )}, err = ${err}`
-        )
+            code,
+          )}, err = ${err}`,
+        ),
       );
     } else if (this.state === EXITING) {
       // no error, this is the good case
@@ -624,14 +624,14 @@ class CodeCallerContainer {
   _checkReadyForCall(fcn) {
     if (!this.container) {
       return this._logError(
-        `Not ready for call, container is not created (state: ${String(this.state)})`
+        `Not ready for call, container is not created (state: ${String(this.state)})`,
       );
     }
     if (fcn !== 'ping' && fcn !== 'restart') {
       // 'ping' and 'restart' are fake functions that don't need a course path
       if (!this.coursePath) {
         return this._logError(
-          `Not ready for call, course was not set (state: ${String(this.state)})`
+          `Not ready for call, course was not set (state: ${String(this.state)})`,
         );
       }
     }
@@ -648,8 +648,8 @@ class CodeCallerContainer {
       const allowedStatesList = allowedStates.map(String).join(', ');
       return this._logError(
         `Expected CodeCallerContainer to be in states [${allowedStatesList}] but actually have state ${String(
-          this.state
-        )}`
+          this.state,
+        )}`,
       );
     }
 
@@ -681,36 +681,36 @@ class CodeCallerContainer {
     if (containerNull != null) {
       if (containerNull && this.container != null) {
         return this._logError(
-          `CodeCallerContainer state ${String(this.state)}: container should be null`
+          `CodeCallerContainer state ${String(this.state)}: container should be null`,
         );
       }
       if (!containerNull && this.container == null) {
         return this._logError(
-          `CodeCallerContainer state ${String(this.state)}: container should not be null`
+          `CodeCallerContainer state ${String(this.state)}: container should not be null`,
         );
       }
     }
     if (callbackNull != null) {
       if (callbackNull && this.callback != null) {
         return this._logError(
-          `CodeCallerContainer state ${String(this.state)}: callback should be null`
+          `CodeCallerContainer state ${String(this.state)}: callback should be null`,
         );
       }
       if (!callbackNull && this.callback == null) {
         return this._logError(
-          `CodeCallerContainer state ${String(this.state)}: callback should not be null`
+          `CodeCallerContainer state ${String(this.state)}: callback should not be null`,
         );
       }
     }
     if (timeoutIDNull != null) {
       if (timeoutIDNull && this.timeoutID != null) {
         return this._logError(
-          `CodeCallerContainer state ${String(this.state)}: timeoutID should be null`
+          `CodeCallerContainer state ${String(this.state)}: timeoutID should be null`,
         );
       }
       if (!timeoutIDNull && this.timeoutID == null) {
         return this._logError(
-          `CodeCallerContainer state ${String(this.state)}: timeoutID should not be null`
+          `CodeCallerContainer state ${String(this.state)}: timeoutID should not be null`,
         );
       }
     }
@@ -755,7 +755,7 @@ async function cleanupMountDirectories() {
           logger.error(`Failed to remove temporary directory ${absolutePath}`);
           logger.error(e);
         }
-      })
+      }),
     );
   } catch (e) {
     logger.error(e);

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.js
@@ -95,7 +95,7 @@ class CodeCallerNative {
       // logger, which will only write to stdout. So, we allow a different
       // logging function to be provided.
       errorLogger: logger.error,
-    }
+    },
   ) {
     /** @type {CodeCallerState} */
     this.state = CREATED;
@@ -415,7 +415,7 @@ class CodeCallerNative {
         'CodeCallerNative child process exited while in state = WAITING, code = ' +
           String(code) +
           ', signal = ' +
-          String(signal)
+          String(signal),
       );
       this.child = null;
       this.state = EXITED;
@@ -428,8 +428,8 @@ class CodeCallerNative {
           'CodeCallerNative child process exited unexpectedly, code = ' +
             String(code) +
             ', signal = ' +
-            String(signal)
-        )
+            String(signal),
+        ),
       );
     } else if (this.state === EXITING) {
       // no error, this is the good case
@@ -445,14 +445,14 @@ class CodeCallerNative {
     if (this.state === WAITING) {
       this._logError(
         'CodeCallerNative child process raised error while in state = WAITING, message = ' +
-          String(error)
+          String(error),
       );
       this.state = EXITING;
       this.child?.kill('SIGTERM');
     } else if (this.state === IN_CALL) {
       this._logError(
         'CodeCallerNative child process raised error while in state = IN_CALL, message = ' +
-          String(error)
+          String(error),
       );
       this._clearTimeout();
       this.state = EXITING;
@@ -462,7 +462,7 @@ class CodeCallerNative {
     } else if (this.state === EXITING) {
       this._logError(
         'CodeCallerNative child process raised error while in state = EXITING, message = ' +
-          String(error)
+          String(error),
       );
     }
     this._checkState();
@@ -614,7 +614,7 @@ class CodeCallerNative {
         'Expected CodeCallerNative states ' +
           allowedStatesList +
           ' but actually have state ' +
-          String(this.state)
+          String(this.state),
       );
     }
 
@@ -650,36 +650,36 @@ class CodeCallerNative {
     if (childNull != null) {
       if (childNull && this.child != null) {
         return this._logError(
-          'CodeCallerNative state "' + String(this.state) + '": child should be null'
+          'CodeCallerNative state "' + String(this.state) + '": child should be null',
         );
       }
       if (!childNull && this.child == null) {
         return this._logError(
-          'CodeCallerNative state "' + String(this.state) + '": child should not be null'
+          'CodeCallerNative state "' + String(this.state) + '": child should not be null',
         );
       }
     }
     if (callbackNull != null) {
       if (callbackNull && this.callback != null) {
         return this._logError(
-          'CodeCallerNative state "' + String(this.state) + '": callback should be null'
+          'CodeCallerNative state "' + String(this.state) + '": callback should be null',
         );
       }
       if (!callbackNull && this.callback == null) {
         return this._logError(
-          'CodeCallerNative state "' + String(this.state) + '": callback should not be null'
+          'CodeCallerNative state "' + String(this.state) + '": callback should not be null',
         );
       }
     }
     if (timeoutIDNull != null) {
       if (timeoutIDNull && this.timeoutID != null) {
         return this._logError(
-          'CodeCallerNative state "' + String(this.state) + '": timeoutID should be null'
+          'CodeCallerNative state "' + String(this.state) + '": timeoutID should be null',
         );
       }
       if (!timeoutIDNull && this.timeoutID == null) {
         return this._logError(
-          'CodeCallerNative state "' + String(this.state) + '": timeoutID should not be null'
+          'CodeCallerNative state "' + String(this.state) + '": timeoutID should not be null',
         );
       }
     }

--- a/apps/prairielearn/src/lib/code-caller/index.js
+++ b/apps/prairielearn/src/lib/code-caller/index.js
@@ -110,7 +110,7 @@ module.exports = {
       {
         min: numWorkers,
         max: numWorkers,
-      }
+      },
     );
 
     pool.on('factoryCreateError', (err) => {

--- a/apps/prairielearn/src/lib/config.js
+++ b/apps/prairielearn/src/lib/config.js
@@ -454,7 +454,7 @@ const ConfigSchema = z.object({
       z.object({
         key: z.string().length(32),
         iv: z.string().length(12),
-      })
+      }),
     )
     .default([]),
   azureLoggingLevel: z.enum(['error', 'warn', 'info']).default('warn'),
@@ -471,7 +471,7 @@ const ConfigSchema = z.object({
     .string()
     .nullable()
     .default(
-      'https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000'
+      'https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000',
     ),
   features: z.record(z.string(), z.boolean()).default({}),
 });

--- a/apps/prairielearn/src/lib/copy-question.ts
+++ b/apps/prairielearn/src/lib/copy-question.ts
@@ -22,7 +22,7 @@ export function setQuestionCopyTargets(res: Response) {
         url: copyUrl,
         authn_user_id: res.locals.authn_user.user_id,
       },
-      config.secretKey
+      config.secretKey,
     );
 
     return {
@@ -44,7 +44,7 @@ export async function copyQuestionBetweenCourses(
     fromCourse: Course;
     toCourseId: string;
     question: Question;
-  }
+  },
 ) {
   // In this case, we are sending a copy of this question to a different course.
   //
@@ -80,6 +80,6 @@ export async function copyQuestionBetweenCourses(
 
   const result = await sqldb.queryOneRowAsync(sql.insert_file_transfer, params);
   res.redirect(
-    `${res.locals.plainUrlPrefix}/course/${params.to_course_id}/file_transfer/${result.rows[0].id}`
+    `${res.locals.plainUrlPrefix}/course/${params.to_course_id}/file_transfer/${result.rows[0].id}`,
   );
 }

--- a/apps/prairielearn/src/lib/courseUtil.js
+++ b/apps/prairielearn/src/lib/courseUtil.js
@@ -73,5 +73,5 @@ module.exports.getOrUpdateCourseCommitHash = function (course, callback) {
 };
 
 module.exports.getOrUpdateCourseCommitHashAsync = promisify(
-  module.exports.getOrUpdateCourseCommitHash
+  module.exports.getOrUpdateCourseCommitHash,
 );

--- a/apps/prairielearn/src/lib/editors.js
+++ b/apps/prairielearn/src/lib/editors.js
@@ -159,7 +159,7 @@ class Editor {
                   {
                     cwd: this.course.path,
                     env: gitEnv,
-                  }
+                  },
                 );
               } catch (err) {
                 await cleanAndResetRepository(this.course, gitEnv, job);
@@ -188,7 +188,7 @@ class Editor {
       ],
       (err) => {
         callback(err, jobSequenceId);
-      }
+      },
     );
   }
 
@@ -379,7 +379,7 @@ class AssessmentCopyEditor extends Editor {
       this.course.path,
       'courseInstances',
       this.course_instance.short_name,
-      'assessments'
+      'assessments',
     );
 
     debug('Get all existing long names');
@@ -396,7 +396,7 @@ class AssessmentCopyEditor extends Editor {
       this.assessment.tid,
       oldNamesShort,
       this.assessment.title,
-      oldNamesLong
+      oldNamesLong,
     );
     const tid = names.shortName;
     const assessmentTitle = names.longName;
@@ -434,7 +434,7 @@ class AssessmentDeleteEditor extends Editor {
       this.course.path,
       'courseInstances',
       this.course_instance.short_name,
-      'assessments'
+      'assessments',
     );
     await fs.remove(path.join(deletePath, this.assessment.tid));
     await this.removeEmptyPrecedingSubfolders(deletePath, this.assessment.tid);
@@ -463,7 +463,7 @@ class AssessmentRenameEditor extends Editor {
       this.course.path,
       'courseInstances',
       this.course_instance.short_name,
-      'assessments'
+      'assessments',
     );
     const oldPath = path.join(basePath, this.assessment.tid);
     const newPath = path.join(basePath, this.tid_new);
@@ -487,7 +487,7 @@ class AssessmentAddEditor extends Editor {
       this.course.path,
       'courseInstances',
       this.course_instance.short_name,
-      'assessments'
+      'assessments',
     );
 
     debug('Get all existing long names');
@@ -550,7 +550,7 @@ class CourseInstanceCopyEditor extends Editor {
     debug('Get all existing short names');
     const oldNamesShort = await this.getExistingShortNames(
       courseInstancesPath,
-      'infoCourseInstance.json'
+      'infoCourseInstance.json',
     );
 
     debug(`Generate short_name and long_name`);
@@ -558,7 +558,7 @@ class CourseInstanceCopyEditor extends Editor {
       this.course_instance.short_name,
       oldNamesShort,
       this.course_instance.long_name,
-      oldNamesLong
+      oldNamesLong,
     );
     this.short_name = names.shortName;
     this.long_name = names.longName;
@@ -573,7 +573,7 @@ class CourseInstanceCopyEditor extends Editor {
 
     debug(`Read infoCourseInstance.json`);
     const infoJson = await fs.readJson(
-      path.join(this.courseInstancePath, 'infoCourseInstance.json')
+      path.join(this.courseInstancePath, 'infoCourseInstance.json'),
     );
 
     debug(`Write infoCourseInstance.json with new longName and uuid`);
@@ -624,7 +624,7 @@ class CourseInstanceRenameEditor extends Editor {
     await fs.move(oldPath, newPath, { overwrite: false });
     await this.removeEmptyPrecedingSubfolders(
       path.join(this.course.path, 'courseInstances'),
-      this.course_instance.short_name
+      this.course_instance.short_name,
     );
 
     this.pathsToAdd = [oldPath, newPath];
@@ -651,7 +651,7 @@ class CourseInstanceAddEditor extends Editor {
     debug('Get all existing short names');
     const oldNamesShort = await this.getExistingShortNames(
       courseInstancesPath,
-      'infoCourseInstance.json'
+      'infoCourseInstance.json',
     );
 
     debug(`Generate short_name and long_name`);
@@ -736,7 +736,7 @@ class QuestionDeleteEditor extends Editor {
     await fs.remove(path.join(this.course.path, 'questions', this.question.qid));
     await this.removeEmptyPrecedingSubfolders(
       path.join(this.course.path, 'questions'),
-      this.question.qid
+      this.question.qid,
     );
     this.pathsToAdd = [path.join(this.course.path, 'questions', this.question.qid)];
     this.commitMessage = `delete question ${this.question.qid}`;
@@ -776,7 +776,7 @@ class QuestionRenameEditor extends Editor {
     const assessments = result.rows;
 
     debug(
-      `For each assessment, read/write infoAssessment.json to replace ${this.question.qid} with ${this.qid_new}`
+      `For each assessment, read/write infoAssessment.json to replace ${this.question.qid} with ${this.qid_new}`,
     );
     for (const assessment of assessments) {
       let infoPath = path.join(
@@ -785,7 +785,7 @@ class QuestionRenameEditor extends Editor {
         assessment.course_instance_directory,
         'assessments',
         assessment.assessment_directory,
-        'infoAssessment.json'
+        'infoAssessment.json',
       );
       this.pathsToAdd.push(infoPath);
 
@@ -842,7 +842,7 @@ class QuestionCopyEditor extends Editor {
       this.question.qid,
       oldNamesShort,
       this.question.title,
-      oldNamesLong
+      oldNamesLong,
     );
     this.qid = names.shortName;
     this.questionTitle = names.longName;
@@ -933,7 +933,7 @@ class FileDeleteEditor extends Editor {
     }
     this.description = `${this.prefix}delete ${path.relative(
       this.container.rootPath,
-      this.deletePath
+      this.deletePath,
     )}`;
   }
 
@@ -945,13 +945,13 @@ class FileDeleteEditor extends Editor {
         `<p>The path of the file to delete</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.deletePath}</pre></div>` +
           `<p>must be inside the root directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`,
       );
       return callback(err);
     }
 
     const found = this.container.invalidRootPaths.find((invalidRootPath) =>
-      contains(invalidRootPath, this.deletePath)
+      contains(invalidRootPath, this.deletePath),
     );
     if (found) {
       const err = error.makeWithInfo(
@@ -959,7 +959,7 @@ class FileDeleteEditor extends Editor {
         `<p>The path of the file to delete</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.deletePath}</pre></div>` +
           `<p>must <em>not</em> be inside the directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`,
       );
       return callback(err);
     }
@@ -992,7 +992,7 @@ class FileRenameEditor extends Editor {
     }
     this.description = `${this.prefix}rename ${path.relative(
       this.container.rootPath,
-      this.oldPath
+      this.oldPath,
     )} to ${path.relative(this.container.rootPath, this.newPath)}`;
   }
 
@@ -1004,7 +1004,7 @@ class FileRenameEditor extends Editor {
         `<p>The file's old path</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.oldPath}</pre></div>` +
           `<p>must be inside the root directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`,
       );
       return callback(err);
     }
@@ -1015,7 +1015,7 @@ class FileRenameEditor extends Editor {
         `<p>The file's new path</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.newPath}</pre></div>` +
           `<p>must be inside the root directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`,
       );
       return callback(err);
     }
@@ -1023,7 +1023,7 @@ class FileRenameEditor extends Editor {
     let found;
 
     found = this.container.invalidRootPaths.find((invalidRootPath) =>
-      contains(invalidRootPath, this.oldPath)
+      contains(invalidRootPath, this.oldPath),
     );
     if (found) {
       const err = error.makeWithInfo(
@@ -1031,13 +1031,13 @@ class FileRenameEditor extends Editor {
         `<p>The file's old path</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.oldPath}</pre></div>` +
           `<p>must <em>not</em> be inside the directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`,
       );
       return callback(err);
     }
 
     found = this.container.invalidRootPaths.find((invalidRootPath) =>
-      contains(invalidRootPath, this.newPath)
+      contains(invalidRootPath, this.newPath),
     );
     if (found) {
       const err = error.makeWithInfo(
@@ -1045,7 +1045,7 @@ class FileRenameEditor extends Editor {
         `<p>The file's new path</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.newPath}</pre></div>` +
           `<p>must <em>not</em> be inside the directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`,
       );
       return callback(err);
     }
@@ -1082,7 +1082,7 @@ class FileUploadEditor extends Editor {
     }
     this.description = `${this.prefix}upload ${path.relative(
       this.container.rootPath,
-      this.filePath
+      this.filePath,
     )}`;
   }
 
@@ -1124,13 +1124,13 @@ class FileUploadEditor extends Editor {
         `<p>The file path</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.filePath}</pre></div>` +
           `<p>must be inside the root directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.container.rootPath}</pre></div>`,
       );
       return callback(err);
     }
 
     const found = this.container.invalidRootPaths.find((invalidRootPath) =>
-      contains(invalidRootPath, this.filePath)
+      contains(invalidRootPath, this.filePath),
     );
     if (found) {
       const err = error.makeWithInfo(
@@ -1138,7 +1138,7 @@ class FileUploadEditor extends Editor {
         `<p>The file path</p>` +
           `<div class="container"><pre class="bg-dark text-white rounded p-2">${this.filePath}</pre></div>` +
           `<p>must <em>not</em> be inside the directory</p>` +
-          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`
+          `<div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>`,
       );
       return callback(err);
     }

--- a/apps/prairielearn/src/lib/externalGrader.js
+++ b/apps/prairielearn/src/lib/externalGrader.js
@@ -48,7 +48,7 @@ module.exports.beginGradingJobs = function (grading_job_ids, callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 };
 
@@ -72,7 +72,7 @@ module.exports._beginGradingJob = function (grading_job, submission, variant, qu
     assessment
       .processGradingResult(ret)
       .catch((err) =>
-        logger.error(`Error processing results for grading job ${grading_job.id}`, err)
+        logger.error(`Error processing results for grading job ${grading_job.id}`, err),
       );
     return;
   }
@@ -84,7 +84,7 @@ module.exports._beginGradingJob = function (grading_job, submission, variant, qu
     submission,
     variant,
     question,
-    course
+    course,
   );
   gradeRequest.on('submit', () => {
     updateJobSubmissionTime(grading_job.id, (err) => {
@@ -103,7 +103,7 @@ module.exports._beginGradingJob = function (grading_job, submission, variant, qu
     // external grader results wil be delivered via SQS.
     assessment.processGradingResult(gradingResult).then(
       () => logger.verbose(`Successfully processed grading job ${grading_job.id}`),
-      (err) => logger.error(`Error processing grading job ${grading_job.id}`, err)
+      (err) => logger.error(`Error processing grading job ${grading_job.id}`, err),
     );
   });
   gradeRequest.on('error', (err) => {

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -82,7 +82,7 @@ module.exports.buildDirectory = function (dir, submission, variant, question, co
             (err) => {
               if (ERR(err, callback)) return;
               callback(null);
-            }
+            },
           );
         } else {
           callback(null);
@@ -109,7 +109,7 @@ module.exports.buildDirectory = function (dir, submission, variant, question, co
             });
           } else {
             logger.warn(
-              `No tests directory found for ${question.qid}; maybe you meant to specify some?`
+              `No tests directory found for ${question.qid}; maybe you meant to specify some?`,
             );
             callback(null);
           }
@@ -150,7 +150,7 @@ module.exports.buildDirectory = function (dir, submission, variant, question, co
             function (err) {
               if (ERR(err, callback)) return;
               callback(null);
-            }
+            },
           );
         } else {
           callback(null);
@@ -181,7 +181,7 @@ module.exports.buildDirectory = function (dir, submission, variant, question, co
 
       logger.verbose(`Successfully set up ${dir}`);
       callback(null);
-    }
+    },
   );
 };
 
@@ -243,7 +243,7 @@ module.exports.makeGradingResult = function (jobId, rawData) {
     return makeGradingFailureWithMessage(
       jobId,
       data,
-      "results.json did not contain 'results' object."
+      "results.json did not contain 'results' object.",
     );
   }
 
@@ -254,7 +254,7 @@ module.exports.makeGradingResult = function (jobId, rawData) {
     return makeGradingFailureWithMessage(
       jobId,
       data,
-      `score "${data.results.score}" was not a number.`
+      `score "${data.results.score}" was not a number.`,
     );
   }
 

--- a/apps/prairielearn/src/lib/externalGraderLocal.js
+++ b/apps/prairielearn/src/lib/externalGraderLocal.js
@@ -45,7 +45,7 @@ class Grader {
         submission,
         variant,
         question,
-        course
+        course,
       );
 
       if (question.external_grading_entrypoint.includes('serverFilesCourse')) {
@@ -73,7 +73,7 @@ class Grader {
         } catch (err) {
           logger.warn(
             `Error pulling "${question.external_grading_image}" image; attempting to fall back to cached version.`,
-            err
+            err,
           );
         }
       }
@@ -82,7 +82,7 @@ class Grader {
         Image: question.external_grading_image,
         // Convert {key: 'value'} to ['key=value'] and {key: null} to ['key'] for Docker API
         Env: Object.entries(question.external_grading_environment).map(([k, v]) =>
-          v === null ? k : `${k}=${v}`
+          v === null ? k : `${k}=${v}`,
         ),
         AttachStdout: true,
         AttachStderr: true,

--- a/apps/prairielearn/src/lib/externalGraderResults.js
+++ b/apps/prairielearn/src/lib/externalGraderResults.js
@@ -52,7 +52,7 @@ module.exports.init = async function () {
               MaxNumberOfMessages: 10,
               QueueUrl: queueUrl,
               WaitTimeSeconds: 20,
-            })
+            }),
           );
           messages = data.Messages;
         } catch (err) {
@@ -78,13 +78,13 @@ module.exports.init = async function () {
               new DeleteMessageCommand({
                 QueueUrl: queueUrl,
                 ReceiptHandle: receiptHandle,
-              })
+              }),
             );
           } catch (err) {
             logger.error('Error processing external grader results', err);
             Sentry.captureException(err);
           }
-        })
+        }),
       );
     }
   })().then(() => {
@@ -112,17 +112,17 @@ module.exports.stop = async function () {
  */
 async function loadQueueUrl(sqs) {
   logger.verbose(
-    `External grading results queue ${config.externalGradingResultsQueueName}: getting URL...`
+    `External grading results queue ${config.externalGradingResultsQueueName}: getting URL...`,
   );
   const data = await sqs.send(
-    new GetQueueUrlCommand({ QueueName: config.externalGradingResultsQueueName })
+    new GetQueueUrlCommand({ QueueName: config.externalGradingResultsQueueName }),
   );
   const queueUrl = data.QueueUrl;
   if (!queueUrl) {
     throw new Error(`Could not get URL for queue ${config.externalGradingResultsQueueName}`);
   }
   logger.verbose(
-    `External grading results queue ${config.externalGradingResultsQueueName}: got URL ${queueUrl}`
+    `External grading results queue ${config.externalGradingResultsQueueName}: got URL ${queueUrl}`,
   );
   return queueUrl;
 }

--- a/apps/prairielearn/src/lib/externalGraderSqs.js
+++ b/apps/prairielearn/src/lib/externalGraderSqs.js
@@ -42,7 +42,7 @@ class Grader {
               gzip: true,
               cwd: dir,
             },
-            ['.']
+            ['.'],
           );
 
           const passthrough = new PassThroughStream();
@@ -77,7 +77,7 @@ class Grader {
         } else {
           emitter.emit('submit');
         }
-      }
+      },
     );
 
     return emitter;
@@ -98,7 +98,7 @@ async function sendJobToQueue(jobId, question, config) {
       const data = await sqs.send(
         new GetQueueUrlCommand({
           QueueName: config.externalGradingJobsQueueName,
-        })
+        }),
       );
       QUEUE_URL = data.QueueUrl;
     },
@@ -117,7 +117,7 @@ async function sendJobToQueue(jobId, question, config) {
         new SendMessageCommand({
           QueueUrl: QUEUE_URL,
           MessageBody: JSON.stringify(messageBody),
-        })
+        }),
       );
       logger.verbose('Queued external grading job', {
         grading_job_id: jobId,

--- a/apps/prairielearn/src/lib/externalGradingSocket.js
+++ b/apps/prairielearn/src/lib/externalGradingSocket.js
@@ -76,7 +76,7 @@ module.exports.connection = function (socket) {
           questionPanelFooter: panels.questionPanelFooter,
           questionNavNextButton: panels.questionNavNextButton,
         });
-      }
+      },
     );
   });
 };
@@ -114,7 +114,7 @@ module.exports.renderPanelsForSubmission = function (
   questionContext,
   csrfToken,
   authorizedEdit,
-  callback
+  callback,
 ) {
   question.renderPanelsForSubmission(
     submission_id,
@@ -129,7 +129,7 @@ module.exports.renderPanelsForSubmission = function (
     (err, results) => {
       if (ERR(err, callback)) return;
       callback(null, results);
-    }
+    },
   );
 };
 

--- a/apps/prairielearn/src/lib/features/manager.ts
+++ b/apps/prairielearn/src/lib/features/manager.ts
@@ -105,7 +105,7 @@ export class FeatureManager<FeatureName extends string> {
         ...DEFAULT_CONTEXT,
         ...context,
       },
-      z.boolean()
+      z.boolean(),
     );
     if (featureIsEnabled) return true;
 
@@ -128,7 +128,7 @@ export class FeatureManager<FeatureName extends string> {
       course?: { id: string };
       course_instance?: { id: string };
       user?: { user_id: string };
-    }
+    },
   ): Promise<boolean> {
     const user_context = locals.user && { user_id: locals.user.user_id };
     if (!locals.institution) {

--- a/apps/prairielearn/src/lib/file-paths.js
+++ b/apps/prairielearn/src/lib/file-paths.js
@@ -40,7 +40,7 @@ module.exports.questionFilePathAsync = async function (
   questionDirectory,
   coursePath,
   question,
-  nTemplates = 0
+  nTemplates = 0,
 ) {
   const rootPath = path.join(coursePath, 'questions', questionDirectory);
   const fullPath = path.join(rootPath, filename);
@@ -69,7 +69,7 @@ module.exports.questionFilePathAsync = async function (
       throw error.make(
         500,
         `Could not find template question "${question.template_directory}" from question "${question.directory}"`,
-        { sql: sql.select_question, params: params }
+        { sql: sql.select_question, params: params },
       );
     }
 
@@ -79,7 +79,7 @@ module.exports.questionFilePathAsync = async function (
       templateQuestion.directory,
       coursePath,
       templateQuestion,
-      nTemplates + 1
+      nTemplates + 1,
     );
   } else {
     // No template, try default files
@@ -125,7 +125,7 @@ module.exports.questionFilePath = function (
   questionDirectory,
   coursePath,
   question,
-  callback
+  callback,
 ) {
   module.exports
     .questionFilePathAsync(filename, questionDirectory, coursePath, question)

--- a/apps/prairielearn/src/lib/file-store.js
+++ b/apps/prairielearn/src/lib/file-store.js
@@ -34,7 +34,7 @@ module.exports.upload = async (
   instance_question_id,
   user_id,
   authn_user_id,
-  storage_type
+  storage_type,
 ) => {
   storage_type = storage_type || config.fileStoreStorageTypeDefault;
   debug(`upload(): storage_type=${storage_type}`);
@@ -52,7 +52,7 @@ module.exports.upload = async (
       storage_filename,
       null,
       false,
-      buffer
+      buffer,
     );
     debug('upload() : uploaded to ' + res.Location);
   } else if (storage_type === StorageTypes.FileSystem) {
@@ -142,7 +142,7 @@ module.exports.get = async (file_id, data_type = 'buffer') => {
   if (result.rows[0].storage_type === StorageTypes.FileSystem) {
     if (config.filesRoot == null) {
       throw new Error(
-        `config.filesRoot must be non-null to get file_id ${file_id} from file store`
+        `config.filesRoot must be non-null to get file_id ${file_id} from file store`,
       );
     }
 
@@ -153,7 +153,7 @@ module.exports.get = async (file_id, data_type = 'buffer') => {
       buffer = await fsPromises.readFile(filename);
     } else {
       debug(
-        `get(): createReadStream ${filename} and return object with contents stream and file object`
+        `get(): createReadStream ${filename} and return object with contents stream and file object`,
       );
       readStream = fs.createReadStream(filename);
     }
@@ -162,23 +162,23 @@ module.exports.get = async (file_id, data_type = 'buffer') => {
   if (result.rows[0].storage_type === StorageTypes.S3) {
     if (config.fileStoreS3Bucket == null) {
       throw new Error(
-        `config.fileStoreS3Bucket must be configured to get file_id ${file_id} from file store`
+        `config.fileStoreS3Bucket must be configured to get file_id ${file_id} from file store`,
       );
     }
 
     if (data_type === 'buffer') {
       debug(
-        `get(): s3 fetch file ${result.rows[0].storage_filename} from ${config.fileStoreS3Bucket} and return object with contents buffer and file object`
+        `get(): s3 fetch file ${result.rows[0].storage_filename} from ${config.fileStoreS3Bucket} and return object with contents buffer and file object`,
       );
       buffer = await getFromS3Async(config.fileStoreS3Bucket, result.rows[0].storage_filename);
     } else {
       debug(
-        `get(): s3 fetch stream ${result.rows[0].storage_filename} from ${config.fileStoreS3Bucket} and return object with contents stream and file object`
+        `get(): s3 fetch stream ${result.rows[0].storage_filename} from ${config.fileStoreS3Bucket} and return object with contents stream and file object`,
       );
       readStream = await getFromS3Async(
         config.fileStoreS3Bucket,
         result.rows[0].storage_filename,
-        false
+        false,
       );
     }
   }

--- a/apps/prairielearn/src/lib/github.js
+++ b/apps/prairielearn/src/lib/github.js
@@ -186,7 +186,7 @@ module.exports = {
           on_success: resolve,
           on_error: reject,
         },
-        options
+        options,
       );
 
       serverJobs.createJob(options, function (err, job) {
@@ -220,7 +220,7 @@ module.exports = {
           job_sequence_id,
           on_success: resolve,
         },
-        options
+        options,
       );
 
       serverJobs.spawnJob(options, (err, job) => {
@@ -263,7 +263,7 @@ module.exports = {
           authn_user.user_id,
           async () => {
             return;
-          }
+          },
         );
         return;
       }
@@ -277,7 +277,7 @@ module.exports = {
         async (job) => {
           job.info(`Creating course ${options.short_name}`);
           job.info(JSON.stringify(options, null, 4));
-        }
+        },
       );
 
       // Create base github repo from template
@@ -292,7 +292,7 @@ module.exports = {
           await module.exports.createRepoFromTemplateAsync(
             client,
             options.repo_short_name,
-            config.githubCourseTemplate
+            config.githubCourseTemplate,
           );
           job.info(`Created repository ${options.repo_short_name}`);
 
@@ -310,7 +310,7 @@ module.exports = {
           }
           options.branch = branches[0].name || config.githubMainBranch;
           job.info(`Main branch for new repository: "${options.branch}"`);
-        }
+        },
       );
 
       // Update the infoCourse.json file by grabbing the original and JSON editing it.
@@ -322,7 +322,7 @@ module.exports = {
           let { sha: sha, contents } = await module.exports.getFileFromRepoAsync(
             client,
             options.repo_short_name,
-            'infoCourse.json'
+            'infoCourse.json',
           );
           job.info(`Loaded infoCourse.json file (SHA ${sha})`);
 
@@ -341,10 +341,10 @@ module.exports = {
             options.repo_short_name,
             'infoCourse.json',
             newContents,
-            sha
+            sha,
           );
           job.info('Uploaded new infoCourse.json file');
-        }
+        },
       );
 
       // Add machine and instructor to the repo
@@ -357,12 +357,12 @@ module.exports = {
             client,
             options.repo_short_name,
             config.githubMachineTeam,
-            'admin'
+            'admin',
           );
           job.info(
-            `Added team ${config.githubMachineTeam} as administrator of repo ${options.repo_short_name}`
+            `Added team ${config.githubMachineTeam} as administrator of repo ${options.repo_short_name}`,
           );
-        }
+        },
       );
       if (options.github_user) {
         await module.exports._runJobAsync(
@@ -378,15 +378,15 @@ module.exports = {
                 client,
                 options.repo_short_name,
                 options.github_user,
-                'admin'
+                'admin',
               );
               job.info(
-                `Added user ${options.github_user} as administrator of repo ${options.repo_short_name}`
+                `Added user ${options.github_user} as administrator of repo ${options.repo_short_name}`,
               );
             } catch (err) {
               job.error(`Could not add user "${options.github_user}": ${err}`);
             }
-          }
+          },
         );
       }
 
@@ -410,7 +410,7 @@ module.exports = {
           inserted_course = (await sqldb.callAsync('courses_insert', sql_params)).rows[0];
           job.verbose('Inserted course into database:');
           job.verbose(JSON.stringify(inserted_course, null, 4));
-        }
+        },
       );
 
       // Give the owner required permissions
@@ -424,7 +424,7 @@ module.exports = {
             course_request_id: options.course_request_id,
           };
           await sqldb.queryOneRowAsync(sql.set_course_owner_permission, sql_params);
-        }
+        },
       );
 
       // Automatically sync the new course. This part is shamelessly stolen
@@ -442,7 +442,7 @@ module.exports = {
           env: git_env,
         },
         job_sequence_id,
-        authn_user.user_id
+        authn_user.user_id,
       );
       let sync_result;
       await module.exports._runJobAsync(
@@ -457,9 +457,9 @@ module.exports = {
           sync_result = await syncFromDisk.syncDiskToSqlAsync(
             inserted_course.path,
             inserted_course.id,
-            job
+            job,
           );
-        }
+        },
       );
 
       // If we have chunks enabled, then create associated chunks for the new course
@@ -479,7 +479,7 @@ module.exports = {
               courseData: sync_result.courseData,
             });
             chunks.logChunkChangesToJob(chunkChanges, job);
-          }
+          },
         );
       }
 
@@ -492,7 +492,7 @@ module.exports = {
         authn_user.user_id,
         async () => {
           await courseUtil.updateCourseCommitHashAsync(inserted_course);
-        }
+        },
       );
     };
 
@@ -529,10 +529,10 @@ module.exports = {
               ERR(err, () => {
                 logger.error(err);
               });
-            }
+            },
           );
         }
-      }
+      },
     );
   },
 };

--- a/apps/prairielearn/src/lib/group-update.js
+++ b/apps/prairielearn/src/lib/group-update.js
@@ -68,14 +68,14 @@ module.exports = {
             if (err || lock == null) {
               job.verbose(`Did not acquire lock ${lockName}`);
               job.fail(
-                `Another user is already modifying group setting for this assessment. Please try again later.`
+                `Another user is already modifying group setting for this assessment. Please try again later.`,
               );
               return;
             } else {
               job.verbose(`Acquired lock ${lockName}`);
               job.verbose('Uploading group settings for ' + assessmentLabel);
               job.verbose(
-                `Parsing uploaded CSV file "${csvFile.originalname}" (${csvFile.size} bytes)`
+                `Parsing uploaded CSV file "${csvFile.originalname}" (${csvFile.size} bytes)`,
               );
               job.verbose(`----------------------------------------`);
               job.verbose(`Processing group updates...`);
@@ -115,7 +115,7 @@ module.exports = {
                       if (notExist) {
                         job.verbose(`----------------------------------------`);
                         job.verbose(
-                          `ERROR: The following users do not exist. Please check their uids first.`
+                          `ERROR: The following users do not exist. Please check their uids first.`,
                         );
                         notExist.forEach((user) => {
                           job.verbose(user);
@@ -142,7 +142,7 @@ module.exports = {
                     job.verbose(`Released lock ${lockName}`);
                     if (errorCount === 0) {
                       job.verbose(
-                        `Successfully updated groups for ${successCount} students, with no errors`
+                        `Successfully updated groups for ${successCount} students, with no errors`,
                       );
                       job.succeed();
                     } else {
@@ -179,7 +179,7 @@ module.exports = {
     max_group_size,
     min_group_size,
     option,
-    callback
+    callback,
   ) {
     if (max_group_size < 2 || min_group_size < 1 || max_group_size < min_group_size) {
       return callback(new Error('Group Setting Requirements: max > 1; min > 0; max >= min'));
@@ -227,7 +227,7 @@ module.exports = {
             if (err || lock == null) {
               job.verbose(`Did not acquire lock ${lockName}`);
               job.fail(
-                `Another user is already modifying group setting for this assessment. Please try again later.`
+                `Another user is already modifying group setting for this assessment. Please try again later.`,
               );
               return;
             }
@@ -259,7 +259,7 @@ module.exports = {
                 `Processing creating groups - max of ` +
                   max_group_size +
                   ' and min of ' +
-                  min_group_size
+                  min_group_size,
               );
               let numGroup = Math.ceil(numStudents / max_group_size);
               let updateList = [];
@@ -287,7 +287,7 @@ module.exports = {
                 if (notExist) {
                   job.verbose(`----------------------------------------`);
                   job.verbose(
-                    `ERROR: The following users do not exist. Please check their uids first.`
+                    `ERROR: The following users do not exist. Please check their uids first.`,
                   );
                   notExist.forEach((user) => {
                     job.verbose(user);
@@ -307,7 +307,7 @@ module.exports = {
               job.verbose(`----------------------------------------`);
               if (errorCount === 0) {
                 job.verbose(
-                  `Successfully updated groups for ${successCount} students, with no errors`
+                  `Successfully updated groups for ${successCount} students, with no errors`,
                 );
                 job.succeed();
               } else {

--- a/apps/prairielearn/src/lib/groups.js
+++ b/apps/prairielearn/src/lib/groups.js
@@ -108,7 +108,7 @@ module.exports.getGroupId = async function (assessmentId, userId) {
   return await sqldb.queryValidatedSingleColumnZeroOrOneRow(
     sql.get_group_id,
     params,
-    GroupIdSchema
+    GroupIdSchema,
   );
 };
 
@@ -159,7 +159,7 @@ async function getRolesInfo(groupId, groupMembers) {
   let result = await sqldb.queryValidatedRows(
     sql.get_role_assignments,
     params,
-    RoleAssignmentSchema
+    RoleAssignmentSchema,
   );
   let roleAssignments = {}; // {uid: [{role_name, group_role_id, user_id}]}
   result.forEach(({ uid, role_name, group_role_id, user_id }) => {
@@ -176,13 +176,13 @@ async function getRolesInfo(groupId, groupMembers) {
   rolesInfo.groupRoles = await sqldb.queryValidatedRows(
     sql.get_group_roles,
     params,
-    GroupRoleSchema
+    GroupRoleSchema,
   );
 
   // Identify errors for any roles where count is not between max and min (if they exist)
   rolesInfo.validationErrors = rolesInfo.groupRoles.filter(
     (role) =>
-      (role.minimum && role.count < role.minimum) || (role.maximum && role.count > role.maximum)
+      (role.minimum && role.count < role.minimum) || (role.maximum && role.count > role.maximum),
   );
 
   // Identify any disabled roles based on group size, role minimums
@@ -200,7 +200,7 @@ async function getRolesInfo(groupId, groupMembers) {
   // Check if any users have too many roles
   if (groupSize >= minimumRolesToFill) {
     rolesInfo.rolesAreBalanced = Object.values(roleAssignments).every(
-      (roles) => roles.length === 1
+      (roles) => roles.length === 1,
     );
   } else {
     rolesInfo.rolesAreBalanced = true;
@@ -208,7 +208,7 @@ async function getRolesInfo(groupId, groupMembers) {
 
   // Check if users have no roles
   rolesInfo.usersWithoutRoles = groupMembers.filter(
-    (member) => roleAssignments[member.uid] === undefined
+    (member) => roleAssignments[member.uid] === undefined,
   );
 
   return rolesInfo;
@@ -320,7 +320,7 @@ module.exports.getGroupRoleReassignmentsAfterLeave = function (groupInfo, leavin
       (role) =>
         (role.minimum ?? 0) > 0 &&
         role.count <= (role.minimum ?? 0) &&
-        leavingUserRoleIds.includes(role.id)
+        leavingUserRoleIds.includes(role.id),
     )
     .map((role) => role.id);
 
@@ -334,7 +334,7 @@ module.exports.getGroupRoleReassignmentsAfterLeave = function (groupInfo, leavin
     const userIdWithNoRoles = groupInfo.groupMembers.find(
       (m) =>
         m.user_id !== leavingUserId.toString() &&
-        groupRoleAssignmentUpdates.find(({ user_id }) => user_id === m.user_id) === undefined
+        groupRoleAssignmentUpdates.find(({ user_id }) => user_id === m.user_id) === undefined,
     )?.user_id;
     if (userIdWithNoRoles !== undefined) {
       groupRoleAssignmentUpdates.push({
@@ -360,8 +360,8 @@ module.exports.getGroupRoleReassignmentsAfterLeave = function (groupInfo, leavin
       (m) =>
         m.user_id !== leavingUserId.toString() &&
         !groupRoleAssignmentUpdates.some(
-          (u) => u.group_role_id === roleId && u.user_id === m.user_id
-        )
+          (u) => u.group_role_id === roleId && u.user_id === m.user_id,
+        ),
     )?.user_id;
     if (assigneeUserId !== undefined) {
       groupRoleAssignmentUpdates.push({
@@ -385,7 +385,7 @@ module.exports.leaveGroup = async function (assessmentId, userId, authnUserId) {
     const groupId = await module.exports.getGroupId(assessmentId, userId);
     if (groupId === null) {
       throw new Error(
-        "Couldn't access the user's group ID with the provided assessment and user IDs"
+        "Couldn't access the user's group ID with the provided assessment and user IDs",
       );
     }
     const groupConfig = await module.exports.getGroupConfig(assessmentId);
@@ -398,7 +398,7 @@ module.exports.leaveGroup = async function (assessmentId, userId, authnUserId) {
       if (currentSize > 1) {
         const groupRoleAssignmentUpdates = module.exports.getGroupRoleReassignmentsAfterLeave(
           groupInfo,
-          userId
+          userId,
         );
 
         await sqldb.queryAsync(sql.reassign_group_roles_after_leave, {
@@ -409,7 +409,7 @@ module.exports.leaveGroup = async function (assessmentId, userId, authnUserId) {
 
         // Groups with low enough size should only use required roles
         const minRolesToFill = _.sum(
-          groupInfo.rolesInfo.groupRoles.map((role) => role.minimum ?? 0)
+          groupInfo.rolesInfo.groupRoles.map((role) => role.minimum ?? 0),
         );
         if (currentSize - 1 <= minRolesToFill) {
           await sqldb.queryAsync(sql.delete_non_required_roles, {
@@ -439,7 +439,7 @@ module.exports.getAssessmentPermissions = async function (assessmentId, userId) 
   return await sqldb.queryValidatedOneRow(
     sql.get_assessment_level_permissions,
     params,
-    AssessmentLevelPermissionsSchema
+    AssessmentLevelPermissionsSchema,
   );
 };
 
@@ -456,7 +456,7 @@ module.exports.updateGroupRoles = async function (requestBody, assessmentId, use
     const groupId = await module.exports.getGroupId(assessmentId, userId);
     if (groupId === null) {
       throw new Error(
-        "Couldn't access the user's group ID with the provided assessment and user IDs"
+        "Couldn't access the user's group ID with the provided assessment and user IDs",
       );
     }
 
@@ -464,7 +464,7 @@ module.exports.updateGroupRoles = async function (requestBody, assessmentId, use
     if (!permissions.can_assign_roles_at_start) {
       throw error.make(
         403,
-        'User does not have permission to assign roles at the start of this assessment'
+        'User does not have permission to assign roles at the start of this assessment',
       );
     }
 
@@ -488,7 +488,7 @@ module.exports.updateGroupRoles = async function (requestBody, assessmentId, use
       .filter((role) => role.can_assign_roles_at_start)
       .map((role) => role.id);
     const assignerRoleFound = roleAssignments.some((roleAssignment) =>
-      assignerRoleIds.includes(roleAssignment.group_role_id)
+      assignerRoleIds.includes(roleAssignment.group_role_id),
     );
     if (!assignerRoleFound) {
       roleAssignments.push({

--- a/apps/prairielearn/src/lib/instructorFiles.js
+++ b/apps/prairielearn/src/lib/instructorFiles.js
@@ -27,7 +27,7 @@ function getPaths(req, res, callback) {
     paths.rootPath = path.join(
       res.locals.course.path,
       'courseInstances',
-      res.locals.course_instance.short_name
+      res.locals.course_instance.short_name,
     );
     paths.invalidRootPaths = [path.join(paths.rootPath, 'assessments')];
     paths.cannotMove = [path.join(paths.rootPath, 'infoCourseInstance.json')];
@@ -40,7 +40,7 @@ function getPaths(req, res, callback) {
       'courseInstances',
       res.locals.course_instance.short_name,
       'assessments',
-      res.locals.assessment.tid
+      res.locals.assessment.tid,
     );
     paths.invalidRootPaths = [];
     paths.cannotMove = [path.join(paths.rootPath, 'infoAssessment.json')];
@@ -77,7 +77,7 @@ function getPaths(req, res, callback) {
         label: 'Client',
         path: paths.clientDir,
         info: `This file will be placed in the subdirectory <code>${path.basename(
-          paths.clientDir
+          paths.clientDir,
         )}</code> and will be accessible from the student's webbrowser.`,
       });
     }
@@ -86,7 +86,7 @@ function getPaths(req, res, callback) {
         label: 'Server',
         path: paths.serverDir,
         info: `This file will be placed in the subdirectory <code>${path.basename(
-          paths.serverDir
+          paths.serverDir,
         )}</code> and will be accessible only from the server. It will not be accessible from the student's webbrowser.`,
       });
     }
@@ -95,7 +95,7 @@ function getPaths(req, res, callback) {
         label: 'Test',
         path: paths.testsDir,
         info: `This file will be placed in the subdirectory <code>${path.basename(
-          paths.testsDir
+          paths.testsDir,
         )}</code> and will be accessible only from the server. It will not be accessible from the student's webbrowser. This is appropriate for code to support <a href='https://prairielearn.readthedocs.io/en/latest/externalGrading/'>externally graded questions</a>.`,
       });
     }
@@ -113,7 +113,7 @@ function getPaths(req, res, callback) {
   }
 
   const found = paths.invalidRootPaths.find((invalidRootPath) =>
-    contains(invalidRootPath, paths.workingPath)
+    contains(invalidRootPath, paths.workingPath),
   );
   if (found) {
     let err = new Error('Invalid working directory');

--- a/apps/prairielearn/src/lib/json-load.js
+++ b/apps/prairielearn/src/lib/json-load.js
@@ -26,9 +26,9 @@ module.exports.readJSON = function (jsonFilename, callback) {
     } catch (e) {
       ERR(
         new Error(
-          `Error in JSON file format: ${jsonFilename} (line ${e.row}, column ${e.column})\n${e.name}: ${e.message}`
+          `Error in JSON file format: ${jsonFilename} (line ${e.row}, column ${e.column})\n${e.name}: ${e.message}`,
         ),
-        callback
+        callback,
       );
       return;
     }
@@ -58,9 +58,9 @@ module.exports.validateJSON = function (json, schema, callback) {
     callback(
       new Error(
         `JSON validation error: ${ajv.errorsText(
-          validate.errors
-        )}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`
-      )
+          validate.errors,
+        )}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`,
+      ),
     );
   } else {
     callback(null, json);
@@ -96,7 +96,7 @@ module.exports.readJSONSyncOrDie = function (jsonFilename, schema) {
     var json = jju.parse(data, { mode: 'json' });
   } catch (e) {
     logger.error(
-      `Error in JSON file format: ${jsonFilename} (line ${e.row}, column ${e.column})\n${e.name}: ${e.message}`
+      `Error in JSON file format: ${jsonFilename} (line ${e.row}, column ${e.column})\n${e.name}: ${e.message}`,
     );
     process.exit(1);
     return;
@@ -108,8 +108,8 @@ module.exports.readJSONSyncOrDie = function (jsonFilename, schema) {
       if (!valid) {
         logger.error(
           `JSON validation error: ${ajv.errorsText(
-            validate.errors
-          )}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`
+            validate.errors,
+          )}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`,
         );
         process.exit(1);
         return;
@@ -143,7 +143,7 @@ module.exports.readInfoJSON = function (jsonFilename, schema, callback) {
         if (err) {
           ERR(
             new Error("Error validating file '" + jsonFilename + "' against schema: " + err),
-            callback
+            callback,
           );
           return;
         }
@@ -174,7 +174,7 @@ module.exports.validateOptions = function (
   jsonFilename,
   optionsSchemaPrefix,
   schemas,
-  callback
+  callback,
 ) {
   if (optionsSchemaPrefix && _(json).has('type') && _(json).has('options')) {
     const schema = schemas[optionsSchemaPrefix + json.type];
@@ -186,8 +186,8 @@ module.exports.validateOptions = function (
       if (err) {
         callback(
           new Error(
-            "Error validating 'options' field from '" + jsonFilename + "' against schema: " + err
-          )
+            "Error validating 'options' field from '" + jsonFilename + "' against schema: " + err,
+          ),
         );
         return;
       }

--- a/apps/prairielearn/src/lib/lifecycle-hooks.js
+++ b/apps/prairielearn/src/lib/lifecycle-hooks.js
@@ -19,7 +19,7 @@ async function getInstanceLifecycleState(client) {
   const res = await client.send(
     new DescribeAutoScalingInstancesCommand({
       InstanceIds: [config.instanceId],
-    })
+    }),
   );
 
   return res.AutoScalingInstances?.[0]?.LifecycleState;
@@ -52,7 +52,7 @@ module.exports.completeInstanceLaunch = async function () {
       AutoScalingGroupName: config.autoScalingGroupName,
       LifecycleHookName: config.autoScalingLaunchingLifecycleHookName,
       InstanceId: config.instanceId,
-    })
+    }),
   );
   logger.info('Completed Auto Scaling lifecycle action for instance launch');
 };
@@ -83,7 +83,7 @@ module.exports.completeInstanceTermination = async function () {
       AutoScalingGroupName: config.autoScalingGroupName,
       LifecycleHookName: config.autoScalingTerminatingLifecycleHookName,
       InstanceId: config.instanceId,
-    })
+    }),
   );
   logger.info('Completed Auto Scaling lifecycle action for instance termination');
 };

--- a/apps/prairielearn/src/lib/load.js
+++ b/apps/prairielearn/src/lib/load.js
@@ -100,7 +100,7 @@ class LoadEstimator {
       debug(
         `LoadEstimator._reportLoad(): jobType = ${this.jobType}, scheduling next call for ${
           config.reportIntervalSec * 1000
-        } ms`
+        } ms`,
       );
       this.timeoutID = setTimeout(this._reportLoad.bind(this), config.reportIntervalSec * 1000);
     });
@@ -131,7 +131,7 @@ const estimators = {};
 module.exports = {
   initEstimator(jobType, maxJobCount, warnOnOldJobs) {
     debug(
-      `initEstimator(): jobType = ${jobType}, maxJobCount = ${maxJobCount}, warnOnOldJobs = ${warnOnOldJobs}`
+      `initEstimator(): jobType = ${jobType}, maxJobCount = ${maxJobCount}, warnOnOldJobs = ${warnOnOldJobs}`,
     );
     if (_.has(estimators, jobType)) throw new Error(`duplicate jobType: ${jobType}`);
     estimators[jobType] = new LoadEstimator(jobType, maxJobCount, warnOnOldJobs);

--- a/apps/prairielearn/src/lib/ltiOutcomes.js
+++ b/apps/prairielearn/src/lib/ltiOutcomes.js
@@ -103,23 +103,23 @@ function updateScore(ai_id, callback) {
             'imsx_statusInfo',
             'imsx_codeMajor',
           ],
-          null
+          null,
         );
         if (imsx_codeMajor === 'success') {
           logger.info(
-            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} returned ${result.imsx_POXEnvelopeResponse.imsx_POXHeader.imsx_POXResponseHeaderInfo.imsx_statusInfo.imsx_codeMajor}`
+            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} returned ${result.imsx_POXEnvelopeResponse.imsx_POXHeader.imsx_POXResponseHeaderInfo.imsx_statusInfo.imsx_codeMajor}`,
           );
           debug(
-            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} returned ${result.imsx_POXEnvelopeResponse.imsx_POXHeader.imsx_POXResponseHeaderInfo.imsx_statusInfo.imsx_codeMajor}`
+            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} returned ${result.imsx_POXEnvelopeResponse.imsx_POXHeader.imsx_POXResponseHeaderInfo.imsx_statusInfo.imsx_codeMajor}`,
           );
         } else {
           logger.info(
-            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} did not return success, debugging follows:`
+            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} did not return success, debugging follows:`,
           );
           logger.info('post_params:', post_params);
           logger.info('body:', body);
           debug(
-            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} did not return success, debugging follows:`
+            `ltiOutcomes.updateScore() ai_id=${ai_id} score=${score} did not return success, debugging follows:`,
           );
           debug('post_params', post_params);
           debug('body', body);

--- a/apps/prairielearn/src/lib/manualGrading.js
+++ b/apps/prairielearn/src/lib/manualGrading.js
@@ -31,7 +31,7 @@ async function nextUngradedInstanceQuestionUrl(
   assessment_id,
   assessment_question_id,
   user_id,
-  prior_instance_question_id
+  prior_instance_question_id,
 ) {
   const params = {
     assessment_id,
@@ -41,7 +41,7 @@ async function nextUngradedInstanceQuestionUrl(
   };
   const result = await sqldb.queryZeroOrOneRowAsync(
     sql.select_next_ungraded_instance_question,
-    params
+    params,
   );
 
   if (result.rowCount > 0) {
@@ -79,13 +79,13 @@ async function populateRubricData(locals) {
 
   await async.eachLimit(locals.rubric_data?.rubric_items || [], 3, async (item) => {
     item.description_rendered = await markdown.processContentInline(
-      mustache.render(item.description || '', mustache_data)
+      mustache.render(item.description || '', mustache_data),
     );
     item.explanation_rendered = await markdown.processContent(
-      mustache.render(item.explanation || '', mustache_data)
+      mustache.render(item.explanation || '', mustache_data),
     );
     item.grader_note_rendered = await markdown.processContent(
-      mustache.render(item.grader_note || '', mustache_data)
+      mustache.render(item.grader_note || '', mustache_data),
     );
   });
 }
@@ -108,7 +108,7 @@ async function populateManualGradingData(submission) {
   }
   if (submission.feedback?.manual) {
     submission.feedback_manual_html = await markdown.processContent(
-      submission.feedback?.manual?.toString() || ''
+      submission.feedback?.manual?.toString() || '',
     );
   }
 }
@@ -139,7 +139,7 @@ async function updateAssessmentQuestionRubric(
   max_extra_points,
   rubric_items,
   tag_for_manual_grading,
-  authn_user_id
+  authn_user_id,
 ) {
   // Basic validation: points and description must exist, description must be within size limits
   if (use_rubric) {
@@ -156,7 +156,7 @@ async function updateAssessmentQuestionRubric(
       }
       if (item.description.length > 100) {
         throw new Error(
-          'Rubric item description is too long, must be no longer than 100 characters. Use the explanation for further comments.'
+          'Rubric item description is too long, must be no longer than 100 characters. Use the explanation for further comments.',
         );
       }
     });
@@ -179,7 +179,7 @@ async function updateAssessmentQuestionRubric(
       // question's values change.
       if (max_points <= Number(min_points)) {
         throw new Error(
-          `Question has no range of possible points. Rubric points are limited to a minimum of ${min_points} and a maximum of ${max_points}.`
+          `Question has no range of possible points. Rubric points are limited to a minimum of ${min_points} and a maximum of ${max_points}.`,
         );
       }
     }
@@ -253,7 +253,7 @@ async function updateAssessmentQuestionRubric(
               number,
             });
           }
-        }
+        },
       );
 
       await recomputeInstanceQuestions(assessment_question_id, authn_user_id);
@@ -289,7 +289,7 @@ async function recomputeInstanceQuestions(assessment_question_id, authn_user_id)
         {
           manual_rubric_data: instance_question,
         },
-        authn_user_id
+        authn_user_id,
       );
     });
   });
@@ -309,7 +309,7 @@ async function insertRubricGrading(
   max_points,
   max_manual_points,
   rubric_items,
-  adjust_points
+  adjust_points,
 ) {
   return sqldb.runInTransactionAsync(async () => {
     const { rubric_data, rubric_item_data } = (
@@ -324,14 +324,14 @@ async function insertRubricGrading(
         (item) =>
           (item.score ?? 1) *
           (rubric_item_data.find((db_item) => idsEqual(db_item.id, item.rubric_item_id))?.points ??
-            0)
-      )
+            0),
+      ),
     );
     const computed_points =
       Math.min(
         Math.max(rubric_data.starting_points + sum_rubric_item_points, rubric_data.min_points),
         (rubric_data.replace_auto_points ? max_points : max_manual_points) +
-          rubric_data.max_extra_points
+          rubric_data.max_extra_points,
       ) + Number(adjust_points || 0);
 
     const rubric_grading_result = (
@@ -378,7 +378,7 @@ async function updateInstanceQuestionScore(
   submission_id,
   check_modified_at,
   score,
-  authn_user_id
+  authn_user_id,
 ) {
   return sqldb.runInTransactionAsync(async () => {
     const current_submission = (
@@ -407,7 +407,7 @@ async function updateInstanceQuestionScore(
         (100 *
           _.sumBy(
             _.toPairs(score.partial_scores),
-            ([_, value]) => (value?.score ?? 0) * (value?.weight ?? 1)
+            ([_, value]) => (value?.score ?? 0) * (value?.weight ?? 1),
           )) /
         _.sumBy(_.toPairs(score.partial_scores), ([_, value]) => value?.weight ?? 1);
       new_auto_points = (new_auto_score_perc / 100) * current_submission.max_auto_points;
@@ -441,7 +441,7 @@ async function updateInstanceQuestionScore(
         current_submission.max_points,
         current_submission.max_manual_points,
         score?.manual_rubric_data?.applied_rubric_items || [],
-        score?.manual_rubric_data?.adjust_points
+        score?.manual_rubric_data?.adjust_points,
       );
       score.manual_points =
         manual_rubric_grading.computed_points -

--- a/apps/prairielearn/src/lib/opsbot.js
+++ b/apps/prairielearn/src/lib/opsbot.js
@@ -37,7 +37,7 @@ module.exports.sendMessage = (msg, callback) => {
 };
 
 module.exports.sendMessageAsync = util.promisify((msg, callback) =>
-  module.exports.sendMessage(msg, (err, res, body) => callback(err, { res, body }))
+  module.exports.sendMessage(msg, (err, res, body) => callback(err, { res, body })),
 );
 
 /**
@@ -76,7 +76,7 @@ module.exports.sendSlackMessage = (msg, channel, options, callback) => {
     if (ERR(err, callback)) return;
     if (!body.ok) {
       callback(
-        error.makeWithData(`Error sending message to ${default_options.json.channel}`, { body })
+        error.makeWithData(`Error sending message to ${default_options.json.channel}`, { body }),
       );
       return;
     }

--- a/apps/prairielearn/src/lib/question.js
+++ b/apps/prairielearn/src/lib/question.js
@@ -70,7 +70,7 @@ module.exports = {
       (err) => {
         if (ERR(err, callback)) return;
         callback(null);
-      }
+      },
     );
   },
 
@@ -113,7 +113,7 @@ module.exports = {
             variant.params['_required_file_names'] = [];
           }
           variant.params['_required_file_names'] = variant.params['_required_file_names'].concat(
-            variant.params['_workspace_required_file_names']
+            variant.params['_workspace_required_file_names'],
           );
         }
         if (variant.broken) {
@@ -164,7 +164,7 @@ module.exports = {
             if (ERR(err, callback)) return;
 
             return callback(null, fileData);
-          }
+          },
         );
       });
     });
@@ -196,7 +196,7 @@ module.exports = {
           if (ERR(err, callback)) return;
           const question = result.rows[0];
           callback(null, question);
-        }
+        },
       );
     }
   },
@@ -226,7 +226,7 @@ module.exports = {
     question_course,
     options,
     require_open,
-    callback
+    callback,
   ) {
     module.exports._selectQuestion(question_id, instance_question_id, (err, question) => {
       if (ERR(err, callback)) return;
@@ -267,10 +267,10 @@ module.exports = {
               (err) => {
                 if (ERR(err, callback)) return;
                 return callback(null, variant);
-              }
+              },
             );
           });
-        }
+        },
       );
     });
   },
@@ -301,7 +301,7 @@ module.exports = {
     question_course,
     options,
     require_open,
-    callback
+    callback,
   ) {
     if (instance_question_id != null) {
       // see if we have a useable existing variant, otherwise
@@ -329,10 +329,10 @@ module.exports = {
             if (ERR(err, callback)) return;
             debug(
               'instance_questions_select_variant was null, run through _makeAndInsertVariant',
-              variant
+              variant,
             );
             callback(null, variant);
-          }
+          },
         );
       });
     } else {
@@ -351,7 +351,7 @@ module.exports = {
         (err, variant) => {
           if (ERR(err, callback)) return;
           callback(null, variant);
-        }
+        },
       );
     }
   },
@@ -443,7 +443,7 @@ module.exports = {
 
               debug('saveSubmission()', 'completed parse()');
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -459,7 +459,7 @@ module.exports = {
               if (ERR(err, callback)) return;
               debug('saveSubmission()', `wrote courseIssues: ${courseIssues.length}`);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -492,7 +492,7 @@ module.exports = {
         if (ERR(err, callback)) return;
         debug('saveSubmission()', 'returning', 'submission_id:', submission_id);
         callback(null, submission_id);
-      }
+      },
     );
   },
 
@@ -531,7 +531,7 @@ module.exports = {
     variant_course,
     authn_user_id,
     overrideGradeRateCheck,
-    callback
+    callback,
   ) {
     debug('_gradeVariant()');
     let questionModule, question_course, courseIssues, data, submission, grading_job;
@@ -551,7 +551,7 @@ module.exports = {
               submission = result.rows[0];
               debug('_gradeVariant()', 'selected submission', 'submission.id:', submission.id);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -563,7 +563,7 @@ module.exports = {
               '_gradeVariant()',
               'checked grade rate',
               'allow_grade_left_ms:',
-              result.rows[0].allow_grade_left_ms
+              result.rows[0].allow_grade_left_ms,
             );
             if (result.rows[0].allow_grade_left_ms > 0) return callback(new NoSubmissionError());
             callback(null);
@@ -605,7 +605,7 @@ module.exports = {
                 data.broken = hasFatalIssue;
                 debug('_gradeVariant()', 'completed grade()', 'hasFatalIssue:', hasFatalIssue);
                 callback(null);
-              }
+              },
             );
           } else {
             // for External grading we don't do anything
@@ -627,7 +627,7 @@ module.exports = {
               if (ERR(err, callback)) return;
               debug('_gradeVariant()', `wrote courseIssues: ${courseIssues.length}`);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -680,7 +680,7 @@ module.exports = {
                 if (ERR(err, callback)) return;
                 callback(null);
               });
-            }
+            },
           );
         },
       ],
@@ -702,7 +702,7 @@ module.exports = {
         } else {
           callback(null);
         }
-      }
+      },
     );
   },
 
@@ -733,7 +733,7 @@ module.exports = {
               submission_id = ret_submission_id;
               debug('saveAndGradeSubmission()', 'submission_id:', submission_id);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -749,7 +749,7 @@ module.exports = {
               grading_job_id = ret_grading_job_id;
               debug('saveAndGradeSubmission()', 'graded');
               callback(null);
-            }
+            },
           );
         },
       ],
@@ -767,7 +767,7 @@ module.exports = {
           // We're done!
           callback(null, submission_id);
         }
-      }
+      },
     );
   },
 
@@ -810,7 +810,7 @@ module.exports = {
               data.broken = hasFatalIssue;
               debug('_createTestSubmission()', 'completed test()');
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -826,7 +826,7 @@ module.exports = {
               if (ERR(err, callback)) return;
               debug('_createTestSubmission()', `wrote courseIssues: ${courseIssues.length}`);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -895,7 +895,7 @@ module.exports = {
         if (ERR(err, callback)) return;
         debug('_createTestSubmission()', 'returning', 'submission_id:', submission_id);
         callback(null, submission_id);
-      }
+      },
     );
   },
 
@@ -930,7 +930,7 @@ module.exports = {
     checkEqual(
       'format_errors keys',
       Object.keys(expected_submission.format_errors),
-      Object.keys(test_submission.format_errors)
+      Object.keys(test_submission.format_errors),
     );
     if (!test_submission.gradable || !expected_submission.gradable) {
       return callback(null, courseIssues);
@@ -938,7 +938,7 @@ module.exports = {
     checkEqual(
       'partial_scores',
       expected_submission.partial_scores,
-      test_submission.partial_scores
+      test_submission.partial_scores,
     );
     checkEqual('score', expected_submission.score, test_submission.score);
     callback(null, courseIssues);
@@ -973,7 +973,7 @@ module.exports = {
               expected_submission_id = ret_submission_id;
               debug('_testVariant()', 'expected_submission_id:', expected_submission_id);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -1000,7 +1000,7 @@ module.exports = {
               test_submission_id = ret_submission_id;
               debug('_testVariant()', 'test_submission_id:', test_submission_id);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -1015,7 +1015,7 @@ module.exports = {
               if (ERR(err, callback)) return;
               debug('testVariant()', 'graded');
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -1049,9 +1049,9 @@ module.exports = {
                 (err) => {
                   if (ERR(err, callback)) return;
                   callback(null);
-                }
+                },
               );
-            }
+            },
           );
         },
       ],
@@ -1059,7 +1059,7 @@ module.exports = {
         if (ERR(err, callback)) return;
         debug('_testVariant()', 'returning');
         callback(null, expected_submission, test_submission);
-      }
+      },
     );
   },
 
@@ -1080,7 +1080,7 @@ module.exports = {
     variant_course,
     test_type,
     authn_user_id,
-    callback
+    callback,
   ) {
     debug('_testQuestion()');
 
@@ -1114,7 +1114,7 @@ module.exports = {
               variant = ret_variant;
               debug('_testQuestion()', 'created variant_id: :', variant.id);
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -1135,10 +1135,10 @@ module.exports = {
                 'expected_submission_id:',
                 expected_submission ? expected_submission.id : null,
                 'test_submission_id:',
-                test_submission ? test_submission.id : null
+                test_submission ? test_submission.id : null,
               );
               callback(null);
-            }
+            },
           );
         },
       ],
@@ -1146,7 +1146,7 @@ module.exports = {
         if (ERR(err, callback)) return;
         debug('_testQuestion()', 'returning');
         callback(null, variant, expected_submission, test_submission);
-      }
+      },
     );
   },
 
@@ -1173,7 +1173,7 @@ module.exports = {
     course,
     test_type,
     authn_user_id,
-    callback
+    callback,
   ) {
     let variant,
       expected_submission,
@@ -1196,7 +1196,7 @@ module.exports = {
               expected_submission = ret_expected_submission;
               test_submission = ret_test_submission;
               callback(null);
-            }
+            },
           );
         },
         (callback) => {
@@ -1216,18 +1216,18 @@ module.exports = {
             'true_answer',
           ];
           logger.verbose(
-            'variant:\n' + jsonStringifySafe(_.pick(variant, variantKeys), null, '    ')
+            'variant:\n' + jsonStringifySafe(_.pick(variant, variantKeys), null, '    '),
           );
           if (_.isObject(expected_submission)) {
             logger.verbose(
               'expected_submission:\n' +
-                jsonStringifySafe(_.pick(expected_submission, submissionKeys), null, '    ')
+                jsonStringifySafe(_.pick(expected_submission, submissionKeys), null, '    '),
             );
           }
           if (_.isObject(test_submission)) {
             logger.verbose(
               'test_submission:\n' +
-                jsonStringifySafe(_.pick(test_submission, submissionKeys), null, '    ')
+                jsonStringifySafe(_.pick(test_submission, submissionKeys), null, '    '),
             );
           }
           callback(null);
@@ -1248,7 +1248,7 @@ module.exports = {
       (err) => {
         if (ERR(err, callback)) return;
         callback(null, success);
-      }
+      },
     );
   },
 
@@ -1271,7 +1271,7 @@ module.exports = {
     group_work,
     course_instance,
     course,
-    authn_user_id
+    authn_user_id,
   ) {
     let success = true;
     const test_types = ['correct', 'incorrect', 'invalid'];
@@ -1301,7 +1301,7 @@ module.exports = {
             if (ERR(err, callback)) return;
             success = success && ret_success;
             callback(null);
-          }
+          },
         );
       });
 
@@ -1336,7 +1336,7 @@ module.exports = {
     course,
     course_instance,
     locals,
-    callback
+    callback,
   ) {
     questionServers.getModule(question.type, (err, questionModule) => {
       if (ERR(err, callback)) return;
@@ -1365,9 +1365,9 @@ module.exports = {
             (err) => {
               if (ERR(err, callback)) return;
               return callback(null, htmls);
-            }
+            },
           );
-        }
+        },
       );
     });
   },
@@ -1441,7 +1441,7 @@ module.exports = {
     assessment,
     assessment_instance,
     assessment_question,
-    authz_result
+    authz_result,
   ) {
     const locals = {};
 
@@ -1519,7 +1519,7 @@ module.exports = {
     // ID is coerced to a string so that it matches what we get back from the client
     locals.variantToken = generateSignedToken(
       { variantId: variant.id.toString() },
-      config.secretKey
+      config.secretKey,
     );
 
     if (variant.broken) {
@@ -1571,7 +1571,7 @@ module.exports = {
         async () => {
           locals.question_course = await module.exports._getQuestionCourse(
             locals.question,
-            locals.course
+            locals.course,
           );
         },
         (callback) => {
@@ -1611,7 +1611,7 @@ module.exports = {
                 if (ERR(err, callback)) return;
                 locals.variant = variant;
                 callback(null);
-              }
+              },
             );
           }
         },
@@ -1623,7 +1623,7 @@ module.exports = {
             variant,
             question,
             instance_question,
-            assessment
+            assessment,
           );
           _.assign(locals, urls);
           callback(null);
@@ -1651,7 +1651,7 @@ module.exports = {
             assessment,
             assessment_instance,
             assessment_question,
-            authz_result
+            authz_result,
           );
           _.assign(locals, newLocals);
           if (locals.manualGradingInterface && question?.show_correct_answer) {
@@ -1684,7 +1684,7 @@ module.exports = {
               sql.select_detailed_submissions,
               {
                 submission_ids: submissionsToRender.map((s) => s.id),
-              }
+              },
             );
 
             locals.submissions = result.rows.map((s, idx) => ({
@@ -1737,7 +1737,7 @@ module.exports = {
               locals.submissionHtmls = htmls.submissionHtmls;
               locals.answerHtml = htmls.answerHtml;
               callback(null);
-            }
+            },
           );
         },
         async () => {
@@ -1790,7 +1790,7 @@ module.exports = {
       (err) => {
         if (ERR(err, callback)) return;
         callback(null);
-      }
+      },
     );
   },
 
@@ -1799,7 +1799,7 @@ module.exports = {
       const phases = [];
       const totalDuration = differenceInMilliseconds(
         parseISO(job.graded_at),
-        parseISO(job.grading_requested_at)
+        parseISO(job.grading_requested_at),
       );
       const formatDiff = (start, end, addToPhases = true) => {
         const duration = differenceInMilliseconds(parseISO(end), parseISO(start));
@@ -1850,7 +1850,7 @@ module.exports = {
     csrfToken,
     authorizedEdit,
     renderScorePanels,
-    callback
+    callback,
   ) {
     const params = {
       submission_id,
@@ -1901,8 +1901,8 @@ module.exports = {
           variant,
           question,
           instance_question,
-          assessment
-        )
+          assessment,
+        ),
       );
       _.assign(
         locals,
@@ -1912,8 +1912,8 @@ module.exports = {
           instance_question,
           assessment,
           assessment_instance,
-          assessment_question
-        )
+          assessment_question,
+        ),
       );
 
       // Using util.promisify on renderFile instead of {async: true} from EJS, because the
@@ -1935,7 +1935,7 @@ module.exports = {
               submissions,
               question_course,
               course_instance,
-              locals
+              locals,
             );
             submission.grading_job_id = grading_job_id;
             submission.grading_job_status = grading_job_status;
@@ -1983,7 +1983,7 @@ module.exports = {
               '..',
               'pages',
               'partials',
-              'questionScorePanel.ejs'
+              'questionScorePanel.ejs',
             );
             panels.questionScorePanel = await renderFileAsync(templatePath, renderParams);
           },
@@ -2006,7 +2006,7 @@ module.exports = {
               '..',
               'pages',
               'partials',
-              'assessmentScorePanel.ejs'
+              'assessmentScorePanel.ejs',
             );
             panels.assessmentScorePanel = await renderFileAsync(templatePath, renderParams);
           },
@@ -2030,7 +2030,7 @@ module.exports = {
               '..',
               'pages',
               'partials',
-              'questionFooter.ejs'
+              'questionFooter.ejs',
             );
             panels.questionPanelFooter = await renderFileAsync(templatePath, renderParams);
           },
@@ -2059,7 +2059,7 @@ module.exports = {
               '..',
               'pages',
               'partials',
-              'questionNavSideButton.ejs'
+              'questionNavSideButton.ejs',
             );
             panels.questionNavNextButton = await renderFileAsync(templatePath, renderParams);
           },
@@ -2067,7 +2067,7 @@ module.exports = {
         (err) => {
           if (ERR(err, callback)) return;
           callback(null, panels);
-        }
+        },
       );
     });
   },

--- a/apps/prairielearn/src/lib/regrading.js
+++ b/apps/prairielearn/src/lib/regrading.js
@@ -77,7 +77,7 @@ module.exports = {
                     Math.floor(regrade.new_score_perc) +
                     '% (was ' +
                     Math.floor(regrade.old_score_perc) +
-                    '%)'
+                    '%)',
                 );
               } else {
                 job.verbose('No changes made');
@@ -216,7 +216,7 @@ module.exports = {
                 } else {
                   job.succeed();
                 }
-              }
+              },
             );
           });
         });

--- a/apps/prairielearn/src/lib/require-frontend.js
+++ b/apps/prairielearn/src/lib/require-frontend.js
@@ -51,7 +51,7 @@ requirejs.undefQuestionServers = function (coursePath, logger, callback) {
       if (ERR(err, callback)) return;
       logger.verbose('Successfully unloaded ' + count + ' cached files');
       callback(null);
-    }
+    },
   );
 };
 

--- a/apps/prairielearn/src/lib/score-upload.js
+++ b/apps/prairielearn/src/lib/score-upload.js
@@ -85,7 +85,7 @@ module.exports = {
             await module.exports._updateInstanceQuestionFromJson(
               json,
               assessment_id,
-              authn_user_id
+              authn_user_id,
             );
             successCount++;
           } catch (err) {
@@ -218,7 +218,7 @@ module.exports = {
 
       if (errorCount === 0) {
         job.verbose(
-          `Successfully updated scores for ${successCount} assessment instances, with no errors`
+          `Successfully updated scores for ${successCount} assessment instances, with no errors`,
         );
       } else {
         job.verbose(`Successfully updated scores for ${successCount} assessment instances`);
@@ -297,17 +297,17 @@ module.exports = {
 
       if (submission_data.rowCount === 0) {
         throw new Error(
-          `Could not locate submission with id=${submission_id}, instance=${ai_number}, uid/group=${uid_or_group}, qid=${qid} for this assessment.`
+          `Could not locate submission with id=${submission_id}, instance=${ai_number}, uid/group=${uid_or_group}, qid=${qid} for this assessment.`,
         );
       }
       if (uid_or_group !== null && submission_data.rows[0].uid_or_group !== uid_or_group) {
         throw new Error(
-          `Found submission with id=${submission_id}, but uid/group does not match ${uid_or_group}.`
+          `Found submission with id=${submission_id}, but uid/group does not match ${uid_or_group}.`,
         );
       }
       if (qid !== null && submission_data.rows[0].qid !== qid) {
         throw new Error(
-          `Found submission with id=${submission_id}, but QID does not match ${qid}.`
+          `Found submission with id=${submission_id}, but QID does not match ${qid}.`,
         );
       }
 
@@ -326,7 +326,7 @@ module.exports = {
           feedback: module.exports._getFeedbackOrNull(json),
           partial_scores: module.exports._getPartialScoresOrNull(json),
         },
-        authn_user_id
+        authn_user_id,
       );
     });
   },

--- a/apps/prairielearn/src/lib/server-jobs-legacy.js
+++ b/apps/prairielearn/src/lib/server-jobs-legacy.js
@@ -244,11 +244,11 @@ module.exports.connection = function (socket) {
       !checkSignedToken(
         msg.token,
         { jobSequenceId: msg.job_sequence_id.toString() },
-        config.secretKey
+        config.secretKey,
       )
     ) {
       logger.error(
-        `joinJobSequence called with invalid token for job_sequence_id ${msg.job_sequence_id}`
+        `joinJobSequence called with invalid token for job_sequence_id ${msg.job_sequence_id}`,
       );
       return;
     }
@@ -261,7 +261,7 @@ module.exports.connection = function (socket) {
       if (err) {
         return logger.error(
           'socket.io joinJobSequence error selecting job_sequence_id ' + msg.job_sequence_id,
-          err
+          err,
         );
       }
       var job_count = result.rows[0].job_count;
@@ -296,7 +296,7 @@ module.exports.createJob = function (options, callback) {
       on_error: undefined,
       on_success: undefined,
     },
-    options
+    options,
   );
 
   var params = {
@@ -423,7 +423,7 @@ module.exports.createJobSequence = function (options, callback) {
       type: null,
       description: null,
     },
-    options
+    options,
   );
 
   var params = {
@@ -529,7 +529,7 @@ module.exports.getJobSequenceWithFormattedOutput = function (job_sequence_id, co
   });
 };
 module.exports.getJobSequenceWithFormattedOutputAsync = util.promisify(
-  module.exports.getJobSequenceWithFormattedOutput
+  module.exports.getJobSequenceWithFormattedOutput,
 );
 
 // Exported so others can use it as a type.

--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -126,7 +126,7 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
 
   private async executeInternal(
     fn: ServerJobExecutionFunction,
-    shouldThrow: boolean
+    shouldThrow: boolean,
   ): Promise<void> {
     try {
       await fn(this);
@@ -210,7 +210,7 @@ export async function createServerJob(options: CreateServerJobOptions): Promise<
     z.object({
       job_sequence_id: z.string(),
       job_id: z.string(),
-    })
+    }),
   );
 
   const serverJob = new ServerJobImpl(job_sequence_id, job_id);

--- a/apps/prairielearn/src/lib/workspace.js
+++ b/apps/prairielearn/src/lib/workspace.js
@@ -86,7 +86,7 @@ module.exports = {
         await workspaceUtils.updateWorkspaceState(
           workspace_id,
           'stopped',
-          `Error! Click "Reboot" to try again. Detail: ${err}`
+          `Error! Click "Reboot" to try again. Detail: ${err}`,
         );
       });
     });
@@ -207,7 +207,7 @@ module.exports = {
               `${initializeResult.destinationPath}-bak-${timestampSuffix}`,
               {
                 overwrite: true,
-              }
+              },
             );
           } catch (err) {
             // If the directory couldn't be moved because it didn't exist, ignore the error.
@@ -227,7 +227,7 @@ module.exports = {
         await workspaceUtils.updateWorkspaceState(
           workspace_id,
           'stopped',
-          'Initialization complete'
+          'Initialization complete',
         );
       }
 
@@ -237,7 +237,7 @@ module.exports = {
         await workspaceUtils.updateWorkspaceState(
           workspace_id,
           'launching',
-          'Assigning workspace host'
+          'Assigning workspace host',
         );
         shouldAssignHost = true;
       }
@@ -261,7 +261,7 @@ module.exports = {
       const t = attempt * config.workspaceLaunchingRetryIntervalSec;
       await workspaceUtils.updateWorkspaceMessage(
         workspace_id,
-        `Deploying more computational resources (${t} seconds elapsed)`
+        `Deploying more computational resources (${t} seconds elapsed)`,
       );
       await util.promisify(setTimeout)(config.workspaceLaunchingRetryIntervalSec * 1000);
       attempt++;
@@ -321,7 +321,7 @@ module.exports = {
             return file.stats.isFile()
               ? { name: path.relative(localPath, file.path), localPath: file.path }
               : null;
-          }
+          },
         )
         .catch(() => {
           // Path does not exist or is not accessible, do nothing
@@ -329,7 +329,7 @@ module.exports = {
         })
     ).filter(
       /** @returns {file is WorkspaceFile} */
-      (file) => !!file
+      (file) => !!file,
     );
 
     const mustacheParams = { params: variant.params, correct_answers: variant.true_answer };
@@ -343,7 +343,7 @@ module.exports = {
           async (file) => {
             const generatedFileName = path.relative(
               templatePath,
-              file.path.replace(/\.mustache$/i, '')
+              file.path.replace(/\.mustache$/i, ''),
             );
             try {
               if (!file.stats.isFile()) return null;
@@ -351,14 +351,14 @@ module.exports = {
                 name: generatedFileName,
                 buffer: mustache.render(
                   await fsPromises.readFile(file.path, { encoding: 'utf-8' }),
-                  mustacheParams
+                  mustacheParams,
                 ),
               };
             } catch (_err) {
               // File cannot be rendered, treat file as static file
               return { name: generatedFileName, localPath: file.path };
             }
-          }
+          },
         )
         .catch(() => {
           // Template directory does not exist or is not accessible, do nothing
@@ -366,7 +366,7 @@ module.exports = {
         })
     ).filter(
       /** @returns {file is WorkspaceFile} */
-      (file) => !!file
+      (file) => !!file,
     );
 
     /** @type {WorkspaceFile[]} */
@@ -407,7 +407,7 @@ module.exports = {
       })
     ).filter(
       /** @returns {file is WorkspaceFile} */
-      (file) => !!file
+      (file) => !!file,
     );
 
     const allWorkspaceFiles = staticFiles.concat(templateFiles).concat(dynamicFiles);
@@ -420,7 +420,7 @@ module.exports = {
     await fsPromises.chown(
       sourcePath,
       config.workspaceJobsDirectoryOwnerUid,
-      config.workspaceJobsDirectoryOwnerGid
+      config.workspaceJobsDirectoryOwnerGid,
     );
 
     if (allWorkspaceFiles.length > 0) {
@@ -443,7 +443,7 @@ module.exports = {
         await fsPromises.chown(
           file.path,
           config.workspaceJobsDirectoryOwnerUid,
-          config.workspaceJobsDirectoryOwnerGid
+          config.workspaceJobsDirectoryOwnerGid,
         );
       }
     }
@@ -510,7 +510,7 @@ module.exports = {
         {
           maxFiles: config.workspaceMaxGradedFilesCount,
           maxSize: config.workspaceMaxGradedFilesSize,
-        }
+        },
       );
     } catch (err) {
       // Turn any error into a `SubmissionFormatError` so that it is handled correctly.

--- a/apps/prairielearn/src/middlewares/ansifySyncErrorsAndWarnings.js
+++ b/apps/prairielearn/src/middlewares/ansifySyncErrorsAndWarnings.js
@@ -8,43 +8,43 @@ module.exports = function (req, res, next) {
     }
     if (res.locals.course.sync_warnings) {
       res.locals.course.sync_warnings_ansified = ansiUp.ansi_to_html(
-        res.locals.course.sync_warnings
+        res.locals.course.sync_warnings,
       );
     }
   }
   if (res.locals.course_instance) {
     if (res.locals.course_instance.sync_errors) {
       res.locals.course_instance.sync_errors_ansified = ansiUp.ansi_to_html(
-        res.locals.course_instance.sync_errors
+        res.locals.course_instance.sync_errors,
       );
     }
     if (res.locals.course_instance.sync_warnings) {
       res.locals.course_instance.sync_warnings_ansified = ansiUp.ansi_to_html(
-        res.locals.course_instance.sync_warnings
+        res.locals.course_instance.sync_warnings,
       );
     }
   }
   if (res.locals.question) {
     if (res.locals.question.sync_errors) {
       res.locals.question.sync_errors_ansified = ansiUp.ansi_to_html(
-        res.locals.question.sync_errors
+        res.locals.question.sync_errors,
       );
     }
     if (res.locals.question.sync_warnings) {
       res.locals.question.sync_warnings_ansified = ansiUp.ansi_to_html(
-        res.locals.question.sync_warnings
+        res.locals.question.sync_warnings,
       );
     }
   }
   if (res.locals.assessment) {
     if (res.locals.assessment.sync_errors) {
       res.locals.assessment.sync_errors_ansified = ansiUp.ansi_to_html(
-        res.locals.assessment.sync_errors
+        res.locals.assessment.sync_errors,
       );
     }
     if (res.locals.assessment.sync_warnings) {
       res.locals.assessment.sync_warnings_ansified = ansiUp.ansi_to_html(
-        res.locals.assessment.sync_warnings
+        res.locals.assessment.sync_warnings,
       );
     }
   }

--- a/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.js
+++ b/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.js
@@ -11,7 +11,7 @@ module.exports = function (req, res, next) {
     return next(
       error.make(403, 'Requires either course preview access or student data view access', {
         locals: res.locals,
-      })
+      }),
     );
   }
   next();

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
@@ -42,7 +42,7 @@ module.exports = function (req, res, next) {
 
         if (params.course_id == null && params.course_instance_id == null) {
           callback(
-            error.make(403, 'Access denied (both course_id and course_instance_id are null)')
+            error.make(403, 'Access denied (both course_id and course_instance_id are null)'),
           );
         }
 
@@ -78,7 +78,7 @@ module.exports = function (req, res, next) {
             courses: authn_courses,
             course_instances: authn_course_instances,
             editable_courses: authn_courses.filter(
-              (course) => course.permissions_course.has_course_permission_edit
+              (course) => course.permissions_course.has_course_permission_edit,
             ),
           };
           res.locals.user = res.locals.authz_data.user;
@@ -288,7 +288,7 @@ module.exports = function (req, res, next) {
               user_with_requested_uid_has_instructor_access_to_course_instance =
                 result.rows[0].is_instructor;
               debug(
-                `requested uid has instructor access: ${user_with_requested_uid_has_instructor_access_to_course_instance}`
+                `requested uid has instructor access: ${user_with_requested_uid_has_instructor_access_to_course_instance}`,
               );
 
               // FIXME: also override institution?
@@ -546,14 +546,14 @@ module.exports = function (req, res, next) {
               //
               // We then update editable_courses as usual.
               res.locals.authz_data.courses = (result.rows[0].courses || []).filter((course) =>
-                idsEqual(course.id, result.rows[0].course.id)
+                idsEqual(course.id, result.rows[0].course.id),
               );
               res.locals.authz_data.courses.forEach(
                 (course) =>
-                  (course.permissions_course = _.cloneDeep(result.rows[0].permissions_course))
+                  (course.permissions_course = _.cloneDeep(result.rows[0].permissions_course)),
               );
               res.locals.authz_data.editable_courses = res.locals.authz_data.courses.filter(
-                (course) => course.permissions_course.has_course_permission_edit
+                (course) => course.permissions_course.has_course_permission_edit,
               );
 
               // Use the course_instances for the effective user, but keeping only
@@ -562,8 +562,8 @@ module.exports = function (req, res, next) {
               res.locals.authz_data.course_instances =
                 res.locals.authz_data.course_instances.filter((ci) =>
                   res.locals.authz_data.authn_course_instances.some((authn_ci) =>
-                    idsEqual(authn_ci.id, ci.id)
-                  )
+                    idsEqual(authn_ci.id, ci.id),
+                  ),
                 );
 
               if (isCourseInstance) {
@@ -599,8 +599,8 @@ module.exports = function (req, res, next) {
         (err) => {
           if (ERR(err, next)) return;
           next();
-        }
+        },
       );
-    }
+    },
   );
 };

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.js
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.js
@@ -11,7 +11,7 @@ module.exports = function (req, res, next) {
     return next(
       error.make(403, 'Requires either course preview access or student data view access', {
         locals: res.locals,
-      })
+      }),
     );
   }
   next();

--- a/apps/prairielearn/src/middlewares/authzIsAdministrator.js
+++ b/apps/prairielearn/src/middlewares/authzIsAdministrator.js
@@ -5,7 +5,7 @@ module.exports = function (req, res, next) {
     return next(
       error.make(403, 'Requires administrator privileges', {
         locals: res.locals,
-      })
+      }),
     );
   }
   next();

--- a/apps/prairielearn/src/middlewares/authzWorkspace.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspace.js
@@ -10,7 +10,7 @@ const selectAndAuthzInstanceQuestion = promisify(require('./selectAndAuthzInstan
 const selectAndAuthzAssessmentInstance = promisify(require('./selectAndAuthzAssessmentInstance'));
 const selectAndAuthzInstructorQuestion = promisify(require('./selectAndAuthzInstructorQuestion'));
 const authzHasCoursePreviewOrInstanceView = promisify(
-  require('./authzHasCoursePreviewOrInstanceView')
+  require('./authzHasCoursePreviewOrInstanceView'),
 );
 
 module.exports = asyncHandler(async (req, res, next) => {

--- a/apps/prairielearn/src/middlewares/cors.js
+++ b/apps/prairielearn/src/middlewares/cors.js
@@ -7,7 +7,7 @@ router.all('/*', function (req, res, next) {
   res.header('Access-Control-Allow-Methods', 'POST, PUT, PATCH, GET, OPTIONS');
   res.header(
     'Access-Control-Allow-Headers',
-    'X-Requested-With, Accept, X-Auth-UID, X-Auth-Name, X-Auth-Date, X-Auth-Signature, Content-Type'
+    'X-Requested-With, Accept, X-Auth-UID, X-Auth-Name, X-Auth-Date, X-Auth-Signature, Content-Type',
   );
 
   // disable all caching for all requests

--- a/apps/prairielearn/src/middlewares/csrfToken.js
+++ b/apps/prairielearn/src/middlewares/csrfToken.js
@@ -30,7 +30,7 @@ module.exports = function (req, res, next) {
           locals: res.locals,
           tokenData,
           __csrf_token,
-        })
+        }),
       );
     }
   }

--- a/apps/prairielearn/src/middlewares/redirectEffectiveAccessDenied.js
+++ b/apps/prairielearn/src/middlewares/redirectEffectiveAccessDenied.js
@@ -30,7 +30,7 @@ module.exports = function (err, req, res, next) {
       res.locals?.authz_data?.has_course_permission_preview)
   ) {
     res.redirect(
-      `${res.locals.plainUrlPrefix}/course_instance/${res.locals.course_instance.id}/instructor`
+      `${res.locals.plainUrlPrefix}/course_instance/${res.locals.course_instance.id}/instructor`,
     );
     return;
   }

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstructorQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstructorQuestion.js
@@ -20,7 +20,7 @@ module.exports = function (req, res, next) {
         if (result.rowCount === 0) return next(error.make(403, 'Access denied'));
         _.assign(res.locals, result.rows[0]);
         next();
-      }
+      },
     );
   } else {
     const params = {

--- a/apps/prairielearn/src/middlewares/undefCourseCode.js
+++ b/apps/prairielearn/src/middlewares/undefCourseCode.js
@@ -21,7 +21,7 @@ var undefAllCourseCode = function (callback) {
       function (err) {
         if (ERR(err, callback)) return;
         callback(null);
-      }
+      },
     );
   });
 };

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.js
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.js
@@ -4,7 +4,7 @@ const { renderEjs } = require('@prairielearn/html-ejs');
 
 function AdministratorAdmins({ admins, resLocals }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../../pages/partials/head') %>", resLocals)}
@@ -38,7 +38,7 @@ function AdministratorAdmins({ admins, resLocals }) {
                   AdministratorInsertForm({
                     csrfToken: resLocals.__csrf_token,
                     id: 'administratorInsertButton',
-                  })
+                  }),
                 )}"
                 data-trigger="manual"
                 onclick="$(this).popover('show')"
@@ -81,7 +81,7 @@ function AdministratorAdmins({ admins, resLocals }) {
                                 id: 'administratorDeleteButton' + i,
                                 uid: admin.uid,
                                 userId: admin.user_id,
-                              })
+                              }),
                             )}"
                             data-trigger="manual"
                             onclick="$(this).popover('show')"
@@ -90,7 +90,7 @@ function AdministratorAdmins({ admins, resLocals }) {
                           </button>
                         </td>
                       </tr>
-                    `
+                    `,
                   )}
                 </tbody>
               </table>

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.js
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.js
@@ -13,7 +13,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const result = await sqldb.queryAsync(sql.select_admins, []);
     res.send(AdministratorAdmins({ admins: result.rows, resLocals: res.locals }));
-  })
+  }),
 );
 
 router.post(
@@ -36,7 +36,7 @@ router.post(
     } else {
       throw error.make(400, 'unknown __action', { locals: res.locals, body: req.body });
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.js
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.js
@@ -30,7 +30,7 @@ const { renderEjs } = require('@prairielearn/html-ejs');
 function AdministratorBatchedMigrations({ batchedMigrations, resLocals }) {
   const hasBatchedMigrations = batchedMigrations.length > 0;
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}
@@ -81,7 +81,7 @@ function AdministratorBatchedMigration({
   resLocals,
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}
@@ -217,7 +217,7 @@ function MigrationJobsCard({ title, jobs, emptyText }) {
                           <pre class="mt-3 p-3 rounded bg-dark text-white"><code>${JSON.stringify(
                             job.data,
                             null,
-                            2
+                            2,
                           )}</code></pre>
                         </details>
                       `

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.js
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.js
@@ -25,7 +25,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const batchedMigrations = await selectAllBatchedMigrations(PROJECT);
     res.send(AdministratorBatchedMigrations({ batchedMigrations, resLocals: res.locals }));
-  })
+  }),
 );
 
 router.get(
@@ -35,7 +35,7 @@ router.get(
     const recentSucceededJobs = await selectRecentJobsWithStatus(
       batchedMigration.id,
       'succeeded',
-      10
+      10,
     );
     const recentFailedJobs = await selectRecentJobsWithStatus(batchedMigration.id, 'failed', 10);
     res.send(
@@ -44,9 +44,9 @@ router.get(
         recentSucceededJobs,
         recentFailedJobs,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 router.post(
@@ -58,7 +58,7 @@ router.post(
     } else {
       throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.js
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.js
@@ -85,7 +85,7 @@ router.post('/', (req, res, next) => {
             ERR(err, () => {
               logger.error(err);
             });
-          }
+          },
         );
       });
     });
@@ -94,7 +94,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.js
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.js
@@ -67,8 +67,8 @@ router.post('/', (req, res, next) => {
               req.body.confirm_short_name +
               '" did not match expected value of "' +
               short_name +
-              '"'
-          )
+              '"',
+          ),
         );
       }
 
@@ -134,7 +134,7 @@ router.post('/', (req, res, next) => {
             ERR(err, () => {
               logger.error(err);
             });
-          }
+          },
         );
       });
     });
@@ -143,7 +143,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -28,7 +28,7 @@ export function AdministratorFeatures({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}
@@ -75,7 +75,7 @@ export function AdministratorFeature({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -19,9 +19,9 @@ router.get(
       AdministratorFeatures({
         features: features.allFeatures().sort(),
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 router.get(
@@ -32,7 +32,7 @@ router.get(
     const featureGrants = await queryValidatedRows(
       sql.select_feature_grants,
       { name: feature },
-      FeatureGrantRowSchema
+      FeatureGrantRowSchema,
     );
 
     res.send(
@@ -40,9 +40,9 @@ router.get(
         feature: req.params.feature,
         featureGrants,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
@@ -18,7 +18,7 @@ export function AdministratorInstitutions({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", {
@@ -71,7 +71,7 @@ export function AdministratorInstitutions({
                         <td><code>${institution.uid_regexp}</code></td>
                         <td>${authn_providers.join(', ')}</td>
                       </tr>
-                    `
+                    `,
                   )}
                 </tbody>
               </table>

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
@@ -12,7 +12,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const institutions = await sqldb.queryRows(sql.select_institutions, InstitutionRowSchema);
     res.send(AdministratorInstitutions({ institutions, resLocals: res.locals }));
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.js
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.js
@@ -3,7 +3,7 @@ const { renderEjs } = require('@prairielearn/html-ejs');
 
 function AdministratorNetworks({ resLocals }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}
@@ -39,7 +39,7 @@ function AdministratorNetworks({ resLocals }) {
                         <td>${network.location}</td>
                         <td>${network.purpose}</td>
                       </tr>
-                    `
+                    `,
                   )}
                 </tbody>
               </table>

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.js
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.js
@@ -14,7 +14,7 @@ router.get(
     const result = await sqldb.queryOneRowAsync(sql.select, []);
     _.assign(res.locals, result.rows[0]);
     res.send(AdministratorNetworks({ resLocals: res.locals }));
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.js
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.js
@@ -20,10 +20,10 @@ router.get(
         contents.sqlFilename = f.replace(/\.json$/, '.sql');
         contents.link = f.replace(/\.json$/, '');
         return contents;
-      })
+      }),
     );
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.js
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.js
@@ -68,7 +68,7 @@ router.get(
       res.locals.recent_query_runs = recentQueryRuns.rows;
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
     }
-  })
+  }),
 );
 
 router.post(
@@ -84,7 +84,7 @@ router.post(
 
     const queryParams = _.pick(
       req.body,
-      _.map(info.params || {}, (p) => p.name)
+      _.map(info.params || {}, (p) => p.name),
     );
     const params = {
       name: req.params.query,
@@ -108,7 +108,7 @@ router.post(
     const result = await sqldb.queryOneRowAsync(sql.insert_query_run, params);
     const query_run_id = result.rows[0].id;
     res.redirect(`${req.baseUrl}${req.path}?query_run_id=${query_run_id}`);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.js
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.js
@@ -3,7 +3,7 @@ const { renderEjs } = require('@prairielearn/html-ejs');
 
 function AdministratorSettings({ resLocals }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.js
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.js
@@ -13,7 +13,7 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     res.send(AdministratorSettings({ resLocals: res.locals }));
-  })
+  }),
 );
 
 router.post(
@@ -34,7 +34,7 @@ router.post(
       } catch (err) {
         throw error.make(
           400,
-          `could not split course_ids into an array of integers: ${course_ids_string}`
+          `could not split course_ids into an array of integers: ${course_ids_string}`,
         );
       }
       const jobSequenceId = await chunks.generateAllChunksForCourseList(course_ids, authn_user_id);
@@ -42,7 +42,7 @@ router.post(
     } else {
       throw error.make(400, 'unknown __action', { locals: res.locals, body: req.body });
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.js
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.js
@@ -54,11 +54,11 @@ function AdministratorWorkspaces({ workspaces, workspaceLoadHostCapacity, resLoc
         time_in_state: workspace.workspace_host_time_in_state,
         workspaces: workspacesForHost,
       };
-    }
+    },
   );
 
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.js
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.js
@@ -17,9 +17,9 @@ router.get(
         workspaces,
         workspaceLoadHostCapacity: config.workspaceLoadHostCapacity,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -57,7 +57,7 @@ router.post('/', function (req, res, next) {
         parameters,
         ltiresult.secret,
         null,
-        { encodeSignature: false }
+        { encodeSignature: false },
       );
       if (genSignature !== signature) {
         return next(error.make(500, 'Invalid signature'));
@@ -92,7 +92,7 @@ router.post('/', function (req, res, next) {
 
       if (!parameters.user_id) {
         return next(
-          error.make(500, 'Authentication problem: UserID required. Anonymous access disabled.')
+          error.make(500, 'Authentication problem: UserID required. Anonymous access disabled.'),
         );
       }
 
@@ -163,7 +163,7 @@ router.post('/', function (req, res, next) {
             }
 
             res.redirect(
-              `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/assessment/${result.rows[0].assessment_id}/`
+              `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/assessment/${result.rows[0].assessment_id}/`,
             );
           } else {
             // No linked assessment
@@ -173,7 +173,7 @@ router.post('/', function (req, res, next) {
               if (ERR(err, next)) return;
               if (result.rowCount === 0) {
                 return next(
-                  error.make(403, 'Access denied (could not determine if user is instructor)')
+                  error.make(403, 'Access denied (could not determine if user is instructor)'),
                 );
               }
               if (!result.rows[0].is_instructor) {
@@ -181,13 +181,13 @@ router.post('/', function (req, res, next) {
                 return next(error.make(400, 'Assignment not available yet'));
               }
               res.redirect(
-                `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/instructor/instance_admin/lti`
+                `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/instructor/instance_admin/lti`,
               );
             });
           }
         });
       });
-    }
+    },
   );
 });
 

--- a/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -34,7 +34,7 @@ router.get(
     oauth2Client = new OAuth2Client(
       config.googleClientId,
       config.googleClientSecret,
-      config.googleRedirectUrl
+      config.googleRedirectUrl,
     );
 
     logger.verbose('Got Google auth with code: ' + code);
@@ -77,7 +77,7 @@ router.get(
       pl_authn_cookie: true,
       redirect: true,
     });
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
+++ b/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
@@ -32,7 +32,7 @@ router.get(
       pl_authn_cookie: true,
       redirect: true,
     });
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -18,7 +18,7 @@ interface AuthLoginProps {
 
 export function AuthLogin({ institutionAuthnProviders, service, resLocals }: AuthLoginProps) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en" class="bg-dark">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}
@@ -48,7 +48,9 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
             }
             .login-container {
               border-radius: 5px;
-              box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
+              box-shadow:
+                0 19px 38px rgba(0, 0, 0, 0.3),
+                0 15px 12px rgba(0, 0, 0, 0.22);
               height: auto;
               margin: 20px;
             }
@@ -171,7 +173,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
                           <a href="${provider.url}" class="btn btn-outline-dark btn-block">
                             ${provider.name}
                           </a>
-                        `
+                        `,
                       )}
                     </div>
                   `

--- a/apps/prairielearn/src/pages/authLogin/authLogin.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.ts
@@ -26,7 +26,7 @@ router.get(
       const institutionAuthnProvidersRes = await queryValidatedRows(
         sql.select_institution_authn_providers,
         {},
-        InstitutionAuthnProviderSchema
+        InstitutionAuthnProviderSchema,
       );
       institutionAuthnProviders = institutionAuthnProvidersRes
         .map((provider) => {
@@ -64,9 +64,9 @@ router.get(
         institutionAuthnProviders,
         service: ServiceSchema.parse(req.query.service ?? null),
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/pages/authLoginDev/authLoginDev.js
+++ b/apps/prairielearn/src/pages/authLoginDev/authLoginDev.js
@@ -29,7 +29,7 @@ router.get(
       redirect: true,
       pl_authn_cookie: true,
     });
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
+++ b/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
@@ -23,7 +23,7 @@ router.get('/', function (req, res, next) {
     const oauth2Client = new OAuth2Client(
       config.googleClientId,
       config.googleClientSecret,
-      config.googleRedirectUrl
+      config.googleRedirectUrl,
     );
     const scopes = ['openid', 'profile', 'email'];
     url = oauth2Client.generateAuthUrl({

--- a/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
+++ b/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
@@ -13,7 +13,7 @@ router.get('/*', function (req, res, next) {
       error.make(400, 'No filename provided within clientFilesAssessment directory', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
@@ -31,7 +31,7 @@ router.get('/*', function (req, res, next) {
       res.locals.course_instance.short_name,
       'assessments',
       res.locals.assessment.tid,
-      'clientFilesAssessment'
+      'clientFilesAssessment',
     );
     res.sendFile(filename, { root: clientFilesDir });
   });

--- a/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
+++ b/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
@@ -13,7 +13,7 @@ router.get('/*', function (req, res, next) {
       error.make(400, 'No filename provided within clientFilesCourse directory', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);

--- a/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
+++ b/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
@@ -13,7 +13,7 @@ router.get('/*', function (req, res, next) {
       error.make(400, 'No filename provided within clientFilesCourseInstance directory', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
@@ -28,7 +28,7 @@ router.get('/*', function (req, res, next) {
       coursePath,
       'courseInstances',
       res.locals.course_instance.short_name,
-      'clientFilesCourseInstance'
+      'clientFilesCourseInstance',
     );
     res.sendFile(filename, { root: clientFilesDir });
   });

--- a/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
+++ b/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
@@ -13,7 +13,7 @@ router.get('/*', function (req, res, next) {
       error.make(400, 'No filename provided within clientFilesQuestion directory', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
@@ -28,7 +28,7 @@ router.get('/*', function (req, res, next) {
       coursePath,
       'questions',
       res.locals.question.directory,
-      'clientFilesQuestion'
+      'clientFilesQuestion',
     );
     res.sendFile(filename, { root: clientFilesDir });
   });

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
@@ -103,7 +103,7 @@ router.get('/', function (req, res, next) {
 
               res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
             });
-          }
+          },
         );
       } else {
         //  no config.cacheImageRegistry
@@ -142,7 +142,7 @@ router.post(
         body: req.body,
       });
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/editError/editError.js
+++ b/apps/prairielearn/src/pages/editError/editError.js
@@ -77,7 +77,7 @@ router.post('/:job_sequence_id', (req, res, next) => {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/enroll/enroll.html.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.html.ts
@@ -24,7 +24,7 @@ export function Enroll({
   });
 
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head') %>", {
@@ -242,7 +242,7 @@ export function EnrollLtiMessage({
   resLocals: Record<string, any>;
 }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", {
@@ -290,7 +290,7 @@ export function EnrollLtiMessage({
 
 export function EnrollmentLimitExceededMessage({ resLocals }: { resLocals: Record<string, any> }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", {

--- a/apps/prairielearn/src/pages/enroll/enroll.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.ts
@@ -41,17 +41,17 @@ router.get(
         user_id: res.locals.authn_user.user_id,
         req_date: res.locals.req_date,
       },
-      CourseInstanceRowSchema
+      CourseInstanceRowSchema,
     );
     res.send(Enroll({ courseInstances, resLocals: res.locals }));
-  })
+  }),
 );
 
 router.get(
   '/limit_exceeded',
   asyncHandler((req, res) => {
     res.send(EnrollmentLimitExceededMessage({ resLocals: res.locals }));
-  })
+  }),
 );
 
 router.post(
@@ -79,7 +79,7 @@ router.post(
               course_instance: CourseInstanceSchema,
               institution_enrollment_count: z.number(),
               course_instance_enrollment_count: z.number(),
-            })
+            }),
           );
 
           const yearlyEnrollmentLimit = institution.yearly_enrollment_limit;
@@ -124,7 +124,7 @@ router.post(
         body: req.body,
       });
     }
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/pages/error/error.js
+++ b/apps/prairielearn/src/pages/error/error.js
@@ -50,7 +50,7 @@ module.exports = function (err, req, res, _next) {
     error_data: jsonStringifySafe(
       _.omit(_.get(err, ['data'], {}), ['sql', 'sqlParams', 'sqlError']),
       null,
-      '    '
+      '    ',
     ),
     error_data_sqlError: jsonStringifySafe(_.get(err, ['data', 'sqlError'], null), null, '    '),
     error_data_sqlParams: jsonStringifySafe(_.get(err, ['data', 'sqlParams'], null), null, '    '),

--- a/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
+++ b/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
@@ -32,7 +32,7 @@ router.get('/variant/:variant_id/*', function (req, res, next) {
         if (ERR(err, next)) return;
         res.attachment(filename);
         res.send(fileData);
-      }
+      },
     );
   });
 });

--- a/apps/prairielearn/src/pages/home/home.js
+++ b/apps/prairielearn/src/pages/home/home.js
@@ -38,7 +38,7 @@ router.get('/', function (req, res, next) {
         config.devMode
       ) {
         res.locals.instructor_courses = res.locals.instructor_courses.concat(
-          result.rows[0].example_courses
+          result.rows[0].example_courses,
         );
       }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js
@@ -21,7 +21,7 @@ const setFilenames = function (locals) {
     locals.assessment,
     locals.assessment_set,
     locals.course_instance,
-    locals.course
+    locals.course,
   );
   locals.scoresCsvFilename = prefix + 'scores.csv';
   locals.scoresAllCsvFilename = prefix + 'scores_all.csv';
@@ -139,7 +139,7 @@ router.get(
       usernameColumn.concat([
         ['Name', 'name'],
         ['Role', 'role'],
-      ])
+      ]),
     );
     if (res.locals.assessment.group_work) {
       identityColumn = groupNameColumn;
@@ -209,7 +209,7 @@ router.get(
 
       // Replace user-friendly column names with upload-friendly names
       identityColumn = (res.locals.assessment.group_work ? groupNameColumn : studentColumn).map(
-        (pair) => [pair[1], pair[1]]
+        (pair) => [pair[1], pair[1]],
       );
       const columns = identityColumn.concat([
         ['qid', 'qid'],
@@ -305,7 +305,7 @@ router.get(
       const archive = archiver('zip');
       const dirname = (res.locals.assessment_set.name + res.locals.assessment.number).replace(
         ' ',
-        ''
+        '',
       );
       const prefix = `${dirname}/`;
       archive.append(null, { name: prefix });
@@ -341,7 +341,7 @@ router.get(
       const archive = archiver('zip');
       const dirname = (res.locals.assessment_set.name + res.locals.assessment.number).replace(
         ' ',
-        ''
+        '',
       );
       const prefix = `${dirname}/`;
       archive.append(null, { name: prefix });
@@ -389,7 +389,7 @@ router.get(
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
@@ -28,14 +28,14 @@ router.get(
       res.locals.assessment,
       res.locals.assessment_set,
       res.locals.course_instance,
-      res.locals.course
+      res.locals.course,
     );
     res.locals.groupsCsvFilename = prefix + 'groups.csv';
 
     const groupConfig = await sqldb.queryOptionalRow(
       sql.config_info,
       { assessment_id: res.locals.assessment.id },
-      GroupConfigSchema
+      GroupConfigSchema,
     );
     res.locals.isGroup = !!groupConfig;
     if (!groupConfig) {
@@ -56,7 +56,7 @@ router.get(
         id: IdSchema,
         tid: z.string().nullable(),
         title: z.string().nullable(),
-      })
+      }),
     );
 
     res.locals.groups = await sqldb.queryRows(
@@ -69,7 +69,7 @@ router.get(
         name: z.string(),
         size: z.number(),
         uid_list: z.array(z.string()),
-      })
+      }),
     );
 
     res.locals.notAssigned = await sqldb.queryRows(
@@ -78,11 +78,11 @@ router.get(
         group_config_id: res.locals.config_info.id,
         course_instance_id: res.locals.config_info.course_instance_id,
       },
-      z.string()
+      z.string(),
     );
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.post(
@@ -101,7 +101,7 @@ router.post(
         function (err, job_sequence_id) {
           if (ERR(err, next)) return;
           res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-        }
+        },
       );
     } else if (req.body.__action === 'auto_assessment_groups') {
       groupUpdate.autoGroups(
@@ -114,7 +114,7 @@ router.post(
         function (err, job_sequence_id) {
           if (ERR(err, next)) return;
           res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-        }
+        },
       );
     } else if (req.body.__action === 'copy_assessment_groups') {
       await sqldb.callAsync('assessment_groups_copy', [
@@ -154,7 +154,7 @@ router.post(
       if (notExist) {
         flash(
           'error',
-          `Could not create group. The following users do not exist: ${notExist.toString()}`
+          `Could not create group. The following users do not exist: ${notExist.toString()}`,
         );
       }
 
@@ -162,7 +162,7 @@ router.post(
       if (inGroup) {
         flash(
           'error',
-          `Could not create group. The following users are already in another group: ${inGroup.toString()}`
+          `Could not create group. The following users are already in another group: ${inGroup.toString()}`,
         );
       }
 
@@ -185,7 +185,7 @@ router.post(
         const uids = failedUids.join(', ');
         flash(
           'error',
-          `Failed to add the following users: ${uids}. Please check if the users exist.`
+          `Failed to add the following users: ${uids}. Please check if the users exist.`,
         );
       }
       res.redirect(req.originalUrl);
@@ -207,7 +207,7 @@ router.post(
         const uids = failedUids.join(', ');
         flash(
           'error',
-          `Failed to remove the following users: ${uids}. Please check if the users exist.`
+          `Failed to remove the following users: ${uids}. Please check if the users exist.`,
         );
       }
       res.redirect(req.originalUrl);
@@ -224,7 +224,7 @@ router.post(
         body: req.body,
       });
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -19,10 +19,10 @@ const logCsvFilename = (locals) => {
       locals.assessment,
       locals.assessment_set,
       locals.course_instance,
-      locals.course
+      locals.course,
     ) +
     sanitizeName.sanitizeString(
-      locals.instance_group?.name ?? locals.instance_user?.uid ?? 'unknown'
+      locals.instance_group?.name ?? locals.instance_user?.uid ?? 'unknown',
     ) +
     '_' +
     locals.assessment_instance.number +
@@ -57,11 +57,11 @@ router.get(
 
     res.locals.log = await assessment.selectAssessmentInstanceLog(
       res.locals.assessment_instance.id,
-      false
+      false,
     );
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -70,7 +70,7 @@ router.get(
     if (req.params.filename === logCsvFilename(res.locals)) {
       const cursor = await assessment.selectAssessmentInstanceLogCursor(
         res.locals.assessment_instance.id,
-        false
+        false,
       );
 
       const stringifier = stringifyStream({
@@ -99,7 +99,7 @@ router.get(
     } else {
       next(error.make(404, 'Unknown filename: ' + req.params.filename));
     }
-  })
+  }),
 );
 
 router.post(
@@ -137,11 +137,11 @@ router.post(
             manual_points: req.body.manual_points,
             auto_points: req.body.auto_points,
           },
-          res.locals.authn_user.user_id
+          res.locals.authn_user.user_id,
         );
       if (modified_at_conflict) {
         return res.redirect(
-          `${res.locals.urlPrefix}/assessment/${res.locals.assessment.id}/manual_grading/instance_question/${req.body.instance_question_id}?conflict_grading_job_id=${grading_job_id}`
+          `${res.locals.urlPrefix}/assessment/${res.locals.assessment.id}/manual_grading/instance_question/${req.body.instance_question_id}?conflict_grading_job_id=${grading_job_id}`,
         );
       }
       res.redirect(req.originalUrl);
@@ -153,11 +153,11 @@ router.post(
           null, // submission_id
           req.body.modified_at,
           { score_perc: req.body.score_perc },
-          res.locals.authn_user.user_id
+          res.locals.authn_user.user_id,
         );
       if (modified_at_conflict) {
         return res.redirect(
-          `${res.locals.urlPrefix}/assessment/${res.locals.assessment.id}/manual_grading/instance_question/${req.body.instance_question_id}?conflict_grading_job_id=${grading_job_id}`
+          `${res.locals.urlPrefix}/assessment/${res.locals.assessment.id}/manual_grading/instance_question/${req.body.instance_question_id}?conflict_grading_job_id=${grading_job_id}`,
         );
       }
       res.redirect(req.originalUrl);
@@ -166,10 +166,10 @@ router.post(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
@@ -69,7 +69,7 @@ router.post('/', function (req, res, next) {
         function (err) {
           if (ERR(err, next)) return;
           res.send(JSON.stringify({}));
-        }
+        },
       );
     });
   } else if (req.body.__action === 'delete') {
@@ -97,7 +97,7 @@ router.post('/', function (req, res, next) {
       function (err, job_sequence_id) {
         if (ERR(err, next)) return;
         res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-      }
+      },
     );
   } else if (req.body.__action === 'delete_all') {
     const params = [res.locals.assessment.id, res.locals.authn_user.user_id];
@@ -118,7 +118,7 @@ router.post('/', function (req, res, next) {
         function (err, job_sequence_id) {
           if (ERR(err, next)) return;
           res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-        }
+        },
       );
     });
   } else if (req.body.__action === 'set_time_limit') {
@@ -178,7 +178,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.js
@@ -20,7 +20,7 @@ router.get(
     res.locals.questions = result.rows;
     res.locals.num_open_instances = result.rows[0]?.num_open_instances || 0;
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
@@ -15,7 +15,7 @@ router.get(
       return next(error.make(403, 'Access denied (must be a student data viewer)'));
     }
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -31,7 +31,7 @@ router.get(
 
     const result = await sqldb.queryAsync(sql.select_instance_questions_manual_grading, params);
     res.send({ instance_questions: result.rows.map((row, idx) => ({ index: idx + 1, ...row })) });
-  })
+  }),
 );
 
 router.get(
@@ -46,10 +46,10 @@ router.get(
         res.locals.assessment.id,
         res.locals.assessment_question.id,
         res.locals.authz_data.user.user_id,
-        req.query.prior_instance_question_id
-      )
+        req.query.prior_instance_question_id,
+      ),
     );
-  })
+  }),
 );
 
 router.post(
@@ -85,7 +85,7 @@ router.post(
           manual_points: req.body.manual_points,
           auto_points: req.body.auto_points,
         },
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       if (result.modified_at_conflict) {
         return res.send({
@@ -101,7 +101,7 @@ router.post(
         null, // submission_id
         req.body.modified_at,
         { score_perc: req.body.score_perc },
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       if (result.modified_at_conflict) {
         return res.send({
@@ -115,10 +115,10 @@ router.post(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
@@ -30,13 +30,13 @@ async function prepareLocalsForRender(req, res) {
     await util.promisify(question.getAndRenderVariant)(
       variant_with_submission.variant_id,
       null,
-      res.locals
+      res.locals,
     );
   }
 
   res.locals.rubric_settings_visible = await features.enabledFromLocals(
     'manual-grading-rubrics',
-    res.locals
+    res.locals,
   );
 
   // If student never loaded question or never submitted anything (submission is null)
@@ -71,7 +71,7 @@ router.get(
 
     await prepareLocalsForRender(req, res);
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -86,10 +86,10 @@ router.get(
       null, // questionContext
       null, // csrfToken
       null, // authorizedEdit
-      false // renderScorePanels
+      false, // renderScorePanels
     );
     res.send({ submissionPanel: results.submissionPanel });
-  })
+  }),
 );
 
 router.get(
@@ -101,17 +101,17 @@ router.get(
       // latter would require all includes in EJS to be translated to await recursively.
       const gradingPanel = await util.promisify(ejs.renderFile)(
         path.join(__dirname, 'gradingPanel.ejs'),
-        { context: 'main', ...res.locals }
+        { context: 'main', ...res.locals },
       );
       const rubricSettings = await util.promisify(ejs.renderFile)(
         path.join(__dirname, 'rubricSettingsModal.ejs'),
-        res.locals
+        res.locals,
       );
       res.send({ gradingPanel, rubricSettings });
     } catch (err) {
       res.send({ err: String(err) });
     }
-  })
+  }),
 );
 
 router.post(
@@ -147,12 +147,12 @@ router.post(
           feedback: { manual: req.body.submission_note },
           manual_rubric_data,
         },
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
 
       if (update_result.modified_at_conflict) {
         return res.redirect(
-          req.baseUrl + `?conflict_grading_job_id=${update_result.grading_job_id}`
+          req.baseUrl + `?conflict_grading_job_id=${update_result.grading_job_id}`,
         );
       }
       res.redirect(
@@ -161,8 +161,8 @@ router.post(
           res.locals.assessment.id,
           res.locals.assessment_question.id,
           res.locals.authz_data.user.user_id,
-          res.locals.instance_question.id
-        )
+          res.locals.instance_question.id,
+        ),
       );
     } else if (req.body.__action === 'modify_rubric_settings') {
       // Parse using qs, which allows deep objects to be created based on parameter names
@@ -178,7 +178,7 @@ router.post(
           req.body.max_extra_points,
           rubric_items,
           !!req.body.tag_for_manual_grading,
-          res.locals.authn_user.user_id
+          res.locals.authn_user.user_id,
         )
         .then(() => {
           res.redirect(req.baseUrl + '/grading_rubric_panels');
@@ -203,17 +203,17 @@ router.post(
           res.locals.assessment.id,
           res.locals.assessment_question.id,
           res.locals.authz_data.user.user_id,
-          res.locals.instance_question.id
-        )
+          res.locals.instance_question.id,
+        ),
       );
     } else {
       return next(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
@@ -16,7 +16,7 @@ const setFilenames = function (locals) {
     locals.assessment,
     locals.assessment_set,
     locals.course_instance,
-    locals.course
+    locals.course,
   );
   locals.questionStatsCsvFilename = prefix + 'question_stats.csv';
 };
@@ -52,7 +52,7 @@ router.get(
     res.locals.questions = questionResult.rows;
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -118,7 +118,7 @@ router.get(
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }
-  })
+  }),
 );
 
 router.post(
@@ -139,7 +139,7 @@ router.post(
         body: req.body,
       });
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
@@ -39,14 +39,14 @@ router.post('/', function (req, res, next) {
       function (err, job_sequence_id) {
         if (ERR(err, next)) return;
         res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-      }
+      },
     );
   } else {
     return next(
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
@@ -33,7 +33,7 @@ router.get('/', function (req, res, next) {
             if (ERR(err, callback)) return;
             res.locals.tids = result.rows[0].tids;
             callback(null);
-          }
+          },
         );
       },
     ],
@@ -46,7 +46,7 @@ router.get('/', function (req, res, next) {
           res.locals.course_instance.id +
           '/assessment/' +
           res.locals.assessment.id,
-        host
+        host,
       ).href;
       res.locals.studentLinkQRCode = new QR({
         content: res.locals.studentLink,
@@ -59,11 +59,11 @@ router.get('/', function (req, res, next) {
           res.locals.course_instance.short_name,
           'assessments',
           res.locals.assessment.tid,
-          'infoAssessment.json'
-        )
+          'infoAssessment.json',
+        ),
       );
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 
@@ -81,7 +81,7 @@ router.post('/', function (req, res, next) {
           res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
         } else {
           debug(
-            `Get assessment_id from uuid=${editor.uuid} with course_instance_id=${res.locals.course_instance.id}`
+            `Get assessment_id from uuid=${editor.uuid} with course_instance_id=${res.locals.course_instance.id}`,
           );
           sqldb.queryOneRow(
             sql.select_assessment_id_from_uuid,
@@ -92,9 +92,9 @@ router.post('/', function (req, res, next) {
             (err, result) => {
               if (ERR(err, next)) return;
               res.redirect(
-                res.locals.urlPrefix + '/assessment/' + result.rows[0].assessment_id + '/settings'
+                res.locals.urlPrefix + '/assessment/' + result.rows[0].assessment_id + '/settings',
               );
-            }
+            },
           );
         }
       });
@@ -120,8 +120,8 @@ router.post('/', function (req, res, next) {
     if (!/^[-A-Za-z0-9_/]+$/.test(req.body.id)) {
       return next(
         new Error(
-          `Invalid TID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`
-        )
+          `Invalid TID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`,
+        ),
       );
     }
     let tid_new;
@@ -155,7 +155,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
@@ -15,7 +15,7 @@ const setFilenames = function (locals) {
     locals.assessment,
     locals.assessment_set,
     locals.course_instance,
-    locals.course
+    locals.course,
   );
   locals.scoreStatsCsvFilename = prefix + 'score_stats.csv';
   locals.durationStatsCsvFilename = prefix + 'duration_stats.csv';
@@ -57,7 +57,7 @@ router.get(
     res.locals.user_scores = userScoresResult.rows;
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -204,7 +204,7 @@ router.get(
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.js
@@ -39,7 +39,7 @@ router.post(
         res.locals.assessment.id,
         req.file,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
     } else if (req.body.__action === 'upload_assessment_instance_scores') {
@@ -47,7 +47,7 @@ router.post(
         res.locals.assessment.id,
         req.file,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
     } else {
@@ -56,7 +56,7 @@ router.post(
         body: req.body,
       });
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
@@ -48,7 +48,7 @@ router.get(
       .map((row) => row.id);
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -75,7 +75,7 @@ router.get(
     res.locals.row = result.rows[0];
 
     res.render(`${__dirname}/assessmentStats.ejs`, res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -155,7 +155,7 @@ router.get(
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }
-  })
+  }),
 );
 
 router.post('/', (req, res, next) => {
@@ -172,7 +172,7 @@ router.post('/', (req, res, next) => {
           res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
         } else {
           debug(
-            `Get assessment_id from uuid=${editor.uuid} with course_instance_id=${res.locals.course_instance.id}`
+            `Get assessment_id from uuid=${editor.uuid} with course_instance_id=${res.locals.course_instance.id}`,
           );
           sqldb.queryOneRow(
             sql.select_assessment_id_from_uuid,
@@ -183,9 +183,9 @@ router.post('/', (req, res, next) => {
             (err, result) => {
               if (ERR(err, next)) return;
               res.redirect(
-                res.locals.urlPrefix + '/assessment/' + result.rows[0].assessment_id + '/settings'
+                res.locals.urlPrefix + '/assessment/' + result.rows[0].assessment_id + '/settings',
               );
-            }
+            },
           );
         }
       });
@@ -195,7 +195,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCopyTemplateCourseQuestion/instructorCopyTemplateCourseQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorCopyTemplateCourseQuestion/instructorCopyTemplateCourseQuestion.ts
@@ -33,7 +33,7 @@ router.post(
       z.object({
         question: QuestionSchema,
         course: CourseSchema,
-      })
+      }),
     );
 
     if (result.course.template_course === false) {
@@ -45,7 +45,7 @@ router.post(
       toCourseId: res.locals.course.id,
       question: result.question,
     });
-  })
+  }),
 );
 
 export default router;

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
@@ -58,7 +58,7 @@ router.get('/', function (req, res, next) {
     (err) => {
       if (ERR(err, next)) return;
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 
@@ -76,7 +76,7 @@ router.post('/', (req, res, next) => {
           res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
         } else {
           debug(
-            `Get course_instance_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`
+            `Get course_instance_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`,
           );
           sqldb.queryOneRow(
             sql.select_course_instance_id_from_uuid,
@@ -87,9 +87,9 @@ router.post('/', (req, res, next) => {
                 res.locals.plainUrlPrefix +
                   '/course_instance/' +
                   result.rows[0].course_instance_id +
-                  '/instructor/instance_admin/settings'
+                  '/instructor/instance_admin/settings',
               );
-            }
+            },
           );
         }
       });
@@ -99,7 +99,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
@@ -44,14 +44,14 @@ router.get('/', function (req, res, next) {
     (err) => {
       if (ERR(err, next)) return;
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 
 router.post('/', (req, res, next) => {
   if (!res.locals.authz_data.has_course_permission_edit || res.locals.course.example_course) {
     return next(
-      error.make(403, 'Access denied (must be course editor and must not be example course)')
+      error.make(403, 'Access denied (must be course editor and must not be example course)'),
     );
   }
 
@@ -76,7 +76,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
@@ -36,7 +36,7 @@ router.post('/', (req, res, next) => {
       req.body.uid
         .split(/[\s,;]+/)
         .map((uid) => uid.trim())
-        .filter((uid) => uid)
+        .filter((uid) => uid),
     );
 
     // Verify there is at least one UID
@@ -53,7 +53,7 @@ router.post('/', (req, res, next) => {
     let course_instance = null;
     if (req.body.course_instance_id) {
       course_instance = res.locals.authz_data.course_instances.find((ci) =>
-        idsEqual(ci.id, req.body.course_instance_id)
+        idsEqual(ci.id, req.body.course_instance_id),
       );
       if (!course_instance) return next(error.make(400, `Invalid requested course instance role`));
     }
@@ -64,7 +64,7 @@ router.post('/', (req, res, next) => {
       !['Student Data Viewer', 'Student Data Editor'].includes(req.body.course_instance_role)
     ) {
       return next(
-        error.make(400, `Invalid requested course instance role: ${req.body.course_instance_role}`)
+        error.make(400, `Invalid requested course instance role: ${req.body.course_instance_role}`),
       );
     }
     // Iterate through UIDs
@@ -101,7 +101,7 @@ router.post('/', (req, res, next) => {
           sqldb.call('course_instance_permissions_insert', ci_params, (err, _result) => {
             if (
               ERR(err, (e) =>
-                logger.verbose(`Failed to insert course instance permission for uid: ${uid}`, e)
+                logger.verbose(`Failed to insert course instance permission for uid: ${uid}`, e),
               )
             ) {
               memo.not_given_cip.push(uid);
@@ -119,7 +119,7 @@ router.post('/', (req, res, next) => {
           err = error.make(409, 'Failed to grant access to some users');
           err.info = '';
           const given_cp_and_cip = result.given_cp.filter(
-            (uid) => !result.not_given_cip.includes(uid)
+            (uid) => !result.not_given_cip.includes(uid),
           );
           debug(`given_cp: ${result.given_cp}`);
           debug(`not_given_cip: ${result.not_given_cip}`);
@@ -178,7 +178,7 @@ router.post('/', (req, res, next) => {
           return next(err);
         }
         res.redirect(req.originalUrl);
-      }
+      },
     );
   } else if (req.body.__action === 'course_permissions_update_role') {
     if (
@@ -195,8 +195,8 @@ router.post('/', (req, res, next) => {
       return next(
         error.make(
           403,
-          'Owners cannot change their own course content access even if they are emulating another user'
-        )
+          'Owners cannot change their own course content access even if they are emulating another user',
+        ),
       );
     }
 
@@ -236,8 +236,8 @@ router.post('/', (req, res, next) => {
       return next(
         error.make(
           403,
-          'Owners cannot remove themselves from the course staff even if they are emulating another user'
-        )
+          'Owners cannot remove themselves from the course staff even if they are emulating another user',
+        ),
       );
     }
 
@@ -259,7 +259,7 @@ router.post('/', (req, res, next) => {
     if (req.body.course_instance_id) {
       if (
         !res.locals.authz_data.course_instances.find((ci) =>
-          idsEqual(ci.id, req.body.course_instance_id)
+          idsEqual(ci.id, req.body.course_instance_id),
         )
       ) {
         return next(error.make(400, `Invalid requested course instance role`));
@@ -302,7 +302,7 @@ router.post('/', (req, res, next) => {
     if (req.body.course_instance_id) {
       if (
         !res.locals.authz_data.course_instances.find((ci) =>
-          idsEqual(ci.id, req.body.course_instance_id)
+          idsEqual(ci.id, req.body.course_instance_id),
         )
       ) {
         return next(error.make(400, `Invalid requested course instance role`));
@@ -348,7 +348,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -59,14 +59,14 @@ router.get('/', function (req, res, next) {
       "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
       {
         timeZone: displayTimezone,
-      }
+      },
     );
     res.locals.req_date_for_display = format(
       utcToZonedTime(res.locals.req_date, displayTimezone),
       "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
       {
         timeZone: displayTimezone,
-      }
+      },
     );
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
@@ -131,7 +131,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown action: ' + res.locals.__action, {
         __action: req.body.__action,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -49,7 +49,7 @@ function browseDirectory(file_browser, callback) {
               const relative_path = path.relative(file_browser.paths.coursePath, filepath);
               const sync_data = await editorUtil.getErrorsAndWarningsForFilePath(
                 file_browser.paths.courseId,
-                relative_path
+                relative_path,
               );
               return {
                 id: file.index,
@@ -74,7 +74,7 @@ function browseDirectory(file_browser, callback) {
                   file_browser.has_course_permission_edit &&
                   !file_browser.example_course,
                 canView: !file_browser.paths.invalidRootPaths.some((invalidRootPath) =>
-                  contains(invalidRootPath, filepath)
+                  contains(invalidRootPath, filepath),
                 ),
                 sync_errors: sync_data.errors,
                 sync_errors_ansified: ansiUp.ansi_to_html(sync_data.errors),
@@ -90,13 +90,13 @@ function browseDirectory(file_browser, callback) {
                 path: path.relative(file_browser.paths.coursePath, filepath),
                 encodedPath: encodePath(path.relative(file_browser.paths.coursePath, filepath)),
                 canView: !file_browser.paths.invalidRootPaths.some((invalidRootPath) =>
-                  contains(invalidRootPath, filepath)
+                  contains(invalidRootPath, filepath),
                 ),
               };
             } else {
               return null;
             }
-          }
+          },
         );
         file_browser.files = all_files.filter((f) => f?.isFile);
         file_browser.dirs = all_files.filter((f) => f?.isDirectory);
@@ -105,7 +105,7 @@ function browseDirectory(file_browser, callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 
@@ -187,11 +187,11 @@ function browseFile(file_browser, callback) {
         canDelete:
           movable && file_browser.has_course_permission_edit && !file_browser.example_course,
         canView: !file_browser.paths.invalidRootPaths.some((invalidRootPath) =>
-          contains(invalidRootPath, filepath)
+          contains(invalidRootPath, filepath),
         ),
       };
       callback(null);
-    }
+    },
   );
 }
 
@@ -245,8 +245,8 @@ router.get('/*', function (req, res, next) {
         } else {
           callback(
             new Error(
-              `Invalid working path - ${file_browser.paths.workingPath} is neither a directory nor a file`
-            )
+              `Invalid working path - ${file_browser.paths.workingPath} is neither a directory nor a file`,
+            ),
           );
         }
       },
@@ -262,7 +262,7 @@ router.get('/*', function (req, res, next) {
       }
       res.locals.file_browser = file_browser;
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 
@@ -312,7 +312,7 @@ router.post('/*', function (req, res, next) {
         oldPath = path.join(req.body.working_path, req.body.old_file_name);
       } catch (err) {
         return next(
-          new Error(`Invalid old file path: ${req.body.working_path} / ${req.body.old_file_name}`)
+          new Error(`Invalid old file path: ${req.body.working_path} / ${req.body.old_file_name}`),
         );
       }
       if (!req.body.new_file_name) {
@@ -320,13 +320,13 @@ router.post('/*', function (req, res, next) {
       }
       if (
         !/^(?:[-A-Za-z0-9_]+|\.\.)(?:\/(?:[-A-Za-z0-9_]+|\.\.))*(?:\.[-A-Za-z0-9_]+)?$/.test(
-          req.body.new_file_name
+          req.body.new_file_name,
         )
       ) {
         return next(
           new Error(
-            `Invalid new file name (did not match required pattern): ${req.body.new_file_name}`
-          )
+            `Invalid new file name (did not match required pattern): ${req.body.new_file_name}`,
+          ),
         );
       }
       let newPath;
@@ -334,7 +334,7 @@ router.post('/*', function (req, res, next) {
         newPath = path.join(req.body.working_path, req.body.new_file_name);
       } catch (err) {
         return next(
-          new Error(`Invalid new file path: ${req.body.working_path} / ${req.body.new_file_name}`)
+          new Error(`Invalid new file path: ${req.body.working_path} / ${req.body.new_file_name}`),
         );
       }
       if (oldPath === newPath) {
@@ -356,8 +356,8 @@ router.post('/*', function (req, res, next) {
               if (req.body.was_viewing_file) {
                 res.redirect(
                   `${res.locals.urlPrefix}/${res.locals.navPage}/file_view/${encodePath(
-                    path.relative(res.locals.course.path, newPath)
-                  )}`
+                    path.relative(res.locals.course.path, newPath),
+                  )}`,
                 );
               } else {
                 res.redirect(req.originalUrl);
@@ -382,7 +382,7 @@ router.post('/*', function (req, res, next) {
           filePath = path.join(req.body.working_path, req.file.originalname);
         } catch (err) {
           return next(
-            new Error(`Invalid file path: ${req.body.working_path} / ${req.file.originalname}`)
+            new Error(`Invalid file path: ${req.body.working_path} / ${req.file.originalname}`),
           );
         }
       }

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -64,7 +64,7 @@ router.get('/*', (req, res, next) => {
       error.make(400, `attempting to edit file inside example course: ${workingPath}`, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 
@@ -72,14 +72,14 @@ router.get('/*', (req, res, next) => {
   const fullPath = path.join(fileEdit.coursePath, fileEdit.dirName, fileEdit.fileName);
   const relPath = path.relative(fileEdit.coursePath, fullPath);
   debug(
-    `Edit file in browser\n fileName: ${fileEdit.fileName}\n coursePath: ${fileEdit.coursePath}\n fullPath: ${fullPath}\n relPath: ${relPath}`
+    `Edit file in browser\n fileName: ${fileEdit.fileName}\n coursePath: ${fileEdit.coursePath}\n fullPath: ${fullPath}\n relPath: ${relPath}`,
   );
   if (!contains(fileEdit.coursePath, fullPath)) {
     return next(
       error.make(400, `attempting to edit file outside course directory: ${workingPath}`, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 
@@ -107,13 +107,13 @@ router.get('/*', (req, res, next) => {
           debug('Read job sequence');
           fileEdit.jobSequence = await serverJobs.getJobSequenceWithFormattedOutputAsync(
             fileEdit.jobSequenceId,
-            res.locals.course.id
+            res.locals.course.id,
           );
         }
 
         const data = await editorUtil.getErrorsAndWarningsForFilePath(
           res.locals.course.id,
-          relPath
+          relPath,
         );
         const ansiUp = new AnsiUp();
         fileEdit.sync_errors = data.errors;
@@ -161,7 +161,7 @@ router.get('/*', (req, res, next) => {
         res.locals.fileEdit.paths = paths;
         res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
       });
-    }
+    },
   );
 });
 
@@ -200,7 +200,7 @@ router.post('/*', (req, res, next) => {
       error.make(400, `attempting to edit file inside example course: ${workingPath}`, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 
@@ -208,14 +208,14 @@ router.post('/*', (req, res, next) => {
   const fullPath = path.join(fileEdit.coursePath, fileEdit.dirName, fileEdit.fileName);
   const relPath = path.relative(fileEdit.coursePath, fullPath);
   debug(
-    `Edit file in browser\n fileName: ${fileEdit.fileName}\n coursePath: ${fileEdit.coursePath}\n fullPath: ${fullPath}\n relPath: ${relPath}`
+    `Edit file in browser\n fileName: ${fileEdit.fileName}\n coursePath: ${fileEdit.coursePath}\n fullPath: ${fullPath}\n relPath: ${relPath}`,
   );
   if (!contains(fileEdit.coursePath, fullPath)) {
     return next(
       error.make(400, `attempting to edit file outside course directory: ${workingPath}`, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 
@@ -234,8 +234,8 @@ router.post('/*', (req, res, next) => {
           {
             locals: res.locals,
             body: req.body,
-          }
-        )
+          },
+        ),
       );
     }
 
@@ -249,11 +249,11 @@ router.post('/*', (req, res, next) => {
       const rootPath = path.join(
         res.locals.course.path,
         'courseInstances',
-        res.locals.course_instance.short_name
+        res.locals.course_instance.short_name,
       );
       fileEdit.commitMessage = `${path.basename(rootPath)}: edit ${path.relative(
         rootPath,
-        fullPath
+        fullPath,
       )}`;
     } else if (res.locals.navPage === 'assessment') {
       const rootPath = path.join(
@@ -261,17 +261,17 @@ router.post('/*', (req, res, next) => {
         'courseInstances',
         res.locals.course_instance.short_name,
         'assessments',
-        res.locals.assessment.tid
+        res.locals.assessment.tid,
       );
       fileEdit.commitMessage = `${path.basename(rootPath)}: edit ${path.relative(
         rootPath,
-        fullPath
+        fullPath,
       )}`;
     } else if (res.locals.navPage === 'question') {
       const rootPath = path.join(res.locals.course.path, 'questions', res.locals.question.qid);
       fileEdit.commitMessage = `${path.basename(rootPath)}: edit ${path.relative(
         rootPath,
-        fullPath
+        fullPath,
       )}`;
     } else {
       const rootPath = res.locals.course.path;
@@ -300,14 +300,14 @@ router.post('/*', (req, res, next) => {
       (err) => {
         if (ERR(err, next)) return;
         res.redirect(req.originalUrl);
-      }
+      },
     );
   } else {
     next(
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });
@@ -326,7 +326,7 @@ async function readEdit(fileEdit) {
   });
   if (draftResult.rows.length > 0) {
     debug(
-      `Found ${draftResult.rows.length} saved drafts, the first of which has id ${draftResult.rows[0].id}`
+      `Found ${draftResult.rows.length} saved drafts, the first of which has id ${draftResult.rows[0].id}`,
     );
     if (draftResult.rows[0].age < 24) {
       fileEdit.editID = draftResult.rows[0].id;
@@ -386,7 +386,7 @@ function updateJobSequenceId(fileEdit, job_sequence_id, callback) {
       if (ERR(err, callback)) return;
       debug(`Update file edit id=${fileEdit.editID}: job_sequence_id=${job_sequence_id}`);
       callback(null);
-    }
+    },
   );
 }
 
@@ -400,7 +400,7 @@ function updateDidSave(fileEdit, callback) {
       if (ERR(err, callback)) return;
       debug(`Update file edit id=${fileEdit.editID}: did_save=true`);
       callback(null);
-    }
+    },
   );
 }
 
@@ -414,7 +414,7 @@ function updateDidSync(fileEdit, callback) {
       if (ERR(err, callback)) return;
       debug(`Update file edit id=${fileEdit.editID}: did_sync=true`);
       callback(null);
-    }
+    },
   );
 }
 
@@ -445,7 +445,7 @@ async function createEdit(fileEdit) {
     file_id: fileEdit.fileID,
   };
   debug(
-    `Insert file edit into db: ${params.user_id}, ${params.course_id}, ${params.dir_name}, ${params.file_name}`
+    `Insert file edit into db: ${params.user_id}, ${params.course_id}, ${params.dir_name}, ${params.file_name}`,
   );
   const result = await sqldb.queryOneRowAsync(sql.insert_file_edit, params);
   fileEdit.editID = result.rows[0].id;
@@ -460,7 +460,7 @@ async function writeEdit(fileEdit) {
     null,
     null,
     fileEdit.userID, // TODO: could distinguish between user_id and authn_user_id,
-    fileEdit.userID //       although I don't think there's any need to do so
+    fileEdit.userID, //       although I don't think there's any need to do so
   );
   debug(`writeEdit(): wrote file edit to file store with file_id=${fileID}`);
   return fileID;
@@ -549,8 +549,8 @@ function saveAndSync(fileEdit, locals, callback) {
             job.verbose(`Did not acquire lock ${lockName}`);
             job.fail(
               new Error(
-                `Another user is already syncing or modifying the course: ${options.courseDir}`
-              )
+                `Another user is already syncing or modifying the course: ${options.courseDir}`,
+              ),
             );
           } else {
             courseLock = lock;
@@ -926,7 +926,7 @@ function saveAndSync(fileEdit, locals, callback) {
                   chunks.logChunkChangesToJob(chunkChanges, job);
                   updateCourseCommitHash();
                 }
-              }
+              },
             );
           } else {
             updateCourseCommitHash();

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
@@ -29,8 +29,8 @@ function getFileTransfer(file_transfer_id, user_id, callback) {
               new Error(
                 `must have same user_id: ${
                   file_transfer.user_id
-                } and ${user_id} (types: ${typeof file_transfer.user_id}, ${typeof user_id})`
-              )
+                } and ${user_id} (types: ${typeof file_transfer.user_id}, ${typeof user_id})`,
+              ),
             );
           }
           callback(null);
@@ -44,14 +44,14 @@ function getFileTransfer(file_transfer_id, user_id, callback) {
             if (ERR(err, callback)) return;
             file_transfer.from_course = result.rows[0];
             callback(null);
-          }
+          },
         );
       },
     ],
     (err) => {
       if (ERR(err, callback)) return;
       callback(null, file_transfer);
-    }
+    },
   );
 }
 
@@ -85,7 +85,7 @@ router.get('/:file_transfer_id', function (req, res, next) {
             (err, _result) => {
               if (ERR(err, next)) return;
               debug(
-                `Get question_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`
+                `Get question_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`,
               );
               sqldb.queryOneRow(
                 sql.select_question_id_from_uuid,
@@ -94,12 +94,12 @@ router.get('/:file_transfer_id', function (req, res, next) {
                   if (ERR(err, next)) return;
                   flash(
                     'success',
-                    'Question copied successfully. You are now viewing your copy of the question.'
+                    'Question copied successfully. You are now viewing your copy of the question.',
                   );
                   res.redirect(res.locals.urlPrefix + '/question/' + result.rows[0].question_id);
-                }
+                },
               );
-            }
+            },
           );
         }
       });

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
@@ -108,7 +108,7 @@ router.get(
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }
-  })
+  }),
 );
 
 router.post('/', function (req, res, next) {
@@ -145,7 +145,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
@@ -75,7 +75,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
@@ -38,7 +38,7 @@ router.get('/', function (req, res, next) {
       const host = config.serverCanonicalHost || `${req.protocol}://${req.headers.host}`;
       res.locals.studentLink = new URL(
         res.locals.plainUrlPrefix + '/course_instance/' + res.locals.course_instance.id,
-        host
+        host,
       ).href;
       res.locals.studentLinkQRCode = new QR({
         content: res.locals.studentLink,
@@ -49,11 +49,11 @@ router.get('/', function (req, res, next) {
         path.join(
           'courseInstances',
           res.locals.course_instance.short_name,
-          'infoCourseInstance.json'
-        )
+          'infoCourseInstance.json',
+        ),
       );
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 
@@ -71,7 +71,7 @@ router.post('/', function (req, res, next) {
           res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
         } else {
           debug(
-            `Get course_instance_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`
+            `Get course_instance_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`,
           );
           sqldb.queryOneRow(
             sql.select_course_instance_id_from_uuid,
@@ -82,9 +82,9 @@ router.post('/', function (req, res, next) {
                 res.locals.plainUrlPrefix +
                   '/course_instance/' +
                   result.rows[0].course_instance_id +
-                  '/instructor/instance_admin/settings'
+                  '/instructor/instance_admin/settings',
               );
-            }
+            },
           );
         }
       });
@@ -110,8 +110,8 @@ router.post('/', function (req, res, next) {
     if (!/^[-A-Za-z0-9_/]+$/.test(req.body.id)) {
       return next(
         new Error(
-          `Invalid CIID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`
-        )
+          `Invalid CIID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`,
+        ),
       );
     }
     let ciid_new;
@@ -144,7 +144,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
@@ -130,7 +130,7 @@ router.get('/', function (req, res, next) {
           acc.add(ci.id);
           return acc;
         },
-        new Set()
+        new Set(),
       );
 
       res.locals.issueCount = result.rowCount ? result.rows[0].issue_count : 0;
@@ -148,8 +148,8 @@ router.get('/', function (req, res, next) {
           if (!row.course_instance_id) {
             return next(
               new Error(
-                `Issue id ${row.issue_id} is associated with an assessment but not a course instance`
-              )
+                `Issue id ${row.issue_id} is associated with an assessment but not a course instance`,
+              ),
             );
           }
 
@@ -161,7 +161,7 @@ router.get('/', function (req, res, next) {
           //
           // Add a flag to each row saying if the effective user has this access.
           row.assessment.hide_link = !linkable_course_instance_ids.has(
-            parseInt(row.course_instance_id)
+            parseInt(row.course_instance_id),
           );
 
           // If necessary, construct the URL prefix to the appropriate course instance
@@ -204,7 +204,7 @@ router.get('/', function (req, res, next) {
             _.some(
               res.locals.authz_data.course_instances,
               (ci) =>
-                idsEqual(ci.id, row.course_instance_id) && ci.has_course_instance_permission_view
+                idsEqual(ci.id, row.course_instance_id) && ci.has_course_instance_permission_view,
             ));
       });
 
@@ -264,7 +264,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorJobSequence/instructorJobSequence.js
+++ b/apps/prairielearn/src/pages/instructorJobSequence/instructorJobSequence.js
@@ -34,13 +34,13 @@ router.get('/:job_sequence_id', function (req, res, next) {
           // a course instance through a course page route. Redirect to the course
           // instance page route so we get authz_data for the course instance.
           res.redirect(
-            `${res.locals.plainUrlPrefix}/course_instance/${job_sequence.course_instance_id}/instructor/jobSequence/${job_sequence.id}`
+            `${res.locals.plainUrlPrefix}/course_instance/${job_sequence.course_instance_id}/instructor/jobSequence/${job_sequence.id}`,
           );
         }
 
         if (!res.locals.authz_data.has_course_instance_permission_view) {
           return next(
-            error.make(403, 'Access denied (must be a Student Data Viewer in the course instance)')
+            error.make(403, 'Access denied (must be a Student Data Viewer in the course instance)'),
           );
         }
       }

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.js
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.js
@@ -50,7 +50,7 @@ async function update(locals) {
 
     if (anyCourseHadJsonErrors) {
       throw new Error(
-        'One or more courses had JSON files that contained errors and were unable to be synced'
+        'One or more courses had JSON files that contained errors and were unable to be synced',
       );
     }
   });
@@ -64,7 +64,7 @@ router.get(
     if (!res.locals.devMode) return next();
     const jobSequenceId = await update(res.locals);
     res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
@@ -31,7 +31,7 @@ function processSubmission(req, res, callback) {
         error.make(400, 'JSON parse failed on body.postData', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
     variant_id = postData.variant ? postData.variant.id : null;
@@ -59,7 +59,7 @@ function processSubmission(req, res, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null, submission.variant_id);
-          }
+          },
         );
       } else if (req.body.__action === 'save') {
         question.saveSubmission(
@@ -70,17 +70,17 @@ function processSubmission(req, res, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null, submission.variant_id);
-          }
+          },
         );
       } else {
         callback(
           error.make(400, 'unknown __action', {
             locals: res.locals,
             body: req.body,
-          })
+          }),
         );
       }
-    }
+    },
   );
 }
 
@@ -114,7 +114,7 @@ router.post('/', function (req, res, next) {
           '/question/' +
           res.locals.question.id +
           '/preview/?variant_id=' +
-          variant_id
+          variant_id,
       );
     });
   } else if (req.body.__action === 'report_issue') {
@@ -125,7 +125,7 @@ router.post('/', function (req, res, next) {
           '/question/' +
           res.locals.question.id +
           '/preview/?variant_id=' +
-          variant_id
+          variant_id,
       );
     });
   } else {
@@ -133,7 +133,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });
@@ -152,7 +152,7 @@ router.get('/variant/:variant_id/submission/:submission_id', function (req, res,
     (err, results) => {
       if (ERR(err, next)) return;
       res.send({ submissionPanel: results.submissionPanel });
-    }
+    },
   );
 });
 
@@ -170,7 +170,7 @@ router.get('/', function (req, res, next) {
           function (err) {
             if (ERR(err, callback)) return;
             callback(null);
-          }
+          },
         );
       },
       (callback) => {
@@ -185,7 +185,7 @@ router.get('/', function (req, res, next) {
       question.setRendererHeader(res);
       setQuestionCopyTargets(res);
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -44,7 +44,7 @@ router.post(
         assessmentGroupWork,
         res.locals.course_instance,
         res.locals.course,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
     } else if (req.body.__action === 'test_100') {
@@ -64,7 +64,7 @@ router.post(
           assessmentGroupWork,
           res.locals.course_instance,
           res.locals.course,
-          res.locals.authn_user.user_id
+          res.locals.authn_user.user_id,
         );
         res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
       } else {
@@ -76,7 +76,7 @@ router.post(
         body: req.body,
       });
     }
-  })
+  }),
 );
 
 router.post('/', function (req, res, next) {
@@ -86,8 +86,8 @@ router.post('/', function (req, res, next) {
     if (!/^[-A-Za-z0-9_/]+$/.test(req.body.id)) {
       return next(
         new Error(
-          `Invalid QID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`
-        )
+          `Invalid QID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`,
+        ),
       );
     }
     let qid_new;
@@ -129,7 +129,7 @@ router.post('/', function (req, res, next) {
             res.redirect(res.locals.urlPrefix + '/edit_error/' + job_sequence_id);
           } else {
             debug(
-              `Get question_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`
+              `Get question_id from uuid=${editor.uuid} with course_id=${res.locals.course.id}`,
             );
             sqldb.queryOneRow(
               sql.select_question_id_from_uuid,
@@ -138,12 +138,12 @@ router.post('/', function (req, res, next) {
                 if (ERR(err, next)) return;
                 flash(
                   'success',
-                  'Question copied successfully. You are now viewing your copy of the question.'
+                  'Question copied successfully. You are now viewing your copy of the question.',
                 );
                 res.redirect(
-                  res.locals.urlPrefix + '/question/' + result.rows[0].question_id + '/settings'
+                  res.locals.urlPrefix + '/question/' + result.rows[0].question_id + '/settings',
                 );
-              }
+              },
             );
           }
         });
@@ -160,7 +160,7 @@ router.post('/', function (req, res, next) {
           if (ERR(err, next)) return;
           // `copyQuestionBetweenCourses` performs the redirect automatically,
           // so if there wasn't an error, there's nothing to do here.
-        }
+        },
       );
     }
   } else if (req.body.__action === 'delete_question') {
@@ -183,7 +183,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });
@@ -202,7 +202,7 @@ router.get('/', function (req, res, next) {
   // here because this form will actually post to a different route, not `req.originalUrl`.
   const questionTestCsrfToken = generateSignedToken(
     { url: questionTestPath, authn_user_id: res.locals.authn_user.user_id },
-    config.secretKey
+    config.secretKey,
   );
 
   res.locals.questionTestPath = questionTestPath;
@@ -214,7 +214,7 @@ router.get('/', function (req, res, next) {
         res.locals.questionGHLink = null;
         if (res.locals.course.repository) {
           const GHfound = res.locals.course.repository.match(
-            /^git@github.com:\/?(.+?)(\.git)?\/?$/
+            /^git@github.com:\/?(.+?)(\.git)?\/?$/,
           );
           if (GHfound) {
             res.locals.questionGHLink =
@@ -243,17 +243,17 @@ router.get('/', function (req, res, next) {
             if (ERR(err, callback)) return;
             res.locals.a_with_q_for_all_ci = result.rows[0].assessments_from_question_id;
             callback(null);
-          }
+          },
         );
       },
     ],
     (err) => {
       if (ERR(err, next)) return;
       res.locals.infoPath = encodePath(
-        path.join('questions', res.locals.question.qid, 'info.json')
+        path.join('questions', res.locals.question.qid, 'info.json'),
       );
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
@@ -25,7 +25,7 @@ router.get(
     res.locals.assessment_stats = statsResult.rows;
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.get(
@@ -91,7 +91,7 @@ router.get(
     } else {
       throw error.make(404, 'Unknown filename: ' + req.params.filename);
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.js
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.js
@@ -42,7 +42,7 @@ router.get('/', function (req, res, next) {
               row.sync_warnings_ansified = ansiUp.ansi_to_html(row.sync_warnings);
             }
             row.assessments = _.filter(row.assessments, (assessment) =>
-              ci_ids.includes(assessment.course_instance_id)
+              ci_ids.includes(assessment.course_instance_id),
             );
             return row;
           });
@@ -54,7 +54,7 @@ router.get('/', function (req, res, next) {
     (err) => {
       if (ERR(err, next)) return;
       res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-    }
+    },
   );
 });
 
@@ -78,9 +78,9 @@ router.post('/', (req, res, next) => {
             (err, result) => {
               if (ERR(err, next)) return;
               res.redirect(
-                res.locals.urlPrefix + '/question/' + result.rows[0].question_id + '/settings'
+                res.locals.urlPrefix + '/question/' + result.rows[0].question_id + '/settings',
               );
-            }
+            },
           );
         }
       });
@@ -90,7 +90,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.js
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.js
@@ -65,7 +65,7 @@ router.post(
         user_id: res.locals.authn_user.user_id,
         short_name,
         title,
-      }
+      },
     );
 
     if (existingCourseRequestsResult.rows[0].has_existing_request) {
@@ -75,7 +75,7 @@ router.post(
 
     const conflictingCourseOwnersResult = await sqldb.queryAsync(
       sql.get_conflicting_course_owners,
-      { short_name: short_name.trim().toLowerCase() }
+      { short_name: short_name.trim().toLowerCase() },
     );
 
     const courseOwners = conflictingCourseOwnersResult.rows;
@@ -127,7 +127,7 @@ router.post(
       // Automatically fill in institution ID and display timezone from the user's other courses.
       const existingSettingsResult = await sqldb.queryOneRowAsync(
         sql.get_existing_owner_course_settings,
-        { user_id: res.locals.authn_user.user_id }
+        { user_id: res.locals.authn_user.user_id },
       );
       const repo_short_name = github.reponameFromShortname(short_name);
       const repo_options = {
@@ -163,7 +163,7 @@ router.post(
             ERR(err, () => {
               logger.error(err);
             });
-          }
+          },
         );
 
         // Redirect on success so that refreshing doesn't create another request
@@ -182,11 +182,11 @@ router.post(
           ERR(err, () => {
             logger.error(err);
           });
-        }
+        },
       );
       res.redirect(req.originalUrl);
     }
-  })
+  }),
 );
 
 router.post('/', get);

--- a/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
+++ b/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
@@ -26,7 +26,7 @@ router.get('/:filename', function (req, res, next) {
         error.make(403, 'Access denied', {
           locals: res.locals,
           filename: filename,
-        })
+        }),
       );
     }
 
@@ -56,7 +56,7 @@ router.get('/:filename', function (req, res, next) {
           function (err, fullPath, effectiveFilename, rootPath) {
             if (ERR(err, next)) return;
             res.sendFile(effectiveFilename, { root: rootPath });
-          }
+          },
         );
       });
     });

--- a/apps/prairielearn/src/pages/legacyQuestionText/legacyQuestionText.js
+++ b/apps/prairielearn/src/pages/legacyQuestionText/legacyQuestionText.js
@@ -34,7 +34,7 @@ router.get('/:filename', function (req, res, next) {
         function (err, fullPath, effectiveFilename, rootPath) {
           if (ERR(err, next)) return;
           res.sendFile(effectiveFilename, { root: rootPath });
-        }
+        },
       );
     });
   });

--- a/apps/prairielearn/src/pages/news_item/news_item.js
+++ b/apps/prairielearn/src/pages/news_item/news_item.js
@@ -29,7 +29,7 @@ router.get('/:news_item_id', function (req, res, next) {
       '..',
       'news_items',
       res.locals.news_item.directory,
-      'index.html'
+      'index.html',
     );
     fs.readFile(indexFilename, (err, news_item_html) => {
       if (ERR(err, next)) return;
@@ -58,7 +58,7 @@ router.get('/:news_item_id/*', function (req, res, next) {
       '..',
       '..',
       'news_items',
-      res.locals.news_item.directory
+      res.locals.news_item.directory,
     );
 
     res.sendFile(filename, { root: news_item_dir });

--- a/apps/prairielearn/src/pages/shared/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/shared/studentAssessmentInstance.js
@@ -15,7 +15,7 @@ module.exports.processFileUpload = async (req, res) => {
     res.locals.assessment_instance.id,
     null,
     res.locals.user.user_id,
-    res.locals.authn_user.user_id
+    res.locals.authn_user.user_id,
   );
 };
 
@@ -31,7 +31,7 @@ module.exports.processTextUpload = async (req, res) => {
     res.locals.assessment_instance.id,
     null,
     res.locals.user.user_id,
-    res.locals.authn_user.user_id
+    res.locals.authn_user.user_id,
   );
 };
 

--- a/apps/prairielearn/src/pages/shared/studentInstanceQuestion.js
+++ b/apps/prairielearn/src/pages/shared/studentInstanceQuestion.js
@@ -22,7 +22,7 @@ module.exports.getValidVariantId = async (req, res) => {
     await sqldb.callOneRowAsync('variants_ensure_instance_question', params);
   } catch (e) {
     throw new Error(
-      `Client-provided __variant_id "${req.body.__variant_id}" does not belong to the authorized instance_question_id "${res.locals.instance_question_id}"`
+      `Client-provided __variant_id "${req.body.__variant_id}" does not belong to the authorized instance_question_id "${res.locals.instance_question_id}"`,
     );
   }
   return variant_id;
@@ -43,7 +43,7 @@ module.exports.processFileUpload = async (req, res) => {
     res.locals.assessment_instance.id,
     res.locals.instance_question.id,
     res.locals.user.user_id,
-    res.locals.authn_user.user_id
+    res.locals.authn_user.user_id,
   );
   const variant_id = await module.exports.getValidVariantId(req, res);
   return variant_id;
@@ -61,7 +61,7 @@ module.exports.processTextUpload = async (req, res) => {
     res.locals.assessment_instance.id,
     res.locals.instance_question.id,
     res.locals.user.user_id,
-    res.locals.authn_user.user_id
+    res.locals.authn_user.user_id,
   );
   const variant_id = await module.exports.getValidVariantId(req, res);
   return variant_id;

--- a/apps/prairielearn/src/pages/shared/syncHelpers.js
+++ b/apps/prairielearn/src/pages/shared/syncHelpers.js
@@ -46,7 +46,7 @@ module.exports.pullAndUpdate = async function (locals) {
           // Executed in the root directory, but this shouldn't really matter.
           cwd: '/',
           env: gitEnv,
-        }
+        },
       );
     } else {
       // path exists, update remote origin address, then 'git fetch' and reset to latest with 'git reset'
@@ -83,7 +83,7 @@ module.exports.pullAndUpdate = async function (locals) {
     const syncResult = await syncFromDisk.syncDiskToSqlAsync(
       locals.course.path,
       locals.course.id,
-      job
+      job,
     );
 
     if (config.chunksGenerator) {
@@ -133,7 +133,7 @@ module.exports.gitStatus = async function (locals) {
       ['log', '--all', '--graph', '--date=short', '--format=format:%h %cd%d %cn %s'],
       {
         cwd: locals.course.path,
-      }
+      },
     );
   });
 
@@ -289,9 +289,9 @@ function pullAndPushToECR(image, dockerAuth, job, callback) {
                     },
                     (output) => {
                       logProgressOutput(output, job, printedInfos, 'Push progress: ');
-                    }
+                    },
                   );
-                }
+                },
               );
             });
           });
@@ -299,7 +299,7 @@ function pullAndPushToECR(image, dockerAuth, job, callback) {
       },
       (output) => {
         logProgressOutput(output, job, printedInfos, 'Pull progress: ');
-      }
+      },
     );
   });
 }

--- a/apps/prairielearn/src/pages/studentAssessmentExam/studentAssessmentExam.js
+++ b/apps/prairielearn/src/pages/studentAssessmentExam/studentAssessmentExam.js
@@ -35,7 +35,7 @@ router.get(
         // Check whether the user is currently in a group in the current assessment by trying to get a group_id
         const groupId = await groupAssessmentHelper.getGroupId(
           res.locals.assessment.id,
-          res.locals.user.user_id
+          res.locals.user.user_id,
         );
 
         if (groupId === null) {
@@ -52,7 +52,7 @@ router.get(
           if (groupConfig.hasRoles) {
             const result = await groupAssessmentHelper.getAssessmentPermissions(
               res.locals.assessment.id,
-              res.locals.user.user_id
+              res.locals.user.user_id,
             );
             res.locals.canViewRoleTable = result.can_assign_roles_at_start;
           }
@@ -75,7 +75,7 @@ router.get(
           // Check whether the user is currently in a group in the current assessment by trying to get a group_id
           const groupId = await groupAssessmentHelper.getGroupId(
             res.locals.assessment.id,
-            res.locals.user.user_id
+            res.locals.user.user_id,
           );
 
           if (groupId === null) {
@@ -93,7 +93,7 @@ router.get(
             if (groupConfig.has_roles) {
               const result = await groupAssessmentHelper.getAssessmentPermissions(
                 res.locals.assessment.id,
-                res.locals.user.user_id
+                res.locals.user.user_id,
               );
               res.locals.canViewRoleTable = result.can_assign_roles_at_start;
             }
@@ -104,7 +104,7 @@ router.get(
         res.redirect(res.locals.urlPrefix + '/assessment_instance/' + result.rows[0].id);
       }
     }
-  })
+  }),
 );
 
 router.post(
@@ -139,7 +139,7 @@ router.post(
         (err, assessment_instance_id) => {
           if (ERR(err, next)) return;
           res.redirect(res.locals.urlPrefix + '/assessment_instance/' + assessment_instance_id);
-        }
+        },
       );
     } else if (req.body.__action === 'join_group') {
       groupAssessmentHelper.joinGroup(
@@ -158,7 +158,7 @@ router.post(
             res.locals.notInGroup = true;
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
           }
-        }
+        },
       );
     } else if (req.body.__action === 'create_group') {
       groupAssessmentHelper.createGroup(
@@ -181,21 +181,21 @@ router.post(
             res.locals.groupSize = 0;
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
           }
-        }
+        },
       );
     } else if (req.body.__action === 'update_group_roles') {
       await groupAssessmentHelper.updateGroupRoles(
         req.body,
         res.locals.assessment.id,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'leave_group') {
       await groupAssessmentHelper.leaveGroup(
         res.locals.assessment.id,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(req.originalUrl);
     } else {
@@ -203,10 +203,10 @@ router.post(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/studentAssessmentHomework/studentAssessmentHomework.js
+++ b/apps/prairielearn/src/pages/studentAssessmentHomework/studentAssessmentHomework.js
@@ -23,7 +23,7 @@ router.get(
       return next(
         error.makeWithData('"Homework" assessments do not support multiple instances', {
           assessment: res.locals.assessment,
-        })
+        }),
       );
     }
 
@@ -56,7 +56,7 @@ router.get(
         // Check whether the user is currently in a group in the current assessment by trying to get a group_id
         const groupId = await groupAssessmentHelper.getGroupId(
           res.locals.assessment.id,
-          res.locals.user.user_id
+          res.locals.user.user_id,
         );
 
         if (groupId === null) {
@@ -74,7 +74,7 @@ router.get(
           if (groupConfig.has_roles) {
             const result = await groupAssessmentHelper.getAssessmentPermissions(
               res.locals.assessment.id,
-              res.locals.user.user_id
+              res.locals.user.user_id,
             );
             res.locals.canViewRoleTable = result.can_assign_roles_at_start;
           }
@@ -101,14 +101,14 @@ router.get(
             if (ERR(err, next)) return;
             debug('redirecting');
             res.redirect(res.locals.urlPrefix + '/assessment_instance/' + assessment_instance_id);
-          }
+          },
         );
       }
     } else {
       debug('redirecting');
       res.redirect(res.locals.urlPrefix + '/assessment_instance/' + result.rows[0].id);
     }
-  })
+  }),
 );
 
 router.post(
@@ -142,7 +142,7 @@ router.post(
               if (ERR(err, next)) return;
               debug('redirecting');
               res.redirect(res.locals.urlPrefix + '/assessment_instance/' + assessment_instance_id);
-            }
+            },
           );
         } else {
           debug('redirecting');
@@ -166,7 +166,7 @@ router.post(
             res.locals.notInGroup = true;
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
           }
-        }
+        },
       );
     } else if (req.body.__action === 'create_group') {
       groupAssessmentHelper.createGroup(
@@ -189,21 +189,21 @@ router.post(
             res.locals.groupSize = 0;
             res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
           }
-        }
+        },
       );
     } else if (req.body.__action === 'update_group_roles') {
       await groupAssessmentHelper.updateGroupRoles(
         req.body,
         res.locals.assessment.id,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'leave_group') {
       await groupAssessmentHelper.leaveGroup(
         res.locals.assessment.id,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(req.originalUrl);
     } else {
@@ -211,10 +211,10 @@ router.post(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceExam/studentAssessmentInstanceExam.js
@@ -57,7 +57,7 @@ router.post(
           error.make(400, 'unknown __action', {
             locals: res.locals,
             body: req.body,
-          })
+          }),
         );
       }
       const requireOpen = true;
@@ -74,30 +74,30 @@ router.post(
           } else {
             res.redirect(req.originalUrl);
           }
-        }
+        },
       );
     } else if (req.body.__action === 'leave_group') {
       if (!res.locals.authz_result.active) throw error.make(400, 'Unauthorized request.');
       await groupAssessmentHelper.leaveGroup(
         res.locals.assessment.id,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(
         '/pl/course_instance/' +
           res.locals.course_instance.id +
           '/assessment/' +
-          res.locals.assessment.id
+          res.locals.assessment.id,
       );
     } else {
       next(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 
 router.get(
@@ -114,15 +114,15 @@ router.get(
 
     res.locals.has_manual_grading_question = _.some(
       res.locals.instance_questions,
-      (q) => q.max_manual_points || q.manual_points || q.requires_manual_grading
+      (q) => q.max_manual_points || q.manual_points || q.requires_manual_grading,
     );
     res.locals.has_auto_grading_question = _.some(
       res.locals.instance_questions,
-      (q) => q.max_auto_points || q.auto_points || !q.max_points
+      (q) => q.max_auto_points || q.auto_points || !q.max_points,
     );
     const assessment_text_templated = assessment.renderText(
       res.locals.assessment,
-      res.locals.urlPrefix
+      res.locals.urlPrefix,
     );
     res.locals.assessment_text_templated = assessment_text_templated;
 
@@ -146,7 +146,7 @@ router.get(
       // Check whether the user is currently in a group in the current assessment by trying to get a group_id
       const groupId = await groupAssessmentHelper.getGroupId(
         res.locals.assessment.id,
-        res.locals.user.user_id
+        res.locals.user.user_id,
       );
 
       if (groupId === null) {
@@ -164,7 +164,7 @@ router.get(
       }
     }
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.js
@@ -30,7 +30,7 @@ router.get(
     // and not as a webpage.
     res.attachment(displayFilename);
     stream.on('error', next).pipe(res);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceHomework/studentAssessmentInstanceHomework.js
@@ -59,17 +59,17 @@ router.get(
 
     res.locals.has_manual_grading_question = _.some(
       res.locals.questions,
-      (q) => q.max_manual_points || q.manual_points || q.requires_manual_grading
+      (q) => q.max_manual_points || q.manual_points || q.requires_manual_grading,
     );
     res.locals.has_auto_grading_question = _.some(
       res.locals.questions,
-      (q) => q.max_auto_points || q.auto_points || !q.max_points
+      (q) => q.max_auto_points || q.auto_points || !q.max_points,
     );
 
     debug('rendering assessment text');
     const assessment_text_templated = assessment.renderText(
       res.locals.assessment,
-      res.locals.urlPrefix
+      res.locals.urlPrefix,
     );
     res.locals.assessment_text_templated = assessment_text_templated;
 
@@ -82,7 +82,7 @@ router.get(
       // Check whether the user is currently in a group in the current assessment by trying to get a group_id
       const groupId = await groupAssessmentHelper.getGroupId(
         res.locals.assessment.id,
-        res.locals.user.user_id
+        res.locals.user.user_id,
       );
 
       if (groupId === null) {
@@ -100,14 +100,14 @@ router.get(
         if (groupConfig.has_roles) {
           const result = await groupAssessmentHelper.getAssessmentPermissions(
             res.locals.assessment.id,
-            res.locals.user.user_id
+            res.locals.user.user_id,
           );
           res.locals.canViewRoleTable = result.can_assign_roles_at_start;
         }
       }
     }
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-  })
+  }),
 );
 
 router.post(
@@ -138,23 +138,23 @@ router.post(
       await groupAssessmentHelper.leaveGroup(
         res.locals.assessment.id,
         res.locals.user.user_id,
-        res.locals.authn_user.user_id
+        res.locals.authn_user.user_id,
       );
       res.redirect(
         '/pl/course_instance/' +
           res.locals.course_instance.id +
           '/assessment/' +
-          res.locals.assessment.id
+          res.locals.assessment.id,
       );
     } else {
       next(
         error.make(400, 'unknown __action', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
+++ b/apps/prairielearn/src/pages/studentInstanceQuestionExam/studentInstanceQuestionExam.js
@@ -38,7 +38,7 @@ function processSubmission(req, res, callback) {
         error.make(400, 'JSON parse failed on body.postData', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
     variant_id = postData.variant ? postData.variant.id : null;
@@ -68,7 +68,7 @@ function processSubmission(req, res, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null, submission.variant_id);
-          }
+          },
         );
       } else if (req.body.__action === 'save') {
         question.saveSubmission(
@@ -79,17 +79,17 @@ function processSubmission(req, res, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null, submission.variant_id);
-          }
+          },
         );
       } else {
         callback(
           error.make(400, 'unknown __action', {
             locals: res.locals,
             body: req.body,
-          })
+          }),
         );
       }
-    }
+    },
   );
 }
 
@@ -103,7 +103,7 @@ router.post('/', function (req, res, next) {
   if (req.body.__action === 'grade' || req.body.__action === 'save') {
     if (res.locals.authz_result.time_limit_expired) {
       return next(
-        error.make(403, 'time limit is expired, please go back and finish your assessment')
+        error.make(403, 'time limit is expired, please go back and finish your assessment'),
       );
     }
     if (req.body.__action === 'grade' && !res.locals.assessment.allow_real_time_grading) {
@@ -135,9 +135,9 @@ router.post('/', function (req, res, next) {
           res.locals.urlPrefix +
             '/assessment_instance/' +
             res.locals.assessment_instance.id +
-            '?timeLimitExpired=true'
+            '?timeLimitExpired=true',
         );
-      }
+      },
     );
   } else if (req.body.__action === 'attach_file') {
     util.callbackify(studentInstanceQuestion.processFileUpload)(
@@ -150,9 +150,9 @@ router.post('/', function (req, res, next) {
             '/instance_question/' +
             res.locals.instance_question.id +
             '/?variant_id=' +
-            variant_id
+            variant_id,
         );
-      }
+      },
     );
   } else if (req.body.__action === 'attach_text') {
     util.callbackify(studentInstanceQuestion.processTextUpload)(
@@ -165,9 +165,9 @@ router.post('/', function (req, res, next) {
             '/instance_question/' +
             res.locals.instance_question.id +
             '/?variant_id=' +
-            variant_id
+            variant_id,
         );
-      }
+      },
     );
   } else if (req.body.__action === 'delete_file') {
     util.callbackify(studentInstanceQuestion.processDeleteFile)(
@@ -180,9 +180,9 @@ router.post('/', function (req, res, next) {
             '/instance_question/' +
             res.locals.instance_question.id +
             '/?variant_id=' +
-            variant_id
+            variant_id,
         );
-      }
+      },
     );
   } else if (req.body.__action === 'report_issue') {
     util.callbackify(studentInstanceQuestion.processIssue)(req, res, function (err, variant_id) {
@@ -192,7 +192,7 @@ router.post('/', function (req, res, next) {
           '/instance_question/' +
           res.locals.instance_question.id +
           '/?variant_id=' +
-          variant_id
+          variant_id,
       );
     });
   } else {
@@ -200,7 +200,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });
@@ -219,7 +219,7 @@ router.get('/variant/:variant_id/submission/:submission_id', function (req, res,
     (err, results) => {
       if (ERR(err, next)) return;
       res.send({ submissionPanel: results.submissionPanel });
-    }
+    },
   );
 });
 

--- a/apps/prairielearn/src/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
+++ b/apps/prairielearn/src/pages/studentInstanceQuestionHomework/studentInstanceQuestionHomework.js
@@ -31,7 +31,7 @@ function processSubmission(req, res, callback) {
         error.make(400, 'JSON parse failed on body.postData', {
           locals: res.locals,
           body: req.body,
-        })
+        }),
       );
     }
     variant_id = postData.variant ? postData.variant.id : null;
@@ -61,7 +61,7 @@ function processSubmission(req, res, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null, submission.variant_id);
-          }
+          },
         );
       } else if (req.body.__action === 'save') {
         question.saveSubmission(
@@ -72,17 +72,17 @@ function processSubmission(req, res, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null, submission.variant_id);
-          }
+          },
         );
       } else {
         callback(
           error.make(400, 'unknown __action', {
             locals: res.locals,
             body: req.body,
-          })
+          }),
         );
       }
-    }
+    },
   );
 }
 
@@ -101,7 +101,7 @@ router.post('/', function (req, res, next) {
           '/instance_question/' +
           res.locals.instance_question.id +
           '/?variant_id=' +
-          variant_id
+          variant_id,
       );
     });
   } else if (req.body.__action === 'attach_file') {
@@ -115,9 +115,9 @@ router.post('/', function (req, res, next) {
             '/instance_question/' +
             res.locals.instance_question.id +
             '/?variant_id=' +
-            variant_id
+            variant_id,
         );
-      }
+      },
     );
   } else if (req.body.__action === 'attach_text') {
     util.callbackify(studentInstanceQuestion.processTextUpload)(
@@ -130,9 +130,9 @@ router.post('/', function (req, res, next) {
             '/instance_question/' +
             res.locals.instance_question.id +
             '/?variant_id=' +
-            variant_id
+            variant_id,
         );
-      }
+      },
     );
   } else if (req.body.__action === 'delete_file') {
     util.callbackify(studentInstanceQuestion.processDeleteFile)(
@@ -145,9 +145,9 @@ router.post('/', function (req, res, next) {
             '/instance_question/' +
             res.locals.instance_question.id +
             '/?variant_id=' +
-            variant_id
+            variant_id,
         );
-      }
+      },
     );
   } else if (req.body.__action === 'report_issue') {
     util.callbackify(studentInstanceQuestion.processIssue)(req, res, function (err, variant_id) {
@@ -157,7 +157,7 @@ router.post('/', function (req, res, next) {
           '/instance_question/' +
           res.locals.instance_question.id +
           '/?variant_id=' +
-          variant_id
+          variant_id,
       );
     });
   } else {
@@ -165,7 +165,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action: ' + req.body.__action, {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });
@@ -184,7 +184,7 @@ router.get('/variant/:variant_id/submission/:submission_id', function (req, res,
     (err, results) => {
       if (ERR(err, next)) return;
       res.send({ submissionPanel: results.submissionPanel });
-    }
+    },
   );
 });
 

--- a/apps/prairielearn/src/pages/submissionFile/submissionFile.js
+++ b/apps/prairielearn/src/pages/submissionFile/submissionFile.js
@@ -59,7 +59,7 @@ router.get(
     res.setHeader('Content-Type', mimeType);
 
     res.status(200).send(buffer);
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/userSettings/userSettings.js
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.js
@@ -38,7 +38,7 @@ router.post('/', (req, res, next) => {
       error.make(400, 'unknown __action', {
         locals: res.locals,
         body: req.body,
-      })
+      }),
     );
   }
 });

--- a/apps/prairielearn/src/pages/workspace/workspace.html.js
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.js
@@ -5,7 +5,7 @@ const { compiledScriptTag } = require('../../lib/assets');
 
 function Workspace({ navTitle, showLogs, heartbeatIntervalSec, visibilityTimeoutSec, resLocals }) {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en" class="h-100">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", resLocals)}

--- a/apps/prairielearn/src/pages/workspace/workspace.js
+++ b/apps/prairielearn/src/pages/workspace/workspace.js
@@ -34,7 +34,7 @@ router.get('/', (_req, res, _next) => {
       heartbeatIntervalSec: config.workspaceHeartbeatIntervalSec,
       visibilityTimeoutSec: config.workspaceVisibilityTimeoutSec,
       resLocals: res.locals,
-    })
+    }),
   );
 });
 
@@ -55,14 +55,14 @@ router.post(
       await workspaceUtils.updateWorkspaceState(
         workspace_id,
         'uninitialized',
-        'Resetting container'
+        'Resetting container',
       );
       await sqldb.queryAsync(sql.increment_workspace_version, { workspace_id });
       res.redirect(`/pl/workspace/${workspace_id}`);
     } else {
       return next(error.make(400, `unknown __action: ${req.body.__action}`));
     }
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.html.js
+++ b/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.html.js
@@ -19,7 +19,7 @@ const WorkspaceLogs = ({ workspaceLogs, resLocals }) => {
   });
 
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", {
@@ -77,7 +77,7 @@ const WorkspaceVersionLogs = ({
   resLocals,
 }) => {
   return html`
-    <!DOCTYPE html>
+    <!doctype html>
     <html lang="en">
       <head>
         ${renderEjs(__filename, "<%- include('../partials/head'); %>", {

--- a/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.js
+++ b/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.js
@@ -128,7 +128,7 @@ router.get(
         res.locals.course_instance?.display_timezone ?? res.locals.course.display_timezone,
     });
     res.send(WorkspaceLogs({ workspaceLogs: workspaceLogs.rows, resLocals: res.locals }));
-  })
+  }),
 );
 
 // All state transitions for a single workspace version, as well as the container
@@ -149,7 +149,7 @@ router.get(
     if (containerLogsEnabled && !containerLogsExpired) {
       containerLogs = await loadLogsForWorkspaceVersion(
         res.locals.workspace_id,
-        req.params.version
+        req.params.version,
       );
     }
 
@@ -160,9 +160,9 @@ router.get(
         containerLogsEnabled,
         containerLogsExpired,
         resLocals: res.locals,
-      })
+      }),
     );
-  })
+  }),
 );
 
 module.exports = router;

--- a/apps/prairielearn/src/question-servers/calculation-inprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-inprocess.js
@@ -61,15 +61,15 @@ module.exports = {
               (err) => {
                 const e = error.makeWithData(
                   `Error loading server.js for QID ${question.qid}`,
-                  err
+                  err,
                 );
                 if (err.originalError != null) {
                   e.stack = err.originalError.stack + '\n\n' + err.stack;
                 }
                 return callback(e);
-              }
+              },
             );
-          }
+          },
         );
       });
     });
@@ -84,7 +84,7 @@ module.exports = {
     course,
     course_instance,
     locals,
-    callback
+    callback,
   ) {
     const htmls = {
       extraHeadersHtml: '',
@@ -186,7 +186,7 @@ module.exports = {
           trueAnswer,
           submittedAnswer,
           options,
-          questionDir
+          questionDir,
         );
       } catch (err) {
         const data = {

--- a/apps/prairielearn/src/question-servers/calculation-subprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.js
@@ -41,7 +41,7 @@ async function callFunction(func, question_course, question, inputData) {
     'server.js',
     question.directory,
     coursePath,
-    question
+    question,
   );
   try {
     return withCodeCaller(coursePath, async (codeCaller) => {
@@ -69,14 +69,14 @@ async function callFunction(func, question_course, question, inputData) {
 module.exports.generate = (question, course, variant_seed, callback) => {
   callFunction('generate', course, question, { variant_seed }).then(
     ({ data, courseIssues }) => callback(null, courseIssues, data),
-    (err) => callback(err)
+    (err) => callback(err),
   );
 };
 
 module.exports.grade = (submission, variant, question, question_course, callback) => {
   callFunction('grade', question_course, question, { submission, variant }).then(
     ({ data, courseIssues }) => callback(null, courseIssues, data),
-    (err) => console.log(err)
+    (err) => console.log(err),
   );
 };
 
@@ -88,7 +88,7 @@ module.exports.getFile = (filename, variant, question, course, callback) => {
       const unwrappedData = isBuffer ? Buffer.from(data.data, 'base64') : data.data;
       callback(null, courseIssues, unwrappedData);
     },
-    (err) => callback(err)
+    (err) => callback(err),
   );
 };
 
@@ -104,7 +104,7 @@ module.exports.render = function (
   course,
   course_instance,
   locals,
-  callback
+  callback,
 ) {
   const htmls = {
     extraHeadersHtml: '',

--- a/apps/prairielearn/src/question-servers/calculation-worker.js
+++ b/apps/prairielearn/src/question-servers/calculation-worker.js
@@ -53,7 +53,7 @@ async function loadServer(questionServerPath, coursePath) {
           e.stack = err.originalError.stack + '\n\n' + err.stack;
         }
         reject(e);
-      }
+      },
     );
   });
 }
@@ -102,7 +102,7 @@ function grade(server, coursePath, submission, variant, question) {
     trueAnswer,
     submittedAnswer,
     options,
-    questionDir
+    questionDir,
   );
 
   let score = grading.score;

--- a/apps/prairielearn/src/question-servers/calculation.js
+++ b/apps/prairielearn/src/question-servers/calculation.js
@@ -140,35 +140,35 @@ function questionFunctionExperiment(name, control, candidate) {
 module.exports.generate = questionFunctionExperiment(
   'calculation-question-generate',
   calculationInprocess.generate,
-  calculationSubprocess.generate
+  calculationSubprocess.generate,
 );
 
 module.exports.prepare = questionFunctionExperiment(
   'calculation-question-prepare',
   calculationInprocess.prepare,
-  calculationSubprocess.prepare
+  calculationSubprocess.prepare,
 );
 
 module.exports.render = questionFunctionExperiment(
   'calculation-question-render',
   calculationInprocess.render,
-  calculationSubprocess.render
+  calculationSubprocess.render,
 );
 
 module.exports.getFile = questionFunctionExperiment(
   'calculation-question-getFile',
   calculationInprocess.getFile,
-  calculationSubprocess.getFile
+  calculationSubprocess.getFile,
 );
 
 module.exports.parse = questionFunctionExperiment(
   'calculation-question-parse',
   calculationInprocess.parse,
-  calculationSubprocess.parse
+  calculationSubprocess.parse,
 );
 
 module.exports.grade = questionFunctionExperiment(
   'calculation-question-grade',
   calculationInprocess.grade,
-  calculationSubprocess.grade
+  calculationSubprocess.grade,
 );

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -96,7 +96,7 @@ module.exports = {
     // Populate the list of PrairieLearn elements
     coreElementsCache = await module.exports.loadElements(
       path.join(APP_ROOT_PATH, 'elements'),
-      'core'
+      'core',
     );
   },
 
@@ -279,7 +279,7 @@ module.exports = {
 
     const extensions = await module.exports.loadExtensions(
       path.join(course_dir_host, 'elementExtensions'),
-      path.join(course_dir, 'elementExtensions')
+      path.join(course_dir, 'elementExtensions'),
     );
     courseExtensionsCache[course.id] = {
       commit_hash: course.commit_hash,
@@ -327,7 +327,7 @@ module.exports = {
         data.options.base_url,
         'elements',
         elementName,
-        'clientFilesElement'
+        'clientFilesElement',
       );
       dataCopy.options.client_files_extensions_url = {};
 
@@ -338,7 +338,7 @@ module.exports = {
             'elementExtensions',
             elementName,
             extension,
-            'clientFilesExtension'
+            'clientFilesExtension',
           );
           dataCopy.options.client_files_extensions_url[extension] = url;
         });
@@ -408,7 +408,7 @@ module.exports = {
     }
 
     debug(
-      `execPythonServer(): codeCaller.call(pythonFile=${pythonFile}, pythonFunction=${pythonFunction})`
+      `execPythonServer(): codeCaller.call(pythonFile=${pythonFile}, pythonFunction=${pythonFunction})`,
     );
     try {
       const { result, output } = await codeCaller.call(
@@ -416,7 +416,7 @@ module.exports = {
         directory,
         pythonFile,
         pythonFunction,
-        pythonArgs
+        pythonArgs,
       );
       debug(`execPythonServer(): completed`);
       return { result, output };
@@ -475,7 +475,7 @@ module.exports = {
         if (!_.has(origData, prop)) return '"' + prop + '" is missing from "origData"';
         if (!_.isEqual(data[prop], origData[prop])) {
           return `data.${prop} has been illegally modified, new value: "${JSON.stringify(
-            data[prop]
+            data[prop],
           )}", original value: "${JSON.stringify(origData[prop])}"`;
         }
       }
@@ -584,7 +584,7 @@ module.exports = {
         context.question.directory,
         'question.html',
         phase,
-        [data, pythonContext]
+        [data, pythonContext],
       );
       result = res.result;
       output = res.output;
@@ -597,7 +597,7 @@ module.exports = {
         new CourseIssueError(`output logged on console during ${phase}()`, {
           data: { outputBoth: output },
           fatal: false,
-        })
+        }),
       );
     }
 
@@ -645,7 +645,7 @@ module.exports = {
             elementName,
             serializedNode,
             data,
-            context
+            context,
           ));
         } catch (e) {
           // We'll catch this and add it to the course issues list
@@ -664,14 +664,14 @@ module.exports = {
             new CourseIssueError(`${elementFile}: output logged on console during ${phase}()`, {
               data: { outputBoth: consoleLog },
               fatal: false,
-            })
+            }),
           );
         }
         if (phase === 'render') {
           if (!_.isString(ret_val)) {
             throw new CourseIssueError(
               `${elementFile}: Error calling ${phase}(): return value is not a string`,
-              { data: ret_val, fatal: true }
+              { data: ret_val, fatal: true },
             );
           }
           node = parse5.parseFragment(ret_val);
@@ -685,7 +685,7 @@ module.exports = {
               // If fileData already has non-zero length, throw an error
               throw new CourseIssueError(
                 `${elementFile}: Error calling ${phase}(): attempting to overwrite non-empty fileData`,
-                { fatal: true }
+                { fatal: true },
               );
             } else {
               // If not, replace fileData with buffer
@@ -699,7 +699,7 @@ module.exports = {
           if (checkErr) {
             throw new CourseIssueError(
               `${elementFile}: Invalid state after ${phase}(): ${checkErr}`,
-              { fatal: true }
+              { fatal: true },
             );
           }
         }
@@ -770,12 +770,12 @@ module.exports = {
               elementName,
               elementHtml,
               data,
-              context
+              context,
             ));
           } catch (err) {
             const courseIssue = new CourseIssueError(
               `${elementFile}: Error calling ${phase}(): ${err.toString()}`,
-              { data: err.data, fatal: true }
+              { data: err.data, fatal: true },
             );
             courseIssues.push(courseIssue);
 
@@ -790,8 +790,8 @@ module.exports = {
             courseIssues.push(
               new CourseIssueError(
                 elementFile + ': output logged on console during ' + phase + '()',
-                { data: { outputBoth: output }, fatal: false }
-              )
+                { data: { outputBoth: output }, fatal: false },
+              ),
             );
           }
 
@@ -799,7 +799,7 @@ module.exports = {
             if (!_.isString(output)) {
               const courseIssue = new CourseIssueError(
                 elementFile + ': Error calling ' + phase + '(): return value is not a string',
-                { data: { result }, fatal: true }
+                { data: { result }, fatal: true },
               );
               courseIssues.push(courseIssue);
 
@@ -819,7 +819,7 @@ module.exports = {
                 // If fileData already has non-zero length, throw an error
                 const courseIssue = new CourseIssueError(
                   `${elementFile}: Error calling ${phase}(): attempting to overwrite non-empty fileData`,
-                  { fatal: true }
+                  { fatal: true },
                 );
                 courseIssues.push(courseIssue);
 
@@ -836,7 +836,7 @@ module.exports = {
             if (checkErr) {
               const courseIssue = new CourseIssueError(
                 `${elementFile}: Invalid state after ${phase}(): ${checkErr}`,
-                { fatal: true }
+                { fatal: true },
               );
               courseIssues.push(courseIssue);
 
@@ -960,7 +960,7 @@ module.exports = {
       courseIssues.push(
         new CourseIssueError(`Invalid state before calling server ${phase}(): ${checkErrBefore}`, {
           fatal: true,
-        })
+        }),
       );
       return { courseIssues, data, html: '', fileData: Buffer.from(''), renderedElementNames: [] };
     }
@@ -972,7 +972,7 @@ module.exports = {
         phase,
         data,
         html,
-        context
+        context,
       ));
     } catch (err) {
       const serverFile = path.join(context.question_dir, 'server.py');
@@ -981,7 +981,7 @@ module.exports = {
           data: err.data,
           fatal: true,
           cause: err,
-        })
+        }),
       );
       return { courseIssues, data };
     }
@@ -992,7 +992,7 @@ module.exports = {
         new CourseIssueError(`${serverFile}: output logged on console`, {
           data: { outputBoth: output },
           fatal: false,
-        })
+        }),
       );
     }
 
@@ -1011,8 +1011,8 @@ module.exports = {
           courseIssues.push(
             new CourseIssueError(
               `${serverFile}: Error calling ${phase}(): attempting to overwrite non-empty fileData`,
-              { fatal: true }
-            )
+              { fatal: true },
+            ),
           );
           return { courseIssues, data };
         } else {
@@ -1029,7 +1029,7 @@ module.exports = {
       courseIssues.push(
         new CourseIssueError(`${serverFile}: Invalid state after ${phase}(): ${checkErrAfter}`, {
           fatal: true,
-        })
+        }),
       );
       return { courseIssues, data };
     }
@@ -1055,7 +1055,7 @@ module.exports = {
           data,
           '',
           Buffer.from(''),
-          context
+          context,
         );
       } else {
         const {
@@ -1086,7 +1086,7 @@ module.exports = {
           htmlData,
           html,
           fileData,
-          context
+          context,
         );
         courseIssues.push(...serverCourseIssues);
         return {
@@ -1131,7 +1131,7 @@ module.exports = {
           'generate',
           codeCaller,
           data,
-          context
+          context,
         );
         return {
           courseIssues,
@@ -1151,7 +1151,7 @@ module.exports = {
       },
       (err) => {
         callback(err);
-      }
+      },
     );
   },
 
@@ -1174,7 +1174,7 @@ module.exports = {
           'prepare',
           codeCaller,
           data,
-          context
+          context,
         );
         return {
           courseIssues,
@@ -1194,7 +1194,7 @@ module.exports = {
       },
       (err) => {
         callback(err);
-      }
+      },
     );
   },
 
@@ -1285,10 +1285,10 @@ module.exports = {
           'render',
           codeCaller,
           data,
-          context
+          context,
         );
         return { courseIssues, html, renderedElementNames };
-      }
+      },
     );
 
     return {
@@ -1305,7 +1305,7 @@ module.exports = {
     question,
     course,
     locals,
-    context
+    context,
   ) {
     return instrumented(`freeform.renderPanel:${panel}`, async (span) => {
       span.setAttributes({
@@ -1322,7 +1322,7 @@ module.exports = {
         submission,
         course,
         locals,
-        context
+        context,
       );
       span.setAttribute('cache.status', result.cacheHit ? 'hit' : 'miss');
       return result;
@@ -1337,7 +1337,7 @@ module.exports = {
     submissions,
     course,
     course_instance,
-    locals
+    locals,
   ) {
     return instrumented('freeform.render', async () => {
       debug('render()');
@@ -1378,7 +1378,7 @@ module.exports = {
               question,
               course,
               locals,
-              context
+              context,
             );
 
             courseIssues.push(...newCourseIssues);
@@ -1401,7 +1401,7 @@ module.exports = {
                 question,
                 course,
                 locals,
-                context
+                context,
               );
 
               courseIssues.push(...newCourseIssues);
@@ -1424,7 +1424,7 @@ module.exports = {
               question,
               course,
               locals,
-              context
+              context,
             );
 
             courseIssues.push(...newCourseIssues);
@@ -1469,12 +1469,12 @@ module.exports = {
               // since they'll be served from their element's directory
               if (_.has(elementDependencies, 'elementStyles')) {
                 elementDependencies.elementStyles = elementDependencies.elementStyles.map(
-                  (dep) => `${resolvedElement.name}/${dep}`
+                  (dep) => `${resolvedElement.name}/${dep}`,
                 );
               }
               if (_.has(elementDependencies, 'elementScripts')) {
                 elementDependencies.elementScripts = elementDependencies.elementScripts.map(
-                  (dep) => `${resolvedElement.name}/${dep}`
+                  (dep) => `${resolvedElement.name}/${dep}`,
                 );
               }
 
@@ -1524,8 +1524,8 @@ module.exports = {
                     courseIssues.push(
                       new CourseIssueError(
                         `Error getting dependencies for ${resolvedElement.name}: "${type}" is not an array`,
-                        { data: { elementDependencies }, fatal: true }
-                      )
+                        { data: { elementDependencies }, fatal: true },
+                      ),
                     );
                   }
                 }
@@ -1539,16 +1539,16 @@ module.exports = {
                   }
 
                   const extension = _.cloneDeep(
-                    extensions[elementName][extensionName]
+                    extensions[elementName][extensionName],
                   ).dependencies;
                   if (_.has(extension, 'extensionStyles')) {
                     extension.extensionStyles = extension.extensionStyles.map(
-                      (dep) => `${elementName}/${extensionName}/${dep}`
+                      (dep) => `${elementName}/${extensionName}/${dep}`,
                     );
                   }
                   if (_.has(extension, 'extensionScripts')) {
                     extension.extensionScripts = extension.extensionScripts.map(
-                      (dep) => `${elementName}/${extensionName}/${dep}`
+                      (dep) => `${elementName}/${extensionName}/${dep}`,
                     );
                   }
 
@@ -1575,8 +1575,8 @@ module.exports = {
                         courseIssues.push(
                           new CourseIssueError(
                             `Error getting dependencies for extension ${extension.name}: "${type}" is not an array`,
-                            { data: elementDependencies, fatal: true }
-                          )
+                            { data: elementDependencies, fatal: true },
+                          ),
                         );
                       }
                     }
@@ -1590,61 +1590,61 @@ module.exports = {
             const scriptUrls = [];
             const styleUrls = [];
             dependencies.coreStyles.forEach((file) =>
-              styleUrls.push(assets.assetPath(`stylesheets/${file}`))
+              styleUrls.push(assets.assetPath(`stylesheets/${file}`)),
             );
             dependencies.coreScripts.forEach((file) =>
-              coreScriptUrls.push(assets.assetPath(`javascripts/${file}`))
+              coreScriptUrls.push(assets.assetPath(`javascripts/${file}`)),
             );
             dependencies.nodeModulesStyles.forEach((file) =>
-              styleUrls.push(assets.nodeModulesAssetPath(file))
+              styleUrls.push(assets.nodeModulesAssetPath(file)),
             );
             dependencies.nodeModulesScripts.forEach((file) =>
-              coreScriptUrls.push(assets.nodeModulesAssetPath(file))
+              coreScriptUrls.push(assets.nodeModulesAssetPath(file)),
             );
             dependencies.clientFilesCourseStyles.forEach((file) =>
-              styleUrls.push(`${locals.urlPrefix}/clientFilesCourse/${file}`)
+              styleUrls.push(`${locals.urlPrefix}/clientFilesCourse/${file}`),
             );
             dependencies.clientFilesCourseScripts.forEach((file) =>
-              scriptUrls.push(`${locals.urlPrefix}/clientFilesCourse/${file}`)
+              scriptUrls.push(`${locals.urlPrefix}/clientFilesCourse/${file}`),
             );
             dependencies.clientFilesQuestionStyles.forEach((file) =>
-              styleUrls.push(`${locals.clientFilesQuestionUrl}/${file}`)
+              styleUrls.push(`${locals.clientFilesQuestionUrl}/${file}`),
             );
             dependencies.clientFilesQuestionScripts.forEach((file) =>
-              scriptUrls.push(`${locals.clientFilesQuestionUrl}/${file}`)
+              scriptUrls.push(`${locals.clientFilesQuestionUrl}/${file}`),
             );
             dependencies.coreElementStyles.forEach((file) =>
-              styleUrls.push(assets.coreElementAssetPath(file))
+              styleUrls.push(assets.coreElementAssetPath(file)),
             );
             dependencies.coreElementScripts.forEach((file) =>
-              scriptUrls.push(assets.coreElementAssetPath(file))
+              scriptUrls.push(assets.coreElementAssetPath(file)),
             );
             dependencies.courseElementStyles.forEach((file) =>
               styleUrls.push(
-                assets.courseElementAssetPath(course.commit_hash, locals.urlPrefix, file)
-              )
+                assets.courseElementAssetPath(course.commit_hash, locals.urlPrefix, file),
+              ),
             );
             dependencies.courseElementScripts.forEach((file) =>
               scriptUrls.push(
-                assets.courseElementAssetPath(course.commit_hash, locals.urlPrefix, file)
-              )
+                assets.courseElementAssetPath(course.commit_hash, locals.urlPrefix, file),
+              ),
             );
             dependencies.extensionStyles.forEach((file) =>
               styleUrls.push(
-                assets.courseElementExtensionAssetPath(course.commit_hash, locals.urlPrefix, file)
-              )
+                assets.courseElementExtensionAssetPath(course.commit_hash, locals.urlPrefix, file),
+              ),
             );
             dependencies.extensionScripts.forEach((file) =>
               scriptUrls.push(
-                assets.courseElementExtensionAssetPath(course.commit_hash, locals.urlPrefix, file)
-              )
+                assets.courseElementExtensionAssetPath(course.commit_hash, locals.urlPrefix, file),
+              ),
             );
 
             const headerHtmls = [
               ...styleUrls.map((url) => `<link href="${url}" rel="stylesheet" />`),
               // It's important that any library-style scripts come first
               ...coreScriptUrls.map(
-                (url) => `<script type="text/javascript" src="${url}"></script>`
+                (url) => `<script type="text/javascript" src="${url}"></script>`,
               ),
               ...scriptUrls.map((url) => `<script type="text/javascript" src="${url}"></script>`),
             ];
@@ -1666,7 +1666,7 @@ module.exports = {
     course,
     course_instance,
     locals,
-    callback
+    callback,
   ) {
     module.exports
       .renderAsync(
@@ -1677,7 +1677,7 @@ module.exports = {
         submissions,
         course,
         course_instance,
-        locals
+        locals,
       )
       .then(
         ({ courseIssues, htmls }) => {
@@ -1685,7 +1685,7 @@ module.exports = {
         },
         (err) => {
           callback(err);
-        }
+        },
       );
   },
 
@@ -1716,12 +1716,12 @@ module.exports = {
               'file',
               codeCaller,
               data,
-              context
+              context,
             );
             const fileDataBase64 = (fileData || '').toString('base64');
             return { courseIssues, fileDataBase64 };
           });
-        }
+        },
       );
 
       span.setAttribute('cache.status', cacheHit ? 'hit' : 'miss');
@@ -1739,7 +1739,7 @@ module.exports = {
       },
       (err) => {
         callback(err);
-      }
+      },
     );
   },
 
@@ -1765,7 +1765,7 @@ module.exports = {
           'parse',
           codeCaller,
           data,
-          context
+          context,
         );
         if (_.size(resultData.format_errors) > 0) resultData.gradable = false;
         return {
@@ -1790,7 +1790,7 @@ module.exports = {
       },
       (err) => {
         callback(err);
-      }
+      },
     );
   },
 
@@ -1820,7 +1820,7 @@ module.exports = {
           'grade',
           codeCaller,
           data,
-          context
+          context,
         );
         if (_.size(resultData.format_errors) > 0) resultData.gradable = false;
         return {
@@ -1848,7 +1848,7 @@ module.exports = {
       },
       (err) => {
         callback(err);
-      }
+      },
     );
   },
 
@@ -1877,7 +1877,7 @@ module.exports = {
           'test',
           codeCaller,
           data,
-          context
+          context,
         );
         if (_.size(resultData.format_errors) > 0) resultData.gradable = false;
         return {
@@ -1903,7 +1903,7 @@ module.exports = {
       },
       (err) => {
         callback(err);
-      }
+      },
     );
   },
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -152,7 +152,7 @@ module.exports.initExpress = function () {
         secure: 'auto', // uses Express "trust proxy"
         sameSite: config.sessionCookieSameSite,
       },
-    })
+    }),
   );
 
   // browser detection - data format is https://lancedikson.github.io/bowser/docs/global.html#ParsedResult
@@ -182,73 +182,73 @@ module.exports.initExpress = function () {
   });
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/uploads',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instance_question/:instance_question_id',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/assessment_instance/:assessment_instance_id',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/question/:question_id',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post('/pl/course/:course_id/question/:question_id', upload.single('file'));
   app.post('/pl/course/:course_id/question/:question_id/file_view', upload.single('file'));
   app.post('/pl/course/:course_id/question/:question_id/file_view/*', upload.single('file'));
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/settings',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/instance_admin/settings',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/course_admin/settings',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post('/pl/course/:course_id/course_admin/settings', upload.single('file'));
   app.post('/pl/course/:course_id/course_admin/file_view', upload.single('file'));
   app.post('/pl/course/:course_id/course_admin/file_view/*', upload.single('file'));
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/course_admin/file_view',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/course_admin/file_view/*',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/instance_admin/file_view',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/instance_admin/file_view/*',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/file_view',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/file_view/*',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/question/:question_id/file_view',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/question/:question_id/file_view/*',
-    upload.single('file')
+    upload.single('file'),
   );
   app.post(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/groups',
-    upload.single('file')
+    upload.single('file'),
   );
 
   /**
@@ -298,7 +298,7 @@ module.exports.initExpress = function () {
           workspaceUrlRewriteCache.set(workspace_id, workspace_url_rewrite);
         }
         debug(
-          `pathRewrite: found workspace_url_rewrite=${workspace_url_rewrite} for workspace_id=${workspace_id}`
+          `pathRewrite: found workspace_url_rewrite=${workspace_url_rewrite} for workspace_id=${workspace_id}`,
         );
         if (!workspace_url_rewrite) {
           return path;
@@ -320,7 +320,7 @@ module.exports.initExpress = function () {
       const workspace_id = match[1];
       const result = await sqldb.queryZeroOrOneRowAsync(
         "SELECT hostname FROM workspaces WHERE id = $workspace_id AND state = 'running';",
-        { workspace_id }
+        { workspace_id },
       );
 
       if (result.rows.length === 0) {
@@ -408,7 +408,7 @@ module.exports.initExpress = function () {
   // Support legacy use of ace by v2 questions
   app.use(
     '/localscripts/calculationQuestion/ace',
-    staticNodeModules(path.join('ace-builds', 'src-min-noconflict'))
+    staticNodeModules(path.join('ace-builds', 'src-min-noconflict')),
   );
   app.use('/javascripts/ace', staticNodeModules(path.join('ace-builds', 'src-min-noconflict')));
 
@@ -630,11 +630,11 @@ module.exports.initExpress = function () {
   // Some course instance student pages only require course instance authorization (already checked)
   app.use(
     '/pl/course_instance/:course_instance_id/news_items',
-    require('./pages/news_items/news_items.js')
+    require('./pages/news_items/news_items.js'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/news_item',
-    require('./pages/news_item/news_item.js')
+    require('./pages/news_item/news_item.js'),
   );
 
   // Some course instance student pages only require the authn user to have permissions
@@ -660,27 +660,27 @@ module.exports.initExpress = function () {
   // Some course instance instructor pages only require the authn user to have permissions (already checked)
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/effectiveUser',
-    require('./pages/instructorEffectiveUser/instructorEffectiveUser')
+    require('./pages/instructorEffectiveUser/instructorEffectiveUser'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/news_items',
-    require('./pages/news_items/news_items.js')
+    require('./pages/news_items/news_items.js'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/news_item',
-    require('./pages/news_item/news_item.js')
+    require('./pages/news_item/news_item.js'),
   );
 
   // All other course instance student pages require the effective user to have permissions
   app.use(
     '/pl/course_instance/:course_instance_id',
-    require('./middlewares/authzHasCourseInstanceAccess')
+    require('./middlewares/authzHasCourseInstanceAccess'),
   );
 
   // All other course instance instructor pages require the effective user to have permissions
   app.use(
     '/pl/course_instance/:course_instance_id/instructor',
-    require('./middlewares/authzHasCoursePreviewOrInstanceView')
+    require('./middlewares/authzHasCoursePreviewOrInstanceView'),
   );
 
   // all pages under /pl/course require authorization
@@ -703,27 +703,27 @@ module.exports.initExpress = function () {
   // files to be treated as immutable in production and cached aggressively.
   app.use(
     '/pl/course_instance/:course_instance_id/cacheableElements/:cachebuster',
-    require('./pages/elementFiles/elementFiles')
+    require('./pages/elementFiles/elementFiles'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/cacheableElements/:cachebuster',
-    require('./pages/elementFiles/elementFiles')
+    require('./pages/elementFiles/elementFiles'),
   );
   app.use(
     '/pl/course/:course_id/cacheableElements/:cachebuster',
-    require('./pages/elementFiles/elementFiles')
+    require('./pages/elementFiles/elementFiles'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/cacheableElementExtensions/:cachebuster',
-    require('./pages/elementExtensionFiles/elementExtensionFiles')
+    require('./pages/elementExtensionFiles/elementExtensionFiles'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/cacheableElementExtensions/:cachebuster',
-    require('./pages/elementExtensionFiles/elementExtensionFiles')
+    require('./pages/elementExtensionFiles/elementExtensionFiles'),
   );
   app.use(
     '/pl/course/:course_id/cacheableElementExtensions/:cachebuster',
-    require('./pages/elementExtensionFiles/elementExtensionFiles')
+    require('./pages/elementExtensionFiles/elementExtensionFiles'),
   );
 
   // For backwards compatibility, we continue to serve the non-cached element
@@ -735,24 +735,24 @@ module.exports.initExpress = function () {
   app.use('/pl/static/elements', require('./pages/elementFiles/elementFiles'));
   app.use(
     '/pl/course_instance/:course_instance_id/elements',
-    require('./pages/elementFiles/elementFiles')
+    require('./pages/elementFiles/elementFiles'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/elements',
-    require('./pages/elementFiles/elementFiles')
+    require('./pages/elementFiles/elementFiles'),
   );
   app.use('/pl/course/:course_id/elements', require('./pages/elementFiles/elementFiles'));
   app.use(
     '/pl/course_instance/:course_instance_id/elementExtensions',
-    require('./pages/elementExtensionFiles/elementExtensionFiles')
+    require('./pages/elementExtensionFiles/elementExtensionFiles'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/elementExtensions',
-    require('./pages/elementExtensionFiles/elementExtensionFiles')
+    require('./pages/elementExtensionFiles/elementExtensionFiles'),
   );
   app.use(
     '/pl/course/:course_id/elementExtensions',
-    require('./pages/elementExtensionFiles/elementExtensionFiles')
+    require('./pages/elementExtensionFiles/elementExtensionFiles'),
   );
 
   //////////////////////////////////////////////////////////////////////
@@ -765,7 +765,7 @@ module.exports.initExpress = function () {
   if (isEnterprise()) {
     app.use(
       '/pl/institution/:institution_id/admin',
-      require('./ee/routers/institutionAdmin').default
+      require('./ee/routers/institutionAdmin').default,
     );
   }
 
@@ -784,14 +784,14 @@ module.exports.initExpress = function () {
     /^(\/pl\/course_instance\/[0-9]+\/instructor\/assessment\/[0-9]+)\/?$/,
     (req, res, _next) => {
       res.redirect(`${req.params[0]}/questions`);
-    }
+    },
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id',
     function (req, res, next) {
       res.locals.navPage = 'assessment';
       next();
-    }
+    },
   );
   app.use('/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/settings', [
     function (req, res, next) {
@@ -808,7 +808,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorAssessmentQuestions/instructorAssessmentQuestions'),
-    ]
+    ],
   );
   app.use('/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/groups', [
     function (req, res, next) {
@@ -832,7 +832,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorAssessmentStatistics/instructorAssessmentStatistics'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/question_statistics',
@@ -844,7 +844,7 @@ module.exports.initExpress = function () {
       require('./pages/shared/assessmentStatDescriptions'),
       require('./pages/shared/floatFormatters'),
       require('./pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/downloads',
@@ -854,7 +854,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorAssessmentDownloads/instructorAssessmentDownloads'),
-    ]
+    ],
   );
   app.use('/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/uploads', [
     function (req, res, next) {
@@ -871,7 +871,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorAssessmentRegrading/instructorAssessmentRegrading'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/instances',
@@ -881,7 +881,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorAssessmentInstances/instructorAssessmentInstances'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/file_edit',
@@ -891,7 +891,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorFileEditor/instructorFileEditor'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/file_view',
@@ -901,11 +901,11 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorFileBrowser/instructorFileBrowser'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/file_download',
-    require('./pages/instructorFileDownload/instructorFileDownload')
+    require('./pages/instructorFileDownload/instructorFileDownload'),
   );
 
   app.use(
@@ -917,7 +917,7 @@ module.exports.initExpress = function () {
       },
       require('./middlewares/selectAndAuthzAssessmentQuestion'),
       require('./pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/manual_grading/instance_question/:instance_question_id',
@@ -928,14 +928,14 @@ module.exports.initExpress = function () {
       },
       require('./middlewares/selectAndAuthzInstanceQuestion'),
       require('./pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/instance_question/:instance_question_id/clientFilesQuestion',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion'),
       require('./pages/clientFilesQuestion/clientFilesQuestion'),
-    ]
+    ],
   );
 
   app.use(
@@ -943,7 +943,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzInstanceQuestion'),
       require('./pages/generatedFilesQuestion/generatedFilesQuestion'),
-    ]
+    ],
   );
 
   app.use(
@@ -951,14 +951,14 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzInstanceQuestion'),
       require('./pages/legacyQuestionFile/legacyQuestionFile'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/instance_question/:instance_question_id/text',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion'),
       require('./pages/legacyQuestionText/legacyQuestionText'),
-    ]
+    ],
   );
 
   // Submission files
@@ -967,7 +967,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzInstanceQuestion'),
       require('./pages/submissionFile/submissionFile'),
-    ]
+    ],
   );
 
   app.use(
@@ -978,7 +978,7 @@ module.exports.initExpress = function () {
         next();
       },
       require('./pages/instructorAssessmentManualGrading/assessment/assessment'),
-    ]
+    ],
   );
 
   app.use(
@@ -987,7 +987,7 @@ module.exports.initExpress = function () {
       require('./middlewares/selectAndAuthzAssessmentInstance'),
       require('./pages/shared/floatFormatters'),
       require('./pages/instructorAssessmentInstance/instructorAssessmentInstance'),
-    ]
+    ],
   );
 
   // single question
@@ -1005,14 +1005,14 @@ module.exports.initExpress = function () {
       const newUrlParts = url.parse(newUrl);
       newUrlParts.query = req.query;
       res.redirect(url.format(newUrlParts));
-    }
+    },
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/question/:question_id',
     function (req, res, next) {
       res.locals.navPage = 'question';
       next();
-    }
+    },
   );
   app.use('/pl/course_instance/:course_instance_id/instructor/question/:question_id/settings', [
     function (req, res, next) {
@@ -1054,24 +1054,24 @@ module.exports.initExpress = function () {
   ]);
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/question/:question_id/file_download',
-    require('./pages/instructorFileDownload/instructorFileDownload')
+    require('./pages/instructorFileDownload/instructorFileDownload'),
   );
 
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/grading_job',
-    require('./pages/instructorGradingJob/instructorGradingJob')
+    require('./pages/instructorGradingJob/instructorGradingJob'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/jobSequence',
-    require('./pages/instructorJobSequence/instructorJobSequence')
+    require('./pages/instructorJobSequence/instructorJobSequence'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/loadFromDisk',
-    require('./pages/instructorLoadFromDisk/instructorLoadFromDisk')
+    require('./pages/instructorLoadFromDisk/instructorLoadFromDisk'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/edit_error',
-    require('./pages/editError/editError')
+    require('./pages/editError/editError'),
   );
 
   // course instance - course admin pages
@@ -1083,7 +1083,7 @@ module.exports.initExpress = function () {
     function (req, res, next) {
       res.locals.navPage = 'course_admin';
       next();
-    }
+    },
   );
   app.use('/pl/course_instance/:course_instance_id/instructor/course_admin/settings', [
     function (req, res, next) {
@@ -1164,7 +1164,7 @@ module.exports.initExpress = function () {
   ]);
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/course_admin/file_download',
-    require('./pages/instructorFileDownload/instructorFileDownload')
+    require('./pages/instructorFileDownload/instructorFileDownload'),
   );
 
   // course instance - instance admin pages
@@ -1176,7 +1176,7 @@ module.exports.initExpress = function () {
     function (req, res, next) {
       res.locals.navPage = 'instance_admin';
       next();
-    }
+    },
   );
   app.use('/pl/course_instance/:course_instance_id/instructor/instance_admin/settings', [
     function (req, res, next) {
@@ -1229,31 +1229,31 @@ module.exports.initExpress = function () {
   ]);
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/instance_admin/file_download',
-    require('./pages/instructorFileDownload/instructorFileDownload')
+    require('./pages/instructorFileDownload/instructorFileDownload'),
   );
 
   // clientFiles
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse')
+    require('./pages/clientFilesCourse/clientFilesCourse'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/clientFilesCourseInstance',
-    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance')
+    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/clientFilesAssessment',
     [
       require('./middlewares/selectAndAuthzAssessment'),
       require('./pages/clientFilesAssessment/clientFilesAssessment'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instructor/question/:question_id/clientFilesQuestion',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion'),
       require('./pages/clientFilesQuestion/clientFilesQuestion'),
-    ]
+    ],
   );
 
   // generatedFiles
@@ -1262,7 +1262,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzInstructorQuestion'),
       require('./pages/generatedFilesQuestion/generatedFilesQuestion'),
-    ]
+    ],
   );
 
   // Submission files
@@ -1271,7 +1271,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzInstructorQuestion'),
       require('./pages/submissionFile/submissionFile'),
-    ]
+    ],
   );
 
   // legacy client file paths
@@ -1332,7 +1332,7 @@ module.exports.initExpress = function () {
       require('./middlewares/logPageView')('studentAssessmentInstanceFile'),
       require('./middlewares/studentAssessmentAccess'),
       require('./pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/assessment_instance/:assessment_instance_id/time_remaining',
@@ -1340,7 +1340,7 @@ module.exports.initExpress = function () {
       require('./middlewares/selectAndAuthzAssessmentInstance'),
       require('./middlewares/studentAssessmentAccess'),
       require('./pages/studentAssessmentInstanceTimeRemaining/studentAssessmentInstanceTimeRemaining'),
-    ]
+    ],
   );
   app.use('/pl/course_instance/:course_instance_id/assessment_instance/:assessment_instance_id', [
     require('./middlewares/selectAndAuthzAssessmentInstance'),
@@ -1360,11 +1360,11 @@ module.exports.initExpress = function () {
   if (config.devMode) {
     app.use(
       '/pl/course_instance/:course_instance_id/loadFromDisk',
-      require('./pages/instructorLoadFromDisk/instructorLoadFromDisk')
+      require('./pages/instructorLoadFromDisk/instructorLoadFromDisk'),
     );
     app.use(
       '/pl/course_instance/:course_instance_id/jobSequence',
-      require('./pages/instructorJobSequence/instructorJobSequence')
+      require('./pages/instructorJobSequence/instructorJobSequence'),
     );
   }
 
@@ -1383,33 +1383,33 @@ module.exports.initExpress = function () {
       require('./middlewares/selectAndAuthzAssessment'),
       require('./middlewares/studentAssessmentAccess'),
       require('./pages/clientFilesAssessment/clientFilesAssessment'),
-    ]
+    ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instance_question/:instance_question_id/clientFilesQuestion',
-    require('./pages/clientFilesQuestion/clientFilesQuestion')
+    require('./pages/clientFilesQuestion/clientFilesQuestion'),
   );
 
   // generatedFiles
   app.use(
     '/pl/course_instance/:course_instance_id/instance_question/:instance_question_id/generatedFilesQuestion',
-    require('./pages/generatedFilesQuestion/generatedFilesQuestion')
+    require('./pages/generatedFilesQuestion/generatedFilesQuestion'),
   );
 
   // Submission files
   app.use(
     '/pl/course_instance/:course_instance_id/instance_question/:instance_question_id/submission/:submission_id/file',
-    require('./pages/submissionFile/submissionFile')
+    require('./pages/submissionFile/submissionFile'),
   );
 
   // legacy client file paths
   app.use(
     '/pl/course_instance/:course_instance_id/instance_question/:instance_question_id/file',
-    require('./pages/legacyQuestionFile/legacyQuestionFile')
+    require('./pages/legacyQuestionFile/legacyQuestionFile'),
   );
   app.use(
     '/pl/course_instance/:course_instance_id/instance_question/:instance_question_id/text',
-    require('./pages/legacyQuestionText/legacyQuestionText')
+    require('./pages/legacyQuestionText/legacyQuestionText'),
   );
 
   //////////////////////////////////////////////////////////////////////
@@ -1424,7 +1424,7 @@ module.exports.initExpress = function () {
   // Some course pages only require the authn user to have permission (aleady checked)
   app.use(
     '/pl/course/:course_id/effectiveUser',
-    require('./pages/instructorEffectiveUser/instructorEffectiveUser')
+    require('./pages/instructorEffectiveUser/instructorEffectiveUser'),
   );
   app.use('/pl/course/:course_id/news_items', require('./pages/news_items/news_items.js'));
   app.use('/pl/course/:course_id/news_item', require('./pages/news_item/news_item.js'));
@@ -1491,7 +1491,7 @@ module.exports.initExpress = function () {
   ]);
   app.use(
     '/pl/course/:course_id/question/:question_id/file_download',
-    require('./pages/instructorFileDownload/instructorFileDownload')
+    require('./pages/instructorFileDownload/instructorFileDownload'),
   );
 
   app.use('/pl/course/:course_id/file_transfer', [
@@ -1586,16 +1586,16 @@ module.exports.initExpress = function () {
   ]);
   app.use(
     '/pl/course/:course_id/course_admin/file_download',
-    require('./pages/instructorFileDownload/instructorFileDownload')
+    require('./pages/instructorFileDownload/instructorFileDownload'),
   );
 
   app.use(
     '/pl/course/:course_id/loadFromDisk',
-    require('./pages/instructorLoadFromDisk/instructorLoadFromDisk')
+    require('./pages/instructorLoadFromDisk/instructorLoadFromDisk'),
   );
   app.use(
     '/pl/course/:course_id/jobSequence',
-    require('./pages/instructorJobSequence/instructorJobSequence')
+    require('./pages/instructorJobSequence/instructorJobSequence'),
   );
 
   // This route is used to initiate a transfer of a question from a template course.
@@ -1607,13 +1607,13 @@ module.exports.initExpress = function () {
   app.use(
     '/pl/course/:course_id/copy_template_course_question',
     require('./pages/instructorCopyTemplateCourseQuestion/instructorCopyTemplateCourseQuestion')
-      .default
+      .default,
   );
 
   // clientFiles
   app.use(
     '/pl/course/:course_id/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse')
+    require('./pages/clientFilesCourse/clientFilesCourse'),
   );
   app.use('/pl/course/:course_id/question/:question_id/clientFilesQuestion', [
     require('./middlewares/selectAndAuthzInstructorQuestion'),
@@ -1660,44 +1660,44 @@ module.exports.initExpress = function () {
   app.use('/pl/administrator/admins', require('./pages/administratorAdmins/administratorAdmins'));
   app.use(
     '/pl/administrator/settings',
-    require('./pages/administratorSettings/administratorSettings')
+    require('./pages/administratorSettings/administratorSettings'),
   );
   app.use(
     '/pl/administrator/institutions',
-    require('./pages/administratorInstitutions/administratorInstitutions').default
+    require('./pages/administratorInstitutions/administratorInstitutions').default,
   );
   app.use(
     '/pl/administrator/courses',
-    require('./pages/administratorCourses/administratorCourses')
+    require('./pages/administratorCourses/administratorCourses'),
   );
   app.use(
     '/pl/administrator/networks',
-    require('./pages/administratorNetworks/administratorNetworks')
+    require('./pages/administratorNetworks/administratorNetworks'),
   );
   app.use(
     '/pl/administrator/workspaces',
-    require('./pages/administratorWorkspaces/administratorWorkspaces')
+    require('./pages/administratorWorkspaces/administratorWorkspaces'),
   );
   app.use(
     '/pl/administrator/features',
-    require('./pages/administratorFeatures/administratorFeatures').default
+    require('./pages/administratorFeatures/administratorFeatures').default,
   );
   app.use(
     '/pl/administrator/queries',
-    require('./pages/administratorQueries/administratorQueries')
+    require('./pages/administratorQueries/administratorQueries'),
   );
   app.use('/pl/administrator/query', require('./pages/administratorQuery/administratorQuery'));
   app.use(
     '/pl/administrator/jobSequence/',
-    require('./pages/administratorJobSequence/administratorJobSequence')
+    require('./pages/administratorJobSequence/administratorJobSequence'),
   );
   app.use(
     '/pl/administrator/courseRequests/',
-    require('./pages/administratorCourseRequests/administratorCourseRequests')
+    require('./pages/administratorCourseRequests/administratorCourseRequests'),
   );
   app.use(
     '/pl/administrator/batchedMigrations',
-    require('./pages/administratorBatchedMigrations/administratorBatchedMigrations')
+    require('./pages/administratorBatchedMigrations/administratorBatchedMigrations'),
   );
 
   //////////////////////////////////////////////////////////////////////
@@ -1805,7 +1805,7 @@ module.exports.startServer = async () => {
     },
     () => {
       return util.promisify(server.getConnections.bind(server))();
-    }
+    },
   );
 
   server.timeout = config.serverTimeout;
@@ -1935,7 +1935,7 @@ if (require.main === module && config.startServer) {
               // from the `router` function in our `http-proxy-middleware` config.
               if (
                 event.exception?.values?.some(
-                  (value) => value.type === 'Error' && value.value === 'Workspace is not running'
+                  (value) => value.type === 'Error' && value.value === 'Workspace is not running',
                 )
               ) {
                 return null;
@@ -1962,7 +1962,7 @@ if (require.main === module && config.startServer) {
               logger.verbose(msg, { time, stack });
               console.log(msg + '\n' + stack.join('\n'));
             },
-            { threshold: config.blockedWarnThresholdMS }
+            { threshold: config.blockedWarnThresholdMS },
           ); // threshold in milliseconds
         } else if (config.blockedWarnEnable) {
           blocked(
@@ -1971,7 +1971,7 @@ if (require.main === module && config.startServer) {
               logger.verbose(msg, { time });
               console.log(msg);
             },
-            { threshold: config.blockedWarnThresholdMS }
+            { threshold: config.blockedWarnThresholdMS },
           ); // threshold in milliseconds
         }
       },
@@ -2041,7 +2041,7 @@ if (require.main === module && config.startServer) {
         if (config.runMigrations || argv['migrate-and-exit']) {
           await migrations.init(
             [path.join(__dirname, 'migrations'), SCHEMA_MIGRATIONS_PATH],
-            'prairielearn'
+            'prairielearn',
           );
 
           if (argv['migrate-and-exit']) {
@@ -2073,7 +2073,7 @@ if (require.main === module && config.startServer) {
               valueType: opentelemetry.ValueType.INT,
               interval: 1000,
             },
-            () => pool.totalCount
+            () => pool.totalCount,
           );
 
           opentelemetry.createObservableValueGauges(
@@ -2083,7 +2083,7 @@ if (require.main === module && config.startServer) {
               valueType: opentelemetry.ValueType.INT,
               interval: 1000,
             },
-            () => pool.idleCount
+            () => pool.idleCount,
           );
 
           opentelemetry.createObservableValueGauges(
@@ -2093,7 +2093,7 @@ if (require.main === module && config.startServer) {
               valueType: opentelemetry.ValueType.INT,
               interval: 1000,
             },
-            () => pool.waitingCount
+            () => pool.waitingCount,
           );
 
           const queryCounter = opentelemetry.getObservableCounter(
@@ -2101,7 +2101,7 @@ if (require.main === module && config.startServer) {
             `postgres.pool.${name}.query.count`,
             {
               valueType: opentelemetry.ValueType.INT,
-            }
+            },
           );
           queryCounter.addCallback((observableResult) => {
             observableResult.observe(pool.queryCount);
@@ -2270,6 +2270,6 @@ if (require.main === module && config.startServer) {
           }
         });
       }
-    }
+    },
   );
 }

--- a/apps/prairielearn/src/sprocs/index.js
+++ b/apps/prairielearn/src/sprocs/index.js
@@ -173,6 +173,6 @@ module.exports.init = function (callback) {
       if (ERR(err, callback)) return;
       logger.verbose('Successfully completed DB stored procedure initialization');
       callback(null);
-    }
+    },
   );
 };

--- a/apps/prairielearn/src/sync/course-db.js
+++ b/apps/prairielearn/src/sync/course-db.js
@@ -435,7 +435,7 @@ module.exports.loadFullCourse = async function (courseDir) {
     const assessments = await module.exports.loadAssessments(
       courseDir,
       courseInstanceId,
-      questions
+      questions,
     );
     const courseInstance = {
       courseInstance: courseInstanceInfos[courseInstanceId],
@@ -487,7 +487,7 @@ module.exports.writeErrorsAndWarningsForCourseData = function (courseId, courseD
     courseId,
     'infoCourse.json',
     courseData.course,
-    writeLine
+    writeLine,
   );
   Object.entries(courseData.questions).forEach(([qid, question]) => {
     const questionPath = path.posix.join('questions', qid, 'info.json');
@@ -499,7 +499,7 @@ module.exports.writeErrorsAndWarningsForCourseData = function (courseId, courseD
       courseId,
       courseInstancePath,
       courseInstanceData.courseInstance,
-      writeLine
+      writeLine,
     );
     Object.entries(courseInstanceData.assessments).forEach(([aid, assessment]) => {
       const assessmentPath = path.posix.join(
@@ -507,7 +507,7 @@ module.exports.writeErrorsAndWarningsForCourseData = function (courseId, courseD
         ciid,
         'assessments',
         aid,
-        'infoAssessment.json'
+        'infoAssessment.json',
       );
       writeErrorsAndWarningsForInfoFileIfNeeded(courseId, assessmentPath, assessment, writeLine);
     });
@@ -755,7 +755,7 @@ module.exports.loadCourseInfo = async function (coursePath) {
   const assessmentSets = getFieldWithoutDuplicates(
     'assessmentSets',
     'name',
-    DEFAULT_ASSESSMENT_SETS
+    DEFAULT_ASSESSMENT_SETS,
   );
   const tags = getFieldWithoutDuplicates('tags', 'name', DEFAULT_TAGS);
   const topics = getFieldWithoutDuplicates('topics', 'name');
@@ -888,7 +888,7 @@ async function loadInfoForDirectory({
           const subInfoFiles = await walk(path.join(relativeDir, dir));
           if (_.isEmpty(subInfoFiles)) {
             infoFiles[path.join(relativeDir, dir)] = infofile.makeError(
-              `Missing JSON file: ${infoFilePath}`
+              `Missing JSON file: ${infoFilePath}`,
             );
           }
           _.assign(infoFiles, subInfoFiles);
@@ -898,7 +898,7 @@ async function loadInfoForDirectory({
           } else if (e.code === 'ENOENT') {
             // Missing directory; record it
             infoFiles[path.join(relativeDir, dir)] = infofile.makeError(
-              `Missing JSON file: ${infoFilePath}`
+              `Missing JSON file: ${infoFilePath}`,
             );
           } else {
             // Some other error, permissions perhaps. Throw to abort sync.
@@ -968,7 +968,7 @@ function checkAllowAccessRoles(rule) {
   if ('role' in rule) {
     if (rule.role !== 'Student') {
       warnings.push(
-        `The entire "allowAccess" rule with "role: ${rule.role}" should be deleted. Instead, course owners can now manage course staff access on the "Staff" page.`
+        `The entire "allowAccess" rule with "role: ${rule.role}" should be deleted. Instead, course owners can now manage course staff access on the "Staff" page.`,
       );
     }
   }
@@ -999,7 +999,7 @@ function checkAllowAccessDates(rule) {
   }
   if (startDate && endDate && isAfter(startDate, endDate)) {
     errors.push(
-      `Invalid allowAccess rule: startDate (${rule.startDate}) must not be after endDate (${rule.endDate})`
+      `Invalid allowAccess rule: startDate (${rule.startDate}) must not be after endDate (${rule.endDate})`,
     );
   }
   let dateInFuture = false;
@@ -1099,7 +1099,7 @@ async function validateAssessment(assessment, questions) {
       const autoPoints = zoneQuestion.autoPoints ?? zoneQuestion.points;
       if (!allowRealTimeGrading && Array.isArray(autoPoints) && autoPoints.length > 1) {
         errors.push(
-          `Cannot specify an array of multiple point values for a question if real-time grading is disabled`
+          `Cannot specify an array of multiple point values for a question if real-time grading is disabled`,
         );
       }
       // We'll normalize either single questions or alternative groups
@@ -1115,7 +1115,7 @@ async function validateAssessment(assessment, questions) {
           const autoPoints = alternative.autoPoints ?? alternative.points;
           if (!allowRealTimeGrading && Array.isArray(autoPoints) && autoPoints.length > 1) {
             errors.push(
-              `Cannot specify an array of multiple point values for an alternative if real-time grading is disabled`
+              `Cannot specify an array of multiple point values for an alternative if real-time grading is disabled`,
             );
           }
           return {
@@ -1156,13 +1156,13 @@ async function validateAssessment(assessment, questions) {
             alternative.maxAutoPoints !== undefined)
         ) {
           errors.push(
-            'Cannot specify "points" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified'
+            'Cannot specify "points" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified',
           );
         }
         if (assessment.type === 'Exam') {
           if (alternative.maxPoints !== undefined || alternative.maxAutoPoints !== undefined) {
             errors.push(
-              'Cannot specify "maxPoints" or "maxAutoPoints" for a question in an "Exam" assessment'
+              'Cannot specify "maxPoints" or "maxAutoPoints" for a question in an "Exam" assessment',
             );
           }
 
@@ -1173,7 +1173,7 @@ async function validateAssessment(assessment, questions) {
           const autoPoints = (hasSplitPoints ? alternative.autoPoints : alternative.points) ?? 0;
           const pointsList = Array.isArray(autoPoints) ? autoPoints : [autoPoints];
           const isNonIncreasing = pointsList.every(
-            (points, index) => index === 0 || points <= pointsList[index - 1]
+            (points, index) => index === 0 || points <= pointsList[index - 1],
           );
           if (!isNonIncreasing) {
             errors.push('Points for a question must be non-increasing');
@@ -1187,12 +1187,12 @@ async function validateAssessment(assessment, questions) {
               alternative.maxAutoPoints !== undefined)
           ) {
             errors.push(
-              'Cannot specify "maxPoints" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified'
+              'Cannot specify "maxPoints" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified',
             );
           }
           if (Array.isArray(alternative.autoPoints ?? alternative.points)) {
             errors.push(
-              'Cannot specify "points" or "autoPoints" as a list for a question in a "Homework" assessment'
+              'Cannot specify "points" or "autoPoints" as a list for a question in a "Homework" assessment',
             );
           }
         }
@@ -1202,13 +1202,13 @@ async function validateAssessment(assessment, questions) {
 
   if (duplicateQids.size > 0) {
     errors.push(
-      `The following questions are used more than once: ${[...duplicateQids].join(', ')}`
+      `The following questions are used more than once: ${[...duplicateQids].join(', ')}`,
     );
   }
 
   if (missingQids.size > 0) {
     errors.push(
-      `The following questions do not exist in this course: ${[...missingQids].join(', ')}`
+      `The following questions do not exist in this course: ${[...missingQids].join(', ')}`,
     );
   }
 
@@ -1222,14 +1222,14 @@ async function validateAssessment(assessment, questions) {
       (zoneQuestion.canView || []).forEach((roleName) => {
         if (!validRoleNames.has(roleName)) {
           errors.push(
-            `A zone question's "canView" permission contains the non-existent group role name "${roleName}".`
+            `A zone question's "canView" permission contains the non-existent group role name "${roleName}".`,
           );
         }
       });
       (zoneQuestion.canSubmit || []).forEach((roleName) => {
         if (!validRoleNames.has(roleName)) {
           errors.push(
-            `A zone question's "canSubmit" permission contains the non-existent group role name "${roleName}".`
+            `A zone question's "canSubmit" permission contains the non-existent group role name "${roleName}".`,
           );
         }
       });
@@ -1252,12 +1252,12 @@ async function validateAssessment(assessment, questions) {
 
     if (!foundCanAssignRolesAtStart) {
       errors.push(
-        'Could not find a role with minimum >= 1 and "can_assign_roles_at_start" set to "true".'
+        'Could not find a role with minimum >= 1 and "can_assign_roles_at_start" set to "true".',
       );
     }
     if (!foundCanAssignRolesDuringAssessment) {
       errors.push(
-        'Could not find a role with minimum >= 1 and "can_assign_roles_during_assessment" set to "true".'
+        'Could not find a role with minimum >= 1 and "can_assign_roles_during_assessment" set to "true".',
       );
     }
 
@@ -1265,22 +1265,22 @@ async function validateAssessment(assessment, questions) {
     assessment.groupRoles.forEach((role) => {
       if (role.minimum > assessment.groupMinSize) {
         warnings.push(
-          `Group role "${role.name}" has a minimum greater than the group's minimum size.`
+          `Group role "${role.name}" has a minimum greater than the group's minimum size.`,
         );
       }
       if (role.minimum && role.minimum > assessment.groupMaxSize) {
         errors.push(
-          `Group role "${role.name}" contains an invalid minimum. (Expected at most ${assessment.groupMaxSize}, found ${role.minimum}).`
+          `Group role "${role.name}" contains an invalid minimum. (Expected at most ${assessment.groupMaxSize}, found ${role.minimum}).`,
         );
       }
       if (role.maximum && role.maximum > assessment.groupMaxSize) {
         errors.push(
-          `Group role "${role.name}" contains an invalid maximum. (Expected at most ${assessment.groupMaxSize}, found ${role.maximum}).`
+          `Group role "${role.name}" contains an invalid maximum. (Expected at most ${assessment.groupMaxSize}, found ${role.maximum}).`,
         );
       }
       if (role.minimum > role.maximum) {
         errors.push(
-          `Group role "${role.name}" must have a minimum <= maximum. (Expected minimum <= ${role.maximum}, found minimum = ${role.minimum}).`
+          `Group role "${role.name}" must have a minimum <= maximum. (Expected minimum <= ${role.maximum}, found minimum = ${role.minimum}).`,
         );
       }
     });
@@ -1302,7 +1302,7 @@ async function validateCourseInstance(courseInstance) {
       warnings.push('"allowIssueReporting" is no longer needed.');
     } else {
       errors.push(
-        '"allowIssueReporting" is no longer permitted in "infoCourseInstance.json". Instead, set "allowIssueReporting" in "infoAssessment.json" files.'
+        '"allowIssueReporting" is no longer permitted in "infoCourseInstance.json". Instead, set "allowIssueReporting" in "infoAssessment.json" files.',
       );
     }
   }
@@ -1326,7 +1326,7 @@ async function validateCourseInstance(courseInstance) {
 
     if (_(courseInstance).has('userRoles')) {
       warnings.push(
-        'The property "userRoles" should be deleted. Instead, course owners can now manage staff access on the "Staff" page.'
+        'The property "userRoles" should be deleted. Instead, course owners can now manage staff access on the "Staff" page.',
       );
     }
   }
@@ -1359,7 +1359,7 @@ module.exports.loadQuestions = async function (coursePath) {
   }
   checkDuplicateUUIDs(
     questions,
-    (uuid, ids) => `UUID "${uuid}" is used in other questions: ${ids.join(', ')}`
+    (uuid, ids) => `UUID "${uuid}" is used in other questions: ${ids.join(', ')}`,
   );
   return questions;
 };
@@ -1382,7 +1382,7 @@ module.exports.loadCourseInstances = async function (coursePath) {
   });
   checkDuplicateUUIDs(
     courseInstances,
-    (uuid, ids) => `UUID "${uuid}" is used in other course instances: ${ids.join(', ')}`
+    (uuid, ids) => `UUID "${uuid}" is used in other course instances: ${ids.join(', ')}`,
   );
   return courseInstances;
 };
@@ -1411,7 +1411,7 @@ module.exports.loadAssessments = async function (coursePath, courseInstance, que
   checkDuplicateUUIDs(
     assessments,
     (uuid, ids) =>
-      `UUID "${uuid}" is used in other assessments in this course instance: ${ids.join(', ')}`
+      `UUID "${uuid}" is used in other assessments in this course instance: ${ids.join(', ')}`,
   );
   return assessments;
 };

--- a/apps/prairielearn/src/sync/fromDisk/assessmentModules.js
+++ b/apps/prairielearn/src/sync/fromDisk/assessmentModules.js
@@ -21,7 +21,7 @@ module.exports.sync = async function (courseId, courseData) {
   let courseAssessmentModules = [];
   if (!infofile.hasErrors(courseData.course)) {
     courseAssessmentModules = (courseData.course.data?.assessmentModules ?? []).map((u) =>
-      JSON.stringify([u.name, u.heading])
+      JSON.stringify([u.name, u.heading]),
     );
   }
 

--- a/apps/prairielearn/src/sync/fromDisk/assessmentSets.js
+++ b/apps/prairielearn/src/sync/fromDisk/assessmentSets.js
@@ -21,7 +21,7 @@ module.exports.sync = async function (courseId, courseData) {
   let courseAssessmentSets = [];
   if (!infofile.hasErrors(courseData.course)) {
     courseAssessmentSets = (courseData.course.data?.assessmentSets ?? []).map((t) =>
-      JSON.stringify([t.name, t.abbreviation, t.heading, t.color])
+      JSON.stringify([t.name, t.abbreviation, t.heading, t.color]),
     );
   }
 

--- a/apps/prairielearn/src/sync/fromDisk/assessments.js
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.js
@@ -245,7 +245,7 @@ function getParamsForAssessment(assessmentInfoFile, questionIds) {
               assessment.advanceScorePerc ??
               0,
           };
-        }
+        },
       );
 
       return alternativeGroupParams;
@@ -309,7 +309,7 @@ module.exports.sync = async function (courseId, courseInstanceId, assessments, q
         uuidAssessmentMap.get(uuid)?.forEach((tid) => {
           infofile.addWarning(
             assessments[tid],
-            `examUuid "${uuid}" not found. Ensure you copied the correct UUID from the scheduler.`
+            `examUuid "${uuid}" not found. Ensure you copied the correct UUID from the scheduler.`,
           );
         });
       }

--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.js
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.js
@@ -52,7 +52,7 @@ module.exports.sync = async function (courseId, courseData) {
         infofile.stringifyWarnings(courseInstance),
         getParamsForCourseInstance(courseInstance.data),
       ]);
-    }
+    },
   );
 
   const params = [courseInstanceParams, courseId];

--- a/apps/prairielearn/src/sync/fromDisk/tags.js
+++ b/apps/prairielearn/src/sync/fromDisk/tags.js
@@ -14,7 +14,7 @@ module.exports.sync = async function (courseId, courseData, questionIds) {
   // question `info.json` files are valid.
   const isInfoCourseValid = !infofile.hasErrors(courseData.course);
   const areAllInfoQuestionsValid = Object.values(courseData.questions).every(
-    (q) => !infofile.hasErrors(q)
+    (q) => !infofile.hasErrors(q),
   );
   const deleteUnused = isInfoCourseValid && areAllInfoQuestionsValid;
 
@@ -22,7 +22,7 @@ module.exports.sync = async function (courseId, courseData, questionIds) {
   let courseTags = [];
   if (!infofile.hasErrors(courseData.course)) {
     courseTags = (courseData.course.data?.tags ?? []).map((t) =>
-      JSON.stringify([t.name, t.description, t.color])
+      JSON.stringify([t.name, t.description, t.color]),
     );
   }
 

--- a/apps/prairielearn/src/sync/fromDisk/topics.js
+++ b/apps/prairielearn/src/sync/fromDisk/topics.js
@@ -12,7 +12,7 @@ module.exports.sync = async function (courseId, courseData) {
   // question `info.json` files are valid.
   const isInfoCourseValid = !infofile.hasErrors(courseData.course);
   const areAllInfoQuestionsValid = Object.values(courseData.questions).every(
-    (q) => !infofile.hasErrors(q)
+    (q) => !infofile.hasErrors(q),
   );
   const deleteUnused = isInfoCourseValid && areAllInfoQuestionsValid;
 
@@ -20,7 +20,7 @@ module.exports.sync = async function (courseId, courseData) {
   let courseTopics = [];
   if (!infofile.hasErrors(courseData.course)) {
     courseTopics = (courseData.course.data?.topics ?? []).map((t) =>
-      JSON.stringify([t.name, t.description, t.color])
+      JSON.stringify([t.name, t.description, t.color]),
     );
   }
 

--- a/apps/prairielearn/src/sync/syncFromDisk.js
+++ b/apps/prairielearn/src/sync/syncFromDisk.js
@@ -44,21 +44,21 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
   perf.start('sync');
 
   const courseData = await perf.timedAsync('loadCourseData', () =>
-    courseDB.loadFullCourse(courseDir)
+    courseDB.loadFullCourse(courseDir),
   );
   logger.info('Syncing info to database');
   await perf.timedAsync('syncCourseInfo', () => syncCourseInfo.sync(courseData, courseId));
   const courseInstanceIds = await perf.timedAsync('syncCourseInstances', () =>
-    syncCourseInstances.sync(courseId, courseData)
+    syncCourseInstances.sync(courseId, courseData),
   );
   await perf.timedAsync('syncTopics', () => syncTopics.sync(courseId, courseData));
   const questionIds = await perf.timedAsync('syncQuestions', () =>
-    syncQuestions.sync(courseId, courseData)
+    syncQuestions.sync(courseId, courseData),
   );
   await perf.timedAsync('syncTags', () => syncTags.sync(courseId, courseData, questionIds));
   await perf.timedAsync('syncAssessmentSets', () => syncAssessmentSets.sync(courseId, courseData));
   await perf.timedAsync('syncAssessmentModules', () =>
-    syncAssessmentModules.sync(courseId, courseData)
+    syncAssessmentModules.sync(courseId, courseData),
   );
   perf.start('syncAssessments');
   await Promise.all(
@@ -69,10 +69,10 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
           courseId,
           courseInstanceId,
           courseInstanceData.assessments,
-          questionIds
-        )
+          questionIds,
+        ),
       );
-    })
+    }),
   );
   perf.end('syncAssessments');
   if (config.devMode) {
@@ -85,7 +85,7 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
     logger.info(chalk.red('✖ Some JSON files contained errors and were unable to be synced'));
   } else if (courseDataHasErrorsOrWarnings) {
     logger.info(
-      chalk.yellow('⚠ Some JSON files contained warnings but all were successfully synced')
+      chalk.yellow('⚠ Some JSON files contained warnings but all were successfully synced'),
     );
   } else {
     logger.info(chalk.green('✓ Course sync successful'));
@@ -96,7 +96,7 @@ async function syncDiskToSqlWithLock(courseDir, courseId, logger) {
   // sync process. For instance, we don't actually validate exam UUIDs until
   // the database sync step.
   courseDB.writeErrorsAndWarningsForCourseData(courseId, courseData, (line) =>
-    logger.info(line || '')
+    logger.info(line || ''),
   );
 
   perf.end('sync');

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -273,7 +273,7 @@ describe('Access control', function () {
         }
         page = body;
         callback(null);
-      }
+      },
     );
   };
 
@@ -335,7 +335,7 @@ describe('Access control', function () {
           return callback(new Error('did not find addVectors instance question in DB'));
         } else if (result.rowCount > 1) {
           return callback(
-            new Error('multiple rows found: ' + JSON.stringify(result.rows, null, '    '))
+            new Error('multiple rows found: ' + JSON.stringify(result.rows, null, '    ')),
           );
         }
         instance_question = result.rows[0];
@@ -392,7 +392,7 @@ describe('Access control', function () {
     });
     it('base64 data should parse to JSON', function () {
       questionData = JSON.parse(
-        decodeURIComponent(Buffer.from(elemList[0].children[0].data, 'base64').toString())
+        decodeURIComponent(Buffer.from(elemList[0].children[0].data, 'base64').toString()),
       );
     });
     it('should have a variant_id in the questionData', function () {
@@ -430,7 +430,7 @@ describe('Access control', function () {
           return callback(new Error('bad status: ' + response.statusCode));
         }
         callback(null);
-      }
+      },
     );
   };
 

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -278,21 +278,21 @@ describe('accessibility', () => {
 
     const firstNewsItemResult = await sqldb.queryOneRowAsync(
       'SELECT id FROM news_items ORDER BY id ASC LIMIT 1',
-      {}
+      {},
     );
 
     const questionGalleryAssessmentResult = await sqldb.queryOneRowAsync(
       'SELECT id FROM assessments WHERE tid = $tid',
       {
         tid: 'gallery/elements',
-      }
+      },
     );
 
     const codeElementQuestionResult = await sqldb.queryOneRowAsync(
       'SELECT id FROM questions WHERE qid = $qid',
       {
         qid: 'element/code',
-      }
+      },
     );
 
     routeParams = {

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -68,7 +68,7 @@ describe('Exam and homework assessment with active access restriction', function
       assert.isTrue(response.ok);
 
       assert.lengthOf(response.$('a:contains("Test Active Access Rule")'), 0);
-    }
+    },
   );
 
   step('try to access the exam when no access rule applies', async () => {
@@ -90,7 +90,7 @@ describe('Exam and homework assessment with active access restriction', function
 
       assert.lengthOf(response.$('td:contains("Test Active Access Rule")'), 1);
       assert.lengthOf(response.$('a:contains("Test Active Access Rule")'), 0); // there should be no link
-    }
+    },
   );
 
   step('try to access the exam when it is not active', async () => {
@@ -120,7 +120,7 @@ describe('Exam and homework assessment with active access restriction', function
       assert.isTrue(response.ok);
 
       assert.lengthOf(response.$('a:contains("Test Active Access Rule")'), 1);
-    }
+    },
   );
 
   step('visit start exam page when the exam is active', async () => {
@@ -196,7 +196,7 @@ describe('Exam and homework assessment with active access restriction', function
       assert.isTrue(response.ok);
 
       assert.lengthOf(response.$('a:contains("Test Active Access Rule")'), 1);
-    }
+    },
   );
 
   step('access the exam when it is no longer active', async () => {
@@ -232,7 +232,7 @@ describe('Exam and homework assessment with active access restriction', function
 
       assert.lengthOf(response.$('div.test-suite-assessment-closed-message'), 1);
       assert.lengthOf(response.$('div.progress'), 0); // score should NOT be shown
-    }
+    },
   );
 
   step('try to access the homework when it is not active', async () => {
@@ -322,7 +322,7 @@ describe('Exam and homework assessment with active access restriction', function
       assert.match(msg.text(), /Assessment will become available on 2030-01-01 00:00:01/);
 
       assert.lengthOf(response.$('div.progress'), 1); // score should be shown
-    }
+    },
   );
 
   step(
@@ -334,7 +334,7 @@ describe('Exam and homework assessment with active access restriction', function
         headers,
       });
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step(
@@ -352,7 +352,7 @@ describe('Exam and homework assessment with active access restriction', function
       assert.match(msg.text(), /Assessment is no longer available\./);
 
       assert.lengthOf(response.$('div.progress'), 1); // score should be shown
-    }
+    },
   );
 
   step('submit an answer to a question when active is false', async () => {
@@ -382,7 +382,7 @@ describe('Exam and homework assessment with active access restriction', function
 
       const result = await sqldb.queryOneRowAsync(sql.read_assessment_instance_points, params);
       assert.equal(result.rows[0].points, 0);
-    }
+    },
   );
 
   step('get CSRF token and variant ID for attaching file on question page', async () => {

--- a/apps/prairielearn/src/tests/api.test.js
+++ b/apps/prairielearn/src/tests/api.test.js
@@ -107,7 +107,7 @@ describe('API', function () {
 
       // Check that the token has the correct format
       assert.ok(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(locals.api_token)
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(locals.api_token),
       );
     });
   });

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -57,7 +57,7 @@ function getAllChunksForCourse(course_id) {
       course_instance_id: z.string().nullable(),
       assessment_id: z.string().nullable(),
       question_id: z.string().nullable(),
-    })
+    }),
   );
 }
 
@@ -66,7 +66,7 @@ describe('chunks', () => {
     it('should identify change in element', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['elements/my-special-element/impl.py'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.elements);
     });
@@ -74,7 +74,7 @@ describe('chunks', () => {
     it('should identify change in clientFilesCourse', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['clientFilesCourse/path/to/file.js'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.clientFilesCourse);
     });
@@ -82,7 +82,7 @@ describe('chunks', () => {
     it('should identify change in serverFilesCourse', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['serverFilesCourse/path/to/file.js'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.serverFilesCourse);
     });
@@ -90,7 +90,7 @@ describe('chunks', () => {
     it('should identify simple question', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['questions/simple-question/tests/test.py'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.questions.has('simple-question'));
     });
@@ -98,7 +98,7 @@ describe('chunks', () => {
     it('should identify complex question', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['questions/complex/question/tests/test.py'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.questions.has('complex/question'));
     });
@@ -108,10 +108,10 @@ describe('chunks', () => {
         [
           'courseInstances/simple-course-instance/assessments/simple-assessment/clientFilesAssessment/file.txt',
         ],
-        COURSE
+        COURSE,
       );
       assert.isOk(
-        chunks.courseInstances['simple-course-instance'].assessments.has('simple-assessment')
+        chunks.courseInstances['simple-course-instance'].assessments.has('simple-assessment'),
       );
     });
 
@@ -120,10 +120,10 @@ describe('chunks', () => {
         [
           'courseInstances/simple-course-instance/assessments/complex/assessment/clientFilesAssessment/file.txt',
         ],
-        COURSE
+        COURSE,
       );
       assert.isOk(
-        chunks.courseInstances['simple-course-instance'].assessments.has('complex/assessment')
+        chunks.courseInstances['simple-course-instance'].assessments.has('complex/assessment'),
       );
     });
 
@@ -132,10 +132,10 @@ describe('chunks', () => {
         [
           'courseInstances/complex/course/instance/assessments/simple-assessment/clientFilesAssessment/file.txt',
         ],
-        COURSE
+        COURSE,
       );
       assert.isOk(
-        chunks.courseInstances['complex/course/instance'].assessments.has('simple-assessment')
+        chunks.courseInstances['complex/course/instance'].assessments.has('simple-assessment'),
       );
     });
 
@@ -144,17 +144,17 @@ describe('chunks', () => {
         [
           'courseInstances/complex/course/instance/assessments/complex/assessment/clientFilesAssessment/file.txt',
         ],
-        COURSE
+        COURSE,
       );
       assert.isOk(
-        chunks.courseInstances['complex/course/instance'].assessments.has('complex/assessment')
+        chunks.courseInstances['complex/course/instance'].assessments.has('complex/assessment'),
       );
     });
 
     it('should identify clientFilesCourseInstance in simple course instance', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['courseInstances/simple-course-instance/clientFilesCourseInstance/file.txt'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.courseInstances['simple-course-instance'].clientFilesCourseInstance);
     });
@@ -162,7 +162,7 @@ describe('chunks', () => {
     it('should identify clientFilesCourseInstance in complex course instance', () => {
       const chunks = chunksLib.identifyChunksFromChangedFiles(
         ['courseInstances/complex/course/instance/clientFilesCourseInstance/file.txt'],
-        COURSE
+        COURSE,
       );
       assert.isOk(chunks.courseInstances['complex/course/instance'].clientFilesCourseInstance);
     });
@@ -172,28 +172,28 @@ describe('chunks', () => {
     it('works for elements chunk', () => {
       assert.equal(
         chunksLib.coursePathForChunk('/course/', { type: 'elements' }),
-        '/course/elements'
+        '/course/elements',
       );
     });
 
     it('works for elementExtensions chunk', () => {
       assert.equal(
         chunksLib.coursePathForChunk('/course/', { type: 'elementExtensions' }),
-        '/course/elementExtensions'
+        '/course/elementExtensions',
       );
     });
 
     it('works for clientFilesCourse chunk', () => {
       assert.equal(
         chunksLib.coursePathForChunk('/course/', { type: 'clientFilesCourse' }),
-        '/course/clientFilesCourse'
+        '/course/clientFilesCourse',
       );
     });
 
     it('works for serverFilesCourse chunk', () => {
       assert.equal(
         chunksLib.coursePathForChunk('/course/', { type: 'serverFilesCourse' }),
-        '/course/serverFilesCourse'
+        '/course/serverFilesCourse',
       );
     });
 
@@ -203,7 +203,7 @@ describe('chunks', () => {
           type: 'clientFilesCourseInstance',
           courseInstanceName: 'foo',
         }),
-        '/course/courseInstances/foo/clientFilesCourseInstance'
+        '/course/courseInstances/foo/clientFilesCourseInstance',
       );
     });
 
@@ -213,7 +213,7 @@ describe('chunks', () => {
           type: 'clientFilesCourseInstance',
           courseInstanceName: 'foo/bar',
         }),
-        '/course/courseInstances/foo/bar/clientFilesCourseInstance'
+        '/course/courseInstances/foo/bar/clientFilesCourseInstance',
       );
     });
 
@@ -224,7 +224,7 @@ describe('chunks', () => {
           courseInstanceName: 'foo',
           assessmentName: 'bar',
         }),
-        '/course/courseInstances/foo/assessments/bar/clientFilesAssessment'
+        '/course/courseInstances/foo/assessments/bar/clientFilesAssessment',
       );
     });
 
@@ -235,7 +235,7 @@ describe('chunks', () => {
           courseInstanceName: 'foo/bar',
           assessmentName: 'bar/baz',
         }),
-        '/course/courseInstances/foo/bar/assessments/bar/baz/clientFilesAssessment'
+        '/course/courseInstances/foo/bar/assessments/bar/baz/clientFilesAssessment',
       );
     });
 
@@ -245,7 +245,7 @@ describe('chunks', () => {
           type: 'question',
           questionName: 'foo',
         }),
-        '/course/questions/foo'
+        '/course/questions/foo',
       );
     });
 
@@ -255,7 +255,7 @@ describe('chunks', () => {
           type: 'question',
           questionName: 'foo/bar',
         }),
-        '/course/questions/foo/bar'
+        '/course/questions/foo/bar',
       );
     });
   });
@@ -386,8 +386,8 @@ describe('chunks', () => {
       // Check that the chunk was written to the correct location.
       assert.isOk(
         await fs.pathExists(
-          path.join(courseRuntimeDir, 'questions', 'addNumbers', 'addNumbersNested', 'info.json')
-        )
+          path.join(courseRuntimeDir, 'questions', 'addNumbers', 'addNumbersNested', 'info.json'),
+        ),
       );
     });
 
@@ -444,8 +444,8 @@ describe('chunks', () => {
       assert.isOk(await fs.pathExists(path.join(courseRuntimeDir, 'clientFilesCourse')));
       assert.isOk(
         await fs.pathExists(
-          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance')
-        )
+          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance'),
+        ),
       );
       assert.isOk(
         await fs.pathExists(
@@ -455,12 +455,14 @@ describe('chunks', () => {
             'Sp15',
             'assessments',
             'exam1-automaticTestSuite',
-            'clientFilesAssessment'
-          )
-        )
+            'clientFilesAssessment',
+          ),
+        ),
       );
       assert.isOk(
-        await fs.pathExists(path.join(courseRuntimeDir, 'questions', 'addNumbers', 'question.html'))
+        await fs.pathExists(
+          path.join(courseRuntimeDir, 'questions', 'addNumbers', 'question.html'),
+        ),
       );
 
       // Remove subset of directories from the course
@@ -495,8 +497,8 @@ describe('chunks', () => {
       assert.isOk(await fs.pathExists(path.join(courseRuntimeDir, 'clientFilesCourse')));
       assert.isOk(
         await fs.pathExists(
-          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance')
-        )
+          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance'),
+        ),
       );
       assert.isOk(
         await fs.pathExists(
@@ -506,9 +508,9 @@ describe('chunks', () => {
             'Sp15',
             'assessments',
             'exam1-automaticTestSuite',
-            'clientFilesAssessment'
-          )
-        )
+            'clientFilesAssessment',
+          ),
+        ),
       );
       assert.isOk(await fs.pathExists(path.join(courseRuntimeDir, 'questions', 'addNumbers')));
 
@@ -519,13 +521,13 @@ describe('chunks', () => {
         databaseChunks.find(
           (chunk) =>
             chunk.type === 'clientFilesCourseInstance' &&
-            chunk.course_instance_id === courseInstanceId
-        )
+            chunk.course_instance_id === courseInstanceId,
+        ),
       );
       assert.isOk(
         databaseChunks.find(
-          (chunk) => chunk.type === 'clientFilesAssessment' && chunk.assessment_id === assessmentId
-        )
+          (chunk) => chunk.type === 'clientFilesAssessment' && chunk.assessment_id === assessmentId,
+        ),
       );
       assert.isOk(databaseChunks.find((chunk) => chunk.type === 'question' && chunk.question_id));
 
@@ -540,8 +542,8 @@ describe('chunks', () => {
           'Sp15',
           'assessments',
           'exam1-automaticTestSuite',
-          'clientFilesAssessment'
-        )
+          'clientFilesAssessment',
+        ),
       );
       await fs.remove(path.join(courseDir, 'questions', 'addNumbers'));
 
@@ -563,8 +565,8 @@ describe('chunks', () => {
       assert.isNotOk(await fs.pathExists(path.join(courseRuntimeDir, 'clientFilesCourse')));
       assert.isNotOk(
         await fs.pathExists(
-          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance')
-        )
+          path.join(courseRuntimeDir, 'courseInstances', 'Sp15', 'clientFilesCourseInstance'),
+        ),
       );
       assert.isNotOk(
         await fs.pathExists(
@@ -574,12 +576,14 @@ describe('chunks', () => {
             'Sp15',
             'assessments',
             'exam1-automaticTestSuite',
-            'clientFilesAssessment'
-          )
-        )
+            'clientFilesAssessment',
+          ),
+        ),
       );
       assert.isNotOk(
-        await fs.pathExists(path.join(courseRuntimeDir, 'questions', 'addNumbers', 'question.html'))
+        await fs.pathExists(
+          path.join(courseRuntimeDir, 'questions', 'addNumbers', 'question.html'),
+        ),
       );
 
       // Assert that the remaining chunks have been deleted from the database
@@ -590,18 +594,18 @@ describe('chunks', () => {
         databaseChunks.find(
           (chunk) =>
             chunk.type === 'clientFilesCourseInstance' &&
-            chunk.course_instance_id === courseInstanceId
-        )
+            chunk.course_instance_id === courseInstanceId,
+        ),
       );
       assert.isUndefined(
         databaseChunks.find(
-          (chunk) => chunk.type === 'clientFilesAssessment' && chunk.assessment_id === assessmentId
-        )
+          (chunk) => chunk.type === 'clientFilesAssessment' && chunk.assessment_id === assessmentId,
+        ),
       );
       assert.isUndefined(
         databaseChunks.find(
-          (chunk) => chunk.type === 'question' && chunk.question_id === questionId
-        )
+          (chunk) => chunk.type === 'question' && chunk.question_id === questionId,
+        ),
       );
     });
   });

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -540,7 +540,7 @@ function createCourseFiles(callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 
@@ -569,7 +569,7 @@ function deleteCourseFiles(callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -30,7 +30,7 @@ describe('Course element extensions', function () {
       assert.isTrue(element in loaded, `did not find element ${element} in loaded extensions`);
       assert(
         _.isEqual(Object.keys(loaded[element]).sort(), element_extensions.sort()),
-        'could not load all extensions'
+        'could not load all extensions',
       );
     };
 
@@ -66,11 +66,11 @@ describe('Course element extensions', function () {
     it("shouldn't fail when there are no extensions to load", async () => {
       const extensions = await freeform.loadExtensions(
         path.join(TEST_COURSE_PATH, 'elementExtensions'),
-        path.join(TEST_COURSE_PATH, 'elementExtensions')
+        path.join(TEST_COURSE_PATH, 'elementExtensions'),
       );
       assert.isEmpty(
         extensions,
-        'non-zero number of extensions were loaded from a course without extensions'
+        'non-zero number of extensions were loaded from a course without extensions',
       );
     });
   });
@@ -129,7 +129,7 @@ describe('Course element extensions', function () {
       assert(found_image !== null, 'could not find image on page');
 
       const image_response = await helperClient.fetchCheerio(
-        locals.siteUrl + found_image.attribs.src
+        locals.siteUrl + found_image.attribs.src,
       );
       assert.isTrue(image_response.ok, 'could not fetch image');
     });

--- a/apps/prairielearn/src/tests/database.test.js
+++ b/apps/prairielearn/src/tests/database.test.js
@@ -54,13 +54,13 @@ describe('database', function () {
       _.some(data.tables[table].columns, { name: 'deleted_at' });
     const [softDeleteTables, hardDeleteTables] = _.partition(
       _.keys(data.tables),
-      tableHasDeletedAtColumn
+      tableHasDeletedAtColumn,
     );
 
     for (const table of softDeleteTables) {
       for (const constraint of data.tables[table].foreignKeyConstraints) {
         const match = constraint.def.match(
-          /^FOREIGN KEY \((.*)\) REFERENCES (.*)\(.*\) ON UPDATE .* ON DELETE (.*)$/
+          /^FOREIGN KEY \((.*)\) REFERENCES (.*)\(.*\) ON UPDATE .* ON DELETE (.*)$/,
         );
         if (!match) {
           throw new Error(`Failed to match foreign key for ${table}: ${constraint.def}`);
@@ -68,7 +68,7 @@ describe('database', function () {
         const [, keyName, otherTable, deleteAction] = match;
         if (deleteAction === 'CASCADE' && _.includes(hardDeleteTables, otherTable)) {
           throw new Error(
-            `Soft-delete table "${table}" has ON DELETE CASCADE foreign key "${keyName}" to hard-delete table "${otherTable}"`
+            `Soft-delete table "${table}" has ON DELETE CASCADE foreign key "${keyName}" to hard-delete table "${otherTable}"`,
           );
         }
       }

--- a/apps/prairielearn/src/tests/editorUtil.test.js
+++ b/apps/prairielearn/src/tests/editorUtil.test.js
@@ -27,7 +27,7 @@ describe('editor library', () => {
   it('gets details for assessment info file', () => {
     const details = /** @type {import('../lib/editorUtil').AssessmentInfo} */ (
       editor.getDetailsForFile(
-        'courseInstances/testinstance/assessments/testassessment/infoAssessment.json'
+        'courseInstances/testinstance/assessments/testassessment/infoAssessment.json',
       )
     );
     assert.equal(details.type, 'assessment');

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -139,7 +139,7 @@ describe('Enroll page (enterprise)', function () {
     await queryAsync('UPDATE course_instances SET enrollment_limit = NULL WHERE id = 1', {});
     await queryAsync(
       'UPDATE institutions SET course_instance_enrollment_limit = 1 WHERE id = 1',
-      {}
+      {},
     );
   });
 
@@ -169,7 +169,7 @@ describe('Enroll page (enterprise)', function () {
     await queryAsync('UPDATE course_instances SET enrollment_limit = NULL WHERE id = 1', {});
     await queryAsync(
       'UPDATE institutions SET course_instance_enrollment_limit = 100000, yearly_enrollment_limit = 2 WHERE id = 1',
-      {}
+      {},
     );
   });
 

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -1462,9 +1462,9 @@ describe('Exam assessment', function () {
       helperExam.startExam(locals);
 
       partialCreditTest.forEach(function (questionTest, iQuestionTest) {
-        describe(`${
-          questionTest.action
-        } answer number #${iQuestionTest + 1} for question ${questionTest.qid} with score ${questionTest.score}`, function () {
+        describe(`${questionTest.action} answer number #${iQuestionTest + 1} for question ${
+          questionTest.qid
+        } with score ${questionTest.score}`, function () {
           describe('setting up the submission data', function () {
             it('should succeed', function () {
               if (questionTest.action === 'check-closed') {

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -43,50 +43,50 @@ const questionHtmlPath = path.join(questionPath, 'question.html');
 const questionPythonPath = path.join(questionPath, 'server.py');
 
 const infoCourseJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
 );
 let infoCourseJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
 );
 infoCourseJsonB.title = 'Test Course (Renamed)';
 let infoCourseJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
 );
 infoCourseJsonC.title = 'Test Course (Renamed Yet Again)';
 
 const infoCourseInstanceJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
 );
 let infoCourseInstanceJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
 );
 infoCourseInstanceJsonB.longName = 'Fall 2019';
 let infoCourseInstanceJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
 );
 infoCourseInstanceJsonC.longName = 'Spring 2020';
 
 const infoAssessmentJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
 );
 let infoAssessmentJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
 );
 infoAssessmentJsonB.title = 'Homework for file editor test (Renamed)';
 let infoAssessmentJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
 );
 infoAssessmentJsonC.title = 'Homework for file editor test (Renamed Yet Aagain)';
 
 const questionJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
 );
 let questionJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
 );
 questionJsonB.title = 'Test question (Renamed)';
 let questionJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8')
+  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
 );
 questionJsonC.title = 'Test question (Renamed Yet Again)';
 
@@ -367,7 +367,7 @@ function badPost(action, fileEditContents, url) {
             return callback(new Error('bad status: ' + response.statusCode + '\n' + body));
           }
           callback(null);
-        }
+        },
       );
     });
   });
@@ -452,7 +452,7 @@ function createCourseFiles(callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 
@@ -481,7 +481,7 @@ function deleteCourseFiles(callback) {
     (err) => {
       if (ERR(err, callback)) return;
       callback(null);
-    }
+    },
   );
 }
 
@@ -491,7 +491,7 @@ function editPost(
   url,
   expectedToFindResults,
   expectedToFindChoice,
-  expectedDiskContents
+  expectedDiskContents,
 ) {
   describe(`POST to edit url with action ${action}`, function () {
     it('should load successfully', function (callback) {
@@ -518,7 +518,7 @@ function editPost(
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -529,7 +529,7 @@ function editPost(
         expectedToFindResults,
         expectedToFindChoice,
         fileEditContents,
-        expectedDiskContents
+        expectedDiskContents,
       );
     }
   });
@@ -572,7 +572,7 @@ function verifyEdit(
   expectedToFindResults,
   expectedToFindChoice,
   expectedDraftContents,
-  expectedDiskContents
+  expectedDiskContents,
 ) {
   it('should have a CSRF token', function () {
     elemList = locals.$('form[name="editor-form"] input[name="__csrf_token"]');
@@ -624,7 +624,7 @@ function verifyEdit(
         if (elem.children.length > 0) {
           if (Object.prototype.hasOwnProperty.call(elem.children[0], 'data')) {
             let match = elem.children[0].data.match(
-              /{[^{]*contents: "([^"]*)"[^{]*elementId: "file-editor-([^"]*)-draft"[^{]*}/ms
+              /{[^{]*contents: "([^"]*)"[^{]*elementId: "file-editor-([^"]*)-draft"[^{]*}/ms,
             );
             if (match != null) {
               locals.fileContents = b64Util.b64DecodeUnicode(match[1]);
@@ -655,7 +655,7 @@ function verifyEdit(
         if (elem.children.length > 0) {
           if (Object.prototype.hasOwnProperty.call(elem.children[0], 'data')) {
             let match = elem.children[0].data.match(
-              /{[^{]*contents: "([^"]*)"[^{]*elementId: "file-editor-([^"]*)-disk"[^{]*}/ms
+              /{[^{]*contents: "([^"]*)"[^{]*elementId: "file-editor-([^"]*)-disk"[^{]*}/ms,
             );
             if (match != null) {
               if (expectedToFindChoice) {
@@ -687,7 +687,7 @@ function editGet(
   expectedToFindResults,
   expectedToFindChoice,
   expectedDraftContents,
-  expectedDiskContents
+  expectedDiskContents,
 ) {
   describe(`GET to edit url`, function () {
     it('should load successfully', function (callback) {
@@ -711,7 +711,7 @@ function editGet(
       expectedToFindResults,
       expectedToFindChoice,
       expectedDraftContents,
-      expectedDiskContents
+      expectedDiskContents,
     );
   });
 }
@@ -1146,7 +1146,7 @@ function testUploadFile(params) {
       const $ = cheerio.load(elemList[0].attribs['data-content']);
       // __csrf_token
       elemList = $(
-        `form[name="instructor-file-upload-form-${params.id}"] input[name="__csrf_token"]`
+        `form[name="instructor-file-upload-form-${params.id}"] input[name="__csrf_token"]`,
       );
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
@@ -1161,7 +1161,7 @@ function testUploadFile(params) {
         locals.working_path = undefined;
       } else {
         elemList = $(
-          `form[name="instructor-file-upload-form-${params.id}"] input[name="working_path"]`
+          `form[name="instructor-file-upload-form-${params.id}"] input[name="working_path"]`,
         );
         assert.lengthOf(elemList, 1);
         assert.nestedProperty(elemList[0], 'attribs.value');
@@ -1211,7 +1211,7 @@ function testRenameFile(params) {
       const $ = cheerio.load(elemList[0].attribs['data-content']);
       // __csrf_token
       elemList = $(
-        `form[name="instructor-file-rename-form-${params.id}"] input[name="__csrf_token"]`
+        `form[name="instructor-file-rename-form-${params.id}"] input[name="__csrf_token"]`,
       );
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
@@ -1219,14 +1219,14 @@ function testRenameFile(params) {
       assert.isString(locals.__csrf_token);
       // old_file_name
       elemList = $(
-        `form[name="instructor-file-rename-form-${params.id}"] input[name="old_file_name"]`
+        `form[name="instructor-file-rename-form-${params.id}"] input[name="old_file_name"]`,
       );
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
       locals.old_file_name = elemList[0].attribs.value;
       // working_path
       elemList = $(
-        `form[name="instructor-file-rename-form-${params.id}"] input[name="working_path"]`
+        `form[name="instructor-file-rename-form-${params.id}"] input[name="working_path"]`,
       );
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
@@ -1265,7 +1265,7 @@ function testDeleteFile(params) {
       const $ = cheerio.load(elemList[0].attribs['data-content']);
       // __csrf_token
       elemList = $(
-        `form[name="instructor-file-delete-form-${params.id}"] input[name="__csrf_token"]`
+        `form[name="instructor-file-delete-form-${params.id}"] input[name="__csrf_token"]`,
       );
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -21,7 +21,7 @@ const defaultUser = {
 };
 
 const fibonacciSolution = fs.readFileSync(
-  path.resolve(TEST_COURSE_PATH, 'questions', 'externalGrade', 'codeUpload', 'tests', 'ans.py')
+  path.resolve(TEST_COURSE_PATH, 'questions', 'externalGrade', 'codeUpload', 'tests', 'ans.py'),
 );
 
 const mockStudents = [
@@ -55,7 +55,7 @@ const waitForExternalGrader = async ($questionsPage) => {
       function (msg) {
         if (!msg) return reject(new Error('Socket initialization failed'));
         handleStatusChange(msg);
-      }
+      },
     );
 
     socket.on('change:status', function (msg) {
@@ -81,7 +81,7 @@ const loadHomeworkPage = async (user) => {
   hm9InternalExternalManaulUrl =
     siteUrl +
     $courseInstancePage(
-      'a:contains("Homework for Internal, External, Manual grading methods")'
+      'a:contains("Homework for Internal, External, Manual grading methods")',
     ).attr('href');
   let res = await fetch(hm9InternalExternalManaulUrl);
   assert.equal(res.ok, true);
@@ -197,7 +197,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
-              'href'
+              'href',
             );
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
@@ -219,7 +219,7 @@ describe('Grading method(s)', function () {
         it('should display submission status', async () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
-            'manual grading: waiting for grading'
+            'manual grading: waiting for grading',
           );
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -234,7 +234,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body('a:contains("HW9.2. Manual Grading: Fibonacci function, file upload")').attr(
-              'href'
+              'href',
             );
         });
         it('should be possible to submit a save action to "Manual" type question', async () => {
@@ -253,7 +253,7 @@ describe('Grading method(s)', function () {
         it('should display submission status', async () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
-            'manual grading: waiting for grading'
+            'manual grading: waiting for grading',
           );
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -270,7 +270,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body('a:contains("HW9.3. External Grading: Fibonacci function, file upload")').attr(
-              'href'
+              'href',
             );
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
@@ -312,7 +312,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body('a:contains("HW9.3. External Grading: Fibonacci function, file upload")').attr(
-              'href'
+              'href',
             );
 
           gradeRes = await saveOrGrade(iqUrl, {}, 'save', [
@@ -349,7 +349,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body(
-              'a:contains("HW9.5. Manual Grading: Adding two numbers (with auto points)")'
+              'a:contains("HW9.5. Manual Grading: Adding two numbers (with auto points)")',
             ).attr('href');
 
           // open page to produce variant because we want to get the correct answer
@@ -389,7 +389,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body(
-              'a:contains("HW9.5. Manual Grading: Adding two numbers (with auto points)")'
+              'a:contains("HW9.5. Manual Grading: Adding two numbers (with auto points)")',
             ).attr('href');
 
           // open page to produce variant because we want to get the correct answer
@@ -428,7 +428,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body(
-              'a:contains("HW9.4. Internal Grading: Adding two numbers (with manual points)")'
+              'a:contains("HW9.4. Internal Grading: Adding two numbers (with manual points)")',
             ).attr('href');
 
           // open page to produce variant because we want to get the correct answer
@@ -454,7 +454,7 @@ describe('Grading method(s)', function () {
         it('should display submission status', async () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
-            'manual grading: waiting for grading'
+            'manual grading: waiting for grading',
           );
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -469,7 +469,7 @@ describe('Grading method(s)', function () {
           iqUrl =
             siteUrl +
             $hm1Body(
-              'a:contains("HW9.4. Internal Grading: Adding two numbers (with manual points)")'
+              'a:contains("HW9.4. Internal Grading: Adding two numbers (with manual points)")',
             ).attr('href');
 
           // open page to produce variant because we want to get the correct answer
@@ -492,7 +492,7 @@ describe('Grading method(s)', function () {
         it('should display submission status', async () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
-            'manual grading: waiting for grading'
+            'manual grading: waiting for grading',
           );
         });
         it('should NOT result in "grading-block" component being displayed', () => {

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -41,7 +41,7 @@ describe('test auto group and delete groups', function () {
       authn_user_id,
       max_group_size,
       min_group_size,
-      option
+      option,
     );
     await helperServer.waitForJobSequenceAsync(job_sequence_id);
   });
@@ -49,7 +49,7 @@ describe('test auto group and delete groups', function () {
   step('check groups and users', async () => {
     const groupUserCounts = await sqldb.queryAsync(
       'SELECT count(group_id) FROM group_users GROUP BY group_id',
-      []
+      [],
     );
     assert.equal(groupUserCounts.rows.length, 50);
 
@@ -62,7 +62,7 @@ describe('test auto group and delete groups', function () {
 
     const groups = await sqldb.queryAsync(
       'SELECT deleted_at FROM groups WHERE deleted_at IS NULL',
-      []
+      [],
     );
     assert.equal(groups.rows.length, 0);
 

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -377,7 +377,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.roleUpdates,
       locals.groupRoles,
       locals.studentUsers,
-      locals.assessmentUrl
+      locals.assessmentUrl,
     );
   });
 
@@ -393,7 +393,7 @@ describe('Test group based assessments with custom group roles from student side
 
   step('should have error displayed for requiring all users have a role', function () {
     elemList = locals.$(
-      '.alert:contains(At least one user does not have a role. All users must have a role.)'
+      '.alert:contains(At least one user does not have a role. All users must have a role.)',
     );
     assert.lengthOf(elemList, 1);
   });
@@ -446,7 +446,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.roleUpdates,
       locals.groupRoles,
       locals.studentUsers,
-      locals.assessmentUrl
+      locals.assessmentUrl,
     );
   });
 
@@ -457,13 +457,13 @@ describe('Test group based assessments with custom group roles from student side
         locals.studentUsers[1],
         locals.assessmentUrl,
         '00000002',
-        2
+        2,
       );
 
       elemList = locals.$('#role-select-form').find('tr');
       // Header row and two user rows
       assert.lengthOf(elemList, 3);
-    }
+    },
   );
 
   step('displays errors for incorrect number of role assignments', function () {
@@ -495,7 +495,7 @@ describe('Test group based assessments with custom group roles from student side
         { roleId: locals.recorder.id, groupUserId: locals.studentUsers[1].user_id },
       ];
       await verifyRoleAssignmentsInDatabase(expectedRoleUpdates, locals.assessment_id);
-    }
+    },
   );
 
   step('third user can load assessment and join group', async function () {
@@ -590,9 +590,9 @@ describe('Test group based assessments with custom group roles from student side
         locals.roleUpdates,
         locals.groupRoles,
         locals.studentUsers,
-        locals.assessmentUrl
+        locals.assessmentUrl,
       );
-    }
+    },
   );
 
   step('database contains correct role configuration after reassigning roles', async function () {
@@ -638,7 +638,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.roleUpdates,
       locals.groupRoles,
       locals.studentUsers,
-      locals.assessmentUrl
+      locals.assessmentUrl,
     );
   });
 
@@ -646,7 +646,7 @@ describe('Test group based assessments with custom group roles from student side
     'should have correct role configuration in the database after assigning two recorders',
     async function () {
       await verifyRoleAssignmentsInDatabase(locals.roleUpdates, locals.assessment_id);
-    }
+    },
   );
 
   step('should have correct roles checked in the table', async function () {
@@ -677,7 +677,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.roleUpdates,
       locals.groupRoles,
       locals.studentUsers,
-      locals.assessmentUrl
+      locals.assessmentUrl,
     );
   });
 
@@ -719,7 +719,7 @@ describe('Test group based assessments with custom group roles from student side
         { roleId: locals.reflector.id, groupUserId: locals.studentUsers[2].user_id },
       ];
       await verifyRoleAssignmentsInDatabase(locals.roleUpdates, locals.assessment_id);
-    }
+    },
   );
 
   step('first user should see correct roles checked in the table', async function () {
@@ -754,7 +754,7 @@ describe('Test group based assessments with custom group roles from student side
         locals.studentUsers[4],
         locals.assessmentUrl,
         '00000005',
-        2
+        2,
       );
       await joinGroup(locals.assessmentUrl, locals.joinCode);
 
@@ -767,7 +767,7 @@ describe('Test group based assessments with custom group roles from student side
         { roleId: locals.contributor.id, groupUserId: locals.studentUsers[4].user_id },
       ];
       await verifyRoleAssignmentsInDatabase(locals.roleUpdates, locals.assessment_id);
-    }
+    },
   );
 
   step('first user should see five roles checked in the table', async function () {
@@ -792,7 +792,7 @@ describe('Test group based assessments with custom group roles from student side
         locals.roleUpdates,
         locals.groupRoles,
         locals.studentUsers,
-        locals.assessmentUrl
+        locals.assessmentUrl,
       );
       await verifyRoleAssignmentsInDatabase(locals.roleUpdates, locals.assessment_id);
 
@@ -802,7 +802,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.$ = cheerio.load(await res.text());
 
       verifyRoleAssignmentsInRoleTable(locals.roleUpdates);
-    }
+    },
   );
 
   step(
@@ -813,7 +813,7 @@ describe('Test group based assessments with custom group roles from student side
         locals.studentUsers[4],
         locals.assessmentUrl,
         '00000005',
-        2
+        2,
       );
       await leaveGroup(locals.assessmentUrl);
 
@@ -841,14 +841,14 @@ describe('Test group based assessments with custom group roles from student side
       assert.lengthOf(result.rows, 4);
 
       const secondUserRoles = result.rows.filter(
-        (row) => row.user_id === locals.studentUsers[1].user_id
+        (row) => row.user_id === locals.studentUsers[1].user_id,
       );
       assert.isTrue(secondUserRoles.length === 1);
 
       const secondUserRole = secondUserRoles[0];
       assert.isTrue(
         secondUserRole.group_role_id === locals.recorder.id ||
-          secondUserRole.group_role_id === locals.contributor.id
+          secondUserRole.group_role_id === locals.contributor.id,
       );
 
       const roleUpdates = secondUserRole.id === locals.recorder.id ? roleUpdates1 : roleUpdates2;
@@ -859,7 +859,7 @@ describe('Test group based assessments with custom group roles from student side
 
       assert.sameDeepMembers(expected, result.rows);
       locals.roleUpdates = roleUpdates;
-    }
+    },
   );
 
   step(
@@ -870,11 +870,11 @@ describe('Test group based assessments with custom group roles from student side
         locals.studentUsers[0],
         locals.assessmentUrl,
         '00000001',
-        3
+        3,
       );
 
       verifyRoleAssignmentsInRoleTable(locals.roleUpdates);
-    }
+    },
   );
 
   step(
@@ -893,7 +893,7 @@ describe('Test group based assessments with custom group roles from student side
         locals.roleUpdates,
         locals.groupRoles,
         locals.studentUsers,
-        locals.assessmentUrl
+        locals.assessmentUrl,
       );
       await verifyRoleAssignmentsInDatabase(locals.roleUpdates, locals.assessment_id);
 
@@ -903,7 +903,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.$ = cheerio.load(await res.text());
 
       verifyRoleAssignmentsInRoleTable(locals.roleUpdates);
-    }
+    },
   );
 
   step('should be able to switch to fourth user and leave group', async function () {
@@ -927,10 +927,10 @@ describe('Test group based assessments with custom group roles from student side
         locals.studentUsers[0],
         locals.assessmentUrl,
         '00000001',
-        3
+        3,
       );
       verifyRoleAssignmentsInRoleTable(locals.roleUpdates);
-    }
+    },
   );
 
   step('should be able to switch to fourth user and leave group', async function () {
@@ -965,7 +965,7 @@ describe('Test group based assessments with custom group roles from student side
 
       // Get all roles for first user
       const firstUserRoleUpdates = result.rows.filter(
-        (row) => row.user_id === locals.studentUsers[0].user_id
+        (row) => row.user_id === locals.studentUsers[0].user_id,
       );
       assert.isTrue(firstUserRoleUpdates.length === 1 || firstUserRoleUpdates.length === 2);
 
@@ -977,7 +977,7 @@ describe('Test group based assessments with custom group roles from student side
 
       assert.sameDeepMembers(expected, result.rows);
       locals.roleUpdates = roleUpdates;
-    }
+    },
   );
 
   step(
@@ -987,10 +987,10 @@ describe('Test group based assessments with custom group roles from student side
         locals.studentUsers[0],
         locals.assessmentUrl,
         '00000001',
-        3
+        3,
       );
       verifyRoleAssignmentsInRoleTable(locals.roleUpdates);
-    }
+    },
   );
 
   step('all required roles of a leaving user should be transferred if possible', async function () {
@@ -1021,7 +1021,7 @@ describe('Test group based assessments with custom group roles from student side
       locals.studentUsers[0],
       locals.assessmentUrlWithoutRoles,
       '00000001',
-      2
+      2,
     );
   });
 
@@ -1057,7 +1057,7 @@ const changeGroupRolesConfig = async (courseDir, groupRoles) => {
     'Sp15',
     'assessments',
     'hw5-templateGroupWork',
-    'infoAssessment.json'
+    'infoAssessment.json',
   );
   const infoAssessment = await fs.readJSON(infoAssessmentPath);
   infoAssessment.groupRoles = groupRoles;
@@ -1314,9 +1314,9 @@ describe('Test group role reassignments with role of minimum > 1', function () {
           locals.roleUpdates,
           locals.groupRoles,
           locals.studentUsers,
-          assessmentUrl
+          assessmentUrl,
         );
-      }
+      },
     );
 
     step(
@@ -1333,14 +1333,14 @@ describe('Test group role reassignments with role of minimum > 1', function () {
 
         // Group role table should also have all role updates plus assigner role
         verifyRoleAssignmentsInRoleTable(locals.roleUpdates);
-      }
+      },
     );
 
     step('should have no errors displayed', function () {
       elemList = locals.$('.alert:contains(to be assigned)');
       assert.lengthOf(elemList, 0);
       elemList = locals.$(
-        '.alert:contains(At least one user does not have a role. All users must have a role.)'
+        '.alert:contains(At least one user does not have a role. All users must have a role.)',
       );
       assert.lengthOf(elemList, 0);
     });
@@ -1391,7 +1391,7 @@ describe('Test group role reassignments with role of minimum > 1', function () {
       elemList = locals.$('.alert:contains(to be assigned)');
       assert.lengthOf(elemList, 0);
       elemList = locals.$(
-        '.alert:contains(At least one user does not have a role. All users must have a role.)'
+        '.alert:contains(At least one user does not have a role. All users must have a role.)',
       );
       assert.lengthOf(elemList, 0);
     });
@@ -1422,7 +1422,7 @@ describe('Test group role reassignments with role of minimum > 1', function () {
         locals.roleUpdates,
         locals.groupRoles,
         locals.studentUsers,
-        assessmentUrl
+        assessmentUrl,
       );
 
       // Verify update in database
@@ -1437,7 +1437,7 @@ describe('Test group role reassignments with role of minimum > 1', function () {
 
     step('should have correct errors displayed', function () {
       elemList = locals.$(
-        '.alert:contains(A user has too many roles. Every student should be assigned to exactly one role with group size 5)'
+        '.alert:contains(A user has too many roles. Every student should be assigned to exactly one role with group size 5)',
       );
       assert.lengthOf(elemList, 1);
     });
@@ -1472,7 +1472,7 @@ describe('Test group role reassignments with role of minimum > 1', function () {
         locals.roleUpdates,
         locals.groupRoles,
         locals.studentUsers,
-        assessmentUrl
+        assessmentUrl,
       );
 
       // Verify update in database
@@ -1487,11 +1487,11 @@ describe('Test group role reassignments with role of minimum > 1', function () {
 
     step('should have correct errors displayed', function () {
       elemList = locals.$(
-        '.alert:contains(1 more person needs to be assigned Recorder. (Found 1, expected exactly 2).)'
+        '.alert:contains(1 more person needs to be assigned Recorder. (Found 1, expected exactly 2).)',
       );
       assert.lengthOf(elemList, 0);
       elemList = locals.$(
-        '.alert:contains(At least one user does not have a role. All users must have a role.)'
+        '.alert:contains(At least one user does not have a role. All users must have a role.)',
       );
       assert.lengthOf(elemList, 1);
     });
@@ -1518,7 +1518,7 @@ describe('Test group role reassignments with role of minimum > 1', function () {
         locals.roleUpdates,
         locals.groupRoles,
         locals.studentUsers,
-        assessmentUrl
+        assessmentUrl,
       );
 
       // Verify in database
@@ -1536,12 +1536,12 @@ describe('Test group role reassignments with role of minimum > 1', function () {
       assert.lengthOf(elemList, 0);
 
       elemList = locals.$(
-        '.alert:contains(At least one user does not have a role. All users must have a role.)'
+        '.alert:contains(At least one user does not have a role. All users must have a role.)',
       );
       assert.lengthOf(elemList, 1);
 
       elemList = locals.$(
-        '.alert:contains(A user has too many roles. Every student should be assigned to exactly one role with group size 4)'
+        '.alert:contains(A user has too many roles. Every student should be assigned to exactly one role with group size 4)',
       );
       assert.lengthOf(elemList, 1);
     });
@@ -1570,7 +1570,7 @@ describe('Test group role reassignments with role of minimum > 1', function () {
           { roleId: locals.reflector.id, groupUserId: locals.studentUsers[2].user_id },
         ];
         await verifyRoleAssignmentsInDatabase(locals.roleUpdates, assessmentId);
-      }
+      },
     );
 
     step('first user sees group role table with three users', async function () {
@@ -1602,21 +1602,21 @@ describe('Test group role reassignments with role of minimum > 1', function () {
         // Ensure that there are two recorder assignments, one manager, and one reflector, and no contributors
         assert.lengthOf(
           result.rows.filter(({ group_role_id }) => group_role_id === locals.manager.id),
-          1
+          1,
         );
         assert.lengthOf(
           result.rows.filter(({ group_role_id }) => group_role_id === locals.recorder.id),
-          2
+          2,
         );
         assert.lengthOf(
           result.rows.filter(({ group_role_id }) => group_role_id === locals.reflector.id),
-          1
+          1,
         );
         assert.lengthOf(
           result.rows.filter(({ group_role_id }) => group_role_id === locals.contributor.id),
-          0
+          0,
         );
-      }
+      },
     );
   });
 });
@@ -1726,7 +1726,7 @@ describe('Test group role reassignment logic when user leaves', function () {
       // Get role reassignments if second user leaves
       const result = getGroupRoleReassignmentsAfterLeave(
         locals.groupInfo,
-        locals.studentUsers[1].user_id
+        locals.studentUsers[1].user_id,
       );
       // Recorder role should be transferred to first user
       const expected = [
@@ -1740,7 +1740,7 @@ describe('Test group role reassignment logic when user leaves', function () {
         },
       ];
       assert.sameDeepMembers(result, expected);
-    }
+    },
   );
 
   step(
@@ -1769,7 +1769,7 @@ describe('Test group role reassignment logic when user leaves', function () {
       // Get role reassignments if first user leaves
       const result = getGroupRoleReassignmentsAfterLeave(
         locals.groupInfo,
-        locals.studentUsers[0].user_id
+        locals.studentUsers[0].user_id,
       );
       // Manager role should replace first user's contributor role
       const expected = [
@@ -1779,7 +1779,7 @@ describe('Test group role reassignment logic when user leaves', function () {
         },
       ];
       assert.sameDeepMembers(result, expected);
-    }
+    },
   );
 
   step(
@@ -1816,7 +1816,7 @@ describe('Test group role reassignment logic when user leaves', function () {
       // Get role reassignments if first user leaves
       const result = getGroupRoleReassignmentsAfterLeave(
         locals.groupInfo,
-        locals.studentUsers[0].user_id
+        locals.studentUsers[0].user_id,
       );
       // Case 1: Manager role should replace second user's contributor role, and
       // reflector role should replace third user's contributor role
@@ -1844,13 +1844,13 @@ describe('Test group role reassignment logic when user leaves', function () {
       assert.lengthOf(result, 2);
       // If second user receives manager, we expect case 1; otherwise, we expect case 2
       const secondUserRoleAssignment = result.find(
-        ({ user_id }) => user_id === locals.studentUsers[1].user_id
+        ({ user_id }) => user_id === locals.studentUsers[1].user_id,
       );
       assert.isDefined(secondUserRoleAssignment);
       const expected =
         secondUserRoleAssignment.group_role_id === locals.manager.id ? expected1 : expected2;
       assert.sameDeepMembers(result, expected);
-    }
+    },
   );
 
   step(
@@ -1891,29 +1891,29 @@ describe('Test group role reassignment logic when user leaves', function () {
       // Get role reassignments if first user leaves
       const result = getGroupRoleReassignmentsAfterLeave(
         locals.groupInfo,
-        locals.studentUsers[0].user_id
+        locals.studentUsers[0].user_id,
       );
 
       // Ensure that there is a single role assignment for manager, recorder, and reflector each
       assert.lengthOf(
         result.filter(({ group_role_id }) => group_role_id === locals.manager.id),
-        1
+        1,
       );
       assert.lengthOf(
         result.filter(({ group_role_id }) => group_role_id === locals.recorder.id),
-        1
+        1,
       );
       assert.lengthOf(
         result.filter(({ group_role_id }) => group_role_id === locals.reflector.id),
-        1
+        1,
       );
 
       // Ensure that there are no contributors
       assert.lengthOf(
         result.filter(({ group_role_id }) => group_role_id === locals.contributor.id),
-        0
+        0,
       );
-    }
+    },
   );
 
   step('should not transfer non-required roles to another user', function () {
@@ -1940,7 +1940,7 @@ describe('Test group role reassignment logic when user leaves', function () {
     // Get role reassignments if second user leaves
     const result = getGroupRoleReassignmentsAfterLeave(
       locals.groupInfo,
-      locals.studentUsers[1].user_id
+      locals.studentUsers[1].user_id,
     );
     // Recorder role should be transferred to first user
     const expected = [
@@ -1972,7 +1972,7 @@ describe('Test group role reassignment logic when user leaves', function () {
     // Get role reassignments if second user leaves
     const result = getGroupRoleReassignmentsAfterLeave(
       locals.groupInfo,
-      locals.studentUsers[1].user_id
+      locals.studentUsers[1].user_id,
     );
     // Recorder role should be transferred to first user
     const expected = [

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -111,7 +111,7 @@ describe('assessment instance group synchronization test', function () {
             return callback(new Error('bad status: ' + response.statusCode));
           }
           callback(null);
-        }
+        },
       );
     });
     it('should create the correct group configuration', function (callback) {
@@ -169,7 +169,7 @@ describe('assessment instance group synchronization test', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should have 1 assessment instance in db', function (callback) {
@@ -268,7 +268,7 @@ describe('assessment instance group synchronization test', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -321,12 +321,12 @@ describe('assessment instance group synchronization test', function () {
               new Error('bad status: ' + response.statusCode, {
                 response,
                 body,
-              })
+              }),
             );
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -195,7 +195,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -266,7 +266,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -336,7 +336,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should have 3 students in group 1 in db', function (callback) {
@@ -404,7 +404,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -473,7 +473,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should have 1 assessment instance in db', function (callback) {
@@ -571,7 +571,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -612,7 +612,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should NOT be able to access the assessment instance 1 as a student from a different group', function (callback) {
@@ -691,7 +691,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should NOT be able to access the assessment instance 1 as a student from a different group', function (callback) {
@@ -750,7 +750,7 @@ describe('Group based homework assess control on student side', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
       it('should contain a prompt to inform the user that the group is full', function () {
         elemList = locals.$('.alert:contains(It is already full)');

--- a/apps/prairielearn/src/tests/helperDb.js
+++ b/apps/prairielearn/src/tests/helperDb.js
@@ -31,7 +31,7 @@ const postgresTestUtils = sqldb.makePostgresTestUtils({
     // table when resetting the database, we lose the default institution, so we
     // add it back here.
     await client.query(
-      "INSERT INTO institutions (id, long_name, short_name) VALUES (1, 'Default', 'Default') ON CONFLICT DO NOTHING;"
+      "INSERT INTO institutions (id, long_name, short_name) VALUES (1, 'Default', 'Default') ON CONFLICT DO NOTHING;",
     );
   },
 });
@@ -68,7 +68,7 @@ async function runMigrationsAndSprocs(dbName, runMigrations) {
   if (runMigrations) {
     await initMigrations(
       [path.resolve(__dirname, '..', 'migrations'), SCHEMA_MIGRATIONS_PATH],
-      'prairielearn'
+      'prairielearn',
     );
   }
 
@@ -105,7 +105,7 @@ async function databaseExists(dbName) {
   const client = new pg.Client(POSTGRES_INIT_CONNECTION_STRING);
   await client.connect();
   const result = await client.query(
-    `SELECT exists(SELECT * FROM pg_catalog.pg_database WHERE datname = '${dbName}');`
+    `SELECT exists(SELECT * FROM pg_catalog.pg_database WHERE datname = '${dbName}');`,
   );
   const existsResult = result.rows[0].exists;
   await client.end();

--- a/apps/prairielearn/src/tests/helperExam.js
+++ b/apps/prairielearn/src/tests/helperExam.js
@@ -99,7 +99,7 @@ module.exports = {
         locals.assessmentUrl = locals.siteUrl + elemList[0].attribs.href;
         assert.equal(
           locals.assessmentUrl,
-          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/'
+          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/',
         );
       });
     });
@@ -158,7 +158,7 @@ module.exports = {
             res = response;
             page = body;
             callback(null);
-          }
+          },
         );
       });
       it('should parse', function () {
@@ -187,8 +187,8 @@ module.exports = {
           if (result.rowCount !== questionsArray.length) {
             return callback(
               new Error(
-                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount
-              )
+                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount,
+              ),
             );
           }
           locals.instance_questions = result.rows;

--- a/apps/prairielearn/src/tests/helperQuestion.js
+++ b/apps/prairielearn/src/tests/helperQuestion.js
@@ -80,7 +80,7 @@ module.exports = {
       it('base64 data should parse to JSON if Calculation', function () {
         if (locals.question.type !== 'Calculation') return;
         locals.questionData = JSON.parse(
-          decodeURIComponent(Buffer.from(elemList[0].children[0].data, 'base64').toString())
+          decodeURIComponent(Buffer.from(elemList[0].children[0].data, 'base64').toString()),
         );
       });
       it('should have a variant_id in the questionData if Calculation', function () {
@@ -255,7 +255,7 @@ module.exports = {
             }
             page = body;
             callback(null);
-          }
+          },
         );
       });
       it('should parse', function () {
@@ -336,12 +336,12 @@ module.exports = {
             }
             if (response.statusCode !== 400 && response.statusCode !== 500) {
               return callback(
-                new Error('bad status (expected 400 or 500): ' + response.statusCode)
+                new Error('bad status (expected 400 or 500): ' + response.statusCode),
               );
             }
             page = body;
             callback(null);
-          }
+          },
         );
       });
     });
@@ -382,7 +382,7 @@ module.exports = {
             if (ERR(err, callback)) return;
             locals.submission = result.rows[0];
             callback(null);
-          }
+          },
         );
       });
       it('should be graded with expected score', function () {
@@ -407,14 +407,14 @@ module.exports = {
         assert.approximately(
           locals.instance_question.points,
           locals.expectedResult.instance_question_points,
-          1e-6
+          1e-6,
         );
       });
       it('should have the correct instance_question score_perc', function () {
         assert.approximately(
           locals.instance_question.score_perc,
           locals.expectedResult.instance_question_score_perc,
-          1e-6
+          1e-6,
         );
       });
       it('should have the correct instance_question auto_points', function () {
@@ -422,7 +422,7 @@ module.exports = {
         assert.approximately(
           locals.instance_question.auto_points,
           locals.expectedResult.instance_question_auto_points,
-          1e-6
+          1e-6,
         );
       });
       it('should have the correct instance_question manual_points', function () {
@@ -430,7 +430,7 @@ module.exports = {
         assert.approximately(
           locals.instance_question.manual_points,
           locals.expectedResult.instance_question_manual_points,
-          1e-6
+          1e-6,
         );
       });
     });
@@ -452,14 +452,14 @@ module.exports = {
         assert.approximately(
           locals.assessment_instance.points,
           locals.expectedResult.assessment_instance_points,
-          1e-6
+          1e-6,
         );
       });
       it('should have the correct assessment_instance score_perc', function () {
         assert.approximately(
           locals.assessment_instance.score_perc,
           locals.expectedResult.assessment_instance_score_perc,
-          1e-6
+          1e-6,
         );
       });
     });
@@ -483,7 +483,7 @@ module.exports = {
         for (const p in locals.expectedFeedback.feedback) {
           assert.deepEqual(
             locals.question_feedback.feedback[p],
-            locals.expectedFeedback.feedback[p]
+            locals.expectedFeedback.feedback[p],
           );
         }
       });
@@ -540,7 +540,7 @@ module.exports = {
               return callback(new Error('bad status: ' + response.statusCode + '\n' + body));
             }
             callback(null);
-          }
+          },
         );
       });
     });
@@ -573,7 +573,7 @@ module.exports = {
       });
       it('should have a CSRF token', function () {
         elemList = locals.$(
-          'form[name="upload-instance-question-scores-form"] input[name="__csrf_token"]'
+          'form[name="upload-instance-question-scores-form"] input[name="__csrf_token"]',
         );
         assert.lengthOf(elemList, 1);
         assert.nestedProperty(elemList[0], 'attribs.value');
@@ -610,7 +610,7 @@ module.exports = {
               return callback(new Error('bad status: ' + response.statusCode + '\n' + body));
             }
             callback(null);
-          }
+          },
         );
       });
     });
@@ -643,7 +643,7 @@ module.exports = {
       });
       it('should have a CSRF token', function () {
         elemList = locals.$(
-          'form[name="upload-assessment-instance-scores-form"] input[name="__csrf_token"]'
+          'form[name="upload-assessment-instance-scores-form"] input[name="__csrf_token"]',
         );
         assert.lengthOf(elemList, 1);
         assert.nestedProperty(elemList[0], 'attribs.value');
@@ -680,7 +680,7 @@ module.exports = {
               return callback(new Error('bad status: ' + response.statusCode + '\n' + body));
             }
             callback(null);
-          }
+          },
         );
       });
     });
@@ -717,8 +717,8 @@ module.exports = {
               callback(
                 new Error(
                   `found ${result.rowCount} issues (expected zero issues):\n` +
-                    JSON.stringify(result.rows, null, '    ')
-                )
+                    JSON.stringify(result.rows, null, '    '),
+                ),
               );
               return;
             }
@@ -768,7 +768,7 @@ module.exports = {
                 return callback(new Error('bad status: ' + response.statusCode + '\n' + body));
               }
               callback(null);
-            }
+            },
           );
         });
         it('should have an id', function (callback) {
@@ -824,8 +824,8 @@ module.exports.checkNoIssuesForLastVariant = (callback) => {
       callback(
         new Error(
           `found ${result.rowCount} issues (expected zero issues):\n` +
-            JSON.stringify(result.rows, null, '    ')
-        )
+            JSON.stringify(result.rows, null, '    '),
+        ),
       );
       return;
     }
@@ -833,5 +833,5 @@ module.exports.checkNoIssuesForLastVariant = (callback) => {
   });
 };
 module.exports.checkNoIssuesForLastVariantAsync = util.promisify(
-  module.exports.checkNoIssuesForLastVariant
+  module.exports.checkNoIssuesForLastVariant,
 );

--- a/apps/prairielearn/src/tests/helperServer.js
+++ b/apps/prairielearn/src/tests/helperServer.js
@@ -118,7 +118,7 @@ module.exports = {
           debug('before(): completed');
           if (ERR(err, callback)) return;
           callback(null);
-        }
+        },
       );
     };
   },
@@ -175,7 +175,7 @@ module.exports = {
         debug('after(): complete');
         if (ERR(err, callback)) return;
         callback(null);
-      }
+      },
     );
   },
 };
@@ -218,5 +218,5 @@ module.exports.waitForJobSequenceSuccessAsync = async (job_sequence_id) => {
   assert.equal(job_sequence.status, 'Success');
 };
 module.exports.waitForJobSequenceSuccess = util.callbackify(
-  module.exports.waitForJobSequenceSuccessAsync
+  module.exports.waitForJobSequenceSuccessAsync,
 );

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -276,7 +276,7 @@ describe('Homework assessment', function () {
         locals.assessmentUrl = locals.siteUrl + elemList[0].attribs.href;
         assert.equal(
           locals.assessmentUrl,
-          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/'
+          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/',
         );
       });
     });
@@ -320,8 +320,8 @@ describe('Homework assessment', function () {
           if (result.rowCount !== questionsArray.length) {
             return callback(
               new Error(
-                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount
-              )
+                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount,
+              ),
             );
           }
           locals.instance_questions = result.rows;
@@ -1378,9 +1378,9 @@ describe('Homework assessment', function () {
       startAssessment();
 
       partialCreditTest.forEach(function (questionTest, iQuestionTest) {
-        describe(`${
-          questionTest.action
-        } answer number #${iQuestionTest + 1} for question ${questionTest.qid} with score ${questionTest.score}`, function () {
+        describe(`${questionTest.action} answer number #${iQuestionTest + 1} for question ${
+          questionTest.qid
+        } with score ${questionTest.score}`, function () {
           describe('setting up the submission data', function () {
             it('should succeed', function () {
               if (questionTest.action === 'check-closed') {

--- a/apps/prairielearn/src/tests/instructorAssessment.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.js
@@ -134,7 +134,7 @@ describe('Instructor assessment editing', function () {
       locals.instructorAssessmentUrl = locals.siteUrl + elemList[0].attribs.href;
       assert.equal(
         locals.instructorAssessmentUrl,
-        locals.instructorBaseUrl + '/assessment/' + locals.assessment_id + '/'
+        locals.instructorBaseUrl + '/assessment/' + locals.assessment_id + '/',
       );
     });
   });
@@ -204,7 +204,7 @@ describe('Instructor assessment editing', function () {
   describe('7. edit-question-points form', function () {
     it('should exist', function () {
       elemList = locals.$(
-        '#instanceQuestionList td:contains("addNumbers") ~ td .editQuestionPointsButton'
+        '#instanceQuestionList td:contains("addNumbers") ~ td .editQuestionPointsButton',
       );
       assert.lengthOf(elemList, 1);
     });
@@ -265,7 +265,7 @@ describe('Instructor assessment editing', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -282,7 +282,7 @@ describe('Instructor assessment editing', function () {
   describe('9. edit-question-score-perc form', function () {
     it('should exist', function () {
       elemList = locals.$(
-        '#instanceQuestionList td:contains("addNumbers") ~ td .editQuestionScorePercButton'
+        '#instanceQuestionList td:contains("addNumbers") ~ td .editQuestionScorePercButton',
       );
       assert.lengthOf(elemList, 1);
     });
@@ -343,7 +343,7 @@ describe('Instructor assessment editing', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -420,7 +420,7 @@ describe('Instructor assessment editing', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -497,7 +497,7 @@ describe('Instructor assessment editing', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {
@@ -554,14 +554,14 @@ describe('Instructor assessment editing', function () {
     it('should contain a row for the dev user', function () {
       locals.gradebookDataRow = _.filter(
         locals.gradebookData,
-        (row) => row.uid === 'dev@illinois.edu'
+        (row) => row.uid === 'dev@illinois.edu',
       );
       assert.lengthOf(locals.gradebookDataRow, 1);
     });
     it('should contain the correct score in the dev user row', function () {
       assert.equal(
         locals.gradebookDataRow[0][`score_${locals.assessment_id}`],
-        assessmentSetScorePerc
+        assessmentSetScorePerc,
       );
     });
     it('should contain the correct assessment instance id in the dev user row', function () {
@@ -593,7 +593,7 @@ describe('Instructor assessment editing', function () {
           }
           page = body;
           callback(null);
-        }
+        },
       );
     });
     it('should parse', function () {

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -131,7 +131,7 @@ describe('Instructor questions', function () {
     });
     it('should include differentiatePolynomial question', function () {
       elemList = questionData.filter((question) =>
-        idsEqual(question.id, differentiatePolynomial.id)
+        idsEqual(question.id, differentiatePolynomial.id),
       );
       assert.lengthOf(elemList, 1);
       assert.equal(differentiatePolynomial.qid, elemList[0].qid);
@@ -180,7 +180,7 @@ describe('Instructor questions', function () {
     });
     it('should include differentiatePolynomial question', function () {
       elemList = questionData.filter((question) =>
-        idsEqual(question.id, differentiatePolynomial.id)
+        idsEqual(question.id, differentiatePolynomial.id),
       );
       assert.lengthOf(elemList, 1);
       assert.equal(differentiatePolynomial.qid, elemList[0].qid);

--- a/apps/prairielearn/src/tests/manualGrading.test.js
+++ b/apps/prairielearn/src/tests/manualGrading.test.js
@@ -24,7 +24,7 @@ const defaultUser = {
 };
 
 const fibonacciSolution = fs.readFileSync(
-  path.resolve(TEST_COURSE_PATH, 'questions', 'externalGrade', 'codeUpload', 'tests', 'ans.py')
+  path.resolve(TEST_COURSE_PATH, 'questions', 'externalGrade', 'codeUpload', 'tests', 'ans.py'),
 );
 
 const mockStudents = [
@@ -197,20 +197,20 @@ const checkGradingResults = (assigned_grader, grader) => {
 
     assert.equal(
       getLatestSubmissionStatus($questionsPage),
-      `manual grading: ${Math.floor(score_percent)}%`
+      `manual grading: ${Math.floor(score_percent)}%`,
     );
     assert.equal(
       $questionsPage(
-        '#question-score-panel tr:contains("Total points") [data-testid="awarded-points"]'
+        '#question-score-panel tr:contains("Total points") [data-testid="awarded-points"]',
       )
         .first()
         .text()
         .trim(),
-      `${score_points}`
+      `${score_points}`,
     );
     assert.equal(
       feedbackBlock.find('[data-testid="feedback-body"]').first().text().trim(),
-      feedback_note
+      feedback_note,
     );
 
     if (!rubric_items) {
@@ -222,20 +222,20 @@ const checkGradingResults = (assigned_grader, grader) => {
         assert.equal(container.length, 1);
         assert.equal(
           container.find('input[type="checkbox"]').is(':checked'),
-          selected_rubric_items.includes(index)
+          selected_rubric_items.includes(index),
         );
         assert.equal(
           container.find('[data-testid="rubric-item-points"]').text().trim(),
-          `[${item.points >= 0 ? '+' : ''}${item.points}]`
+          `[${item.points >= 0 ? '+' : ''}${item.points}]`,
         );
         assert.equal(
           container.find('[data-testid="rubric-item-description"]').html()?.trim(),
-          item.description_render ?? item.description
+          item.description_render ?? item.description,
         );
         if (item.explanation) {
           assert.equal(
             container.find('[data-testid="rubric-item-explanation"]').attr('data-content'),
-            item.explanation_render ?? `<p>${item.explanation}</p>`
+            item.explanation_render ?? `<p>${item.explanation}</p>`,
           );
         } else {
           assert.equal(container.find('[data-testid="rubric-item-explanation"]').length, 0);
@@ -245,7 +245,7 @@ const checkGradingResults = (assigned_grader, grader) => {
     if (adjust_points) {
       assert.equal(
         feedbackBlock.find('[data-testid="rubric-adjust-points"]').text().trim(),
-        `[${adjust_points >= 0 ? '+' : ''}${adjust_points}]`
+        `[${adjust_points >= 0 ? '+' : ''}${adjust_points}]`,
       );
     } else {
       assert.equal(feedbackBlock.find('[data-testid="rubric-adjust-points"]').length, 0);
@@ -261,7 +261,7 @@ const checkSettingsResults = (starting_points, min_points, max_extra_points) => 
 
     assert.equal(
       form.find(`input[name="starting_points"][value="${starting_points}"]`).is(':checked'),
-      true
+      true,
     );
     assert.equal(form.find('input[name="max_extra_points"]').val(), max_extra_points.toString());
     assert.equal(form.find('input[name="min_points"]').val(), min_points.toString());
@@ -281,11 +281,11 @@ const checkSettingsResults = (starting_points, min_points, max_extra_points) => 
       const description = form.find(`[name="rubric_item[cur${item.id}][description]"]`);
       assert.equal(description.val(), item.description);
       const explanation = form.find(
-        `label[data-input-name="rubric_item[cur${item.id}][explanation]"]`
+        `label[data-input-name="rubric_item[cur${item.id}][explanation]"]`,
       );
       assert.equal(explanation.attr('data-current-value') ?? '', item.explanation ?? '');
       const graderNote = form.find(
-        `label[data-input-name="rubric_item[cur${item.id}][grader_note]"]`
+        `label[data-input-name="rubric_item[cur${item.id}][grader_note]"]`,
       );
       assert.equal(graderNote.attr('data-current-value') ?? '', item.grader_note ?? '');
     });
@@ -303,19 +303,19 @@ const checkSettingsResults = (starting_points, min_points, max_extra_points) => 
       assert.equal(container.length, 1);
       assert.equal(
         container.find('[data-testid="rubric-item-points"]').text().trim(),
-        `[${item.points >= 0 ? '+' : ''}${item.points}]`
+        `[${item.points >= 0 ? '+' : ''}${item.points}]`,
       );
       assert.equal(
         container.find('[data-testid="rubric-item-description"]').html()?.trim(),
-        item.description_render ?? item.description
+        item.description_render ?? item.description,
       );
       assert.equal(
         container.find('[data-testid="rubric-item-explanation"]').html()?.trim(),
-        item.explanation_render ?? (item.explanation ? `<p>${item.explanation}</p>` : '')
+        item.explanation_render ?? (item.explanation ? `<p>${item.explanation}</p>` : ''),
       );
       assert.equal(
         container.find('[data-testid="rubric-item-grader-note"]').html()?.trim(),
-        item.grader_note_render ?? (item.grader_note ? `<p>${item.grader_note}</p>` : '')
+        item.grader_note_render ?? (item.grader_note ? `<p>${item.grader_note}</p>` : ''),
       );
     });
   });
@@ -329,8 +329,8 @@ const buildRubricItemFields = (items) =>
         _.map(_.toPairs({ order, ...item }), ([field, value]) => [
           `rubric_item[${key}][${field}]`,
           value,
-        ])
-    )
+        ]),
+    ),
   );
 
 describe('Manual Grading', function () {
@@ -356,17 +356,17 @@ describe('Manual Grading', function () {
         const courseStaffParams = [1, staff.authUid, 'None', 1];
         const courseStaffResult = await sqldb.callAsync(
           'course_permissions_insert_by_user_uid',
-          courseStaffParams
+          courseStaffParams,
         );
         assert.equal(courseStaffResult.rowCount, 1);
         staff.user_id = courseStaffResult.rows[0].user_id;
         const ciStaffParams = [1, staff.user_id, 1, 'Student Data Editor', 1];
         const ciStaffResult = await sqldb.callAsync(
           'course_instance_permissions_insert',
-          ciStaffParams
+          ciStaffParams,
         );
         assert.equal(ciStaffResult.rowCount, 1);
-      })
+      }),
     );
   });
 
@@ -395,7 +395,7 @@ describe('Manual Grading', function () {
         assert.equal(gradeRes.status, 200);
         assert.equal(
           getLatestSubmissionStatus($questionsPage),
-          'manual grading: waiting for grading'
+          'manual grading: waiting for grading',
         );
       });
 
@@ -438,7 +438,7 @@ describe('Manual Grading', function () {
           const $manualGradingAQPage = cheerio.load(manualGradingAQPage);
           const row = $manualGradingAQPage('div.alert:contains("has one open instance")');
           assert.equal(row.length, 1);
-        }
+        },
       );
 
       step('manual grading page for assessment question should list one instance', async () => {
@@ -465,7 +465,7 @@ describe('Manual Grading', function () {
           const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
           const row = $manualGradingIQPage('div.alert:contains("is still open")');
           assert.equal(row.length, 1);
-        }
+        },
       );
     });
 
@@ -505,7 +505,7 @@ describe('Manual Grading', function () {
           const $manualGradingAQPage = cheerio.load(manualGradingAQPage);
           const row = $manualGradingAQPage('div.alert:contains("has one open instance")');
           assert.equal(row.length, 0);
-        }
+        },
       );
 
       step(
@@ -516,7 +516,7 @@ describe('Manual Grading', function () {
           const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
           const row = $manualGradingIQPage('div.alert:contains("is still open")');
           assert.equal(row.length, 0);
-        }
+        },
       );
 
       step('next ungraded button should point to existing instance for all graders', async () => {
@@ -596,7 +596,7 @@ describe('Manual Grading', function () {
           assert.equal(count, '1/1');
           const nextButton = row.find('.btn:contains("next submission")');
           assert.equal(nextButton.length, 0);
-        }
+        },
       );
 
       step(
@@ -606,7 +606,7 @@ describe('Manual Grading', function () {
           const nextUngraded = await fetch(manualGradingNextUngradedUrl, { redirect: 'manual' });
           assert.equal(nextUngraded.status, 302);
           assert.equal(nextUngraded.headers.get('location'), manualGradingIQUrl);
-        }
+        },
       );
 
       step(
@@ -616,7 +616,7 @@ describe('Manual Grading', function () {
           const nextUngraded = await fetch(manualGradingNextUngradedUrl, { redirect: 'manual' });
           assert.equal(nextUngraded.status, 302);
           assert.equal(nextUngraded.headers.get('location'), manualGradingAssessmentQuestionUrl);
-        }
+        },
       );
     });
 
@@ -967,7 +967,7 @@ describe('Manual Grading', function () {
         assert.equal(gradeRes.status, 200);
         assert.equal(
           getLatestSubmissionStatus($questionsPage),
-          'manual grading: waiting for grading'
+          'manual grading: waiting for grading',
         );
       });
 
@@ -987,7 +987,7 @@ describe('Manual Grading', function () {
         assert.equal(submissions.eq(1).find('[id^="submission-feedback-"]').length, 1);
         assert.equal(
           submissions.eq(1).find('[data-testid="feedback-body"]').first().text().trim(),
-          feedback_note
+          feedback_note,
         );
       });
 
@@ -1019,7 +1019,7 @@ describe('Manual Grading', function () {
           const $manualGradingAQPage = cheerio.load(manualGradingAQPage);
           const row = $manualGradingAQPage('div.alert:contains("has one open instance")');
           assert.equal(row.length, 1);
-        }
+        },
       );
 
       step('manual grading page for assessment question should list one instance', async () => {
@@ -1042,7 +1042,7 @@ describe('Manual Grading', function () {
           const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
           const row = $manualGradingIQPage('div.alert:contains("is still open")');
           assert.equal(row.length, 1);
-        }
+        },
       );
 
       step('submit a new grade', async () => {

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -14,7 +14,7 @@ async function checkPermissions(users) {
   });
   assert.includeMembers(
     users.map((user) => user.uid),
-    result.rows.map((row) => row.uid)
+    result.rows.map((row) => row.uid),
   );
   users.forEach((user) => {
     const row = result.rows.find((row) => row.uid === user.uid);
@@ -116,7 +116,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsInsertButton]'
+      'button[id=coursePermissionsInsertButton]',
     );
     const form = {
       __action: 'course_permissions_insert_by_user_uids',
@@ -141,7 +141,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsInsertButton]'
+      'button[id=coursePermissionsInsertButton]',
     );
     const form = {
       __action: 'course_permissions_insert_by_user_uids',
@@ -168,7 +168,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsInsertButton]'
+      'button[id=coursePermissionsInsertButton]',
     );
     const form = {
       __action: 'course_permissions_insert_by_user_uids',
@@ -195,7 +195,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=student-data-access-add-3]`
+      `form[name=student-data-access-add-3]`,
     );
     const form = {
       __action: 'course_instance_permissions_insert',
@@ -221,7 +221,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=course-content-access-form-3]`
+      `form[name=course-content-access-form-3]`,
     );
     const form = {
       __action: 'course_permissions_delete',
@@ -267,7 +267,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=course-content-access-form-4]`
+      `form[name=course-content-access-form-4]`,
     );
     const form = {
       __action: 'course_permissions_update_role',
@@ -364,7 +364,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsInsertButton]'
+      'button[id=coursePermissionsInsertButton]',
     );
     const form = {
       __action: 'course_permissions_insert_by_user_uids',
@@ -390,7 +390,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=student-data-access-add-3]`
+      `form[name=student-data-access-add-3]`,
     );
     const form = {
       __action: 'course_instance_permissions_insert',
@@ -416,7 +416,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=student-data-access-change-3-1]`
+      `form[name=student-data-access-change-3-1]`,
     );
     const form = {
       __action: 'course_instance_permissions_update_role_or_delete',
@@ -443,7 +443,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=student-data-access-add-5]`
+      `form[name=student-data-access-add-5]`,
     );
     const form = {
       __action: 'course_instance_permissions_insert',
@@ -469,7 +469,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=student-data-access-change-5-1]`
+      `form[name=student-data-access-change-5-1]`,
     );
     const form = {
       __action: 'course_instance_permissions_update_role_or_delete',
@@ -495,7 +495,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsRemoveStudentDataAccessButton]'
+      'button[id=coursePermissionsRemoveStudentDataAccessButton]',
     );
     const form = {
       __action: 'remove_all_student_data_access',
@@ -519,7 +519,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=student-data-access-add-5]`
+      `form[name=student-data-access-add-5]`,
     );
     const form = {
       __action: 'course_instance_permissions_insert',
@@ -545,7 +545,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsDeleteNoAccessButton]'
+      'button[id=coursePermissionsDeleteNoAccessButton]',
     );
     const form = {
       __action: 'delete_no_access',
@@ -570,7 +570,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFTokenFromDataContent(
       context,
       response.$,
-      'button[id=coursePermissionsDeleteNonOwnersButton]'
+      'button[id=coursePermissionsDeleteNonOwnersButton]',
     );
     const form = {
       __action: 'delete_non_owners',
@@ -594,7 +594,7 @@ function runTest(context) {
     helperClient.extractAndSaveCSRFToken(
       context,
       response.$,
-      `form[name=course-content-access-form-4]`
+      `form[name=course-content-access-form-4]`,
     );
     const form = {
       __action: 'course_permissions_update_role',

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -191,7 +191,7 @@ describe('effective user', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -202,7 +202,7 @@ describe('effective user', function () {
       };
       const response = await helperClient.fetchCheerio(context.pageUrlCourseInstance, { headers });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -215,7 +215,7 @@ describe('effective user', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step('cannot request invalid date', async () => {
@@ -400,7 +400,7 @@ describe('effective user', function () {
       };
       const response = await helperClient.fetchCheerio(context.pageUrlCourseInstance, { headers });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -414,7 +414,7 @@ describe('effective user', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -426,6 +426,6 @@ describe('effective user', function () {
       };
       const response = await helperClient.fetchCheerio(context.pageUrlCourseInstance, { headers });
       assert.isTrue(response.ok);
-    }
+    },
   );
 });

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -218,7 +218,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -243,7 +243,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -268,7 +268,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -291,7 +291,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step('instructor (student data viewer) cannot emulate student', async () => {
@@ -333,7 +333,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -358,7 +358,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -383,7 +383,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -406,7 +406,7 @@ describe('student data access', function () {
         headers,
       });
       assert.equal(response.status, 403);
-    }
+    },
   );
 
   step(
@@ -432,7 +432,7 @@ describe('student data access', function () {
         headers,
       });
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step(
@@ -459,7 +459,7 @@ describe('student data access', function () {
         headers,
       });
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step(
@@ -486,7 +486,7 @@ describe('student data access', function () {
         headers,
       });
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step(
@@ -512,14 +512,14 @@ describe('student data access', function () {
         headers,
       });
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step('instructor (student data editor) can view gradebook', async () => {
     const headers = { cookie: 'pl_test_user=test_instructor' };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/instance_admin/gradebook`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -528,7 +528,7 @@ describe('student data access', function () {
     const headers = { cookie: 'pl_test_user=test_instructor' };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/instance_admin/gradebook/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -537,7 +537,7 @@ describe('student data access', function () {
     const headers = { cookie: 'pl_test_user=test_instructor' };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.homeworkAssessmentId}/instances`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -548,17 +548,17 @@ describe('student data access', function () {
       const headers = { cookie: 'pl_test_user=test_instructor' };
       let response = await helperClient.fetchCheerio(
         `${context.courseInstanceBaseUrl}/instructor/assessment/${context.homeworkAssessmentId}/instances/raw_data.json`,
-        { headers }
+        { headers },
       );
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step('instructor (student data editor) can view exam assessment instances', async () => {
     const headers = { cookie: 'pl_test_user=test_instructor' };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.examAssessmentId}/instances`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -567,7 +567,7 @@ describe('student data access', function () {
     const headers = { cookie: 'pl_test_user=test_instructor' };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.examAssessmentId}/instances/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -578,7 +578,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/instance_admin/gradebook`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -589,7 +589,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/instance_admin/gradebook/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -600,7 +600,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.homeworkAssessmentId}/instances`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -614,10 +614,10 @@ describe('student data access', function () {
       };
       let response = await helperClient.fetchCheerio(
         `${context.courseInstanceBaseUrl}/instructor/assessment/${context.homeworkAssessmentId}/instances/raw_data.json`,
-        { headers }
+        { headers },
       );
       assert.isTrue(response.ok);
-    }
+    },
   );
 
   step('instructor (student data viewer) can view exam assessment instances', async () => {
@@ -626,7 +626,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.examAssessmentId}/instances`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -637,7 +637,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.examAssessmentId}/instances/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.isTrue(response.ok);
   });
@@ -648,7 +648,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/instance_admin/gradebook`,
-      { headers }
+      { headers },
     );
     // This page itself is visible even if the user doesn't have permissions to
     // view student data, but it won't actually show student data, which is
@@ -667,7 +667,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/instance_admin/gradebook/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.equal(response.status, 403);
   });
@@ -678,7 +678,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.homeworkAssessmentId}/instances`,
-      { headers }
+      { headers },
     );
     assert.equal(response.status, 403);
   });
@@ -689,7 +689,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.homeworkAssessmentId}/instances/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.equal(response.status, 403);
   });
@@ -700,7 +700,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.examAssessmentId}/instances`,
-      { headers }
+      { headers },
     );
     assert.equal(response.status, 403);
   });
@@ -711,7 +711,7 @@ describe('student data access', function () {
     };
     let response = await helperClient.fetchCheerio(
       `${context.courseInstanceBaseUrl}/instructor/assessment/${context.examAssessmentId}/instances/raw_data.json`,
-      { headers }
+      { headers },
     );
     assert.equal(response.status, 403);
   });

--- a/apps/prairielearn/src/tests/redirects.test.js
+++ b/apps/prairielearn/src/tests/redirects.test.js
@@ -46,7 +46,7 @@ describe('Redirects', function () {
           assert.equal(response.statusCode, 302);
           assert.equal(response.headers.location, redirect.redirect);
           done();
-        }
+        },
       );
     });
   });

--- a/apps/prairielearn/src/tests/schemas.test.js
+++ b/apps/prairielearn/src/tests/schemas.test.js
@@ -24,7 +24,7 @@ const validateRequiredRecursive = (obj, path = '') => {
   for (const property in obj) {
     const errorsRecursive = validateRequiredRecursive(
       obj[property],
-      `${path && path + '.'}${property}`
+      `${path && path + '.'}${property}`,
     );
     errors = [...errors, ...errorsRecursive];
   }

--- a/apps/prairielearn/src/tests/serverJobs.test.ts
+++ b/apps/prairielearn/src/tests/serverJobs.test.ts
@@ -61,7 +61,7 @@ describe('server-jobs', () => {
         job.info('testing info');
         throw new Error('failing job');
       }),
-      'failing job'
+      'failing job',
     );
 
     const finishedJobSequence = await serverJobs.getJobSequenceAsync(serverJob.jobSequenceId, null);

--- a/apps/prairielearn/src/tests/session-store.test.js
+++ b/apps/prairielearn/src/tests/session-store.test.js
@@ -56,7 +56,7 @@ describe('session-store', function () {
       "destroy('sid1') succeeds again, no error on destroying not present sessions",
       async () => {
         await promisify(store.destroy)('sid1');
-      }
+      },
     );
 
     step("get('sid1') returns null when called on not present session", async () => {
@@ -88,7 +88,7 @@ describe('session-store', function () {
       await sqldb.queryAsync(
         `UPDATE pl_sessions SET updated_at = '1900-01-01 00:00:00'
                 WHERE sid='expire1'`,
-        {}
+        {},
       );
       let result = await promisify(store.get)('expire1');
       assert.isNull(result);
@@ -109,7 +109,7 @@ describe('session-store', function () {
 
       await sqldb.queryAsync(
         `UPDATE pl_sessions SET updated_at = '1900-01-01 00:00:00' WHERE sid ~ 'expire';`,
-        {}
+        {},
       );
     });
 

--- a/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
@@ -10,7 +10,7 @@ var caa_reservation_tests = function (
   exam_id,
   second_assessment_id,
   expectWideOpen = false,
-  seeOtherExams = false
+  seeOtherExams = false,
 ) {
   var expectedWord = 'fail';
   var expectedBool = false;
@@ -87,7 +87,7 @@ var caa_reservation_tests = function (
           assert.strictEqual(result.rows[0].authorized, expectedBool);
           callback(null);
         });
-      }
+      },
     );
 
     var otherExams = {

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -178,7 +178,7 @@ describe('sproc users_select_or_insert tests', () => {
         // The user should still have the same UIN.
         uin: '444444444',
       },
-      fromdb
+      fromdb,
     );
   });
 
@@ -192,7 +192,7 @@ describe('sproc users_select_or_insert tests', () => {
 
     await assert.isRejected(
       usersSelectOrInsert(user, 'Azure'),
-      /authentication provider is not allowed for institution/
+      /authentication provider is not allowed for institution/,
     );
   });
 
@@ -247,7 +247,7 @@ describe('sproc users_select_or_insert tests', () => {
         // The user should still have the same UIN.
         uin: '555566665',
       },
-      fromdb
+      fromdb,
     );
   });
 

--- a/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
@@ -33,7 +33,7 @@ describe('Assessment modules syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedAssessmentModules = await util.dumpTable('assessment_modules');
     const syncedAssessmentModule = syncedAssessmentModules.find(
-      (am) => am.name === newAssessmentModule.name
+      (am) => am.name === newAssessmentModule.name,
     );
     checkAssessmentModule(syncedAssessmentModule, newAssessmentModule);
   });
@@ -50,7 +50,7 @@ describe('Assessment modules syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedAssessmentModules = await util.dumpTable('assessment_modules');
     const syncedAssessmentModule = syncedAssessmentModules.find(
-      (am) => am.name === newAssessmentModule.name
+      (am) => am.name === newAssessmentModule.name,
     );
     assert.isUndefined(syncedAssessmentModule);
   });
@@ -70,7 +70,7 @@ describe('Assessment modules syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessmentModules = await util.dumpTable('assessment_modules');
     const syncedAssessmentModule = syncedAssessmentModules.find(
-      (as) => as.name === newAssessmentModule2.name
+      (as) => as.name === newAssessmentModule2.name,
     );
     checkAssessmentModule(syncedAssessmentModule, newAssessmentModule2);
     const syncedCourses = await util.dumpTable('pl_courses');

--- a/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
@@ -46,7 +46,7 @@ describe('Assessment set syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedAssessmentSets = await util.dumpTable('assessment_sets');
     const syncedAssessmentSet = syncedAssessmentSets.find(
-      (as) => as.name === newAssessmentSet.name
+      (as) => as.name === newAssessmentSet.name,
     );
     checkAssessmentSet(syncedAssessmentSet, newAssessmentSet);
   });
@@ -61,7 +61,7 @@ describe('Assessment set syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedAssessmentSets = await util.dumpTable('assessment_sets');
     const syncedAssessmentSet = syncedAssessmentSets.find(
-      (as) => as.name === oldAssessmentSet.name
+      (as) => as.name === oldAssessmentSet.name,
     );
     assert.isUndefined(syncedAssessmentSet);
   });
@@ -101,7 +101,7 @@ describe('Assessment set syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessmentSets = await util.dumpTable('assessment_sets');
     const syncedAssessmentSet = syncedAssessmentSets.find(
-      (as) => as.name === newAssessmentSet1.name
+      (as) => as.name === newAssessmentSet1.name,
     );
     checkAssessmentSet(syncedAssessmentSet, newAssessmentSet2);
     const syncedCourses = await util.dumpTable('pl_courses');

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -185,7 +185,7 @@ describe('Assessment syncing', () => {
     assert.lengthOf(syncedData.assessment_questions, 3);
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.equal(firstAssessmentQuestion.max_points, 10);
     assert.equal(firstAssessmentQuestion.max_auto_points, 10);
@@ -193,7 +193,7 @@ describe('Assessment syncing', () => {
     assert.equal(firstAssessmentQuestion.max_manual_points, 0);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.equal(secondAssessmentQuestion.max_points, 5);
     assert.equal(secondAssessmentQuestion.max_auto_points, 5);
@@ -201,7 +201,7 @@ describe('Assessment syncing', () => {
     assert.equal(secondAssessmentQuestion.max_manual_points, 0);
 
     const thirdAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID
+      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID,
     );
     assert.equal(thirdAssessmentQuestion.max_points, 7);
     assert.equal(thirdAssessmentQuestion.max_auto_points, 0);
@@ -244,7 +244,7 @@ describe('Assessment syncing', () => {
     assert.lengthOf(syncedData.assessment_questions, 3);
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.equal(firstAssessmentQuestion.init_points, 10);
     assert.equal(firstAssessmentQuestion.max_points, 20);
@@ -252,7 +252,7 @@ describe('Assessment syncing', () => {
     assert.equal(firstAssessmentQuestion.max_manual_points, 0);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.equal(secondAssessmentQuestion.init_points, 5);
     assert.equal(secondAssessmentQuestion.max_points, 15);
@@ -260,7 +260,7 @@ describe('Assessment syncing', () => {
     assert.equal(secondAssessmentQuestion.max_manual_points, 0);
 
     const thirdAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID
+      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID,
     );
     assert.equal(thirdAssessmentQuestion.init_points, 7);
     assert.equal(thirdAssessmentQuestion.max_points, 7);
@@ -303,7 +303,7 @@ describe('Assessment syncing', () => {
     assert.lengthOf(syncedData.assessment_questions, 3);
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.equal(firstAssessmentQuestion.max_points, 13);
     assert.equal(firstAssessmentQuestion.max_auto_points, 10);
@@ -311,7 +311,7 @@ describe('Assessment syncing', () => {
     assert.equal(firstAssessmentQuestion.max_manual_points, 3);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.equal(secondAssessmentQuestion.max_points, 8);
     assert.equal(secondAssessmentQuestion.max_auto_points, 5);
@@ -319,7 +319,7 @@ describe('Assessment syncing', () => {
     assert.equal(secondAssessmentQuestion.max_manual_points, 3);
 
     const thirdAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID
+      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID,
     );
     assert.equal(thirdAssessmentQuestion.max_points, 8);
     assert.equal(thirdAssessmentQuestion.max_auto_points, 1);
@@ -364,7 +364,7 @@ describe('Assessment syncing', () => {
     assert.lengthOf(syncedData.assessment_questions, 3);
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.equal(firstAssessmentQuestion.init_points, 13);
     assert.equal(firstAssessmentQuestion.max_points, 23);
@@ -372,7 +372,7 @@ describe('Assessment syncing', () => {
     assert.equal(firstAssessmentQuestion.max_manual_points, 3);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.equal(secondAssessmentQuestion.init_points, 8);
     assert.equal(secondAssessmentQuestion.max_points, 18);
@@ -380,7 +380,7 @@ describe('Assessment syncing', () => {
     assert.equal(secondAssessmentQuestion.max_manual_points, 3);
 
     const thirdAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID
+      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID,
     );
     assert.equal(thirdAssessmentQuestion.init_points, 8);
     assert.equal(thirdAssessmentQuestion.max_points, 8);
@@ -421,7 +421,7 @@ describe('Assessment syncing', () => {
     assert.lengthOf(syncedData.assessment_questions, 3);
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.equal(firstAssessmentQuestion.max_points, 10);
     assert.equal(firstAssessmentQuestion.max_auto_points, 10);
@@ -429,7 +429,7 @@ describe('Assessment syncing', () => {
     assert.equal(firstAssessmentQuestion.max_manual_points, 0);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.equal(secondAssessmentQuestion.max_points, 5);
     assert.equal(secondAssessmentQuestion.max_auto_points, 5);
@@ -437,7 +437,7 @@ describe('Assessment syncing', () => {
     assert.equal(secondAssessmentQuestion.max_manual_points, 0);
 
     const thirdAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID
+      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID,
     );
     assert.equal(thirdAssessmentQuestion.max_points, 7);
     assert.equal(thirdAssessmentQuestion.max_auto_points, 0);
@@ -480,7 +480,7 @@ describe('Assessment syncing', () => {
     assert.lengthOf(syncedData.assessment_questions, 3);
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.equal(firstAssessmentQuestion.max_points, 18);
     assert.equal(firstAssessmentQuestion.max_auto_points, 10);
@@ -488,7 +488,7 @@ describe('Assessment syncing', () => {
     assert.equal(firstAssessmentQuestion.max_manual_points, 8);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.equal(secondAssessmentQuestion.max_points, 13);
     assert.equal(secondAssessmentQuestion.max_auto_points, 5);
@@ -496,7 +496,7 @@ describe('Assessment syncing', () => {
     assert.equal(secondAssessmentQuestion.max_manual_points, 8);
 
     const thirdAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID
+      (aq) => aq.question.qid === util.MANUAL_GRADING_QUESTION_ID,
     );
     assert.equal(thirdAssessmentQuestion.max_points, 10);
     assert.equal(thirdAssessmentQuestion.max_auto_points, 7);
@@ -526,10 +526,10 @@ describe('Assessment syncing', () => {
     const courseDir = await util.writeAndSyncCourseData(courseData);
     let syncedData = await getSyncedAssessmentData('newexam');
     const originalFirstSyncedAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     const originalSecondSyncedAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
 
     const removedQuestion = assessment.zones[0].questions?.shift();
@@ -537,7 +537,7 @@ describe('Assessment syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     syncedData = await getSyncedAssessmentData('newexam');
     const deletedFirstSyncedAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.isOk(deletedFirstSyncedAssessmentQuestion);
     assert.isNotNull(deletedFirstSyncedAssessmentQuestion.deleted_at);
@@ -546,10 +546,10 @@ describe('Assessment syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     syncedData = await getSyncedAssessmentData('newexam');
     const newFirstSyncedAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     const newSecondSyncedAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     // The questions were reordered, but they should still have the same assessment question IDs
     assert.equal(newFirstSyncedAssessmentQuestion.id, originalSecondSyncedAssessmentQuestion.id);
@@ -585,7 +585,7 @@ describe('Assessment syncing', () => {
       },
       {
         mode: 'Public',
-      }
+      },
     );
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['newexam'] = assessment;
     const courseDir = await util.writeAndSyncCourseData(courseData);
@@ -596,7 +596,7 @@ describe('Assessment syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedAssessmentAccessRules = await util.dumpTable('assessment_access_rules');
     const rulesForAssessment = syncedAssessmentAccessRules.filter((aar) =>
-      idsEqual(aar.assessment_id, originalSyncedAssessment?.id)
+      idsEqual(aar.assessment_id, originalSyncedAssessment?.id),
     );
     assert.lengthOf(rulesForAssessment, 1);
     assert.equal(rulesForAssessment[0].mode, 'Public');
@@ -619,7 +619,7 @@ describe('Assessment syncing', () => {
 
     const assessmentAccessRules = await util.dumpTable('assessment_access_rules');
     const assessmentAccessRule = assessmentAccessRules.find((aar) =>
-      idsEqual(aar.assessment_id, syncedAssessment?.id)
+      idsEqual(aar.assessment_id, syncedAssessment?.id),
     );
     assert.isArray(assessmentAccessRule?.uids, 'uids should be an array');
     assert.isEmpty(assessmentAccessRule?.uids, 'uids should be empty');
@@ -701,10 +701,10 @@ describe('Assessment syncing', () => {
     const syncedData = await getSyncedAssessmentData('groupAssessment');
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
 
     // Check group roles
@@ -723,42 +723,42 @@ describe('Assessment syncing', () => {
       syncedPermissions.find(
         (p) =>
           parseInt(p.assessment_question_id) === parseInt(assessmentQuestion.id) &&
-          parseInt(p.group_role_id) === parseInt(foundRole.id)
+          parseInt(p.group_role_id) === parseInt(foundRole.id),
       );
     const firstQuestionRecorderPermission = getPermission(foundRecorder, firstAssessmentQuestion);
     assert.isDefined(firstQuestionRecorderPermission);
     assert.isTrue(
       firstQuestionRecorderPermission?.can_view && firstQuestionRecorderPermission?.can_submit,
-      'recorder should have permission to view and submit first question'
+      'recorder should have permission to view and submit first question',
     );
 
     const firstQuestionContributorPermission = getPermission(
       foundContributor,
-      firstAssessmentQuestion
+      firstAssessmentQuestion,
     );
     assert.isDefined(firstQuestionContributorPermission);
     assert.isTrue(
       firstQuestionContributorPermission?.can_view &&
         !firstQuestionContributorPermission?.can_submit,
-      'contributor should only have permission to view first question'
+      'contributor should only have permission to view first question',
     );
 
     const secondQuestionRecorderPermission = getPermission(foundRecorder, secondAssessmentQuestion);
     assert.isDefined(secondQuestionRecorderPermission);
     assert.isTrue(
       secondQuestionRecorderPermission?.can_view && secondQuestionRecorderPermission?.can_submit,
-      'recorder should have permission to view and submit second question'
+      'recorder should have permission to view and submit second question',
     );
 
     const secondQuestionContributorPermission = getPermission(
       foundContributor,
-      secondAssessmentQuestion
+      secondAssessmentQuestion,
     );
     assert.isOk(secondQuestionContributorPermission);
     assert.isTrue(
       !secondQuestionContributorPermission?.can_view &&
         !secondQuestionContributorPermission?.can_submit,
-      'contributor should not be able to view or submit second question'
+      'contributor should not be able to view or submit second question',
     );
   });
 
@@ -811,12 +811,12 @@ describe('Assessment syncing', () => {
     assert.equal(
       syncedPermissions.filter((p) => parseInt(p.group_role_id) === parseInt(foundRecorder?.id))
         .length,
-      2
+      2,
     );
     assert.equal(
       syncedPermissions.filter((p) => parseInt(p.group_role_id) === parseInt(foundContributor?.id))
         .length,
-      2
+      2,
     );
 
     // Remove the "Contributor" group role and re-sync
@@ -851,7 +851,7 @@ describe('Assessment syncing', () => {
     assert.equal(newSyncedRoles.length, 1);
     assert.notEqual(
       newSyncedRoles.find((role) => role.role_name === 'Recorder'),
-      undefined
+      undefined,
     );
     assert.isUndefined(newSyncedRoles.find((role) => role.role_name === 'Contributor'));
 
@@ -859,13 +859,13 @@ describe('Assessment syncing', () => {
     assert.equal(
       newSyncedPermissions.filter((p) => parseInt(p.group_role_id) === parseInt(foundRecorder?.id))
         .length,
-      2
+      2,
     );
     assert.equal(
       newSyncedPermissions.filter(
-        (p) => parseInt(p.group_role_id) === parseInt(foundContributor?.id)
+        (p) => parseInt(p.group_role_id) === parseInt(foundContributor?.id),
       ).length,
-      0
+      0,
     );
   });
 
@@ -899,7 +899,7 @@ describe('Assessment syncing', () => {
 
     assert.match(
       syncedAssessment?.sync_errors,
-      /A zone question's "canView" permission contains the non-existent group role name "Invalid"./
+      /A zone question's "canView" permission contains the non-existent group role name "Invalid"./,
     );
   });
 
@@ -922,11 +922,11 @@ describe('Assessment syncing', () => {
 
     assert.match(
       syncedAssessment?.sync_errors,
-      /Could not find a role with minimum >= 1 and "can_assign_roles_at_start" set to "true"./
+      /Could not find a role with minimum >= 1 and "can_assign_roles_at_start" set to "true"./,
     );
     assert.match(
       syncedAssessment?.sync_errors,
-      /Could not find a role with minimum >= 1 and "can_assign_roles_during_assessment" set to "true"./
+      /Could not find a role with minimum >= 1 and "can_assign_roles_during_assessment" set to "true"./,
     );
   });
 
@@ -955,11 +955,11 @@ describe('Assessment syncing', () => {
 
     assert.match(
       syncedAssessment?.sync_errors,
-      /Group role "Manager" contains an invalid minimum. \(Expected at most 4, found 10\)./
+      /Group role "Manager" contains an invalid minimum. \(Expected at most 4, found 10\)./,
     );
     assert.match(
       syncedAssessment?.sync_errors,
-      /Group role "Reflector" contains an invalid maximum. \(Expected at most 4, found 10\)./
+      /Group role "Reflector" contains an invalid maximum. \(Expected at most 4, found 10\)./,
     );
   });
 
@@ -1032,10 +1032,10 @@ describe('Assessment syncing', () => {
 
     const syncedData = await getSyncedAssessmentData('groupAssessment');
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
 
     const newSyncedPermissions = await util.dumpTable('assessment_question_role_permissions');
@@ -1043,7 +1043,7 @@ describe('Assessment syncing', () => {
     const firstQuestionContributorPermission = newSyncedPermissions.find(
       (p) =>
         parseInt(p.assessment_question_id) === parseInt(firstAssessmentQuestion.id) &&
-        parseInt(p.group_role_id) === parseInt(foundContributor?.id)
+        parseInt(p.group_role_id) === parseInt(foundContributor?.id),
     );
     assert.isFalse(firstQuestionContributorPermission?.can_view);
     assert.isFalse(firstQuestionContributorPermission?.can_submit);
@@ -1052,7 +1052,7 @@ describe('Assessment syncing', () => {
     const secondQuestionContributorPermission = newSyncedPermissions.find(
       (p) =>
         parseInt(p.assessment_question_id) === parseInt(secondAssessmentQuestion.id) &&
-        parseInt(p.group_role_id) === parseInt(foundContributor?.id)
+        parseInt(p.group_role_id) === parseInt(foundContributor?.id),
     );
     assert.isTrue(secondQuestionContributorPermission?.can_view);
     assert.isFalse(secondQuestionContributorPermission?.can_submit);
@@ -1068,12 +1068,12 @@ describe('Assessment syncing', () => {
     const courseDir = await util.writeAndSyncCourseData(courseData);
     let syncedAssessmentSets = await util.dumpTable('assessment_sets');
     let syncedAssessmentSet = syncedAssessmentSets.find(
-      (aset) => aset.name === missingAssessmentSetName
+      (aset) => aset.name === missingAssessmentSetName,
     );
     assert.isOk(syncedAssessmentSet);
     assert.isTrue(
       syncedAssessmentSet?.heading && syncedAssessmentSet.heading.length > 0,
-      'assessment set should not have empty heading'
+      'assessment set should not have empty heading',
     );
 
     // When missing assessment sets are no longer used in any questions, they should
@@ -1082,7 +1082,7 @@ describe('Assessment syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     syncedAssessmentSets = await util.dumpTable('assessment_sets');
     syncedAssessmentSet = syncedAssessmentSets.find(
-      (aset) => aset.name === missingAssessmentSetName
+      (aset) => aset.name === missingAssessmentSetName,
     );
     assert.isUndefined(syncedAssessmentSet);
   });
@@ -1099,7 +1099,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Invalid allowAccess rule: startDate \(2020-01-01T11:11:11\) must not be after endDate \(2019-01-01T00:00:00\)/
+      /Invalid allowAccess rule: startDate \(2020-01-01T11:11:11\) must not be after endDate \(2019-01-01T00:00:00\)/,
     );
   });
 
@@ -1115,7 +1115,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Invalid allowAccess rule: startDate \(not a valid date\) is not valid/
+      /Invalid allowAccess rule: startDate \(not a valid date\) is not valid/,
     );
   });
 
@@ -1131,7 +1131,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Invalid allowAccess rule: endDate \(not a valid date\) is not valid/
+      /Invalid allowAccess rule: endDate \(not a valid date\) is not valid/,
     );
   });
 
@@ -1147,7 +1147,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Invalid allowAccess rule: credit must be 0 if active is false/
+      /Invalid allowAccess rule: credit must be 0 if active is false/,
     );
   });
 
@@ -1163,7 +1163,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Zone question must specify either "alternatives" or "id"/
+      /Zone question must specify either "alternatives" or "id"/,
     );
   });
 
@@ -1185,7 +1185,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify "maxPoints" or "maxAutoPoints" for a question in an "Exam" assessment/
+      /Cannot specify "maxPoints" or "maxAutoPoints" for a question in an "Exam" assessment/,
     );
   });
 
@@ -1205,7 +1205,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Must specify "points", "autoPoints" or "manualPoints" for a question/
+      /Must specify "points", "autoPoints" or "manualPoints" for a question/,
     );
   });
 
@@ -1225,7 +1225,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Must specify "points", "autoPoints" or "manualPoints" for a question/
+      /Must specify "points", "autoPoints" or "manualPoints" for a question/,
     );
   });
 
@@ -1247,7 +1247,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify "points" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified/
+      /Cannot specify "points" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified/,
     );
   });
 
@@ -1269,7 +1269,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify "points" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified/
+      /Cannot specify "points" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified/,
     );
   });
 
@@ -1291,7 +1291,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify "maxPoints" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified/
+      /Cannot specify "maxPoints" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified/,
     );
   });
 
@@ -1313,7 +1313,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify "points" or "autoPoints" as a list for a question in a "Homework" assessment/
+      /Cannot specify "points" or "autoPoints" as a list for a question in a "Homework" assessment/,
     );
   });
 
@@ -1326,7 +1326,7 @@ describe('Assessment syncing', () => {
     assert.isOk(syncedAssessment);
     assert.match(
       syncedAssessment?.sync_errors,
-      /Missing JSON file: courseInstances\/Fa19\/assessments\/fail\/infoAssessment.json/
+      /Missing JSON file: courseInstances\/Fa19\/assessments\/fail\/infoAssessment.json/,
     );
   });
 
@@ -1347,7 +1347,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /The following questions do not exist in this course: i do not exist/
+      /The following questions do not exist in this course: i do not exist/,
     );
   });
 
@@ -1372,7 +1372,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /The following questions are used more than once: test/
+      /The following questions are used more than once: test/,
     );
   });
 
@@ -1385,7 +1385,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Real-time grading cannot be disabled for Homework-type assessments/
+      /Real-time grading cannot be disabled for Homework-type assessments/,
     );
   });
 
@@ -1413,7 +1413,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify an array of multiple point values for a question/
+      /Cannot specify an array of multiple point values for a question/,
     );
   });
 
@@ -1442,12 +1442,12 @@ describe('Assessment syncing', () => {
     const syncedData = await getSyncedAssessmentData('points_array_size_one');
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.deepEqual(firstAssessmentQuestion.points_list, [5]);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.deepEqual(secondAssessmentQuestion.points_list, [10]);
 
@@ -1483,7 +1483,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /Cannot specify an array of multiple point values for an alternative/
+      /Cannot specify an array of multiple point values for an alternative/,
     );
   });
 
@@ -1536,12 +1536,12 @@ describe('Assessment syncing', () => {
     const syncedData = await getSyncedAssessmentData('points_array_size_one');
 
     const firstAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.QUESTION_ID
+      (aq) => aq.question.qid === util.QUESTION_ID,
     );
     assert.deepEqual(firstAssessmentQuestion.points_list, [10]);
 
     const secondAssessmentQuestion = syncedData.assessment_questions.find(
-      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID
+      (aq) => aq.question.qid === util.ALTERNATIVE_QUESTION_ID,
     );
     assert.deepEqual(secondAssessmentQuestion.points_list, [5]);
 
@@ -1558,12 +1558,12 @@ describe('Assessment syncing', () => {
     const syncedAssessment1 = await findSyncedAssessment('fail1');
     assert.match(
       syncedAssessment1?.sync_warnings,
-      /UUID "1e0724c3-47af-4ca3-9188-5227ef0c5549" is used in other assessments in this course instance: fail2/
+      /UUID "1e0724c3-47af-4ca3-9188-5227ef0c5549" is used in other assessments in this course instance: fail2/,
     );
     const syncedAssessment2 = await findSyncedAssessment('fail2');
     assert.match(
       syncedAssessment2?.sync_warnings,
-      /UUID "1e0724c3-47af-4ca3-9188-5227ef0c5549" is used in other assessments in this course instance: fail1/
+      /UUID "1e0724c3-47af-4ca3-9188-5227ef0c5549" is used in other assessments in this course instance: fail1/,
     );
   });
 
@@ -1688,14 +1688,14 @@ describe('Assessment syncing', () => {
     // check that the newly-synced assessment has an error
     const syncedAssessments = await util.dumpTable('assessments');
     const syncedAssessment = syncedAssessments.find(
-      (a) => a.tid === 'repeatedAssessment' && a.deleted_at == null
+      (a) => a.tid === 'repeatedAssessment' && a.deleted_at == null,
     );
     assert.equal(syncedAssessment?.uuid, newAssessment.uuid);
     assert.match(syncedAssessment?.sync_errors, /must have required property 'title'/);
 
     // check that the old deleted assessment does not have any errors
     const deletedAssessment = syncedAssessments.find(
-      (a) => a.tid === 'repeatedAssessment' && a.deleted_at != null
+      (a) => a.tid === 'repeatedAssessment' && a.deleted_at != null,
     );
     assert.equal(deletedAssessment?.uuid, originalAssessment.uuid);
     assert.equal(deletedAssessment?.sync_errors, null);
@@ -1717,8 +1717,8 @@ describe('Assessment syncing', () => {
         'courseInstances',
         util.COURSE_INSTANCE_ID,
         'assessments',
-        ...nestedAssessmentStructure
-      )
+        ...nestedAssessmentStructure,
+      ),
     );
     await util.syncCourseData(courseDir);
 
@@ -1727,8 +1727,8 @@ describe('Assessment syncing', () => {
     assert.match(
       syncedAssessment?.sync_errors,
       new RegExp(
-        `Missing JSON file: courseInstances/${util.COURSE_INSTANCE_ID}/assessments/subfolder1/subfolder2/subfolder3/nestedAssessment/infoAssessment.json`
-      )
+        `Missing JSON file: courseInstances/${util.COURSE_INSTANCE_ID}/assessments/subfolder1/subfolder2/subfolder3/nestedAssessment/infoAssessment.json`,
+      ),
     );
 
     // We should only record an error for the most deeply nested directories,
@@ -1752,7 +1752,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.equal(
       syncedAssessment?.sync_errors,
-      `"multipleInstance" cannot be used for Homework-type assessments`
+      `"multipleInstance" cannot be used for Homework-type assessments`,
     );
   });
 

--- a/apps/prairielearn/src/tests/sync/courseDb.test.js
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.js
@@ -222,12 +222,12 @@ describe('course database', () => {
         assert.equal(Object.keys(result).length, 3);
         assert.match(
           infofile.stringifyWarnings(result['question1']),
-          /UUID.*is used in other questions/
+          /UUID.*is used in other questions/,
         );
         assert.isFalse(infofile.hasErrors(result['question1']));
         assert.match(
           infofile.stringifyWarnings(result['question2']),
-          /UUID.*is used in other questions/
+          /UUID.*is used in other questions/,
         );
         assert.isFalse(infofile.hasErrors(result['question2']));
         assert.isFalse(infofile.hasErrors(result['question3']));

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -42,7 +42,7 @@ describe('Course instance syncing', () => {
 
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === courseInstanceId
+      (ci) => ci.short_name === courseInstanceId,
     );
     assert.isOk(syncedCourseInstance);
   });
@@ -54,7 +54,7 @@ describe('Course instance syncing', () => {
     const syncedAccessRules = await util.dumpTable('course_instance_access_rules');
     assert.equal(
       syncedAccessRules.length,
-      courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.allowAccess?.length
+      courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.allowAccess?.length,
     );
   });
 
@@ -63,7 +63,7 @@ describe('Course instance syncing', () => {
     const originalCourseInstance = courseData.courseInstances[util.COURSE_INSTANCE_ID];
     let syncedCourseInstances = await util.dumpTable('course_instances');
     const originalSyncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.isOk(originalSyncedCourseInstance);
 
@@ -71,7 +71,7 @@ describe('Course instance syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     syncedCourseInstances = await util.dumpTable('course_instances');
     const deletedSyncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.isOk(deletedSyncedCourseInstance);
     assert.isNotNull(deletedSyncedCourseInstance?.deleted_at);
@@ -80,7 +80,7 @@ describe('Course instance syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     syncedCourseInstances = await util.dumpTable('course_instances');
     const newSyncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.isOk(newSyncedCourseInstance);
     assert.isNull(newSyncedCourseInstance?.deleted_at);
@@ -91,7 +91,7 @@ describe('Course instance syncing', () => {
     const courseData = util.getCourseData();
     const courseDir = await util.writeCourseToTempDirectory(courseData);
     await fs.remove(
-      path.join(courseDir, 'courseInstances', util.COURSE_INSTANCE_ID, 'assessments')
+      path.join(courseDir, 'courseInstances', util.COURSE_INSTANCE_ID, 'assessments'),
     );
     await util.syncCourseData(courseDir);
   });
@@ -108,10 +108,10 @@ describe('Course instance syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     const syncedAccessRules = (await util.dumpTable('course_instance_access_rules')).filter((ar) =>
-      idsEqual(ar.course_instance_id, syncedCourseInstance?.id)
+      idsEqual(ar.course_instance_id, syncedCourseInstance?.id),
     );
     assert.lengthOf(syncedAccessRules, 1);
     const [syncedAccessRule] = syncedAccessRules;
@@ -127,20 +127,20 @@ describe('Course instance syncing', () => {
     await util.syncCourseData(courseDir);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const firstCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.match(
       firstCourseInstance?.sync_warnings,
-      /UUID "a17b1abd-eaf6-45dc-99bc-9890a7fb345e" is used in other course instances: newinstance/
+      /UUID "a17b1abd-eaf6-45dc-99bc-9890a7fb345e" is used in other course instances: newinstance/,
     );
     const secondCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === 'newinstance'
+      (ci) => ci.short_name === 'newinstance',
     );
     assert.match(
       secondCourseInstance?.sync_warnings,
       new RegExp(
-        `UUID "a17b1abd-eaf6-45dc-99bc-9890a7fb345e" is used in other course instances: ${util.COURSE_INSTANCE_ID}`
-      )
+        `UUID "a17b1abd-eaf6-45dc-99bc-9890a7fb345e" is used in other course instances: ${util.COURSE_INSTANCE_ID}`,
+      ),
     );
   });
 
@@ -153,11 +153,11 @@ describe('Course instance syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.match(
       syncedCourseInstance?.sync_errors,
-      /Invalid allowAccess rule: startDate \(2020-01-01T11:11:11\) must not be after endDate \(2019-01-01T00:00:00\)/
+      /Invalid allowAccess rule: startDate \(2020-01-01T11:11:11\) must not be after endDate \(2019-01-01T00:00:00\)/,
     );
   });
 
@@ -170,11 +170,11 @@ describe('Course instance syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.match(
       syncedCourseInstance?.sync_errors,
-      /Invalid allowAccess rule: startDate \(not a valid date\) is not valid/
+      /Invalid allowAccess rule: startDate \(not a valid date\) is not valid/,
     );
   });
 
@@ -187,11 +187,11 @@ describe('Course instance syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === util.COURSE_INSTANCE_ID
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
     );
     assert.match(
       syncedCourseInstance?.sync_errors,
-      /Invalid allowAccess rule: endDate \(not a valid date\) is not valid/
+      /Invalid allowAccess rule: endDate \(not a valid date\) is not valid/,
     );
   });
 
@@ -202,12 +202,12 @@ describe('Course instance syncing', () => {
     await util.syncCourseData(courseDir);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === 'badCourseInstance'
+      (ci) => ci.short_name === 'badCourseInstance',
     );
     assert.isOk(syncedCourseInstance);
     assert.match(
       syncedCourseInstance?.sync_errors,
-      /Missing JSON file: courseInstances\/badCourseInstance\/infoCourseInstance.json/
+      /Missing JSON file: courseInstances\/badCourseInstance\/infoCourseInstance.json/,
     );
   });
 
@@ -226,12 +226,12 @@ describe('Course instance syncing', () => {
 
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === courseInstanceId
+      (ci) => ci.short_name === courseInstanceId,
     );
     assert.isOk(syncedCourseInstance);
     assert.match(
       syncedCourseInstance?.sync_errors,
-      /Missing JSON file: courseInstances\/subfolder1\/subfolder2\/subfolder3\/nestedCourseInstance\/infoCourseInstance.json/
+      /Missing JSON file: courseInstances\/subfolder1\/subfolder2\/subfolder3\/nestedCourseInstance\/infoCourseInstance.json/,
     );
 
     // We should only record an error for the most deeply nested directories,
@@ -240,7 +240,7 @@ describe('Course instance syncing', () => {
       const partialNestedCourseInstanceStructure = nestedCourseInstanceStructure.slice(0, i);
       const partialCourseInstanceId = partialNestedCourseInstanceStructure.join('/');
       const syncedCourseInstance = syncedCourseInstances.find(
-        (ci) => ci.short_name === partialCourseInstanceId
+        (ci) => ci.short_name === partialCourseInstanceId,
       );
       assert.isUndefined(syncedCourseInstance);
     }
@@ -258,7 +258,7 @@ describe('Course instance syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at == null
+      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at == null,
     );
     assert.equal(syncedCourseInstance?.uuid, courseInstance.courseInstance.uuid);
     assert.equal(syncedCourseInstance?.long_name, courseInstance.courseInstance.longName);
@@ -278,7 +278,7 @@ describe('Course instance syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const deletedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at != null
+      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at != null,
     );
     assert.equal(deletedCourseInstance?.uuid, originalCourseInstance.courseInstance.uuid);
     assert.equal(deletedCourseInstance?.long_name, originalCourseInstance.courseInstance.longName);
@@ -300,14 +300,14 @@ describe('Course instance syncing', () => {
     // check that the newly-synced course instance has an error
     const syncedCourseInstances = await util.dumpTable('course_instances');
     const syncedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at == null
+      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at == null,
     );
     assert.equal(syncedCourseInstance?.uuid, newCourseInstance.courseInstance.uuid);
     assert.match(syncedCourseInstance?.sync_errors, /must have required property 'longName'/);
 
     // check that the old deleted course instance does not have any errors
     const deletedCourseInstance = syncedCourseInstances.find(
-      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at != null
+      (ci) => ci.short_name === 'repeatedCourseInstance' && ci.deleted_at != null,
     );
     assert.equal(deletedCourseInstance?.uuid, originalCourseInstance.courseInstance.uuid);
     assert.equal(deletedCourseInstance?.sync_errors, null);
@@ -351,12 +351,12 @@ describe('Course instance syncing', () => {
 
     // New course instances should exist and have the correct UUIDs.
     const newCourseInstanceRow1 = courseInstances.find(
-      (ci) => ci.short_name === 'b' && ci.deleted_at === null
+      (ci) => ci.short_name === 'b' && ci.deleted_at === null,
     );
     assert.isNull(newCourseInstanceRow1?.deleted_at);
     assert.equal(newCourseInstanceRow1?.uuid, '0e8097aa-b554-4908-9eac-d46a78d6c249');
     const newCourseInstanceRow2 = courseInstances.find(
-      (q) => q.short_name === 'c' && q.deleted_at === null
+      (q) => q.short_name === 'c' && q.deleted_at === null,
     );
     assert.isNull(newCourseInstanceRow2?.deleted_at);
     assert.equal(newCourseInstanceRow2?.uuid, '0e3097ba-b554-4908-9eac-d46a78d6c249');

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -140,11 +140,11 @@ describe('Question syncing', () => {
     assert.isEmpty(syncedQuestion?.client_files, 'client_files should be empty');
     assert.isArray(
       syncedQuestion?.external_grading_files,
-      'external_grading_files should be an array'
+      'external_grading_files should be an array',
     );
     assert.isEmpty(
       syncedQuestion?.external_grading_files,
-      'external_grading_files should be empty'
+      'external_grading_files should be empty',
     );
   });
 
@@ -211,7 +211,7 @@ describe('Question syncing', () => {
     const syncedTag = syncedTags.find((t) => t.name === newTag.name);
     const syncedQuestionTags = await util.dumpTable('question_tags');
     const syncedQuestionTag = syncedQuestionTags.find(
-      (qt) => idsEqual(qt.question_id, newSyncedQuestion?.id) && idsEqual(qt.tag_id, syncedTag?.id)
+      (qt) => idsEqual(qt.question_id, newSyncedQuestion?.id) && idsEqual(qt.tag_id, syncedTag?.id),
     );
     assert.ok(syncedQuestionTag);
   });
@@ -231,7 +231,7 @@ describe('Question syncing', () => {
     const syncedQuestion = syncedQuestions.find((q) => q.qid === util.QUESTION_ID);
     assert.match(
       syncedQuestion?.sync_errors,
-      /data must have required property 'incorrectAnswers'/
+      /data must have required property 'incorrectAnswers'/,
     );
   });
 
@@ -244,14 +244,14 @@ describe('Question syncing', () => {
     const firstSyncedQuestion = syncedQuestions.find((q) => q.qid === util.QUESTION_ID);
     assert.match(
       firstSyncedQuestion?.sync_warnings,
-      /UUID "f4ff2429-926e-4358-9e1f-d2f377e2036a" is used in other questions: test2/
+      /UUID "f4ff2429-926e-4358-9e1f-d2f377e2036a" is used in other questions: test2/,
     );
     const secondSyncedQuestion = syncedQuestions.find((q) => q.qid === util.QUESTION_ID);
     assert.match(
       secondSyncedQuestion?.sync_warnings,
       new RegExp(
-        `UUID "f4ff2429-926e-4358-9e1f-d2f377e2036a" is used in other questions: ${util.QUESTION_ID}`
-      )
+        `UUID "f4ff2429-926e-4358-9e1f-d2f377e2036a" is used in other questions: ${util.QUESTION_ID}`,
+      ),
     );
   });
 
@@ -266,7 +266,7 @@ describe('Question syncing', () => {
     assert.isOk(syncedQuestion);
     assert.match(
       syncedQuestion?.sync_errors,
-      /Missing JSON file: questions\/badQuestion\/info.json/
+      /Missing JSON file: questions\/badQuestion\/info.json/,
     );
   });
 
@@ -283,7 +283,7 @@ describe('Question syncing', () => {
     assert.isOk(syncedQuestion);
     assert.match(
       syncedQuestion?.sync_errors,
-      /Missing JSON file: questions\/subfolder1\/subfolder2\/subfolder3\/nestedQuestion\/info.json/
+      /Missing JSON file: questions\/subfolder1\/subfolder2\/subfolder3\/nestedQuestion\/info.json/,
     );
 
     // We should only record an error for the most deeply nested directories,
@@ -323,7 +323,7 @@ describe('Question syncing', () => {
     await util.overwriteAndSyncCourseData(courseData, courseDir);
     const syncedQuestions = await util.dumpTable('questions');
     const deletedQuestion = syncedQuestions.find(
-      (q) => q.qid === 'repeatedQuestion' && q.deleted_at != null
+      (q) => q.qid === 'repeatedQuestion' && q.deleted_at != null,
     );
     assert.equal(deletedQuestion?.uuid, originalQuestion.uuid);
     assert.equal(deletedQuestion?.title, originalQuestion.title);
@@ -346,14 +346,14 @@ describe('Question syncing', () => {
     // check that the newly-synced question has an error
     const syncedQuestions = await util.dumpTable('questions');
     const syncedQuestion = syncedQuestions.find(
-      (q) => q.qid === 'repeatedQuestion' && q.deleted_at == null
+      (q) => q.qid === 'repeatedQuestion' && q.deleted_at == null,
     );
     assert.equal(syncedQuestion?.uuid, newQuestion.uuid);
     assert.match(syncedQuestion?.sync_errors, /must have required property 'title'/);
 
     // check that the old deleted question does not have any errors
     const deletedQuestion = syncedQuestions.find(
-      (q) => q.qid === 'repeatedQuestion' && q.deleted_at != null
+      (q) => q.qid === 'repeatedQuestion' && q.deleted_at != null,
     );
     assert.equal(deletedQuestion?.uuid, originalQuestion.uuid);
     assert.equal(deletedQuestion?.sync_errors, null);

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -579,7 +579,7 @@ module.exports.assertSnapshotsMatch = function (snapshotA, snapshotB, ignoredKey
   // Sanity check - make sure both snapshots have the same keys
   assert(
     checkSetsSame(new Set(Object.keys(snapshotA)), new Set(Object.keys(snapshotB))),
-    'snapshots contained different keys'
+    'snapshots contained different keys',
   );
   for (const key of Object.keys(snapshotA)) {
     if (ignoredKeys.indexOf(key) !== -1) continue;
@@ -602,7 +602,7 @@ module.exports.assertSnapshotSubset = function (snapshotA, snapshotB, ignoredKey
   // Sanity check - make sure both snapshots have the same keys
   assert(
     checkSetsSame(new Set(Object.keys(snapshotA)), new Set(Object.keys(snapshotB))),
-    'snapshots contained different keys'
+    'snapshots contained different keys',
   );
   for (const key of Object.keys(snapshotA)) {
     if (ignoredKeys.indexOf(key) !== -1) continue;
@@ -611,7 +611,7 @@ module.exports.assertSnapshotSubset = function (snapshotA, snapshotB, ignoredKey
     const setB = new Set(snapshotB[key].map((s) => stringify(s)));
     assert(
       [...setA].every((entry) => setB.has(entry)),
-      `Snapshot of ${key} is not a subset`
+      `Snapshot of ${key} is not a subset`,
     );
   }
 };

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -86,7 +86,7 @@ describe('Assessment that forces students to complete questions in-order', funct
         context.instanceQuestions.map((e) => {
           return e.locked;
         }),
-        initialExpectedLocks
+        initialExpectedLocks,
       );
     });
 
@@ -103,7 +103,7 @@ describe('Assessment that forces students to complete questions in-order', funct
     it('Question 3 should require 60% on Question 2 to unlock', () => {
       assert.include(
         response.$('table[data-testid="assessment-questions"] tbody tr:nth-child(3)').html(),
-        '60% on Question 2'
+        '60% on Question 2',
       );
     });
   });

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -180,7 +180,7 @@ describe('Zone grading exam assessment', function () {
         locals.assessmentUrl = locals.siteUrl + elemList[0].attribs.href;
         assert.equal(
           locals.assessmentUrl,
-          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/'
+          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/',
         );
       });
     });
@@ -239,7 +239,7 @@ describe('Zone grading exam assessment', function () {
             res = response;
             page = body;
             callback(null);
-          }
+          },
         );
       });
       it('should parse', function () {
@@ -268,8 +268,8 @@ describe('Zone grading exam assessment', function () {
           if (result.rowCount !== questionsArray.length) {
             return callback(
               new Error(
-                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount
-              )
+                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount,
+              ),
             );
           }
           locals.instance_questions = result.rows;
@@ -334,9 +334,9 @@ describe('Zone grading exam assessment', function () {
       startAssessment();
 
       zoneGradingTest.forEach(function (questionTest, iQuestionTest) {
-        describe(`${
-          questionTest.action
-        } answer number #${iQuestionTest + 1} for question ${questionTest.qid} with score ${questionTest.score}`, function () {
+        describe(`${questionTest.action} answer number #${iQuestionTest + 1} for question ${
+          questionTest.qid
+        } with score ${questionTest.score}`, function () {
           describe('setting up the submission data', function () {
             it('should succeed', function () {
               if (questionTest.action === 'check-closed') {

--- a/apps/prairielearn/src/tests/zoneGradingHomework.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingHomework.test.js
@@ -205,7 +205,7 @@ describe('Zone grading homework assessment', function () {
         locals.assessmentUrl = locals.siteUrl + elemList[0].attribs.href;
         assert.equal(
           locals.assessmentUrl,
-          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/'
+          locals.courseInstanceBaseUrl + '/assessment/' + locals.assessment_id + '/',
         );
       });
     });
@@ -249,8 +249,8 @@ describe('Zone grading homework assessment', function () {
           if (result.rowCount !== questionsArray.length) {
             return callback(
               new Error(
-                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount
-              )
+                `expected ${questionsArray.length} instance_questions, got: ` + result.rowCount,
+              ),
             );
           }
           locals.instance_questions = result.rows;
@@ -315,9 +315,9 @@ describe('Zone grading homework assessment', function () {
       startAssessment();
 
       zoneGradingTest.forEach(function (questionTest, iQuestionTest) {
-        describe(`${
-          questionTest.action
-        } answer number #${iQuestionTest + 1} for question ${questionTest.qid} with score ${questionTest.score}`, function () {
+        describe(`${questionTest.action} answer number #${iQuestionTest + 1} for question ${
+          questionTest.qid
+        } with score ${questionTest.score}`, function () {
           describe('setting up the submission data', function () {
             it('should succeed', function () {
               if (questionTest.action === 'check-closed') {

--- a/apps/prairielearn/v2-question-servers/FileClient.js
+++ b/apps/prairielearn/v2-question-servers/FileClient.js
@@ -3,7 +3,7 @@ var httpDownloadPrefix = 'data:text/plain;base64,';
 define(['SimpleClient', 'text!./question.html', 'text!./answer.html'], function (
   SimpleClient,
   questionTemplate,
-  answerTemplate
+  answerTemplate,
 ) {
   var simpleClient = new SimpleClient.SimpleClient({
     questionTemplate: questionTemplate,
@@ -57,6 +57,6 @@ define(['SimpleClient', 'text!./question.html', 'text!./answer.html'], function 
 if (!window.File || !window.FileReader || !window.FileList || !window.Blob) {
   alert(
     'Warning: Your browser does not fully support HTML5 file upload operations.' +
-      'Please use a more current browser or you may not be able to complete this question.'
+      'Please use a more current browser or you may not be able to complete this question.',
   );
 }

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -71,7 +71,7 @@ app.get(
       docker: containers,
       postgres: db_status,
     });
-  })
+  }),
 );
 
 // TODO: refactor into RESTful endpoints (https://github.com/PrairieLearn/PrairieLearn/pull/2841#discussion_r467245108)
@@ -94,7 +94,7 @@ app.post(
     } else {
       res.status(500).send(`Action '${action}' undefined`);
     }
-  })
+  }),
 );
 
 app.use(Sentry.Handlers.errorHandler());
@@ -158,7 +158,7 @@ async
         idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
       };
       logger.verbose(
-        `Connecting to database ${pgConfig.user}@${pgConfig.host}:${pgConfig.database}`
+        `Connecting to database ${pgConfig.user}@${pgConfig.host}:${pgConfig.database}`,
       );
       const idleErrorHandler = function (err) {
         logger.error('idle client error', err);
@@ -245,7 +245,7 @@ async
         if (result.rows.some((ws) => ws.id === containerWorkspaceId)) continue;
 
         logger.info(
-          `Killing dangling container ${container.Id} for workspace ${containerWorkspaceId}`
+          `Killing dangling container ${container.Id} for workspace ${containerWorkspaceId}`,
         );
         await dockerAttemptKillAndRemove(docker.getContainer(container.Id));
       }
@@ -300,7 +300,7 @@ async function pruneRunawayContainers() {
     instance_id,
   });
   const db_workspaces_uuid_set = new Set(
-    db_workspaces.rows.map((ws) => `workspace-${ws.launch_uuid}`)
+    db_workspaces.rows.map((ws) => `workspace-${ws.launch_uuid}`),
   );
   let running_workspaces;
   try {
@@ -467,7 +467,7 @@ async function _allocateContainerPort(workspace) {
       port =
         config.workspaceHostMinPortRange +
         Math.floor(
-          Math.random() * (config.workspaceHostMaxPortRange - config.workspaceHostMinPortRange)
+          Math.random() * (config.workspaceHostMaxPortRange - config.workspaceHostMinPortRange),
         );
       if (!(await check_port_db(port))) continue;
       if (!(await check_port_server(port))) continue;
@@ -512,14 +512,14 @@ function _checkServer(workspace, callback) {
             const { id, version, launch_uuid } = workspace;
             callback(
               new Error(
-                `Max startup time exceeded for workspace ${id} (version ${version}, launch uuid ${launch_uuid})`
-              )
+                `Max startup time exceeded for workspace ${id} (version ${version}, launch uuid ${launch_uuid})`,
+              ),
             );
           } else {
             setTimeout(checkWorkspace, checkMilliseconds);
           }
         }
-      }
+      },
     );
   }
   setTimeout(checkWorkspace, checkMilliseconds);
@@ -549,7 +549,7 @@ async function _getWorkspaceSettingsAsync(workspace_id) {
     workspace_enable_networking: !!result.rows[0].workspace_enable_networking,
     // Convert {key: 'value'} to ['key=value'] and {key: null} to ['key'] for Docker API
     workspace_environment: Object.entries(workspace_environment).map(([k, v]) =>
-      v === null ? k : `${k}=${v}`
+      v === null ? k : `${k}=${v}`,
     ),
   };
 
@@ -585,7 +585,7 @@ async function _pullImage(workspace) {
   } catch (err) {
     logger.error(
       `Error pulling "${workspace_image}" image; attempting to fall back to cached version.`,
-      err
+      err,
     );
     return;
   }
@@ -645,11 +645,11 @@ async function _pullImage(workspace) {
         }
         current = Object.values(progressDetails).reduce(
           (current, detail) => detail.current + current,
-          0
+          0,
         );
         const newTotal = Object.values(progressDetails).reduce(
           (total, detail) => detail.total + total,
-          0
+          0,
         );
         if (outputCount <= 200) {
           // limit progress initially to wait for most layers to be seen
@@ -682,7 +682,7 @@ async function _pullImage(workspace) {
               });
           }
         }
-      }
+      },
     );
   });
 }
@@ -730,7 +730,7 @@ function _createContainer(workspace, callback) {
   debug(`Network mode: ${networkMode}`);
   debug(`Env vars: ${workspace.settings.workspace_environment}`);
   debug(
-    `User binding: ${config.workspaceJobsDirectoryOwnerUid}:${config.workspaceJobsDirectoryOwnerGid}`
+    `User binding: ${config.workspaceJobsDirectoryOwnerUid}:${config.workspaceJobsDirectoryOwnerGid}`,
   );
   debug(`Port binding: ${workspace.settings.workspace_port}:${workspace.launch_port}`);
   debug(`Volume mount: ${workspacePath}:${containerPath}`);
@@ -766,7 +766,7 @@ function _createContainer(workspace, callback) {
           (err) => {
             if (ERR(err, callback)) return;
             callback(null);
-          }
+          },
         );
       },
       (callback) => {
@@ -817,16 +817,16 @@ function _createContainer(workspace, callback) {
               function (err, _result) {
                 if (ERR(err, callback)) return;
                 callback(null, container);
-              }
+              },
             );
-          }
+          },
         );
       },
     ],
     (err) => {
       if (ERR(err, callback)) return;
       callback(null, container);
-    }
+    },
   );
 }
 const _createContainerAsync = util.promisify(_createContainer);
@@ -891,7 +891,7 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
       safeUpdateWorkspaceState(
         workspace_id,
         'stopped',
-        `Error configuring workspace. Click "Reboot" to try again.`
+        `Error configuring workspace. Click "Reboot" to try again.`,
       );
       return; // don't set host to unhealthy
     }
@@ -904,7 +904,7 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
       safeUpdateWorkspaceState(
         workspace_id,
         'stopped',
-        `Error pulling image. Click "Reboot" to try again.`
+        `Error pulling image. Click "Reboot" to try again.`,
       );
       return; // don't set host to unhealthy
     }
@@ -922,7 +922,7 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
       safeUpdateWorkspaceState(
         workspace_id,
         'stopped',
-        `Error creating container. Click "Reboot" to try again.`
+        `Error creating container. Click "Reboot" to try again.`,
       );
       return; // don't set host to unhealthy
     }
@@ -937,7 +937,7 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
       safeUpdateWorkspaceState(
         workspace_id,
         'stopped',
-        `Error starting container. Click "Reboot" to try again.`
+        `Error starting container. Click "Reboot" to try again.`,
       );
       return; // don't set host to unhealthy
     }
@@ -966,7 +966,7 @@ async function sendGradedFilesArchive(workspace_id, res) {
       {
         maxFiles: config.workspaceMaxGradedFilesCount,
         maxSize: config.workspaceMaxGradedFilesSize,
-      }
+      },
     );
   } catch (err) {
     res.status(500).send(err.message);

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -141,7 +141,7 @@ pages/instructorGradebook
 ```javascript
 app.use(
   '/instructor/:courseInstanceId/gradebook',
-  require('./pages/instructorGradebook/instructorGradebook')
+  require('./pages/instructorGradebook/instructorGradebook'),
 );
 ```
 
@@ -579,7 +579,7 @@ router.get(
   '/',
   asyncHandler(async (req, res, next) => {
     // can use "await" here
-  })
+  }),
 );
 ```
 
@@ -812,7 +812,7 @@ router.post('/', function (req, res, next) {
       error.make(400, 'unknown __action', {
         body: req.body,
         locals: res.locals,
-      })
+      }),
     );
   }
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-no-only-tests": "^3.1.0",
     "htmlhint": "^1.1.4",
     "jsdoc": "^4.0.2",
-    "prettier": "2.8.8",
+    "prettier": "3.0.0",
     "pyright": "^1.1.311",
     "s3rver": "^3.7.1",
     "turbo": "^1.10.1",

--- a/packages/browser-utils/README.md
+++ b/packages/browser-utils/README.md
@@ -30,7 +30,7 @@ const elements = parseHTML(
   html`
     <div>Hello, world</div>
     <div>Goodbye, world</div>
-  `
+  `,
 );
 const div = parseHTMLElement(document, html`<div>Hello, world</div>`);
 ```

--- a/packages/compiled-assets/src/cli.ts
+++ b/packages/compiled-assets/src/cli.ts
@@ -15,7 +15,7 @@ type CompressedSizes = Record<string, Record<string, number>>;
 
 async function writeCompressedAssets(
   destination: string,
-  manifest: Record<string, string>
+  manifest: Record<string, string>,
 ): Promise<CompressedSizes> {
   const compressedSizes: CompressedSizes = {};
   await Promise.all(
@@ -31,7 +31,7 @@ async function writeCompressedAssets(
         gzip: gzipCompressed.length,
         brotli: brotliCompressed.length,
       };
-    })
+    }),
   );
   return compressedSizes;
 }

--- a/packages/compiled-assets/src/index.test.ts
+++ b/packages/compiled-assets/src/index.test.ts
@@ -70,7 +70,7 @@ async function testProject(options: CompiledAssetsOptions) {
     },
     {
       unsafeCleanup: true,
-    }
+    },
   );
 }
 

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -123,7 +123,7 @@ export function handler(): RequestHandler {
       (proxyRes) => {
         res.writeHead(proxyRes.statusCode ?? 500, proxyRes.headers);
         proxyRes.pipe(res, { end: true });
-      }
+      },
     );
     req.pipe(proxyReq, { end: true });
   };
@@ -201,7 +201,7 @@ async function buildAssets(sourceDirectory: string, buildDirectory: string) {
 function makeManifest(
   metafile: Metafile,
   sourceDirectory: string,
-  buildDirectory: string
+  buildDirectory: string,
 ): Record<string, string> {
   const manifest: Record<string, string> = {};
   Object.entries(metafile.outputs).forEach(([outputPath, meta]) => {
@@ -216,7 +216,7 @@ function makeManifest(
 
 export async function build(
   sourceDirectory: string,
-  buildDirectory: string
+  buildDirectory: string,
 ): Promise<AssetsManifest> {
   // Remove existing assets to ensure that no stale assets are left behind.
   await fs.remove(buildDirectory);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -42,7 +42,7 @@ export function makeSecretsManagerConfigSource(tagKey: string): ConfigSource {
       const tags = await ec2Client.send(
         new DescribeTagsCommand({
           Filters: [{ Name: 'resource-id', Values: [identity.instanceId] }],
-        })
+        }),
       );
 
       const secretId = tags.Tags?.find((tag) => tag.Key === tagKey)?.Value;
@@ -50,7 +50,7 @@ export function makeSecretsManagerConfigSource(tagKey: string): ConfigSource {
 
       const secretsManagerClient = new SecretsManagerClient({ region: identity.region });
       const secretValue = await secretsManagerClient.send(
-        new GetSecretValueCommand({ SecretId: secretId })
+        new GetSecretValueCommand({ SecretId: secretId }),
       );
       if (!secretValue.SecretString) return {};
 

--- a/packages/csv/src/index.ts
+++ b/packages/csv/src/index.ts
@@ -14,7 +14,7 @@ export interface StringifyNonblockingOptions extends StringifierOptions {
  */
 export function stringifyNonblocking(
   data: any[],
-  options: StringifyNonblockingOptions = {}
+  options: StringifyNonblockingOptions = {},
 ): Stringifier {
   const { batchSize = 100, ...stringifierOptions } = options;
   const stringifier = new Stringifier(stringifierOptions);
@@ -54,7 +54,7 @@ interface StringifyOptions<T = any, U = any>
  * `node:stream/promises`, which will help ensure that errors are handled properly.
  */
 export function stringifyStream<T = any, U = any>(
-  options: StringifyOptions<T, U> = {}
+  options: StringifyOptions<T, U> = {},
 ): NodeJS.ReadWriteStream {
   const { transform: _transform, ...stringifierOptions } = options;
   const stringifier = new Stringifier(stringifierOptions);

--- a/packages/flash/README.md
+++ b/packages/flash/README.md
@@ -20,7 +20,7 @@ app.use(
     secret: 'secret',
     resave: false,
     saveUninitialized: true,
-  })
+  }),
 );
 app.use(flashMiddleware());
 ```

--- a/packages/html-ejs/README.md
+++ b/packages/html-ejs/README.md
@@ -17,6 +17,6 @@ console.log(
   html`
     <div>Hello, world!</div>
     <div>${renderEjs(__filename, "<%- include('./hello'); %>", { name: 'Anjali' })}</div>
-  `.toString()
+  `.toString(),
 );
 ```

--- a/packages/html-ejs/src/index.test.ts
+++ b/packages/html-ejs/src/index.test.ts
@@ -10,7 +10,7 @@ describe('renderEjs', () => {
   it('renders EJS template with data', () => {
     assert.equal(
       renderEjs(__filename, '<p>Hello <%= name %></p>', { name: 'Divya' }).toString(),
-      '<p>Hello Divya</p>'
+      '<p>Hello Divya</p>',
     );
   });
 });

--- a/packages/html/src/index.test.ts
+++ b/packages/html/src/index.test.ts
@@ -29,7 +29,7 @@ describe('html', () => {
     assert.equal(
       // prettier-ignore
       html`<ul>${arr}</ul>`.toString(),
-      '<ul>cats&gt;&lt;dogs</ul>'
+      '<ul>cats&gt;&lt;dogs</ul>',
     );
   });
 
@@ -38,7 +38,7 @@ describe('html', () => {
     assert.equal(
       // prettier-ignore
       html`<ul>${arr.map((e) => html`<li>${e}</li>`)}</ul>`.toString(),
-      '<ul><li>cats</li><li>dogs</li></ul>'
+      '<ul><li>cats</li><li>dogs</li></ul>',
     );
   });
 
@@ -46,7 +46,7 @@ describe('html', () => {
     assert.throws(
       // @ts-expect-error -- Testing runtime behavior of bad input.
       () => html`<p>${{ foo: 'bar' }}</p>`.toString(),
-      'Cannot interpolate object in template'
+      'Cannot interpolate object in template',
     );
   });
 

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -39,7 +39,7 @@ function escapeValue(value: unknown): string {
   } else {
     // There shouldn't be any other types
     throw new Error(
-      `Unexpected type in template: ${typeof value} for value ${JSON.stringify(value)}`
+      `Unexpected type in template: ${typeof value} for value ${JSON.stringify(value)}`,
     );
   }
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -21,6 +21,6 @@ export function addFileLogging(options: AddFileLoggingOptions) {
       filename: options.filename,
       level: options.level ?? 'debug',
       format: format.combine(format.timestamp(), format.json()),
-    })
+    }),
   );
 }

--- a/packages/migrations/src/batched-migrations/batched-migration-job.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-job.ts
@@ -24,11 +24,11 @@ export type BatchedMigrationJobRow = z.infer<typeof BatchedMigrationJobRowSchema
 export async function selectRecentJobsWithStatus(
   batchedMigrationId: string,
   status: BatchedMigrationJobStatus,
-  limit: number
+  limit: number,
 ): Promise<BatchedMigrationJobRow[]> {
   return queryValidatedRows(
     sql.select_recent_jobs_with_status,
     { batched_migration_id: batchedMigrationId, status, limit },
-    BatchedMigrationJobRowSchema
+    BatchedMigrationJobRowSchema,
   );
 }

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
@@ -57,7 +57,7 @@ async function getBatchedMigration(migrationId: string) {
   return queryValidatedOneRow(
     'SELECT * FROM batched_migrations WHERE id = $id;',
     { id: migrationId },
-    BatchedMigrationRowSchema
+    BatchedMigrationRowSchema,
   );
 }
 
@@ -65,7 +65,7 @@ async function getBatchedMigrationJobs(migrationId: string) {
   return queryValidatedRows(
     'SELECT * FROM batched_migration_jobs WHERE batched_migration_id = $batched_migration_id ORDER BY id ASC;',
     { batched_migration_id: migrationId },
-    BatchedMigrationJobRowSchema
+    BatchedMigrationJobRowSchema,
   );
 }
 
@@ -74,7 +74,7 @@ async function resetFailedBatchedMigrationJobs(migrationId: string) {
     "UPDATE batched_migration_jobs SET status = 'pending', updated_at = CURRENT_TIMESTAMP WHERE batched_migration_id = $batched_migration_id AND status = 'failed'",
     {
       batched_migration_id: migrationId,
-    }
+    },
   );
 }
 

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.ts
@@ -37,7 +37,7 @@ export class BatchedMigrationRunner {
   constructor(
     migration: BatchedMigrationRow,
     migrationImplementation: BatchedMigrationImplementation,
-    options: BatchedMigrationRunnerOptions = {}
+    options: BatchedMigrationRunnerOptions = {},
   ) {
     this.options = options;
     this.migration = migration;
@@ -55,7 +55,7 @@ export class BatchedMigrationRunner {
     return queryValidatedSingleColumnOneRow(
       sql.batched_migration_has_incomplete_jobs,
       { batched_migration_id: migration.id },
-      z.boolean()
+      z.boolean(),
     );
   }
 
@@ -63,7 +63,7 @@ export class BatchedMigrationRunner {
     return queryValidatedSingleColumnOneRow(
       sql.batched_migration_has_failed_jobs,
       { batched_migration_id: migration.id },
-      z.boolean()
+      z.boolean(),
     );
   }
 
@@ -73,7 +73,7 @@ export class BatchedMigrationRunner {
       {
         id: migration.id,
       },
-      BatchedMigrationStatusSchema
+      BatchedMigrationStatusSchema,
     );
   }
 
@@ -92,12 +92,12 @@ export class BatchedMigrationRunner {
   }
 
   private async getNextBatchBounds(
-    migration: BatchedMigrationRow
+    migration: BatchedMigrationRow,
   ): Promise<null | [bigint, bigint]> {
     const lastJob = await queryValidatedZeroOrOneRow(
       sql.select_last_batched_migration_job,
       { batched_migration_id: migration.id },
-      BatchedMigrationJobRowSchema
+      BatchedMigrationJobRowSchema,
     );
 
     const nextMin = lastJob ? lastJob.max_value + 1n : migration.min_value;
@@ -129,7 +129,7 @@ export class BatchedMigrationRunner {
   private async finishJob(
     job: BatchedMigrationJobRow,
     status: Extract<BatchedMigrationJobStatus, 'failed' | 'succeeded'>,
-    data?: unknown
+    data?: unknown,
   ) {
     await queryAsync(sql.finish_batched_migration_job, {
       id: job.id,
@@ -140,7 +140,7 @@ export class BatchedMigrationRunner {
   }
 
   private async getOrCreateNextMigrationJob(
-    migration: BatchedMigrationRow
+    migration: BatchedMigrationRow,
   ): Promise<BatchedMigrationJobRow | null> {
     const nextBatchBounds = await this.getNextBatchBounds(migration);
     if (nextBatchBounds) {
@@ -151,7 +151,7 @@ export class BatchedMigrationRunner {
           min_value: nextBatchBounds[0],
           max_value: nextBatchBounds[1],
         },
-        BatchedMigrationJobRowSchema
+        BatchedMigrationJobRowSchema,
       );
     } else {
       // Pick up any old pending jobs from this migration. These will only exist if
@@ -160,14 +160,14 @@ export class BatchedMigrationRunner {
       return queryValidatedZeroOrOneRow(
         sql.select_first_pending_batched_migration_job,
         { batched_migration_id: migration.id },
-        BatchedMigrationJobRowSchema
+        BatchedMigrationJobRowSchema,
       );
     }
   }
 
   private async runMigrationJob(
     migration: BatchedMigrationRow,
-    migrationImplementation: BatchedMigrationImplementation
+    migrationImplementation: BatchedMigrationImplementation,
   ) {
     const nextJob = await this.getOrCreateNextMigrationJob(migration);
     if (nextJob) {

--- a/packages/migrations/src/batched-migrations/batched-migration.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration.ts
@@ -54,7 +54,7 @@ export function makeBatchedMigration<T extends BatchedMigrationImplementation>(f
 }
 
 export function validateBatchedMigrationImplementation(
-  fns: BatchedMigrationImplementation
+  fns: BatchedMigrationImplementation,
 ): asserts fns is BatchedMigrationImplementation {
   if (typeof fns.getParameters !== 'function') {
     throw new Error('getParameters() must be a function');
@@ -74,12 +74,12 @@ type NewBatchedMigration = Pick<
  * project/timestamp pair, returns null, otherwise returns the inserted row.
  */
 export async function insertBatchedMigration(
-  migration: NewBatchedMigration
+  migration: NewBatchedMigration,
 ): Promise<BatchedMigrationRow | null> {
   return queryValidatedZeroOrOneRow(
     sql.insert_batched_migration,
     migration,
-    BatchedMigrationRowSchema
+    BatchedMigrationRowSchema,
   );
 }
 
@@ -87,40 +87,40 @@ export async function selectAllBatchedMigrations(project: string) {
   return queryValidatedRows(
     sql.select_all_batched_migrations,
     { project },
-    BatchedMigrationRowSchema
+    BatchedMigrationRowSchema,
   );
 }
 
 export async function selectBatchedMigration(
   project: string,
-  id: string
+  id: string,
 ): Promise<BatchedMigrationRow> {
   return queryValidatedOneRow(
     sql.select_batched_migration,
     { project, id },
-    BatchedMigrationRowSchema
+    BatchedMigrationRowSchema,
   );
 }
 
 export async function selectBatchedMigrationForTimestamp(
   project: string,
-  timestamp: string
+  timestamp: string,
 ): Promise<BatchedMigrationRow> {
   return queryValidatedOneRow(
     sql.select_batched_migration_for_timestamp,
     { project, timestamp },
-    BatchedMigrationRowSchema
+    BatchedMigrationRowSchema,
   );
 }
 
 export async function updateBatchedMigrationStatus(
   id: string,
-  status: BatchedMigrationStatus
+  status: BatchedMigrationStatus,
 ): Promise<BatchedMigrationRow> {
   return queryValidatedOneRow(
     sql.update_batched_migration_status,
     { id, status },
-    BatchedMigrationRowSchema
+    BatchedMigrationRowSchema,
   );
 }
 

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.test.ts
@@ -100,7 +100,7 @@ describe('BatchedMigrationsRunner', () => {
       runner.finalizeBatchedMigration('20230406184107_failing_migration', {
         logProgress: false,
       }),
-      "but it is 'failed'"
+      "but it is 'failed'",
     );
 
     const migrations = await selectAllBatchedMigrations('test');

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
@@ -60,7 +60,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
     if (!this.migrationFiles) {
       this.migrationFiles = await readAndValidateMigrationsFromDirectories(
         this.options.directories,
-        EXTENSIONS
+        EXTENSIONS,
       );
     }
     return this.migrationFiles;
@@ -153,7 +153,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
     if (migration.status === 'succeeded') return;
 
     throw new Error(
-      `Expected batched migration with identifier ${identifier} to be marked as 'succeeded', but it is '${migration.status}'.`
+      `Expected batched migration with identifier ${identifier} to be marked as 'succeeded', but it is '${migration.status}'.`,
     );
   }
 
@@ -208,14 +208,14 @@ export class BatchedMigrationsRunner extends EventEmitter {
       let migration = await queryValidatedZeroOrOneRow(
         sql.select_running_migration,
         { project: this.options.project },
-        BatchedMigrationRowSchema
+        BatchedMigrationRowSchema,
       );
 
       if (!migration) {
         migration = await queryValidatedZeroOrOneRow(
           sql.start_next_pending_migration,
           { project: this.options.project },
-          BatchedMigrationRowSchema
+          BatchedMigrationRowSchema,
         );
       }
 
@@ -252,7 +252,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
         } catch (err) {
           this.emit('error', err);
         }
-      }
+      },
     );
 
     return didWork;
@@ -271,7 +271,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
 let runner: BatchedMigrationsRunner | null = null;
 
 function assertRunner(
-  runner: BatchedMigrationsRunner | null
+  runner: BatchedMigrationsRunner | null,
 ): asserts runner is BatchedMigrationsRunner {
   if (!runner) throw new Error('Batched migrations not initialized');
 }
@@ -320,7 +320,7 @@ export async function enqueueBatchedMigration(identifier: string) {
  */
 export async function finalizeBatchedMigration(
   identifier: string,
-  options?: BatchedMigrationFinalizeOptions
+  options?: BatchedMigrationFinalizeOptions,
 ) {
   assertRunner(runner);
   await runner.finalizeBatchedMigration(identifier, options);

--- a/packages/migrations/src/load-migrations.test.ts
+++ b/packages/migrations/src/load-migrations.test.ts
@@ -20,7 +20,7 @@ async function withMigrationFiles(files: string[], fn: (tmpDir: string) => Promi
       }
       await fn(tmpDir.path);
     },
-    { unsafeCleanup: true }
+    { unsafeCleanup: true },
   );
 }
 
@@ -30,7 +30,7 @@ describe('load-migrations', () => {
       await withMigrationFiles(['001_testing.sql'], async (tmpDir) => {
         await assert.isRejected(
           readAndValidateMigrationsFromDirectory(tmpDir, ['.sql']),
-          'Invalid migration filename: 001_testing.sql'
+          'Invalid migration filename: 001_testing.sql',
         );
       });
     });
@@ -41,9 +41,9 @@ describe('load-migrations', () => {
         async (tmpDir) => {
           await assert.isRejected(
             readAndValidateMigrationsFromDirectory(tmpDir, ['.sql']),
-            'Duplicate migration timestamp'
+            'Duplicate migration timestamp',
           );
-        }
+        },
       );
     });
   });
@@ -84,7 +84,7 @@ describe('load-migrations', () => {
             filename: '20220101010103_testing_3.sql',
             timestamp: '20220101010103',
           },
-        ]
+        ],
       );
     });
   });

--- a/packages/migrations/src/load-migrations.ts
+++ b/packages/migrations/src/load-migrations.ts
@@ -26,10 +26,10 @@ export interface MigrationFile {
 
 export async function readAndValidateMigrationsFromDirectory(
   dir: string,
-  extensions: string[]
+  extensions: string[],
 ): Promise<MigrationFile[]> {
   const migrationFiles = (await fs.readdir(dir)).filter((m) =>
-    extensions.some((e) => m.endsWith(e))
+    extensions.some((e) => m.endsWith(e)),
   );
 
   const migrations = migrationFiles.map((mf) => {
@@ -71,7 +71,7 @@ export async function readAndValidateMigrationsFromDirectory(
 
 export async function readAndValidateMigrationsFromDirectories(
   directories: string[],
-  extensions: string[]
+  extensions: string[],
 ): Promise<MigrationFile[]> {
   const allMigrations: MigrationFile[] = [];
   for (const directory of directories) {

--- a/packages/migrations/src/migrations/migrations.ts
+++ b/packages/migrations/src/migrations/migrations.ts
@@ -34,14 +34,14 @@ export async function init(directories: string | string[], project: string) {
     async () => {
       logger.verbose(`Acquired lock ${lockName}`);
       await initWithLock(migrationDirectories, project);
-    }
+    },
   );
   logger.verbose(`Released lock ${lockName}`);
 }
 
 export function getMigrationsToExecute(
   migrationFiles: MigrationFile[],
-  executedMigrations: { timestamp: string | null }[]
+  executedMigrations: { timestamp: string | null }[],
 ): MigrationFile[] {
   // If no migrations have ever been run, run them all.
   if (executedMigrations.length === 0) {
@@ -101,7 +101,7 @@ export async function initWithLock(directories: string[], project: string) {
         // This revision was the most recent commit to `master` before the
         // code handling indexes was removed.
         'You must deploy revision 1aa43c7348fa24cf636413d720d06a2fa9e38ef2 first.',
-      ].join('\n')
+      ].join('\n'),
     );
   }
 

--- a/packages/named-locks/README.md
+++ b/packages/named-locks/README.md
@@ -16,7 +16,7 @@ await init(
   },
   (err) => {
     throw err;
-  }
+  },
 );
 ```
 
@@ -42,7 +42,7 @@ await doWithLock(
   },
   async () => {
     console.log('Doing some work');
-  }
+  },
 );
 ```
 

--- a/packages/named-locks/src/index.ts
+++ b/packages/named-locks/src/index.ts
@@ -84,13 +84,13 @@ let renewIntervalMs = 60_000;
 export async function init(
   pgConfig: PoolConfig,
   idleErrorHandler: (error: Error, client: PoolClient) => void,
-  namedLocksConfig: NamedLocksConfig = {}
+  namedLocksConfig: NamedLocksConfig = {},
 ) {
   renewIntervalMs = namedLocksConfig.renewIntervalMs ?? renewIntervalMs;
   await pool.initAsync(pgConfig, idleErrorHandler);
   await pool.queryAsync(
     'CREATE TABLE IF NOT EXISTS named_locks (id bigserial PRIMARY KEY, name text NOT NULL UNIQUE);',
-    {}
+    {},
   );
 }
 
@@ -111,7 +111,7 @@ export async function close() {
  */
 export async function tryLockAsync(
   name: string,
-  options: TryLockOptions = {}
+  options: TryLockOptions = {},
 ): Promise<Lock | null> {
   return getLock(name, { timeout: 0, ...options });
 }
@@ -152,7 +152,7 @@ export const releaseLock = util.callbackify(releaseLockAsync);
 export async function doWithLock<T>(
   name: string,
   options: LockOptions,
-  func: () => Promise<T>
+  func: () => Promise<T>,
 ): Promise<T> {
   const lock = await waitLockAsync(name, options);
   try {
@@ -170,7 +170,7 @@ export async function doWithLock<T>(
 export async function tryWithLock<T>(
   name: string,
   options: TryLockOptions,
-  func: () => Promise<T>
+  func: () => Promise<T>,
 ): Promise<T | null> {
   const lock = await tryLockAsync(name, options);
   if (lock == null) return null;
@@ -192,7 +192,7 @@ export async function tryWithLock<T>(
 async function getLock(name: string, options: LockOptions) {
   await pool.queryAsync(
     'INSERT INTO named_locks (name) VALUES ($name) ON CONFLICT (name) DO NOTHING;',
-    { name }
+    { name },
   );
 
   const client = await pool.beginTransactionAsync();
@@ -206,7 +206,7 @@ async function getLock(name: string, options: LockOptions) {
       await pool.queryWithClientAsync(
         client,
         `SET LOCAL lock_timeout = ${client.escapeLiteral(options.timeout.toString())}`,
-        {}
+        {},
       );
     }
 

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -116,6 +116,6 @@ createObservableValueGauges(
     // The interval that your value will be observed, in milliseconds.
     interval: 1000,
   },
-  () => pool.size
+  () => pool.size,
 );
 ```

--- a/packages/opentelemetry/src/init.ts
+++ b/packages/opentelemetry/src/init.ts
@@ -203,7 +203,7 @@ function getMetricExporter(config: OpenTelemetryConfig): PushMetricExporter | nu
       });
     default:
       throw new Error(
-        `Unknown OpenTelemetry metric exporter: ${config.openTelemetryMetricExporter}`
+        `Unknown OpenTelemetry metric exporter: ${config.openTelemetryMetricExporter}`,
       );
   }
 }
@@ -275,7 +275,7 @@ export async function init(config: OpenTelemetryConfig) {
 
   if (config.serviceName) {
     resource = resource.merge(
-      new Resource({ [SemanticResourceAttributes.SERVICE_NAME]: config.serviceName })
+      new Resource({ [SemanticResourceAttributes.SERVICE_NAME]: config.serviceName }),
     );
   }
 

--- a/packages/opentelemetry/src/metrics.test.ts
+++ b/packages/opentelemetry/src/metrics.test.ts
@@ -64,7 +64,7 @@ describe('instrumentedWithMetrics', () => {
       instrumentedWithMetrics(meter, 'test', async () => {
         throw new Error('error for test');
       }),
-      'error for test'
+      'error for test',
     );
 
     await waitForMetricsExport(exporter);

--- a/packages/opentelemetry/src/metrics.ts
+++ b/packages/opentelemetry/src/metrics.ts
@@ -21,7 +21,7 @@ function getCachedMetric<T>(
   cache: WeakMap<Meter, Map<string, T>>,
   meter: Meter,
   name: string,
-  create: () => T
+  create: () => T,
 ): T {
   let meterCache = cache.get(meter);
   if (!meterCache) {
@@ -48,32 +48,32 @@ export function getCounter(meter: Meter, name: string, options?: MetricOptions) 
 
 export function getUpDownCounter(meter: Meter, name: string, options?: MetricOptions) {
   return getCachedMetric(upDownCounterCache, meter, name, () =>
-    meter.createUpDownCounter(name, options)
+    meter.createUpDownCounter(name, options),
   );
 }
 
 export function getObservableCounter(meter: Meter, name: string, options?: MetricOptions) {
   return getCachedMetric(observableCounterCache, meter, name, () =>
-    meter.createObservableCounter(name, options)
+    meter.createObservableCounter(name, options),
   );
 }
 
 export function getObservableUpDownCounter(meter: Meter, name: string, options?: MetricOptions) {
   return getCachedMetric(observableUpDownCounterCache, meter, name, () =>
-    meter.createObservableUpDownCounter(name, options)
+    meter.createObservableUpDownCounter(name, options),
   );
 }
 
 export function getObservableGauge(meter: Meter, name: string, options?: MetricOptions) {
   return getCachedMetric(observableGaugeCache, meter, name, () =>
-    meter.createObservableGauge(name, options)
+    meter.createObservableGauge(name, options),
   );
 }
 
 export async function instrumentedWithMetrics<T>(
   meter: Meter,
   name: string,
-  fn: () => Promise<T> | T
+  fn: () => Promise<T> | T,
 ): Promise<T> {
   const error = getCounter(meter, `${name}.error`, { valueType: ValueType.INT });
   const histogram = getHistogram(meter, `${name}.duration`, {
@@ -111,7 +111,7 @@ export async function createObservableValueGauges(
   meter: Meter,
   name: string,
   options: createObservableValueGaugesOptions,
-  observe: () => number
+  observe: () => number,
 ) {
   const { interval, ...metricOptions } = options;
 

--- a/packages/opentelemetry/src/tracing.ts
+++ b/packages/opentelemetry/src/tracing.ts
@@ -2,7 +2,7 @@ import { Span, SpanStatusCode, trace } from '@opentelemetry/api';
 
 export async function instrumented<T>(
   name: string,
-  fn: (span: Span) => Promise<T> | T
+  fn: (span: Span) => Promise<T> | T,
 ): Promise<T> {
   return trace
     .getTracer('default')

--- a/packages/path-utils/src/index.test.ts
+++ b/packages/path-utils/src/index.test.ts
@@ -21,7 +21,7 @@ describe('File paths', () => {
       assert.notOk(contains('/PrairieLearn', '/tmp'));
       assert.notOk(contains('/PrairieLearn/exampleCourse', '/PrairieLearn/tests'));
       assert.notOk(
-        contains('/PrairieLearn/exampleCourse/questions', '/PrairieLearn/exampleCourse')
+        contains('/PrairieLearn/exampleCourse/questions', '/PrairieLearn/exampleCourse'),
       );
     });
 

--- a/packages/postgres-tools/src/bin/pg-describe.ts
+++ b/packages/postgres-tools/src/bin/pg-describe.ts
@@ -35,7 +35,7 @@ const args = yargs
   .example('$0 postgres', 'Describe the "postgres" database')
   .example(
     '$0 userdb -o db_description --ignore-tables a b --ignore-columns a.col1 a.col2',
-    'Describe the "userdb" database; ignore specific tables and columns'
+    'Describe the "userdb" database; ignore specific tables and columns',
   )
   .strict();
 
@@ -74,7 +74,7 @@ describeDatabase(argv._[0].toString(), options).then(
   (err) => {
     console.error(err);
     process.exit(1);
-  }
+  },
 );
 
 function printDescription(description: DatabaseDescription) {

--- a/packages/postgres-tools/src/bin/pg-diff.ts
+++ b/packages/postgres-tools/src/bin/pg-diff.ts
@@ -21,11 +21,11 @@ const args = yargs
   .alias('h', 'help')
   .example(
     '$0 --db postgres --dir db_dump',
-    'Diffs the database "postgres" with the description in the directory "db_dump"'
+    'Diffs the database "postgres" with the description in the directory "db_dump"',
   )
   .example(
     '$0 --db postgres --db old_restore',
-    'Diffs the database "postgres" with the database "old_restore"'
+    'Diffs the database "postgres" with the database "old_restore"',
   )
   .strict();
 

--- a/packages/postgres-tools/src/describe.ts
+++ b/packages/postgres-tools/src/describe.ts
@@ -58,7 +58,7 @@ interface DescribeOptions {
 
 async function describeWithPool(
   pool: PostgresPool,
-  options: DescribeOptions
+  options: DescribeOptions,
 ): Promise<DatabaseDescription> {
   const ignoreTables = options?.ignoreTables || [];
   const ignoreEnums = options?.ignoreEnums || [];
@@ -80,16 +80,19 @@ async function describeWithPool(
       .filter((ignore) => {
         return /^[^\s.]*\.[^\s.]*$/.test(ignore);
       })
-      .reduce((result, value) => {
-        const res = /^(([^\s.]*)\.([^\s.]*))$/.exec(value);
-        if (!res) {
-          throw new Error(`Invalid ignore column: ${value}`);
-        }
-        const table = res[2];
-        const column = res[3];
-        (result[table] || (result[table] = [])).push(column);
-        return result;
-      }, {} as Record<string, string[]>);
+      .reduce(
+        (result, value) => {
+          const res = /^(([^\s.]*)\.([^\s.]*))$/.exec(value);
+          if (!res) {
+            throw new Error(`Invalid ignore column: ${value}`);
+          }
+          const table = res[2];
+          const column = res[3];
+          (result[table] || (result[table] = [])).push(column);
+          return result;
+        },
+        {} as Record<string, string[]>,
+      );
   }
 
   // Get column info for each table
@@ -110,7 +113,7 @@ async function describeWithPool(
       sql.get_foreign_key_constraints_for_table,
       {
         oid: table.oid,
-      }
+      },
     );
 
     const referenceResults = await pool.queryAsync(sql.get_references_for_table, {
@@ -156,7 +159,7 @@ async function describeWithPool(
  */
 export async function describeDatabase(
   databaseName: string,
-  options: DescribeOptions = {}
+  options: DescribeOptions = {},
 ): Promise<DatabaseDescription> {
   // Connect to the database.
   const pool = new PostgresPool();
@@ -181,7 +184,7 @@ export async function describeDatabase(
 
 export function formatDatabaseDescription(
   description: DatabaseDescription,
-  options = { coloredOutput: true }
+  options = { coloredOutput: true },
 ): { tables: Record<string, string>; enums: Record<string, string> } {
   const output = {
     tables: {} as Record<string, string>,

--- a/packages/postgres-tools/src/diff.ts
+++ b/packages/postgres-tools/src/diff.ts
@@ -40,7 +40,7 @@ async function diff(db1: DiffTarget, db2: DiffTarget, options: DiffOptions): Pro
     result += formatText(`Tables added to ${db2NameBold} (${db2.type})\n`, chalk.underline);
     result += formatText(
       tablesMissingFrom1.map((table) => `+ ${table}`).join('\n') + '\n\n',
-      chalk.green
+      chalk.green,
     );
   }
 
@@ -48,7 +48,7 @@ async function diff(db1: DiffTarget, db2: DiffTarget, options: DiffOptions): Pro
     result += formatText(`Tables missing from ${db2NameBold} (${db2.type})\n`, chalk.underline);
     result += formatText(
       tablesMissingFrom2.map((table) => `- ${table}`).join('\n') + '\n\n',
-      chalk.red
+      chalk.red,
     );
   }
 
@@ -60,7 +60,7 @@ async function diff(db1: DiffTarget, db2: DiffTarget, options: DiffOptions): Pro
     result += formatText(`Enums added to ${db2NameBold} (${db1.type})\n`, chalk.underline);
     result += formatText(
       enumsMissingFrom1.map((enumName) => `+ ${enumName}`).join('\n') + '\n\n',
-      chalk.green
+      chalk.green,
     );
   }
 
@@ -68,7 +68,7 @@ async function diff(db1: DiffTarget, db2: DiffTarget, options: DiffOptions): Pro
     result += formatText(`Enums missing from ${db2NameBold} (${db2.type})\n`, chalk.underline);
     result += formatText(
       enumsMissingFrom2.map((enumName) => `- ${enumName}`).join('\n') + '\n\n',
-      chalk.red
+      chalk.red,
     );
   }
 
@@ -79,7 +79,7 @@ async function diff(db1: DiffTarget, db2: DiffTarget, options: DiffOptions): Pro
       `tables/${table}`,
       `tables/${table}`,
       description1.tables[table],
-      description2.tables[table]
+      description2.tables[table],
     );
 
     if (patch.hunks.length === 0) return;
@@ -164,14 +164,14 @@ export async function diffDatabases(database1: string, database2: string, option
       type: 'database',
       name: database2,
     },
-    options
+    options,
   );
 }
 
 export async function diffDatabaseAndDirectory(
   database: string,
   directory: string,
-  options: DiffOptions
+  options: DiffOptions,
 ) {
   return diff(
     {
@@ -182,14 +182,14 @@ export async function diffDatabaseAndDirectory(
       type: 'directory',
       path: directory,
     },
-    options
+    options,
   );
 }
 
 export async function diffDirectoryAndDatabase(
   directory: string,
   database: string,
-  options: DiffOptions
+  options: DiffOptions,
 ) {
   return diff(
     {
@@ -200,14 +200,14 @@ export async function diffDirectoryAndDatabase(
       type: 'database',
       name: database,
     },
-    options
+    options,
   );
 }
 
 export async function diffDirectories(
   directory1: string,
   directory2: string,
-  options: DiffOptions
+  options: DiffOptions,
 ) {
   return diff(
     {
@@ -218,6 +218,6 @@ export async function diffDirectories(
       type: 'directory',
       path: directory2,
     },
-    options
+    options,
   );
 }

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -23,7 +23,7 @@ await sqldb.initAsync(
     max: 2,
     idleTimeoutMillis: 30000,
   },
-  idleErrorHandler
+  idleErrorHandler,
 );
 ```
 

--- a/packages/postgres/src/pool.test.ts
+++ b/packages/postgres/src/pool.test.ts
@@ -31,7 +31,7 @@ describe('@prairielearn/postgres', function () {
     await postgresTestUtils.createDatabase();
     await queryAsync(
       'CREATE TABLE workspaces (id BIGSERIAL PRIMARY KEY, created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP);',
-      {}
+      {},
     );
     await queryAsync('INSERT INTO workspaces (id) SELECT s FROM generate_series(1, 100) AS s', {});
   });
@@ -58,7 +58,7 @@ describe('@prairielearn/postgres', function () {
       const rows = await queryRows(
         'SELECT * FROM workspaces WHERE id <= $1;',
         [10],
-        WorkspaceSchema
+        WorkspaceSchema,
       );
       assert.lengthOf(rows, 10);
     });
@@ -109,7 +109,7 @@ describe('@prairielearn/postgres', function () {
       const row = await queryOptionalRow(
         'SELECT * FROM workspaces WHERE id = $1;',
         [1],
-        WorkspaceSchema
+        WorkspaceSchema,
       );
       assert.isNotNull(row);
       assert.equal(row?.id, '1');
@@ -118,7 +118,7 @@ describe('@prairielearn/postgres', function () {
     it('handles missing result', async () => {
       const row = await queryOptionalRow(
         'SELECT * FROM workspaces WHERE id = -1;',
-        WorkspaceSchema
+        WorkspaceSchema,
       );
       assert.isNull(row);
     });
@@ -196,7 +196,7 @@ describe('@prairielearn/postgres', function () {
         const cursor = await queryValidatedCursor(
           'SELECT * FROM workspaces WHERE id <= 10 ORDER BY id ASC;',
           {},
-          WorkspaceSchema
+          WorkspaceSchema,
         );
         const allRows = [];
         for await (const rows of cursor.iterate(10)) {
@@ -212,7 +212,7 @@ describe('@prairielearn/postgres', function () {
         const cursor = await queryValidatedCursor(
           'SELECT * FROM workspaces WHERE id <= 10 ORDER BY id ASC;',
           {},
-          BadWorkspaceSchema
+          BadWorkspaceSchema,
         );
 
         async function readAllRows() {
@@ -234,7 +234,7 @@ describe('@prairielearn/postgres', function () {
         const cursor = await queryValidatedCursor(
           'SELECT * FROM workspaces WHERE id <= 10 ORDER BY id ASC;',
           {},
-          WorkspaceSchema
+          WorkspaceSchema,
         );
         const stream = cursor.stream(1);
         const allRows = [];
@@ -249,7 +249,7 @@ describe('@prairielearn/postgres', function () {
         const cursor = await queryValidatedCursor(
           'SELECT * FROM workspaces ORDER BY id ASC;',
           {},
-          BadWorkspaceSchema
+          BadWorkspaceSchema,
         );
         const stream = cursor.stream(1);
 

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -67,7 +67,7 @@ function debugParams(params: QueryParams): string {
  */
 function paramsToArray(
   sql: string,
-  params: QueryParams
+  params: QueryParams,
 ): { processedSql: string; paramsArray: any } {
   if (typeof sql !== 'string') throw new Error('SQL must be a string');
   if (Array.isArray(params)) {
@@ -159,7 +159,7 @@ export class PostgresPool {
    */
   async initAsync(
     pgConfig: pg.PoolConfig,
-    idleErrorHandler: (error: Error, client: pg.PoolClient) => void
+    idleErrorHandler: (error: Error, client: pg.PoolClient) => void,
   ): Promise<void> {
     this.pool = new pg.Pool(pgConfig);
     this.pool.on('error', function (err, client) {
@@ -192,7 +192,7 @@ export class PostgresPool {
       } catch (err: any) {
         if (retryCount === retryTimeouts.length) {
           throw new Error(
-            `Could not connect to Postgres after ${retryTimeouts.length} attempts: ${err.message}`
+            `Could not connect to Postgres after ${retryTimeouts.length} attempts: ${err.message}`,
           );
         }
 
@@ -288,7 +288,7 @@ export class PostgresPool {
   async queryWithClientAsync(
     client: pg.PoolClient,
     sql: string,
-    params: QueryParams
+    params: QueryParams,
   ): Promise<pg.QueryResult> {
     this._queryCount += 1;
     debug('queryWithClient()', 'sql:', debugString(sql));
@@ -316,7 +316,7 @@ export class PostgresPool {
   async queryWithClientOneRowAsync(
     client: pg.PoolClient,
     sql: string,
-    params: QueryParams
+    params: QueryParams,
   ): Promise<pg.QueryResult> {
     debug('queryWithClientOneRow()', 'sql:', debugString(sql));
     debug('queryWithClientOneRow()', 'params:', debugParams(params));
@@ -345,7 +345,7 @@ export class PostgresPool {
   async queryWithClientZeroOrOneRowAsync(
     client: pg.PoolClient,
     sql: string,
-    params: QueryParams
+    params: QueryParams,
   ): Promise<QueryResult> {
     debug('queryWithClientZeroOrOneRow()', 'sql:', debugString(sql));
     debug('queryWithClientZeroOrOneRow()', 'params:', debugParams(params));
@@ -395,7 +395,7 @@ export class PostgresPool {
   rollbackWithClient(
     client: pg.PoolClient,
     _done: (release?: any) => void,
-    callback: (err: Error | null) => void
+    callback: (err: Error | null) => void,
   ) {
     // Note that we can't use `util.callbackify` here because this function
     // has an additional unused `done` parameter for backwards compatibility.
@@ -456,7 +456,7 @@ export class PostgresPool {
     client: pg.PoolClient,
     _done: (rollback?: any) => void,
     err: Error | null | undefined,
-    callback: (error: Error | null) => void
+    callback: (error: Error | null) => void,
   ): void {
     this.endTransactionAsync(client, err)
       .then(() => callback(null))
@@ -645,7 +645,7 @@ export class PostgresPool {
   async callWithClientAsync(
     client: pg.PoolClient,
     functionName: string,
-    params: any[]
+    params: any[],
   ): Promise<pg.QueryResult> {
     debug('callWithClient()', 'function:', functionName);
     debug('callWithClient()', 'params:', debugParams(params));
@@ -668,7 +668,7 @@ export class PostgresPool {
   async callWithClientOneRowAsync(
     client: pg.PoolClient,
     functionName: string,
-    params: any[]
+    params: any[],
   ): Promise<pg.QueryResult> {
     debug('callWithClientOneRow()', 'function:', functionName);
     debug('callWithClientOneRow()', 'params:', debugParams(params));
@@ -696,7 +696,7 @@ export class PostgresPool {
   async callWithClientZeroOrOneRowAsync(
     client: pg.PoolClient,
     functionName: string,
-    params: any[]
+    params: any[],
   ): Promise<pg.QueryResult> {
     debug('callWithClientZeroOrOneRow()', 'function:', functionName);
     debug('callWithClientZeroOrOneRow()', 'params:', debugParams(params));
@@ -724,7 +724,7 @@ export class PostgresPool {
   async queryValidatedRows<Model extends z.ZodTypeAny>(
     query: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>[]> {
     const results = await this.queryAsync(query, params);
     return z.array(model).parse(results.rows);
@@ -737,7 +737,7 @@ export class PostgresPool {
   async queryValidatedOneRow<Model extends z.ZodTypeAny>(
     query: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>> {
     const results = await this.queryOneRowAsync(query, params);
     return model.parse(results.rows[0]);
@@ -750,7 +750,7 @@ export class PostgresPool {
   async queryValidatedZeroOrOneRow<Model extends z.ZodTypeAny>(
     query: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model> | null> {
     const results = await this.queryZeroOrOneRowAsync(query, params);
     if (results.rows.length === 0) {
@@ -768,7 +768,7 @@ export class PostgresPool {
   async queryValidatedSingleColumnRows<Model extends z.ZodTypeAny>(
     query: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>[]> {
     const results = await this.queryAsync(query, params);
     if (results.fields.length !== 1) {
@@ -787,7 +787,7 @@ export class PostgresPool {
   async queryValidatedSingleColumnOneRow<Model extends z.ZodTypeAny>(
     query: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>> {
     const results = await this.queryOneRowAsync(query, params);
     if (results.fields.length !== 1) {
@@ -805,7 +805,7 @@ export class PostgresPool {
   async queryValidatedSingleColumnZeroOrOneRow<Model extends z.ZodTypeAny>(
     query: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model> | null> {
     const results = await this.queryZeroOrOneRowAsync(query, params);
     if (results.fields.length !== 1) {
@@ -826,7 +826,7 @@ export class PostgresPool {
   async callValidatedRows<Model extends z.ZodTypeAny>(
     sprocName: string,
     params: any[],
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>[]> {
     const results = await this.callAsync(sprocName, params);
     return z.array(model).parse(results.rows);
@@ -839,7 +839,7 @@ export class PostgresPool {
   async callValidatedOneRow<Model extends z.ZodTypeAny>(
     sprocName: string,
     params: any[],
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>> {
     const results = await this.callOneRowAsync(sprocName, params);
     return model.parse(results.rows[0]);
@@ -852,7 +852,7 @@ export class PostgresPool {
   async callValidatedZeroOrOneRow<Model extends z.ZodTypeAny>(
     sprocName: string,
     params: any[],
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model> | null> {
     const results = await this.callZeroOrOneRowAsync(sprocName, params);
     if (results.rows.length === 0) {
@@ -866,12 +866,12 @@ export class PostgresPool {
   async queryRows<Model extends z.ZodTypeAny>(
     sql: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>[]>;
   async queryRows<Model extends z.ZodTypeAny>(
     sql: string,
     paramsOrSchema: QueryParams | Model,
-    maybeModel?: Model
+    maybeModel?: Model,
   ) {
     const params = maybeModel === undefined ? {} : (paramsOrSchema as QueryParams);
     const model = maybeModel === undefined ? (paramsOrSchema as Model) : maybeModel;
@@ -889,12 +889,12 @@ export class PostgresPool {
   async queryRow<Model extends z.ZodTypeAny>(
     sql: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model>>;
   async queryRow<Model extends z.ZodTypeAny>(
     sql: string,
     paramsOrSchema: QueryParams | Model,
-    maybeModel?: Model
+    maybeModel?: Model,
   ) {
     const params = maybeModel === undefined ? {} : (paramsOrSchema as QueryParams);
     const model = maybeModel === undefined ? (paramsOrSchema as Model) : maybeModel;
@@ -909,17 +909,17 @@ export class PostgresPool {
 
   async queryOptionalRow<Model extends z.ZodTypeAny>(
     sql: string,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model> | null>;
   async queryOptionalRow<Model extends z.ZodTypeAny>(
     sql: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<z.infer<Model> | null>;
   async queryOptionalRow<Model extends z.ZodTypeAny>(
     sql: string,
     paramsOrSchema: QueryParams | Model,
-    maybeModel?: Model
+    maybeModel?: Model,
   ) {
     const params = maybeModel === undefined ? {} : (paramsOrSchema as QueryParams);
     const model = maybeModel === undefined ? (paramsOrSchema as Model) : maybeModel;
@@ -941,7 +941,7 @@ export class PostgresPool {
   async queryCursorWithClient(
     client: pg.PoolClient,
     sql: string,
-    params: QueryParams
+    params: QueryParams,
   ): Promise<Cursor> {
     this._queryCount += 1;
     debug('queryCursorWithClient()', 'sql:', debugString(sql));
@@ -957,7 +957,7 @@ export class PostgresPool {
    */
   async queryCursor<Model extends z.ZodTypeAny>(
     sql: string,
-    params: QueryParams
+    params: QueryParams,
   ): Promise<CursorIterator<z.infer<Model>>> {
     return this.queryValidatedCursorInternal(sql, params);
   }
@@ -970,7 +970,7 @@ export class PostgresPool {
   async queryValidatedCursor<Model extends z.ZodTypeAny>(
     sql: string,
     params: QueryParams,
-    model: Model
+    model: Model,
   ): Promise<CursorIterator<z.infer<Model>>> {
     return this.queryValidatedCursorInternal(sql, params, model);
   }
@@ -978,7 +978,7 @@ export class PostgresPool {
   private async queryValidatedCursorInternal<Model extends z.ZodTypeAny>(
     sql: string,
     params: QueryParams,
-    model?: Model
+    model?: Model,
   ): Promise<CursorIterator<z.infer<Model>>> {
     const client = await this.getClientAsync();
     const cursor = await this.queryCursorWithClient(client, sql, params);

--- a/packages/postgres/src/test-utils.ts
+++ b/packages/postgres/src/test-utils.ts
@@ -37,7 +37,7 @@ async function createDatabase(
     database,
     templateDatabase,
     prepare,
-  }: CreateDatabaseOptions = {}
+  }: CreateDatabaseOptions = {},
 ): Promise<void> {
   const client = new pg.Client({
     ...getPoolConfig(options),
@@ -46,7 +46,7 @@ async function createDatabase(
   await client.connect();
 
   const escapedDatabase = client.escapeIdentifier(
-    database ?? getDatabaseNameForCurrentMochaWorker(options.database)
+    database ?? getDatabaseNameForCurrentMochaWorker(options.database),
   );
   if (dropExistingDatabase ?? true) {
     await client.query(`DROP DATABASE IF EXISTS ${escapedDatabase}`);
@@ -76,7 +76,7 @@ async function createDatabase(
       },
       (err) => {
         throw err;
-      }
+      },
     );
   }
 }
@@ -103,7 +103,7 @@ async function resetDatabase(options: PostgresTestUtilsOptions): Promise<void> {
 
 async function dropDatabase(
   options: PostgresTestUtilsOptions,
-  { closePool = true, force = false, database }: DropDatabaseOptions = {}
+  { closePool = true, force = false, database }: DropDatabaseOptions = {},
 ): Promise<void> {
   if (closePool) {
     await defaultPool.closeAsync();

--- a/packages/prettier-plugin-sql/package.json
+++ b/packages/prettier-plugin-sql/package.json
@@ -14,10 +14,10 @@
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^18.16.16",
+    "prettier": "3.0.0",
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@types/prettier": "^2.7.3",
     "sql-formatter": "^12.2.1"
   }
 }

--- a/packages/prettier-plugin-sql/src/index.ts
+++ b/packages/prettier-plugin-sql/src/index.ts
@@ -22,7 +22,7 @@ export const printers = {
   sql: {
     print(path: AstPath) {
       return (
-        format(path.getValue(), {
+        format(path.node, {
           language: 'postgresql',
           paramTypes: { named: ['$'] },
         }) + '\n'

--- a/packages/sanitize/README.md
+++ b/packages/sanitize/README.md
@@ -21,6 +21,6 @@ recursivelyTruncateStrings(
       },
     },
   },
-  100
+  100,
 );
 ```

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -25,7 +25,7 @@ export function generateSignedToken(data: any, secretKey: string) {
       dateString,
       checkString,
       encodedSignature,
-    })}`
+    })}`,
   );
   const token = encodedSignature + sep + checkString;
   debug(`generateSignedToken(): token = ${token}`);
@@ -35,7 +35,7 @@ export function generateSignedToken(data: any, secretKey: string) {
 export function getCheckedSignedTokenData(
   token: string,
   secretKey: string,
-  options: CheckOptions = {}
+  options: CheckOptions = {},
 ) {
   debug(`getCheckedSignedTokenData(): token = ${token}`);
   debug(`getCheckedSignedTokenData(): secretKey = ${secretKey}`);
@@ -61,7 +61,7 @@ export function getCheckedSignedTokenData(
   const encodedCheckSignature = base64url.encode(checkSignature);
   if (encodedCheckSignature !== tokenSignature) {
     debug(
-      `getCheckedSignedTokenData(): FAIL - signature mismatch: checkSig=${encodedCheckSignature} != tokenSig=${tokenSignature}`
+      `getCheckedSignedTokenData(): FAIL - signature mismatch: checkSig=${encodedCheckSignature} != tokenSig=${tokenSignature}`,
     );
     return null;
   }
@@ -79,7 +79,7 @@ export function getCheckedSignedTokenData(
     const elapsedTime = currentTime - tokenDate.getTime();
     if (elapsedTime > options.maxAge) {
       debug(
-        `getCheckedSignedTokenData(): FAIL - too old: elapsedTime=${elapsedTime} > maxAge=${options.maxAge}`
+        `getCheckedSignedTokenData(): FAIL - too old: elapsedTime=${elapsedTime} > maxAge=${options.maxAge}`,
       );
       return null;
     }
@@ -107,7 +107,7 @@ export function checkSignedToken(
   token: string,
   data: any,
   secretKey: string,
-  options: CheckOptions = {}
+  options: CheckOptions = {},
 ) {
   debug(`checkSignedToken(): token = ${token}`);
   debug(`checkSignedToken(): data = ${JSON.stringify(data)}`);

--- a/packages/workspace-utils/src/index.ts
+++ b/packages/workspace-utils/src/index.ts
@@ -34,7 +34,7 @@ export function getWorkspaceSocketNamespace() {
 export async function updateWorkspaceMessage(
   workspace_id: string | number,
   message: string,
-  toDatabase = true
+  toDatabase = true,
 ): Promise<void> {
   if (toDatabase) await queryAsync(sql.update_workspace_message, { workspace_id, message });
   emitMessageForWorkspace(workspace_id, 'change:message', {
@@ -53,7 +53,7 @@ export async function updateWorkspaceMessage(
 export async function updateWorkspaceState(
   workspace_id: string | number,
   state: string,
-  message = ''
+  message = '',
 ): Promise<void> {
   // TODO: add locking
   await queryAsync(sql.update_workspace_state, { workspace_id, state, message });
@@ -72,7 +72,7 @@ interface GradedFilesLimits {
 export async function getWorkspaceGradedFiles(
   workspaceDir: string,
   gradedFiles: string[],
-  limits: GradedFilesLimits
+  limits: GradedFilesLimits,
 ): Promise<Entry[]> {
   const files = (
     await fg(gradedFiles, {
@@ -91,7 +91,7 @@ export async function getWorkspaceGradedFiles(
     throw new Error(
       `Workspace files exceed limit of ${filesize(limits.maxSize, {
         base: 2,
-      })}.`
+      })}.`,
     );
   }
 

--- a/testCourse/questions/prairieDrawFigure/PDelementDemo.js
+++ b/testCourse/questions/prairieDrawFigure/PDelementDemo.js
@@ -42,7 +42,7 @@ this.pd.triangularDistributedLoad(
   '1',
   '0.5',
   true,
-  true
+  true,
 );
 // Next, a point force acting upward at point Q
 this.pd.arrow(Q.subtract($V([0, 2])), Q, 'force');

--- a/tools/rewrite-migrations.js
+++ b/tools/rewrite-migrations.js
@@ -5,7 +5,7 @@ const prefixZero = (value) => ('0' + value).slice(-2);
 
 function formatDate(date) {
   return `${date.getFullYear()}${prefixZero(date.getMonth() + 1)}${prefixZero(
-    date.getDate()
+    date.getDate(),
   )}${prefixZero(date.getHours())}${prefixZero(date.getMinutes())}${prefixZero(date.getSeconds())}`;
 }
 

--- a/tools/verify_course_repo.js
+++ b/tools/verify_course_repo.js
@@ -3,7 +3,7 @@ const courseDB = require('../apps/prairielearn/dist/sync/course-db');
   const courseData = await courseDB.loadFullCourse('/course');
   const errors = [];
   courseDB.writeErrorsAndWarningsForCourseData(null, courseData, (line) =>
-    line ? errors.push(line) : null
+    line ? errors.push(line) : null,
   );
   if (errors.length !== 0) {
     errors.forEach((line) => console.error(line));

--- a/workspaces/desktop/server/server.js
+++ b/workspaces/desktop/server/server.js
@@ -107,7 +107,7 @@ const spawn_gui = async (width, height) => {
       env: {
         X11VNC_FINDDISPLAY_ALWAYS_FAILS: '1',
       },
-    }
+    },
   );
   attach_listeners(x11vnc_proc);
 

--- a/workspaces/xtermjs/src/server.js
+++ b/workspaces/xtermjs/src/server.js
@@ -111,5 +111,5 @@ app.ws('/', (ws, req) => {
 });
 
 app.listen(options.port, () =>
-  console.log(`XTerm server listening at http://localhost:${options.port}`)
+  console.log(`XTerm server listening at http://localhost:${options.port}`),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13520,7 +13520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.8.8, prettier@npm:^2.7.1":
+"prettier@npm:3.0.0":
+  version: 3.0.0
+  resolution: "prettier@npm:3.0.0"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.7.1":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
@@ -14356,7 +14365,7 @@ __metadata:
     eslint-plugin-no-only-tests: ^3.1.0
     htmlhint: ^1.1.4
     jsdoc: ^4.0.2
-    prettier: 2.8.8
+    prettier: 3.0.0
     pyright: ^1.1.311
     s3rver: ^3.7.1
     turbo: ^1.10.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,7 +3449,7 @@ __metadata:
   dependencies:
     "@prairielearn/tsconfig": "workspace:^"
     "@types/node": ^18.16.16
-    "@types/prettier": ^2.7.3
+    prettier: 3.0.0
     sql-formatter: ^12.2.1
     typescript: ^5.1.3
   languageName: unknown
@@ -4576,13 +4576,6 @@ __metadata:
     pg-protocol: "*"
     pg-types: ^2.2.0
   checksum: a44710ff06e70f57685ddb88edbb93d4b46e03fed90619f09853ed3868ab28541c4da03eccf6b0b444a7566a0b3c56028543ced43554d51168ca3f8ae15e194f
-  languageName: node
-  linkType: hard
-
-"@types/prettier@npm:^2.7.3":
-  version: 2.7.3
-  resolution: "@types/prettier@npm:2.7.3"
-  checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Two major changes here:

- Plugins are no longer automatically discovered, so I had to add `"plugins": ["@prairielearn/prettier-plugin-sql"]` to `.prettierrc.json`.
- `trailingComma` now defaults to `"all"`, which necessitated reformatting a _lot_ of files. We could change the value back to `"es5"`, but I'm inclined to stick with the default. This makes function call formatting match what we do with object/array literals and makes for marginally cleaner diffs when additional arguments are added to function calls.