### PR TITLE
Await Promise to fix external grading results

### DIFF
--- a/apps/prairielearn/src/lib/externalGraderResults.js
+++ b/apps/prairielearn/src/lib/externalGraderResults.js
@@ -169,7 +169,7 @@ async function processMessage(data) {
         ResponseContentType: 'application/json',
       });
       if (!data.Body) throw new Error('No body in S3 response');
-      await processResults(jobId, data.Body.transformToString());
+      await processResults(jobId, await data.Body.transformToString());
       return;
     }
   } else {


### PR DESCRIPTION
`grader-host` will inline results if they are less than 256kB (an SQS limit), but if they're larger, it writes them to S3 and expects PL to read them back for processing. This explains why jobs generally work: most results are smaller than 256kB.

In the case of Norm from UBC who reported this issue, I looked at the size of his `results.json` files and they precisely straddle the line of 256kB. That, combined with the fact that his tests are non-deterministic, explains why the same student code would sometimes get a zero.