### PR TITLE
Use null as default value for v2 outputs

### DIFF
--- a/apps/prairielearn/src/question-servers/calculation-inprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-inprocess.js
@@ -124,8 +124,8 @@ module.exports = {
         return ERR(error.addData(err, data), callback);
       }
       let data = {
-        params: jsonRoundTrip(questionData.params),
-        true_answer: jsonRoundTrip(questionData.trueAnswer),
+        params: jsonRoundTrip(questionData.params ?? null),
+        true_answer: jsonRoundTrip(questionData.trueAnswer ?? null),
         options: jsonRoundTrip(questionData.options || question.options || {}),
       };
       callback(null, [], data);
@@ -221,13 +221,13 @@ module.exports = {
       const data = {
         score: score,
         v2_score: grading.score,
-        feedback: jsonRoundTrip(grading.feedback),
+        feedback: jsonRoundTrip(grading.feedback ?? null),
         partial_scores: {},
-        submitted_answer: jsonRoundTrip(submittedAnswer),
+        submitted_answer: jsonRoundTrip(submittedAnswer ?? null),
         format_errors: {},
         gradable: true,
-        params: jsonRoundTrip(params),
-        true_answer: jsonRoundTrip(trueAnswer),
+        params: jsonRoundTrip(params ?? null),
+        true_answer: jsonRoundTrip(trueAnswer ?? null),
       };
       callback(null, [], data);
     });

--- a/apps/prairielearn/src/question-servers/calculation-worker.js
+++ b/apps/prairielearn/src/question-servers/calculation-worker.js
@@ -64,8 +64,8 @@ function generate(server, coursePath, question, variant_seed) {
 
   const questionData = server.getData(variant_seed, options, questionDir);
   return {
-    params: questionData.params,
-    true_answer: questionData.trueAnswer,
+    params: questionData.params ?? null,
+    true_answer: questionData.trueAnswer ?? null,
     options: questionData.options || question.options || {},
   };
 }
@@ -116,11 +116,11 @@ function grade(server, coursePath, submission, variant, question) {
     v2_score: grading.score,
     feedback: grading.feedback ?? null,
     partial_scores: {},
-    submitted_answer: submission.submitted_answer,
+    submitted_answer: submission.submitted_answer ?? null,
     format_errors: {},
     gradable: true,
-    params: variant.params,
-    true_answer: variant.true_answer,
+    params: variant.params ?? null,
+    true_answer: variant.true_answer ?? null,
   };
 }
 

--- a/apps/prairielearn/src/question-servers/calculation.js
+++ b/apps/prairielearn/src/question-servers/calculation.js
@@ -106,6 +106,7 @@ function questionFunctionExperiment(name, control, candidate) {
 
         if (errorsMismatched || dataMismatched) {
           logger.error('Experiment results did not match', {
+            name,
             controlError,
             controlResult,
             candidateError,
@@ -114,6 +115,7 @@ function questionFunctionExperiment(name, control, candidate) {
           Sentry.captureException(new Error('Experiment results did not match'), {
             contexts: {
               experiment: {
+                name,
                 control: observationPayload(controlError, controlResult),
                 candidate: observationPayload(candidateError, candidateResult),
               },


### PR DESCRIPTION
We were seeing errors like the following in production when running with `"legacyQuestionExecutionMode": "parallel-run"` (formatted for legibility):

```json
{
  "candidateResult": [
    [],
    {
      "options": {},
      "true_answer": {
        "answers": {}
      }
    }
  ],
  "controlResult": [
    [],
    {
      "options": {},
      "params": null,
      "true_answer": {
        "answers": {}
      }
    }
  ],
  "name": "calculation-question-generate"
}
```

The value for `params` didn't match because the `subprocess` branch would omit `undefined` properties entirely, whereas the `inprocess` variant would always convert those to `null`:

https://github.com/PrairieLearn/PrairieLearn/blob/9c35a890518d54b7958f7ea4e04a3781e43c92a4/apps/prairielearn/src/question-servers/calculation-inprocess.js#L10-L15

By always defaulting to `null`, we ensure that we don't have false positive mismatched for this experiment.