### PR TITLE
Fix update of LTI outcomes in external grader

### DIFF
--- a/apps/prairielearn/src/lib/assessment.sql
+++ b/apps/prairielearn/src/lib/assessment.sql
@@ -15,8 +15,8 @@ FROM
   grading_jobs AS gj
   JOIN submissions AS s ON (s.id = gj.submission_id)
   JOIN variants AS v ON (v.id = s.variant_id)
-  LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
-  LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+  JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+  JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
 WHERE
   gj.id = $grading_job_id;
 

--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -391,12 +391,14 @@ export async function processGradingResult(content: any): Promise<void> {
       content.grading.score,
       null, // `v2_score`: gross legacy, this can safely be null
     ]);
-    const assessment_instance_id = await sqldb.queryRow(
+    const assessment_instance_id = await sqldb.queryOptionalRow(
       sql.select_assessment_for_grading_job,
       { grading_job_id: content.gradingId },
       IdSchema,
     );
-    await promisify(ltiOutcomes.updateScore)(assessment_instance_id);
+    if (assessment_instance_id != null) {
+      await promisify(ltiOutcomes.updateScore)(assessment_instance_id);
+    }
   } finally {
     externalGradingSocket.gradingJobStatusUpdated(content.gradingId);
   }


### PR DESCRIPTION
In #8829 the queries in assessment.js were updated to use Zod validation. One query was incorrectly marked as requiring a mandatory ID, even though the query allowed for a null ID. This wouldn't cause a problem before because the function being called would ignore null inputs, but the new validation caused an error. This error would typically not cause an issue on user interface, since this happened after the grading results were saved, but an exception would be thrown in the background.

 To avoid confusion, in this fix the query is replaced with `queryOptionalRow`, which more clearly identifies this as a query that may not result a valid entry.