### PR TITLE
Fix copying a question using the default course

### DIFF
--- a/apps/prairielearn/src/pages/partials/question.ejs
+++ b/apps/prairielearn/src/pages/partials/question.ejs
@@ -218,7 +218,7 @@
   <div id="copyQuestionModal" class="modal fade" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form method="POST" action="<%= question_copy_targets[0].copy_url %>">
+        <form method="POST" action="<%= question_copy_targets[0]?.copy_url ?? '' %>">
           <div class="modal-header">
             <h5 class="modal-title">Copy question</h5>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -268,7 +268,7 @@
             <% } %>
           </div>
           <div class="modal-footer">
-            <input type="hidden" name="__csrf_token" value="<%= question_copy_targets[0].__csrf_token %>" />
+            <input type="hidden" name="__csrf_token" value="<%= question_copy_targets[0]?.__csrf_token ?? '' %>" />
             <input type="hidden" name="question_id" value="<%= question.id %>" />
             <input type="hidden" name="course_id" value="<%= course.id %>" /> 
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/apps/prairielearn/src/pages/partials/question.ejs
+++ b/apps/prairielearn/src/pages/partials/question.ejs
@@ -218,7 +218,7 @@
   <div id="copyQuestionModal" class="modal fade" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form method="POST">
+        <form method="POST" action="<%= question_copy_targets[0].copy_url %>">
           <div class="modal-header">
             <h5 class="modal-title">Copy question</h5>
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -268,7 +268,7 @@
             <% } %>
           </div>
           <div class="modal-footer">
-            <input type="hidden" name="__csrf_token" value="" />
+            <input type="hidden" name="__csrf_token" value="<%= question_copy_targets[0].__csrf_token %>" />
             <input type="hidden" name="question_id" value="<%= question.id %>" />
             <input type="hidden" name="course_id" value="<%= course.id %>" /> 
             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/apps/prairielearn/src/pages/partials/question.ejs
+++ b/apps/prairielearn/src/pages/partials/question.ejs
@@ -238,11 +238,12 @@
                 Select one of your courses to copy this question.
               </p>
               <select class="form-control" name="to_course_id" required>
-                <% question_copy_targets.forEach(function(course) { %>
+                <% question_copy_targets.forEach(function(course, index) { %>
                   <option
                     value="<%= course.id %>"
                     data-csrf-token="<%= course.__csrf_token %>"
                     data-copy-url="<%= course.copy_url %>"
+                    <%= index === 0 ? 'selected' : '' %>
                   >
                     <%= course.short_name %>
                   </option>


### PR DESCRIPTION
This handles the case where someone tries to copy a question to the default (first) option in the course `<select>` in the question copy modal. If the selected option didn't change, our little script would never have set the appropriate action or CSRF token. Now, they default to the values corresponding to the first course in the options.