### PR TITLE
fix: authn_providers sequence number set to match table

### DIFF
--- a/apps/prairielearn/src/migrations/20230815184404_authn_providers_sequence__setval.sql
+++ b/apps/prairielearn/src/migrations/20230815184404_authn_providers_sequence__setval.sql
@@ -1,0 +1,11 @@
+SELECT
+  setval(
+    'authn_providers_id_seq',
+    (
+      SELECT
+        MAX(id)
+      FROM
+        authn_providers
+    ),
+    true
+  );


### PR DESCRIPTION
The `authn_providers` table has a `nextval('authn_providers_id_seq'::regclass)` setting, but at least on the containers it was being set to 1 each time. This migration sets the sequence number to the appropriate next number.

Before:
```
postgres=# insert into authn_providers (name) values ('dave');
ERROR:  duplicate key value violates unique constraint "authn_providers_pkey"
DETAIL:  Key (id)=(1) already exists.
postgres=# 
```

After:
```
postgres=# insert into authn_providers (name) values ('Dave');
INSERT 0 1
postgres=# select * from authn_providers;
 id |    name    
----+------------
  1 | Shibboleth
  2 | Google
  3 | Azure
  4 | LTI
  5 | SAML
  6 | Dave
(6 rows)
```