### PR TITLE
Honor show-correct-answers option in number input feedback

### DIFF
--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -458,7 +458,9 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
         else:
             assert_never(comparison)
 
-        if is_correct:
+        if is_correct and pl.get_boolean_attrib(
+            element, "show-correct-answer", SHOW_CORRECT_ANSWER_DEFAULT
+        ):
             feedback += f"The correct answer used for grading was {a_tru_converted}"
         return (is_correct, feedback)
 


### PR DESCRIPTION
Resolves issue brought up on Slack. The `show-correct-answers` option is not considered when showing feedback on the submission panel. See: https://us.prairielearn.com/pl/course_instance/4970/instructor/question/8211637/preview/?variant_id=81286593