### PR TITLE
Enable filtering by sharing set on questions page

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -19,7 +19,9 @@ onDocumentReady(() => {
 
   window.sharingSetsList = function () {
     var data = $('#questionsTable').bootstrapTable('getData');
-    return _.keyBy(_.map(_.flatten(_.filter(_.map(data, (row) => row.sharing_sets))), (row) => row.name));
+    return _.keyBy(
+      _.map(_.flatten(_.filter(_.map(data, (row) => row.sharing_sets))), (row) => row.name),
+    );
   };
 
   window.versionList = function () {

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -75,6 +75,12 @@ onDocumentReady(() => {
     ).join(' ');
   };
 
+  window.sharingSetFormatter = function (sharing_sets, question) {
+    return _.map(question.sharing_sets ?? [], (sharing_set) =>
+      html`<span class="badge color-gray1">${sharing_set.name}</span>`.toString(),
+    ).join(' ');
+  };
+
   window.versionFormatter = function (version, question) {
     return html`<span class="badge color-${question.display_type === 'v3' ? 'green1' : 'red1'}"
       >${question.display_type}</span

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -17,6 +17,11 @@ onDocumentReady(() => {
     return _.keyBy(_.map(_.flatten(_.filter(_.map(data, (row) => row.tags))), (row) => row.name));
   };
 
+  window.sharingSetsList = function () {
+    var data = $('#questionsTable').bootstrapTable('getData');
+    return _.keyBy(_.map(_.flatten(_.filter(_.map(data, (row) => row.sharing_sets))), (row) => row.name));
+  };
+
   window.versionList = function () {
     var data = $('#questionsTable').bootstrapTable('getData');
     return _.keyBy(_.map(data, (row) => row.display_type));

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -130,6 +130,20 @@ export function QuestionsTable({
               Tags
             </th>
             <th
+              data-field="sharing_sets"
+              data-sortable="false"
+              data-class="align-middle text-nowrap"
+              data-formatter="tagsFormatter"
+              data-filter-control="select"
+              data-filter-control-placeholder="(All Sharing Sets)"
+              data-filter-data="func:sharingSetsList"
+              data-filter-custom-search="badgeFilterSearch"
+              data-switchable="true"
+              data-visible="false"
+            >
+              Sharing Sets
+            </th>
+            <th
               data-field="display_type"
               data-sortable="true"
               data-class="align-middle text-nowrap"

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -24,7 +24,7 @@ export function QuestionsTableHead() {
 export function QuestionsTable({
   questions,
   showAddQuestionButton,
-  questionSharingEnabled,
+  showSharingSets,
   current_course_instance,
   course_instances,
   urlPrefix,
@@ -33,7 +33,7 @@ export function QuestionsTable({
 }: {
   questions: QuestionsPageDataAnsified[];
   showAddQuestionButton: boolean;
-  questionSharingEnabled: boolean;
+  showSharingSets: boolean;
   current_course_instance: CourseInstance;
   course_instances: CourseInstance[];
   urlPrefix: string;
@@ -131,7 +131,7 @@ export function QuestionsTable({
             >
               Tags
             </th>
-            ${questionSharingEnabled
+            ${showSharingSets
               ? html` <th
                   data-field="sharing_sets"
                   data-sortable="false"

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -24,6 +24,7 @@ export function QuestionsTableHead() {
 export function QuestionsTable({
   questions,
   showAddQuestionButton,
+  questionSharingEnabled,
   current_course_instance,
   course_instances,
   urlPrefix,
@@ -32,6 +33,7 @@ export function QuestionsTable({
 }: {
   questions: QuestionsPageDataAnsified[];
   showAddQuestionButton: boolean;
+  questionSharingEnabled: boolean;
   current_course_instance: CourseInstance;
   course_instances: CourseInstance[];
   urlPrefix: string;
@@ -129,20 +131,22 @@ export function QuestionsTable({
             >
               Tags
             </th>
-            <th
-              data-field="sharing_sets"
-              data-sortable="false"
-              data-class="align-middle text-nowrap"
-              data-formatter="tagsFormatter"
-              data-filter-control="select"
-              data-filter-control-placeholder="(All Sharing Sets)"
-              data-filter-data="func:sharingSetsList"
-              data-filter-custom-search="badgeFilterSearch"
-              data-switchable="true"
-              data-visible="false"
-            >
-              Sharing Sets
-            </th>
+            ${questionSharingEnabled
+              ? html` <th
+                  data-field="sharing_sets"
+                  data-sortable="false"
+                  data-class="align-middle text-nowrap"
+                  data-formatter="sharingSetFormatter"
+                  data-filter-control="select"
+                  data-filter-control-placeholder="(All Sharing Sets)"
+                  data-filter-data="func:sharingSetsList"
+                  data-filter-custom-search="badgeFilterSearch"
+                  data-switchable="true"
+                  data-visible="false"
+                >
+                  Sharing Sets
+                </th>`
+              : ''}
             <th
               data-field="display_type"
               data-sortable="true"

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -289,6 +289,13 @@ export const TopicSchema = z.object({
 });
 export type Topic = z.infer<typeof TopicSchema>;
 
+export const SharingSetSchema = z.object({
+  course_id: IdSchema,
+  id: IdSchema,
+  name: z.string().nullable(),
+});
+export type SharingSet = z.infer<typeof SharingSetSchema>;
+
 export const UserSessionSchema = z.object({
   id: IdSchema,
   session_id: z.string(),

--- a/apps/prairielearn/src/models/questions.sql
+++ b/apps/prairielearn/src/models/questions.sql
@@ -36,7 +36,15 @@ SELECT
     WHERE
       qt.question_id = q.id
   ) AS tags,
-  assessments_format_for_question (q.id, NULL) AS assessments
+  (
+    SELECT
+      jsonb_agg(to_jsonb(ss))
+    FROM
+      sharing_sets_questions AS ssq
+      JOIN sharing_sets AS ss on (ss.id = ssq.sharing_set_id)
+    WHERE
+      ssq.question_id = q.id
+  ) AS sharing_sets assessments_format_for_question (q.id, NULL) AS assessments
 FROM
   questions AS q
   JOIN topics AS top ON (top.id = q.topic_id)

--- a/apps/prairielearn/src/models/questions.sql
+++ b/apps/prairielearn/src/models/questions.sql
@@ -40,11 +40,12 @@ SELECT
     SELECT
       jsonb_agg(to_jsonb(ss))
     FROM
-      sharing_sets_questions AS ssq
+      sharing_set_questions AS ssq
       JOIN sharing_sets AS ss on (ss.id = ssq.sharing_set_id)
     WHERE
       ssq.question_id = q.id
-  ) AS sharing_sets assessments_format_for_question (q.id, NULL) AS assessments
+  ) AS sharing_sets,
+  assessments_format_for_question (q.id, NULL) AS assessments
 FROM
   questions AS q
   JOIN topics AS top ON (top.id = q.topic_id)

--- a/apps/prairielearn/src/models/questions.ts
+++ b/apps/prairielearn/src/models/questions.ts
@@ -3,8 +3,9 @@ import AnsiUp from 'ansi_up';
 import {
   CourseInstance,
   TopicSchema,
-  TagSchema,
+  SharingSetSchema,
   AssessmentsFormatForQuestionSchema,
+  TagSchema,
 } from '../lib/db-types';
 import { z } from 'zod';
 import { idsEqual } from '../lib/id';
@@ -21,6 +22,7 @@ const QuestionsPageDataSchema = z.object({
   open_issue_count: z.string(),
   topic: TopicSchema,
   tags: z.array(TagSchema).nullable(),
+  sharing_sets: z.array(SharingSetSchema).nullable(),
   assessments: AssessmentsFormatForQuestionSchema.nullable(),
 });
 type QuestionsPageData = z.infer<typeof QuestionsPageDataSchema>;

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.html.ts
@@ -31,6 +31,7 @@ export const QuestionsPage = ({
           ${QuestionsTable({
             questions,
             showAddQuestionButton,
+            showSharingSets: resLocals.question_sharing_enabled,
             current_course_instance: resLocals.course_instance,
             course_instances: resLocals.authz_data.course_instances,
             urlPrefix: resLocals.urlPrefix,


### PR DESCRIPTION
Currently there is no way to view which questions are in a given sharing set. 

This fixes that by enabling filtering by sharing set on the instructor questions page.

