### PR TITLE
Soft-delete user sessions

### DIFF
--- a/apps/prairielearn/src/lib/session-store.sql
+++ b/apps/prairielearn/src/lib/session-store.sql
@@ -5,7 +5,8 @@ FROM
   user_sessions
 WHERE
   session_id = $session_id
-  AND expires_at > now();
+  AND expires_at > now()
+  AND revoked_at IS NULL;
 
 -- BLOCK set_session
 INSERT INTO
@@ -26,6 +27,8 @@ SET
   expires_at = $expires_at;
 
 -- BLOCK destroy_session
-DELETE FROM user_sessions
+UPDATE user_sessions
+SET
+  revoked_at = now()
 WHERE
   session_id = $session_id;

--- a/apps/prairielearn/src/migrations/20231121232108_user_sessions__revoked_at__add.sql
+++ b/apps/prairielearn/src/migrations/20231121232108_user_sessions__revoked_at__add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_sessions
+ADD COLUMN revoked_at TIMESTAMP WITH TIME ZONE;

--- a/database/tables/user_sessions.pg
+++ b/database/tables/user_sessions.pg
@@ -3,6 +3,7 @@ columns
     data: jsonb not null
     expires_at: timestamp with time zone not null
     id: bigint not null default nextval('user_sessions_id_seq'::regclass)
+    revoked_at: timestamp with time zone
     session_id: text not null
     updated_at: timestamp with time zone not null default now()
     user_id: bigint


### PR DESCRIPTION
As discussed on #8798, we want sessions to stay around forever so that we can associate them with client fingerprints. This PR switches our session store to "destroy" sessions by setting `revoked_at`.