### PR TITLE
Sync explicitly-created default assessment module

### DIFF
--- a/apps/prairielearn/src/sprocs/sync_assessment_modules.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessment_modules.sql
@@ -50,9 +50,13 @@ BEGIN
     -- Make sure we have the "Default" assessment module under all
     -- conditions, because we will use this as a last resort for
     -- assessments.
-    INSERT INTO assessment_modules (
-              number, course_id
-    ) VALUES (0,      syncing_course_id)
+    --
+    -- If the instructor has explicitly created a module named "Default",
+    -- we'll use that, including whatever number they've assigned to it.
+    INSERT INTO
+        assessment_modules (name, number, course_id)
+    VALUES
+        ('Default', 0, syncing_course_id)
     ON CONFLICT (name, course_id) DO NOTHING;
 
     IF ('Default' != ALL(used_assessment_module_names)) THEN

--- a/apps/prairielearn/src/sprocs/sync_assessments.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessments.sql
@@ -566,11 +566,13 @@ BEGIN
         AND a.course_instance_id = syncing_course_instance_id
         AND (da.errors IS NOT NULL AND da.errors != '');
 
-    -- Ensure all assessments have an assessment module, default number=0.
+    -- Ensure all assessments have an assessment module. We'll use the "Default"
+    -- module if one is not specified. The assessment module syncing code will
+    -- ensure that such a module exists.
     UPDATE assessments AS a
     SET
         assessment_module_id = COALESCE(a.assessment_module_id,
-            (SELECT id FROM assessment_modules WHERE number = 0 AND course_id = syncing_course_id))
+            (SELECT id FROM assessment_modules WHERE name = 'Default' AND course_id = syncing_course_id))
     WHERE a.deleted_at IS NULL
     AND a.course_instance_id = syncing_course_instance_id;
 

--- a/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
@@ -77,4 +77,29 @@ describe('Assessment modules syncing', () => {
     const syncedCourse = syncedCourses.find((c) => c.short_name === courseData.course.name);
     assert.match(syncedCourse?.sync_warnings, /Found duplicates in 'assessmentModules'/);
   });
+
+  it('uses explicitly-created default assessment module', async () => {
+    const courseData = util.getCourseData();
+    const defaultAssessmentModule = {
+      name: 'Default',
+      heading: 'Default assessment module',
+    };
+    courseData.course.assessmentModules = [defaultAssessmentModule];
+    await util.writeAndSyncCourseData(courseData);
+
+    const syncedAssessmentModules = await util.dumpTable('assessment_modules');
+    assert.lengthOf(syncedAssessmentModules, 1);
+
+    const syncedAssessmentModule = syncedAssessmentModules.find(
+      (am) => am.name === defaultAssessmentModule.name,
+    );
+    checkAssessmentModule(syncedAssessmentModule, defaultAssessmentModule);
+
+    const syncedAssessments = await util.dumpTable('assessments');
+    assert.lengthOf(syncedAssessments, 1);
+
+    const syncedAssessment = syncedAssessments.find((a) => a.tid === 'test');
+    assert.isOk(syncedAssessment);
+    assert.equal(syncedAssessment?.assessment_module_id, syncedAssessmentModule?.id);
+  });
 });


### PR DESCRIPTION
The syncing code previously assumed that a course would always have an `assessment_modules` row with `number = 0`. However, if an instructor explicitly added an assessment module named "Default", that row would have a non-zero `number`.

This PR changes the assessment syncing code to instead look for some row with `name = 'Default'`, which is guaranteed to have been created by the assessment module syncing code.

Fixes #8344.