### PR TITLE
Allow authenticating as arbitrary users in dev mode

### DIFF
--- a/apps/prairielearn/src/middlewares/authn.js
+++ b/apps/prairielearn/src/middlewares/authn.js
@@ -65,7 +65,10 @@ module.exports = asyncHandler(async (req, res, next) => {
   }
 
   // Allow auth to be bypassed for local dev mode; also used for tests.
-  // See `pages/authLoginDev` for cookie-based authentication in dev mode.
+  //
+  // To authenticate as specific users in dev mode, set `authType` to some
+  // other value in your config (e.g. "x-auth"). Then, visit the login page
+  // and enter a UID, name, and UIN. This is implemented in `pages/authLogin`.
   if (config.authType === 'none') {
     var uid = config.authUid;
     var name = config.authName;

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -119,9 +119,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
               </h2>
               ${resLocals.devMode
                 ? html`
-                    <a class="btn btn-success w-100" href="/pl/dev_login" role="button">
-                      <span class="font-weight-bold">Dev Mode Bypass</span>
-                    </a>
+                    ${DevModeBypass({ csrfToken: resLocals.__csrf_token })}
                     <hr />
                     ${DevModeLogin({ csrfToken: resLocals.__csrf_token })}
                     <hr />
@@ -187,6 +185,15 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
       </body>
     </html>
   `.toString();
+}
+
+function DevModeBypass() {
+  return html`
+    <a class="btn btn-success w-100" href="/pl/dev_login" role="button">
+      <span class="font-weight-bold">Dev Mode Bypass</span>
+    </a>
+    <small class="text-muted">You will be authenticated as <tt>${config.authUid}</tt>.</small>
+  `;
 }
 
 function DevModeLogin({ csrfToken }: { csrfToken: string }) {

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -124,7 +124,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
                     ${DevModeLogin({ csrfToken: resLocals.__csrf_token })}
                     <hr />
                   `
-                : null}
+                : ''}
               <div class="login-methods">
                 ${config.hasShib && !config.hideShibLogin
                   ? html`
@@ -139,7 +139,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
                         <span class="font-weight-bold">${config.shibLinkText}</span>
                       </a>
                     `
-                  : null}
+                  : ''}
                 ${config.hasOauth
                   ? html`
                       <a
@@ -151,7 +151,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
                         <span class="font-weight-bold">Sign in with Google</span>
                       </a>
                     `
-                  : null}
+                  : ''}
                 ${config.hasAzure && isEnterprise()
                   ? html`
                       <a
@@ -163,7 +163,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
                         <span class="font-weight-bold">Sign in with Microsoft</span>
                       </a>
                     `
-                  : null}
+                  : ''}
               </div>
               ${institutionAuthnProviders?.length
                 ? html`
@@ -178,7 +178,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
                       )}
                     </div>
                   `
-                : null}
+                : ''}
             </div>
           </div>
         </main>

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -119,7 +119,7 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
               </h2>
               ${resLocals.devMode
                 ? html`
-                    ${DevModeBypass({ csrfToken: resLocals.__csrf_token })}
+                    ${DevModeBypass()}
                     <hr />
                     ${DevModeLogin({ csrfToken: resLocals.__csrf_token })}
                     <hr />

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -114,17 +114,20 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
           <div class="login-container">
             <div>
               <h1 class="text-center">PrairieLearn</h1>
-              <h2 class="text-center subheader">
+              <h2 class="text-center subheader mb-5">
                 Sign in ${service ? `to continue to ${service}` : ''}
               </h2>
-              <div class="login-methods mt-5">
-                ${resLocals.devMode
-                  ? html`
-                      <a class="btn btn-success w-100" href="/pl/dev_login" role="button">
-                        <span class="font-weight-bold">DevMode by-pass</span>
-                      </a>
-                    `
-                  : null}
+              ${resLocals.devMode
+                ? html`
+                    <a class="btn btn-success w-100" href="/pl/dev_login" role="button">
+                      <span class="font-weight-bold">Dev Mode Bypass</span>
+                    </a>
+                    <hr />
+                    ${DevModeLogin({ csrfToken: resLocals.__csrf_token })}
+                    <hr />
+                  `
+                : null}
+              <div class="login-methods">
                 ${config.hasShib && !config.hideShibLogin
                   ? html`
                       <a
@@ -184,4 +187,30 @@ export function AuthLogin({ institutionAuthnProviders, service, resLocals }: Aut
       </body>
     </html>
   `.toString();
+}
+
+function DevModeLogin({ csrfToken }: { csrfToken: string }) {
+  return html`
+    <form method="POST">
+      <div class="form-group">
+        <label for="dev_uid">UID</label>
+        <input class="form-control" id="dev_uid" name="uid" required />
+      </div>
+      <div class="form-group">
+        <label for="dev_name">Name</label>
+        <input class="form-control" id="dev_name" name="name" required />
+      </div>
+      <div class="form-group">
+        <label for="dev_uin">UIN</label>
+        <input class="form-control" id="dev_uin" name="uin" aria-describedby="dev_uin_help" />
+        <small id="dev_uin_help" class="form-text text-muted">
+          Optional; will be set to <tt>null</tt> if not specified.
+        </small>
+      </div>
+      <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+      <button type="submit" class="btn btn-primary btn-block" name="__action" value="dev_login">
+        <span class="font-weight-bold">Dev Mode Login</span>
+      </button>
+    </form>
+  `;
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
@@ -1,3 +1,4 @@
+// @ts-check
 const express = require('express');
 const router = express.Router();
 const asyncHandler = require('express-async-handler');

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
@@ -1,4 +1,3 @@
-// @ts-check
 const express = require('express');
 const router = express.Router();
 const asyncHandler = require('express-async-handler');


### PR DESCRIPTION
This supports a workflow where devs can authenticate as multiple users in multiple browsers in development mode. For instance, one could be a global admin in one browser, an instructor in another, and a student in an incognito window. This should make it easier to test complex interactions/states.

I believe this can close #2428.

<img width="726" alt="Screenshot 2023-07-19 at 12 34 04" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/face8720-73f2-4f0f-bf2f-caa00b89581c">
