### PR TITLE
Improve workspace logs when workspace fails to start

### DIFF
--- a/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.js
+++ b/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.js
@@ -89,7 +89,11 @@ async function loadLogsForWorkspaceVersion(workspaceId, version) {
   // If the current workspace version matches the requested version, we can
   // reach out to the workspace host directly to get the remaining logs. Otherwise,
   // they should have been flushed to S3 already.
-  if (workspace.state === 'running' && workspace.is_current_version && workspace.hostname) {
+  if (
+    ['launching', 'running'].includes(workspace.state) &&
+    workspace.is_current_version &&
+    workspace.hostname
+  ) {
     const res = await fetch(`http://${workspace.hostname}/`, {
       method: 'POST',
       body: JSON.stringify({ workspace_id: workspaceId, action: 'getLogs' }),

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -948,7 +948,13 @@ async function initSequenceAsync(workspace_id, useInitialZip, res) {
         'stopped',
         `Error starting container. Click "Reboot" to try again.`,
       );
-      return; // don't set host to unhealthy
+
+      // Immediately kill and remove the container, which will flush any
+      // logs to S3 for better debugging.
+      await dockerAttemptKillAndRemove(workspace.container);
+
+      // Don't set host to unhealthy.
+      return;
     }
   } catch (err) {
     logger.error(`Error initializing workspace ${workspace_id}; marking self as unhealthy`);


### PR DESCRIPTION
This PR makes two improvements to the instructor experience when when a workspace fails to start:

- We now allow logs to be fetched directly from the workspace host when the workspace is in the `launching` state. This makes it possible to view logs before the container health-checks, which can be useful if a container crashes or takes a really long time to start up.
- If a workspace fails to health check, we now immediately invoke `dockerAttemptKillAndRemove()`. This will in turn immediately flush the workspace's logs to S3 instead of having to wait for our background maintenance processes to kill the container.