### PR TITLE
Fix dynamic submission loading in instructor view for issues

### DIFF
--- a/apps/prairielearn/src/lib/question.sql
+++ b/apps/prairielearn/src/lib/question.sql
@@ -240,10 +240,8 @@ WHERE
   s.id = $submission_id
   AND q.id = $question_id
   AND (
-    CASE
-      WHEN $instance_question_id::BIGINT IS NULL THEN iq.id IS NULL
-      ELSE iq.id = $instance_question_id::BIGINT
-    END
+    $instance_question_id::BIGINT IS NULL
+    OR iq.id = $instance_question_id::BIGINT
   )
   AND v.id = $variant_id;
 


### PR DESCRIPTION
Resolves #8783. The original query had a control to ensure that the instructor preview page was only able to retrieve submissions from variants that were not associated to an assessment, but the preview page itself does not have that control (see #5418). After this change, the submission loading URL supports retrieving any variant/submission, as long as the user has access to the URL (which requires staff permission in the course). This matches the permissions needed in instructor preview itself.

The check remains in place for the other URL entrypoints for this code that have a validated instance question ID, e.g., student instance questions (can only open variants associated to the instance question) and manual grading.