### PR TITLE
Fix public question preview page

### DIFF
--- a/apps/prairielearn/.mocharc.js
+++ b/apps/prairielearn/.mocharc.js
@@ -1,13 +1,29 @@
+// We support running our tests in two modes:
+//
+// - Directly against the source files in `src/`, in which case we use
+// `ts-node` to transpile it on the fly. Useful for quick iteration during
+// development.
+//
+// - Against the compiled files in `dist/`, in which case we use the compiled
+// files directly without compilation. This is useful for CI and for ensuring
+// that the code that will actually run in production is tested.
+//
+// We use the presence of any arguments starting with `dist/` or containing
+// `/dist/` to determine whether we're running in the latter mode.
+const isRunningOnDist = process.argv
+  .slice(2)
+  .some((arg) => arg.startsWith('dist/') || arg.includes('/dist/'));
+
 module.exports = {
   require: [
     // Set up `TS_NODE_*` environment variables. This must be loaded before
     // `ts-node/register`. Environment variables are implemented here instead
     // of via `ENV=...` so that they're used even when executing Mocha directly,
     // e.g. `yarn mocha path/to/file.ts`.
-    './src/tests/mocha-env.mjs',
-    'ts-node/register',
-    './src/tests/mocha-hooks.ts',
-  ],
+    isRunningOnDist ? null : './src/tests/mocha-env.mjs',
+    isRunningOnDist ? null : 'ts-node/register',
+    isRunningOnDist ? './dist/tests/mocha-hooks.js' : './src/tests/mocha-hooks.ts',
+  ].filter(Boolean),
   timeout: '30000', // in milliseconds
   'watch-files': ['.'],
 };

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon --exec \"yarn dev:no-watch\" --",
     "start-executor": "node dist/executor.js",
     "start": "node dist/server.js",
-    "test": "mocha --parallel src/**/*.test.{js,ts}"
+    "test": "mocha --parallel src/**/*.test.{js,ts}",
+    "test:dist": "mocha --parallel dist/**/*.test.js"
   },
   "dependencies": {
     "@aws-sdk/client-auto-scaling": "^3.438.0",

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -100,7 +100,7 @@ router.get('/', function (req, res, next) {
         (err) => {
           if (ERR(err, next)) return;
           question.setRendererHeader(res);
-          res.render(__filename.replace(/\.ts$/, '.ejs'), res.locals);
+          res.render(__filename.replace(/\.(js|ts)$/, '.ejs'), res.locals);
         },
       );
     })


### PR DESCRIPTION
Using `.ts` in the regexp works in dev, but won't work in prod when the file actually has a `.js` extension.

I added support for running our PL tests against the contents of `dist`, which is what will actually run in production. This is useful since it lets us validate that TypeScript/ESM transforms will produce code that works as expected. I'm not quite ready to make this the default thing we run in CI, but I think that will be a good thing to do in the near future, especially as work on TS/ESM picks up.