### PR TITLE
Scope sync popover JavaScript to specific popovers

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -33,19 +33,25 @@ onDocumentReady(() => {
     var text = '';
     if (question.sync_errors) {
       text += html`<button
-        class="btn btn-xs mr-1"
+        class="btn btn-xs mr-1 js-sync-popover"
         data-toggle="popover"
+        data-trigger="hover"
+        data-container="body"
+        data-html="true"
         data-title="Sync Errors"
-        data-content='<pre style="background-color: black" class="text-white rounded p-3">${question.sync_errors_ansified}</pre>'
+        data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_errors_ansified}</pre>'
       >
         <i class="fa fa-times text-danger" aria-hidden="true"></i>
       </button>`;
     } else if (question.sync_warnings) {
       text += html`<button
-        class="btn btn-xs mr-1"
+        class="btn btn-xs mr-1 js-sync-popover"
         data-toggle="popover"
+        data-trigger="hover"
+        data-container="body"
+        data-html="true"
         data-title="Sync Warnings"
-        data-content='<pre style="background-color: black" class="text-white rounded p-3">${question.sync_warnings_ansified}</pre>'
+        data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_warnings_ansified}</pre>'
       >
         <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
       </button>`;
@@ -163,12 +169,9 @@ onDocumentReady(() => {
     },
     onPreBody: function () {},
     onResetView: function () {
-      $('[data-toggle="popover"]')
+      $('.js-sync-popover[data-toggle="popover"]')
         .popover({
           sanitize: false,
-          container: 'body',
-          html: true,
-          trigger: 'hover',
         })
         .on('show.bs.popover', function () {
           $($(this).data('bs.popover').getTipElement()).css('max-width', '80%');

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ejs
@@ -8,11 +8,8 @@
   </head>
   <script>
     $(() => {
-        $('[data-toggle="popover"]').popover({
+        $('.js-sync-popover[data-toggle="popover"]').popover({
             sanitize: false,
-            container: 'body',
-            html: true,
-            trigger: 'hover',
         }).on("show.bs.popover", function() {
             $($(this).data("bs.popover").getTipElement()).css("max-width", "80%");
         });;
@@ -105,15 +102,29 @@
                 </td>
                 <td>
                   <% if (question.sync_errors) { %>
-                  <button class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Errors"
-                          data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3&quot;><%= question.sync_errors_ansified %></pre>">
-                    <i class="fa fa-times text-danger" aria-hidden="true"></i>
-                  </button>
+                    <button
+                      class="btn btn-xs mr-1 js-sync-popover"
+                      data-toggle="popover"
+                      data-trigger="hover"
+                      data-container="body"
+                      data-html="true"
+                      data-title="Sync Errors"
+                      data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3 mb-0&quot;><%= question.sync_errors_ansified %></pre>"
+                    >
+                      <i class="fa fa-times text-danger" aria-hidden="true"></i>
+                    </button>
                   <% } else if (question.sync_warnings) { %>
-                  <button class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Warnings"
-                          data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3&quot;><%= question.sync_warnings_ansified %></pre>">
-                    <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
-                  </button>
+                    <button
+                      class="btn btn-xs mr-1 js-sync-popover"
+                      data-toggle="popover"
+                      data-trigger="hover"
+                      data-container="body"
+                      data-html="true"
+                      data-title="Sync Warnings"
+                      data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3 mb-0&quot;><%= question.sync_warnings_ansified %></pre>"
+                    >
+                      <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
+                    </button>
                   <% } %>
                   <%= question.display_name %>
                 </td>

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ejs
@@ -9,11 +9,8 @@
   </head>
   <script>
     $(() => {
-        $('[data-toggle="popover"]').popover({
+        $('.js-sync-popover[data-toggle="popover"]').popover({
             sanitize: false,
-            container: 'body',
-            html: true,
-            trigger: 'hover',
         }).on("show.bs.popover", function() {
             $($(this).data("bs.popover").getTipElement()).css("max-width", "80%");
         });
@@ -105,15 +102,29 @@
                 </td>
                 <td class="align-middle">
                   <% if (row.sync_errors) { %>
-                  <button class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Errors"
-                          data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3&quot;><%= row.sync_errors_ansified %></pre>">
-                    <i class="fa fa-times text-danger" aria-hidden="true"></i>
-                  </button>
+                    <button
+                      class="btn btn-xs mr-1 js-sync-popover"
+                      data-toggle="popover"
+                      data-trigger="hover"
+                      data-container="body"
+                      data-html="true"
+                      data-title="Sync Errors"
+                      data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3 mb-0&quot;><%= row.sync_errors_ansified %></pre>"
+                    >
+                      <i class="fa fa-times text-danger" aria-hidden="true"></i>
+                    </button>
                   <% } else if (row.sync_warnings) { %>
-                  <button class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Warnings"
-                          data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3&quot;><%= row.sync_warnings_ansified %></pre>">
-                    <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
-                  </button>
+                    <button
+                      class="btn btn-xs mr-1 js-sync-popover"
+                      data-toggle="popover"
+                      data-trigger="hover"
+                      data-container="body"
+                      data-html="true"
+                      data-title="Sync Warnings"
+                      data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3 mb-0&quot;><%= row.sync_warnings_ansified %></pre>"
+                    >
+                      <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
+                    </button>
                   <% } %>
                   <a href="<%= urlPrefix %>/assessment/<%= row.id %>/"><%= row.title %>
                   <% if (row.group_work) { %>


### PR DESCRIPTION
`$('[data-toggle="popover"]').popover(...)` is problematic if you want to have *other* popovers on a page that don't follow the settings of the sync popovers (80% max width, HTML, etc). All sync popovers now have a `js-sync-popover` class so that we can specifically target those popovers.