### PR TITLE
fix: Questions table retrieval of assessments for a course instance

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -103,7 +103,7 @@ onDocumentReady(() => {
   let assessmentsByCourseInstanceFormatter = function (ci_id, question) {
     var ci_assessments = _.filter(
       question.assessments ?? [],
-      (assessment) => assessment.course_instance_id === ci_id,
+      (assessment) => assessment.course_instance_id.toString() === ci_id.toString(),
     );
     return _.map(ci_assessments, (assessment) =>
       html`<a

--- a/apps/prairielearn/src/models/questions.ts
+++ b/apps/prairielearn/src/models/questions.ts
@@ -7,6 +7,7 @@ import {
   AssessmentsFormatForQuestionSchema,
 } from '../lib/db-types';
 import { z } from 'zod';
+import { idsEqual } from '../lib/id';
 
 const QuestionsPageDataSchema = z.object({
   id: z.string(),
@@ -44,14 +45,14 @@ export async function selectQuestionsForCourse(
     QuestionsPageDataSchema,
   );
 
-  const ci_ids = course_instances.map((ci) => ci.id);
   const questions = rows.map((row) => ({
     ...row,
     sync_errors_ansified: row.sync_errors && ansiUp.ansi_to_html(row.sync_errors),
     sync_warnings_ansified: row.sync_warnings && ansiUp.ansi_to_html(row.sync_warnings),
-    assessments: row.assessments
-      ? row.assessments.filter((assessment) => ci_ids.includes(assessment.course_instance_id))
-      : null,
+    assessments:
+      row.assessments?.filter((assessment) =>
+        course_instances.some((ci) => idsEqual(ci.id, assessment.course_instance_id)),
+      ) ?? null,
   }));
   return questions;
 }


### PR DESCRIPTION
Two similar issues related to the assessments column:
* Only assessments in course instances that the instructor has access to are listed. The ID comparison here was using `includes`, which expects equality, but the course instance ID was an int, while the course instance of the assessment was a string;
* Each column only lists the assessments associated to a particular course instance ID. Again, the types don't match.