### PR TITLE
Remove useless studentAssessmentAccess middleware

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1365,7 +1365,6 @@ module.exports.initExpress = function () {
       next();
     },
     require('./middlewares/logPageView')('studentGradebook'),
-    require('./middlewares/studentAssessmentAccess'),
     require('./pages/studentGradebook/studentGradebook'),
   ]);
   app.use('/pl/course_instance/:course_instance_id/assessments', [
@@ -1374,7 +1373,6 @@ module.exports.initExpress = function () {
       next();
     },
     require('./middlewares/logPageView')('studentAssessments'),
-    require('./middlewares/studentAssessmentAccess'),
     require('./pages/studentAssessments/studentAssessments'),
   ]);
   // Exam/Homeworks student routes are polymorphic - they have multiple handlers, each of
@@ -1431,14 +1429,14 @@ module.exports.initExpress = function () {
   }
 
   // clientFiles
-  app.use('/pl/course_instance/:course_instance_id/clientFilesCourse', [
-    require('./middlewares/studentAssessmentAccess'),
+  app.use(
+    '/pl/course_instance/:course_instance_id/clientFilesCourse',
     require('./pages/clientFilesCourse/clientFilesCourse'),
-  ]);
-  app.use('/pl/course_instance/:course_instance_id/clientFilesCourseInstance', [
-    require('./middlewares/studentAssessmentAccess'),
+  );
+  app.use(
+    '/pl/course_instance/:course_instance_id/clientFilesCourseInstance',
     require('./pages/clientFilesCourseInstance/clientFilesCourseInstance'),
-  ]);
+  );
   app.use(
     '/pl/course_instance/:course_instance_id/assessment/:assessment_id/clientFilesAssessment',
     [


### PR DESCRIPTION
As far as I can tell, `studentAssessmentAccess` only does anything useful in the context of an assessment (or assessment instance).

@trombonekenny I know you haven't touched SEB code in a long time, but it looks like this was added to these routes as part of that work. It'd be helpful if you could confirm that this middleware is in fact unnecessary for these routes.