### PR TITLE
refactor: Simplify symbolic input parsing

### DIFF
--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -380,10 +380,14 @@ def evaluate_with_source(
     global_dict = {}
     exec("from sympy import *", global_dict)
 
-    builtins_dict = vars(builtins)
-    for name, obj in builtins_dict.items():
-        if isinstance(obj, types.BuiltinFunctionType):
-            global_dict[name] = obj
+    global_dict.update(
+        (name, obj)
+        for name, obj in vars(builtins).items()
+        if isinstance(obj, types.BuiltinFunctionType)
+    )
+
+    global_dict["max"] = sympy.Max
+    global_dict["min"] = sympy.Min
 
     transformations = standard_transformations + (implicit_multiplication_application,)
 

--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -1,7 +1,5 @@
 import ast
-import builtins
 import copy
-import types
 from collections import deque
 from dataclasses import dataclass
 from tokenize import TokenError
@@ -377,17 +375,11 @@ def evaluate_with_source(
     # Based on code here:
     # https://github.com/sympy/sympy/blob/26f7bdbe3f860e7b4492e102edec2d6b429b5aaf/sympy/parsing/sympy_parser.py#L1086
 
+    # Global dict is set up to be very permissive for parsing purposes
+    # (makes it cleaner to call this function with a custom locals dict).
+    # This line shouldn't be dangerous, as it's just loading the global dict.
     global_dict = {}
     exec("from sympy import *", global_dict)
-
-    global_dict.update(
-        (name, obj)
-        for name, obj in vars(builtins).items()
-        if isinstance(obj, types.BuiltinFunctionType)
-    )
-
-    global_dict["max"] = sympy.Max
-    global_dict["min"] = sympy.Min
 
     transformations = standard_transformations + (implicit_multiplication_application,)
 

--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -342,11 +342,12 @@ def sympy_check(
 
     while work_stack:
         item = work_stack.pop()
+        str_item = str(item)
 
-        if isinstance(item, sympy.Symbol) and str(item) not in valid_symbols:
-            raise HasInvalidSymbolError(str(item))
+        if isinstance(item, sympy.Symbol) and str_item not in valid_symbols:
+            raise HasInvalidSymbolError(str_item)
         elif isinstance(item, sympy.Float):
-            raise HasFloatError(float(str(item)))
+            raise HasFloatError(float(str_item))
         elif not allow_complex and item == sympy.I:
             raise HasComplexError()
 
@@ -397,18 +398,14 @@ def evaluate_with_source(
     # Add locals that appear after sympy stringification
     # This check is only for safety, so won't change what gets parsed
     parsed_locals_to_eval["functions"].update(
-        {
-            "Integer": sympy.Integer,
-            "Symbol": sympy.Symbol,
-            "Float": sympy.Float,
-        }
+        Integer=sympy.Integer,
+        Symbol=sympy.Symbol,
+        Float=sympy.Float,
     )
 
     parsed_locals_to_eval["variables"].update(
-        {
-            "I": sympy.I,
-            "oo": sympy.oo,
-        }
+        I=sympy.I,
+        oo=sympy.oo,
     )
 
     ast_check(code, parsed_locals_to_eval)

--- a/apps/prairielearn/python/python_helper_sympy_test.py
+++ b/apps/prairielearn/python/python_helper_sympy_test.py
@@ -56,6 +56,7 @@ class TestSympy:
     ]
 
     EXPR_PAIRS = [
+        ("Max(m,n)", sympy.Max(N, M)),
         ("min(alpha, m, n)", sympy.Min(N, M, ALPHA)),
         ("max(m)", M),
         ("max(m,n)", sympy.Max(N, M)),
@@ -159,6 +160,22 @@ class TestSympy:
         assert sympy_ref != phs.convert_string_to_sympy(
             a_sub, ["i", "j"], allow_complex=False
         )
+
+    def test_string_conversion_complex_conflict(self) -> None:
+        """
+        Check for no issues in the case where complex is not
+        allowed and variable is named "I".
+        """
+
+        a_sub = "2I"
+        var = sympy.symbols("I")
+        ref_expr = 2 * var
+
+        assert ref_expr == phs.convert_string_to_sympy(
+            a_sub, ["I"], allow_complex=False
+        )
+
+        assert ref_expr == phs.json_to_sympy(phs.sympy_to_json(ref_expr))
 
     @pytest.mark.parametrize(
         "a_pair, custom_functions",

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1061,7 +1061,7 @@ Correct answers are best created as `sympy` expressions and converted to json us
 
 Variables with the same name as greek letters (e.g., `alpha`, `beta`, etc.) will be automatically converted to their LaTeX equivalents for display on the correct answer and submission panels.
 
-Do not include `i` or `j` in the list of `variables` if `allow-complex="true"`. Do not include any other reserved name in your list of `variables` (`e`, `pi`, `cos`, `sin`, etc.) The element code will check for (and disallow) conflicts between your list of `variables`, `custom-functions` and reserved names.
+Do not include `i` or `j` in the list of `variables` if `allow-complex="true"`, and do not include any other reserved name in your list of `variables` (`e`, `pi`, `cos`, `sin`, etc). The element code will check for (and disallow) conflicts between your list of `variables`, `custom-functions`, and reserved names.
 
 Note that variables created with additional assumptions in a correct answer will have those assumptions respected when evaluating student answers.
 See example question for details.


### PR DESCRIPTION
See title. Minor style changes to symbolic input backend code and docs typo fixes.

EDIT: After playing with this more, figured out a way to simplify the symbolic input parser use fewer dangerous function calls.