### PR TITLE
Replace request with fetch in workspace host source

### DIFF
--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -30,7 +30,6 @@
     "express-async-handler": "^1.2.0",
     "lodash": "^4.17.21",
     "redis": "^4.6.7",
-    "request": "^2.88.2",
     "socket.io": "^4.7.2",
     "uuid": "^9.0.0",
     "yargs-parser": "^21.1.1",

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const util = require('util');
 const express = require('express');
 const http = require('http');
-const request = require('request');
+const fetch = require('node-fetch').default;
 const path = require('path');
 const { S3 } = require('@aws-sdk/client-s3');
 const { Upload } = require('@aws-sdk/lib-storage');
@@ -496,35 +496,34 @@ function _checkServer(workspace, callback) {
 
   const startTime = new Date().getTime();
   function checkWorkspace() {
-    request(
-      {
-        url: `http://${workspace_server_settings.server_to_container_hostname}:${workspace.launch_port}/`,
-        timeout: healthCheckTimeout,
-      },
-      function (err, res, _body) {
-        if (err) {
-          // Do nothing, because errors are expected while the container is launching.
-        }
-        if (res && res.statusCode) {
-          // We might get all sorts of strange status codes from the server.
-          // This is okay since it still means the server is running and we're
-          // getting responses.
-          callback(null, workspace);
+    const abortController = new AbortController();
+    const abortTimeout = setTimeout(() => abortController.abort(), healthCheckTimeout);
+
+    fetch(
+      `http://${workspace_server_settings.server_to_container_hostname}:${workspace.launch_port}/`,
+      { signal: abortController.signal },
+    )
+      .then(() => {
+        // We might get all sorts of strange status codes from the server.
+        // This is okay since it still means the server is running and we're
+        // getting responses. So we don't need to check the response status.
+        callback(null, workspace);
+      })
+      .catch(() => {
+        // Do nothing, because errors are expected while the container is launching.
+        const endTime = new Date().getTime();
+        if (endTime - startTime > startTimeout) {
+          const { id, version, launch_uuid } = workspace;
+          callback(
+            new Error(
+              `Max startup time exceeded for workspace ${id} (version ${version}, launch uuid ${launch_uuid})`,
+            ),
+          );
         } else {
-          const endTime = new Date().getTime();
-          if (endTime - startTime > startTimeout) {
-            const { id, version, launch_uuid } = workspace;
-            callback(
-              new Error(
-                `Max startup time exceeded for workspace ${id} (version ${version}, launch uuid ${launch_uuid})`,
-              ),
-            );
-          } else {
-            setTimeout(checkWorkspace, healthCheckInterval);
-          }
+          setTimeout(checkWorkspace, healthCheckInterval);
         }
-      },
-    );
+      })
+      .finally(() => clearTimeout(abortTimeout));
   }
   checkWorkspace();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3058,7 +3058,6 @@ __metadata:
     mocha: ^10.2.0
     nodemon: ^3.0.1
     redis: ^4.6.7
-    request: ^2.88.2
     socket.io: ^4.7.2
     ts-node: ^10.9.1
     typescript: ^5.1.6


### PR DESCRIPTION
The request library has been deprecated for quite some time. This PR replaces the use of request in the workspace host code with the more modern fetch interface.