### PR TITLE
Update Debian version of xtermjs workspace

### DIFF
--- a/workspaces/xtermjs/Dockerfile
+++ b/workspaces/xtermjs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bookworm
+FROM node:20-bookworm
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y emacs-nox vim tmux

--- a/workspaces/xtermjs/Dockerfile
+++ b/workspaces/xtermjs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:buster
+FROM node:18-bookworm
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y emacs-nox vim tmux


### PR DESCRIPTION
`buster` was released in 2019, and it's [past official end-of-life, in LTS mode](https://wiki.debian.org/DebianReleases). `bookworm` has been release this past June and is the latest stable version, with plans for long term support.

The previous version used a generic distro name without an explicit Node version (i.e., `node:buster` instead of `node:20-buster`). For bookworm this would be Node 21, which didn't work for `node-pty`. `20-bookworm` (using Node 20) worked as expected, and I believe setting a specific version of Node might not be a bad idea anyway.

The plan is to open this PR for review, but hold off on deploying it until late December (in between terms) to avoid potential issues in the middle of the term.