### PR TITLE
Add explicit error codes for more SQL exceptions

### DIFF
--- a/apps/prairielearn/src/sprocs/instance_questions_ensure_open.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_ensure_open.sql
@@ -11,8 +11,8 @@ BEGIN
     FROM instance_questions
     WHERE id = instance_question_id;
 
-    IF NOT FOUND THEN RAISE EXCEPTION 'no such instance_question_id: %', instance_question_id; END IF;
+    IF NOT FOUND THEN RAISE EXCEPTION 'no such instance_question_id: %', instance_question_id USING ERRCODE = 'ST404'; END IF;
 
-    IF NOT current_open THEN RAISE EXCEPTION 'instance question is not open: %', instance_question_id; END IF;
+    IF NOT current_open THEN RAISE EXCEPTION 'instance question is not open: %', instance_question_id USING ERRCODE = 'ST403'; END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/apps/prairielearn/src/sprocs/variants_select.sql
+++ b/apps/prairielearn/src/sprocs/variants_select.sql
@@ -31,7 +31,7 @@ BEGIN
             OR v.instance_question_id = variants_select.instance_question_id
         );
 
-    IF NOT FOUND THEN RAISE EXCEPTION 'no such variant_id for this question: %', variant_id; END IF;
+    IF NOT FOUND THEN RAISE EXCEPTION 'no such variant_id for this question: %', variant_id USING ERROCDE = 'ST404'; END IF;
 
     IF variant_with_id.course_instance_id IS NOT NULL THEN
         SELECT ci.display_timezone

--- a/apps/prairielearn/src/sprocs/variants_select.sql
+++ b/apps/prairielearn/src/sprocs/variants_select.sql
@@ -31,7 +31,7 @@ BEGIN
             OR v.instance_question_id = variants_select.instance_question_id
         );
 
-    IF NOT FOUND THEN RAISE EXCEPTION 'no such variant_id for this question: %', variant_id USING ERROCDE = 'ST404'; END IF;
+    IF NOT FOUND THEN RAISE EXCEPTION 'no such variant_id for this question: %', variant_id USING ERRCODE = 'ST404'; END IF;
 
     IF variant_with_id.course_instance_id IS NOT NULL THEN
         SELECT ci.display_timezone

--- a/apps/prairielearn/src/sprocs/variants_select_submission_for_grading.sql
+++ b/apps/prairielearn/src/sprocs/variants_select_submission_for_grading.sql
@@ -46,7 +46,7 @@ BEGIN
     IF NOT FOUND THEN RETURN; END IF; -- no submissions
 
     IF check_submission_id IS NOT NULL and check_submission_id != submission.id THEN
-        RAISE EXCEPTION 'check_submission_id mismatch: % vs %', check_submission_id, submission.id;
+        RAISE EXCEPTION 'check_submission_id mismatch: % vs %', check_submission_id, submission.id USING ERRCODE = 'ST400';
     END IF;
 
     -- mark submission as regradable


### PR DESCRIPTION
This ensures that Sentry and our load balancer won't unnecessarily treat these as 500s.

This error code is processed here:

https://github.com/PrairieLearn/PrairieLearn/blob/ebc9ec4faf2c2e114e4c3223d26048c190f6ea32/apps/prairielearn/src/server.js#L1858