### PR TITLE
Rely on implicit installation of npm

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -37,10 +37,6 @@ git checkout `git describe --abbrev=0 --tags --match "v[0-9]*" $(git rev-list --
 source /nvm/nvm.sh
 export NVM_SYMLINK_CURRENT=true
 nvm install 16
-# PrairieLearn doesn't currently use `npm` itself, but we can't be sure that
-# someone else isn't using our base image and relying on `npm`, so we'll
-# continue to install it to avoid breaking things.
-npm install npm@latest -g
 npm install yarn@latest -g
 for f in /nvm/current/bin/* ; do ln -s $f /usr/local/bin/`basename $f` ; done
 


### PR DESCRIPTION
Explicitly installing `npm@latest` now fails becuase the latest version of npm requires a version of Node newer than the one we're using, which causes our `plbase` image to fail to build:

```
#8 74.80 npm ERR! notsup Not compatible with your version of node/npm: npm@10.0.0
#8 74.80 npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
#8 74.80 npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.2"}
```

We'll instead rely on nvm automatically installing npm when it installs Node.