### PR TITLE
Require ECR client to be passed to setupDockerAuth

### DIFF
--- a/apps/grader-host/src/index.js
+++ b/apps/grader-host/src/index.js
@@ -6,6 +6,7 @@ const tmp = require('tmp');
 const Docker = require('dockerode');
 const { S3 } = require('@aws-sdk/client-s3');
 const { SQSClient, SendMessageCommand } = require('@aws-sdk/client-sqs');
+const { ECRClient } = require('@aws-sdk/client-ecr');
 const { Upload } = require('@aws-sdk/lib-storage');
 const { exec } = require('child_process');
 const path = require('path');
@@ -14,7 +15,7 @@ const { pipeline } = require('node:stream/promises');
 const Sentry = require('@prairielearn/sentry');
 const sqldb = require('@prairielearn/postgres');
 const { sanitizeObject } = require('@prairielearn/sanitize');
-const { DockerName, setupDockerAuthAsync } = require('@prairielearn/docker-utils');
+const { DockerName, setupDockerAuth } = require('@prairielearn/docker-utils');
 
 const globalLogger = require('./lib/logger');
 const jobLogger = require('./lib/jobLogger');
@@ -286,7 +287,8 @@ function initDocker(info, callback) {
       async () => {
         if (config.cacheImageRegistry) {
           logger.info('Authenticating to docker');
-          dockerAuth = await setupDockerAuthAsync(config.awsRegion);
+          const ecr = new ECRClient({ region: config.awsRegion });
+          dockerAuth = await setupDockerAuth(ecr);
         }
       },
       async () => {

--- a/apps/grader-host/src/lib/pullImages.js
+++ b/apps/grader-host/src/lib/pullImages.js
@@ -1,8 +1,9 @@
 const ERR = require('async-stacktrace');
 const async = require('async');
 const Docker = require('dockerode');
+const { ECRClient } = require('@aws-sdk/client-ecr');
 const sqldb = require('@prairielearn/postgres');
-const { DockerName, setupDockerAuthAsync } = require('@prairielearn/docker-utils');
+const { DockerName, setupDockerAuth } = require('@prairielearn/docker-utils');
 
 const logger = require('./logger');
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -24,7 +25,8 @@ module.exports = function (callback) {
       async () => {
         if (config.cacheImageRegistry) {
           logger.info('Authenticating to docker');
-          dockerAuth = await setupDockerAuthAsync(config.awsRegion);
+          const ecr = new ECRClient({ region: config.awsRegion });
+          dockerAuth = await setupDockerAuth(ecr);
         }
       },
       (callback) => {

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.js
@@ -9,9 +9,10 @@ const { Mutex } = require('async-mutex');
 const os = require('os');
 const fs = require('fs-extra');
 const execa = require('execa');
+const { ECRClient } = require('@aws-sdk/client-ecr');
 const bindMount = require('@prairielearn/bind-mount');
 const { instrumented } = require('@prairielearn/opentelemetry');
-const { setupDockerAuthAsync } = require('@prairielearn/docker-utils');
+const { setupDockerAuth } = require('@prairielearn/docker-utils');
 
 const { config } = require('../config');
 const { logger } = require('@prairielearn/logger');
@@ -78,9 +79,8 @@ async function ensureImage() {
     if (e.statusCode === 404) {
       logger.info('Image not found, pulling from registry');
       const start = Date.now();
-      const dockerAuth = config.cacheImageRegistry
-        ? await setupDockerAuthAsync(config.awsRegion)
-        : null;
+      const ecr = new ECRClient({ region: config.awsRegion });
+      const dockerAuth = config.cacheImageRegistry ? await setupDockerAuth(ecr) : null;
       const stream = await docker.createImage(dockerAuth, { fromImage: imageName });
       await new Promise((resolve, reject) => {
         docker.modem.followProgress(

--- a/apps/prairielearn/src/pages/shared/syncHelpers.js
+++ b/apps/prairielearn/src/pages/shared/syncHelpers.js
@@ -1,11 +1,11 @@
 // @ts-check
-const { ECR } = require('@aws-sdk/client-ecr');
+const { ECR, ECRClient } = require('@aws-sdk/client-ecr');
 const _ = require('lodash');
 const ERR = require('async-stacktrace');
 const fs = require('fs-extra');
 const async = require('async');
 const Docker = require('dockerode');
-const { DockerName, setupDockerAuthAsync } = require('@prairielearn/docker-utils');
+const { DockerName, setupDockerAuth } = require('@prairielearn/docker-utils');
 const namedLocks = require('@prairielearn/named-locks');
 
 const { makeAwsClientConfig } = require('../../lib/aws');
@@ -327,7 +327,8 @@ module.exports.ecrUpdate = async function (images, locals) {
     throw new Error('cacheImageRegistry not defined');
   }
 
-  const auth = await setupDockerAuthAsync(config.awsRegion);
+  const ecr = new ECRClient({ region: config.awsRegion });
+  const auth = await setupDockerAuth(ecr);
 
   const serverJob = await createServerJob({
     courseId: locals.course.id,

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -7,6 +7,7 @@ const http = require('http');
 const fetch = require('node-fetch').default;
 const path = require('path');
 const { S3 } = require('@aws-sdk/client-s3');
+const { ECRClient } = require('@aws-sdk/client-ecr');
 const { Upload } = require('@aws-sdk/lib-storage');
 const Docker = require('dockerode');
 const fs = require('fs');
@@ -20,7 +21,7 @@ const net = require('net');
 const asyncHandler = require('express-async-handler');
 const bodyParser = require('body-parser');
 const { Mutex } = require('async-mutex');
-const { DockerName, setupDockerAuthAsync } = require('@prairielearn/docker-utils');
+const { DockerName, setupDockerAuth } = require('@prairielearn/docker-utils');
 const { logger } = require('@prairielearn/logger');
 const sqldb = require('@prairielearn/postgres');
 const Sentry = require('@prairielearn/sentry');
@@ -575,7 +576,8 @@ async function _pullImage(workspace) {
 
   // We only auth if a specific ECR registry is configured. Otherwise, we'll
   // assume we're pulling from the public Docker Hub registry.
-  const auth = config.cacheImageRegistry ? await setupDockerAuthAsync(config.awsRegion) : null;
+  const ecr = new ECRClient({ region: config.awsRegion });
+  const auth = config.cacheImageRegistry ? await setupDockerAuth(ecr) : null;
 
   let percentDisplayed = false;
   let stream;

--- a/packages/docker-utils/package.json
+++ b/packages/docker-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prairielearn/docker-utils",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "private": true,
   "main": "./dist/index.js",
   "repository": {


### PR DESCRIPTION
I'm making this change in advance of some changes to the way we construct our AWS clients that will allow us to avoid exceeding IMDS rate limits.