### PR TITLE
Don't query for unused submissions.sid column

### DIFF
--- a/apps/prairielearn/src/lib/question.sql
+++ b/apps/prairielearn/src/lib/question.sql
@@ -62,7 +62,6 @@ SELECT
   s.override_score,
   s.regradable,
   s.score,
-  s.sid,
   s.v2_score,
   s.variant_id,
   s.manual_rubric_grading_id,


### PR DESCRIPTION
This column is no longer used; it appears to be left over from an ancient migration from MongoDB.