### PR TITLE
feat: pl-multiple-choice duplicate checking and allow blank.

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -2,12 +2,12 @@ import json
 import math
 import pathlib
 import random
+from collections import Counter
+from itertools import chain
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from collections import Counter
-from itertools import chain
 
 SCORE_INCORRECT_DEFAULT = 0.0
 SCORE_CORRECT_DEFAULT = 1.0
@@ -145,7 +145,9 @@ def prepare(element_html, data):
     duplicates = [item for item, count in choices_dict.items() if count > 1]
 
     if duplicates:
-        raise ValueError(f'pl-multiple-choice element has duplicate choices: {duplicates}')
+        raise ValueError(
+            f"pl-multiple-choice element has duplicate choices: {duplicates}"
+        )
 
     len_correct = len(correct_answers)
     len_incorrect = len(incorrect_answers)
@@ -457,13 +459,13 @@ def parse(element_html, data):
     element = lxml.html.fragment_fromstring(element_html)
     name = pl.get_string_attrib(element, "answers-name")
 
-    allow_blank = pl.get_boolean_attrib(element, 'allow-blank', ALLOW_BLANK_DEFAULT)
+    allow_blank = pl.get_boolean_attrib(element, "allow-blank", ALLOW_BLANK_DEFAULT)
     submitted_key = data["submitted_answers"].get(name, None)
     all_keys = [a["key"] for a in data["params"][name]]
 
     if not allow_blank:
         if submitted_key is None:
-            data['format_errors'][name] = 'No answer was submitted.'
+            data["format_errors"][name] = "No answer was submitted."
             return
 
         if submitted_key not in all_keys:

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -147,7 +147,7 @@ def prepare(element_html, data):
 
     if duplicates:
         raise ValueError(
-            f'pl-multiple-choice element "{name}" has duplicate choices: {duplicates}'
+            f'pl-multiple-choice element "{name}" has duplicate choices: {"; ".join(duplicates)}'
         )
 
     len_correct = len(correct_answers)

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -147,7 +147,7 @@ def prepare(element_html, data):
 
     if duplicates:
         raise ValueError(
-            f"pl-multiple-choice element has duplicate choices: {duplicates}"
+            f'pl-multiple-choice element "{name}" has duplicate choices: {duplicates}'
         )
 
     len_correct = len(correct_answers)

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -22,6 +22,7 @@ EXTERNAL_JSON_CORRECT_KEY_DEFAULT = "correct"
 EXTERNAL_JSON_INCORRECT_KEY_DEFAULT = "incorrect"
 FEEDBACK_DEFAULT = None
 ALLOW_BLANK_DEFAULT = False
+SUBMITTED_ANSWER_BLANK = {"html": "No answer submitted"}
 
 
 def categorize_options(element, data):
@@ -395,19 +396,23 @@ def render(element_html, data):
             html = chevron.render(f, html_params).strip()
     elif data["panel"] == "submission":
         parse_error = data["format_errors"].get(name, None)
-        html_params = {
-            "submission": True,
-            "parse_error": parse_error,
-            "uuid": pl.get_uuid(),
-            "hide_letter_keys": pl.get_boolean_attrib(
-                element, "hide-letter-keys", HIDE_LETTER_KEYS_DEFAULT
-            ),
-        }
 
         if parse_error is None:
             submitted_answer = next(
-                filter(lambda a: a["key"] == submitted_key, answers), None
+                filter(lambda a: a["key"] == submitted_key, answers),
+                SUBMITTED_ANSWER_BLANK,
             )
+            hide_letter_keys = pl.get_boolean_attrib(
+                element, "hide-letter-keys", HIDE_LETTER_KEYS_DEFAULT
+            )
+
+            html_params = {
+                "submission": True,
+                "parse_error": parse_error,
+                "uuid": pl.get_uuid(),
+                "hide_letter_keys": hide_letter_keys or submitted_key is None,
+            }
+
             html_params["key"] = submitted_key
             html_params["answer"] = submitted_answer
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -695,21 +695,21 @@ generation if two (or more) choices are identical.
 
 #### Customizations
 
-| Attribute                     | Type    | Default | Description                                                                                                                                                          |
-| ----------------------------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `answers-name`                | string  | —       | Variable name to store data in. Note that this attribute has to be unique within a question, i.e., no value for this attribute should be repeated within a question. |
-| `weight`                      | integer | 1       | Weight to use when computing a weighted average score over elements.                                                                                                 |
-| `inline`                      | boolean | false   | List answer choices on a single line instead of as separate paragraphs.                                                                                              |
-| `number-answers`              | integer | special | The total number of answer choices to display. Defaults to displaying one correct answer and all incorrect answers.                                                  |
-| `fixed-order`                 | boolean | false   | Disable the randomization of answer order.                                                                                                                           |
-| `hide-letter-keys`            | boolean | false   | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.                                                                                                   |
-| `all-of-the-above`            | string  | `false` | Add "All of the above" choice. See below for details.                                                                                                                |
-| `none-of-the-above`           | string  | `false` | Add "None of the above" choice. See below for details.                                                                                                               |
-| `all-of-the-above-feedback`   | string  | —       | Helper text to be displayed to the student next to the `all-of-the-above` option after question is graded if this option has been selected by the student.           |
-| `none-of-the-above-feedback`  | string  | —       | Helper text to be displayed to the student next to the `none-of-the-above` option after question is graded if this option has been selected by the student.          |
-| `external-json`               | string  | special | Optional path to a JSON file to load external answer choices from. Answer choices are stored as lists under "correct" and "incorrect" key names.                     |
-| `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                           |
-| `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                         |
+| Attribute                     | Type    | Default | Description                                                                                                                                                                    |
+| ----------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `answers-name`                | string  | —       | Variable name to store data in. Note that this attribute has to be unique within a question, i.e., no value for this attribute should be repeated within a question.           |
+| `weight`                      | integer | 1       | Weight to use when computing a weighted average score over elements.                                                                                                           |
+| `inline`                      | boolean | false   | List answer choices on a single line instead of as separate paragraphs.                                                                                                        |
+| `number-answers`              | integer | special | The total number of answer choices to display. Defaults to displaying one correct answer and all incorrect answers.                                                            |
+| `fixed-order`                 | boolean | false   | Disable the randomization of answer order.                                                                                                                                     |
+| `hide-letter-keys`            | boolean | false   | Hide the letter keys in the answer list, i.e., (a), (b), (c), etc.                                                                                                             |
+| `all-of-the-above`            | string  | `false` | Add "All of the above" choice. See below for details.                                                                                                                          |
+| `none-of-the-above`           | string  | `false` | Add "None of the above" choice. See below for details.                                                                                                                         |
+| `all-of-the-above-feedback`   | string  | —       | Helper text to be displayed to the student next to the `all-of-the-above` option after question is graded if this option has been selected by the student.                     |
+| `none-of-the-above-feedback`  | string  | —       | Helper text to be displayed to the student next to the `none-of-the-above` option after question is graded if this option has been selected by the student.                    |
+| `external-json`               | string  | special | Optional path to a JSON file to load external answer choices from. Answer choices are stored as lists under "correct" and "incorrect" key names.                               |
+| `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                                     |
+| `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                                   |
 | `allow-blank`                 | boolean | false   | Whether or not an empty submission is allowed. If `allow-blank` is set to `true`, a submission that does not select any option will be marked as incorrect instead of invalid. |
 
 The attributes `none-of-the-above` and `all-of-the-above` can be set to one of these values:

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -677,6 +677,9 @@ In the submission panel, a `pl-matrix-input` element displays either the submitt
 
 A `pl-multiple-choice` element selects **one** correct answer and zero or more
 incorrect answers and displays them in a random order as radio buttons.
+Duplicate answer choices (string equivalents) are not permitted in the
+`pl-multiple-choice` element, and an exception will be raised upon question
+generation if two (or more) choices are identical.
 
 #### Sample element
 
@@ -707,6 +710,8 @@ incorrect answers and displays them in a random order as radio buttons.
 | `external-json`               | string  | special | Optional path to a JSON file to load external answer choices from. Answer choices are stored as lists under "correct" and "incorrect" key names.                     |
 | `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                           |
 | `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                         |
+| `allow-blank`                 | boolean | false   | Whether or not an empty submission is allowed. If `allow-blank` is set to `true`, no response will be marked as incorrect instead of invalid.                        |
+
 
 The attributes `none-of-the-above` and `all-of-the-above` can be set to one of these values:
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -672,6 +672,7 @@ In the submission panel, a `pl-matrix-input` element displays either the submitt
 - [`pl-symbolic-input` for a mathematical expression input](#pl-symbolic-input-element)
 
 ---
+
 ### `pl-multiple-choice` element
 
 A `pl-multiple-choice` element selects **one** correct answer and zero or more

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -710,7 +710,7 @@ generation if two (or more) choices are identical.
 | `external-json`               | string  | special | Optional path to a JSON file to load external answer choices from. Answer choices are stored as lists under "correct" and "incorrect" key names.                     |
 | `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                           |
 | `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                         |
-| `allow-blank`                 | boolean | false   | Whether or not an empty submission is allowed. If `allow-blank` is set to `true`, no response will be marked as incorrect instead of invalid.                        |
+| `allow-blank`                 | boolean | false   | Whether or not an empty submission is allowed. If `allow-blank` is set to `true`, a submission that does not select any option will be marked as incorrect instead of invalid. |
 
 The attributes `none-of-the-above` and `all-of-the-above` can be set to one of these values:
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -672,7 +672,6 @@ In the submission panel, a `pl-matrix-input` element displays either the submitt
 - [`pl-symbolic-input` for a mathematical expression input](#pl-symbolic-input-element)
 
 ---
-
 ### `pl-multiple-choice` element
 
 A `pl-multiple-choice` element selects **one** correct answer and zero or more
@@ -711,7 +710,6 @@ generation if two (or more) choices are identical.
 | `external-json-correct-key`   | string  | special | Optionally override default json "correct" attribute name when using `external-json` file.                                                                           |
 | `external-json-incorrect-key` | string  | special | Optionally override default json "incorrect" attribute name when using `external-json` file.                                                                         |
 | `allow-blank`                 | boolean | false   | Whether or not an empty submission is allowed. If `allow-blank` is set to `true`, no response will be marked as incorrect instead of invalid.                        |
-
 
 The attributes `none-of-the-above` and `all-of-the-above` can be set to one of these values:
 

--- a/exampleCourse/questions/element/multipleChoice/question.html
+++ b/exampleCourse/questions/element/multipleChoice/question.html
@@ -243,12 +243,13 @@
         <pl-question-panel>
             <p>Here, you can observe the behavior of the <code>score</code> attribute in <code>pl-answer</code>.
             The score for a question the percentage of points given to it if selected (default is 0 for
-            incorrect answers and 1 for correct ones.)</p>
+            incorrect answers and 1 for correct ones). This also allows no submission by the student, done by
+            setting <code>allow-blank="true"</code>.</p>
 
             <p> What is the color of the sky? </p>
         </pl-question-panel>
 
-        <pl-multiple-choice answers-name="sky-color9">
+        <pl-multiple-choice answers-name="sky-color9" allow-blank="true">
             <pl-answer correct="true" feedback="Correct! The sky is indeed blue.">Blue</pl-answer>
             <pl-answer>Pink</pl-answer>
             <pl-answer score=0.5>Purple</pl-answer>


### PR DESCRIPTION
See title, resolves #1228 and #6350 for the multiple choice element. Uses code from https://github.com/PrairieLearn/PrairieLearn/pull/6119 (with attribution) for the allow blank logic.

Screenshots of allow blank behavior:

Blank submission:
![image](https://github.com/PrairieLearn/PrairieLearn/assets/1345068/5634e99f-b281-4451-a4ba-56c6bbb3eb77)
Submission panel:
![image](https://github.com/PrairieLearn/PrairieLearn/assets/1345068/6853d7eb-b6c8-41e6-9ce6-830661fc9d97)
