### PR TITLE
Fix chunk generation for large diffs

### DIFF
--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -275,7 +275,15 @@ export async function identifyChangedFiles(
 
   const { stdout: diffStdout } = await util.promisify(child_process.exec)(
     `git diff --name-only ${oldHash}..${newHash}`,
-    { cwd: coursePath },
+    {
+      cwd: coursePath,
+      // This defaults to 1MB of output, however, we've observed in the past that
+      // courses will go long periods of time without syncing, which in turn will
+      // result in a large number of changed files. The largest diff we've seen
+      // is 1.6MB of text; this new value was chosen to give us plenty of
+      // headroom.
+      maxBuffer: 10 * 1024 * 1024,
+    },
   );
   const changedFiles = diffStdout.trim().split('\n');
 


### PR DESCRIPTION
Ass discussed in office hours today. If a large number of files changed, syncing would fail with the following error:

```
RangeError: stdout maxBuffer length exceeded
at new NodeError (node:internal/errors:387:5)
at Socket.onChildStdout (node:child_process:470:14)
at Socket.emit (node:events: 513:28) at Socket.emit (node: domain: 489:12)
at addChunk (node: internal/streams/readable: 315:12)
at readableAddChunk (node: internal/streams/readable:285:11)
at Socket. Readable.push (node: internal/streams/readable:228:10) at Pipe.onStreamRead (node: internal/stream_base_commons: 190:23) at Pipe.callbackTrampoline (node:internal/async_hooks:130:17)
```

See https://us.prairielearn.com/pl/course/2691/jobSequence/443882 for one such failing job.