### PR TITLE
Export OpenTelemetry metrics for the session store

### DIFF
--- a/.changeset/green-bugs-tell.md
+++ b/.changeset/green-bugs-tell.md
@@ -1,0 +1,13 @@
+---
+'@prairielearn/opentelemetry': minor
+---
+
+The following types are now exported:
+
+- `Meter`
+- `Counter`
+- `Histogram`
+- `UpDownCounter`
+- `ObservableCounter`
+- `ObservableUpDownCounter`
+- `ObservableGauge`

--- a/apps/prairielearn/src/lib/session-store.ts
+++ b/apps/prairielearn/src/lib/session-store.ts
@@ -1,6 +1,7 @@
 import session = require('express-session');
 import util = require('util');
 import sqldb = require('@prairielearn/postgres');
+import * as opentelemetry from '@prairielearn/opentelemetry';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
@@ -14,14 +15,29 @@ interface SessionStoreOptions {
  */
 export class SessionStore extends session.Store {
   private expireSeconds: number;
+  private meter: opentelemetry.Meter;
+  private setCounter: opentelemetry.Counter;
+  private getCounter: opentelemetry.Counter;
+  private destroyCounter: opentelemetry.Counter;
 
   constructor(options: SessionStoreOptions = {}) {
     super();
 
     this.expireSeconds = options.expireSeconds || 86400;
+    this.meter = opentelemetry.metrics.getMeter('prairielearn');
+    this.setCounter = opentelemetry.getCounter(this.meter, 'session_store.set', {
+      valueType: opentelemetry.ValueType.INT,
+    });
+    this.getCounter = opentelemetry.getCounter(this.meter, 'session_store.get', {
+      valueType: opentelemetry.ValueType.INT,
+    });
+    this.destroyCounter = opentelemetry.getCounter(this.meter, 'session_store.destroy', {
+      valueType: opentelemetry.ValueType.INT,
+    });
   }
 
   async setAsync(sid: string, session: session.SessionData) {
+    this.setCounter.add(1);
     await sqldb.queryOneRowAsync(sql.upsert, {
       sid,
       session: JSON.stringify(session),
@@ -30,6 +46,7 @@ export class SessionStore extends session.Store {
   set = util.callbackify(this.setAsync).bind(this);
 
   async getAsync(sid: string): Promise<session.SessionData> {
+    this.getCounter.add(1);
     const results = await sqldb.queryZeroOrOneRowAsync(sql.get, {
       sid,
       expirationInSeconds: this.expireSeconds,
@@ -39,6 +56,7 @@ export class SessionStore extends session.Store {
   get = util.callbackify(this.getAsync).bind(this);
 
   async destroyAsync(sid: string) {
+    this.destroyCounter.add(1);
     await sqldb.queryZeroOrOneRowAsync(sql.destroy, { sid });
   }
   destroy = util.callbackify(this.destroyAsync).bind(this);

--- a/apps/prairielearn/src/lib/session-store.ts
+++ b/apps/prairielearn/src/lib/session-store.ts
@@ -15,7 +15,6 @@ interface SessionStoreOptions {
  */
 export class SessionStore extends session.Store {
   private expireSeconds: number;
-  private meter: opentelemetry.Meter;
   private setCounter: opentelemetry.Counter;
   private getCounter: opentelemetry.Counter;
   private destroyCounter: opentelemetry.Counter;
@@ -24,14 +23,15 @@ export class SessionStore extends session.Store {
     super();
 
     this.expireSeconds = options.expireSeconds || 86400;
-    this.meter = opentelemetry.metrics.getMeter('prairielearn');
-    this.setCounter = opentelemetry.getCounter(this.meter, 'session_store.set', {
+
+    const meter = opentelemetry.metrics.getMeter('prairielearn');
+    this.setCounter = opentelemetry.getCounter(meter, 'session_store.set', {
       valueType: opentelemetry.ValueType.INT,
     });
-    this.getCounter = opentelemetry.getCounter(this.meter, 'session_store.get', {
+    this.getCounter = opentelemetry.getCounter(meter, 'session_store.get', {
       valueType: opentelemetry.ValueType.INT,
     });
-    this.destroyCounter = opentelemetry.getCounter(this.meter, 'session_store.destroy', {
+    this.destroyCounter = opentelemetry.getCounter(meter, 'session_store.destroy', {
       valueType: opentelemetry.ValueType.INT,
     });
   }

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,4 +1,18 @@
-export { trace, metrics, context, SpanStatusCode, ValueType, TraceFlags } from '@opentelemetry/api';
+export {
+  trace,
+  metrics,
+  context,
+  SpanStatusCode,
+  ValueType,
+  TraceFlags,
+  Meter,
+  Counter,
+  Histogram,
+  UpDownCounter,
+  ObservableCounter,
+  ObservableUpDownCounter,
+  ObservableGauge,
+} from '@opentelemetry/api';
 export { suppressTracing } from '@opentelemetry/core';
 
 export { init, shutdown, disableInstrumentations } from './init';


### PR DESCRIPTION
These metrics will allow us to validate that upcoming changes to the session store significantly reduce the write load on the database.