### PR TITLE
Make pl_courses.create_at NOT NULL

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -29,7 +29,7 @@ export const DateFromISOString = z
 export const CourseSchema = z.object({
   branch: z.string(),
   commit_hash: z.string().nullable(),
-  created_at: DateFromISOString.nullable(),
+  created_at: DateFromISOString,
   deleted_at: DateFromISOString.nullable(),
   display_timezone: z.string(),
   example_course: z.boolean(),

--- a/apps/prairielearn/src/migrations/20230922173830_pl_courses__created_at__backfill__finalize.ts
+++ b/apps/prairielearn/src/migrations/20230922173830_pl_courses__created_at__backfill__finalize.ts
@@ -1,0 +1,5 @@
+import { finalizeBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await finalizeBatchedMigration('20230913181816_pl_courses_created_at');
+}

--- a/apps/prairielearn/src/migrations/20230922173839_pl_courses__created_at__set_not_null.sql
+++ b/apps/prairielearn/src/migrations/20230922173839_pl_courses__created_at__set_not_null.sql
@@ -1,0 +1,3 @@
+ALTER TABLE pl_courses
+ALTER COLUMN created_at
+SET NOT NULL;

--- a/database/tables/pl_courses.pg
+++ b/database/tables/pl_courses.pg
@@ -1,7 +1,7 @@
 columns
     branch: text default 'master'::text
     commit_hash: text
-    created_at: timestamp with time zone default now()
+    created_at: timestamp with time zone not null default now()
     deleted_at: timestamp with time zone
     display_timezone: text not null
     example_course: boolean not null default false


### PR DESCRIPTION
The batched migration has finished successfully in all our environments; we can safely finalize it and make the column `NOT NULL` in the schema.