### PR TITLE
Fix dev login with empty UIN

### DIFF
--- a/apps/prairielearn/src/pages/authLogin/authLogin.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.ts
@@ -105,8 +105,8 @@ router.get(
 );
 
 const DevLoginParamsSchema = z.object({
-  uid: z.string().nonempty(),
-  name: z.string().nonempty(),
+  uid: z.string().min(1),
+  name: z.string().min(1),
   uin: z.string().nullable().optional().default(null),
 });
 
@@ -123,7 +123,7 @@ router.post(
       const authnParams = {
         uid: body.uid,
         name: body.name,
-        uin: body.uin,
+        uin: body.uin || null,
         provider: 'dev',
       };
 


### PR DESCRIPTION
Without this change, we'd end up with the empty string as a UIN. This meant that logging in as a *different* user, also with an empty UIN, would actually update the existing user.