### PR TITLE
Fix pl-drawing ID generation

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -119,7 +119,7 @@ window.PLDrawingApi = {
    */
   restoreAnswer: function (canvas, submittedAnswer) {
     for (const [id, obj] of Object.entries(submittedAnswer._answerData)) {
-      this._idCounter = Math.max(id + 1, this._idCounter);
+      this._idCounter = Math.max(parseInt(id) + 1, this._idCounter);
       let newObj = JSON.parse(JSON.stringify(obj));
       this.createElement(canvas, newObj, submittedAnswer);
     }


### PR DESCRIPTION
`Object.keys()` coerces object keys to strings. This means that `id + 1` would end up concatenating `1` to the end of each ID, meaning that our numbers would actually grow very very rapidly as more submissions were made an objects were added. Eventually, `id` would exceed $2^{53} - 1$ and the zygote would refuse to serialize it to JSON. Now, we explicitly parse the ID to an integer to ensure that we're doing math and not string concatenation.