### PR TITLE
add: bash-completion to docker shells

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -9,6 +9,7 @@ dnf update -y
 # - `procps-ng` is needed for the `pkill` executable, which is used by `zygote.py`
 # - `texlive` and `texlive-dvipng` are needed for matplotlib LaTeX labels
 dnf -y install \
+    bash-completion \
     gcc \
     gcc-c++ \
     git \


### PR DESCRIPTION
How do we feel about adding developer niceties into the containers? Can we spare 292k (1.0M installed) for tab completing make commands?

Or are we trying to keep things super slim and I should just run it locally?