### PR TITLE
Add configuration for session cookie names

### DIFF
--- a/apps/prairielearn/src/lib/config.js
+++ b/apps/prairielearn/src/lib/config.js
@@ -68,6 +68,7 @@ const ConfigSchema = z.object({
   authUin: z.string().nullable().default('000000000'),
   authnCookieMaxAgeMilliseconds: z.number().default(30 * 24 * 60 * 60 * 1000),
   sessionStoreExpireSeconds: z.number().default(86400),
+  sessionCookieNames: z.array(z.string()).default(['prairielearn_session']),
   sessionCookieSameSite: z.string().default(process.env.NODE_ENV === 'production' ? 'none' : 'lax'),
   serverType: z.enum(['http', 'https']).default('http'),
   serverPort: z.string().default('3000'),

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -154,7 +154,7 @@ module.exports.initExpress = function () {
       secret: config.secretKey,
       store: new PostgresSessionStore(),
       cookie: {
-        name: 'prairielearn_session',
+        name: config.sessionCookieNames,
         httpOnly: true,
         maxAge: config.sessionStoreExpireSeconds * 1000,
         secure: 'auto', // uses Express "trust proxy" setting


### PR DESCRIPTION
Builds on the changes from #8703. We'll need this to be configurable so we can configure the move of our session cookie to an explicit domain.