### PR TITLE
Handle case of comment key in question/element dependencies

### DIFF
--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1423,9 +1423,9 @@ module.exports = {
               clientFilesCourseScripts: {},
             };
 
-            // Question dependencies are checked via schema on sync-time, so
-            // there's no need for sanity checks here.
             for (let type in question.dependencies) {
+              if (!_.has(dependencies, type)) continue;
+
               for (let dep of question.dependencies[type]) {
                 if (!_.includes(dependencies[type], dep)) {
                   dependencies[type].push(dep);
@@ -1493,6 +1493,8 @@ module.exports = {
               }
 
               for (const type in elementDependencies) {
+                if (!_.has(dependencies, type)) continue;
+
                 for (const dep of elementDependencies[type]) {
                   if (!_.includes(dependencies[type], dep)) {
                     dependencies[type].push(dep);
@@ -1560,6 +1562,8 @@ module.exports = {
                   }
 
                   for (const type in extension) {
+                    if (!_.has(dependencies, type)) continue;
+
                     for (const dep of extension[type]) {
                       if (!_.includes(dependencies[type], dep)) {
                         dependencies[type].push(dep);


### PR DESCRIPTION
Before this fix, the `demo/custom/elementHiddenTag` question would crash because there's a `comment` key in the element's `dependencies`:

https://github.com/PrairieLearn/PrairieLearn/blob/92523a44662f6cc7c5eed8f0ba8b9128d5b70c3d/exampleCourse/elements/clickable-image/info.json#L5