### PR TITLE
Remove unused json-load functions

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -215,7 +215,6 @@
     "mocha": "^10.2.0",
     "mocha-steps": "^1.3.0",
     "request": "^2.88.2",
-    "sinon": "^15.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
     "typescript-cp": "^0.1.9"

--- a/apps/prairielearn/src/lib/json-load.js
+++ b/apps/prairielearn/src/lib/json-load.js
@@ -2,11 +2,8 @@
 const ERR = require('async-stacktrace');
 const util = require('util');
 const fs = require('fs');
-const _ = require('lodash');
 const jju = require('jju');
 const Ajv = require('ajv').default;
-
-const { logger } = require('@prairielearn/logger');
 
 // We use a single global instance so that schemas aren't recompiled every time they're used
 const ajv = new Ajv();
@@ -77,55 +74,6 @@ module.exports.validateJSON = function (json, schema, callback) {
 module.exports.validateJSONAsync = util.promisify(module.exports.validateJSON);
 
 /**
- * Synchronously reads the specified JSON file and validates it against a
- * schema. If there are any failures, it exits the process with a non-zero
- * exit code.
- *
- * @param {string} jsonFilename The name of the file to read
- * @param {object} schema The schema used to validate the JSON file
- */
-module.exports.readJSONSyncOrDie = function (jsonFilename, schema) {
-  try {
-    var data = fs.readFileSync(jsonFilename, { encoding: 'utf8' });
-  } catch (e) {
-    logger.error(`Error reading JSON file: ${jsonFilename}`, e);
-    process.exit(1);
-    return;
-  }
-  try {
-    var json = jju.parse(data, { mode: 'json' });
-  } catch (e) {
-    logger.error(
-      `Error in JSON file format: ${jsonFilename} (line ${e.row}, column ${e.column})\n${e.name}: ${e.message}`,
-    );
-    process.exit(1);
-    return;
-  }
-  if (schema) {
-    try {
-      const validate = ajv.compile(schema);
-      const valid = validate(json);
-      if (!valid) {
-        logger.error(
-          `JSON validation error: ${ajv.errorsText(
-            validate.errors,
-          )}\nError details:\n${JSON.stringify(validate.errors, null, 2)}`,
-        );
-        process.exit(1);
-        return;
-      } else {
-        return json;
-      }
-    } catch (e) {
-      logger.error('Error validating JSON', e);
-      process.exit(1);
-      return;
-    }
-  }
-  return json;
-};
-
-/**
  * Reads and validates some type of `info.json` file.
  *
  * @param {string} jsonFilename The name of the file to read
@@ -157,45 +105,3 @@ module.exports.readInfoJSON = function (jsonFilename, schema, callback) {
   });
 };
 module.exports.readInfoJSONAsync = util.promisify(module.exports.readInfoJSON);
-
-/**
- * Validates the `options` property of an object against a particular schema
- * based on the `type` of the object. For example, given an `optionsSchemaPrefix`
- * of `foo`, an object with type `Bar` would attemt to be validated against the
- * `schemas.fooBar` schema.
- *
- * @param {Object} json The object to validate
- * @param {string} jsonFilename The filename of the original JSON file, for context in errors
- * @param {string} optionsSchemaPrefix The prefix of the schema name
- * @param {Object} schemas The set of schemas to select from
- */
-module.exports.validateOptions = function (
-  json,
-  jsonFilename,
-  optionsSchemaPrefix,
-  schemas,
-  callback,
-) {
-  if (optionsSchemaPrefix && _(json).has('type') && _(json).has('options')) {
-    const schema = schemas[optionsSchemaPrefix + json.type];
-    if (!schema) {
-      callback(new Error(`Could not find options schema for type ${json.type}`));
-      return;
-    }
-    module.exports.validateJSON(json.options, schema, function (err) {
-      if (err) {
-        callback(
-          new Error(
-            "Error validating 'options' field from '" + jsonFilename + "' against schema: " + err,
-          ),
-        );
-        return;
-      }
-      if (json.uuid) json.uuid = json.uuid.toLowerCase();
-      callback(null, json);
-    });
-  } else {
-    return callback(null, json);
-  }
-};
-module.exports.validateOptionsAsync = util.promisify(module.exports.validateOptions);

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -16,7 +16,7 @@ const schemas = require('../schemas');
 const { config } = require('../lib/config');
 const { logger } = require('@prairielearn/logger');
 const { withCodeCaller, FunctionMissingError } = require('../lib/code-caller');
-const jsonLoader = require('../lib/json-load');
+const jsonLoad = require('../lib/json-load');
 const cache = require('../lib/cache');
 const courseUtil = require('../lib/courseUtil');
 const markdown = require('../lib/markdown');
@@ -158,7 +158,7 @@ module.exports = {
         throw err;
       }
 
-      await jsonLoader.validateJSONAsync(info, elementSchema);
+      await jsonLoad.validateJSONAsync(info, elementSchema);
       info.name = elementName;
       info.directory = path.join(sourceDir, elementName);
       info.type = elementType;
@@ -260,7 +260,7 @@ module.exports = {
         }
       }
 
-      await jsonLoader.validateJSONAsync(info, schemas.infoElementExtension);
+      await jsonLoad.validateJSONAsync(info, schemas.infoElementExtension);
       info.name = extensionDir;
       info.directory = path.join(runtimeDir, element, extensionDir);
       elements[element][extensionDir] = info;

--- a/apps/prairielearn/src/tests/jsonLoad.test.js
+++ b/apps/prairielearn/src/tests/jsonLoad.test.js
@@ -1,5 +1,4 @@
 const assert = require('chai').assert;
-const sinon = require('sinon');
 const path = require('path');
 const jsonLoad = require('../lib/json-load');
 
@@ -68,27 +67,6 @@ describe('JSON loading', () => {
         assert.isUndefined(json);
         done();
       });
-    });
-  });
-
-  describe('readJSONSyncOrDie', () => {
-    beforeEach(() => {
-      sinon.stub(process, 'exit');
-    });
-
-    afterEach(() => {
-      process.exit.restore();
-    });
-
-    it('reads JSON that matches a schema', () => {
-      const json = jsonLoad.readJSONSyncOrDie(testfile('forSchemaValid.json'), schema);
-      assert.deepEqual(json, { foo: 'bar' });
-      assert.isFalse(process.exit.called);
-    });
-
-    it('exits if JSON does not match scehma', () => {
-      jsonLoad.readJSONSyncOrDie(testfile('forSchemaInvalid.json'), schema);
-      assert.isTrue(process.exit.calledWith(1));
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,7 +3303,6 @@ __metadata:
     search-string: ^3.1.0
     serve-favicon: ^2.5.0
     showdown: ^2.1.0
-    sinon: ^15.2.0
     socket.io: ^4.7.2
     socket.io-adapter: ^2.5.2
     socket.io-client: ^4.7.2


### PR DESCRIPTION
This came out of #8596, where I was looking into why `sinon` was installed. These functions/tests were unused, which allows us to remove the only usage of `sinon` from the `prairielearn` app.