### PR TITLE
Drop default for course_instance_access_rules.institution

### DIFF
--- a/apps/prairielearn/src/migrations/20230830221243_course_instance_access_rules__institution__drop_default.sql
+++ b/apps/prairielearn/src/migrations/20230830221243_course_instance_access_rules__institution__drop_default.sql
@@ -1,0 +1,3 @@
+ALTER TABLE course_instance_access_rules
+ALTER COLUMN institution
+DROP DEFAULT;

--- a/database/tables/course_instance_access_rules.pg
+++ b/database/tables/course_instance_access_rules.pg
@@ -2,7 +2,7 @@ columns
     course_instance_id: bigint not null
     end_date: timestamp with time zone
     id: bigint not null default nextval('course_instance_access_rules_id_seq'::regclass)
-    institution: text default 'UIUC'::text
+    institution: text
     number: integer
     role: enum_role
     start_date: timestamp with time zone


### PR DESCRIPTION
This default hasn't mattered for a long time. We always explicitly default the institution to `null` when syncing access rules:

https://github.com/PrairieLearn/PrairieLearn/blob/9c35a890518d54b7958f7ea4e04a3781e43c92a4/apps/prairielearn/src/sync/fromDisk/courseInstances.js#L25