### PR TITLE
Allow images from non-DockerHub registries

### DIFF
--- a/apps/prairielearn/src/pages/shared/syncHelpers.js
+++ b/apps/prairielearn/src/pages/shared/syncHelpers.js
@@ -237,7 +237,7 @@ function pullAndPushToECR(image, dockerAuth, job, callback) {
 
   const repository = new DockerName(image);
   const params = {
-    fromImage: repository.getRepository(),
+    fromImage: repository.getRegistryRepo(),
     tag: repository.getTag() || 'latest',
   };
   job.info(`Pulling ${repository.getCombined()}`);


### PR DESCRIPTION
Simple enough change, partially resolves #5285.

Worked on this because our course really wants to use the CI-built images since sharing DockerHub credentials is no longer practical. Addressing the following two caveats will be more involved and tricky, but this MVP is good enough for us.

Two caveats of this simple change:

- **Any same owner-imageName pair will be considered same regardless of the registry.** For example, PL won't be able to differentiate `ghcr.io/natepark01/randomImage` and `quay.dev.cs128.org/natepark01/randomImage`. If both exists in any question, PL will only use `DockerName::getRepository` so they will be considered identical sync-time. This might cause some confusions.
- Does not support authentication (i.e. `docker login`). So for private registries that require authentication for pulls, this won't work.