### PR TITLE
Desktop workspace: add option to bypass desktop environment

### DIFF
--- a/exampleCourse/courseInstances/SectionA/assessments/demo/workspaces/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/demo/workspaces/infoAssessment.json
@@ -11,6 +11,7 @@
               {"id": "demo/workspace/jupyterlab",   "points": 1, "maxPoints": 5},
               {"id": "demo/workspace/xtermjs",      "points": 1, "maxPoints": 5},
               {"id": "demo/workspace/desktop",      "points": 1, "maxPoints": 5},
+              {"id": "demo/workspace/desktopEmacs", "points": 1, "maxPoints": 5},
               {"id": "demo/workspace/rstudio",      "points": 1, "maxPoints": 5},
               {"id": "demo/workspace/dynamicFiles", "points": 1, "maxPoints": 5}
             ]

--- a/exampleCourse/questions/demo/workspace/desktopEmacs/info.json
+++ b/exampleCourse/questions/demo/workspace/desktopEmacs/info.json
@@ -1,0 +1,22 @@
+{
+    "uuid": "b39c1f28-ee87-40ad-8ab6-22a7672158ea",
+    "title": "Workspace demo: Linux application",
+    "topic": "Workspace",
+    "tags": [
+        "jonatan"
+    ],
+    "type": "v3",
+    "singleVariant": true,
+    "workspaceOptions": {
+        "image": "prairielearn/workspace-desktop",
+        "port": 8080,
+        "home": "/home/prairielearner",
+        "environment": {
+             "DESKTOP_ENVIRONMENT": "/usr/bin/emacs --no-splash /home/prairielearner/starter_code.c"
+        },
+        "gradedFiles": [
+            "starter_code.h",
+            "starter_code.c"
+        ]
+    }
+}

--- a/exampleCourse/questions/demo/workspace/desktopEmacs/question.html
+++ b/exampleCourse/questions/demo/workspace/desktopEmacs/question.html
@@ -1,0 +1,4 @@
+<pl-question-panel>
+    <p> The desktop workspace allows for individual applications to be executed in its enviroment, bypassing the desktop environment. This question uses this workspace to run the emacs text editor. </p>
+  <pl-workspace></pl-workspace>
+</pl-question-panel>

--- a/exampleCourse/questions/demo/workspace/desktopEmacs/workspace/starter_code.c
+++ b/exampleCourse/questions/demo/workspace/desktopEmacs/workspace/starter_code.c
@@ -1,0 +1,9 @@
+// starter_code.c
+
+#include <stdio.h>
+#include "starter_code.h"
+
+int main()
+{
+    // enter your code
+}

--- a/exampleCourse/questions/demo/workspace/desktopEmacs/workspace/starter_code.h
+++ b/exampleCourse/questions/demo/workspace/desktopEmacs/workspace/starter_code.h
@@ -1,0 +1,1 @@
+// starter_code.h

--- a/workspaces/desktop/server/server.js
+++ b/workspaces/desktop/server/server.js
@@ -32,7 +32,7 @@ const argument_option_defs = [
   {
     name: 'de',
     type: String,
-    defaultValue: '/usr/bin/xfce4-session',
+    defaultValue: process.env.DESKTOP_ENVIRONMENT || '/usr/bin/xfce4-session',
     description: 'Binary for the desktop environment to run',
   },
 ];
@@ -114,6 +114,9 @@ const spawn_gui = async (width, height) => {
   // Now finally, create the window manager. We don't need to kill this.
   // For some reason it gets mad if we _do_ try to kill it.  So, I'm not touching it.
   wm_proc = child_process.spawn(options.de, [], {
+    // This option allows the DESKTOP_ENVIRONMENT setting to include arguments,
+    // e.g., `/usr/bin/firefox --kiosk www.example.com`.
+    shell: true,
     env: {
       DISPLAY: ':1',
     },


### PR DESCRIPTION
As discussed on Slack. This change allows the desktop workspace to execute individual applications in its environment instead of a full desktop, bypassing the desktop environment. For example, it could allow libreoffice, firefox, vscode and other apps to run instead of xfce4. The example question uses this workspace to run the emacs text editor.

This still has the caveat that the application does not start maximized.