### PR TITLE
Fix rubric settings change when no items selected

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.js
+++ b/apps/prairielearn/src/lib/manualGrading.js
@@ -75,7 +75,6 @@ const InstanceQuestionToUpdateSchema = RubricGradingSchema.extend({
   instance_question_id: IdSchema,
   submission_id: IdSchema,
   rubric_settings_changed: z.boolean(),
-  rubric_grading_id: IdSchema,
   applied_rubric_items: RubricGradingItemSchema.array().nullable(),
   rubric_items_changed: z.boolean(),
 });

--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -288,14 +288,15 @@ WITH
   )
 SELECT
   rgr.*,
-  gir.*
+  gir.applied_rubric_items,
+  COALESCE(gir.rubric_items_changed, FALSE) AS rubric_items_changed
 FROM
   rubric_gradings_to_review AS rgr
   JOIN instance_questions AS iq ON (iq.id = rgr.instance_question_id)
   LEFT JOIN grading_items_to_review AS gir ON (gir.rubric_grading_id = rgr.id)
 WHERE
-  rgr.rubric_settings_changed IS NOT FALSE
-  OR gir.rubric_items_changed IS NOT FALSE
+  rgr.rubric_settings_changed IS TRUE
+  OR gir.rubric_items_changed IS TRUE
 FOR NO KEY UPDATE OF
   iq;
 

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -785,6 +785,46 @@ describe('Manual Grading', function () {
               modified_at: form.find('input[name=modified_at]').attr('value') || '',
               use_rubric: 'true',
               starting_points: '0', // Positive grading
+              min_points: '-0.5',
+              max_extra_points: '0.5',
+              ...buildRubricItemFields(rubric_items),
+            }).toString(),
+          });
+
+          assert.equal(response.ok, true);
+        });
+
+        checkSettingsResults(0, -0.5, 0.5);
+        checkGradingResults(mockStaff[0], mockStaff[0]);
+      });
+
+      describe('Grading without rubric items', () => {
+        step('submit a grade using a positive rubric', async () => {
+          setUser(mockStaff[0]);
+          selected_rubric_items = [];
+          score_points = 0;
+          score_percent = 0;
+          feedback_note = 'Test feedback note without any rubric items';
+          await submitGradeForm();
+        });
+
+        checkGradingResults(mockStaff[0], mockStaff[0]);
+
+        step('update rubric items should succeed', async () => {
+          setUser(mockStaff[0]);
+          const manualGradingIQPage = await (await fetch(manualGradingIQUrl)).text();
+          const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
+          const form = $manualGradingIQPage('form[name=rubric-settings]');
+
+          const response = await fetch(manualGradingIQUrl, {
+            method: 'POST',
+            headers: { 'Content-type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+              __action: form.find('input[name=__action]').attr('value') || '',
+              __csrf_token: form.find('input[name=__csrf_token]').attr('value') || '',
+              modified_at: form.find('input[name=modified_at]').attr('value') || '',
+              use_rubric: 'true',
+              starting_points: '0', // Positive grading
               min_points: '-0.3',
               max_extra_points: '0.3',
               ...buildRubricItemFields(rubric_items),


### PR DESCRIPTION
When rubric settings change, all existing gradings are reviewed for potential recomputation of grades. In essence, this recalculation happens when:

* If the starting points (i.e., positive vs negative) change, all existing gradings are recalculated
* If the minimum or maximum points change, all existing gradings are recalculated;
* If a rubric item is deleted, instance questions graded with that item are recalculated;
* If a rubric item has its points changed, instance questions graded with that item are recalculated.

This PR fixes two issues:

* If a question had been graded without applying any of the rubric items, changes in rubric items (points or deletion) still triggered an unnecessary recalculation;
* In the same scenario above, #8777's update would cause a schema problem.

~~There is still another pending issue: changing from "apply to manual points" to "apply to total points" (or vice-versa) may not cause a recalculation in some cases. Since in these cases it is likely that other settings will change as well, and this change is a bit more complex (may require a migration), I'll leave it for a separate PR.~~ moved to #8792 