### PR TITLE
Set default git branch while running tests

### DIFF
--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -475,10 +475,16 @@ function createCourseFiles(callback) {
           cwd: '.',
           env: process.env,
         };
-        exec(`git init --bare ${courseOriginDir}`, execOptions, (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
+        // Ensure that the default branch is master, regardless of how git
+        // is configured on the host machine.
+        exec(
+          `git -c "init.defaultBranch=master" init --bare ${courseOriginDir}`,
+          execOptions,
+          (err) => {
+            if (ERR(err, callback)) return;
+            callback(null);
+          },
+        );
       },
       (callback) => {
         const execOptions = {
@@ -533,6 +539,30 @@ function createCourseFiles(callback) {
         };
         exec(`git clone ${courseOriginDir} ${courseDevDir}`, execOptions, (err) => {
           if (ERR(err, callback)) return;
+          callback(null);
+        });
+      },
+      (callback) => {
+        const execOptions = {
+          cwd: courseLiveDir,
+          env: process.env,
+        };
+        exec(`git remote`, execOptions, (err, stdout, stderr) => {
+          if (ERR(err, callback)) return;
+          console.log('stdout', stdout);
+          console.log('stderr', stderr);
+          callback(null);
+        });
+      },
+      (callback) => {
+        const execOptions = {
+          cwd: courseDevDir,
+          env: process.env,
+        };
+        exec(`git remote`, execOptions, (err, stdout, stderr) => {
+          if (ERR(err, callback)) return;
+          console.log('stdout', stdout);
+          console.log('stderr', stderr);
           callback(null);
         });
       },

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -542,30 +542,6 @@ function createCourseFiles(callback) {
           callback(null);
         });
       },
-      (callback) => {
-        const execOptions = {
-          cwd: courseLiveDir,
-          env: process.env,
-        };
-        exec(`git remote`, execOptions, (err, stdout, stderr) => {
-          if (ERR(err, callback)) return;
-          console.log('stdout', stdout);
-          console.log('stderr', stderr);
-          callback(null);
-        });
-      },
-      (callback) => {
-        const execOptions = {
-          cwd: courseDevDir,
-          env: process.env,
-        };
-        exec(`git remote`, execOptions, (err, stdout, stderr) => {
-          if (ERR(err, callback)) return;
-          console.log('stdout', stdout);
-          console.log('stderr', stderr);
-          callback(null);
-        });
-      },
     ],
     (err) => {
       if (ERR(err, callback)) return;

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -387,10 +387,16 @@ function createCourseFiles(callback) {
           cwd: '.',
           env: process.env,
         };
-        exec(`git init --bare ${courseOriginDir}`, execOptions, (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
+        // Ensure that the default branch is master, regardless of how git
+        // is configured on the host machine.
+        exec(
+          `git -c "init.defaultBranch=master" init --bare ${courseOriginDir}`,
+          execOptions,
+          (err) => {
+            if (ERR(err, callback)) return;
+            callback(null);
+          },
+        );
       },
       (callback) => {
         const execOptions = {


### PR DESCRIPTION
This code was written while pairing with Nathan to fix some local errors. This pull request will set the default git branch to `master` while running tests in `fileEditor` and `courseEditor`. This corrects a use case of a user that has set up git to have a default branch other than 'master'. For example, my local setup had been using 'main' instead of 'master' as the default git branch. This PR ensures that git is using 'master' and that tests are able to run as expected. 