### PR TITLE
Improve administrator feature management

### DIFF
--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -162,7 +162,7 @@ function FeatureGrantBreadcrumbs({ featureGrant }: { featureGrant: FeatureGrantR
       ${
         hasCourse
           ? html`<li class="list-inline-item inline-flex">
-              ${featureGrant.course_title} (${featureGrant.course_short_name})
+              ${featureGrant.course_short_name}: ${featureGrant.course_title}
             </li>`
           : null
       }
@@ -176,7 +176,7 @@ function FeatureGrantBreadcrumbs({ featureGrant }: { featureGrant: FeatureGrantR
       ${
         hasUser
           ? html`<li class="list-inline-item inline-flex">
-              ${featureGrant.user_name} (${featureGrant.user_uid})
+              ${featureGrant.user_uid} (${featureGrant.user_name})
             </li>`
           : null
       }

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.sql
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.sql
@@ -18,9 +18,13 @@ FROM
 WHERE
   fg.name = $name
 ORDER BY
+  i.long_name ASC NULLS FIRST,
   i.id ASC NULLS FIRST,
+  c.short_name ASC NULLS FIRST,
   c.id ASC NULLS FIRST,
+  ci.long_name ASC NULLS FIRST,
   ci.id ASC NULLS FIRST,
+  u.uid ASC NULLS FIRST,
   u.user_id ASC NULLS FIRST;
 
 -- BLOCK select_institutions

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.sql
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.sql
@@ -43,6 +43,7 @@ FROM
   pl_courses
 WHERE
   institution_id = $institution_id
+  AND deleted_at IS NULL
 ORDER BY
   short_name,
   id;
@@ -54,6 +55,7 @@ FROM
   course_instances
 WHERE
   course_id = $course_id
+  AND deleted_at IS NULL
 ORDER BY
   long_name,
   id;


### PR DESCRIPTION
This PR includes a few more improvements to the admin feature management pages:

- Deleted courses and course instances aren't shown as options in the `<select>` tags
- Feature grants are sorted more naturally (by human-readable name instead of ID)
- Feature grants display courses in our more standard `CS 101: Long Name Nere` instead of `Long Name Here (CS 101)`