### PR TITLE
Make cache TTL mandatory

### DIFF
--- a/apps/prairielearn/src/lib/cache.ts
+++ b/apps/prairielearn/src/lib/cache.ts
@@ -46,7 +46,7 @@ export function set(key: string, value: any, maxAgeMS: number) {
 
   switch (cacheType) {
     case 'memory': {
-      cache.set(key, JSON.stringify(value), { ttl: maxAgeMS ?? undefined });
+      cache.set(key, JSON.stringify(value), { ttl: maxAgeMS });
       break;
     }
 
@@ -58,7 +58,7 @@ export function set(key: string, value: any, maxAgeMS: number) {
       // We don't log the error because it contains the cached value,
       // which can be huge and which fills up the logs.
       client
-        .set(key, JSON.stringify(value), { PX: maxAgeMS ?? undefined })
+        .set(key, JSON.stringify(value), { PX: maxAgeMS })
         .catch((_err) => logger.error('Cache set error', { key, maxAgeMS }));
       break;
     }

--- a/apps/prairielearn/src/lib/cache.ts
+++ b/apps/prairielearn/src/lib/cache.ts
@@ -41,7 +41,7 @@ export async function init() {
   }
 }
 
-export function set(key: string, value: any, maxAgeMS?: number) {
+export function set(key: string, value: any, maxAgeMS: number) {
   if (!cacheEnabled) return;
 
   switch (cacheType) {

--- a/apps/prairielearn/src/lib/config.js
+++ b/apps/prairielearn/src/lib/config.js
@@ -263,6 +263,7 @@ const ConfigSchema = z.object({
   ptHost: z.string().default('http://localhost:4000'),
   checkAccessRulesExamUuid: z.boolean().default(false),
   questionRenderCacheType: z.enum(['none', 'redis', 'memory']).default('none'),
+  questionRenderCacheTtlSec: z.number().default(60 * 60),
   hasLti: z.boolean().default(false),
   ltiRedirectUrl: z.string().nullable().default(null),
   filesRoot: z.string().default('/files'),

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -2010,7 +2010,7 @@ module.exports = {
       // tl;dr: don't cache any results that would create course issues.
       const hasCourseIssues = computedData?.courseIssues?.length > 0;
       if (cacheKey && !hasCourseIssues) {
-        cache.set(cacheKey, computedData);
+        cache.set(cacheKey, computedData, config.questionRenderCacheTtlSec * 1000);
       }
 
       return {

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1984,7 +1984,7 @@ module.exports = {
     try {
       const commitHash = await courseUtil.getOrUpdateCourseCommitHashAsync(course);
       const dataHash = objectHash({ data, context }, { algorithm: 'sha1', encoding: 'base64' });
-      return `${commitHash}-${dataHash}`;
+      return `question:${commitHash}-${dataHash}`;
     } catch (err) {
       return null;
     }


### PR DESCRIPTION
This will ensure that Redis can make intelligent choices about when to evict values.