### PR TITLE
Use user's local time settings when displaying times

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/credential-providers": "^3.525.0",
     "@aws-sdk/lib-storage": "^3.525.0",
     "@fortawesome/fontawesome-free": "^6.5.1",
+    "@github/relative-time-element": "^4.3.1",
     "@octokit/rest": "^19.0.13",
     "@prairielearn/aws": "workspace:^",
     "@prairielearn/bind-mount": "workspace:^",

--- a/apps/prairielearn/src/models/course-instances.sql
+++ b/apps/prairielearn/src/models/course-instances.sql
@@ -11,11 +11,11 @@ SELECT
   ci.*,
   CASE
     WHEN d.start_date IS NULL THEN '—'
-    ELSE format_date_full_compact (d.start_date, ci.display_timezone)
+    ELSE format_date_iso8601 (d.start_date, ci.display_timezone)
   END AS formatted_start_date,
   CASE
     WHEN d.end_date IS NULL THEN '—'
-    ELSE format_date_full_compact (d.end_date, ci.display_timezone)
+    ELSE format_date_iso8601 (d.end_date, ci.display_timezone)
   END AS formatted_end_date,
   COALESCE(
     $is_administrator

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ejs
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <%- include('../partials/head', {pageTitle: 'Course Instances'}); %>
+        <script type="module" src="<%= node_modules_asset_path('@github/relative-time-element/dist/index.js') %>"></script>
     </head>
     <body>
         <script>
@@ -63,8 +64,12 @@
                                 <tr>
                                     <td class="align-left"><a href="<%= plainUrlPrefix %>/course_instance/<%= row.id %>/instructor/instance_admin"><%= row.long_name %></a></td>
                                     <td class="align-left"><%= row.short_name %></td>
-                                    <td class="align-left"><%= row.formatted_start_date %></td>
-                                    <td class="align-left"><%= row.formatted_end_date %></td>
+                                    <td class="align-left">
+                                        <relative-time format="datetime" hour="2-digit" minute="2-digit" datetime="<%= row.formatted_start_date %>">-</relative-time>
+                                    </td>
+                                    <td class="align-left">
+                                        <relative-time format="datetime" hour="2-digit" minute="2-digit" datetime="<%= row.formatted_end_date %>">-</relative-time>
+                                    </td>
                                     <td class="align-middle"><%= row.number %></td>
                                 </tr>
                             <% }); %>

--- a/apps/prairielearn/src/sprocs/format_date_iso8601.sql
+++ b/apps/prairielearn/src/sprocs/format_date_iso8601.sql
@@ -5,6 +5,6 @@ CREATE FUNCTION
     ) RETURNS text AS $$
 BEGIN
     EXECUTE 'SET LOCAL timezone TO ' || quote_literal(coalesce(display_timezone, 'UTC'));
-    RETURN to_char(d, 'YYYY-MM-DD') || 'T' || to_char(d, 'HH24:MI:SSOF');
+    RETURN to_char(d, 'YYYY-MM-DD') || 'T' || to_char(d, 'HH24:MI:SSTZH:TZM');
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,6 +1911,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@github/relative-time-element@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@github/relative-time-element@npm:4.3.1"
+  checksum: 26ef7335ec20fe9064019ea2db1d69901963149c4d3a1f1d9e3ec922542b1eb292ccd786c343138c49806de20a92299a15c857a986a150416a08c30a6581b02f
+  languageName: node
+  linkType: hard
+
 "@grpc/grpc-js@npm:^1.10.1, @grpc/grpc-js@npm:^1.7.1":
   version: 1.10.1
   resolution: "@grpc/grpc-js@npm:1.10.1"
@@ -3342,6 +3349,7 @@ __metadata:
     "@aws-sdk/credential-providers": ^3.525.0
     "@aws-sdk/lib-storage": ^3.525.0
     "@fortawesome/fontawesome-free": ^6.5.1
+    "@github/relative-time-element": ^4.3.1
     "@octokit/rest": ^19.0.13
     "@prairielearn/aws": "workspace:^"
     "@prairielearn/bind-mount": "workspace:^"


### PR DESCRIPTION
This is a proof-of-concept PR aimed at displaying times in the user's local time instead of the institution's time format.

Hopefully this work can be continued & ported over to PrairieTest to solve https://github.com/PrairieLearn/PrairieTest-feedback/issues/29!

This PR only affects the admin course instances page.

Before (CST -5:00):
![image](https://github.com/PrairieLearn/PrairieLearn/assets/105177619/81576bad-7e77-46c1-bc09-b7c3e5f84b01)

After (CST -5:00):
![image](https://github.com/PrairieLearn/PrairieLearn/assets/105177619/fb0081d0-885b-449f-97b3-b464dae6ec01)

After (IRST +3:30):
![image](https://github.com/PrairieLearn/PrairieLearn/assets/105177619/8425e5ad-04a6-4431-9803-40c950177da4)



Any feedback is appreciated!