### PR TITLE
Remove unused column from grading job page

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -22,7 +22,6 @@ export const GradingJobQueryResultSchema = z.object({
   formatted_graded_at: z.string().nullable(),
   question_qid: z.string(),
   user_uid: z.string(),
-  course_instance_short_name: z.string(),
 });
 type GradingJobQueryResult = z.infer<typeof GradingJobQueryResultSchema>;
 

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.sql
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.sql
@@ -37,7 +37,6 @@ SELECT
     gj.graded_at,
     coalesce(ci.display_timezone, c.display_timezone)
   ) AS formatted_graded_at,
-  ci.short_name AS course_instance_short_name,
   q.directory AS question_qid,
   u.uid AS user_uid
 FROM


### PR DESCRIPTION
This column was `NULL` when this page was served from the course route. I was originally going to mark it as `nullable()`, but it turns out it's completely unused!