### PR TITLE
Fix beforeunload handler for Chrome and Edge

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/confirmOnUnload.ts
+++ b/apps/prairielearn/assets/scripts/lib/confirmOnUnload.ts
@@ -29,9 +29,12 @@ export function confirmOnUnload(form: HTMLFormElement) {
     if (!isSameForm) {
       // event.preventDefault() is used in Safari/Firefox, but not supported by Chrome/Edge/etc.
       // Returning a string is supported in almost all browsers that support beforeunload.
+      // Newer versions of Chrome/Edge appear to no longer support returning a string,
+      // but they do seem to support setting `event.returnValue`.
       // Safari on iOS does not support confirmation on beforeunload at all.
       // https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#compatibility_notes
       event.preventDefault();
+      event.returnValue = '';
       return '';
     }
   });

--- a/apps/prairielearn/assets/scripts/lib/confirmOnUnload.ts
+++ b/apps/prairielearn/assets/scripts/lib/confirmOnUnload.ts
@@ -33,9 +33,12 @@ export function confirmOnUnload(form: HTMLFormElement) {
       // but they do seem to support setting `event.returnValue`.
       // Safari on iOS does not support confirmation on beforeunload at all.
       // https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#compatibility_notes
+      // Note that per the spec, we must technically return a non-empty string,
+      // although the contents of the string should always be ignored.
+      // https://html.spec.whatwg.org/multipage/browsing-the-web.html#unloading-documents:event-beforeunload
       event.preventDefault();
-      event.returnValue = '';
-      return '';
+      event.returnValue = 'prompt';
+      return 'prompt';
     }
   });
 }


### PR DESCRIPTION
It seems that new versions of Chrome/Edge don't support returning an empty string from a `beforeunload` handler. On top of that, there are two parallel changes being made to Chrome:

- `beforeunload` will support `event.preventDefault()` like all other browsers: https://bugs.chromium.org/p/chromium/issues/detail?id=866818.
  - Note that this landed and was then reverted, but it looks like they'll be turning it back on in Chrome 117.
- `beforeunload` will soon *explicitly* no longer support returning an empty string: https://bugs.chromium.org/p/chromium/issues/detail?id=1434509&q=beforeunload&can=2&sort=-modified
  - The bug is still listed as open, but I'm wondering if they actually shipped this and hence we're seeing the behavior that we're seeing.

This PR aims to cover all our bases: it uses an empty string for both `event.returnValue` and the actual return value, and keeps `event.preventDefault()` so we can use that once it lands in Chrome.