### PR TITLE
Manual grading rubrics: allow instructor to hide items not applied from students

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -504,6 +504,9 @@ function addRubricItemRow() {
   row.querySelector(
     '.js-rubric-item-grader-note',
   ).dataset.inputName = `rubric_item[new${next_id}][grader_note]`;
+  row
+    .querySelectorAll('.js-rubric-item-always-show')
+    .forEach((input) => (input.name = `rubric_item[new${next_id}][always_show_to_students]`));
 
   row.querySelector('.js-rubric-item-points').focus();
 

--- a/apps/prairielearn/src/lib/manualGrading.js
+++ b/apps/prairielearn/src/lib/manualGrading.js
@@ -127,6 +127,7 @@ async function populateManualGradingData(submission) {
  * @param {string} [rubric_items[].explanation] - A longer explanation of the rubric item. Visible to graders and students.
  * @param {string} [rubric_items[].grader_note] - A note associated to the rubric item that is visible to graders only.
  * @param {number} rubric_items[].order - An indicator of the order in which items are to be presented.
+ * @param {boolean} rubric_items[].always_show_to_students - If the rubric item should be shown to students when not applied.
  * @param {boolean} tag_for_manual_grading - If true, tags all currently graded instance questions to be graded again using the new rubric values. If false, existing gradings are recomputed if necessary, but their grading status is retained.
  * @param {number} authn_user_id - The user_id of the logged in user.
  */

--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -207,6 +207,7 @@ SET
     WHEN $number > 10 THEN NULL
     ELSE MOD($number + 1, 10)
   END,
+  always_show_to_students = COALESCE($always_show_to_students, always_show_to_students),
   deleted_at = NULL
 WHERE
   id = $id
@@ -223,7 +224,8 @@ INSERT INTO
     description,
     explanation,
     grader_note,
-    key_binding
+    key_binding,
+    always_show_to_students
   )
 VALUES
   (
@@ -236,7 +238,8 @@ VALUES
     CASE
       WHEN $number > 10 THEN NULL
       ELSE MOD($number + 1, 10)
-    END
+    END,
+    $always_show_to_students
   );
 
 -- BLOCK select_instance_questions_to_update

--- a/apps/prairielearn/src/migrations/20231013150413__rubric_items__always_show_to_students.sql
+++ b/apps/prairielearn/src/migrations/20231013150413__rubric_items__always_show_to_students.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rubric_items
+ADD COLUMN always_show_to_students BOOLEAN NOT NULL DEFAULT TRUE;

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.js
@@ -167,7 +167,9 @@ router.post(
     } else if (req.body.__action === 'modify_rubric_settings') {
       // Parse using qs, which allows deep objects to be created based on parameter names
       // e.g., the key `rubric_item[cur1][points]` converts to `rubric_item: { cur1: { points: ... } ... }`
-      const rubric_items = Object.values(qs.parse(qs.stringify(req.body)).rubric_item || {});
+      const rubric_items = Object.values(qs.parse(qs.stringify(req.body)).rubric_item || {}).map(
+        (item) => ({ ...item, always_show_to_students: item.always_show_to_students === 'true' }),
+      );
       manualGrading
         .updateAssessmentQuestionRubric(
           res.locals.instance_question.assessment_question_id,

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.ejs
@@ -109,6 +109,7 @@
                   <th>Description</th>
                   <th>Detailed explanation (optional)</th>
                   <th>Grader note (optional, not visible to students)</th>
+                  <th>Show to students</th>
                   <th>In use</th>
               </thead>
               <tbody>
@@ -164,6 +165,20 @@
                     </label>
                   </td>
                   <td>
+                    <div class="form-check">
+                      <label class="form-check-label">
+                        <input type="radio" class="form-check-input" required
+                               name="rubric_item[cur<%= item.id %>][always_show_to_students]"
+                               value="true" <%= item.always_show_to_students ? 'checked' : '' %>>Always
+                      </label>
+                      <label class="form-check-label">
+                        <input type="radio" class="form-check-input" required
+                               name="rubric_item[cur<%= item.id %>][always_show_to_students]"
+                               value="false" <%= item.always_show_to_students ? '' : 'checked' %>>If selected
+                      </label>
+                    </div>
+                  </td>
+                  <td>
                     <% if (!item.num_submissions) { %>No
                     <% } else if (item.num_submissions == 1) { %>1 submission
                     <% } else { %><%= item.num_submissions %> submissions
@@ -217,6 +232,18 @@
                       <i class="fas fa-pencil"></i>
                     </button>
                   </label>
+                </td>
+                <td>
+                  <div class="form-check">
+                    <label class="form-check-label">
+                      <input type="radio" class="form-check-input js-rubric-item-always-show" required
+                             value="true" checked>Always
+                    </label>
+                    <label class="form-check-label">
+                      <input type="radio" class="form-check-input js-rubric-item-always-show" required
+                             value="false">If selected
+                    </label>
+                  </div>
                 </td>
                 <td>
                   New

--- a/apps/prairielearn/src/pages/partials/submission.ejs
+++ b/apps/prairielearn/src/pages/partials/submission.ejs
@@ -16,7 +16,9 @@
   <div class="collapse <% if (submission.submission_number == submissionCount) { %>show<% } %>" id="submission-feedback-<%= submission.id %>-body">
     <div class="card-body">
       <% if (submission.rubric_grading) { %>
-      <% (locals.rubric_data?.rubric_items || []).forEach((item) => { %>
+      <% (locals.rubric_data?.rubric_items || [])
+           .filter((item) => item.always_show_to_students || submission.rubric_grading?.rubric_items?.[item.id]?.score)
+           .forEach((item) => { %>
       <div>
         <label class="w-100" data-testid="rubric-item-container-<%= item.id %>">
           <input type="checkbox" disabled <%= submission.rubric_grading?.rubric_items?.[item.id]?.score ? 'checked' : '' %> >

--- a/database/tables/rubric_items.pg
+++ b/database/tables/rubric_items.pg
@@ -1,4 +1,5 @@
 columns
+    always_show_to_students: boolean not null default true
     deleted_at: timestamp with time zone
     description: character varying(100) not null
     explanation: character varying(10000)


### PR DESCRIPTION
Resolves #6777. Allows each rubric item to be set to either always visible to students (the default, current functionality), or only visible when checked. This allows instructors to only show specific items (e.g., penalties) to those students that have received them.