### PR TITLE
Refine Stripe webhooks

### DIFF
--- a/apps/prairielearn/src/ee/lib/billing/stripe.ts
+++ b/apps/prairielearn/src/ee/lib/billing/stripe.ts
@@ -54,12 +54,16 @@ export async function getOrCreateStripeCustomerId(
   return updatedUser.stripe_customer_id;
 }
 
+function stripeProductCacheKey(id: string): string {
+  return `v1:stripe:product:${id}`;
+}
+
 /**
  * Gets the Stripe product with the given ID. Products are cached for up to
  * 10 minutes.
  */
 export async function getStripeProduct(id: string): Promise<Stripe.Product> {
-  const cacheKey = `v1:stripe:product:${id}`;
+  const cacheKey = stripeProductCacheKey(id);
   let product: Stripe.Product = await cache.get(cacheKey);
   if (!product) {
     const stripe = getStripeClient();
@@ -67,6 +71,11 @@ export async function getStripeProduct(id: string): Promise<Stripe.Product> {
     cache.set(cacheKey, product, 1000 * 60 * 10);
   }
   return product;
+}
+
+export async function clearStripeProductCache(id: string) {
+  const cacheKey = stripeProductCacheKey(id);
+  await cache.del(cacheKey);
 }
 
 export async function getDefaultPriceForStripeProduct(id: string): Promise<Stripe.Price> {

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -56,8 +56,9 @@ export function StudentCourseInstanceUpgrade({
             requires an upgrade to support certain features selected by your instructor.
           </p>
 
-          ${planPrices !== null
-            ? html`
+          ${planPrices == null
+            ? html`<p>Please contact your instructor for more information.</p>`
+            : html`
                 ${PriceTable({ planNames: missingPlans, planPrices })}
 
                 <form method="POST">
@@ -93,8 +94,7 @@ export function StudentCourseInstanceUpgrade({
                     Upgrade
                   </button>
                 </form>
-              `
-            : ''}
+              `}
         </main>
       </body>
     </html>

--- a/apps/prairielearn/src/lib/cache.ts
+++ b/apps/prairielearn/src/lib/cache.ts
@@ -76,6 +76,7 @@ export async function del(key: string) {
 
     case 'redis': {
       await client.del(key);
+      break;
     }
   }
 }

--- a/apps/prairielearn/src/lib/cache.ts
+++ b/apps/prairielearn/src/lib/cache.ts
@@ -65,6 +65,21 @@ export function set(key: string, value: any, maxAgeMS?: number) {
   }
 }
 
+export async function del(key: string) {
+  if (!cacheEnabled) return;
+
+  switch (cacheType) {
+    case 'memory': {
+      cache.delete(key);
+      break;
+    }
+
+    case 'redis': {
+      await client.del(key);
+    }
+  }
+}
+
 /**
  * Returns the value for the corresponding key if it exists in the cache; null otherwise.
  */


### PR DESCRIPTION
This PR improves our Stripe webhook handling by flushing the product cache when a product or one of its prices changes.