### PR TITLE
Sharing info edit permissions consistency

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -149,9 +149,8 @@ export const InstructorSharing = ({
                 <tr>
                   <th>Sharing Name</th>
                   <td data-testid="sharing-name">
-                    ${sharingName !== null
-                      ? sharingName
-                      : isCourseOwner
+                    ${sharingName !== null ? sharingName : ''}
+                    ${!sharingName && isCourseOwner
                       ? html`
                           <button
                             type="button"

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -125,6 +125,7 @@ export const InstructorSharing = ({
   sharingSets: { name: string; id: string; shared_with: string[] }[];
   resLocals: Record<string, any>;
 }) => {
+  const isCourseOwner = resLocals.authz_data.has_course_permission_own;
   return html`
     <!doctype html>
     <html lang="en">
@@ -150,7 +151,8 @@ export const InstructorSharing = ({
                   <td data-testid="sharing-name">
                     ${sharingName !== null
                       ? sharingName
-                      : html`
+                      : isCourseOwner
+                      ? html`
                           <button
                             type="button"
                             class="btn btn-xs btn-secondary mx-2"
@@ -164,7 +166,8 @@ export const InstructorSharing = ({
                             <span class="d-none d-sm-inline">Choose Sharing Name</span>
                           </button>
                           ${chooseSharingNameModal(resLocals)}
-                        `}
+                        `
+                      : ''}
                   </td>
                 </tr>
                 <tr>
@@ -198,24 +201,26 @@ export const InstructorSharing = ({
                 <div class="col-auto">
                   <span class="text-white">Sharing Sets</span>
                 </div>
-                <div class="col-auto">
-                  <button
-                    type="button"
-                    class="btn btn-light btn-sm ml-auto"
-                    id="courseSharingSetAdd"
-                    data-toggle="popover"
-                    data-container="body"
-                    data-html="true"
-                    data-placement="auto"
-                    title="Create Sharing Set"
-                    data-content="${addSharingSetPopover(resLocals)}"
-                    data-trigger="manual"
-                    onclick="$(this).popover('show')"
-                  >
-                    <i class="fas fa-plus" aria-hidden="true"></i>
-                    <span class="d-none d-sm-inline">Create Sharing Set</span>
-                  </button>
-                </div>
+                ${isCourseOwner
+                  ? html`<div class="col-auto">
+                      <button
+                        type="button"
+                        class="btn btn-light btn-sm ml-auto"
+                        id="courseSharingSetAdd"
+                        data-toggle="popover"
+                        data-container="body"
+                        data-html="true"
+                        data-placement="auto"
+                        title="Create Sharing Set"
+                        data-content="${addSharingSetPopover(resLocals)}"
+                        data-trigger="manual"
+                        onclick="$(this).popover('show')"
+                      >
+                        <i class="fas fa-plus" aria-hidden="true"></i>
+                        <span class="d-none d-sm-inline">Create Sharing Set</span>
+                      </button>
+                    </div>`
+                  : ''}
               </div>
             </div>
             <table class="table table-sm table-hover table-striped">
@@ -233,25 +238,29 @@ export const InstructorSharing = ({
                           (course_shared_with) => html`
                             <span class="badge color-gray1"> ${course_shared_with} </span>
                           `,
-                        )}
-                        <div class="btn-group btn-group-sm" role="group">
-                          <button
-                            type="button"
-                            class="btn btn-sm btn-outline-dark"
-                            id="addCourseToSS-${sharing_set.id}"
-                            data-toggle="popover"
-                            data-container="body"
-                            data-html="true"
-                            data-placement="auto"
-                            title="Add Course to Sharing Set"
-                            data-content="${addCourseToSharingSetPopover(resLocals, sharing_set)}"
-                            data-trigger="manual"
-                            onclick="$(this).popover('show')"
-                          >
-                            Add...
-                            <i class="fas fa-plus" aria-hidden="true"></i>
-                          </button>
-                        </div>
+                        )}${isCourseOwner
+                          ? html` <div class="btn-group btn-group-sm" role="group">
+                              <button
+                                type="button"
+                                class="btn btn-sm btn-outline-dark"
+                                id="addCourseToSS-${sharing_set.id}"
+                                data-toggle="popover"
+                                data-container="body"
+                                data-html="true"
+                                data-placement="auto"
+                                title="Add Course to Sharing Set"
+                                data-content="${addCourseToSharingSetPopover(
+                                  resLocals,
+                                  sharing_set,
+                                )}"
+                                data-trigger="manual"
+                                onclick="$(this).popover('show')"
+                              >
+                                Add...
+                                <i class="fas fa-plus" aria-hidden="true"></i>
+                              </button>
+                            </div>`
+                          : ''}
                       </td>
                     </tr>
                   `,

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -92,11 +92,15 @@
                   <span class="badge color-green3">Public</span>
                   This question is publicly shared.
                 <% } else { %>
-                  Shared With:
-                  <% sharing_sets_in.forEach(function(sharing_set) { %>
-                    <span class="badge color-gray1"><%= sharing_set.name %></span>
-                  <% }); %>
-                  <% if (authz_data.has_course_permission_edit && !course.example_course) { %>
+                  <% if (sharing_sets_in.length === 0) { %>
+                    Not Shared
+                  <% } else { %>
+                    Shared With:
+                    <% sharing_sets_in.forEach(function(sharing_set) { %>
+                      <span class="badge color-gray1"><%= sharing_set.name %></span>
+                    <% }); %>
+                  <% } %>
+                  <% if (authz_data.has_course_permission_own && !course.example_course) { %>
                     <% if (sharing_sets_other.length > 0) { %>
                     <form name="sharing-set-add" method="POST" class="d-inline">
                       <input type="hidden" name="__action" value="sharing_set_add">

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -194,7 +194,10 @@ router.post('/', function (req, res, next) {
       .enabledFromLocals('question-sharing', res.locals)
       .then((questionSharingEnabled) => {
         if (!questionSharingEnabled) {
-          next(error.make(403, 'Access denied (feature not available)'));
+          return next(error.make(403, 'Access denied (feature not available)'));
+        }
+        if (!res.locals.authz_data.has_course_permission_own) {
+          return next(error.make(403, 'Access denied (must be a course Owner)'));
         }
         sqldb.queryZeroOrOneRow(
           sql.sharing_set_add,
@@ -216,7 +219,10 @@ router.post('/', function (req, res, next) {
       .enabledFromLocals('question-sharing', res.locals)
       .then((questionSharingEnabled) => {
         if (!questionSharingEnabled) {
-          next(error.make(403, 'Access denied (feature not available)'));
+          return next(error.make(403, 'Access denied (feature not available)'));
+        }
+        if (!res.locals.authz_data.has_course_permission_own) {
+          return next(error.make(403, 'Access denied (must be a course Owner)'));
         }
         sqldb.queryZeroOrOneRow(
           sql.update_question_shared_publicly,

--- a/apps/prairielearn/src/pages/publicQuestions/publicQuestions.html.ts
+++ b/apps/prairielearn/src/pages/publicQuestions/publicQuestions.html.ts
@@ -33,8 +33,8 @@ export const QuestionsPage = ({
                 __csrf_token: resLocals.__csrf_token,
               })
             : html`<p>
-                This course doesn't have a sharing name. If you are an administrator of this course,
-                please choose a sharing name on the
+                This course doesn't have a sharing name. If you are an Owner of this course, please
+                choose a sharing name on the
                 <a
                   href="${resLocals.plainUrlPrefix}/course/${resLocals.course
                     .id}/course_admin/sharing"


### PR DESCRIPTION
Previously there were a few inconsistencies in who could edit sharing permissions. 
Only a course owner could edit sharing sets and sharing names, but any course editor
could share a question. The permissions were also not made clear by the user interfaces.

This PR brings consistency by making it so only course owners can edit all sharing information,
and this is properly reflected by what UI elements are present to what users on pages.

