### PR TITLE
Fix flash messages on error page

### DIFF
--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -527,7 +527,7 @@ if (typeof navPage != 'undefined' && navPagesTabs.hasOwnProperty(navPage)) { %>
 
 <div class="mb-3">
   <% const globalFlashColors = { 'notice': 'info', 'success': 'success', 'warning': 'warning', 'error': 'danger' }; %>
-  <% flash(Object.keys(globalFlashColors)).forEach(({ type, message }) => { %>
+  <% typeof flash !== 'undefined' && flash(Object.keys(globalFlashColors)).forEach(({ type, message }) => { %>
     <div class="alert alert-<%= globalFlashColors[type] %> border-left-0 border-right-0 rounded-0 mt-0 mb-0 alert-dismissible fade show js-global-flash" role="alert">
       <%= message %>
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">


### PR DESCRIPTION
If something errors before the `flash` middleware runs, `res.locals.flash` will be undefined and we'll error when rendering the error page (ironic!). This fixes that.