### PR TITLE
Use shared AWS credential provider for grader job logger

### DIFF
--- a/apps/grader-host/src/lib/jobLogger.js
+++ b/apps/grader-host/src/lib/jobLogger.js
@@ -3,15 +3,14 @@ const { S3StreamLogger } = require('s3-streamlogger');
 
 const globalLogger = require('./logger');
 const { config } = require('./config');
+const { makeS3ClientConfig } = require('./aws');
 
 module.exports = function (options) {
   const { bucket, rootKey } = options;
 
   const s3StreamLoggerTransport = new winston.transports.Stream({
     stream: new S3StreamLogger({
-      config: {
-        region: config.awsRegion,
-      },
+      config: makeS3ClientConfig(),
       bucket,
       folder: rootKey,
       name_format: 'output.log', // No need to rotate, all logs go to same file


### PR DESCRIPTION
Follow-up to #8454. Our new lint rule didn't catch this for obvious reasons.

Long-term, I'm inclined to say we should only push logs at the very end of the grading process, similarly to what we do for workspaces. That would remove the need for this little third-party package.