### PR TITLE
Backfill created_at column for all courses

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.sql
+++ b/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.sql
@@ -1,0 +1,22 @@
+-- BLOCK select_course
+SELECT
+  *
+FROM
+  pl_courses
+WHERE
+  id = $course_id;
+
+-- BLOCK select_earliest_job_sequence_for_course
+SELECT
+  MIN(start_date) AS min
+FROM
+  job_sequences
+WHERE
+  course_id = $course_id;
+
+-- BLOCK update_course_created_at
+UPDATE pl_courses
+SET
+  created_at = $created_at
+WHERE
+  id = $course_id;

--- a/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
+++ b/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
@@ -56,7 +56,7 @@ export default makeBatchedMigration({
 
       if (course.created_at != null) {
         // The course already has a date; don't overwrite it.
-        return;
+        continue;
       }
 
       const earliestCommitDate = await getEarliestCommitDateForCourse(course.path);

--- a/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
+++ b/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
@@ -1,0 +1,77 @@
+import execa = require('execa');
+import * as fs from 'fs-extra';
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryOneRowAsync, queryRow } from '@prairielearn/postgres';
+
+import { CourseSchema, DateFromISOString } from '../lib/db-types';
+
+const sql = loadSqlEquiv(__filename);
+
+async function getEarliestCommitDateForCourse(coursePath: string | null): Promise<Date | null> {
+  if (coursePath == null || !(await fs.pathExists(coursePath))) {
+    return null;
+  }
+
+  const res = await execa('git', ['log', '--reverse', '--format=%cI', '--date=iso'], {
+    cwd: coursePath,
+  });
+
+  const lines = res.stdout.trim().split('\n');
+  return lines.length > 0 ? new Date(lines[0]) : null;
+}
+
+async function getEarliestJobSequenceDateForCourse(courseId: string): Promise<Date | null> {
+  const result = await queryRow(
+    sql.select_earliest_job_sequence_for_course,
+    { course_id: courseId },
+    DateFromISOString.nullable(),
+  );
+
+  return result;
+}
+
+function smallestDate(first: Date | null, second: Date | null): Date | null {
+  if (first == null) {
+    return second;
+  }
+  if (second == null) {
+    return first;
+  }
+  return first < second ? first : second;
+}
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const result = await queryOneRowAsync('SELECT MAX(id) as max from pl_courses;', {});
+    return {
+      min: 1n,
+      max: result.rows[0].max,
+      batchSize: 10,
+    };
+  },
+
+  async execute(start: bigint, end: bigint): Promise<void> {
+    for (let id = start; id <= end; id++) {
+      const course = await queryRow(sql.select_course, { course_id: id }, CourseSchema);
+
+      if (course.created_at != null) {
+        // The course already has a date; don't overwrite it.
+        return;
+      }
+
+      const earliestCommitDate = await getEarliestCommitDateForCourse(course.path);
+      const earliestServerJobDate = await getEarliestJobSequenceDateForCourse(course.id);
+
+      // Take the earlier of the two values.
+      const createdAt = smallestDate(earliestCommitDate, earliestServerJobDate);
+      if (!createdAt) {
+        throw new Error(`Could not determine created_at date for course ${course.id}`);
+      }
+
+      await queryOneRowAsync(sql.update_course_created_at, {
+        course_id: id,
+        created_at: createdAt,
+      });
+    }
+  },
+});

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -29,6 +29,7 @@ export const DateFromISOString = z
 export const CourseSchema = z.object({
   branch: z.string(),
   commit_hash: z.string().nullable(),
+  created_at: DateFromISOString.nullable(),
   deleted_at: DateFromISOString.nullable(),
   display_timezone: z.string(),
   example_course: z.boolean(),

--- a/apps/prairielearn/src/migrations/20230913181816_pl_courses__created_at__backfill.ts
+++ b/apps/prairielearn/src/migrations/20230913181816_pl_courses__created_at__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20230913181816_pl_courses_created_at');
+}

--- a/packages/migrations/src/batched-migrations/batched-migration.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration.ts
@@ -35,8 +35,8 @@ export const BatchedMigrationRowSchema = z.object({
 export type BatchedMigrationRow = z.infer<typeof BatchedMigrationRowSchema>;
 
 export interface BatchedMigrationParameters {
-  min?: bigint | null;
-  max: bigint | null;
+  min?: bigint | string | null;
+  max: bigint | string | null;
   batchSize?: number;
 }
 


### PR DESCRIPTION
This PR adds a batched migration to backfill the `pl_courses.created_at` column introduced in #8477. It computes the date of the earliest commit to the repository and the date of the earliest server job, then takes the earliest of those two.