### PR TITLE
docs: Allow indented code blocks

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,7 @@
+.rst-content div[class^=highlight] {
+  border: none;
+}
+
+.rst-content div[class^=highlight] pre {
+  padding: 0;
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs>=1.0
 mdx_truly_sane_lists>=1.2
+pymdown-extensions>=10.1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,9 @@ extra_javascript:
   - mathjax-config.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js
 
+extra_css:
+  - extra.css
+
 nav:
 - Main: 'index.md'
 - Getting Started:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,9 @@ markdown_extensions:
   # https://pypi.org/project/mdx-truly-sane-lists/
   - mdx_truly_sane_lists
 
+  # allows indented code blocks inside lists
+  - pymdownx.superfences
+
 extra_javascript:
   - mathjax-config.js
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js


### PR DESCRIPTION
Mkdocs does not allow indented code blocks by default in markdown (unlike GitHub markdown, which does allow this). See below for an example of bad rendering in our current docs due to this. This PR adds the [SuperFences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/) extension to fix this, as recommended [here](https://github.com/squidfunk/mkdocs-material/issues/2639). I checked the rendering locally and it looks fine (see below), although it does add an extra box around each code block. An alternative approach would be to dedent all the code blocks, as we do on other pages such as https://github.com/PrairieLearn/PrairieLearn/blob/b22e2039732aa67f02dc5d4cc258e2551a2e7c5d/docs/installingLocal.md?plain=1#L7-L11
What does everyone think about dedenting versus using this extension?

# Example of problem in the current docs

For example, in the native install docs we have indented blocks like this: https://github.com/PrairieLearn/PrairieLearn/blob/b22e2039732aa67f02dc5d4cc258e2551a2e7c5d/docs/installingNative.md?plain=1#L18-L35
which renders into this mess:
<img width="725" alt="image" src="https://github.com/PrairieLearn/PrairieLearn/assets/875833/fbdf2a6c-181a-479a-9e87-ea936d01f3d1">

# Fixed example with the new extension

The above example now renders like this:
<img width="726" alt="image" src="https://github.com/PrairieLearn/PrairieLearn/assets/875833/d3351da1-4a2b-411e-8b5b-3ce3928cb733">
