### PR TITLE
Admin: list feature enable in config file as a grant

### DIFF
--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -135,7 +135,7 @@ export function AdministratorFeature({
                     ${featureGrants.map((featureGrant) => {
                       return FeatureGrant({
                         featureGrant,
-                        extraClass: featureInConfig != null ? 'text-muted' : '',
+                        overridden: featureInConfig != null,
                       });
                     })}
                   </div>
@@ -205,13 +205,15 @@ function FeatureGrantBreadcrumbs({ featureGrant }: { featureGrant: FeatureGrantR
 
 function FeatureGrant({
   featureGrant,
-  extraClass,
+  overridden,
 }: {
   featureGrant: FeatureGrantRow;
-  extraClass: string;
+  overridden: boolean;
 }) {
   return html`
-    <div class="list-group-item d-flex flex-row align-items-center ${extraClass}">
+    <div
+      class="list-group-item d-flex flex-row align-items-center ${overridden ? 'text-muted' : ''}"
+    >
       <div>${FeatureGrantBreadcrumbs({ featureGrant })}</div>
     </div>
   `;

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -78,7 +78,7 @@ export function AdministratorFeature({
   feature: string;
   institutions: Institution[];
   featureGrants: FeatureGrantRow[];
-  featureInConfig: boolean;
+  featureInConfig: boolean | null;
   resLocals: Record<string, any>;
 }) {
   return html`
@@ -116,11 +116,11 @@ export function AdministratorFeature({
                 Grant feature
               </button>
             </div>
-            ${featureInConfig
+            ${featureInConfig != null
               ? html`
                   <div class="card-body text-center">
                     <i class="fas fa-check text-success"></i>
-                    Feature enabled in configuration file
+                    Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
                   </div>
                 `
               : featureGrants.length > 0

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -119,7 +119,11 @@ export function AdministratorFeature({
             ${featureInConfig != null
               ? html`
                   <div class="card-body text-center">
-                    <i class="fas fa-check text-success"></i>
+                    <i
+                      class="fas ${featureInConfig
+                        ? 'fa-check text-success'
+                        : 'fa-times text-danger'}"
+                    ></i>
                     Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
                   </div>
                 `

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -71,12 +71,14 @@ export function AdministratorFeatures({
 export function AdministratorFeature({
   feature,
   featureGrants,
+  featureInConfig,
   institutions,
   resLocals,
 }: {
   feature: string;
   institutions: Institution[];
   featureGrants: FeatureGrantRow[];
+  featureInConfig: boolean;
   resLocals: Record<string, any>;
 }) {
   return html`
@@ -114,7 +116,14 @@ export function AdministratorFeature({
                 Grant feature
               </button>
             </div>
-            ${featureGrants.length > 0
+            ${featureInConfig
+              ? html`
+                  <div class="card-body text-center">
+                    <i class="fas fa-check text-success"></i>
+                    Feature enabled in configuration file
+                  </div>
+                `
+              : featureGrants.length > 0
               ? html`
                   <div class="list-group list-group-flush">
                     ${featureGrants.map((featureGrant) => {

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -120,7 +120,7 @@ export function AdministratorFeature({
               ? html`
                   <div class="card-body text-center">
                     <i
-                      class="fas ${featureInConfig
+                      class="fa-solid mr-1 ${featureInConfig
                         ? 'fa-check text-success'
                         : 'fa-times text-danger'}"
                     ></i>

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -135,7 +135,7 @@ export function AdministratorFeature({
                   <div
                     class="list-group list-group-flush ${featureInConfig == null
                       ? ''
-                      : 'text-muted'}"
+                      : 'border-top-0 text-muted'}"
                   >
                     ${featureGrants.map((featureGrant) => {
                       return FeatureGrant({ featureGrant });

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -118,28 +118,37 @@ export function AdministratorFeature({
             </div>
             ${featureInConfig != null
               ? html`
-                  <div class="card-body text-center">
-                    <i
-                      class="fa-solid mr-1 ${featureInConfig
-                        ? 'fa-check text-success'
-                        : 'fa-times text-danger'}"
-                    ></i>
-                    Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
+                  <div class="list-group list-group-flush">
+                    <div class="list-group-item">
+                      <i
+                        class="fa-solid mr-1 ${featureInConfig
+                          ? 'fa-check text-success'
+                          : 'fa-times text-danger'}"
+                      ></i>
+                      Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
+                    </div>
                   </div>
                 `
-              : featureGrants.length > 0
+              : ''}
+            ${featureGrants.length > 0
               ? html`
-                  <div class="list-group list-group-flush">
+                  <div
+                    class="list-group list-group-flush ${featureInConfig == null
+                      ? ''
+                      : 'text-muted'}"
+                  >
                     ${featureGrants.map((featureGrant) => {
                       return FeatureGrant({ featureGrant });
                     })}
                   </div>
                 `
-              : html`
+              : featureInConfig == null
+              ? html`
                   <div class="card-body text-center text-secondary">
                     There are no grants for this feature
                   </div>
-                `}
+                `
+              : ''}
           </div>
         </main>
       </body>

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -116,39 +116,35 @@ export function AdministratorFeature({
                 Grant feature
               </button>
             </div>
-            ${featureInConfig != null
+            ${featureGrants.length > 0 || featureInConfig != null
               ? html`
                   <div class="list-group list-group-flush">
-                    <div class="list-group-item">
-                      <i
-                        class="fa-solid mr-1 ${featureInConfig
-                          ? 'fa-check text-success'
-                          : 'fa-times text-danger'}"
-                      ></i>
-                      Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
-                    </div>
-                  </div>
-                `
-              : ''}
-            ${featureGrants.length > 0
-              ? html`
-                  <div
-                    class="list-group list-group-flush ${featureInConfig == null
-                      ? ''
-                      : 'border-top-0 text-muted'}"
-                  >
+                    ${featureInConfig != null
+                      ? html`
+                          <div class="list-group-item">
+                            <i
+                              class="fa-solid mr-1 ${featureInConfig
+                                ? 'fa-check text-success'
+                                : 'fa-times text-danger'}"
+                            ></i>
+                            Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration
+                            file
+                          </div>
+                        `
+                      : ''}
                     ${featureGrants.map((featureGrant) => {
-                      return FeatureGrant({ featureGrant });
+                      return FeatureGrant({
+                        featureGrant,
+                        extraClass: featureInConfig != null ? 'text-muted' : '',
+                      });
                     })}
                   </div>
                 `
-              : featureInConfig == null
-              ? html`
+              : html`
                   <div class="card-body text-center text-secondary">
                     There are no grants for this feature
                   </div>
-                `
-              : ''}
+                `}
           </div>
         </main>
       </body>
@@ -207,9 +203,15 @@ function FeatureGrantBreadcrumbs({ featureGrant }: { featureGrant: FeatureGrantR
   `;
 }
 
-function FeatureGrant({ featureGrant }: { featureGrant: FeatureGrantRow }) {
+function FeatureGrant({
+  featureGrant,
+  extraClass,
+}: {
+  featureGrant: FeatureGrantRow;
+  extraClass: string;
+}) {
   return html`
-    <div class="list-group-item d-flex flex-row align-items-center">
+    <div class="list-group-item d-flex flex-row align-items-center ${extraClass}">
       <div>${FeatureGrantBreadcrumbs({ featureGrant })}</div>
     </div>
   `;

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -58,7 +58,7 @@ router.get(
         feature: req.params.feature,
         featureGrants,
         institutions,
-        featureInConfig: req.params.feature in config.features,
+        featureInConfig: config.features[req.params.feature] ?? null,
         resLocals: res.locals,
       }),
     );

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -5,6 +5,7 @@ import error = require('@prairielearn/error');
 import { z } from 'zod';
 
 import { FeatureName, features } from '../../lib/features';
+import { config } from '../../lib/config';
 import {
   AdministratorFeatures,
   AdministratorFeature,
@@ -57,6 +58,7 @@ router.get(
         feature: req.params.feature,
         featureGrants,
         institutions,
+        featureInConfig: req.params.feature in config.features,
         resLocals: res.locals,
       }),
     );


### PR DESCRIPTION
The admin page for features currently only lists features granted through the database, but features can also be enabled/disabled through the config file. This change indicates that if a feature is set in the config file in that page, overriding any grants provided through that UI.

There are other means to enable features, like overrides, but those (as far as I can tell) are transient and do not affect the general state of the feature availability.