### PR TITLE
Set maximum value for external grading timeouts

### DIFF
--- a/apps/prairielearn/src/lib/config.js
+++ b/apps/prairielearn/src/lib/config.js
@@ -161,6 +161,7 @@ const ConfigSchema = z.object({
   externalGradingAutoScalingGroupName: z.string().nullable().default(null),
   externalGradingS3Bucket: z.string().default('prairielearn.dev.grading'),
   externalGradingDefaultTimeout: z.number().default(30), // seconds
+  externalGradingMaximumTimeout: z.number().default(60 * 10), // seconds
   externalGradingLoadAverageIntervalSec: z.number().default(30),
   externalGradingHistoryLoadIntervalSec: z.number().default(15 * 60),
   externalGradingCurrentCapacityFactor: z.number().default(1),

--- a/apps/prairielearn/src/lib/externalGraderLocal.js
+++ b/apps/prairielearn/src/lib/externalGraderLocal.js
@@ -23,7 +23,10 @@ class Grader {
 
     const dir = getDevJobDirectory(grading_job.id);
     const hostDir = getDevHostJobDirectory(grading_job.id);
-    const timeout = question.external_grading_timeout || config.externalGradingDefaultTimeout;
+    const timeout = Math.min(
+      question.external_grading_timeout ?? config.externalGradingDefaultTimeout,
+      config.externalGradingMaximumTimeout,
+    );
 
     const docker = new Docker();
 

--- a/apps/prairielearn/src/lib/externalGraderSqs.js
+++ b/apps/prairielearn/src/lib/externalGraderSqs.js
@@ -109,7 +109,10 @@ async function sendJobToQueue(jobId, question, config) {
         entrypoint: question.external_grading_entrypoint,
         s3Bucket: config.externalGradingS3Bucket,
         s3RootKey: getS3RootKey(jobId),
-        timeout: question.external_grading_timeout || config.externalGradingDefaultTimeout,
+        timeout: Math.min(
+          question.external_grading_timeout ?? config.externalGradingDefaultTimeout,
+          config.externalGradingMaximumTimeout,
+        ),
         enableNetworking: question.external_grading_enable_networking || false,
         environment: question.external_grading_environment || {},
       };

--- a/apps/prairielearn/src/sync/course-db.js
+++ b/apps/prairielearn/src/sync/course-db.js
@@ -8,6 +8,7 @@ const Ajv = require('ajv').default;
 const betterAjvErrors = require('better-ajv-errors').default;
 const { parseISO, isValid, isAfter, isFuture } = require('date-fns');
 const { chalk } = require('../lib/chalk');
+const { config } = require('../lib/config');
 
 const schemas = require('../schemas');
 const infofile = require('./infofile');
@@ -1031,6 +1032,15 @@ async function validateQuestion(question) {
       await jsonLoad.validateJSONAsync(options, schema);
     } catch (err) {
       errors.push(err.message);
+    }
+  }
+
+  if (question.externalGradingOptions?.timeout) {
+    if (question.externalGradingOptions.timeout > config.externalGradingMaximumTimeout) {
+      question.externalGradingOptions.timeout = config.externalGradingMaximumTimeout;
+      warnings.push(
+        `External grading timeouts of more than ${config.externalGradingMaximumTimeout} seconds are not allowed. Timeout has been set to ${config.externalGradingMaximumTimeout} seconds.`,
+      );
     }
   }
 

--- a/apps/prairielearn/src/sync/course-db.js
+++ b/apps/prairielearn/src/sync/course-db.js
@@ -1039,7 +1039,7 @@ async function validateQuestion(question) {
     if (question.externalGradingOptions.timeout > config.externalGradingMaximumTimeout) {
       question.externalGradingOptions.timeout = config.externalGradingMaximumTimeout;
       warnings.push(
-        `External grading timeouts of more than ${config.externalGradingMaximumTimeout} seconds are not allowed. Timeout has been set to ${config.externalGradingMaximumTimeout} seconds.`,
+        `External grading timeout value of ${question.externalGradingOptions.timeout} seconds exceeds the maximum value and has been limited to ${config.externalGradingMaximumTimeout} seconds.`,
       );
     }
   }

--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -66,7 +66,7 @@ External grading configuration is done on a per-question basis. All configuratio
 
 - `serverFilesCourse`: Specifies a list of files or directories that will be copied from a course's `serverFilesCourse` into the grading job. This can be useful if you want to share a standard grading framework between many questions. This property is optional.
 
-- `timeout`: Specifies a timeout for the grading job in seconds. If grading has not completed after that time has elapsed, the job will be killed and reported as a failure to the student. This is optional and defaults to 30 seconds. This should be as small as is reasonable for your jobs.
+- `timeout`: Specifies a timeout for the grading job in seconds. If grading has not completed after that time has elapsed, the job will be killed and reported as a failure to the student. This is optional and defaults to 30 seconds. This should be as small as is reasonable for your jobs. This value cannot exceed 600 seconds (10 minutes).
 
 - `enableNetworking`: Allows the container to access the public internet. This is disabled by default to make secure, isolated execution the default behavior.
 

--- a/exampleCourse/questions/demo/autograder/c/salesTax/info.json
+++ b/exampleCourse/questions/demo/autograder/c/salesTax/info.json
@@ -11,7 +11,7 @@
     "externalGradingOptions": {
         "enabled": true,
         "image": "prairielearn/grader-c",
-        "timeout": 1000,
+        "timeout": 100,
         "entrypoint": "python3 /grade/tests/test.py"
     }
 }

--- a/exampleCourse/questions/demo/autograder/c/salesTax/info.json
+++ b/exampleCourse/questions/demo/autograder/c/salesTax/info.json
@@ -11,7 +11,7 @@
     "externalGradingOptions": {
         "enabled": true,
         "image": "prairielearn/grader-c",
-        "timeout": 100,
+        "timeout": 10,
         "entrypoint": "python3 /grade/tests/test.py"
     }
 }


### PR DESCRIPTION
Closes #8808. As noted in that issue, the limit of 10 minutes (600 seconds) has been selected to have minimal impact on current questions. While some courses do have higher limits set, we don't see any evidence that well-behaved submissions are coming anywhere close to exceeding those timeouts. 600 seconds allows virtually all questions/submissions to continue functioning as they have been.