### PR TITLE
Dual-write authentication data to both cookie and session

### DIFF
--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -65,13 +65,11 @@ module.exports.loadUser = async (req, res, authnParams, optionsParams = {}) => {
     throw new Error('user not found with user_id ' + user_id);
   }
 
-  if (req.session) {
-    // The session store will pick this up and store it in the `user_sessions.user_id` column.
-    req.session.user_id = user_id;
+  // The session store will pick this up and store it in the `user_sessions.user_id` column.
+  req.session.user_id = user_id;
 
-    // Our authentication middleware will read this value.
-    req.session.authn_provider_name = authnParams.provider;
-  }
+  // Our authentication middleware will read this value.
+  req.session.authn_provider_name = authnParams.provider;
 
   if (options.pl_authn_cookie) {
     var tokenData = {

--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -65,9 +65,12 @@ module.exports.loadUser = async (req, res, authnParams, optionsParams = {}) => {
     throw new Error('user not found with user_id ' + user_id);
   }
 
-  // The session store will pick this up and store it in the `user_sessions.user_id` column.
   if (req.session) {
+    // The session store will pick this up and store it in the `user_sessions.user_id` column.
     req.session.user_id = user_id;
+
+    // Our authentication middleware will read this value.
+    req.session.authn_provider_name = authnParams.provider;
   }
 
   if (options.pl_authn_cookie) {

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -135,6 +135,11 @@ router.post('/', function (req, res, next) {
           secure: shouldSecureCookie(req),
         });
 
+        // Dual-write information to the session so that we can start reading
+        // it instead of the cookie in the future.
+        req.session.user_id = result.rows[0].user_id;
+        req.session.authn_provider_name = 'LTI';
+
         const params = {
           course_instance_id: ltiresult.course_instance_id,
           context_id: parameters.context_id,


### PR DESCRIPTION
This lays the groundwork for deprecating the `pl_authn` cookie in favor of storing all relevant information in the session. With this PR, we'll start writing the `user_id` and `authn_provider_name` into the session. We also start using those values instead of the cookie whenever possible.

Once this has been deployed for a while, we should be able to stop reading the `pl_authn` cookie entirely.