### PR TITLE
Score upload: skip rows without score values to update

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.js
+++ b/apps/prairielearn/src/lib/manualGrading.js
@@ -115,20 +115,20 @@ async function populateManualGradingData(submission) {
 
 /** Updates the rubric settings for an assessment question.
  *
- * @param {number} assessment_question_id - The ID of the assessment question being updated. Assumed to be authenticated.
+ * @param {string} assessment_question_id - The ID of the assessment question being updated. Assumed to be authenticated.
  * @param {boolean} use_rubric - Indicates if a rubric should be used for manual grading.
  * @param {number} starting_points - The points to assign to a question as a start, before rubric items are applied. Typically 0 for positive grading, or the total points for negative grading.
  * @param {number} min_points - The minimum number of points to assign based on a rubric (floor). Computed points from rubric items are never assigned less than this, even if items bring the total to less than this value, unless an adjustment is used.
  * @param {number} max_extra_points - The maximum number of points to assign based on a rubric beyond the question's assigned points (ceiling). Computed points from rubric items over the assigned points are never assigned more than this, even if items bring the total to more than this value, unless an adjustment is used.
  * @param {Object[]} rubric_items - An array of items available for grading.
- * @param {number} [rubric_items[].id] - The ID of the rubric item, if an existing item already exists and should be modified. Should be ignored or set to null if a new item is to be created.
+ * @param {string} [rubric_items[].id] - The ID of the rubric item, if an existing item already exists and should be modified. Should be ignored or set to null if a new item is to be created.
  * @param {number} rubric_items[].points - The number of points assigned to the rubric item.
  * @param {string} rubric_items[].description - A short text describing the rubric item. Visible to graders and students.
  * @param {string} [rubric_items[].explanation] - A longer explanation of the rubric item. Visible to graders and students.
  * @param {string} [rubric_items[].grader_note] - A note associated to the rubric item that is visible to graders only.
  * @param {number} rubric_items[].order - An indicator of the order in which items are to be presented.
  * @param {boolean} tag_for_manual_grading - If true, tags all currently graded instance questions to be graded again using the new rubric values. If false, existing gradings are recomputed if necessary, but their grading status is retained.
- * @param {number} authn_user_id - The user_id of the logged in user.
+ * @param {string} authn_user_id - The user_id of the logged in user.
  */
 async function updateAssessmentQuestionRubric(
   assessment_question_id,
@@ -267,8 +267,8 @@ async function updateAssessmentQuestionRubric(
 
 /** Recomputes all graded instance questions based on changes in the rubric settings and items. A new grading job is created, but only if settings or item points are changed.
  *
- * @param {number} assessment_question_id - The ID of the assessment question being updated. Assumed to be authenticated.
- * @param {number} authn_user_id - The user_id of the logged in user.
+ * @param {string} assessment_question_id - The ID of the assessment question being updated. Assumed to be authenticated.
+ * @param {string} authn_user_id - The user_id of the logged in user.
  */
 async function recomputeInstanceQuestions(assessment_question_id, authn_user_id) {
   await sqldb.runInTransactionAsync(async () => {
@@ -352,9 +352,9 @@ async function insertRubricGrading(
 }
 
 /** Manually updates the score of an instance question.
- * @param {number} assessment_id - The ID of the assessment associated to the instance question. Assumed to be safe.
- * @param {number} instance_question_id - The ID of the instance question to be updated. May or may not be safe.
- * @param {number|null} submission_id - The ID of the submission. Optional, if not provided the last submission if the instance question is used.
+ * @param {string} assessment_id - The ID of the assessment associated to the instance question. Assumed to be safe.
+ * @param {string} instance_question_id - The ID of the instance question to be updated. May or may not be safe.
+ * @param {string|null} submission_id - The ID of the submission. Optional, if not provided the last submission if the instance question is used.
  * @param {string|null} check_modified_at - The value of modified_at when the question was retrieved, optional. If provided, and the modified_at value does not match this value, a grading job is created but the score is not updated.
  * @param {Object} score - The score values to be used for update.
  * @param {number|string} [score.manual_points] - The manual points to assign to the instance question.
@@ -369,7 +369,7 @@ async function insertRubricGrading(
  * @param {Object} [score.manual_rubric_data.rubric_id] - Rubric ID to use for manual grading.
  * @param {AppliedRubricItem[]} [score.manual_rubric_data.applied_rubric_items] - Applied rubric items.
  * @param {number | string} [score.manual_rubric_data.adjust_points=0] - number of points to add (positive) or subtract (negative) from the total computed from the items.
- * @param {number} authn_user_id - The user_id of the logged in user.
+ * @param {string} authn_user_id - The user_id of the logged in user.
  * @returns {Promise<Object>}
  */
 async function updateInstanceQuestionScore(

--- a/apps/prairielearn/src/lib/score-upload.js
+++ b/apps/prairielearn/src/lib/score-upload.js
@@ -9,372 +9,387 @@ const manualGrading = require('./manualGrading');
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
-module.exports = {
-  /**
-   * Update question instance scores from a CSV file.
-   *
-   * @param {string} assessment_id - The assessment to update.
-   * @param {{ originalname: string, size: number, buffer: Buffer } | null | undefined} csvFile - An object with keys {originalname, size, buffer}.
-   * @param {string} user_id - The current user performing the update.
-   * @param {string} authn_user_id - The current authenticated user.
-   */
-  async uploadInstanceQuestionScores(assessment_id, csvFile, user_id, authn_user_id) {
-    if (csvFile == null) {
-      throw new Error('No CSV file uploaded');
-    }
+/**
+ * Update question instance scores from a CSV file.
+ *
+ * @param {string} assessment_id - The assessment to update.
+ * @param {{ originalname: string, size: number, buffer: Buffer } | null | undefined} csvFile - An object with keys {originalname, size, buffer}.
+ * @param {string} user_id - The current user performing the update.
+ * @param {string} authn_user_id - The current authenticated user.
+ */
+export async function uploadInstanceQuestionScores(assessment_id, csvFile, user_id, authn_user_id) {
+  if (csvFile == null) {
+    throw new Error('No CSV file uploaded');
+  }
 
-    const result = await sqldb.queryOneRowAsync(sql.select_assessment_info, {
-      assessment_id,
+  const result = await sqldb.queryOneRowAsync(sql.select_assessment_info, {
+    assessment_id,
+  });
+
+  const assessment_label = result.rows[0].assessment_label;
+  const course_instance_id = result.rows[0].course_instance_id;
+  const course_id = result.rows[0].course_id;
+
+  const serverJob = await createServerJob({
+    courseId: course_id,
+    courseInstanceId: course_instance_id,
+    assessmentId: assessment_id,
+    userId: user_id,
+    authnUserId: authn_user_id,
+    type: 'upload_instance_question_scores',
+    description: 'Upload question scores for ' + assessment_label,
+  });
+
+  serverJob.executeInBackground(async (job) => {
+    job.info('Uploading question scores for ' + assessment_label);
+
+    // accumulate output lines in the "output" variable and actually
+    // output put them in blocks, to avoid spamming the updates
+    let output = null;
+    let outputCount = 0;
+    let outputThreshold = 100;
+
+    let successCount = 0;
+    let errorCount = 0;
+    let skippedCount = 0;
+
+    job.info(`Parsing uploaded CSV file "${csvFile.originalname}" (${csvFile.size} bytes)`);
+    const csvStream = streamifier.createReadStream(csvFile.buffer, {
+      encoding: 'utf8',
+    });
+    const csvConverter = csvtojson({
+      colParser: {
+        instance: 'number',
+        score_perc: 'number',
+        points: 'number',
+        manual_score_perc: 'number',
+        manual_points: 'number',
+        auto_score_perc: 'number',
+        auto_points: 'number',
+        submission_id: 'number',
+      },
+      maxRowLength: 10000,
     });
 
-    const assessment_label = result.rows[0].assessment_label;
-    const course_instance_id = result.rows[0].course_instance_id;
-    const course_id = result.rows[0].course_id;
-
-    const serverJob = await createServerJob({
-      courseId: course_id,
-      courseInstanceId: course_instance_id,
-      assessmentId: assessment_id,
-      userId: user_id,
-      authnUserId: authn_user_id,
-      type: 'upload_instance_question_scores',
-      description: 'Upload question scores for ' + assessment_label,
-    });
-
-    serverJob.executeInBackground(async (job) => {
-      job.info('Uploading question scores for ' + assessment_label);
-
-      // accumulate output lines in the "output" variable and actually
-      // output put them in blocks, to avoid spamming the updates
-      let output = null;
-      let outputCount = 0;
-      let outputThreshold = 100;
-
-      let successCount = 0;
-      let errorCount = 0;
-
-      job.info(`Parsing uploaded CSV file "${csvFile.originalname}" (${csvFile.size} bytes)`);
-      const csvStream = streamifier.createReadStream(csvFile.buffer, {
-        encoding: 'utf8',
-      });
-      const csvConverter = csvtojson({
-        colParser: {
-          instance: 'number',
-          score_perc: 'number',
-          points: 'number',
-          manual_score_perc: 'number',
-          manual_points: 'number',
-          auto_score_perc: 'number',
-          auto_points: 'number',
-          submission_id: 'number',
-        },
-        maxRowLength: 10000,
-      });
-
-      try {
-        await csvConverter.fromStream(csvStream).subscribe(async (json, number) => {
-          // Replace all keys with their lower-case values
-          json = _.mapKeys(json, (_v, k) => k.toLowerCase());
-          const msg = `Processing CSV record ${number}: ${JSON.stringify(json)}`;
-          if (output == null) {
-            output = msg;
-          } else {
-            output += '\n' + msg;
-          }
-          try {
-            await module.exports._updateInstanceQuestionFromJson(
-              json,
-              assessment_id,
-              authn_user_id,
-            );
+    try {
+      await csvConverter.fromStream(csvStream).subscribe(async (json, number) => {
+        // Replace all keys with their lower-case values
+        json = _.mapKeys(json, (_v, k) => k.toLowerCase());
+        try {
+          if (await _updateInstanceQuestionFromJson(json, assessment_id, authn_user_id)) {
             successCount++;
-          } catch (err) {
-            errorCount++;
-            const msg = String(err);
+            const msg = `Processed CSV record ${number}: ${JSON.stringify(json)}`;
             if (output == null) {
               output = msg;
             } else {
               output += '\n' + msg;
             }
+          } else {
+            skippedCount++;
+            // NO OUTPUT
           }
-          outputCount++;
-          if (outputCount >= outputThreshold) {
-            job.verbose(output);
-            output = null;
-            outputCount = 0;
-            outputThreshold *= 2; // exponential backoff
-          }
-        });
-      } finally {
-        // Log output even in the case of failure.
-        if (output != null) {
-          job.verbose(output);
-        }
-      }
-
-      if (errorCount === 0) {
-        job.info(`Successfully updated scores for ${successCount} questions, with no errors`);
-      } else {
-        job.info(`Successfully updated scores for ${successCount} questions`);
-        job.error(`Error updating ${errorCount} questions`);
-      }
-    });
-
-    return serverJob.jobSequenceId;
-  },
-
-  /**
-   * Update assessment instance scores from a CSV file.
-   *
-   * @param {string} assessment_id - The assessment to update.
-   * @param {{ originalname: string, size: number, buffer: Buffer } | null | undefined} csvFile - An object with keys {originalname, size, buffer}.
-   * @param {string} user_id - The current user performing the update.
-   * @param {string} authn_user_id - The current authenticated user.
-   */
-  async uploadAssessmentInstanceScores(assessment_id, csvFile, user_id, authn_user_id) {
-    if (csvFile == null) {
-      throw new Error('No CSV file uploaded');
-    }
-    const result = await sqldb.queryOneRowAsync(sql.select_assessment_info, {
-      assessment_id,
-    });
-    const assessment_label = result.rows[0].assessment_label;
-    const course_instance_id = result.rows[0].course_instance_id;
-    const course_id = result.rows[0].course_id;
-
-    const serverJob = await createServerJob({
-      courseId: course_id,
-      courseInstanceId: course_instance_id,
-      assessmentId: assessment_id,
-      userId: user_id,
-      authnUserId: authn_user_id,
-      type: 'upload_assessment_instance_scores',
-      description: 'Upload total scores for ' + assessment_label,
-    });
-
-    serverJob.executeInBackground(async (job) => {
-      job.verbose('Uploading total scores for ' + assessment_label);
-
-      // accumulate output lines in the "output" variable and actually
-      // output put them in blocks, to avoid spamming the updates
-      let output = null;
-      let outputCount = 0;
-      let outputThreshold = 100;
-
-      let successCount = 0;
-      let errorCount = 0;
-
-      job.info(`Parsing uploaded CSV file "${csvFile.originalname}" (${csvFile.size} bytes)`);
-      const csvStream = streamifier.createReadStream(csvFile.buffer, {
-        encoding: 'utf8',
-      });
-      const csvConverter = csvtojson({
-        colParser: {
-          instance: 'number',
-          score_perc: 'number',
-          points: 'number',
-        },
-        maxRowLength: 1000,
-      });
-
-      try {
-        await csvConverter.fromStream(csvStream).subscribe(async (json, number) => {
-          // Replace all keys with their lower-case values
-          json = _.mapKeys(json, (v, k) => {
-            return k.toLowerCase();
-          });
-          const msg = `Processing CSV record ${number}: ${JSON.stringify(json)}`;
+        } catch (err) {
+          errorCount++;
+          const msg = `Error processing CSV record ${number}: ${JSON.stringify(json)}\n${err}`;
           if (output == null) {
             output = msg;
           } else {
             output += '\n' + msg;
           }
-          try {
-            await module.exports._updateAssessmentInstanceFromJson(
-              json,
-              assessment_id,
-              authn_user_id,
-            );
-            successCount++;
-          } catch (err) {
-            errorCount++;
-            const msg = String(err);
-            if (output == null) {
-              output = msg;
-            } else {
-              output += '\n' + msg;
-            }
-          }
-          outputCount++;
-          if (outputCount >= outputThreshold) {
-            job.verbose(output);
-            output = null;
-            outputCount = 0;
-            outputThreshold *= 2; // exponential backoff
-          }
-        });
-      } finally {
-        // Log output even in the case of failure.
-        if (output != null) {
-          job.verbose(output);
         }
+        outputCount++;
+        if (outputCount >= outputThreshold) {
+          job.verbose(output);
+          output = null;
+          outputCount = 0;
+          outputThreshold *= 2; // exponential backoff
+        }
+      });
+    } finally {
+      // Log output even in the case of failure.
+      if (output != null) {
+        job.verbose(output);
       }
+    }
 
-      if (errorCount === 0) {
-        job.verbose(
-          `Successfully updated scores for ${successCount} assessment instances, with no errors`,
-        );
-      } else {
-        job.verbose(`Successfully updated scores for ${successCount} assessment instances`);
-        job.error(`Error updating ${errorCount} assessment instances`);
-      }
+    if (errorCount === 0) {
+      job.info(`Successfully updated scores for ${successCount} questions, with no errors`);
+    } else {
+      job.info(`Successfully updated scores for ${successCount} questions`);
+      job.error(`Error updating ${errorCount} questions`);
+    }
+    if (skippedCount !== 0) {
+      job.warn(`${skippedCount} questions were skipped, with no score/feedback values to update`);
+    }
+  });
+
+  return serverJob.jobSequenceId;
+}
+
+/**
+ * Update assessment instance scores from a CSV file.
+ *
+ * @param {string} assessment_id - The assessment to update.
+ * @param {{ originalname: string, size: number, buffer: Buffer } | null | undefined} csvFile - An object with keys {originalname, size, buffer}.
+ * @param {string} user_id - The current user performing the update.
+ * @param {string} authn_user_id - The current authenticated user.
+ */
+export async function uploadAssessmentInstanceScores(
+  assessment_id,
+  csvFile,
+  user_id,
+  authn_user_id,
+) {
+  if (csvFile == null) {
+    throw new Error('No CSV file uploaded');
+  }
+  const result = await sqldb.queryOneRowAsync(sql.select_assessment_info, {
+    assessment_id,
+  });
+  const assessment_label = result.rows[0].assessment_label;
+  const course_instance_id = result.rows[0].course_instance_id;
+  const course_id = result.rows[0].course_id;
+
+  const serverJob = await createServerJob({
+    courseId: course_id,
+    courseInstanceId: course_instance_id,
+    assessmentId: assessment_id,
+    userId: user_id,
+    authnUserId: authn_user_id,
+    type: 'upload_assessment_instance_scores',
+    description: 'Upload total scores for ' + assessment_label,
+  });
+
+  serverJob.executeInBackground(async (job) => {
+    job.verbose('Uploading total scores for ' + assessment_label);
+
+    // accumulate output lines in the "output" variable and actually
+    // output put them in blocks, to avoid spamming the updates
+    let output = null;
+    let outputCount = 0;
+    let outputThreshold = 100;
+
+    let successCount = 0;
+    let errorCount = 0;
+
+    job.info(`Parsing uploaded CSV file "${csvFile.originalname}" (${csvFile.size} bytes)`);
+    const csvStream = streamifier.createReadStream(csvFile.buffer, {
+      encoding: 'utf8',
+    });
+    const csvConverter = csvtojson({
+      colParser: {
+        instance: 'number',
+        score_perc: 'number',
+        points: 'number',
+      },
+      maxRowLength: 1000,
     });
 
-    return serverJob.jobSequenceId;
-  },
+    try {
+      await csvConverter.fromStream(csvStream).subscribe(async (json, number) => {
+        // Replace all keys with their lower-case values
+        json = _.mapKeys(json, (v, k) => {
+          return k.toLowerCase();
+        });
+        const msg = `Processing CSV record ${number}: ${JSON.stringify(json)}`;
+        if (output == null) {
+          output = msg;
+        } else {
+          output += '\n' + msg;
+        }
+        try {
+          await _updateAssessmentInstanceFromJson(json, assessment_id, authn_user_id);
+          successCount++;
+        } catch (err) {
+          errorCount++;
+          const msg = String(err);
+          if (output == null) {
+            output = msg;
+          } else {
+            output += '\n' + msg;
+          }
+        }
+        outputCount++;
+        if (outputCount >= outputThreshold) {
+          job.verbose(output);
+          output = null;
+          outputCount = 0;
+          outputThreshold *= 2; // exponential backoff
+        }
+      });
+    } finally {
+      // Log output even in the case of failure.
+      if (output != null) {
+        job.verbose(output);
+      }
+    }
 
-  // missing values and empty strings get mapped to null
-  _getJsonPropertyOrNull(json, key) {
-    const value = _.get(json, key, null);
-    if (value === '') return null;
-    return value;
-  },
+    if (errorCount === 0) {
+      job.verbose(
+        `Successfully updated scores for ${successCount} assessment instances, with no errors`,
+      );
+    } else {
+      job.verbose(`Successfully updated scores for ${successCount} assessment instances`);
+      job.error(`Error updating ${errorCount} assessment instances`);
+    }
+  });
 
-  // "feedback" gets mapped to {manual: "XXX"} and overrides the contents of "feedback_json"
-  _getFeedbackOrNull(json) {
-    const feedback_string = module.exports._getJsonPropertyOrNull(json, 'feedback');
-    const feedback_json = module.exports._getJsonPropertyOrNull(json, 'feedback_json');
-    let feedback = null;
+  return serverJob.jobSequenceId;
+}
+
+// missing values and empty strings get mapped to null
+function _getJsonPropertyOrNull(json, key) {
+  const value = _.get(json, key, null);
+  if (value === '') return null;
+  return value;
+}
+
+// missing values and empty strings get mapped to null
+function _getNumericJsonPropertyOrNull(json, key) {
+  const value = _getJsonPropertyOrNull(json, key);
+  if (isNaN(value)) {
+    throw new Error(`Value of ${key} is not a numeric value`);
+  }
+  return value;
+}
+
+// "feedback" gets mapped to {manual: "XXX"} and overrides the contents of "feedback_json"
+function _getFeedbackOrNull(json) {
+  const feedback_string = _getJsonPropertyOrNull(json, 'feedback');
+  const feedback_json = _getJsonPropertyOrNull(json, 'feedback_json');
+  let feedback = null;
+  if (feedback_string != null) {
+    feedback = { manual: feedback_string };
+  }
+  if (feedback_json != null) {
+    let feedback_obj = null;
+    try {
+      feedback_obj = JSON.parse(feedback_json);
+    } catch (e) {
+      throw new Error(`Unable to parse "feedback_json" field as JSON: ${e}`);
+    }
+    if (!_.isPlainObject(feedback_obj)) {
+      throw new Error(`Parsed "feedback_json" is not a JSON object: ${feedback_obj}`);
+    }
+    feedback = feedback_obj;
     if (feedback_string != null) {
-      feedback = { manual: feedback_string };
+      feedback.manual = feedback_string;
     }
-    if (feedback_json != null) {
-      let feedback_obj = null;
-      try {
-        feedback_obj = JSON.parse(feedback_json);
-      } catch (e) {
-        throw new Error(`Unable to parse "feedback_json" field as JSON: ${e}`);
-      }
-      if (!_.isPlainObject(feedback_obj)) {
-        throw new Error(`Parsed "feedback_json" is not a JSON object: ${feedback_obj}`);
-      }
-      feedback = feedback_obj;
-      if (feedback_string != null) {
-        feedback.manual = feedback_string;
-      }
+  }
+  return feedback;
+}
+
+function _getPartialScoresOrNull(json) {
+  const partial_scores_json = _getJsonPropertyOrNull(json, 'partial_scores');
+  let partial_scores = null;
+  if (partial_scores_json != null) {
+    try {
+      partial_scores = JSON.parse(partial_scores_json);
+    } catch (e) {
+      throw new Error(`Unable to parse "partial_scores" field as JSON: ${e}`);
     }
-    return feedback;
-  },
-
-  _getPartialScoresOrNull(json) {
-    const partial_scores_json = module.exports._getJsonPropertyOrNull(json, 'partial_scores');
-    let partial_scores = null;
-    if (partial_scores_json != null) {
-      try {
-        partial_scores = JSON.parse(partial_scores_json);
-      } catch (e) {
-        throw new Error(`Unable to parse "partial_scores" field as JSON: ${e}`);
-      }
-      if (!_.isPlainObject(partial_scores)) {
-        throw new Error(`Parsed "partial_scores" is not a JSON object: ${partial_scores}`);
-      }
+    if (!_.isPlainObject(partial_scores)) {
+      throw new Error(`Parsed "partial_scores" is not a JSON object: ${partial_scores}`);
     }
-    return partial_scores;
-  },
+  }
+  return partial_scores;
+}
 
-  async _updateInstanceQuestionFromJson(json, assessment_id, authn_user_id) {
-    const submission_id = module.exports._getJsonPropertyOrNull(json, 'submission_id');
-    const uid_or_group =
-      module.exports._getJsonPropertyOrNull(json, 'group_name') ??
-      module.exports._getJsonPropertyOrNull(json, 'uid');
-    const ai_number = module.exports._getJsonPropertyOrNull(json, 'instance');
-    const qid = module.exports._getJsonPropertyOrNull(json, 'qid');
+async function _updateInstanceQuestionFromJson(json, assessment_id, authn_user_id) {
+  const submission_id = _getJsonPropertyOrNull(json, 'submission_id');
+  const uid_or_group =
+    _getJsonPropertyOrNull(json, 'group_name') ?? _getJsonPropertyOrNull(json, 'uid');
+  const ai_number = _getJsonPropertyOrNull(json, 'instance');
+  const qid = _getJsonPropertyOrNull(json, 'qid');
 
-    await sqldb.runInTransactionAsync(async () => {
-      const submission_data = await sqldb.queryZeroOrOneRowAsync(sql.select_submission_to_update, {
-        assessment_id,
-        submission_id,
-        uid_or_group,
-        ai_number,
-        qid,
-      });
+  return await sqldb.runInTransactionAsync(async () => {
+    const submission_data = await sqldb.queryZeroOrOneRowAsync(sql.select_submission_to_update, {
+      assessment_id,
+      submission_id,
+      uid_or_group,
+      ai_number,
+      qid,
+    });
 
-      if (submission_data.rowCount === 0) {
-        throw new Error(
-          `Could not locate submission with id=${submission_id}, instance=${ai_number}, uid/group=${uid_or_group}, qid=${qid} for this assessment.`,
-        );
-      }
-      if (uid_or_group !== null && submission_data.rows[0].uid_or_group !== uid_or_group) {
-        throw new Error(
-          `Found submission with id=${submission_id}, but uid/group does not match ${uid_or_group}.`,
-        );
-      }
-      if (qid !== null && submission_data.rows[0].qid !== qid) {
-        throw new Error(
-          `Found submission with id=${submission_id}, but QID does not match ${qid}.`,
-        );
-      }
+    if (submission_data.rowCount === 0) {
+      throw new Error(
+        `Could not locate submission with id=${submission_id}, instance=${ai_number}, uid/group=${uid_or_group}, qid=${qid} for this assessment.`,
+      );
+    }
+    if (uid_or_group !== null && submission_data.rows[0].uid_or_group !== uid_or_group) {
+      throw new Error(
+        `Found submission with id=${submission_id}, but uid/group does not match ${uid_or_group}.`,
+      );
+    }
+    if (qid !== null && submission_data.rows[0].qid !== qid) {
+      throw new Error(`Found submission with id=${submission_id}, but QID does not match ${qid}.`);
+    }
 
+    const new_score = {
+      score_perc: _getNumericJsonPropertyOrNull(json, 'score_perc'),
+      points: _getNumericJsonPropertyOrNull(json, 'points'),
+      manual_score_perc: _getNumericJsonPropertyOrNull(json, 'manual_score_perc'),
+      manual_points: _getNumericJsonPropertyOrNull(json, 'manual_points'),
+      auto_score_perc: _getNumericJsonPropertyOrNull(json, 'auto_score_perc'),
+      auto_points: _getNumericJsonPropertyOrNull(json, 'auto_points'),
+      feedback: _getFeedbackOrNull(json),
+      partial_scores: _getPartialScoresOrNull(json),
+    };
+    if (_.some(Object.values(new_score), (value) => value != null)) {
       await manualGrading.updateInstanceQuestionScore(
         assessment_id,
         submission_data.rows[0].instance_question_id,
         submission_data.rows[0].submission_id,
         null, // modified_at
-        {
-          score_perc: module.exports._getJsonPropertyOrNull(json, 'score_perc'),
-          points: module.exports._getJsonPropertyOrNull(json, 'points'),
-          manual_score_perc: module.exports._getJsonPropertyOrNull(json, 'manual_score_perc'),
-          manual_points: module.exports._getJsonPropertyOrNull(json, 'manual_points'),
-          auto_score_perc: module.exports._getJsonPropertyOrNull(json, 'auto_score_perc'),
-          auto_points: module.exports._getJsonPropertyOrNull(json, 'auto_points'),
-          feedback: module.exports._getFeedbackOrNull(json),
-          partial_scores: module.exports._getPartialScoresOrNull(json),
-        },
+        new_score,
         authn_user_id,
       );
-    });
-  },
-
-  async _updateAssessmentInstanceFromJson(json, assessment_id, authn_user_id) {
-    let query, id;
-    if (_.has(json, 'uid')) {
-      query = sql.select_assessment_instance_uid;
-      id = json.uid;
-    } else if (_.has(json, 'group_name')) {
-      query = sql.select_assessment_instance_group;
-      id = json.group_name;
+      return true;
     } else {
-      throw new Error('"uid" or "group_name" not found');
+      return false;
     }
-    if (!_.has(json, 'instance')) throw new Error('"instance" not found');
+  });
+}
 
-    await sqldb.runInTransactionAsync(async () => {
-      const result = await sqldb.queryZeroOrOneRowAsync(query, {
-        assessment_id,
-        uid: json.uid,
-        group_name: json.group_name,
-        instance_number: json.instance,
-      });
-      if (result.rowCount === 0) {
-        throw new Error(`unable to locate instance ${json.instance} for ${id}`);
-      }
-      const assessment_instance_id = result.rows[0].assessment_instance_id;
+async function _updateAssessmentInstanceFromJson(json, assessment_id, authn_user_id) {
+  let query, id;
+  if (_.has(json, 'uid')) {
+    query = sql.select_assessment_instance_uid;
+    id = json.uid;
+  } else if (_.has(json, 'group_name')) {
+    query = sql.select_assessment_instance_group;
+    id = json.group_name;
+  } else {
+    throw new Error('"uid" or "group_name" not found');
+  }
+  if (!_.has(json, 'instance')) throw new Error('"instance" not found');
 
-      if (_.has(json, 'score_perc')) {
-        await sqldb.callAsync('assessment_instances_update_score_perc', [
-          assessment_instance_id,
-          json.score_perc,
-          authn_user_id,
-        ]);
-      } else if (_.has(json, 'points')) {
-        await sqldb.callAsync('assessment_instances_update_points', [
-          assessment_instance_id,
-          json.points,
-          authn_user_id,
-        ]);
-      } else {
-        throw new Error('must specify either "score_perc" or "points"');
-      }
+  await sqldb.runInTransactionAsync(async () => {
+    const result = await sqldb.queryZeroOrOneRowAsync(query, {
+      assessment_id,
+      uid: json.uid,
+      group_name: json.group_name,
+      instance_number: json.instance,
     });
-  },
-};
+    if (result.rowCount === 0) {
+      throw new Error(`unable to locate instance ${json.instance} for ${id}`);
+    }
+    const assessment_instance_id = result.rows[0].assessment_instance_id;
+
+    if (_.has(json, 'score_perc')) {
+      await sqldb.callAsync('assessment_instances_update_score_perc', [
+        assessment_instance_id,
+        json.score_perc,
+        authn_user_id,
+      ]);
+    } else if (_.has(json, 'points')) {
+      await sqldb.callAsync('assessment_instances_update_points', [
+        assessment_instance_id,
+        json.points,
+        authn_user_id,
+      ]);
+    } else {
+      throw new Error('must specify either "score_perc" or "points"');
+    }
+  });
+}

--- a/apps/prairielearn/src/lib/score-upload.js
+++ b/apps/prairielearn/src/lib/score-upload.js
@@ -298,6 +298,13 @@ function getPartialScoresOrNull(json) {
   return partial_scores;
 }
 
+/** Update the score of an instance question based on a single row from the CSV file.
+ *
+ * @param {Record<string, any>} json Data from the CSV row.
+ * @param {string} assessment_id ID of the assessment being updated.
+ * @param {string} authn_user_id User ID currently authenticated.
+ * @returns {Promise<boolean>} True if the record included an update, or false if the record included no scores or feedback to be changed.
+ */
 async function updateInstanceQuestionFromJson(json, assessment_id, authn_user_id) {
   const submission_id = getJsonPropertyOrNull(json, 'submission_id');
   const uid_or_group =

--- a/apps/prairielearn/src/lib/score-upload.js
+++ b/apps/prairielearn/src/lib/score-upload.js
@@ -78,7 +78,10 @@ export async function uploadInstanceQuestionScores(assessment_id, csvFile, user_
         try {
           if (await _updateInstanceQuestionFromJson(json, assessment_id, authn_user_id)) {
             successCount++;
-            const msg = `Processed CSV record ${number}: ${JSON.stringify(json)}`;
+            // The number refers to a zero-based index of the data entries.
+            // Adding 1 to use 1-based (as is used in Excel et al), and 1 to
+            // account for the header.
+            const msg = `Processed CSV line ${number + 2}: ${JSON.stringify(json)}`;
             if (output == null) {
               output = msg;
             } else {
@@ -90,7 +93,7 @@ export async function uploadInstanceQuestionScores(assessment_id, csvFile, user_
           }
         } catch (err) {
           errorCount++;
-          const msg = `Error processing CSV record ${number}: ${JSON.stringify(json)}\n${err}`;
+          const msg = `Error processing CSV line ${number + 2}: ${JSON.stringify(json)}\n${err}`;
           if (output == null) {
             output = msg;
           } else {
@@ -191,7 +194,7 @@ export async function uploadAssessmentInstanceScores(
         json = _.mapKeys(json, (v, k) => {
           return k.toLowerCase();
         });
-        const msg = `Processing CSV record ${number}: ${JSON.stringify(json)}`;
+        const msg = `Processing CSV line ${number + 2}: ${JSON.stringify(json)}`;
         if (output == null) {
           output = msg;
         } else {

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -834,7 +834,8 @@ describe('Exam assessment', function () {
         locals.csvData =
           'uid,instance,qid,score_perc,feedback\n' +
           'dev@illinois.edu,1,addNumbers,40,feedback numbers\n' +
-          'dev@illinois.edu,1,addVectors,50,feedback vectors\n';
+          'dev@illinois.edu,1,addVectors,50,feedback vectors\n' +
+          'dev@illinois.edu,1,fossilFuelsRadio,,\n';
       });
     });
     helperQuestion.uploadInstanceQuestionScores(locals);


### PR DESCRIPTION
Resolves #4064. In particular, rows without a value in any of the score columns (score_perc, points, manual_score_perc, manual_points, auto_score_perc, auto_points, feedback, feedback_json, partial_scores) are skipped in the update. This means:

* these entries don't cause a manual grading log to be created for the assessment instance;
* the corresponding rows are not listed in the grading job log;
* a count of skipped rows is shown at the bottom of the log.

I chose not to give an error if the columns don't exist for simplicity, as in this case the warning will show that no rows were updated anyway.

Additional changes added:
* the corresponding lib was changed to remove references to `module.exports` and use `export function` instead. This should simplify a future renaming to TS, as indentation spacing changes would be reduced.
* numeric scores/points throw an error if the value being retrieved is not a number. In the past this would cause the score to become NaN.

Code diff is better viewed by ignoring whitespace.