### PR TITLE
Allow empty implicit question topics

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/topics.js
+++ b/apps/prairielearn/src/sync/fromDisk/topics.js
@@ -28,10 +28,11 @@ module.exports.sync = async function (courseId, courseData) {
   const knownQuestionTopicNames = new Set();
   Object.values(courseData.questions).forEach((q) => {
     // We technically allow courses to define an "empty string" topic, so we'll
-    // support that for implicit topics as well.
+    // support that for implicit topics as well by checking if the topic is
+    // nullish, rather than falsy (which wouldn't handle empty strings).
     //
     // TODO: consider requiring that all topics have a non-empty name.
-    if (!infofile.hasErrors(q) && typeof q.data?.topic === 'string') {
+    if (!infofile.hasErrors(q) && q.data?.topic != null) {
       knownQuestionTopicNames.add(q.data.topic);
     }
   });

--- a/apps/prairielearn/src/sync/fromDisk/topics.js
+++ b/apps/prairielearn/src/sync/fromDisk/topics.js
@@ -31,7 +31,7 @@ module.exports.sync = async function (courseId, courseData) {
     // support that for implicit topics as well.
     //
     // TODO: consider requiring that all topics have a non-empty name.
-    if (!infofile.hasErrors(q) && typeof q.data?.topic === "string") {
+    if (!infofile.hasErrors(q) && typeof q.data?.topic === 'string') {
       knownQuestionTopicNames.add(q.data.topic);
     }
   });

--- a/apps/prairielearn/src/sync/fromDisk/topics.js
+++ b/apps/prairielearn/src/sync/fromDisk/topics.js
@@ -27,7 +27,11 @@ module.exports.sync = async function (courseId, courseData) {
   /** @type Set<string> */
   const knownQuestionTopicNames = new Set();
   Object.values(courseData.questions).forEach((q) => {
-    if (!infofile.hasErrors(q) && q.data?.topic) {
+    // We technically allow courses to define an "empty string" topic, so we'll
+    // support that for implicit topics as well.
+    //
+    // TODO: consider requiring that all topics have a non-empty name.
+    if (!infofile.hasErrors(q) && typeof q.data?.topic === "string") {
       knownQuestionTopicNames.add(q.data.topic);
     }
   });


### PR DESCRIPTION
Closes #7952. In the long-term, we should consider the inlined TODO and require that all topics (even explicit ones) are not the empty string, or don't `.trim()` to the empty string. However, that would be backwards-incompatible with several courses, so I'm avoiding that disruption for now.