### PR TITLE
Python grader: proper handling of syntax error in test code

### DIFF
--- a/graders/python/python_autograder/pl_main.py
+++ b/graders/python/python_autograder/pl_main.py
@@ -38,8 +38,6 @@ def add_files(results):
 
 if __name__ == "__main__":
     try:
-        from filenames.test import Test as test_case
-
         filenames_dir = os.environ.get("FILENAMES_DIR")
         base_dir = os.environ.get("MERGE_DIR")
 
@@ -49,6 +47,8 @@ if __name__ == "__main__":
         with open(join(filenames_dir, OUTPUT_FILE), "r") as output_f:
             output_fname = output_f.read()
         os.remove(join(filenames_dir, OUTPUT_FILE))
+
+        from filenames.test import Test as test_case
 
         # Update the working directory so tests may access local files
         prev_wd = os.getcwd()


### PR DESCRIPTION
In the Python grader, if there is a syntax error in the test code (tests/test.py), currently an error like the following would show in the grading job terminal:

```
info: container> [run] starting autograder
info: container> Traceback (most recent call last):
info: container>   File "/grade/run/pl_main.py", line 41, in <module>
info: container>     from filenames.test import Test as test_case
info: container>   File "/grade/run/filenames/test.py", line 4, in <module>
info: container>     from faker import Faker
info: container> ModuleNotFoundError: No module named 'faker'
info: container> During handling of the above exception, another exception occurred:
info: container> Traceback (most recent call last):
info: container>   File "/grade/run/pl_main.py", line 144, in <module>
info: container>     with open(output_fname, mode="w") as out:
info: container> NameError: name 'output_fname' is not defined
info: container> [run] autograder completed
```

In essence this was caused because `output_fname` is created after importing the test class, but expected to exist in the exception handler. Rearranging this causes the error to show up in the actual output of the submission, making for an easier debugging of the code.

Not sure if this kind of error was intentionally left out of the submission code, in that case a better solution would be to do a proper handling of the case where this is uninitialized in the error handling.