### PR TITLE
Fix check of string correct answer in integer input

### DIFF
--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
@@ -68,7 +68,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
         correct_answer = pl.from_json(data["correct_answers"].get(name, None))
 
     # Test conversion, but leave as string so proper value is shown on answer panel
-    if correct_answer is not None:
+    if correct_answer is not None and not isinstance(correct_answer, int):
         try:
             int(str(correct_answer), base)
         except Exception:

--- a/exampleCourse/questions/element/integerInput/question.html
+++ b/exampleCourse/questions/element/integerInput/question.html
@@ -107,10 +107,11 @@
       <p>The integer can also be expected to be provided in a different base.</p>
       <p>
         Solve for the value of $c$ given $c = {{params.a16}}_{16} + {{params.b16}}_{16}$ (provide
-        your answer in base $16$).
+        your answer in base $16$ and base $2$).
       </p>
     </pl-question-panel>
-    <pl-integer-input answers-name="c_7" base="16"></pl-integer-input>
+    <pl-integer-input answers-name="c_7_b16" base="16"></pl-integer-input>
+    <pl-integer-input answers-name="c_7_b2" base="2"></pl-integer-input>
   </div>
 </div>
 

--- a/exampleCourse/questions/element/integerInput/server.py
+++ b/exampleCourse/questions/element/integerInput/server.py
@@ -27,7 +27,8 @@ def generate(data):
     data["correct_answers"]["c_2"] = c
     data["correct_answers"]["c_4"] = str(c)
     data["correct_answers"]["c_5"] = str(c)
-    data["correct_answers"]["c_7"] = c16
+    data["correct_answers"]["c_7_b16"] = c16
+    data["correct_answers"]["c_7_b2"] = c16
 
     c_large = "9007199254740991999"
     data["correct_answers"]["c_large"] = c_large


### PR DESCRIPTION
This error can happen in a scenario like:
* in server.py, correct answer is set to: `data["correct_answers"]["input"] = 0o11` (i.e., 9).
* the integer input has the base 8.

Expected behaviour: the correct answer to be accepted is "`11`". Currently this doesn't work, with an exception being thrown because "9" is not a valid correct answer in base 8. This would work if the correct answer had been set to a string, e.g., `'11'`.