### PR TITLE
Add socket-io-long-polling-only feature flag

### DIFF
--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -44,7 +44,10 @@ function externalGradingLiveUpdate() {
   if (!gradingPending) return;
 
   // By this point, it's safe to open a socket
-  const socket = io('/external-grading');
+  const longPollingOnly = document.querySelector('meta[name=socket-io-long-polling-only]') != null;
+  const socket = io('/external-grading', {
+    transports: longPollingOnly ? ['polling'] : ['polling', 'websocket'],
+  });
 
   socket.emit('init', { variant_id: variantId, variant_token: variantToken }, function (msg) {
     handleStatusChange(socket, msg);

--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -29,7 +29,11 @@ $(function () {
     30 * 60,
   );
 
-  const socket = io('/workspace');
+  const longPollingOnly = document.querySelector('meta[name=socket-io-long-polling-only]') != null;
+  const socket = io('/workspace', {
+    transports: longPollingOnly ? ['polling'] : ['polling', 'websocket'],
+  });
+
   const loadingFrame = document.getElementById('loading') as HTMLDivElement;
   const stoppedFrame = document.getElementById('stopped') as HTMLDivElement;
   const workspaceFrame = document.getElementById('workspace') as HTMLIFrameElement;

--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -8,6 +8,8 @@ const featureNames = [
   // Can only be applied to courses/institutions.
   'process-questions-in-worker',
   'question-sharing',
+  // Can only be applied globally.
+  'socket-io-long-polling-only',
 ] as const;
 
 const features = new FeatureManager(featureNames);

--- a/apps/prairielearn/src/middlewares/socketIoLongPolling.ts
+++ b/apps/prairielearn/src/middlewares/socketIoLongPolling.ts
@@ -1,0 +1,20 @@
+import asyncHandler = require('express-async-handler');
+import { features } from '../lib/features';
+
+const REFRESH_INTERVAL_MS = 10_000;
+
+let enabled = false;
+let lastRefreshTime: number | null = null;
+
+export default asyncHandler(async (req, res, next) => {
+  // We'll cache the result of this check for a short period to avoid having
+  // to check for it on every single request.
+  if (lastRefreshTime == null || lastRefreshTime + REFRESH_INTERVAL_MS < Date.now()) {
+    enabled = await features.enabled('socket-io-long-polling-only');
+    lastRefreshTime = Date.now();
+  }
+
+  res.locals.socket_io_long_polling_only = enabled;
+
+  next();
+});

--- a/apps/prairielearn/src/pages/partials/head.ejs
+++ b/apps/prairielearn/src/pages/partials/head.ejs
@@ -10,3 +10,6 @@
 <script src="<%= node_modules_asset_path('bootstrap/dist/js/bootstrap.bundle.min.js') %>"></script>
 <script src="<%= node_modules_asset_path('@fortawesome/fontawesome-free/js/all.min.js') %>"></script>
 <script src="<%= node_modules_asset_path('js-cookie/dist/js.cookie.min.js') %>"></script>
+<% if (typeof socket_io_long_polling_only !== 'undefined' && socket_io_long_polling_only) { %>
+<meta name="socket-io-long-polling-only" content="true">
+<% } %>

--- a/apps/prairielearn/src/pages/partials/jobSequenceResults.ejs
+++ b/apps/prairielearn/src/pages/partials/jobSequenceResults.ejs
@@ -21,7 +21,10 @@
 <% if (job_sequence_enable_live_update) { %>
 <script>
     $(function() {
-        var socket = io();
+        const longPollingOnly = document.querySelector('meta[name=socket-io-long-polling-only]') != null;
+        var socket = io({
+            transports: longPollingOnly ? ['polling'] : ['polling', 'websocket'],
+        });
 
         socket.on('update', function() {
             window.location.reload(true);

--- a/apps/prairielearn/src/pages/shared/syncHelpers.js
+++ b/apps/prairielearn/src/pages/shared/syncHelpers.js
@@ -72,7 +72,6 @@ module.exports.pullAndUpdate = async function (locals) {
           });
 
           job.info('Fetch from remote git repository');
-          console.log(locals.course);
           await job.exec('git', ['fetch'], { cwd: locals.course.path, env: gitEnv });
 
           job.info('Clean local files not in remote git repository');

--- a/apps/prairielearn/src/pages/shared/syncHelpers.js
+++ b/apps/prairielearn/src/pages/shared/syncHelpers.js
@@ -72,6 +72,7 @@ module.exports.pullAndUpdate = async function (locals) {
           });
 
           job.info('Fetch from remote git repository');
+          console.log(locals.course);
           await job.exec('git', ['fetch'], { cwd: locals.course.path, env: gitEnv });
 
           job.info('Clean local files not in remote git repository');

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -483,6 +483,10 @@ module.exports.initExpress = function () {
   app.use('/pl/oauth2callback', require('./pages/authCallbackOAuth2/authCallbackOAuth2'));
   app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
 
+  // Reads the `socket-io-long-polling-only` feature flag and sets
+  // `res.locals.socket_io_long_polling_only` based on it.
+  app.use(require('./middlewares/socketIoLongPolling').default);
+
   if (isEnterprise()) {
     if (config.hasAzure) {
       app.use('/pl/azure_login', require('./ee/auth/azure/login').default);


### PR DESCRIPTION
This allows us to control dynamically at runtime whether `socket.io` will upgrade from long-polling to websockets, or whether it will just use long-polling exclusively.