### PR TITLE
Add socket.io-adapter dependency explicitly

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -146,6 +146,7 @@
     "serve-favicon": "^2.5.0",
     "showdown": "^2.1.0",
     "socket.io": "^4.7.2",
+    "socket.io-adapter": "^2.5.2",
     "socket.io-client": "^4.7.2",
     "streamifier": "^0.1.1",
     "strip-ansi": "^6.0.1",

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -31,6 +31,7 @@
     "lodash": "^4.17.21",
     "redis": "^4.6.7",
     "socket.io": "^4.7.2",
+    "socket.io-adapter": "^2.5.2",
     "uuid": "^9.0.0",
     "yargs-parser": "^21.1.1",
     "zod": "^3.21.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,6 +2948,7 @@ __metadata:
     showdown: ^2.1.0
     sinon: ^15.2.0
     socket.io: ^4.7.2
+    socket.io-adapter: ^2.5.2
     socket.io-client: ^4.7.2
     streamifier: ^0.1.1
     strip-ansi: ^6.0.1
@@ -3059,6 +3060,7 @@ __metadata:
     nodemon: ^3.0.1
     redis: ^4.6.7
     socket.io: ^4.7.2
+    socket.io-adapter: ^2.5.2
     ts-node: ^10.9.1
     typescript: ^5.1.6
     typescript-cp: ^0.1.9
@@ -14804,7 +14806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socket.io-adapter@npm:~2.5.2":
+"socket.io-adapter@npm:^2.5.2, socket.io-adapter@npm:~2.5.2":
   version: 2.5.2
   resolution: "socket.io-adapter@npm:2.5.2"
   dependencies:


### PR DESCRIPTION
The `redis-adapter` package lists `socket.io-adapter` as a peer dependency. Up to this point PL had `socket.io-adapter` indirectly as a dependency of `socket.io`, but this is not properly interpreted by yarn, causing a warning every time a yarn command is issued (e.g., via `make deps`). While the warning can be safely ignored, in multiple occasions (see https://github.com/PrairieLearn/PrairieLearn/discussions/8142#discussioncomment-6642690 for an example, plus questions on Slack) new devs have been confused by this message.

This PR adds `socket.io-adapter` as an explicit dependency to avoid this particular warning. This is not expected to change the behaviour of any part of PL, other than to remove that warning when running yarn.