### PR TITLE
Mark failed external grader jobs as ungradable

### DIFF
--- a/apps/prairielearn/src/lib/assessment.js
+++ b/apps/prairielearn/src/lib/assessment.js
@@ -361,6 +361,7 @@ module.exports = {
           if (!_(content.grading).isObject()) {
             return callback(error.makeWithData('invalid grading', { content: content }));
           }
+
           if (_(content.grading).has('feedback') && !_(content.grading.feedback).isObject()) {
             return callback(
               error.makeWithData('invalid grading.feedback', {
@@ -369,11 +370,25 @@ module.exports = {
             );
           }
 
-          const succeeded = !!_.get(content, 'grading.feedback.results.succeeded', true);
-          let gradable = !!_.get(content, 'grading.feedback.results.gradable', true);
+          // There are two "succeeded" flags in the grading results. The first
+          // is at the top level and is set by `grader-host`; the second is in
+          // `results` and is set by course code.
+          //
+          // If the top-level flag is false, that means there was a serious
+          // error in the grading process and we should treat the submission
+          // as not gradable. This avoids penalizing students for issues outside
+          // their control.
+          const jobSucceeded = !!content.grading?.feedback?.succeeded;
+
+          const succeeded = !!(content.grading.feedback?.results?.succeeded ?? true);
           if (!succeeded) {
             content.grading.score = 0;
           }
+
+          // The submission is only gradable if the job as a whole succeeded
+          // and the course code marked it as gradable. We default to true for
+          // backwards compatibility with graders that don't set this flag.
+          let gradable = jobSucceeded && !!(content.grading.feedback?.results?.gradable ?? true);
 
           if (gradable) {
             // We only care about the score if it is gradable.

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -225,6 +225,10 @@ module.exports.makeGradingResult = function (jobId, rawData) {
   }
   data = replaceNull(data);
 
+  if (typeof data.succeeded !== 'boolean') {
+    return makeGradingFailureWithMessage(jobId, data, "results did not contain 'succeeded' field.");
+  }
+
   if (!data.succeeded) {
     return {
       gradingId: jobId,
@@ -240,11 +244,7 @@ module.exports.makeGradingResult = function (jobId, rawData) {
   }
 
   if (!data.results) {
-    return makeGradingFailureWithMessage(
-      jobId,
-      data,
-      "results.json did not contain 'results' object.",
-    );
+    return makeGradingFailureWithMessage(jobId, data, "results did not contain 'results' object.");
   }
 
   let score = 0.0;

--- a/apps/prairielearn/src/lib/externalGraderCommon.test.ts
+++ b/apps/prairielearn/src/lib/externalGraderCommon.test.ts
@@ -1,0 +1,19 @@
+import { assert } from 'chai';
+
+import { makeGradingResult } from './externalGraderCommon';
+
+describe('externalGraderCommon', () => {
+  describe('makeGradingResult', () => {
+    it('marks as not succeeded if succeeded field is missing', () => {
+      const result = makeGradingResult(1, {});
+
+      assert.isFalse(result.grading.feedback.succeeded);
+    });
+
+    it('marks as not succeeded if results object is missing', () => {
+      const result = makeGradingResult(1, { succeeded: true });
+
+      assert.isFalse(result.grading.feedback.succeeded);
+    });
+  });
+});


### PR DESCRIPTION
As discussed on #8521. If there was a serious error during external grading, we now mark the entire submission as ungradable. This avoids penalizing students for issues outside their control.