### PR TITLE
Don't include NULL if institution doesn't have authn providers

### DIFF
--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.sql
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.sql
@@ -16,7 +16,5 @@ FROM
   institutions AS i
   LEFT JOIN institution_authn_providers AS iap ON (iap.institution_id = i.id)
   LEFT JOIN authn_providers AS ap ON (ap.id = iap.authn_provider_id)
-WHERE
-  i.id = 154
 GROUP BY
   i.id;

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.sql
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.sql
@@ -6,6 +6,9 @@ SELECT
       ap.name
       ORDER BY
         ap.name
+    ) FILTER (
+      WHERE
+        ap.id IS NOT NULL
     ),
     '[]'::jsonb
   ) AS authn_providers
@@ -13,5 +16,7 @@ FROM
   institutions AS i
   LEFT JOIN institution_authn_providers AS iap ON (iap.institution_id = i.id)
   LEFT JOIN authn_providers AS ap ON (ap.id = iap.authn_provider_id)
+WHERE
+  i.id = 154
 GROUP BY
   i.id;


### PR DESCRIPTION
Without this change, if an institution doesn't have any configured authn providers (which might be the case for a newly-created institution), we'd get a Zod error like the following when loading the global administrator institutions page:

```
[ { "code": "invalid_type", "expected": "string", "received": "null", "path": [ 24, "authn_providers", 0 ], "message": "Expected string, received null" } ]
```