### PR TITLE
fix: Add custom int parse function

### DIFF
--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -111,7 +111,7 @@ def worker_loop():
             # wait for a single line of input
             json_inp = sys.stdin.readline()
             # unpack the input line as JSON
-            inp = json.loads(json_inp, parse_int=zu.int_parse_fn)
+            inp = json.loads(json_inp, parse_int=zu.safe_parse_int)
 
             # get the contents of the JSON input
             file = inp.get("file", None)

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -111,7 +111,7 @@ def worker_loop():
             # wait for a single line of input
             json_inp = sys.stdin.readline()
             # unpack the input line as JSON
-            inp = json.loads(json_inp)
+            inp = json.loads(json_inp, parse_int=zu.int_parse_fn)
 
             # get the contents of the JSON input
             file = inp.get("file", None)

--- a/apps/prairielearn/python/zygote_utils.py
+++ b/apps/prairielearn/python/zygote_utils.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import prairielearn as pl

--- a/apps/prairielearn/python/zygote_utils.py
+++ b/apps/prairielearn/python/zygote_utils.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import prairielearn as pl
@@ -22,3 +23,11 @@ def assert_all_integers_within_limits(item: Any) -> None:
         elif isinstance(next_item, dict):
             item_stack.extend(next_item.keys())
             item_stack.extend(next_item.values())
+
+
+def int_parse_fn(int_str: str) -> int | float:
+    equiv_int = int(int_str)
+    if pl.is_int_json_serializable(equiv_int):
+        return equiv_int
+
+    return float(int_str)

--- a/apps/prairielearn/python/zygote_utils.py
+++ b/apps/prairielearn/python/zygote_utils.py
@@ -3,8 +3,26 @@ from typing import Any
 import prairielearn as pl
 
 
+def safe_parse_int(int_str: str) -> int | float:
+    """
+    Parses a JSON string. If the string contains an integer that is too large,
+    it will be parsed as a float instead. This ensures that we don't error out
+    if the number is later re-serialized back to JSON.
+    """
+    equiv_int = int(int_str)
+    if pl.is_int_json_serializable(equiv_int):
+        return equiv_int
+
+    return float(int_str)
+
+
 def assert_all_integers_within_limits(item: Any) -> None:
-    """Raise an exception if the input item contains any oversized integers."""
+    """
+    Raise an exception if the input item contains any oversized integers.
+
+    We consider an integer to be oversized if it cannot be losslessly parsed
+    from JSON into a JavaScript number.
+    """
     item_stack = [item]
 
     while item_stack:
@@ -22,11 +40,3 @@ def assert_all_integers_within_limits(item: Any) -> None:
         elif isinstance(next_item, dict):
             item_stack.extend(next_item.keys())
             item_stack.extend(next_item.values())
-
-
-def int_parse_fn(int_str: str) -> int | float:
-    equiv_int = int(int_str)
-    if pl.is_int_json_serializable(equiv_int):
-        return equiv_int
-
-    return float(int_str)

--- a/apps/prairielearn/python/zygote_utils_test.py
+++ b/apps/prairielearn/python/zygote_utils_test.py
@@ -8,7 +8,7 @@ import zygote_utils as zu
 @pytest.mark.parametrize(
     "item", ["-9007199254740991", "-1", "0", "1", "9007199254740991"]
 )
-def test_load_json_small_ints(item: str) -> None:
+def test_safe_parse_int_small_ints(item: str) -> None:
     loaded_item = json.loads(item, parse_int=zu.safe_parse_int)
     assert isinstance(loaded_item, int)
     assert int(item) == loaded_item
@@ -25,7 +25,7 @@ def test_load_json_small_ints(item: str) -> None:
         "2.8e16",
     ],
 )
-def test_load_json_large_ints(item: str) -> None:
+def test_safe_parse_int_large_ints(item: str) -> None:
     loaded_item = json.loads(item, parse_int=zu.safe_parse_int)
     assert isinstance(loaded_item, float)
     assert float(item) == loaded_item

--- a/apps/prairielearn/python/zygote_utils_test.py
+++ b/apps/prairielearn/python/zygote_utils_test.py
@@ -6,6 +6,32 @@ import zygote_utils as zu
 
 
 @pytest.mark.parametrize(
+    "item", ["-9007199254740991", "-1", "0", "1", "9007199254740991"]
+)
+def test_load_json_small_ints(item: str) -> None:
+    loaded_item = json.loads(item, parse_int=zu.safe_parse_int)
+    assert isinstance(loaded_item, int)
+    assert int(item) == loaded_item
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        "-2.8e16",
+        "28000000000000000",
+        "-9007199254740992",
+        "9007199254740992",
+        "28000000000000000",
+        "2.8e16",
+    ],
+)
+def test_load_json_large_ints(item: str) -> None:
+    loaded_item = json.loads(item, parse_int=zu.safe_parse_int)
+    assert isinstance(loaded_item, float)
+    assert float(item) == loaded_item
+
+
+@pytest.mark.parametrize(
     "item",
     [
         1,
@@ -33,10 +59,3 @@ def test_all_integers_within_limits_no_exception(item: Any) -> None:
 def test_all_integers_within_limits_raise_exception(item: Any) -> None:
     with pytest.raises(ValueError):
         zu.assert_all_integers_within_limits(item)
-
-
-def test_custom_decoder() -> None:
-    json_str = r'{"thing" : 280000000000000000000}'
-    output = json.loads(json_str, parse_int=zu.int_parse_fn)
-    assert type(output["thing"]) is float
-    assert output["thing"] == 280000000000000000000

--- a/apps/prairielearn/python/zygote_utils_test.py
+++ b/apps/prairielearn/python/zygote_utils_test.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -32,3 +33,10 @@ def test_all_integers_within_limits_no_exception(item: Any) -> None:
 def test_all_integers_within_limits_raise_exception(item: Any) -> None:
     with pytest.raises(ValueError):
         zu.assert_all_integers_within_limits(item)
+
+
+def test_custom_decoder() -> None:
+    json_str = r'{"thing" : 280000000000000000000}'
+    output = json.loads(json_str, parse_int=zu.int_parse_fn)
+    assert type(output["thing"]) is float
+    assert output["thing"] == 280000000000000000000


### PR DESCRIPTION
See title, partial resolution to #8462. Forces numbers that would be oversized ints to be parsed as floats using a custom deserialization function. Still needs more unit / functional tests, but code should be mostly complete.