### PR TITLE
Immediately persist new sessions

### DIFF
--- a/.changeset/wise-ads-explain.md
+++ b/.changeset/wise-ads-explain.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/session': minor
+---
+
+Immediately persist newly-created sessions to store

--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -482,7 +482,7 @@ describe('session middleware', () => {
       // There should not be a cookie.
       assert.isNull(res.headers.get('set-cookie'));
 
-      // Even though the cookies wasn't set, we should still have persisted the
+      // Even though the cookie wasn't set, we should still have persisted the
       // session to the store.
       const originalSessionId = await res.text();
       assert.isNotNull(await store.get(originalSessionId));

--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -482,10 +482,10 @@ describe('session middleware', () => {
       // There should not be a cookie.
       assert.isNull(res.headers.get('set-cookie'));
 
-      // Since the cookie wasn't set, the session should not have been persisted
-      // to the store.
+      // Even though the cookies wasn't set, we should still have persisted the
+      // session to the store.
       const originalSessionId = await res.text();
-      assert.isNull(await store.get(originalSessionId));
+      assert.isNotNull(await store.get(originalSessionId));
 
       // Now fetch from the correct domain.
       res = await fetchWithCookies(url, {
@@ -688,6 +688,32 @@ describe('session middleware', () => {
 
       // Ensure that the legacy session is migrated to a new session.
       assert.equal(newSessionId, legacySessionId);
+    });
+  });
+
+  it('persists the session immediately after creation', async () => {
+    const store = new MemoryStore();
+
+    const app = express();
+    app.use(
+      createSessionMiddleware({
+        store,
+        secret: TEST_SECRET,
+      }),
+    );
+    app.get(
+      '/',
+      asyncHandler(async (req, res) => {
+        const persistedSession = await store.get(req.session.id);
+        res.status(persistedSession == null ? 500 : 200).send();
+      }),
+    );
+
+    await withServer(app, async ({ url }) => {
+      const fetchWithCookies = fetchCookie(fetch);
+
+      const res = await fetchWithCookies(url);
+      assert.equal(res.status, 200);
     });
   });
 });

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -11,7 +11,13 @@ import {
   getSessionCookie,
   getSessionIdFromCookie,
 } from './cookie';
-import { type Session, generateSessionId, loadSession, hashSession } from './session';
+import {
+  type Session,
+  generateSessionId,
+  loadSession,
+  hashSession,
+  truncateExpirationDate,
+} from './session';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -119,14 +125,17 @@ export function createSessionMiddleware(options: SessionOptions) {
 
       sessionPersisted = true;
 
-      const isExistingSession = cookieSessionId && cookieSessionId === req.session.id;
+      // If this is a new session, we would have already persisted it to the
+      // store, so we don't need to take that into consideration here.
+      //
+      // If the hash of the session data changed, we'll unconditionally persist
+      // the updated data to the store. However, if the hash didn't change, we
+      // only want to persist it if the expiration changed *and* if we can set
+      // a cookie to reflect the updated expiration date.
       const hashChanged = hashSession(req.session) !== originalHash;
       const didExpirationChange =
         originalExpirationDate.getTime() !== req.session.getExpirationDate().getTime();
-      if (
-        (hashChanged && isExistingSession) ||
-        (canSetCookie && (!isExistingSession || didExpirationChange))
-      ) {
+      if (hashChanged || (didExpirationChange && canSetCookie)) {
         // Only update the expiration date in the store if we were actually
         // able to update the cookie too.
         const expirationDate = canSetCookie
@@ -182,10 +191,4 @@ function getCookieNames(cookieName: string | string[] | undefined): string[] {
 
 function signSessionId(sessionId: string, secret: string): string {
   return signature.sign(sessionId, secret);
-}
-
-function truncateExpirationDate(date: Date) {
-  const time = date.getTime();
-  const truncatedTime = Math.floor(time / 1000) * 1000;
-  return new Date(truncatedTime);
 }

--- a/packages/session/src/session.test.ts
+++ b/packages/session/src/session.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 
 import { MemoryStore } from './memory-store';
-import { hashSession, loadSession, makeSession } from './session';
+import { loadSession, makeSession } from './session';
 
 const SESSION_MAX_AGE = 10000;
 const SESSION_EXPIRATION_DATE = new Date(Date.now() + SESSION_MAX_AGE);

--- a/packages/session/src/session.test.ts
+++ b/packages/session/src/session.test.ts
@@ -108,15 +108,4 @@ describe('session', () => {
       assert.isNull(await store.get('123'));
     });
   });
-
-  describe('hashSession', () => {
-    it('ignores the cookie property', () => {
-      const hash1 = hashSession({ id: '123' } as any);
-      const hash2 = hashSession({ id: '123', cookie: { foo: 'bar' } } as any);
-
-      assert.equal(hash1, hash2);
-    });
-  });
-
-  it('has cookie property', () => {});
 });


### PR DESCRIPTION
This is a prerequisite for #8798. We want to be able to unconditionally look up a session by its `session_id` during a request and get a valid `id` back.