### PR TITLE
Fix manual grading submission query

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.ts
+++ b/apps/prairielearn/src/lib/manualGrading.ts
@@ -57,7 +57,7 @@ const PartialScoresSchema = z
 type PartialScores = z.infer<typeof PartialScoresSchema>;
 
 const SubmissionForScoreUpdateSchema = z.object({
-  submission_id: IdSchema,
+  submission_id: IdSchema.nullable(),
   instance_question_id: IdSchema,
   assessment_instance_id: IdSchema,
   max_points: z.number().nullable(),


### PR DESCRIPTION
We `LEFT JOIN` on `submissions`, so we aren't guaranteed to have a submission ID:

https://github.com/PrairieLearn/PrairieLearn/blob/2cdc962b6f3e9401491512b40b090870d5d970b6/apps/prairielearn/src/lib/manualGrading.sql#L391

In fact, the code actually explicitly handles the case of no submission:

https://github.com/PrairieLearn/PrairieLearn/blob/2cdc962b6f3e9401491512b40b090870d5d970b6/apps/prairielearn/src/lib/manualGrading.ts#L571-L579