### PR TITLE
Fix return type of workspace initialize function

### DIFF
--- a/apps/prairielearn/src/lib/workspace.js
+++ b/apps/prairielearn/src/lib/workspace.js
@@ -293,7 +293,7 @@ module.exports = {
    * are not atomic.
    *
    * @param {string | number} workspace_id
-   * @returns {Promise<InitializeResult | null>}
+   * @returns {Promise<InitializeResult>}
    */
   async initialize(workspace_id) {
     const { workspace, variant, question, course } = (


### PR DESCRIPTION
The existing type confused me for a while when I was investigating #8637. It took actually reading the code to determine that this function will in fact never return `null`.