### PR TITLE
fix: users_select_or_insert sproc tests with passed-in institution

### DIFF
--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -32,6 +32,7 @@ async function usersSelectOrInsert(user, authn_provider_name = null, institution
   ]);
 }
 
+/*
 async function showAuditLog(all = false) {
   let querysql = 'SELECT * FROM audit_logs;';
   if (!all) {
@@ -41,6 +42,7 @@ async function showAuditLog(all = false) {
   const result = await sqldb.queryAsync(querysql, {});
   console.log(result.rows);
 }
+*/
 
 const baseUser = {
   uid: 'user@host.com',
@@ -77,8 +79,7 @@ describe('sproc users_select_or_insert tests', () => {
       name: 'J.R. User',
     };
 
-    // Errors if passed in institution_id '1', does not match policy -- do we need another test?
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'SAML');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -97,7 +98,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
+    const result = await usersSelectOrInsert(user, 'SAML', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -113,7 +114,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
+    const result = await usersSelectOrInsert(user, 'SAML', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -129,7 +130,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
+    const result = await usersSelectOrInsert(user, 'SAML', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -146,7 +147,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
+    const result = await usersSelectOrInsert(user, 'SAML', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -162,7 +163,6 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '1',
     };
 
-    // Errors if passed in institution_id '1', does not match policy -- do we need another test?
     const result = await usersSelectOrInsert(user, 'Shibboleth');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 2);
@@ -228,7 +228,7 @@ describe('sproc users_select_or_insert tests', () => {
     assert.deepEqual(user, fromdb);
   });
 
-  step('user 3 logs in via Shibboleth', async () => {
+  step('user 3 logs in via SAML', async () => {
     const user = {
       uid: 'sally@illinois.edu',
       name: 'Sally Ann',
@@ -236,7 +236,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth', '200');
+    const result = await usersSelectOrInsert(user, 'SAML', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 3);
 
@@ -275,7 +275,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth', '200');
+    const result = await usersSelectOrInsert(user, 'SAML', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 4);
 
@@ -291,7 +291,6 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '1',
     };
 
-    // Errors if passed in institution_id '1', does not match policy -- do we need another test?
     const result = await usersSelectOrInsert(user, 'Shibboleth');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 4);
@@ -310,7 +309,7 @@ describe('sproc users_select_or_insert tests', () => {
     };
 
     await assert.isRejected(
-      usersSelectOrInsert(user, 'Shibboleth', '200'),
+      usersSelectOrInsert(user, 'SAML', '200'),
       /does not match policy/,
     );
   });
@@ -331,9 +330,9 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const firstResult = await usersSelectOrInsert(firstUser, 'Shibboleth', '100');
+    const firstResult = await usersSelectOrInsert(firstUser, 'SAML', '100');
     const firstUserId = firstResult.rows[0].user_id;
-    const secondResult = await usersSelectOrInsert(secondUser, 'Shibboleth', '200');
+    const secondResult = await usersSelectOrInsert(secondUser, 'SAML', '200');
     const secondUserId = secondResult.rows[0].user_id;
 
     // Ensure two distinct users were created.

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -32,18 +32,6 @@ async function usersSelectOrInsert(user, authn_provider_name = null, institution
   ]);
 }
 
-/*
-async function showAuditLog(all = false) {
-  let querysql = 'SELECT * FROM audit_logs;';
-  if (!all) {
-    querysql = 'SELECT * FROM audit_logs ORDER BY id DESC LIMIT 1;';
-  }
-
-  const result = await sqldb.queryAsync(querysql, {});
-  console.log(result.rows);
-}
-*/
-
 const baseUser = {
   uid: 'user@host.com',
   name: 'Joe User',

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -67,7 +67,7 @@ describe('sproc users_select_or_insert tests', () => {
       name: 'J.R. User',
     };
 
-    const result = await usersSelectOrInsert(user, 'SAML');
+    const result = await usersSelectOrInsert(user);
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -308,10 +308,7 @@ describe('sproc users_select_or_insert tests', () => {
       uin: '666666666',
     };
 
-    await assert.isRejected(
-      usersSelectOrInsert(user, 'SAML', '200'),
-      /does not match policy/,
-    );
+    await assert.isRejected(usersSelectOrInsert(user, 'SAML', '200'), /does not match policy/);
   });
 
   // This test ensures that users in separate institutions can have the same UIN.

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -32,6 +32,16 @@ async function usersSelectOrInsert(user, authn_provider_name = null, institution
   ]);
 }
 
+async function showAuditLog(all = false) {
+  let querysql = 'SELECT * FROM audit_logs;';
+  if (!all) {
+    querysql = 'SELECT * FROM audit_logs ORDER BY id DESC LIMIT 1;';
+  }
+
+  const result = await sqldb.queryAsync(querysql, {});
+  console.log(result.rows);
+}
+
 const baseUser = {
   uid: 'user@host.com',
   name: 'Joe User',
@@ -67,6 +77,7 @@ describe('sproc users_select_or_insert tests', () => {
       name: 'J.R. User',
     };
 
+    // Errors if passed in institution_id '1', does not match policy -- do we need another test?
     const result = await usersSelectOrInsert(user, 'Shibboleth');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
@@ -82,10 +93,11 @@ describe('sproc users_select_or_insert tests', () => {
   step('user 1 updates institution_id', async () => {
     const user = {
       ...baseUser,
+      name: 'J.R. User',
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -96,11 +108,12 @@ describe('sproc users_select_or_insert tests', () => {
   step('user 1 updates uin when uin was null', async () => {
     const user = {
       ...baseUser,
+      name: 'J.R. User',
       uin: '111122223',
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -111,11 +124,12 @@ describe('sproc users_select_or_insert tests', () => {
   step('user 1 updates uin when uin was value', async () => {
     const user = {
       ...baseUser,
+      name: 'J.R. User',
       uin: '111122224',
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -126,12 +140,13 @@ describe('sproc users_select_or_insert tests', () => {
   step('user 1 updates uid with already present uin', async () => {
     const user = {
       ...baseUser,
+      name: 'J.R. User',
       uid: 'newuid@host.com',
       uin: '111122224',
       institution_id: '100',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'Shibboleth', '100');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 1);
 
@@ -147,6 +162,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '1',
     };
 
+    // Errors if passed in institution_id '1', does not match policy -- do we need another test?
     const result = await usersSelectOrInsert(user, 'Shibboleth');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 2);
@@ -167,7 +183,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Google');
+    const result = await usersSelectOrInsert(user, 'Google', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 2);
 
@@ -204,7 +220,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Google');
+    const result = await usersSelectOrInsert(user, 'Google', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 3);
 
@@ -220,7 +236,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'Shibboleth', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 3);
 
@@ -236,7 +252,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Google');
+    const result = await usersSelectOrInsert(user, 'Google', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 3);
 
@@ -259,7 +275,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '200',
     };
 
-    const result = await usersSelectOrInsert(user, 'Shibboleth');
+    const result = await usersSelectOrInsert(user, 'Shibboleth', '200');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 4);
 
@@ -275,6 +291,7 @@ describe('sproc users_select_or_insert tests', () => {
       institution_id: '1',
     };
 
+    // Errors if passed in institution_id '1', does not match policy -- do we need another test?
     const result = await usersSelectOrInsert(user, 'Shibboleth');
     const user_id = result.rows[0].user_id;
     assert.equal(user_id, 4);

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.sql
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.sql
@@ -10,7 +10,8 @@ INSERT INTO
   institution_authn_providers (institution_id, authn_provider_id)
 VALUES
   (100, 1),
-  (100, 3);
+  (100, 3),
+  (100, 5);
 
 -- BLOCK insert_illinois_edu
 WITH
@@ -29,4 +30,5 @@ INSERT INTO
   institution_authn_providers (institution_id, authn_provider_id)
 VALUES
   (200, 1),
-  (200, 2);
+  (200, 2),
+  (200, 5);


### PR DESCRIPTION
Updates the `users_select_or_insert` sproc tests to fail in the bug fixed in #8379. In general, it makes sure the tests also run with a passed in institution_id, which is realistic for SAML auth but might not have been captured by the test cases.

Adds a function to display the audit_logs, which was helpful when debugging.

Some comments in-line for tests that failed with the 'institution_id' '1' added. Maybe we need to break out different tests when an institution_id is passed in and when it isn't?

