### PR TITLE
Add missing await in score upload handling

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.js
+++ b/apps/prairielearn/src/lib/score-upload.js
@@ -190,7 +190,11 @@ module.exports = {
             output += '\n' + msg;
           }
           try {
-            module.exports._updateAssessmentInstanceFromJson(json, assessment_id, authn_user_id);
+            await module.exports._updateAssessmentInstanceFromJson(
+              json,
+              assessment_id,
+              authn_user_id,
+            );
             successCount++;
           } catch (err) {
             errorCount++;


### PR DESCRIPTION
I found out about this via Sentry in production.