### PR TITLE
Switch from `node-redis` to `ioredis` for `socket-server`

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -100,6 +100,7 @@
     "htmx.org": "^1.9.6",
     "http-proxy-middleware": "^2.0.6",
     "http-status": "^1.7.0",
+    "ioredis": "^5.3.2",
     "isbinaryfile": "^5.0.0",
     "jju": "^1.4.0",
     "jose": "^4.15.1",

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -14,22 +14,22 @@ const { config } = require('./config');
  */
 function attachEventListeners(client, type) {
   client.on('error', (err) => {
-    logger.error(`redis ${type} client: error`, err);
+    logger.error(`redis client event for ${type}: error`, err);
   });
   client.on('connect', () => {
-    logger.verbose(`redis ${type} client: connect`);
+    logger.verbose(`redis client event for ${type}: connect`);
   });
   client.on('ready', () => {
-    logger.verbose(`redis ${type} client: ready`);
+    logger.verbose(`redis client event for ${type}: ready`);
   });
   client.on('reconnecting', () => {
-    logger.verbose(`redis ${type} client: reconnecting`);
+    logger.verbose(`redis client event for ${type}: reconnecting`);
   });
   client.on('close', () => {
-    logger.verbose(`redis ${type} client: close`);
+    logger.verbose(`redis client event for ${type}: close`);
   });
   client.on('end', () => {
-    logger.verbose(`redis ${type} client: end`);
+    logger.verbose(`redis client event for ${type}: end`);
   });
 }
 

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -14,19 +14,22 @@ const { config } = require('./config');
  */
 function attachEventListeners(client, type) {
   client.on('error', (err) => {
-    logger.error(`redis ${type} client error`, err);
+    logger.error(`redis ${type} client: error`, err);
   });
   client.on('connect', () => {
-    logger.verbose(`redis ${type} client connected`);
+    logger.verbose(`redis ${type} client: connect`);
   });
   client.on('ready', () => {
-    logger.verbose(`redis ${type} client ready`);
+    logger.verbose(`redis ${type} client: ready`);
   });
   client.on('reconnecting', () => {
-    logger.verbose(`redis ${type} client reconnecting`);
+    logger.verbose(`redis ${type} client: reconnecting`);
   });
   client.on('close', () => {
-    logger.verbose(`redis ${type} client closed`);
+    logger.verbose(`redis ${type} client: close`);
+  });
+  client.on('end', () => {
+    logger.verbose(`redis ${type} client: end`);
   });
 }
 

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -1,11 +1,34 @@
 // @ts-check
 const { Server } = require('socket.io');
-const redis = require('redis');
 const { createAdapter } = require('@socket.io/redis-adapter');
+const { Redis } = require('ioredis');
+const { logger } = require('@prairielearn/logger');
 const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
 const { config } = require('./config');
+
+/**
+ * @param {Redis} client
+ * @param {string} type
+ */
+function attachEventListeners(client, type) {
+  client.on('error', (err) => {
+    logger.error(`redis ${type} client error`, err);
+  });
+  client.on('connect', () => {
+    logger.verbose(`redis ${type} client connected`);
+  });
+  client.on('ready', () => {
+    logger.verbose(`redis ${type} client ready`);
+  });
+  client.on('reconnecting', () => {
+    logger.verbose(`redis ${type} client reconnecting`);
+  });
+  client.on('close', () => {
+    logger.verbose(`redis ${type} client closed`);
+  });
+}
 
 module.exports.init = async function (server) {
   debug('init(): creating socket server');
@@ -13,18 +36,20 @@ module.exports.init = async function (server) {
   if (config.redisUrl) {
     // Use redis to mirror broadcasts via all servers
     debug('init(): initializing redis pub/sub clients');
-    module.exports.pub = redis.createClient({ url: config.redisUrl });
-    module.exports.sub = redis.createClient({ url: config.redisUrl });
-    await Promise.all([module.exports.pub.connect(), module.exports.sub.connect()]);
+    module.exports.pub = new Redis(config.redisUrl);
+    module.exports.sub = new Redis(config.redisUrl);
+
+    attachEventListeners(module.exports.pub, 'pub');
+    attachEventListeners(module.exports.sub, 'sub');
+
     debug('init(): initializing redis socket adapter');
     module.exports.io.adapter(createAdapter(module.exports.pub, module.exports.sub));
   }
 };
 
 module.exports.close = async function () {
-  if (config.redisUrl) {
-    await Promise.all([module.exports.pub.quit(), module.exports.sub.quit()]);
-  }
+  await module.exports.pub?.quit();
+  await module.exports.sub?.quit();
 
   // Note that we don't use `io.close()` here, as that actually tries to close
   // the underlying HTTP server. In our desired shutdown sequence, we first

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -31,6 +31,12 @@ function attachEventListeners(client, type) {
   client.on('end', () => {
     logger.verbose(`redis client event for ${type}: end`);
   });
+  client.on('wait', () => {
+    logger.verbose(`redis client event for ${type}: wait`);
+  });
+  client.on('select', () => {
+    logger.verbose(`redis client event for ${type}: select`);
+  });
 }
 
 module.exports.init = async function (server) {

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -22,8 +22,10 @@ function attachEventListeners(client, type) {
   client.on('ready', () => {
     logger.verbose(`redis client event for ${type}: ready`);
   });
-  client.on('reconnecting', () => {
-    logger.verbose(`redis client event for ${type}: reconnecting`);
+  client.on('reconnecting', (reconnectTimeMilliseconds) => {
+    logger.verbose(
+      `redis client event for ${type}: reconnecting in ${reconnectTimeMilliseconds} milliseconds`,
+    );
   });
   client.on('close', () => {
     logger.verbose(`redis client event for ${type}: close`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,6 +1871,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ioredis/commands@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "@ioredis/commands@npm:1.2.0"
+  checksum: 9b20225ba36ef3e5caf69b3c0720597c3016cc9b1e157f519ea388f621dd9037177f84cfe7e25c4c32dad7dd90c70ff9123cd411f747e053cf292193c9c461e2
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -3240,6 +3247,7 @@ __metadata:
     htmx.org: ^1.9.6
     http-proxy-middleware: ^2.0.6
     http-status: ^1.7.0
+    ioredis: ^5.3.2
     isbinaryfile: ^5.0.0
     jju: ^1.4.0
     jose: ^4.15.1
@@ -6714,7 +6722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cluster-key-slot@npm:1.1.2":
+"cluster-key-slot@npm:1.1.2, cluster-key-slot@npm:^1.1.0":
   version: 1.1.2
   resolution: "cluster-key-slot@npm:1.1.2"
   checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
@@ -7751,6 +7759,13 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"denque@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "denque@npm:2.1.0"
+  checksum: 1d4ae1d05e59ac3a3481e7b478293f4b4c813819342273f3d5b826c7ffa9753c520919ba264f377e09108d24ec6cf0ec0ac729a5686cbb8f32d797126c5dae74
   languageName: node
   linkType: hard
 
@@ -10270,6 +10285,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ioredis@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "ioredis@npm:5.3.2"
+  dependencies:
+    "@ioredis/commands": ^1.1.1
+    cluster-key-slot: ^1.1.0
+    debug: ^4.3.4
+    denque: ^2.1.0
+    lodash.defaults: ^4.2.0
+    lodash.isarguments: ^3.1.0
+    redis-errors: ^1.2.0
+    redis-parser: ^3.0.0
+    standard-as-callback: ^2.1.0
+  checksum: 9a23559133e862a768778301efb68ae8c2af3c33562174b54a4c2d6574b976e85c75a4c34857991af733e35c48faf4c356e7daa8fb0a3543d85ff1768c8754bc
+  languageName: node
+  linkType: hard
+
 "ip-regex@npm:^2.1.0":
   version: 2.1.0
   resolution: "ip-regex@npm:2.1.0"
@@ -11421,6 +11453,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.defaults@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.defaults@npm:4.2.0"
+  checksum: 84923258235592c8886e29de5491946ff8c2ae5c82a7ac5cddd2e3cb697e6fbdfbbb6efcca015795c86eec2bb953a5a2ee4016e3735a3f02720428a40efbb8f1
+  languageName: node
+  linkType: hard
+
 "lodash.flattendeep@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.flattendeep@npm:4.4.0"
@@ -11432,6 +11471,13 @@ __metadata:
   version: 4.4.2
   resolution: "lodash.get@npm:4.4.2"
   checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
+  languageName: node
+  linkType: hard
+
+"lodash.isarguments@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "lodash.isarguments@npm:3.1.0"
+  checksum: ae1526f3eb5c61c77944b101b1f655f846ecbedcb9e6b073526eba6890dc0f13f09f72e11ffbf6540b602caee319af9ac363d6cdd6be41f4ee453436f04f13b5
   languageName: node
   linkType: hard
 
@@ -14077,6 +14123,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis-errors@npm:^1.0.0, redis-errors@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "redis-errors@npm:1.2.0"
+  checksum: f28ac2692113f6f9c222670735aa58aeae413464fd58ccf3fce3f700cae7262606300840c802c64f2b53f19f65993da24dc918afc277e9e33ac1ff09edb394f4
+  languageName: node
+  linkType: hard
+
+"redis-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redis-parser@npm:3.0.0"
+  dependencies:
+    redis-errors: ^1.0.0
+  checksum: 89290ae530332f2ae37577647fa18208d10308a1a6ba750b9d9a093e7398f5e5253f19855b64c98757f7129cccce958e4af2573fdc33bad41405f87f1943459a
+  languageName: node
+  linkType: hard
+
 "redis@npm:^4.6.10":
   version: 4.6.10
   resolution: "redis@npm:4.6.10"
@@ -15109,6 +15171,13 @@ __metadata:
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
+  languageName: node
+  linkType: hard
+
+"standard-as-callback@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "standard-as-callback@npm:2.1.0"
+  checksum: 88bec83ee220687c72d94fd86a98d5272c91d37ec64b66d830dbc0d79b62bfa6e47f53b71646011835fc9ce7fae62739545d13124262b53be4fbb3e2ebad551c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR replaces #8628 by building on plain `master` rather than the forked copy of `socket.io-redis-adapter`.

We are switching to `ioredis` because `node-redis` does not reestablish subscriptions on reconnects. This is crucial for use with `socket.io/redis-adapter` because the adapter doesn't have any logic to do this itself. With `node-redis`, if we lose the Redis connection then `node-redis` will correctly reestablish it, but we won't be subscribed to notifications for the pub/sub channels and so the sub part of pub/sub will never receive any more events. In contrast, `ioredis` explicitly supports [resubscribing on reconnect](https://github.com/redis/ioredis#auto-reconnect):
> When reconnected, the client will auto subscribe to channels that the previous connection subscribed to.

I tested this locally by killing/restarting Redis and checking that we did reconnect and websockets were working correctly after the reconnect.

At some point in the future we should fully switch to `ioredis` to avoid having two Redis client libraries. In particular we'll need to switch:
* The Redis client in `apps/prairielearn/lib/cache.js`
* The Redis client in `apps/workspace-host/interface.js`