### PR TITLE
Add function to join HTML safe values

### DIFF
--- a/.changeset/thin-birds-smell.md
+++ b/.changeset/thin-birds-smell.md
@@ -2,4 +2,4 @@
 '@prairielearn/html': minor
 ---
 
-Add function to join an array of HTML values with a given separator
+Add `joinHtml` function to join an array of HTML values with a given separator

--- a/.changeset/thin-birds-smell.md
+++ b/.changeset/thin-birds-smell.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/html': minor
+---
+
+Add function to join an array of HTML values with a given separator

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -76,7 +76,7 @@ export function html(strings: TemplateStringsArray, ...values: HtmlValue[]): Htm
 }
 
 /**
- * Pre-escpapes the rendered HTML. Useful for when you want to inline the HTML
+ * Pre-escapes the rendered HTML. Useful for when you want to inline the HTML
  * in something else, for instance in a `data-content` attribute for a Bootstrap
  * popover.
  */
@@ -93,4 +93,14 @@ export function escapeHtml(html: HtmlSafeString): HtmlSafeString {
  */
 export function unsafeHtml(value: string): HtmlSafeString {
   return new HtmlSafeString([value], []);
+}
+
+/**
+ * Joins a list of HTML values with a separator.
+ *
+ * @param values The values to join.
+ * @param separator The separator to use between values.
+ */
+export function joinHtml(values: HtmlValue[], separator: HtmlValue = ''): HtmlSafeString {
+  return unsafeHtml(values.map(escapeValue).join(escapeValue(separator)));
 }


### PR DESCRIPTION
Resolves #8742. Follow up to https://github.com/PrairieLearn/PrairieLearn/pull/8685#discussion_r1376853780. I made the separator optional and default to a blank string, though this may not be necessary as the `html` function already handles the case of arrays, but I added it to make it closer to the functionality of join.