### PR TITLE
Disable core dumps in all Docker containers

### DIFF
--- a/apps/grader-host/src/index.js
+++ b/apps/grader-host/src/index.js
@@ -464,6 +464,14 @@ function runJob(info, callback) {
               CpuPeriod: config.graderDockerCpuPeriod,
               CpuQuota: config.graderDockerCpuQuota,
               PidsLimit: config.graderDockerPidsLimit,
+              Ulimits: [
+                {
+                  // Disable core dumps, which can get very large and bloat our storage.
+                  Name: 'core',
+                  Soft: 0,
+                  Hard: 0,
+                },
+              ],
             },
             Entrypoint: entrypoint.split(' '),
           },

--- a/apps/prairielearn/src/lib/externalGraderLocal.js
+++ b/apps/prairielearn/src/lib/externalGraderLocal.js
@@ -98,6 +98,14 @@ class Grader {
           CpuPeriod: 100000, // microseconds
           CpuQuota: 90000, // portion of the CpuPeriod for this container
           PidsLimit: 1024,
+          Ulimits: [
+            {
+              // Disable core dumps, which can get very large and bloat our storage.
+              Name: 'core',
+              Soft: 0,
+              Hard: 0,
+            },
+          ],
         },
         Entrypoint: question.external_grading_entrypoint.split(' '),
       });

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -795,6 +795,14 @@ function _createContainer(workspace, callback) {
               PidsLimit: config.workspaceDockerPidsLimit,
               IpcMode: 'private',
               NetworkMode: networkMode,
+              Ulimits: [
+                {
+                  // Disable core dumps, which can get very large and bloat our storage.
+                  Name: 'core',
+                  Soft: 0,
+                  Hard: 0,
+                },
+              ],
             },
             Labels: {
               'prairielearn.workspace-id': String(workspace.id),


### PR DESCRIPTION
We noticed recently that some courses were producing extremely large core dumps (>1GB) in workspaces. We're opting to disable core dump generation for now to prevent these files from bloating our storage.

Closes https://github.com/PrairieLearnInc/sysconf/issues/1246.