### PR TITLE
Add cookie rotation to @prairielearn/session

### DIFF
--- a/.changeset/curvy-waves-end.md
+++ b/.changeset/curvy-waves-end.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/session': minor
+---
+
+Add cookie rotation

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -21,6 +21,21 @@ app.use(
 );
 ```
 
+### Rotate session cookies
+
+If you want to rotate to a new session cookie name, you can provide an array of cookie names to `createSessionMiddleware`.
+
+```ts
+createSessionMiddleware({
+  // ...
+  cookie: {
+    name: ['session', 'legacy_session', 'ancient_session'],
+  },
+})
+```
+
+If a request is received with a `legacy_session` or an `ancient_session` cookie, the session will be loaded from the store and then persisted as a new cookie named `session`. For all other requests, the session will be loaded from and persisted to the `session` cookie.
+
 ### Controlling when cookies are set
 
 You can pass a `canSetCookie` function to `createSessionMiddleware` to provide control over when session cookies will be returned to the client.

--- a/packages/session/README.md
+++ b/packages/session/README.md
@@ -31,7 +31,7 @@ createSessionMiddleware({
   cookie: {
     name: ['session', 'legacy_session', 'ancient_session'],
   },
-})
+});
 ```
 
 If a request is received with a `legacy_session` or an `ancient_session` cookie, the session will be loaded from the store and then persisted as a new cookie named `session`. For all other requests, the session will be loaded from and persisted to the `session` cookie.

--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -8,7 +8,6 @@ import asyncHandler from 'express-async-handler';
 import { createSessionMiddleware } from './index';
 import { MemoryStore } from './memory-store';
 import { withServer } from './test-utils';
-import { create } from 'node:domain';
 
 const TEST_SECRET = 'test-secret';
 


### PR DESCRIPTION
This is a prerequisite for #8403. We need to start explicitly specifying a domain for all our cookies. However, if we just blindly added a `domain` property to our existing cookies, we'd actually be left in a situation where we have two identically-named cookies. So, we actually have to migrate to a brand-new cookie. This change will let us do so transparently to users.

The intended usage of this code: we'll simultaneously deploy config for this change with `name: ['_prairielearn_session', ['prairielearn_session']` (or some other suitable new name) and config to set the cookie domain. That way, we'll guarantee that `_prairielearn_session`, if it's present, has an explicit domain specified. Then, after this has been in production for a while (a week? maybe even shorter), we can drop the old `prairielearn_session` name and rely on the old cookie to eventually expire.