### PR TITLE
Remove automata-lib from Python grader and Jupyter images

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -1,4 +1,3 @@
-automata-lib==7.1.0
 beautifulsoup4==4.12.2
 bokeh==3.2.2
 colormath==3.0.0

--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -1,4 +1,3 @@
-automata-lib==7.1.0
 beautifulsoup4==4.12.2
 bokeh==3.2.2
 colormath==3.0.0


### PR DESCRIPTION
As discussed with @eliotwrobson. He says that all courses are now using inline copies of this library, and a manual review of course repositories shows that to be true. Even then, only CS 347 actually appears to be using this library in external grading.

This should be extra safe to remove from `workspaces/jupyterlab-python`, as that image has only been around for a week or so and hasn't seen any adoption yet.