### PR TITLE
Change migration to allow null created_at

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
+++ b/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
@@ -1,9 +1,10 @@
 import execa = require('execa');
 import * as fs from 'fs-extra';
+import { z } from 'zod';
 import { makeBatchedMigration } from '@prairielearn/migrations';
 import { loadSqlEquiv, queryOneRowAsync, queryOptionalRow, queryRow } from '@prairielearn/postgres';
 
-import { CourseSchema, DateFromISOString } from '../lib/db-types';
+import { DateFromISOString, IdSchema } from '../lib/db-types';
 
 const sql = loadSqlEquiv(__filename);
 
@@ -55,8 +56,12 @@ export default makeBatchedMigration({
       const course = await queryOptionalRow(
         sql.select_course,
         { course_id: id },
-        CourseSchema.omit({ created_at: true }).extend({
+        // CourseSchema isn't used to avoid problems if the schema changes in
+        // the future. Only fields that are actually used are added here.
+        z.object({
           created_at: DateFromISOString.nullable(),
+          id: IdSchema,
+          path: z.string().nullable(),
         }),
       );
 

--- a/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
+++ b/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
@@ -52,7 +52,13 @@ export default makeBatchedMigration({
 
   async execute(start: bigint, end: bigint): Promise<void> {
     for (let id = start; id <= end; id++) {
-      const course = await queryOptionalRow(sql.select_course, { course_id: id }, CourseSchema);
+      const course = await queryOptionalRow(
+        sql.select_course,
+        { course_id: id },
+        CourseSchema.omit({ created_at: true }).extend({
+          created_at: DateFromISOString.nullable(),
+        }),
+      );
 
       if (course == null || course.created_at != null) {
         // This course does not exist, or it already has a created_at date.


### PR DESCRIPTION
The change in the schema in #8509 meant that anyone that runs the `created_at` backfill migration after merging with #8509 would see a schema error. This change causes the migration to allow the `created_at` column to be null at the point of migration.