### PR TITLE
Optimize rendering of pl-variable-output element

### DIFF
--- a/apps/prairielearn/elements/pl-variable-output/pl-variable-output.mustache
+++ b/apps/prairielearn/elements/pl-variable-output/pl-variable-output.mustache
@@ -14,21 +14,31 @@
     </div>
     <div class="card-body">
         <div class="tab-content">
+            {{#show_matlab}}
             <div role="tabpanel" class="tab-pane {{#active_tab_matlab}}active{{/active_tab_matlab}}" id="matlab-{{uuid}}">
                 <pl-code language="matlab" copy-code-button="True">{{{matlab_data}}}</pl-code>
             </div>
+            {{/show_matlab}}
+            {{#show_mathematica}}
             <div role="tabpanel" class="tab-pane {{#active_tab_mathematica}}active{{/active_tab_mathematica}}" id="mathematica-{{uuid}}">
                 <pl-code language="mathematica" copy-code-button="True">{{{mathematica_data}}}</pl-code>
             </div>
+            {{/show_mathematica}}
+            {{#show_python}}
             <div role="tabpanel" class="tab-pane {{#active_tab_python}}active{{/active_tab_python}}" id="python-{{uuid}}">
                 <pl-code language="python" copy-code-button="True">{{{python_data}}}</pl-code>
             </div>
+            {{/show_python}}
+            {{#show_r}}
             <div role="tabpanel" class="tab-pane {{#active_tab_r}}active{{/active_tab_r}}" id="r-{{uuid}}">
                 <pl-code language="r" copy-code-button="True">{{{r_data}}}</pl-code>
             </div>
+            {{/show_r}}
+            {{#show_sympy}}
             <div role="tabpanel" class="tab-pane {{#active_tab_sympy}}active{{/active_tab_sympy}}" id="sympy-{{uuid}}">
                 <pl-code language="python" copy-code-button="True">{{{sympy_data}}}</pl-code>
             </div>
+            {{/show_sympy}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
By only rendering the tab contents for tabs that will actually be shown, we can save CPU cycles - around 100ms in my testing of a question that only showed Python and Sympy!