### PR TITLE
Handle case of no course instances on staff page

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.sql
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.sql
@@ -37,6 +37,7 @@ SELECT
   ) FILTER (
     WHERE
       cip.course_instance_role IS NULL
+      AND ci.id IS NOT NULL
   ) AS other_course_instances
 FROM
   course_permissions AS cp


### PR DESCRIPTION
If a course has no course instances, we used to still show the "Add..." button for student data access that rendered for a null course instance:

<img width="509" alt="Screenshot 2023-11-21 at 16 49 56" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/c9cf7747-aa2d-4d94-ac10-cf706f8df8de">

This is because `other_course_instances` looked like `[{ id: null, short_name: null }]`. Now we filter out rows where there wasn't even a course instance to join with. The staff page already correctly handled the case where the `other_course_instances` array was empty.