### PR TITLE
Use flash messages for errors creating/joining groups

### DIFF
--- a/apps/prairielearn/src/lib/groups.js
+++ b/apps/prairielearn/src/lib/groups.js
@@ -1,6 +1,7 @@
 //@ts-check
 const ERR = require('async-stacktrace');
 const error = require('@prairielearn/error');
+const { flash } = require('@prairielearn/flash');
 const z = require('zod');
 const _ = require('lodash');
 
@@ -215,48 +216,33 @@ async function getRolesInfo(groupId, groupMembers) {
 }
 
 /**
- * @param {string} joinCode
+ * @param {string} fullJoinCode
  * @param {string} assessmentId
  * @param {string} userId
  * @param {string} authnUserId
- * @param {Function} callback
  */
-module.exports.joinGroup = function (joinCode, assessmentId, userId, authnUserId, callback) {
-  var splitJoinCode = joinCode.split('-');
-  const validJoinCode = splitJoinCode.length === 2;
-  if (validJoinCode) {
-    const group_name = splitJoinCode[0];
-    const join_code = splitJoinCode[1].toUpperCase();
-    if (join_code.length !== 4) {
-      callback(new Error('invalid length of join code'));
-      return;
-    }
-    let params = [assessmentId, userId, authnUserId, group_name, join_code];
-    sqldb.call('group_users_insert', params, function (err, _result) {
-      if (err) {
-        let params = {
-          assessment_id: assessmentId,
-        };
-        sqldb.query(sql.get_group_config, params, function (err, result) {
-          if (ERR(err, callback)) return;
-          const permissions = result.rows[0];
-          callback(null, false, permissions);
-          return;
-        });
-      } else {
-        callback(null, true);
-      }
-    });
-  } else {
+module.exports.joinGroup = async function (fullJoinCode, assessmentId, userId, authnUserId) {
+  var splitJoinCode = fullJoinCode.split('-');
+  if (splitJoinCode.length !== 2 || splitJoinCode[1].length !== 4) {
     // the join code input by user is not valid (not in format of groupname+4-character)
-    let params = {
-      assessment_id: assessmentId,
-    };
-    sqldb.query(sql.get_group_config, params, function (err, result) {
-      if (ERR(err, callback)) return;
-      const groupConfig = result.rows[0];
-      callback(null, false, groupConfig);
-    });
+    flash('error', 'The join code has an incorrect format');
+    return;
+  }
+  const groupName = splitJoinCode[0];
+  const joinCode = splitJoinCode[1].toUpperCase();
+  try {
+    await sqldb.callAsync('group_users_insert', [
+      assessmentId,
+      userId,
+      authnUserId,
+      groupName,
+      joinCode,
+    ]);
+  } catch (err) {
+    flash(
+      'error',
+      `Failed to join the group with join code ${req.body.join_code}. It is already full or does not exist. Please try to join another one.`,
+    );
   }
 };
 
@@ -265,40 +251,28 @@ module.exports.joinGroup = function (joinCode, assessmentId, userId, authnUserId
  * @param {string} assessmentId
  * @param {string} userId
  * @param {string} authnUserId
- * @param {Function} callback
  */
-module.exports.createGroup = function (groupName, assessmentId, userId, authnUserId, callback) {
-  let params = {
-    assessment_id: assessmentId,
-    user_id: userId,
-    authn_user_id: authnUserId,
-    group_name: groupName,
-  };
+module.exports.createGroup = async function (groupName, assessmentId, userId, authnUserId) {
   //alphanumeric characters only
-  let invalidGroupName = true;
-  const letters = /^[0-9a-zA-Z]+$/;
-  if (groupName.length <= 30 && groupName.match(letters)) {
-    invalidGroupName = false;
-    sqldb.query(sql.create_group, params, function (err, _result) {
-      if (!err) {
-        callback(null, true);
-      } else {
-        sqldb.query(sql.get_group_config, params, function (err, result) {
-          if (ERR(err, callback)) return;
-          const groupConfig = result.rows[0];
-          const uniqueGroupName = true;
-          callback(null, false, uniqueGroupName, null, groupConfig);
-        });
-      }
-    });
+  if (groupName.length > 30 || !groupName.match(/^[0-9a-zA-Z]+$/)) {
+    flash(
+      'error',
+      'The group name is invalid. Alpha and numeric characters only. ([0-9] [a-z] [A-Z]), with maximum length of 30 characters.',
+    );
+    return;
   }
-  if (invalidGroupName) {
-    sqldb.query(sql.get_group_config, params, function (err, result) {
-      if (ERR(err, callback)) return;
-      const groupConfig = result.rows[0];
-      const invalidGroupName = true;
-      callback(null, false, null, invalidGroupName, groupConfig);
+  try {
+    await sqldb.queryAsync(sql.create_group, {
+      assessment_id: assessmentId,
+      user_id: userId,
+      authn_user_id: authnUserId,
+      group_name: groupName,
     });
+  } catch (err) {
+    flash(
+      'error',
+      `Failed to create the group ${groupName}. It is already taken. Please try another one.`,
+    );
   }
 };
 

--- a/apps/prairielearn/src/pages/partials/studentGroupControls.ejs
+++ b/apps/prairielearn/src/pages/partials/studentGroupControls.ejs
@@ -13,22 +13,6 @@
   <br/>To work individually, you must also create a group, but you don't need to share your join code.
   <% } %>
 </p>
-<% if (typeof used_join_code !== 'undefined') { %>
-  <div class="alert alert-danger" role="alert">
-    Failed to join the group with join code <span class="badge badge-secondary"><%= used_join_code %></span>. It is already full or does not exist. Please try to join another one.
-  </div>
-<% } %>
-<% if (typeof invalidGroupName !== 'undefined') { %>
-  <div class="alert alert-danger" role="alert">
-    The group name is invalid. Alpha and numeric characters only. ([0-9] [a-z] [A-Z]), with maximum length of 30 characters.
-  </div>
-<% } %>
-<% if (typeof uniqueGroupName !== 'undefined') { %>
-  <div class="alert alert-danger" role="alert">
-    Failed to create the group. It is already taken. Please try another one.
-  </div>
-<% } %>
-
 <%- include('../shared/groupWorkInitial.ejs', {groupConfig: groupConfig}); %>
 <% } %>
 <% } else {%>

--- a/apps/prairielearn/src/pages/studentAssessmentExam/studentAssessmentExam.js
+++ b/apps/prairielearn/src/pages/studentAssessmentExam/studentAssessmentExam.js
@@ -7,6 +7,7 @@ const { checkPasswordOrRedirect } = require('../../middlewares/studentAssessment
 const error = require('@prairielearn/error');
 const assessment = require('../../lib/assessment');
 const sqldb = require('@prairielearn/postgres');
+const { flash } = require('@prairielearn/flash');
 
 const sql = sqldb.loadSqlEquiv(__filename);
 const groupAssessmentHelper = require('../../lib/groups');
@@ -142,47 +143,21 @@ router.post(
         },
       );
     } else if (req.body.__action === 'join_group') {
-      groupAssessmentHelper.joinGroup(
+      await groupAssessmentHelper.joinGroup(
         req.body.join_code,
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,
-        function (err, succeeded, groupConfig) {
-          if (ERR(err, next)) return err;
-          if (succeeded) {
-            res.redirect(req.originalUrl);
-          } else {
-            res.locals.groupConfig = groupConfig;
-            res.locals.groupSize = 0;
-            res.locals.used_join_code = req.body.join_code;
-            res.locals.notInGroup = true;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-          }
-        },
       );
+      res.redirect(req.originalUrl);
     } else if (req.body.__action === 'create_group') {
-      groupAssessmentHelper.createGroup(
+      await groupAssessmentHelper.createGroup(
         req.body.groupName,
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,
-        function (err, succeeded, uniqueGroupName, invalidGroupName, groupConfig) {
-          if (ERR(err, next)) return;
-          if (succeeded) {
-            res.redirect(req.originalUrl);
-          } else {
-            if (invalidGroupName) {
-              res.locals.invalidGroupName = true;
-            } else {
-              res.locals.uniqueGroupName = uniqueGroupName;
-            }
-            res.locals.notInGroup = true;
-            res.locals.groupConfig = groupConfig;
-            res.locals.groupSize = 0;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-          }
-        },
       );
+      res.redirect(req.originalUrl);
     } else if (req.body.__action === 'update_group_roles') {
       await groupAssessmentHelper.updateGroupRoles(
         req.body,

--- a/apps/prairielearn/src/pages/studentAssessmentHomework/studentAssessmentHomework.js
+++ b/apps/prairielearn/src/pages/studentAssessmentHomework/studentAssessmentHomework.js
@@ -9,6 +9,7 @@ const { checkPasswordOrRedirect } = require('../../middlewares/studentAssessment
 const error = require('@prairielearn/error');
 const assessment = require('../../lib/assessment');
 const sqldb = require('@prairielearn/postgres');
+const { flash } = require('@prairielearn/flash');
 const groupAssessmentHelper = require('../../lib/groups');
 
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -150,47 +151,21 @@ router.post(
         }
       });
     } else if (req.body.__action === 'join_group') {
-      groupAssessmentHelper.joinGroup(
+      await groupAssessmentHelper.joinGroup(
         req.body.join_code,
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,
-        function (err, succeeded, groupConfig) {
-          if (ERR(err, next)) return err;
-          if (succeeded) {
-            res.redirect(req.originalUrl);
-          } else {
-            res.locals.groupConfig = groupConfig;
-            res.locals.groupSize = 0;
-            res.locals.used_join_code = req.body.join_code;
-            res.locals.notInGroup = true;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-          }
-        },
       );
+      res.redirect(req.originalUrl);
     } else if (req.body.__action === 'create_group') {
-      groupAssessmentHelper.createGroup(
+      await groupAssessmentHelper.createGroup(
         req.body.groupName,
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,
-        function (err, succeeded, uniqueGroupName, invalidGroupName, groupConfig) {
-          if (ERR(err, next)) return;
-          if (succeeded) {
-            res.redirect(req.originalUrl);
-          } else {
-            if (invalidGroupName) {
-              res.locals.invalidGroupName = true;
-            } else {
-              res.locals.uniqueGroupName = uniqueGroupName;
-            }
-            res.locals.notInGroup = true;
-            res.locals.groupConfig = groupConfig;
-            res.locals.groupSize = 0;
-            res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
-          }
-        },
       );
+      res.redirect(req.originalUrl);
     } else if (req.body.__action === 'update_group_roles') {
       await groupAssessmentHelper.updateGroupRoles(
         req.body,


### PR DESCRIPTION
This is a starting step simplifying the process of showing error messages when students create or join groups. It is intended to simplify the future work addressing #8394 in a future PR. From what I could tell this is the last instance of group-related code that renders content directly from a POST request (leftover from #7905 and #4857).