### PR TITLE
Replace deprecated pandas function in pl-dataframe

### DIFF
--- a/apps/prairielearn/elements/pl-dataframe/pl-dataframe.py
+++ b/apps/prairielearn/elements/pl-dataframe/pl-dataframe.py
@@ -57,7 +57,9 @@ def get_pandas_dtype(s: pd.Series) -> str:
 
 
 def using_default_index(df: pd.DataFrame) -> bool:
-    return df.index.is_integer() and pd.Index(range(len(df))).equals(df.index)
+    return pd.api.types.is_integer_dtype(df.index) and pd.Index(range(len(df))).equals(
+        df.index
+    )
 
 
 def prepare(element_html: str, data: pl.QuestionData) -> None:


### PR DESCRIPTION
The example question `element/dataframe` was giving a deprecation warning:
```
/PrairieLearn/apps/prairielearn/elements/pl-dataframe/pl-dataframe.py:60: FutureWarning: Index.is_integer is deprecated. Use pandas.api.types.is_integer_dtype instead.
```

Since the warning was given in the output, it caused an issue to be raised. This code gets rid of the warning.