### PR TITLE
add exception for dev auth provider to work for all institutions

### DIFF
--- a/apps/prairielearn/src/sprocs/users_select_or_insert.sql
+++ b/apps/prairielearn/src/sprocs/users_select_or_insert.sql
@@ -68,7 +68,7 @@ BEGIN
             iap.institution_id = institution.id
             AND ap.name = authn_provider_name;
 
-        IF NOT FOUND THEN
+        IF NOT FOUND AND authn_provider_name != 'dev' THEN
             RAISE EXCEPTION '"%" authentication provider is not allowed for institution "%"', authn_provider_name, institution.long_name;
         END IF;
     END IF;


### PR DESCRIPTION
I ran into the error ["dev authentication provider is not allowed for institution foo"](https://github.com/PrairieLearn/PrairieLearn/blob/51b7a6d0bcfb2210335eeff82ef3b37bb3139ef1/apps/prairielearn/src/sprocs/users_select_or_insert.sql#L72) when trying to authenticate into an institution as the dev@illinois.edu user. This is new since we made devMode login a full class, but triggers when I'm doing some LTI 1.3 local testing. The whole idea behind making 'dev' its own authentication provider to let it co-exist with other providers in development.

This PR works around the error checking to never do institution restrictions against the 'dev' authentication provider. I'm not usually a fan of magic strings like this, but the alternative (adding UX to manage the 'dev' auth provider to institutions and set it in reasonable defaults so we don't have to do it each time) seemed heavyweight. 

So this is a problem report, proposed solution, and discussion request in one PR. What do you think?