### PR TITLE
Add openai to python-requirements.txt

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -14,6 +14,7 @@ matplotlib==3.8.2
 networkx==3.2.1
 nltk==3.8.1
 numpy==1.26.2
+openai==0.27.4
 openpyxl==3.1.2
 pandas-stubs==2.1.1.230928
 pandas==2.1.1


### PR DESCRIPTION
Hi there! I a prospective customer looking at using PrairieLearn. As I build out a few sample questions to see if it fits our use cases, I'm working on building a basic example of an AI-graded open response assessment. I am wondering if other customers might want to do the same. I'm proposing adding support for that in python-requirements.txt so that autograders can call to openai/chatgpt based on the student's response. Open to any push back on this (including being told to install the package on my own course like is called out in the docs) - but I thought I might start here first since it is a one line effort (although I recognize allowing an AI package might trigger large conversations of "does PrairieLearn want to do that?").