### PR TITLE
Enable grouped dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     timezone: America/Chicago
   open-pull-requests-limit: 99
   rebase-strategy: disabled
+  groups:
+    aws:
+      patterns:
+        - "@aws-sdk/*"
+    opentelemetry:
+      patterns:
+        - "@opentelemetry/*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Grouped updated for Dependabot are now in public beta (https://github.com/dependabot/dependabot-core/issues/1190#issuecomment-1623832701) 🎉 

I'm turning it on for `@aws-sdk/*` and `@opentelemetry/*` packages, which generally need to all be upgraded at the same time.