### PR TITLE
Improve grader-host visibility timeout handling

### DIFF
--- a/apps/grader-host/.mocharc.js
+++ b/apps/grader-host/.mocharc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  require: ['ts-node/register'],
+};

--- a/apps/grader-host/package.json
+++ b/apps/grader-host/package.json
@@ -7,7 +7,7 @@
     "dev:no-watch": "ts-node --transpile-only src/index.js",
     "dev": "nodemon --exec \"yarn dev:no-watch\" --",
     "start": "node dist/index.js",
-    "test": "mocha --no-config --require ts-node/register src/**/*.test.{js,ts}"
+    "test": "mocha src/**/*.test.{js,ts}"
   },
   "dependencies": {
     "@aws-sdk/client-auto-scaling": "^3.438.0",

--- a/apps/grader-host/src/index.js
+++ b/apps/grader-host/src/index.js
@@ -115,24 +115,24 @@ async.series(
           receiveFromQueue(
             sqs,
             config.jobsQueueUrl,
-            (job, fail, success) => {
+            (job, done) => {
               globalLogger.info(`received ${job.jobId} from queue`);
 
               // Ensure that this job wasn't canceled in the time since job submission.
               isJobCanceled(job, (err, canceled) => {
-                if (ERR(err, fail)) return;
+                if (ERR(err, done)) return;
 
                 if (canceled) {
                   globalLogger.info(`Job ${job.jobId} was canceled; skipping job`);
-                  success();
+                  done();
                   return;
                 }
 
                 handleJob(job, (err) => {
                   globalLogger.info(`handleJob(${job.jobId}) completed with err=${err}`);
-                  if (ERR(err, fail)) return;
+                  if (ERR(err, done)) return;
                   globalLogger.info(`handleJob(${job.jobId}) succeeded`);
-                  success();
+                  done();
                 });
               });
             },

--- a/apps/grader-host/src/lib/config.js
+++ b/apps/grader-host/src/lib/config.js
@@ -52,6 +52,8 @@ const ConfigSchema = z.object({
   sentryDsn: z.string().nullable().default(null),
   sentryEnvironment: z.string().nullable().default(null),
   awsRegion: z.string().default('us-east-2'),
+  visibilityTimeout: z.number().default(60),
+  visibilityTimeoutHeartbeatIntervalSec: z.number().default(30),
 });
 
 function makeProductionConfigSource() {

--- a/apps/grader-host/src/lib/receiveFromQueue.js
+++ b/apps/grader-host/src/lib/receiveFromQueue.js
@@ -9,11 +9,62 @@ const {
   ChangeMessageVisibilityCommand,
   DeleteMessageCommand,
 } = require('@aws-sdk/client-sqs');
+const Sentry = require('@prairielearn/sentry');
+const { setTimeout: sleep } = require('node:timers/promises');
 
 const globalLogger = require('./logger');
 const { config } = require('./config');
 
 let messageSchema = null;
+
+/**
+ * @param {import('@aws-sdk/client-sqs').SQSClient} sqs
+ * @param {string} queueUrl
+ * @param {string} receiptHandle
+ * @param {number} timeout
+ * @returns {Promise<void>}
+ */
+async function extendVisibilityTimeout(sqs, queueUrl, receiptHandle, timeout) {
+  await sqs.send(
+    new ChangeMessageVisibilityCommand({
+      QueueUrl: queueUrl,
+      ReceiptHandle: receiptHandle,
+      VisibilityTimeout: timeout,
+    }),
+  );
+}
+
+/**
+ * @param {import('@aws-sdk/client-sqs').SQSClient} sqs
+ * @param {string} queueUrl
+ * @param {string} receiptHandle
+ */
+async function startHeartbeat(sqs, queueUrl, receiptHandle) {
+  const abortController = new AbortController();
+
+  // Run the first extension immediately before we start processing the job.
+  await extendVisibilityTimeout(sqs, queueUrl, receiptHandle, config.visibilityTimeout);
+
+  // We want this process to run in the background, so we don't await it.
+  // `extendVisibilityTimeout` will handle errors.
+  // eslint-disable-next-line no-floating-promise/no-floating-promise
+  (async () => {
+    while (!abortController.signal.aborted) {
+      await sleep(config.visibilityTimeoutHeartbeatIntervalSec * 1000, null, { ref: false });
+
+      if (abortController.signal.aborted) return;
+
+      try {
+        await extendVisibilityTimeout(sqs, queueUrl, receiptHandle, config.visibilityTimeout);
+      } catch (err) {
+        globalLogger.error('Error extending visibility timeout', err);
+        Sentry.captureException(err);
+      }
+    }
+  })();
+
+  return abortController;
+}
 
 /**
  *
@@ -24,6 +75,10 @@ let messageSchema = null;
  */
 module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
   let parsedMessage, receiptHandle;
+
+  /** @type {AbortController} */
+  let heartbeatAbortController;
+
   async.series(
     [
       (callback) => {
@@ -78,29 +133,19 @@ module.exports = function (sqs, queueUrl, receiveCallback, doneCallback) {
         }
       },
       async () => {
-        const timeout = parsedMessage.timeout || config.defaultTimeout;
-        // Add additional time to account for pulling the image, downloading/uploading files, etc.
-        const newTimeout = timeout + config.timeoutOverhead;
-        await sqs.send(
-          new ChangeMessageVisibilityCommand({
-            QueueUrl: queueUrl,
-            ReceiptHandle: receiptHandle,
-            VisibilityTimeout: newTimeout,
-          }),
-        );
+        heartbeatAbortController = await startHeartbeat(sqs, queueUrl, receiptHandle);
       },
       (callback) => {
-        receiveCallback(
-          parsedMessage,
-          (err) => {
+        receiveCallback(parsedMessage, (err) => {
+          heartbeatAbortController.abort();
+          if (err) {
             globalLogger.info(`Job ${parsedMessage.jobId} errored.`);
             callback(err);
-          },
-          () => {
+          } else {
             globalLogger.info(`Job ${parsedMessage.jobId} finished successfully.`);
             callback(null);
-          },
-        );
+          }
+        });
       },
       async () => {
         await sqs.send(

--- a/apps/grader-host/src/lib/receiveFromQueue.js
+++ b/apps/grader-host/src/lib/receiveFromQueue.js
@@ -24,7 +24,7 @@ let messageSchema = null;
  * @param {number} timeout
  * @returns {Promise<void>}
  */
-async function extendVisibilityTimeout(sqs, queueUrl, receiptHandle, timeout) {
+async function changeVisibilityTimeout(sqs, queueUrl, receiptHandle, timeout) {
   await sqs.send(
     new ChangeMessageVisibilityCommand({
       QueueUrl: queueUrl,
@@ -43,7 +43,7 @@ async function startHeartbeat(sqs, queueUrl, receiptHandle) {
   const abortController = new AbortController();
 
   // Run the first extension immediately before we start processing the job.
-  await extendVisibilityTimeout(sqs, queueUrl, receiptHandle, config.visibilityTimeout);
+  await changeVisibilityTimeout(sqs, queueUrl, receiptHandle, config.visibilityTimeout);
 
   // We want this process to run in the background, so we don't await it.
   // `extendVisibilityTimeout` will handle errors.
@@ -55,7 +55,7 @@ async function startHeartbeat(sqs, queueUrl, receiptHandle) {
       if (abortController.signal.aborted) return;
 
       try {
-        await extendVisibilityTimeout(sqs, queueUrl, receiptHandle, config.visibilityTimeout);
+        await changeVisibilityTimeout(sqs, queueUrl, receiptHandle, config.visibilityTimeout);
       } catch (err) {
         globalLogger.error('Error extending visibility timeout', err);
         Sentry.captureException(err);

--- a/apps/grader-host/src/tests/receiveFromQueue.test.js
+++ b/apps/grader-host/src/tests/receiveFromQueue.test.js
@@ -69,14 +69,13 @@ function fakeSqs(options = {}) {
   });
 }
 
-const TIMEOUT_OVERHEAD = 300;
+const VISIBILITY_TIMEOUT = 60;
 
 describe('queueReceiver', () => {
   beforeEach(() => {
     // Our config-loading system chokes when it's not running in AWS. Instead
     // of loading it, we'll just set the values we need for these tests.
-    config.visibilityTimeout = 60;
-    config.timeoutOverhead = TIMEOUT_OVERHEAD;
+    config.visibilityTimeout = VISIBILITY_TIMEOUT;
   });
 
   it('tries to receive a message from the correct queue url', (done) => {
@@ -159,7 +158,7 @@ describe('queueReceiver', () => {
         assert.isNull(err);
         assert.equal(sqs.changeMessageVisibility.callCount, 1);
         const params = sqs.changeMessageVisibility.args[0][0].input;
-        assert.equal(params.VisibilityTimeout, 60);
+        assert.equal(params.VisibilityTimeout, VISIBILITY_TIMEOUT);
         done();
       },
     );


### PR DESCRIPTION
Previously, we would compute an expected visibility timeout immediately after receiving a message from SQS and update the visibility timeout to that. However, this causes problems if a grader host dies while processing a job, as we'll end up waiting quite a bit of time until it's retried.

Now, we use [the heartbeat approach from the SQS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#configuring-visibility-timeout):

> If you don't know how long it takes to process a message, create a heartbeat for your consumer process: Specify the initial visibility timeout (for example, 2 minutes) and then—as long as your consumer still works on the message—keep extending the visibility timeout by 2 minutes every minute.

This should allow us to retry lost jobs much more quickly (though probably still not quickly enough for students in some cases, who may elect to re-submit a job in the meantime).

This code is difficult to test locally; I plan to test it on our staging environment before merging.