### PR TITLE
Fix rendering of pl-drawing in dynamically-loaded submission

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
@@ -42,7 +42,7 @@
 </div>
 <script>
  (function() {
-     let element = document.currentScript.previousElementSibling;
+     let element = document.getElementById("pl-drawing-{{uuid}}");
      let options = JSON.parse(`{{{options_json}}}`);
      {{^input_answer}}
      let submitted_answer = null;


### PR DESCRIPTION
To reproduce the underlying bug here, make 4 submissions to an `pl-drawing` question, then try to view the first submission; it would be an empty canvas.

We do moderately-hacky things when dynamically rendering submissions to ensure that any embedded scripts execute. In this case, it meant that the `<script>` tag was actually at a different point in the document and thus `document.currentScript.previousElementSibling` returned a completely unrelated element. I'm not 100% sure why it was done this way originally, but looking up the element by the ID (which was already set) should be much more robust.