### PR TITLE
Fix localhost cookies for Safari

### DIFF
--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -4,6 +4,7 @@ const sqldb = require('@prairielearn/postgres');
 const { generateSignedToken } = require('@prairielearn/signed-token');
 
 const { config } = require('../lib/config');
+const { shouldSecureCookie } = require('../lib/cookie');
 const { InstitutionSchema, UserSchema } = require('./db-types');
 
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -66,7 +67,7 @@ module.exports.loadUser = async (req, res, authnParams, optionsParams = {}) => {
     res.cookie('pl_authn', pl_authn, {
       maxAge: config.authnCookieMaxAgeMilliseconds,
       httpOnly: true,
-      secure: true,
+      secure: shouldSecureCookie(req),
     });
   }
 

--- a/apps/prairielearn/src/lib/cookie.ts
+++ b/apps/prairielearn/src/lib/cookie.ts
@@ -1,0 +1,12 @@
+import type { Request } from 'express';
+
+import { config } from './config';
+
+export function shouldSecureCookie(req: Request): boolean {
+  // In production, always set secure: true. Otherwise, only set it to true if
+  // the request is made over HTTPS.
+  //
+  // `req.protocol` should reflect Express' `trust proxy` setting, which should
+  // be used when the app is behind a reverse proxy or load balancer.
+  return !config.devMode || req.protocol === 'https';
+}

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
@@ -1,5 +1,6 @@
 const { generateSignedToken } = require('@prairielearn/signed-token');
 const { config } = require('../lib/config');
+const { shouldSecureCookie } = require('../lib/cookie');
 
 module.exports = (req, res, next) => {
   // We should only have arrived here if we passed authn/authz and
@@ -17,7 +18,7 @@ module.exports = (req, res, next) => {
   res.cookie(cookieName, cookieData, {
     maxAge: config.workspaceAuthzCookieMaxAgeMilliseconds,
     httpOnly: true,
-    secure: true,
+    secure: shouldSecureCookie(req),
   });
   next();
 };

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -13,6 +13,7 @@ const error = require('@prairielearn/error');
 const { generateSignedToken } = require('@prairielearn/signed-token');
 const { config } = require('../../lib/config');
 const cache = require('../../lib/cache');
+const { shouldSecureCookie } = require('../../lib/cookie');
 
 var timeTolerance = 3000; // seconds
 
@@ -131,7 +132,7 @@ router.post('/', function (req, res, next) {
         res.cookie('pl_authn', pl_authn, {
           maxAge: config.authnCookieMaxAgeMilliseconds,
           httpOnly: true,
-          secure: true,
+          secure: shouldSecureCookie(req),
         });
 
         const params = {

--- a/apps/prairielearn/src/pages/authPassword/authPassword.js
+++ b/apps/prairielearn/src/pages/authPassword/authPassword.js
@@ -1,8 +1,9 @@
-var express = require('express');
-var router = express.Router();
-
+const express = require('express');
 const { generateSignedToken } = require('@prairielearn/signed-token');
 const { config } = require('../../lib/config');
+const { shouldSecureCookie } = require('../../lib/cookie');
+
+const router = express.Router();
 
 router.get('/', function (req, res) {
   res.locals.passwordInvalid = 'pl_assessmentpw' in req.cookies;
@@ -14,7 +15,11 @@ router.post('/', function (req, res) {
   var maxAge = 1000 * 60 * 60 * 12; // 12 hours
 
   var pwCookie = generateSignedToken({ password: req.body.password, maxAge }, config.secretKey);
-  res.cookie('pl_assessmentpw', pwCookie, { maxAge, httpOnly: true, secure: true });
+  res.cookie('pl_assessmentpw', pwCookie, {
+    maxAge,
+    httpOnly: true,
+    secure: shouldSecureCookie(req),
+  });
   res.clearCookie('pl_pw_origUrl');
   return res.redirect(redirectUrl);
 });


### PR DESCRIPTION
Unlike other browsers, Safari does not persist `Secure` cookies on localhost. This means that changes like #8198 (and in fact any feature that uses cookies) won't work on Safari when developing locally.

This fix maintains the property that cookies will *always* be marked as secure in production, but makes an exception for development environments where HTTP is used. If HTTPS is used in development, the cookie will still be marked `Secure`.