### PR TITLE
feat: Add unidecode to the Python grader image

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -22,4 +22,5 @@ scikit-image==0.21.0
 scikit-learn==1.3.1
 scipy==1.11.3
 sympy==1.12
+text-unidecode==1.3
 typing-extensions==4.8.0

--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4==4.12.2
 bokeh==3.2.2
 colormath==3.0.0
 defusedxml==0.7.1
+Faker==19.6.2
 folium==0.14.0
 ipython==8.14.0
 jupyter-collaboration==1.2.0
@@ -23,4 +24,5 @@ scikit-image==0.21.0
 scikit-learn==1.3.0
 scipy==1.11.2
 sympy==1.12
+text-unidecode==1.3
 typing-extensions==4.7.1


### PR DESCRIPTION
See title, adds unidecode to the Python autograder. Useful in some situations, especially if externally grading student input rather than student code.