### PR TITLE
Ignore vendored files from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,9 @@
 # https://stackoverflow.com/a/51564689 and
 # https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/** binary
-public/images/** binary
+
+# Exclude vendored files from GitHub statistics. Note that this also includes
+# legacy v2 question client files, which is first-party code that we intend
+# to never touch again.
+apps/prairielearn/public/javascripts/** linguist-vendored
+apps/prairielearn/public/localscripts/** linguist-vendored


### PR DESCRIPTION
This should make the language stats that GitHub generates a little more accurate.