### PR TITLE
Improve checks for GitHub repository creation

### DIFF
--- a/apps/prairielearn/src/lib/github.js
+++ b/apps/prairielearn/src/lib/github.js
@@ -58,7 +58,7 @@ async function createRepoFromTemplateAsync(client, repo, template) {
       await client.repos.getContent({
         owner: config.githubCourseOwner,
         repo: repo,
-        path: '',
+        path: 'infoCourse.json',
       });
       return;
     } catch (err) {


### PR DESCRIPTION
Apparently, the `getContent` API will succeed after the repo has been created but before the contents of the template repository have been copied in. This PR updates the repository creation process to check for the existence of a specific file before deciding that the repository has been created successfully.