### PR TITLE
Fix workspace launch race condition

### DIFF
--- a/apps/workspace-host/src/interface.sql
+++ b/apps/workspace-host/src/interface.sql
@@ -12,6 +12,15 @@ FROM
 WHERE
   w.id = $workspace_id;
 
+-- BLOCK select_and_lock_workspace
+SELECT
+  *
+FROM
+  workspaces
+WHERE
+  id = $workspace_id
+FOR UPDATE;
+
 -- BLOCK select_workspace_settings
 SELECT
   q.*

--- a/apps/workspace-host/src/interface.sql
+++ b/apps/workspace-host/src/interface.sql
@@ -19,7 +19,7 @@ FROM
   workspaces
 WHERE
   id = $workspace_id
-FOR UPDATE;
+FOR NO KEY UPDATE;
 
 -- BLOCK select_workspace_settings
 SELECT


### PR DESCRIPTION
Closes #8648. See inline description for more details.

Note that in some sense, this is just a bandaid, and results in what is still a subpar UX: the browser will receive launching updates from both launch attempts, which might result in the image pull percentage oscillating rapidly between two values from two different hosts or other weirdness. There are various ways we could fix this. One idea when updating the workspace state message, always do the same `launch_uuid` check to determine if we're still the "current" launch attempt.

I opted not to implement that or anything else in this PR; this will be valuable on its own as it will avoid the "Error proxying workspace request" message that can only be recovered from with another request.

Note: I was unable to test how this behaves during a race, as it's actually a little difficult to force things into a bad state. I did validate that workspaces can still launch, which is what we really care about.