### PR TITLE
Migrate to v2 of Read the Docs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,13 @@
-requirements_file: docs/requirements.txt
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.10'
+
+mkdocs:
+  configuration: mkdocs.yml
+
 python:
-  version: 3
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
This is now required: https://blog.readthedocs.com/migrate-configuration-v2/

I tested a build of this branch and it's working as expected: https://prairielearn.readthedocs.io/en/readthedocs-config/

Closes #8794.