### PR TITLE
Add faker to Python autograder

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4==4.12.2
 bokeh==3.2.2
 colormath==3.0.0
 defusedxml==0.7.1
+Faker==19.6.2
 folium==0.14.0
 ipython==8.16.1
 matplotlib==3.8.0


### PR DESCRIPTION
Faker can be used to create randomized inputs for tests. It's already in use in plbase to randomize questions.