### PR TITLE
Add created_at column to pl_courses table

### DIFF
--- a/apps/prairielearn/src/migrations/20230913180450_pl_courses__created_at__add.sql
+++ b/apps/prairielearn/src/migrations/20230913180450_pl_courses__created_at__add.sql
@@ -1,0 +1,8 @@
+ALTER TABLE pl_courses
+ADD COLUMN created_at TIMESTAMP WITH TIME ZONE;
+
+-- Set the default separately so that it doesn't update the value on all
+-- existing rows. We'll backfill this data for existing courses separately.
+ALTER TABLE pl_courses
+ALTER COLUMN created_at
+SET DEFAULT NOW();

--- a/database/tables/pl_courses.pg
+++ b/database/tables/pl_courses.pg
@@ -1,6 +1,7 @@
 columns
     branch: text default 'master'::text
     commit_hash: text
+    created_at: timestamp with time zone default now()
     deleted_at: timestamp with time zone
     display_timezone: text not null
     example_course: boolean not null default false


### PR DESCRIPTION
I'll open another PR to backfill this data. Right now, I'm thinking of filling it in based on several sources, with each one serving as a fallback if previous ones aren't available:

- The date of the earliest server job for the course (this should typically be a sync done right around when the course was first created)
- The date of the first commit in the course's repository