### PR TITLE
Improve robustness of question sharing tests

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -147,7 +147,7 @@ export const InstructorSharing = ({
               <tbody>
                 <tr>
                   <th>Sharing Name</th>
-                  <td>
+                  <td data-testid="sharing-name">
                     ${sharingName !== null
                       ? sharingName
                       : html`
@@ -228,7 +228,7 @@ export const InstructorSharing = ({
                   (sharing_set) => html`
                     <tr>
                       <td class="align-middle">${sharing_set.name}</td>
-                      <td class="align-middle">
+                      <td class="align-middle" data-testid="shared-with">
                         ${sharing_set.shared_with.map(
                           (course_shared_with) => html`
                             <span class="badge color-gray1"> ${course_shared_with} </span>

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -87,7 +87,7 @@
             <% if (sharing_enabled) { %>
             <tr>
               <th class="align-middle">Sharing</th>
-              <td>
+              <td data-testid="shared-with">
                 <% if (question.shared_publicly) { %>
                   <span class="badge color-green3">Public</span>
                   This question is publicly shared.


### PR DESCRIPTION
Tests were previously using `String.prototype.includes` to check for the presence of text on pages. However, this isn't ideal, as string may appear or disappear from pages for reasons unrelated to the thing being tested. This PR adds some `data-testid` attributes and uses Cheerio to run tests against those elements specifically.