### PR TITLE
Add shift-click multiple selection functionality for manual grading table

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ejs
@@ -33,6 +33,7 @@
          theadClasses: 'thead-light',
          stickyHeader: true,
          filterControl: true,
+         multipleSelectRow: true,
          rowStyle: row => (row.requires_manual_grading ? {} : { classes: 'text-muted bg-light' }),
          buttons: {
            showStudentInfo: {


### PR DESCRIPTION
I encountered a small annoyance the other day, where I had to select multiple student assessment instances for regrading. I tried using shift clicking to select multiple instances at once, but this feature wasn't supported.

I did some quick digging, turns out this is already a feature in the bootstrap-table: https://bootstrap-table.com/docs/api/table-options/#multipleselectrow. This PR simply enables this shift clicking feature. 