### PR TITLE
Fix handling of ANSI escape codes in external grader results

### DIFF
--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -98,7 +98,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         html_params["has_message"] = bool(message)
 
         output = results.get("output", None)
-        html_params["output"] = output
+        html_params["output"] = ansi_to_html(output)
         html_params["has_output"] = bool(output)
 
         images = results.get("images", [])
@@ -142,9 +142,9 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 test: dict[str, Any] = {
                     "index": index,
                     "name": name,
-                    "message": message,
+                    "message": ansi_to_html(message),
                     "has_message": bool(message),
-                    "output": output,
+                    "output": ansi_to_html(output),
                     "has_output": bool(output),
                     "description": description,
                     "has_description": bool(description),


### PR DESCRIPTION
This regression was introduced by #7977. As far as I can tell, it was unintentional.

As reported on Slack, this manifested as strange output from the Python autograder:

![Screenshot showing unhandled escape sequences](https://github.com/PrairieLearn/PrairieLearn/assets/1476544/3fea3299-a33b-4cc6-9195-feb4ff8ada80)

