### PR TITLE
fix: error reporting for unmatched institution in users_select_or_insert

### DIFF
--- a/apps/prairielearn/src/sprocs/users_select_or_insert.sql
+++ b/apps/prairielearn/src/sprocs/users_select_or_insert.sql
@@ -55,7 +55,13 @@ BEGIN
     -- providers, as we want to ensure that any identity they return is scoped
     -- to the appropriate institution.
     IF institution_id IS NOT NULL AND (institution.id IS NULL OR institution.id != institution_id) THEN
-        RAISE EXCEPTION 'Identity % does not match policy for institution %', users_select_or_insert.uid, institution.short_name;
+        -- explicitly get the passed in institution name for the error
+        SELECT i.*
+        INTO institution
+        FROM institutions AS i
+        WHERE i.id = institution_id;
+
+        RAISE EXCEPTION 'Identity "%" does not match policy for institution "%"', users_select_or_insert.uid, institution.long_name;
     END IF;
 
     -- if we've matched an institution, make sure the authn_provider is valid for it


### PR DESCRIPTION
Fix a small mistake in the error reporting where the condition that lead to the error could be reported as `<NULL>` instead of `institution.long_name`