### PR TITLE
Fix file editors that create new items

### DIFF
--- a/apps/prairielearn/src/lib/editors.js
+++ b/apps/prairielearn/src/lib/editors.js
@@ -251,7 +251,7 @@ class Editor {
   async getExistingShortNames(rootDirectory, infoFile) {
     let files = [];
     const walk = async (relativeDir) => {
-      const directories = fs.readdir(path.join(rootDirectory, relativeDir)).catch((err) => {
+      const directories = await fs.readdir(path.join(rootDirectory, relativeDir)).catch((err) => {
         // If the directory doesn't exist, then we have nothing to load
         if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
           return [];
@@ -260,7 +260,7 @@ class Editor {
       });
 
       // For each subdirectory, try to find an Info file
-      async.each(directories, async (dir) => {
+      for (const dir of directories) {
         // Relative path to the current folder
         const subdirPath = path.join(relativeDir, dir);
         // Absolute path to the info file
@@ -273,7 +273,7 @@ class Editor {
           // No info file, let's try recursing
           await walk(subdirPath);
         }
-      });
+      }
     };
 
     await walk('');

--- a/apps/prairielearn/src/lib/editors.js
+++ b/apps/prairielearn/src/lib/editors.js
@@ -254,13 +254,13 @@ class Editor {
       const directories = await fs.readdir(path.join(rootDirectory, relativeDir)).catch((err) => {
         // If the directory doesn't exist, then we have nothing to load
         if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
-          return [];
+          return /** @type {string[]} */ ([]);
         }
         throw err;
       });
 
       // For each subdirectory, try to find an Info file
-      for (const dir of directories) {
+      await async.each(directories, async (dir) => {
         // Relative path to the current folder
         const subdirPath = path.join(relativeDir, dir);
         // Absolute path to the info file
@@ -273,7 +273,7 @@ class Editor {
           // No info file, let's try recursing
           await walk(subdirPath);
         }
-      }
+      });
     };
 
     await walk('');


### PR DESCRIPTION
This was a regression introduced by #7943. Type checking didn't catch the fact that we were trying to iterate over a non-awaited Promise because the types for `async.each` apparently aren't strict enough.