### PR TITLE
Commit session before redirecting

### DIFF
--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -109,11 +109,15 @@ export function createSessionMiddleware(options: SessionOptions) {
       }
     });
 
-    beforeEnd(res, next, async () => {
-      if (!req.session) {
+    let sessionPersisted = false;
+
+    async function persistSession(req: Request) {
+      if (!req.session || sessionPersisted) {
         // There is no session to do anything with.
         return;
       }
+
+      sessionPersisted = true;
 
       const isExistingSession = cookieSessionId && cookieSessionId === req.session.id;
       const hashChanged = hashSession(req.session) !== originalHash;
@@ -138,7 +142,27 @@ export function createSessionMiddleware(options: SessionOptions) {
           truncateExpirationDate(expirationDate),
         );
       }
+    }
+
+    // We'll attempt to persist the session at the end of the request. This
+    // hacky strategy is borrowed from `express-session`.
+    beforeEnd(res, next, async () => {
+      await persistSession(req);
     });
+
+    // We'll also attempt to persist the session before performing a redirect.
+    // This is necessary because browsers and `fetch()` implementations aren't
+    // required to wait for a response body to be received before following a
+    // redirect. So, we need to make sure that the session is persisted before
+    // we send the redirect response. This way, the subsequent GET will be able
+    // to load the latest session data.
+    const originalRedirect = res.redirect as any;
+    res.redirect = function redirect(...args: any[]) {
+      persistSession(req).then(
+        () => originalRedirect.apply(res, args),
+        (err) => next(err),
+      );
+    };
 
     next();
   });


### PR DESCRIPTION
This PR aims to fix a race condition in our session code where a session could be read before the updated session from the previous request was committed. It does so by replacing `res.redirect` with a function that commits the session before the redirect is actually executed. This is safe to do from the caller's point of view, as `res.redirect()` does not return anything.

When I added an artificial delay to session persistence, more of the session tests broke. Specifically, those that use `sendStatus()` didn't work. I briefly considered making the same change to that function, but `sendStatus()` is meant to return the `Response` object for chaining, and there's no way to do something asynchronous before returning from `sendStatus()`. Ultimately, I decided this is fine to avoid:

- We should generally only be writing to the session in `POST` requests.
- We should never be responding to `POST` requests with anything but a redirect.
- We should only ever be performing redirects via `res.redirect()`, not by manually setting headers and status codes.

So, I'm pretty sure that handling just `redirect()` covers our bases. The only other time we write to the session store during a `GET` is the request in which the session is created, which is already handled reasonably well elsewhere.

I'm afraid we'll never get 100% robust handling of sessions until we move away from Express and towards something like https://hono.dev/ that provides proper support for this kind of "unconditionally run async logic before sending any part of the response" thing.