### PR TITLE
Add Sentry group for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,19 @@ updates:
     open-pull-requests-limit: 99
     rebase-strategy: disabled
     groups:
+      ace:
+        patterns:
+          - 'ace-code'
+          - 'ace-builds'
       aws:
         patterns:
           - '@aws-sdk/*'
       opentelemetry:
         patterns:
           - '@opentelemetry/*'
-      ace:
+      sentry:
         patterns:
-          - 'ace-code'
-          - 'ace-builds'
+          - '@sentry/*'
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
`@sentry/*` packages should generally be bumped together.