### PR TITLE
Fix grading job output spinner

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ejs
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ejs
@@ -119,7 +119,9 @@
             });
           </script>
           <pre class="bg-dark text-white rounded p-3 mb-0" id="job-output" style="display: none;"></pre>
-          <i class="fa fa-spinner fa-spin fa-2x" id="job-output-loading" style="width: 100%; text-align: center;"></i>
+          <div id="job-output-loading" class="w-100 text-center">
+            <i class="fa fa-spinner fa-spin fa-2x"></i>
+          </div>
           <% } else { %>
           <% if (grading_job.output) { %>
           <pre class="bg-dark text-white rounded p-3 mb-0" id="job-output"><%= grading_job.output %></pre>


### PR DESCRIPTION
This PR fixes two bugs with the external grading results page:

- Sometimes, the spinner wouldn't be hidden once the output was loaded. AFAICT this is a race condition with Fontawesome, which actually replaces the `<i>` tag with an `<svg>` tag. Somehow, this results in jQuery not finding the node to remove it.
- The spinner was very wide and rotating, which made the page grow and shrink vertically as it rotated.

Both of these issues are visible in the following screen recording from prod:

https://github.com/PrairieLearn/PrairieLearn/assets/1476544/00016451-fa3a-49a1-96b8-6f5cc3d92541

