### PR TITLE
Fix score upload of questions without submissions

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -340,7 +340,7 @@ async function updateInstanceQuestionFromJson(
         qid,
       },
       z.object({
-        submission_id: IdSchema,
+        submission_id: IdSchema.nullable(),
         instance_question_id: IdSchema,
         uid_or_group: z.string(),
         qid: z.string(),


### PR DESCRIPTION
As reported by @glherman . The score upload functionality fails with a Zod error when the specific question does not have a submission.