### PR TITLE
Lay groundwork for workspace socket authentication

### DIFF
--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -99,18 +99,22 @@ $(function () {
     setMessage(msg.message);
   });
 
-  socket.emit(
-    'joinWorkspace',
-    {
-      token: socketToken,
-      workspace_id: workspaceId,
-    },
-    (msg) => {
-      console.log('joinWorkspace, msg =', msg);
-      setState(msg.state);
-    },
-  );
+  // Whenever we establish or reestablish a connection, join the workspace room.
+  socket.on('connect', () => {
+    socket.emit(
+      'joinWorkspace',
+      {
+        token: socketToken,
+        workspace_id: workspaceId,
+      },
+      (msg) => {
+        console.log('joinWorkspace, msg =', msg);
+        setState(msg.state);
+      },
+    );
+  });
 
+  // Only start the workspace when the page is first loaded, not on reconnects.
   socket.emit('startWorkspace', { workspace_id: workspaceId });
 
   let lastVisibleTime = Date.now();

--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -17,6 +17,7 @@ $(function () {
     trigger: 'focus',
   });
 
+  const socketToken = document.body.getAttribute('data-socket-token');
   const workspaceId = document.body.getAttribute('data-workspace-id');
   const heartbeatIntervalSec = getNumericalAttribute(
     document.body,
@@ -29,7 +30,12 @@ $(function () {
     30 * 60,
   );
 
-  const socket = io('/workspace');
+  const socket = io('/workspace', {
+    auth: {
+      token: socketToken,
+      workspace_id: workspaceId,
+    },
+  });
   const loadingFrame = document.getElementById('loading') as HTMLDivElement;
   const stoppedFrame = document.getElementById('stopped') as HTMLDivElement;
   const workspaceFrame = document.getElementById('workspace') as HTMLIFrameElement;
@@ -93,12 +99,17 @@ $(function () {
     setMessage(msg.message);
   });
 
-  socket.on('connect', () => {
-    socket.emit('joinWorkspace', { workspace_id: workspaceId }, (msg) => {
+  socket.emit(
+    'joinWorkspace',
+    {
+      token: socketToken,
+      workspace_id: workspaceId,
+    },
+    (msg) => {
       console.log('joinWorkspace, msg =', msg);
       setState(msg.state);
-    });
-  });
+    },
+  );
 
   socket.emit('startWorkspace', { workspace_id: workspaceId });
 

--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -101,17 +101,10 @@ $(function () {
 
   // Whenever we establish or reestablish a connection, join the workspace room.
   socket.on('connect', () => {
-    socket.emit(
-      'joinWorkspace',
-      {
-        token: socketToken,
-        workspace_id: workspaceId,
-      },
-      (msg) => {
-        console.log('joinWorkspace, msg =', msg);
-        setState(msg.state);
-      },
-    );
+    socket.emit('joinWorkspace', { workspace_id: workspaceId }, (msg) => {
+      console.log('joinWorkspace, msg =', msg);
+      setState(msg.state);
+    });
   });
 
   // Only start the workspace when the page is first loaded, not on reconnects.

--- a/apps/prairielearn/src/pages/workspace/workspace.html.js
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.js
@@ -3,7 +3,14 @@ const { renderEjs } = require('@prairielearn/html-ejs');
 
 const { compiledScriptTag } = require('../../lib/assets');
 
-function Workspace({ navTitle, showLogs, heartbeatIntervalSec, visibilityTimeoutSec, resLocals }) {
+function Workspace({
+  navTitle,
+  showLogs,
+  heartbeatIntervalSec,
+  visibilityTimeoutSec,
+  socketToken,
+  resLocals,
+}) {
   return html`
     <!doctype html>
     <html lang="en" class="h-100">
@@ -15,6 +22,7 @@ function Workspace({ navTitle, showLogs, heartbeatIntervalSec, visibilityTimeout
 
       <body
         class="d-flex flex-column h-100"
+        data-socket-token="${socketToken}"
         data-workspace-id="${resLocals.workspace_id}"
         data-heartbeat-interval-sec="${heartbeatIntervalSec}"
         data-visibility-timeout-sec="${visibilityTimeoutSec}"

--- a/apps/prairielearn/src/pages/workspace/workspace.js
+++ b/apps/prairielearn/src/pages/workspace/workspace.js
@@ -35,9 +35,7 @@ router.get('/', (_req, res, _next) => {
       heartbeatIntervalSec: config.workspaceHeartbeatIntervalSec,
       visibilityTimeoutSec: config.workspaceVisibilityTimeoutSec,
       socketToken: generateSignedToken(
-        {
-          workspace_id: res.locals.workspace_id.toString(),
-        },
+        { workspace_id: res.locals.workspace_id.toString() },
         config.secretKey,
       ),
       resLocals: res.locals,

--- a/apps/prairielearn/src/pages/workspace/workspace.js
+++ b/apps/prairielearn/src/pages/workspace/workspace.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const asyncHandler = require('express-async-handler');
 const sqldb = require('@prairielearn/postgres');
 const workspaceUtils = require('@prairielearn/workspace-utils');
+import { generateSignedToken } from '@prairielearn/signed-token';
 
 const { config } = require('../../lib/config');
 
@@ -33,6 +34,12 @@ router.get('/', (_req, res, _next) => {
       showLogs: res.locals.authn_is_administrator || res.locals.authn_is_instructor,
       heartbeatIntervalSec: config.workspaceHeartbeatIntervalSec,
       visibilityTimeoutSec: config.workspaceVisibilityTimeoutSec,
+      socketToken: generateSignedToken(
+        {
+          workspace_id: res.locals.workspace_id.toString(),
+        },
+        config.secretKey,
+      ),
       resLocals: res.locals,
     }),
   );


### PR DESCRIPTION
Currently, workspace sockets aren't fully authenticated, meaning a user could in theory read the state (though not the contents) of another workspace. This PR implements token-based authentication to fix that.

Closes https://github.com/PrairieLearnInc/sysconf/issues/1468.