### PR TITLE
Set X-Response-ID header for all requests

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -416,6 +416,7 @@ module.exports.initExpress = function () {
   // response_id is logged on request, response, and error to link them together
   app.use(function (req, res, next) {
     res.locals.response_id = uuidv4();
+    req.set('X-Response-ID', res.locals.response_id);
     next();
   });
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -416,7 +416,7 @@ module.exports.initExpress = function () {
   // response_id is logged on request, response, and error to link them together
   app.use(function (req, res, next) {
     res.locals.response_id = uuidv4();
-    req.set('X-Response-ID', res.locals.response_id);
+    res.set('X-Response-ID', res.locals.response_id);
     next();
   });
 


### PR DESCRIPTION
Closes #832. This will help us tie requests to logs, Sentry events, etc.