### PR TITLE
Handle native intervals in IntervalSchema

### DIFF
--- a/apps/prairielearn/src/lib/db-types.test.ts
+++ b/apps/prairielearn/src/lib/db-types.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import parsePostgresInterval = require('postgres-interval');
 
 import { IdSchema, IntervalSchema } from './db-types';
 
@@ -30,6 +31,11 @@ describe('IdSchema', () => {
 });
 
 describe('IntervalSchema', () => {
+  it('handles a PostgresInterval object', () => {
+    const interval = IntervalSchema.parse(parsePostgresInterval('1 year 2 months 3 days'));
+    assert.equal(interval, 37000800000);
+  });
+
   it('parses an interval with date', () => {
     const interval = IntervalSchema.parse('1 year 2 months 3 days');
     assert.equal(interval, 37000800000);

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -8,37 +8,69 @@ const INTERVAL_MS_PER_DAY = 24 * INTERVAL_MS_PER_HOUR;
 const INTERVAL_MS_PER_MONTH = 30 * INTERVAL_MS_PER_DAY;
 const INTERVAL_MS_PER_YEAR = 365.25 * INTERVAL_MS_PER_DAY;
 
-// IDs are always coerced to strings. This ensures consistent handling when an
-// ID is fetched directly or via `to_jsonb`, which returns a number.
-//
-// The `refine` step is important to ensure that the thing we've coerced to a
-// string is actually a number. If it's not, we want to fail quickly.
+/**
+ * IDs are always coerced to strings. This ensures consistent handling when an
+ * ID is fetched directly or via `to_jsonb`, which returns a number.
+ *
+ * The `refine` step is important to ensure that the thing we've coerced to a
+ * string is actually a number. If it's not, we want to fail quickly.
+ */
 export const IdSchema = z
   .string({ coerce: true })
   .refine((val) => /^\d+$/.test(val), { message: 'ID is not a non-negative integer' });
 
-export const IntervalSchema = z.string().transform((val) => {
-  const interval = parsePostgresInterval(val);
-
-  // This calculation matches Postgres's behavior when computing the number of
-  // milliseconds in an interval with `EXTRACT(epoch from '...'::interval) * 1000`.
-  // The noteworthy parts of this conversion are that 1 year = 365.25 days and
-  // 1 month = 30 days.
-  return (
-    interval.years * INTERVAL_MS_PER_YEAR +
-    interval.months * INTERVAL_MS_PER_MONTH +
-    interval.days * INTERVAL_MS_PER_DAY +
-    interval.hours * INTERVAL_MS_PER_HOUR +
-    interval.minutes * INTERVAL_MS_PER_MINUTE +
-    interval.seconds * INTERVAL_MS_PER_SECOND +
-    interval.milliseconds
-  );
+/**
+ * This is a schema for the objects produced by the `postgres-interval` library.
+ */
+const PostgresIntervalSchema = z.object({
+  years: z.number(),
+  months: z.number(),
+  days: z.number(),
+  hours: z.number(),
+  minutes: z.number(),
+  seconds: z.number(),
+  milliseconds: z.number(),
 });
 
-// Accepts either a string or a Date object. If a string is passed, it is
-// validated and parsed as an ISO date string.
-//
-// Useful for parsing dates from JSON, which are always strings.
+/**
+ * This schema handles two representations of an interval:
+ *
+ * - A string like "1 year 2 days", which is how intervals will be represented
+ *   if they go through `to_jsonb` in a query.
+ * - A {@link PostgresIntervalSchema} object, which is what we'll get if a
+ *   query directly returns an interval column. The interval will already be
+ *   parsed by `postgres-interval` by way of `pg-types`.
+ *
+ * In either case, we convert the interval to a number of milliseconds.
+ */
+export const IntervalSchema = z
+  .union([z.string(), PostgresIntervalSchema])
+  .transform((interval) => {
+    if (typeof interval === 'string') {
+      interval = parsePostgresInterval(interval);
+    }
+
+    // This calculation matches Postgres's behavior when computing the number of
+    // milliseconds in an interval with `EXTRACT(epoch from '...'::interval) * 1000`.
+    // The noteworthy parts of this conversion are that 1 year = 365.25 days and
+    // 1 month = 30 days.
+    return (
+      interval.years * INTERVAL_MS_PER_YEAR +
+      interval.months * INTERVAL_MS_PER_MONTH +
+      interval.days * INTERVAL_MS_PER_DAY +
+      interval.hours * INTERVAL_MS_PER_HOUR +
+      interval.minutes * INTERVAL_MS_PER_MINUTE +
+      interval.seconds * INTERVAL_MS_PER_SECOND +
+      interval.milliseconds
+    );
+  });
+
+/**
+ * Accepts either a string or a Date object. If a string is passed, it is
+ * validated and parsed as an ISO date string.
+ *
+ * Useful for parsing dates from JSON, which are always strings.
+ */
 export const DateFromISOString = z
   .union([z.string(), z.date()])
   .refine(


### PR DESCRIPTION
See inline comment for more details. tl;dr: sometimes intervals will get to Zod as a pre-parsed object, and we need to handle that case too.