### PR TITLE
Fix navbar script in pages without the default navbar

### DIFF
--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -4,12 +4,15 @@ import CookiesModule from 'js-cookie';
 const COOKIE_EXPIRATION_DAYS = 30;
 
 onDocumentReady(() => {
+  const usernameNav = document.getElementById('username-nav');
+  // The navbar is not present in some pages (e.g., workspace pages), in that case we do nothing.
+  if (!usernameNav) return;
+
   const Cookies = CookiesModule.withAttributes({
     path: '/',
     expires: COOKIE_EXPIRATION_DAYS,
   });
 
-  const usernameNav = document.getElementById('username-nav');
   const accessAsAdministrator = usernameNav.dataset.accessAsAdministrator === 'true';
   const viewType = usernameNav.dataset.viewType;
   const authnCourseRole = usernameNav.dataset.authnCourseRole;


### PR DESCRIPTION
Pages like the workspace page and the login page do not have a regular navbar. This causes the navbar script to trigger an error on start.