### PR TITLE
Fix validation for access tokens on user settings page

### DIFF
--- a/apps/prairielearn/src/pages/userSettings/userSettings.html.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.html.ts
@@ -13,7 +13,7 @@ export const AccessTokenSchema = z.object({
   last_used_at: z.string().nullable(),
   name: z.string(),
   token_hash: z.string(),
-  token: z.string(),
+  token: z.string().nullable(),
 });
 type AccessToken = z.infer<typeof AccessTokenSchema>;
 


### PR DESCRIPTION
We explicitly set `access_tokens.token` to `NULL` after the first page load.