### PR TITLE
Fix bind mount native addon

### DIFF
--- a/packages/bind-mount/addon.cc
+++ b/packages/bind-mount/addon.cc
@@ -48,7 +48,7 @@ public:
       argv[0] = Nan::ErrnoException(this->context->error, syscall, "", this->context->target.c_str());
     }
 
-    this->callback->Call(2, argv, this->async_resource);
+    this->callback->Call(1, argv, this->async_resource);
 
     delete this->context;
   }


### PR DESCRIPTION
This first argument has to correspond to the length of the second argument 🤦 