### PR TITLE
fix: Don't throw errors for large floats

### DIFF
--- a/apps/prairielearn/python/zygote_utils.py
+++ b/apps/prairielearn/python/zygote_utils.py
@@ -10,7 +10,7 @@ def assert_all_integers_within_limits(item: Any) -> None:
     while item_stack:
         next_item = item_stack.pop()
 
-        if isinstance(next_item, int):
+        if type(next_item) == int:
             if not pl.is_int_json_serializable(next_item):
                 raise ValueError(
                     f"Data structure contains oversized integer: {next_item}"

--- a/apps/prairielearn/python/zygote_utils.py
+++ b/apps/prairielearn/python/zygote_utils.py
@@ -10,7 +10,7 @@ def assert_all_integers_within_limits(item: Any) -> None:
     while item_stack:
         next_item = item_stack.pop()
 
-        if type(next_item) == int:
+        if type(next_item) is int:
             if not pl.is_int_json_serializable(next_item):
                 raise ValueError(
                     f"Data structure contains oversized integer: {next_item}"

--- a/apps/prairielearn/python/zygote_utils.py
+++ b/apps/prairielearn/python/zygote_utils.py
@@ -10,7 +10,7 @@ def assert_all_integers_within_limits(item: Any) -> None:
     while item_stack:
         next_item = item_stack.pop()
 
-        if type(next_item) is int:
+        if isinstance(next_item, int):
             if not pl.is_int_json_serializable(next_item):
                 raise ValueError(
                     f"Data structure contains oversized integer: {next_item}"

--- a/apps/prairielearn/python/zygote_utils_test.py
+++ b/apps/prairielearn/python/zygote_utils_test.py
@@ -11,7 +11,7 @@ import zygote_utils as zu
         [1, 2, [3, 4, {"thing": 5}]],
         [1, 2, "999999999999999999999"],
         [{"stuff": 999999}, {"other stuff": "key"}],
-        [{"big_float": 2e30}],
+        [{"big_float": 2.8e30}],
     ],
 )
 def test_all_integers_within_limits_no_exception(item: Any) -> None:

--- a/apps/prairielearn/python/zygote_utils_test.py
+++ b/apps/prairielearn/python/zygote_utils_test.py
@@ -11,6 +11,7 @@ import zygote_utils as zu
         [1, 2, [3, 4, {"thing": 5}]],
         [1, 2, "999999999999999999999"],
         [{"stuff": 999999}, {"other stuff": "key"}],
+        [{"big_float": 2e30}],
     ],
 )
 def test_all_integers_within_limits_no_exception(item: Any) -> None:


### PR DESCRIPTION
See title, resolves #8462 

EDIT: This actually isn't what's causing the issue, has to do with some weird serializing behavior. Will investigate more a little later.