### PR TITLE
Remove session ID from workspace proxied requests

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -275,6 +275,7 @@ module.exports.initExpress = function () {
       return (
         name !== 'pl_authn' &&
         name !== 'pl_assessmentpw' &&
+        name !== 'connect.sid' &&
         // The workspace authz cookies use a prefix plus the workspace ID, so
         // we need to check for that prefix instead of an exact name match.
         !name.startsWith('pl_authz_workspace_')


### PR DESCRIPTION
This was not yet a meaningful vulnerability since the only thing we currently use sessions for is storing flash messages, and flash messages themselves aren't sensitive. Correctly stripping this cookie will be important once we start using the session for more interesting things.