### PR TITLE
Improve navbar overrides

### DIFF
--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -155,7 +155,7 @@ onDocumentReady(() => {
   const effectiveUidInput = document.querySelector<HTMLInputElement>('.js-effective-uid-input');
   const effectiveUidButton = document.querySelector<HTMLButtonElement>('.js-effective-uid-button');
 
-  effectiveUidInput.addEventListener('input', () => {
+  effectiveUidInput?.addEventListener('input', () => {
     if (effectiveUidInput.value.trim() !== '') {
       effectiveUidButton.removeAttribute('disabled');
     } else {
@@ -165,7 +165,7 @@ onDocumentReady(() => {
 
   document
     .querySelector<HTMLFormElement>('.js-effective-uid-form')
-    .addEventListener('submit', (e) => {
+    ?.addEventListener('submit', (e) => {
       e.preventDefault();
 
       const effectiveUid = effectiveUidInput.value.trim();

--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -178,4 +178,12 @@ onDocumentReady(() => {
       location.reload();
     }
   });
+
+  document.querySelectorAll<HTMLButtonElement>('.js-remove-override').forEach((element) => {
+    element.addEventListener('click', () => {
+      const cookieName = element.dataset.overrideCookie;
+      Cookies.remove(cookieName, { path: '/' });
+      location.reload();
+    });
+  });
 });

--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -144,41 +144,6 @@ onDocumentReady(() => {
     }
   });
 
-  const navbarUserEffectiveUidInput = document.querySelector<HTMLInputElement>(
-    '#navbar-user-effective-uid-input',
-  );
-  const navbarUserEffectiveUidButton = document.querySelector<HTMLButtonElement>(
-    '#navbar-user-effective-uid-button',
-  );
-
-  navbarUserEffectiveUidInput?.addEventListener('keyup', () => {
-    if (navbarUserEffectiveUidInput.value.trim() !== '') {
-      navbarUserEffectiveUidButton.removeAttribute('disabled');
-    } else {
-      navbarUserEffectiveUidButton.setAttribute('disabled', 'true');
-    }
-  });
-
-  navbarUserEffectiveUidInput?.addEventListener('keypress', (e) => {
-    if (e.key === 'Enter') {
-      const uid = navbarUserEffectiveUidInput.value.trim();
-      if (uid !== '') {
-        Cookies.set('pl_requested_uid', uid, { path: '/', expires: COOKIE_EXPIRATION_DAYS });
-        Cookies.set('pl_requested_data_changed', 'true', { path: '/' });
-        location.reload();
-      }
-    }
-  });
-
-  navbarUserEffectiveUidButton?.addEventListener('click', () => {
-    const uid = navbarUserEffectiveUidInput.value.trim();
-    if (uid !== '') {
-      Cookies.set('pl_requested_uid', uid, { path: '/', expires: COOKIE_EXPIRATION_DAYS });
-      Cookies.set('pl_requested_data_changed', 'true', { path: '/' });
-      location.reload();
-    }
-  });
-
   document.querySelectorAll<HTMLButtonElement>('.js-remove-override').forEach((element) => {
     element.addEventListener('click', () => {
       const cookieName = element.dataset.overrideCookie;
@@ -186,4 +151,31 @@ onDocumentReady(() => {
       location.reload();
     });
   });
+
+  const effectiveUidInput = document.querySelector<HTMLInputElement>('.js-effective-uid-input');
+  const effectiveUidButton = document.querySelector<HTMLButtonElement>('.js-effective-uid-button');
+
+  effectiveUidInput.addEventListener('input', () => {
+    if (effectiveUidInput.value.trim() !== '') {
+      effectiveUidButton.removeAttribute('disabled');
+    } else {
+      effectiveUidButton.setAttribute('disabled', 'true');
+    }
+  });
+
+  document
+    .querySelector<HTMLFormElement>('.js-effective-uid-form')
+    .addEventListener('submit', (e) => {
+      e.preventDefault();
+
+      const effectiveUid = effectiveUidInput.value.trim();
+      if (effectiveUid) {
+        Cookies.set('pl_requested_uid', effectiveUid, {
+          path: '/',
+          expires: COOKIE_EXPIRATION_DAYS,
+        });
+        Cookies.set('pl_requested_data_changed', 'true', { path: '/' });
+        location.reload();
+      }
+    });
 });

--- a/apps/prairielearn/src/pages/partials/head.ejs
+++ b/apps/prairielearn/src/pages/partials/head.ejs
@@ -10,4 +10,3 @@
 <script src="<%= node_modules_asset_path('jquery/dist/jquery.min.js') %>"></script>
 <script src="<%= node_modules_asset_path('bootstrap/dist/js/bootstrap.bundle.min.js') %>"></script>
 <script src="<%= node_modules_asset_path('@fortawesome/fontawesome-free/js/all.min.js') %>"></script>
-<script src="<%= node_modules_asset_path('js-cookie/dist/js.cookie.min.js') %>"></script>

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -271,24 +271,35 @@
           %>
             <h6 class="dropdown-header">Effective user</h6>
 
-            <div class="dropdown-item-text d-flex flex-row justify-content-left ml-4 align-items-center">
-              <div class="px-0"><input type="email" class="form-control form-control-sm" id="navbar-user-effective-uid-input" placeholder="netid@illinois.edu" style="min-width:15em"></div>
-              <div class="pl-2"><button type="button" class="btn btn-primary btn-sm text-nowrap" id="navbar-user-effective-uid-button" disabled>Change UID</button></div>
-            </div>
+            <form class="form-inline dropdown-item-text d-flex js-effective-uid-form">
+              <label class="sr-only" for="effective-uid">UID</label>
+              <input
+                name="effective-uid"
+                type="email"
+                placeholder="student@example.com"
+                class="form-control form-control-sm mr-2 flex-grow-1 js-effective-uid-input"
+              >
+              <button
+                type="submit"
+                class="btn btn-primary btn-sm text-nowrap js-effective-uid-button"
+                disabled
+              >
+                Change UID
+              </button>
+            </form>
 
             <% if (authz_data.overrides) { %>
-              <div class="list-group small dropdown-item-text pl-5" style="white-space: nowrap">
-                <% authz_data.overrides.forEach(function(override) { %>
-                  <%- include('navbarUserDropdownOverrideItem', {override: override}); %>
-                <% }); %>
+              <div class="dropdown-item-text">
+                <div class="list-group small" style="white-space: nowrap">
+                  <% authz_data.overrides.forEach(function(override) { %>
+                    <%- include('navbarUserDropdownOverrideItem', {override: override}); %>
+                  <% }); %>
+                </div>
               </div>
             <% } %>
 
             <a class="dropdown-item" href="<%= effectiveUserUrl %>">
-              <div class="d-flex flex-row justify-content-left">
-                <div class="col-1 px-0"></div>
-                <div class="pl-0">Customize&hellip;</div>
-              </div>
+              Customize&hellip;
             </a>
 
             <div class="dropdown-divider"></div>

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -271,10 +271,10 @@
           %>
             <h6 class="dropdown-header">Effective user</h6>
 
-            <form class="form-inline dropdown-item-text d-flex js-effective-uid-form">
+            <form class="form-inline dropdown-item-text d-flex flex-nowrap js-effective-uid-form">
               <label class="sr-only" for="effective-uid">UID</label>
               <input
-                name="effective-uid"
+                id="effective-uid"
                 type="email"
                 placeholder="student@example.com"
                 class="form-control form-control-sm mr-2 flex-grow-1 js-effective-uid-input"

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -290,7 +290,7 @@
 
             <% if (authz_data.overrides) { %>
               <div class="dropdown-item-text">
-                <div class="list-group small" style="white-space: nowrap">
+                <div class="list-group small text-nowrap">
                   <% authz_data.overrides.forEach(function(override) { %>
                     <%- include('navbarUserDropdownOverrideItem', {override: override}); %>
                   <% }); %>

--- a/apps/prairielearn/src/pages/partials/navbarUserDropdownOverrideItem.ejs
+++ b/apps/prairielearn/src/pages/partials/navbarUserDropdownOverrideItem.ejs
@@ -7,19 +7,10 @@
             </ul>
         </div>
         <div>
-            <button class="btn btn-xs btn-warning" type="button" id="navbar-user-remove-<%= override.cookie %>-button">
+            <button class="btn btn-xs btn-warning js-remove-override" type="button" data-override-cookie="<%= override.cookie %>">
                 <i class="fas fa-times mr-1"></i>
                 Remove
             </button>
         </div>
     </div>
 </div>
-
-<script>
-  $(function() {
-    $('#navbar-user-remove-<%= override.cookie %>-button').click(function() {
-      Cookies.remove('<%= override.cookie %>', { path: '/' });
-      location.reload();
-    });
-  });
-</script>


### PR DESCRIPTION
Followup to #8704. Makes several improvements discussed there:

- The inline script for override items was replaced with an event handler in the new `navbarClient` code.
- The manual handling of `Enter` to submit a new UID was replaced with a standard `<form>` + `<button type="submit">`.
- The deprecated `keypress` event was replaced with `input`.

I also made some styling changes to make left margins more consistent. There's no need for such margins in this part of the dropdown because we won't ever show checkboxes there. I also changed the placeholder text from `netid@illinois.edu` to `student@example.com` in the interest of removing Illinois-specific details.

Before:

<img width="453" alt="Screenshot 2023-10-31 at 10 45 56" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/a2a3e133-4fdc-4785-b30e-8a5b3271ff9e">

After:

<img width="451" alt="Screenshot 2023-10-31 at 10 44 18" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/bfa29dfb-26e0-4b6f-af9c-a32d1c7d8e64">