### PR TITLE
Improve rendering of pl-drawing Latex text

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -981,10 +981,19 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
         use.parentNode.replaceChild(replacement, use);
       });
 
-    let svgSource = svg.outerHTML;
     const exScale = 1.0 - MathJax.config.svg.font.params.x_height;
-    let width = parseFloat(svg.getAttribute('width')) * parseFloat(options.fontSize) * exScale;
-    let height = parseFloat(svg.getAttribute('height')) * parseFloat(options.fontSize) * exScale;
+
+    // Convert width/height from `ex` units to `px` units. This ensures that
+    // the image renders consistently regardless of the browser's configured
+    // font size.
+    const parsedWidth = parseFloat(svg.getAttribute('width'));
+    const parsedHeight = parseFloat(svg.getAttribute('height'));
+    const width = parsedWidth * exScale * options.fontSize;
+    const height = parsedHeight * exScale * options.fontSize;
+    svg.setAttribute('width', width + 'px');
+    svg.setAttribute('height', height + 'px');
+
+    let svgSource = svg.outerHTML;
 
     // Fix for Safari, https://stackoverflow.com/questions/30273775/namespace-prefix-ns1-for-href-on-tagelement-is-not-defined-setattributens
     svgSource = svgSource.replace(/NS\d+:href/gi, 'xlink:href');
@@ -994,10 +1003,10 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
     fabric.Image.fromURL(
       base64svg,
       (img) => {
-        img.width = width;
-        img.height = height;
-        this.width = Math.ceil(width * exScale) * 2;
-        this.height = Math.ceil(height * exScale) * 2;
+        this.width = Math.ceil(width);
+        this.height = Math.ceil(height);
+        img.width = this.width;
+        img.height = this.height;
 
         this.setCoords(false, false);
         this.image = img;


### PR DESCRIPTION
Fixes a bug reported on Slack. When browser font size is increased, Latex labels in a `<pl-drawing>` element would be cut off. This is easily reproducible with the `demo/drawing/collarRod` question in the example course:

<img width="474" alt="Screenshot 2023-10-30 at 16 55 55" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/2517f99b-0f3e-4adb-a003-ee90aaf77c12">

After this change, labels now render correctly, even at increased font sizes:

<img width="455" alt="Screenshot 2023-10-30 at 16 57 37" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/ae371e90-0909-4df7-94a6-577059fb9c10">

I made an explicit choice to favor rendering fidelity here. That is, an alternative option would have been to allow the font size to increase the size of the label (as was the case before). However, this means that drawings could display unpredictably in a way that the instructor didn't anticipate. So, the label is drawn with a non-scaling size. This matches the behavior of `<pl-text>` in non-Latex mode.

From an accessibility standpoint, I think this is fine. Users can't increase the text size in arbitrary images, and the output of `<pl-drawing>` is more like an image than anything else. Just like with an image, user's can use native browser features (e.g. increasing the zoom level) to better perceive details in a `<pl-drawing>` element if they need to.