### PR TITLE
Fix the docs for making Mathjax ignore specific HTML

### DIFF
--- a/apps/prairielearn/assets/scripts/mathjax.js
+++ b/apps/prairielearn/assets/scripts/mathjax.js
@@ -4,6 +4,11 @@
 const outputComponent = 'output/svg';
 
 window.MathJax = {
+  options: {
+    // We previously documented the `tex2jax_ignore` class, so we'll keep
+    // supporting it for backwards compatibility.
+    ignoreHtmlClass: 'mathjax_ignore|tex2jax_ignore',
+  },
   tex: {
     inlineMath: [
       ['$', '$'],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -274,10 +274,10 @@ To escape either math environment, consider using PrairieLearn's markdown tag an
 ```
 
 In scenarios that do not make sense for using the code environment, consider disabling math entirely by
-adding the `tex2jax_ignore` class to an HTML element.
+adding the `mathjax_ignore` class to an HTML element.
 
 ```html
-<div class="tex2jax_ignore">
+<div class="mathjax_ignore">
   Mary has $5 to spend. If each apple costs $2 dollars and a banana costs $1 dollar, then how many
   pieces of fruit can Mary get?
 </div>


### PR DESCRIPTION
The broken docs were reported on Slack recently. This fix has two parts:

- Support the `tex2jax_ignore` class that we previously documented
- Update the documentation to use the `mathjax_ignore` class because that makes a lot more sense than `tex2jax`.