### PR TITLE
Normalize v2 question feedback to null

### DIFF
--- a/apps/prairielearn/src/question-servers/calculation-inprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-inprocess.js
@@ -207,7 +207,7 @@ module.exports = {
       const data = {
         score: score,
         v2_score: grading.score,
-        feedback: grading.feedback,
+        feedback: grading.feedback ?? null,
         partial_scores: {},
         submitted_answer: submission.submitted_answer,
         format_errors: {},

--- a/apps/prairielearn/src/question-servers/calculation-worker.js
+++ b/apps/prairielearn/src/question-servers/calculation-worker.js
@@ -114,7 +114,7 @@ function grade(server, coursePath, submission, variant, question) {
   return {
     score: score,
     v2_score: grading.score,
-    feedback: grading.feedback,
+    feedback: grading.feedback ?? null,
     partial_scores: {},
     submitted_answer: submission.submitted_answer,
     format_errors: {},


### PR DESCRIPTION
We were previously getting false positives with the `parallel-run` execution mode for v2 questions: the in-process variant would have `feedback: undefined`, but the subprocess one would be missing the `feedback` property entirely since `undefined` can't survive the round trip through JSON serialization.

We now normalize `feedback` to `null` so that it matches in all cases.