### PR TITLE
Add personal notes to manual grading page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ejs
@@ -93,7 +93,7 @@
             </div>
           </div>
 
-          <% if (config.attachedFilesDialogEnabled) { %>
+          <% if (file_list.length > 0) { %>
             <%- include('../../partials/attachFilePanel', {question_context: 'manual_grading'}) %>
           <% } %>
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ejs
@@ -93,6 +93,10 @@
             </div>
           </div>
 
+          <% if (config.attachedFilesDialogEnabled) { %>
+            <%- include('../../partials/attachFilePanel', {question_context: 'manual_grading'}) %>
+          <% } %>
+
           <%- include('../../partials/instructorInfoPanel', {question_context: 'manual_grading'}); %>
         </div>
       </div>

--- a/apps/prairielearn/src/pages/partials/attachFilePanel.ejs
+++ b/apps/prairielearn/src/pages/partials/attachFilePanel.ejs
@@ -38,6 +38,7 @@
     </tbody>
   </table>
 
+  <% if (locals.question_context !== 'manual_grading') { %>
   <div class="card-footer">
     <% if (!assessment_instance.open || !authz_result.active) { %>
     <p class="small mb-0">
@@ -116,4 +117,5 @@
     <!-- END OF FILES -->
     <% } %>
   </div>
+  <% } %>
 </div>

--- a/apps/prairielearn/src/pages/partials/attachFilePanel.ejs
+++ b/apps/prairielearn/src/pages/partials/attachFilePanel.ejs
@@ -11,7 +11,7 @@
       <% file_list.forEach(function(file, iFile) { %>
       <tr>
         <td style="word-break:break-all;">
-          <a class="attached-file" href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>/file/<%= file.id %>/<%= file.display_filename %>">
+          <a class="attached-file" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/assessment_instance/<%= assessment_instance.id %>/file/<%= file.id %>/<%= file.display_filename %>">
             <%= file.display_filename %>
           </a>
         </td>


### PR DESCRIPTION
Resolves #7577 . This can be useful in cases where:
* students want to leave a note to instructors that cannot be saved in existing elements;
* students may include an explanation on how they reached the value;
* students with no attempts left can explain their rationale for manual review.