### PR TITLE
Remove authType config

### DIFF
--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -69,6 +69,10 @@ module.exports.loadUser = async (req, res, authnParams, optionsParams = {}) => {
       httpOnly: true,
       secure: shouldSecureCookie(req),
     });
+
+    // After explicitly authenticating, clear the cookie that disables
+    // automatic authentication.
+    res.clearCookie('pl_disable_auto_authn');
   }
 
   if (options.redirect) {

--- a/apps/prairielearn/src/lib/config.js
+++ b/apps/prairielearn/src/lib/config.js
@@ -47,11 +47,11 @@ const ConfigSchema = z.object({
   redisUrl: z.string().nullable().default('redis://localhost:6379/'),
   logFilename: z.string().default('server.log'),
   logErrorFilename: z.string().nullable().default(null),
-  /** Overrides the user UID in development. */
+  /** Sets the default user UID in development. */
   authUid: z.string().nullable().default('dev@illinois.edu'),
-  /** Overrides the user name in development. */
+  /** Sets the default user name in development. */
   authName: z.string().nullable().default('Dev User'),
-  /** Overrides the user UIN in development. */
+  /** Sets the default user UIN in development. */
   authUin: z.string().nullable().default('000000000'),
   authnCookieMaxAgeMilliseconds: z.number().default(30 * 24 * 60 * 60 * 1000),
   sessionStoreExpireSeconds: z.number().default(86400),

--- a/apps/prairielearn/src/lib/config.js
+++ b/apps/prairielearn/src/lib/config.js
@@ -47,13 +47,11 @@ const ConfigSchema = z.object({
   redisUrl: z.string().nullable().default('redis://localhost:6379/'),
   logFilename: z.string().default('server.log'),
   logErrorFilename: z.string().nullable().default(null),
-  /** `'none'` allows bypassing auth in development. */
-  authType: z.enum(['none', 'x-auth', 'x-trust-auth']).default('none'),
-  /** Overrides the user UID in development with `authType: 'none'` */
+  /** Overrides the user UID in development. */
   authUid: z.string().nullable().default('dev@illinois.edu'),
-  /** Overrides the user name in development with `authType: 'none'` */
+  /** Overrides the user name in development. */
   authName: z.string().nullable().default('Dev User'),
-  /** Overrides the user UIN in development with `authType: 'none'` */
+  /** Overrides the user UIN in development. */
   authUin: z.string().nullable().default('000000000'),
   authnCookieMaxAgeMilliseconds: z.number().default(30 * 24 * 60 * 60 * 1000),
   sessionStoreExpireSeconds: z.number().default(86400),

--- a/apps/prairielearn/src/middlewares/authn.js
+++ b/apps/prairielearn/src/middlewares/authn.js
@@ -64,16 +64,24 @@ module.exports = asyncHandler(async (req, res, next) => {
     return next();
   }
 
-  // Allow auth to be bypassed for local dev mode; also used for tests.
-  // See `pages/authLoginDev` for cookie-based authentication in dev mode.
-  if (config.devMode) {
+  // In dev mode, by default, we'll authenticate the user automatically using
+  // the UID, name, and UIN specified in the config. This is to reduce the
+  // friction of getting started with PrairieLearn.
+  //
+  // If an authentication cookie is already present, we won't set a new one.
+  //
+  // If the user clicks "Log out" in dev mode, we'll set a special cookie to
+  // prevent this automatic authentication. The user will get bounced to the
+  // login page like they would in production. Then can then use the "bypass"
+  // authentication option on the login page to log in as the dev user.
+  // See `pages/authLoginDev` for more details.
+  if (config.devMode && !req.cookies.pl_disable_auto_authn && !req.cookies.pl_authn) {
     var uid = config.authUid;
     var name = config.authName;
     var uin = config.authUin;
 
     // We allow unit tests to override the user. Unit tests may also override the req_date
     // (middlewares/date.js) and the req_mode (middlewares/authzCourseOrInstance.js).
-
     if (req.cookies.pl_test_user === 'test_student') {
       uid = 'student@illinois.edu';
       name = 'Student User';
@@ -95,7 +103,7 @@ module.exports = asyncHandler(async (req, res, next) => {
 
     await authnLib.loadUser(req, res, authnParams, {
       redirect: false,
-      pl_authn_cookie: false,
+      pl_authn_cookie: true,
     });
     return next();
   }
@@ -110,7 +118,10 @@ module.exports = asyncHandler(async (req, res, next) => {
   }
   if (authnData == null) {
     // We failed to authenticate.
-    //
+
+    // Clear the pl_authn cookie in case it was bad
+    res.clearCookie('pl_authn');
+
     // Check if we're requesting the homepage. We avoid the usage of `req.path`
     // since this middleware might be mounted on a subpath.
     const requestPath = req.baseUrl + req.path;
@@ -122,8 +133,6 @@ module.exports = asyncHandler(async (req, res, next) => {
       // we aren't authenticated, and we've requested some page that isn't the homepage, so bounce to the login page
       // first set the preAuthUrl cookie for redirection after authn
       res.cookie('preAuthUrl', req.originalUrl);
-      // clear the pl_authn cookie in case it was bad
-      res.clearCookie('pl_authn');
 
       // If we're in the middle of a PrairieTest login flow, propagate that to
       // the login page so we can show a message to the user.

--- a/apps/prairielearn/src/middlewares/authn.js
+++ b/apps/prairielearn/src/middlewares/authn.js
@@ -66,7 +66,7 @@ module.exports = asyncHandler(async (req, res, next) => {
 
   // Allow auth to be bypassed for local dev mode; also used for tests.
   // See `pages/authLoginDev` for cookie-based authentication in dev mode.
-  if (config.authType === 'none') {
+  if (config.devMode) {
     var uid = config.authUid;
     var name = config.authName;
     var uin = config.authUin;

--- a/apps/prairielearn/src/middlewares/authn.js
+++ b/apps/prairielearn/src/middlewares/authn.js
@@ -72,7 +72,7 @@ module.exports = asyncHandler(async (req, res, next) => {
   //
   // If the user clicks "Log out" in dev mode, we'll set a special cookie to
   // prevent this automatic authentication. The user will get bounced to the
-  // login page like they would in production. Then can then use the "bypass"
+  // login page like they would in production. They can then use the "bypass"
   // authentication option on the login page to log in as the dev user.
   // See `pages/authLoginDev` for more details.
   if (config.devMode && !req.cookies.pl_disable_auto_authn && !req.cookies.pl_authn) {

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
@@ -33,10 +33,7 @@ module.exports = function (req, res, next) {
           allow_example_course_override: true,
           ip: req.ip,
           req_date: res.locals.req_date,
-          req_mode:
-            config.authType === 'none' && req.cookies.pl_test_mode
-              ? req.cookies.pl_test_mode
-              : null,
+          req_mode: config.devMode && req.cookies.pl_test_mode ? req.cookies.pl_test_mode : null,
           req_course_role: null,
           req_course_instance_role: null,
         };

--- a/apps/prairielearn/src/middlewares/clearCookies.js
+++ b/apps/prairielearn/src/middlewares/clearCookies.js
@@ -1,6 +1,11 @@
 const _ = require('lodash');
 
-const cookies_to_ignore = ['pl_authn', 'pl_assessmentpw', 'pl_access_as_administrator'];
+const cookies_to_ignore = [
+  'pl_authn',
+  'pl_assessmentpw',
+  'pl_access_as_administrator',
+  'pl_disable_auto_authn',
+];
 
 module.exports = function (req, res, next) {
   _(req.cookies).each(function (value, key) {

--- a/apps/prairielearn/src/middlewares/date.js
+++ b/apps/prairielearn/src/middlewares/date.js
@@ -6,7 +6,7 @@ module.exports = function (req, res, next) {
 
   // We allow unit tests to override the req_date. Unit tests may also override the user
   // (middlewares/authn.js) and the req_mode (middlewares/authzCourseOrInstance.js).
-  if (config.authType === 'none' && req.cookies.pl_test_date) {
+  if (config.devMode && req.cookies.pl_test_date) {
     res.locals.req_date = new Date(Date.parse(req.cookies.pl_test_date));
   }
 

--- a/apps/prairielearn/src/pages/authLogout/authLogout.js
+++ b/apps/prairielearn/src/pages/authLogout/authLogout.js
@@ -1,12 +1,25 @@
-var express = require('express');
-var router = express.Router();
+// @ts-check
+const express = require('express');
+
+const { config } = require('../../lib/config');
+
+const router = express.Router();
 
 router.get('/', function (req, res, _next) {
   res.clearCookie('pl_authn');
   res.clearCookie('pl_assessmentpw');
 
+  if (config.devMode) {
+    // In dev mode, a user will typically by automatically authenticated by our
+    // authentication middleware to reduce the friction of getting started.
+    // However, folks who want to specifically test authentication behavior can
+    // click "Log out". In this case, we want to disable the automatic login
+    // until the next time the user authenticates.
+    res.cookie('pl_disable_auto_authn', '1');
+  }
+
   const redirect = req.query.redirect;
-  if (redirect) {
+  if (redirect && typeof redirect === 'string') {
     res.redirect(decodeURIComponent(redirect));
   } else if (res.locals.authn_provider_name === 'Shibboleth') {
     res.redirect('/Shibboleth.sso/Logout');

--- a/docs/running-in-production/authentication.md
+++ b/docs/running-in-production/authentication.md
@@ -29,8 +29,7 @@ Now add the keys to `config.json`:
   "googleClientId": "Your Client ID key",
   "googleClientSecret": "Your Client Secret key",
   "googleRedirectUrl": "https://yourdomain/pl/oauth2callback",
-  "hasOauth": true,
-  "authType": "x-auth"
+  "hasOauth": true
 }
 ```
 


### PR DESCRIPTION
As discussed on #8198.

This PR aims to maintain existing devMode behavior as much as possible. If someone opens PrairieLearn for the first time in their browser, we'll automatically authenticate them as `config.authUid` and friends. The only change is when the user clicks "Log out". In this case, we clear the `pl_authn` cookie and set a special `pl_disable_auto_authn` cookie. This prevents the automatic authentication behavior and allows the user to experience the site as a logged-out user. If they visit the login page, they can use the "bypass" auth option to set the cookie to what's configured in `config.authUid` (see `pages/authLoginDev`).

This will all become much more useful in #8198, where the login page will allow authenticating as arbitrary users in dev mode.

This is core auth code, so a thorough and careful review would be appreciated 🙏 