### PR TITLE
Add schemdraw Python library

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -43,3 +43,5 @@ types-Pygments==2.15.0.1
 types-pytest-lazy-fixture==0.6.3.3
 typing-extensions==4.7.0
 tzlocal==4.3
+schemdraw==0.17
+*Add schemdraw:0.17 to PrairieLearn

--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -31,6 +31,7 @@ pytest==7.4.0
 recommonmark==0.7.1
 regex==2023.6.3
 rpy2==3.5.12
+schemdraw==0.17
 scikit-learn==1.3.0
 scipy==1.11.1
 sphinx-markdown-builder==0.6.0
@@ -43,5 +44,3 @@ types-Pygments==2.15.0.1
 types-pytest-lazy-fixture==0.6.3.3
 typing-extensions==4.7.0
 tzlocal==4.3
-schemdraw==0.17
-*Add schemdraw:0.17 to PrairieLearn


### PR DESCRIPTION
Bucknell University's ECE Department wishes to include schemdraw v0.17 to PrairieLearn. Thank you!