### PR TITLE
feat: Use pickling to store arbitrary objects

### DIFF
--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -1,3 +1,4 @@
+import codecs
 import collections
 import html
 import importlib
@@ -6,6 +7,7 @@ import json
 import math
 import numbers
 import os
+import pickle
 import random
 import re
 import unicodedata
@@ -65,6 +67,15 @@ class QuestionData(TypedDict):
 
 class ElementTestData(QuestionData):
     test_type: Literal["correct", "incorrect", "invalid"]
+
+
+def pickle_object(obj: Any) -> str:
+    """Pickle arbitrary object as string. Based on https://stackoverflow.com/a/30469744/2923069"""
+    return codecs.encode(pickle.dumps(obj), "base64").decode()
+
+
+def unpickle_object(obj_str: str) -> Any:
+    return pickle.loads(codecs.decode(obj_str.encode(), "base64"))
 
 
 def check_answers_names(data: QuestionData, name: str) -> None:

--- a/apps/prairielearn/python/prairielearn_test.py
+++ b/apps/prairielearn/python/prairielearn_test.py
@@ -325,3 +325,14 @@ def test_get_uuid() -> None:
 
     # Assert that the first character is a valid hex letter.
     assert pl_uuid[0] in set("abcdef")
+
+
+def test_pickle() -> None:
+    obj = np.array([1.2, 3.5, 5.1, float("nan")])
+    pickled = pl.pickle_object(obj)
+
+    assert type(pickled) is str
+
+    unpickled = pl.unpickle_object(pickled)
+
+    np.testing.assert_array_equal(unpickled, obj)


### PR DESCRIPTION
See title, uses pickling to store arbitrary objects instead of json. Much simpler and more space efficient. _Slight_ security concerns if student input can get into the unpickling function, but I think we just have to warn people about this in the docs (as I think this is a pretty unlikely scenario).

Draft for now.