### PR TITLE
Convert all tests to ESM

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -200,6 +200,7 @@
     "@types/jquery": "^3.5.29",
     "@types/js-cookie": "^3.0.6",
     "@types/jsdom": "^21.1.6",
+    "@types/json-stable-stringify": "^1.0.36",
     "@types/json-stringify-safe": "^5.0.3",
     "@types/klaw": "^3.0.6",
     "@types/lodash": "^4.14.202",

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -123,7 +123,6 @@
     "morphdom": "^2.7.1",
     "multer": "^1.4.5-lts.1",
     "mustache": "^4.2.0",
-    "ncp": "^2.0.0",
     "node-fetch": "^2.7.0",
     "node-jose": "^2.2.0",
     "nodemon": "^3.0.2",

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 var request = require('request');
 var cheerio = require('cheerio');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const { ensureEnrollment } = require('../models/enrollment');
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 import { assert } from 'chai';
-var request = require('request');
+const request = require('request');
 import * as cheerio from 'cheerio';
 import * as sqldb from '@prairielearn/postgres';
 
@@ -11,11 +11,11 @@ import * as helperServer from './helperServer';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
-var siteUrl = 'http://localhost:' + config.serverPort;
-var baseUrl = siteUrl + '/pl';
-var courseInstanceBaseUrl = baseUrl + '/course_instance/1';
-var assessmentsUrl = courseInstanceBaseUrl + '/assessments';
-var assessmentInstanceUrl = courseInstanceBaseUrl + '/assessment_instance/1';
+const siteUrl = 'http://localhost:' + config.serverPort;
+const baseUrl = siteUrl + '/pl';
+const courseInstanceBaseUrl = baseUrl + '/course_instance/1';
+const assessmentsUrl = courseInstanceBaseUrl + '/assessments';
+const assessmentInstanceUrl = courseInstanceBaseUrl + '/assessment_instance/1';
 
 describe('Access control', function () {
   this.timeout(20000);

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -3,13 +3,13 @@ const ERR = require('async-stacktrace');
 import { assert } from 'chai';
 var request = require('request');
 import * as cheerio from 'cheerio';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
 import { ensureEnrollment } from '../models/enrollment';
-import * as sqldb from '@prairielearn/postgres');
-var sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 var siteUrl = 'http://localhost:' + config.serverPort;
 var baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -5,7 +5,7 @@ var request = require('request');
 var cheerio = require('cheerio');
 
 import { config } from '../lib/config';
-const { ensureEnrollment } = require('../models/enrollment');
+import { ensureEnrollment } from '../models/enrollment';
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -329,9 +329,9 @@ describe('Access control', function () {
     it('should produce an addVectors instance_question in the DB', function (callback) {
       sqldb.query(sql.select_instance_question_addVectors, [], function (err, result) {
         if (ERR(err, callback)) return;
-        if (result.rowCount === 0) {
+        if (result.rowCount == null || result.rowCount === 0) {
           return callback(new Error('did not find addVectors instance question in DB'));
-        } else if (result.rowCount == null || result.rowCount > 1) {
+        } else if (result.rowCount > 1) {
           return callback(
             new Error('multiple rows found: ' + JSON.stringify(result.rows, null, '    ')),
           );

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -6,7 +6,7 @@ import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 import { ensureEnrollment } from '../models/enrollment';
-var sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -2,14 +2,14 @@
 const ERR = require('async-stacktrace');
 import { assert } from 'chai';
 var request = require('request');
-var cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 import { ensureEnrollment } from '../models/enrollment';
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 var siteUrl = 'http://localhost:' + config.serverPort;
 var baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 const ERR = require('async-stacktrace');
 import { assert } from 'chai';
 var request = require('request');
@@ -45,49 +46,49 @@ describe('Access control', function () {
 
   var cookiesStudent = function () {
     var cookies = request.jar();
-    cookies.setCookie(request.cookie('pl_test_user=test_student'), siteUrl);
+    cookies.setCookie('pl_test_user=test_student', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExam = function () {
     var cookies = cookiesStudent();
-    cookies.setCookie(request.cookie('pl_test_mode=Exam'), siteUrl);
+    cookies.setCookie('pl_test_mode=Exam', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExamBeforeCourseInstance = function () {
     var cookies = cookiesStudentExam();
-    cookies.setCookie(request.cookie('pl_test_date=1750-06-13T13:12:00Z'), siteUrl);
+    cookies.setCookie('pl_test_date=1750-06-13T13:12:00Z', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExamBeforeAssessment = function () {
     var cookies = cookiesStudentExam();
-    cookies.setCookie(request.cookie('pl_test_date=1850-06-13T13:12:00Z'), siteUrl);
+    cookies.setCookie('pl_test_date=1850-06-13T13:12:00Z', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExamBeforeReservation = function () {
     var cookies = cookiesStudentExam();
-    cookies.setCookie(request.cookie('pl_test_date=1950-06-13T13:12:00Z'), siteUrl);
+    cookies.setCookie('pl_test_date=1950-06-13T13:12:00Z', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExamAfterReservation = function () {
     var cookies = cookiesStudentExam();
-    cookies.setCookie(request.cookie('pl_test_date=2250-06-13T13:12:00Z'), siteUrl);
+    cookies.setCookie('pl_test_date=2250-06-13T13:12:00Z', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExamAfterAssessment = function () {
     var cookies = cookiesStudentExam();
-    cookies.setCookie(request.cookie('pl_test_date=2350-06-13T13:12:00Z'), siteUrl);
+    cookies.setCookie('pl_test_date=2350-06-13T13:12:00Z', siteUrl);
     return cookies;
   };
 
   var cookiesStudentExamAfterCourseInstance = function () {
     var cookies = cookiesStudentExam();
-    cookies.setCookie(request.cookie('pl_test_date=2450-06-13T13:12:00Z'), siteUrl);
+    cookies.setCookie('pl_test_date=2450-06-13T13:12:00Z', siteUrl);
     return cookies;
   };
 
@@ -136,7 +137,7 @@ describe('Access control', function () {
 
   describe('3. Enroll student user into testCourse', function () {
     it('should succeed', async () => {
-      await ensureEnrollment({ user_id: user.user_id, course_instance_id: 1 });
+      await ensureEnrollment({ user_id: user.user_id, course_instance_id: '1' });
     });
   });
 
@@ -330,7 +331,7 @@ describe('Access control', function () {
         if (ERR(err, callback)) return;
         if (result.rowCount === 0) {
           return callback(new Error('did not find addVectors instance question in DB'));
-        } else if (result.rowCount > 1) {
+        } else if (result.rowCount == null || result.rowCount > 1) {
           return callback(
             new Error('multiple rows found: ' + JSON.stringify(result.rows, null, '    ')),
           );

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -1,5 +1,5 @@
 const ERR = require('async-stacktrace');
-var assert = require('chai').assert;
+import { assert } from 'chai';
 var request = require('request');
 var cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/access.test.js
+++ b/apps/prairielearn/src/tests/access.test.js
@@ -1,4 +1,4 @@
-var ERR = require('async-stacktrace');
+const ERR = require('async-stacktrace');
 var assert = require('chai').assert;
 var request = require('request');
 var cheerio = require('cheerio');

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -18,7 +18,7 @@ const news_items = require('../../news_items');
 const { config } = require('../../lib/config');
 const helperServer = require('../helperServer');
 const { features } = require('../../lib/features/index');
-const { EXAMPLE_COURSE_PATH } = require('../../lib/paths');
+import { EXAMPLE_COURSE_PATH } from '../../lib/paths';
 
 const SITE_URL = 'http://localhost:' + config.serverPort;
 

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -13,11 +13,11 @@ const { A11yError } = require('@sa11y/format');
 const expressListEndpoints = require('express-list-endpoints');
 import * as sqldb from '@prairielearn/postgres';
 
-const server = require('../../server');
-const news_items = require('../../news_items');
+import * as server from '../../server';
+import * as news_items from '../../news_items';
 import { config } from '../../lib/config';
 import * as helperServer from '../helperServer';
-const { features } = require('../../lib/features/index');
+import { features } from '../../lib/features/index';
 import { EXAMPLE_COURSE_PATH } from '../../lib/paths';
 
 const SITE_URL = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -2,7 +2,7 @@
 
 // The OpenTelemetry instrumentation for Express breaks our ability to inspect
 // the Express routes. We need to disable it before loading the server.
-const { disableInstrumentations } = require('@prairielearn/opentelemetry');
+import { disableInstrumentations } from '@prairielearn/opentelemetry';
 disableInstrumentations();
 
 const { test } = require('mocha');

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -15,7 +15,7 @@ const sqldb = require('@prairielearn/postgres');
 
 const server = require('../../server');
 const news_items = require('../../news_items');
-const { config } = require('../../lib/config');
+import { config } from '../../lib/config';
 const helperServer = require('../helperServer');
 const { features } = require('../../lib/features/index');
 import { EXAMPLE_COURSE_PATH } from '../../lib/paths';

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -7,7 +7,7 @@ disableInstrumentations();
 
 import { test } from 'mocha';
 const axe = require('axe-core');
-const jsdom = require('jsdom');
+import { JSDOM } from 'jsdom';
 import fetch from 'node-fetch';
 import { A11yError } from '@sa11y/format';
 const expressListEndpoints = require('express-list-endpoints');
@@ -62,7 +62,7 @@ async function loadPageJsdom(url) {
     }
     return res.text();
   });
-  return new jsdom.JSDOM(text);
+  return new JSDOM(text);
 }
 
 /**

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -5,11 +5,11 @@
 import { disableInstrumentations } from '@prairielearn/opentelemetry';
 disableInstrumentations();
 
-const { test } = require('mocha');
+import { test } from 'mocha';
 const axe = require('axe-core');
 const jsdom = require('jsdom');
 import fetch from 'node-fetch';
-const { A11yError } = require('@sa11y/format');
+import { A11yError } from '@sa11y/format';
 const expressListEndpoints = require('express-list-endpoints');
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -16,7 +16,7 @@ const sqldb = require('@prairielearn/postgres');
 const server = require('../../server');
 const news_items = require('../../news_items');
 import { config } from '../../lib/config';
-const helperServer = require('../helperServer');
+import * as helperServer from '../helperServer';
 const { features } = require('../../lib/features/index');
 import { EXAMPLE_COURSE_PATH } from '../../lib/paths';
 

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -8,7 +8,7 @@ disableInstrumentations();
 const { test } = require('mocha');
 const axe = require('axe-core');
 const jsdom = require('jsdom');
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const { A11yError } = require('@sa11y/format');
 const expressListEndpoints = require('express-list-endpoints');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -11,7 +11,7 @@ const jsdom = require('jsdom');
 import fetch from 'node-fetch';
 const { A11yError } = require('@sa11y/format');
 const expressListEndpoints = require('express-list-endpoints');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 const server = require('../../server');
 const news_items = require('../../news_items');

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 import { assert } from 'chai';
 
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -2,7 +2,7 @@
 import { config } from '../lib/config';
 import { assert } from 'chai';
 
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 import { step } from 'mocha-steps';
 

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -6,7 +6,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 import { step } from 'mocha-steps';
 
 describe('Exam and homework assessment with active access restriction', function () {

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -1,13 +1,13 @@
 // @ts-check
-import { config } from '../lib/config';
 import { assert } from 'chai';
-
+import { step } from 'mocha-steps';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
+import { config } from '../lib/config';
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
-import { step } from 'mocha-steps';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam and homework assessment with active access restriction', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -7,7 +7,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
 
 const helperServer = require('./helperServer');
 const helperClient = require('./helperClient');
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 describe('Exam and homework assessment with active access restriction', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.js
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { config } = require('../lib/config');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/administrator.test.ts
+++ b/apps/prairielearn/src/tests/administrator.test.ts
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 import fetch from 'node-fetch';
-import cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
-import helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/administratorQueries.test.js
+++ b/apps/prairielearn/src/tests/administratorQueries.test.js
@@ -5,7 +5,7 @@ import { step } from 'mocha-steps';
 import { config } from '../lib/config';
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('AdministratorQuery page', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/administratorQueries.test.js
+++ b/apps/prairielearn/src/tests/administratorQueries.test.js
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('AdministratorQuery page', function () {

--- a/apps/prairielearn/src/tests/administratorQueries.test.js
+++ b/apps/prairielearn/src/tests/administratorQueries.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 

--- a/apps/prairielearn/src/tests/administratorQueries.test.js
+++ b/apps/prairielearn/src/tests/administratorQueries.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/administratorQueries.test.js
+++ b/apps/prairielearn/src/tests/administratorQueries.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 
 const helperServer = require('./helperServer');
 const helperClient = require('./helperClient');

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -6,7 +6,7 @@ const fetch = require('node-fetch').default;
 
 const { config } = require('../lib/config');
 const assets = require('../lib/assets');
-const { APP_ROOT_PATH } = require('../lib/paths');
+import { APP_ROOT_PATH } from '../lib/paths';
 
 const helperServer = require('./helperServer');
 

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs/promises');
 const path = require('node:path');
 import fetch from 'node-fetch';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const assets = require('../lib/assets');
 import { APP_ROOT_PATH } from '../lib/paths';
 

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const fs = require('node:fs/promises');
 const path = require('node:path');
 const fetch = require('node-fetch').default;

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -8,7 +8,7 @@ import { config } from '../lib/config';
 const assets = require('../lib/assets');
 import { APP_ROOT_PATH } from '../lib/paths';
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 const SITE_URL = 'http://localhost:' + config.serverPort;
 const ELEMENTS_PATH = path.resolve(APP_ROOT_PATH, 'elements');

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const fs = require('node:fs/promises');
 const path = require('node:path');
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 
 const { config } = require('../lib/config');
 const assets = require('../lib/assets');

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -5,7 +5,7 @@ const path = require('node:path');
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config';
-const assets = require('../lib/assets');
+import * as assets from '../lib/assets';
 import { APP_ROOT_PATH } from '../lib/paths';
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -6,7 +6,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Exam assessment with bonus points', function () {

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam assessment with bonus points', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -7,7 +7,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Exam assessment with bonus points', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/bonusPoints.test.js
+++ b/apps/prairielearn/src/tests/bonusPoints.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -6,11 +6,12 @@ import * as tmp from 'tmp-promise';
 import { config } from '../lib/config';
 import * as chunks from '../lib/chunks';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
-const helperQuestion = require('./helperQuestion');
+import * as helperQuestion from './helperQuestion';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Generate chunks and use them for a student homework', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 const tmp = require('tmp-promise');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
 
 import { config } from '../lib/config';
-const chunks = require('../lib/chunks');
+import * as chunks from '../lib/chunks';
 import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const chunks = require('../lib/chunks');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -5,7 +5,7 @@ import * as tmp from 'tmp-promise';
 
 import { config } from '../lib/config';
 const chunks = require('../lib/chunks');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-const tmp = require('tmp-promise');
+import * as tmp from 'tmp-promise';
 
 const { config } = require('../lib/config');
 const chunks = require('../lib/chunks');

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -8,7 +8,7 @@ const chunks = require('../lib/chunks');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 const helperQuestion = require('./helperQuestion');
 

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 const tmp = require('tmp-promise');
 

--- a/apps/prairielearn/src/tests/chunkAssessment.test.js
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.js
@@ -9,7 +9,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 const helperQuestion = require('./helperQuestion');
 
 describe('Generate chunks and use them for a student homework', function () {

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -13,7 +13,7 @@ import { TEST_COURSE_PATH } from '../lib/paths';
 const { makeMockLogger } = require('./mockLogger');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const { syncDiskToSqlAsync } = require('../sync/syncFromDisk');
 const { makeInfoFile } = require('../sync/infofile');
 

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
 const path = require('path');
-const { z } = require('zod');
+import { z } from 'zod';
 import * as sqldb from '@prairielearn/postgres';
 
 import * as courseDB from '../sync/course-db';

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -4,7 +4,7 @@ import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
 const path = require('path');
 const { z } = require('zod');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 const courseDB = require('../sync/course-db');
 const chunksLib = require('../lib/chunks');

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -9,7 +9,7 @@ const sqldb = require('@prairielearn/postgres');
 const courseDB = require('../sync/course-db');
 const chunksLib = require('../lib/chunks');
 const { config } = require('../lib/config');
-const { TEST_COURSE_PATH } = require('../lib/paths');
+import { TEST_COURSE_PATH } from '../lib/paths';
 const { makeMockLogger } = require('./mockLogger');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -6,16 +6,16 @@ const path = require('path');
 const { z } = require('zod');
 import * as sqldb from '@prairielearn/postgres';
 
-const courseDB = require('../sync/course-db');
-const chunksLib = require('../lib/chunks');
+import * as courseDB from '../sync/course-db';
+import * as chunksLib from '../lib/chunks';
 import { config } from '../lib/config';
 import { TEST_COURSE_PATH } from '../lib/paths';
-const { makeMockLogger } = require('./mockLogger');
-const sql = sqldb.loadSqlEquiv(__filename);
-
+import { makeMockLogger } from './mockLogger';
 import * as helperServer from './helperServer';
-const { syncDiskToSqlAsync } = require('../sync/syncFromDisk');
-const { makeInfoFile } = require('../sync/infofile');
+import { syncDiskToSqlAsync } from '../sync/syncFromDisk';
+import { makeInfoFile } from '../sync/infofile';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 /** @type {import('../sync/course-db').CourseData} */
 const COURSE = {

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const tmp = require('tmp-promise');
+import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
 const path = require('path');
 const { z } = require('zod');

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -8,7 +8,7 @@ const sqldb = require('@prairielearn/postgres');
 
 const courseDB = require('../sync/course-db');
 const chunksLib = require('../lib/chunks');
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 import { TEST_COURSE_PATH } from '../lib/paths';
 const { makeMockLogger } = require('./mockLogger');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const tmp = require('tmp-promise');
 import * as fs from 'fs-extra';
 const path = require('path');

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const assert = require('chai').assert;
 const tmp = require('tmp-promise');
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 const { z } = require('zod');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -5,15 +5,16 @@ import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');
 import * as cheerio from 'cheerio';
-const { exec } = require('child_process');
+import { exec } from 'child_process';
 import fetch from 'node-fetch';
 const klaw = require('klaw');
 const tmp = require('tmp');
 
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from './helperServer';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -3,12 +3,12 @@ const ERR = require('async-stacktrace');
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
-const async = require('async');
+import * as async from 'async';
 import * as cheerio from 'cheerio';
 import { exec } from 'child_process';
 import fetch from 'node-fetch';
 const klaw = require('klaw');
-const tmp = require('tmp');
+import * as tmp from 'tmp';
 
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -14,7 +14,7 @@ const tmp = require('tmp');
 import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -5,7 +5,7 @@ import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');
 const ncp = require('ncp');
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 const { exec } = require('child_process');
 import fetch from 'node-fetch';
 const klaw = require('klaw');

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const ERR = require('async-stacktrace');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -11,7 +11,7 @@ import fetch from 'node-fetch';
 const klaw = require('klaw');
 const tmp = require('tmp');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const helperServer = require('./helperServer');

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const assert = require('chai').assert;
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');
 const ncp = require('ncp');

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -12,7 +12,7 @@ const klaw = require('klaw');
 const tmp = require('tmp');
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from './helperServer';
 

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -7,7 +7,7 @@ const async = require('async');
 const ncp = require('ncp');
 const cheerio = require('cheerio');
 const { exec } = require('child_process');
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const klaw = require('klaw');
 const tmp = require('tmp');
 

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import * as fs from 'fs-extra';
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 const _ = require('lodash');
 const path = require('path');

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
 const path = require('path');
 const freeform = require('../question-servers/freeform.js');
 const { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } = require('../lib/paths');
-const { promisify } = require('util');
+import { promisify } from 'util';
 
 const helperServer = require('./helperServer');
 const helperClient = require('./helperClient');

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -7,7 +7,7 @@ import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 const _ = require('lodash');
 const path = require('path');
-const freeform = require('../question-servers/freeform.js');
+import * as freeform from '../question-servers/freeform.js';
 import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths';
 import { promisify } from 'util';
 

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const assert = require('chai').assert;
 const { step } = require('mocha-steps');
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -4,7 +4,6 @@ import { step } from 'mocha-steps';
 import * as fs from 'fs-extra';
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 const _ = require('lodash');
 const path = require('path');
 import * as freeform from '../question-servers/freeform.js';
@@ -13,6 +12,8 @@ import { promisify } from 'util';
 
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Course element extensions', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 import * as fs from 'fs-extra';
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -11,7 +11,7 @@ const freeform = require('../question-servers/freeform.js');
 const { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } = require('../lib/paths');
 import { promisify } from 'util';
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Course element extensions', function () {

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -12,7 +12,7 @@ const { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } = require('../lib/paths');
 import { promisify } from 'util';
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Course element extensions', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -8,7 +8,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
 const _ = require('lodash');
 const path = require('path');
 const freeform = require('../question-servers/freeform.js');
-const { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } = require('../lib/paths');
+import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths';
 import { promisify } from 'util';
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 import * as fs from 'fs-extra';
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import * as fs from 'fs-extra';
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const _ = require('lodash');

--- a/apps/prairielearn/src/tests/cron.test.js
+++ b/apps/prairielearn/src/tests/cron.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const _ = require('lodash');
 const cron = require('../cron');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/cron.test.js
+++ b/apps/prairielearn/src/tests/cron.test.js
@@ -2,12 +2,12 @@
 const _ = require('lodash');
 import * as cron from '../cron';
 import { assert } from 'chai';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Cron', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/cron.test.js
+++ b/apps/prairielearn/src/tests/cron.test.js
@@ -4,7 +4,7 @@ const cron = require('../cron');
 import { assert } from 'chai';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/cron.test.js
+++ b/apps/prairielearn/src/tests/cron.test.js
@@ -7,7 +7,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 describe('Cron', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/cron.test.js
+++ b/apps/prairielearn/src/tests/cron.test.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const cron = require('../cron');
 import { assert } from 'chai';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/cron.test.js
+++ b/apps/prairielearn/src/tests/cron.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const _ = require('lodash');
-const cron = require('../cron');
+import * as cron from '../cron';
 import { assert } from 'chai';
 
 import { config } from '../lib/config';

--- a/apps/prairielearn/src/tests/database.test.js
+++ b/apps/prairielearn/src/tests/database.test.js
@@ -4,7 +4,7 @@ const path = require('node:path');
 const { describeDatabase, diffDirectoryAndDatabase } = require('@prairielearn/postgres-tools');
 
 const { REPOSITORY_ROOT_PATH } = require('../lib/paths');
-const helperDb = require('./helperDb');
+import * as helperDb from './helperDb';
 
 // Custom error type so we can display our own message and omit a stacktrace
 function DatabaseError(message) {

--- a/apps/prairielearn/src/tests/database.test.js
+++ b/apps/prairielearn/src/tests/database.test.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const path = require('node:path');
 const { describeDatabase, diffDirectoryAndDatabase } = require('@prairielearn/postgres-tools');
 
-const { REPOSITORY_ROOT_PATH } = require('../lib/paths');
+import { REPOSITORY_ROOT_PATH } from '../lib/paths';
 import * as helperDb from './helperDb';
 
 // Custom error type so we can display our own message and omit a stacktrace

--- a/apps/prairielearn/src/tests/database.test.js
+++ b/apps/prairielearn/src/tests/database.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const _ = require('lodash');
 const path = require('node:path');
-const { describeDatabase, diffDirectoryAndDatabase } = require('@prairielearn/postgres-tools');
+import { describeDatabase, diffDirectoryAndDatabase } from '@prairielearn/postgres-tools';
 
 import { REPOSITORY_ROOT_PATH } from '../lib/paths';
 import * as helperDb from './helperDb';

--- a/apps/prairielearn/src/tests/editorUtil.test.js
+++ b/apps/prairielearn/src/tests/editorUtil.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const editor = require('../lib/editorUtil');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 
 describe('editor library', () => {
   it('gets details for course info file', () => {

--- a/apps/prairielearn/src/tests/editorUtil.test.js
+++ b/apps/prairielearn/src/tests/editorUtil.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const editor = require('../lib/editorUtil');
+import * as editor from '../lib/editorUtil';
 import { assert } from 'chai';
 
 describe('editor library', () => {

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -3,7 +3,7 @@ import { step } from 'mocha-steps';
 import { queryAsync } from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 import { enrollUser, unenrollUser } from './utils/enrollments';
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -6,12 +6,13 @@ const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperQuestion = require('./helperQuestion');
-const helperExam = require('./helperExam');
-const helperAttachFiles = require('./helperAttachFiles');
+import * as helperQuestion from './helperQuestion';
+import * as helperExam from './helperExam';
+import * as helperAttachFiles from './helperAttachFiles';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -3,7 +3,6 @@ const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
 const path = require('path');
-const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
 import * as sqldb from '@prairielearn/postgres';
 
@@ -1798,16 +1797,12 @@ describe('Exam assessment', function () {
     describe(`partial credit test #${iPartialCreditTest + 1}`, function () {
       describe('server', function () {
         it('should shut down', async function () {
-          debug('partial credit test: server shutting down');
           // pass "this" explicitly to enable this.timeout() calls
           await helperServer.after.call(this);
-          debug('partial credit test: server shutdown complete');
         });
         it('should start up', async function () {
-          debug('partial credit test: server starting up');
           // pass "this" explicitly to enable this.timeout() calls
           await helperServer.before().call(this);
-          debug('partial credit test: server startup complete');
         });
       });
 

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -8,7 +8,7 @@ const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperQuestion = require('./helperQuestion');
 const helperExam = require('./helperExam');
 const helperAttachFiles = require('./helperAttachFiles');

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -2,7 +2,6 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
-const path = require('path');
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/tests/exam.test.js
+++ b/apps/prairielearn/src/tests/exam.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 

--- a/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 
 var helperServer = require('./helperServer');

--- a/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
@@ -3,7 +3,7 @@ import { config } from '../lib/config';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 
 import * as helperServer from './helperServer';
-var helperQuestion = require('./helperQuestion');
+import * as helperQuestion from './helperQuestion';
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
@@ -2,7 +2,7 @@
 import { config } from '../lib/config';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 var helperQuestion = require('./helperQuestion');
 
 const locals = {};

--- a/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/exampleCourseQuestions.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { config } = require('../lib/config');
-const { EXAMPLE_COURSE_PATH } = require('../lib/paths');
+import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 
 var helperServer = require('./helperServer');
 var helperQuestion = require('./helperQuestion');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -12,7 +12,7 @@ import fetch from 'node-fetch';
 const FormData = require('form-data');
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from './helperServer';
 const { exec } = require('child_process');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -6,7 +6,7 @@ import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');
 const ncp = require('ncp');
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 const tmp = require('tmp');
 import fetch from 'node-fetch';
 const FormData = require('form-data');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -14,7 +14,7 @@ const FormData = require('form-data');
 import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const { exec } = require('child_process');
 const b64Util = require('../lib/base64-util');
 const { encodePath } = require('../lib/uri-util');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -13,12 +13,13 @@ const FormData = require('form-data');
 
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from './helperServer';
-const { exec } = require('child_process');
+import { exec } from 'child_process';
 import * as b64Util from '../lib/base64-util';
 import { encodePath } from '../lib/uri-util';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 let page, elemList;

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -5,9 +5,9 @@ import { assert } from 'chai';
 import { readFileSync } from 'node:fs';
 import * as fs from 'fs-extra';
 const path = require('path');
-const async = require('async');
+import * as async from 'async';
 import * as cheerio from 'cheerio';
-const tmp = require('tmp');
+import * as tmp from 'tmp';
 import fetch from 'node-fetch';
 const FormData = require('form-data');
 

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const request = require('request');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -18,7 +18,7 @@ const helperServer = require('./helperServer');
 const { exec } = require('child_process');
 const b64Util = require('../lib/base64-util');
 const { encodePath } = require('../lib/uri-util');
-const { EXAMPLE_COURSE_PATH } = require('../lib/paths');
+import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 
 const locals = {};
 let page, elemList;

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -17,7 +17,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from './helperServer';
 const { exec } = require('child_process');
 const b64Util = require('../lib/base64-util');
-const { encodePath } = require('../lib/uri-util');
+import { encodePath } from '../lib/uri-util';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 
 const locals = {};

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const request = require('request');
 const assert = require('chai').assert;
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');
 const ncp = require('ncp');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -11,7 +11,7 @@ const tmp = require('tmp');
 import fetch from 'node-fetch';
 const FormData = require('form-data');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const helperServer = require('./helperServer');

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -2,10 +2,10 @@
 const ERR = require('async-stacktrace');
 const request = require('request');
 import { assert } from 'chai';
+import { readFileSync } from 'node:fs';
 import * as fs from 'fs-extra';
 const path = require('path');
 const async = require('async');
-const ncp = require('ncp');
 import * as cheerio from 'cheerio';
 const tmp = require('tmp');
 import fetch from 'node-fetch';
@@ -44,58 +44,58 @@ const questionHtmlPath = path.join(questionPath, 'question.html');
 const questionPythonPath = path.join(questionPath, 'server.py');
 
 const infoCourseJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
 );
 let infoCourseJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
 );
 infoCourseJsonB.title = 'Test Course (Renamed)';
 let infoCourseJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoCoursePath), 'utf-8'),
 );
 infoCourseJsonC.title = 'Test Course (Renamed Yet Again)';
 
 const infoCourseInstanceJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
 );
 let infoCourseInstanceJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
 );
 infoCourseInstanceJsonB.longName = 'Fall 2019';
 let infoCourseInstanceJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoCourseInstancePath), 'utf-8'),
 );
 infoCourseInstanceJsonC.longName = 'Spring 2020';
 
 const infoAssessmentJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
 );
 let infoAssessmentJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
 );
 infoAssessmentJsonB.title = 'Homework for file editor test (Renamed)';
 let infoAssessmentJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, infoAssessmentPath), 'utf-8'),
 );
 infoAssessmentJsonC.title = 'Homework for file editor test (Renamed Yet Again)';
 
 const questionJsonA = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
 );
 let questionJsonB = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
 );
 questionJsonB.title = 'Test question (Renamed)';
 let questionJsonC = JSON.parse(
-  fs.readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
+  readFileSync(path.join(courseTemplateDir, questionJsonPath), 'utf-8'),
 );
 questionJsonC.title = 'Test question (Renamed Yet Again)';
 
-const questionHtmlA = fs.readFileSync(path.join(courseTemplateDir, questionHtmlPath), 'utf-8');
+const questionHtmlA = readFileSync(path.join(courseTemplateDir, questionHtmlPath), 'utf-8');
 const questionHtmlB = questionHtmlA + '\nAnother line of text.\n\n';
 const questionHtmlC = questionHtmlB + '\nYet another line of text.\n\n';
 
-const questionPythonA = fs.readFileSync(path.join(courseTemplateDir, questionPythonPath), 'utf-8');
+const questionPythonA = readFileSync(path.join(courseTemplateDir, questionPythonPath), 'utf-8');
 const questionPythonB = questionPythonA + '\n# Comment.\n\n';
 const questionPythonC = questionPythonB + '\n# Another comment.\n\n';
 
@@ -409,11 +409,8 @@ function createCourseFiles(callback) {
           callback(null);
         });
       },
-      (callback) => {
-        ncp(courseTemplateDir, courseLiveDir, { clobber: false }, (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
+      async () => {
+        await fs.copy(courseTemplateDir, courseLiveDir, { overwrite: false });
       },
       (callback) => {
         const execOptions = {
@@ -889,7 +886,7 @@ function pullAndVerifyFileInDev(fileName, fileContents) {
       });
     });
     it('should match contents', function () {
-      assert.strictEqual(fs.readFileSync(path.join(courseDevDir, fileName), 'utf-8'), fileContents);
+      assert.strictEqual(readFileSync(path.join(courseDevDir, fileName), 'utf-8'), fileContents);
     });
   });
 }

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -16,7 +16,7 @@ import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from './helperServer';
 const { exec } = require('child_process');
-const b64Util = require('../lib/base64-util');
+import * as b64Util from '../lib/base64-util';
 import { encodePath } from '../lib/uri-util';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths';
 

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -8,7 +8,7 @@ const async = require('async');
 const ncp = require('ncp');
 const cheerio = require('cheerio');
 const tmp = require('tmp');
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const FormData = require('form-data');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -6,7 +6,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Exam assessment with grade rate set', function () {

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -1,13 +1,14 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam assessment with grade rate set', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -7,7 +7,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Exam assessment with grade rate set', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/gradeRate.test.js
+++ b/apps/prairielearn/src/tests/gradeRate.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -6,10 +6,11 @@ import { config } from '../lib/config';
 import fetch from 'node-fetch';
 import * as helperServer from './helperServer';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 // @ts-expect-error -- Incorrectly thinks that this is ESM.
-const { io } = require('socket.io-client');
-const { setUser, parseInstanceQuestionId, saveOrGrade } = require('./helperClient');
+import { io } from 'socket.io-client';
+import { setUser, parseInstanceQuestionId, saveOrGrade } from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const cheerio = require('cheerio');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 import fetch from 'node-fetch';

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -4,7 +4,7 @@ const cheerio = require('cheerio');
 
 import { config } from '../lib/config';
 import fetch from 'node-fetch';
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 // @ts-expect-error -- Incorrectly thinks that this is ESM.

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 import { config } from '../lib/config';
 import fetch from 'node-fetch';
 import * as helperServer from './helperServer';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 // @ts-expect-error -- Incorrectly thinks that this is ESM.
 const { io } = require('socket.io-client');

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const cheerio = require('cheerio');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 import fetch from 'node-fetch';
 const helperServer = require('./helperServer');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/gradingMethods.test.js
+++ b/apps/prairielearn/src/tests/gradingMethods.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 const cheerio = require('cheerio');
 
 const { config } = require('../lib/config');
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const helperServer = require('./helperServer');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/groupExam.test.ts
+++ b/apps/prairielearn/src/tests/groupExam.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 import fetchCookie = require('fetch-cookie');
 import { config } from '../lib/config';
@@ -8,7 +8,7 @@ import { step } from 'mocha-steps';
 import { queryAsync, queryOneRowAsync, queryRows, loadSqlEquiv } from '@prairielearn/postgres';
 const sql = loadSqlEquiv(__filename);
 
-import helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 import { TEST_COURSE_PATH } from '../lib/paths';
 import { UserSchema } from '../lib/db-types';
 

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -7,7 +7,7 @@ const { step } = require('mocha-steps');
 const helperServer = require('./helperServer');
 const { deleteAllGroups } = require('../lib/groups');
 const groupUpdate = require('../lib/group-update');
-const { TEST_COURSE_PATH } = require('../lib/paths');
+import { TEST_COURSE_PATH } from '../lib/paths';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 const locals = {};

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const util = require('node:util');
 const sqldb = require('@prairielearn/postgres');
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const helperServer = require('./helperServer');
 const { deleteAllGroups } = require('../lib/groups');

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const util = require('node:util');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 import { step } from 'mocha-steps';
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const util = require('node:util');
 const sqldb = require('@prairielearn/postgres');
 const { step } = require('mocha-steps');

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -5,7 +5,7 @@ import * as sqldb from '@prairielearn/postgres';
 import { step } from 'mocha-steps';
 
 import * as helperServer from './helperServer';
-const { deleteAllGroups } = require('../lib/groups');
+import { deleteAllGroups } from '../lib/groups';
 const groupUpdate = require('../lib/group-update');
 import { TEST_COURSE_PATH } from '../lib/paths';
 

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -6,7 +6,7 @@ import { step } from 'mocha-steps';
 
 import * as helperServer from './helperServer';
 import { deleteAllGroups } from '../lib/groups';
-const groupUpdate = require('../lib/group-update');
+import * as groupUpdate from '../lib/group-update';
 import { TEST_COURSE_PATH } from '../lib/paths';
 
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -4,7 +4,7 @@ const util = require('node:util');
 const sqldb = require('@prairielearn/postgres');
 import { step } from 'mocha-steps';
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const { deleteAllGroups } = require('../lib/groups');
 const groupUpdate = require('../lib/group-update');
 import { TEST_COURSE_PATH } from '../lib/paths';

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const cheerio = require('cheerio');
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 import * as fs from 'fs-extra';
 const path = require('path');
 import { step } from 'mocha-steps';

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -12,7 +12,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const { syncCourseData } = require('./sync/util');
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const { URLSearchParams } = require('url');
 const { getGroupRoleReassignmentsAfterLeave } = require('../lib/groups');
 import { TEST_COURSE_PATH } from '../lib/paths';

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -2,7 +2,7 @@
 const assert = require('chai').assert;
 const cheerio = require('cheerio');
 const fetch = require('node-fetch').default;
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 const { step } = require('mocha-steps');
 const tmp = require('tmp-promise');

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -4,7 +4,7 @@ const cheerio = require('cheerio');
 const fetch = require('node-fetch').default;
 import * as fs from 'fs-extra';
 const path = require('path');
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 const tmp = require('tmp-promise');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -14,7 +14,7 @@ const { syncCourseData } = require('./sync/util');
 
 import * as helperServer from './helperServer';
 const { URLSearchParams } = require('url');
-const { getGroupRoleReassignmentsAfterLeave } = require('../lib/groups');
+import { getGroupRoleReassignmentsAfterLeave } from '../lib/groups';
 import { TEST_COURSE_PATH } from '../lib/paths';
 
 let elemList;

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 import * as fs from 'fs-extra';
 const path = require('path');

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const cheerio = require('cheerio');
 const fetch = require('node-fetch').default;
 import * as fs from 'fs-extra';

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -6,16 +6,16 @@ import * as fs from 'fs-extra';
 const path = require('path');
 import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-const { syncCourseData } = require('./sync/util');
+import { syncCourseData } from './sync/util';
 
 import * as helperServer from './helperServer';
-const { URLSearchParams } = require('url');
 import { getGroupRoleReassignmentsAfterLeave } from '../lib/groups';
 import { TEST_COURSE_PATH } from '../lib/paths';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 let elemList;
 const locals = {};

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -7,7 +7,7 @@ const path = require('path');
 import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const { syncCourseData } = require('./sync/util');

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -8,7 +8,7 @@ import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 const { syncCourseData } = require('./sync/util');
 

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -15,7 +15,7 @@ const { syncCourseData } = require('./sync/util');
 const helperServer = require('./helperServer');
 const { URLSearchParams } = require('url');
 const { getGroupRoleReassignmentsAfterLeave } = require('../lib/groups');
-const { TEST_COURSE_PATH } = require('../lib/paths');
+import { TEST_COURSE_PATH } from '../lib/paths';
 
 let elemList;
 const locals = {};

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -5,7 +5,7 @@ import fetch from 'node-fetch';
 import * as fs from 'fs-extra';
 const path = require('path');
 import { step } from 'mocha-steps';
-const tmp = require('tmp-promise');
+import * as tmp from 'tmp-promise';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 import { TEST_COURSE_PATH } from '../lib/paths';
 const _ = require('lodash');
 import { assert } from 'chai';

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 
 const { config } = require('../lib/config');
-const { TEST_COURSE_PATH } = require('../lib/paths');
+import { TEST_COURSE_PATH } from '../lib/paths';
 const _ = require('lodash');
 var assert = require('chai').assert;
 var request = require('request');

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -4,7 +4,7 @@ const ERR = require('async-stacktrace');
 const { config } = require('../lib/config');
 import { TEST_COURSE_PATH } from '../lib/paths';
 const _ = require('lodash');
-var assert = require('chai').assert;
+import { assert } from 'chai';
 var request = require('request');
 var cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-var ERR = require('async-stacktrace');
+const ERR = require('async-stacktrace');
 
 const { config } = require('../lib/config');
 const { TEST_COURSE_PATH } = require('../lib/paths');

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -1,23 +1,24 @@
 // @ts-check
 const ERR = require('async-stacktrace');
-
-import { config } from '../lib/config';
-import { TEST_COURSE_PATH } from '../lib/paths';
 const _ = require('lodash');
 import { assert } from 'chai';
 var request = require('request');
 import * as cheerio from 'cheerio';
+import * as sqldb from '@prairielearn/postgres';
 
-import * as sqldb from '@prairielearn/postgres');
-var sql = sqldb.loadSqlEquiv(__filename);
-var page, form, elemList;
+import { config } from '../lib/config';
+import { TEST_COURSE_PATH } from '../lib/paths';
 import * as helperServer from './helperServer';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 locals.siteUrl = 'http://localhost:' + config.serverPort;
 locals.baseUrl = locals.siteUrl + '/pl';
 locals.courseInstanceUrl = locals.baseUrl + '/course_instance/1';
 locals.courseInstanceBaseUrl = locals.baseUrl + '/course_instance/1';
+
+var page, form, elemList;
 
 const question = [{ qid: 'addNumbers', type: 'Freeform', maxPoints: 5 }];
 const questions = _.keyBy(question, 'qid');

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -8,7 +8,7 @@ import { assert } from 'chai';
 var request = require('request');
 import * as cheerio from 'cheerio';
 
-var sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 var page, form, elemList;
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -6,7 +6,7 @@ import { TEST_COURSE_PATH } from '../lib/paths';
 const _ = require('lodash');
 import { assert } from 'chai';
 var request = require('request');
-var cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
-var request = require('request');
+const request = require('request');
 import * as cheerio from 'cheerio';
 import * as sqldb from '@prairielearn/postgres';
 
@@ -18,7 +18,7 @@ locals.baseUrl = locals.siteUrl + '/pl';
 locals.courseInstanceUrl = locals.baseUrl + '/course_instance/1';
 locals.courseInstanceBaseUrl = locals.baseUrl + '/course_instance/1';
 
-var page, form, elemList;
+let page, form, elemList;
 
 const question = [{ qid: 'addNumbers', type: 'Freeform', maxPoints: 5 }];
 const questions = _.keyBy(question, 'qid');

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.js
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.js
@@ -11,7 +11,7 @@ var cheerio = require('cheerio');
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 var page, form, elemList;
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 const locals = {};
 locals.siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -4,7 +4,7 @@ const ERR = require('async-stacktrace');
 import fetch from 'node-fetch';
 const fetchCookie = require('fetch-cookie');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 import { assert } from 'chai';
 var cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -13,7 +13,7 @@ var sql = sqldb.loadSqlEquiv(__filename);
 
 var helperServer = require('./helperServer');
 const { idsEqual } = require('../lib/id');
-const { TEST_COURSE_PATH } = require('../lib/paths');
+import { TEST_COURSE_PATH } from '../lib/paths';
 const { fetchCheerio } = require('./helperClient');
 
 const locals = {};

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -12,7 +12,7 @@ var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
 var helperServer = require('./helperServer');
-const { idsEqual } = require('../lib/id');
+import { idsEqual } from '../lib/id';
 import { TEST_COURSE_PATH } from '../lib/paths';
 const { fetchCheerio } = require('./helperClient');
 

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -6,12 +6,12 @@ const fetchCookie = require('fetch-cookie');
 
 import { config } from '../lib/config';
 import { assert } from 'chai';
-var cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 import { idsEqual } from '../lib/id';
 import { TEST_COURSE_PATH } from '../lib/paths';
 const { fetchCheerio } = require('./helperClient');

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -8,7 +8,7 @@ import { config } from '../lib/config';
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
 
-var sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -5,7 +5,7 @@ const fetch = require('node-fetch').default;
 const fetchCookie = require('fetch-cookie');
 
 const { config } = require('../lib/config');
-var assert = require('chai').assert;
+import { assert } from 'chai';
 var cheerio = require('cheerio');
 
 var sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const fetchCookie = require('fetch-cookie');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/groupStudent.test.js
+++ b/apps/prairielearn/src/tests/groupStudent.test.js
@@ -1,20 +1,19 @@
 // @ts-check
 const ERR = require('async-stacktrace');
-
 import fetch from 'node-fetch';
 const fetchCookie = require('fetch-cookie');
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
 
-import * as sqldb from '@prairielearn/postgres');
-var sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import { idsEqual } from '../lib/id';
 import { TEST_COURSE_PATH } from '../lib/paths';
-const { fetchCheerio } = require('./helperClient');
+import { fetchCheerio } from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 locals.siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/helperAttachFiles.js
+++ b/apps/prairielearn/src/tests/helperAttachFiles.js
@@ -9,7 +9,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
 
 let elemList;
 
-module.exports.attachFile = (locals, textFile) => {
+export function attachFile(locals, textFile) {
   describe('attachFile-1. GET to assessment_instance URL', () => {
     it('should load successfully', async () => {
       const res = await fetch(locals.attachFilesUrl);
@@ -88,9 +88,9 @@ module.exports.attachFile = (locals, textFile) => {
       assert.equal(locals.file.assessment_instance_id, 1);
     });
   });
-};
+}
 
-module.exports.downloadAttachedFile = (locals) => {
+export function downloadAttachedFile(locals) {
   describe('downloadAttachedFile-1. GET to assessment_instance URL', () => {
     it('should load successfully', async () => {
       const res = await fetch(locals.attachFilesUrl);
@@ -114,9 +114,9 @@ module.exports.downloadAttachedFile = (locals) => {
       assert.equal(contents, 'This is the test text');
     });
   });
-};
+}
 
-module.exports.deleteAttachedFile = (locals) => {
+export function deleteAttachedFile(locals) {
   describe('deleteAttachedFile-1. GET to assessment_instance URL', () => {
     it('should load successfully', async () => {
       const res = await fetch(locals.attachFilesUrl);
@@ -186,9 +186,9 @@ module.exports.deleteAttachedFile = (locals) => {
       assert.equal(result.rowCount, 0);
     });
   });
-};
+}
 
-module.exports.checkNoAttachedFiles = (locals) => {
+export function checkNoAttachedFiles(locals) {
   describe('checkNoAttachedFiles-1. GET to assessment_instance URL', () => {
     it('should load successfully', async () => {
       const res = await fetch(locals.attachFilesUrl);
@@ -200,4 +200,4 @@ module.exports.checkNoAttachedFiles = (locals) => {
       assert.lengthOf(elemList, 0);
     });
   });
-};
+}

--- a/apps/prairielearn/src/tests/helperAttachFiles.js
+++ b/apps/prairielearn/src/tests/helperAttachFiles.js
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 const FormData = require('form-data');
 const cheerio = require('cheerio');
 
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 let elemList;

--- a/apps/prairielearn/src/tests/helperAttachFiles.js
+++ b/apps/prairielearn/src/tests/helperAttachFiles.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const FormData = require('form-data');
 const cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/helperAttachFiles.js
+++ b/apps/prairielearn/src/tests/helperAttachFiles.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const fetch = require('node-fetch').default;
 const FormData = require('form-data');
 const cheerio = require('cheerio');

--- a/apps/prairielearn/src/tests/helperAttachFiles.js
+++ b/apps/prairielearn/src/tests/helperAttachFiles.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import fetch from 'node-fetch';
 const FormData = require('form-data');
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/helperCourse.js
+++ b/apps/prairielearn/src/tests/helperCourse.js
@@ -3,7 +3,7 @@ import { TEST_COURSE_PATH } from '../lib/paths';
 import * as syncFromDisk from '../sync/syncFromDisk';
 import { makeMockLogger } from './mockLogger';
 
-async function syncCourse(courseDir = TEST_COURSE_PATH) {
+export async function syncCourse(courseDir = TEST_COURSE_PATH) {
   const { logger, getOutput } = makeMockLogger();
   const result = await syncFromDisk.syncOrCreateDiskToSqlAsync(courseDir, logger);
   if (!result || result.hadJsonErrorsOrWarnings) {
@@ -11,5 +11,3 @@ async function syncCourse(courseDir = TEST_COURSE_PATH) {
     throw new Error(`Errors or warnings found during sync of ${courseDir}`);
   }
 }
-
-module.exports.syncCourse = syncCourse;

--- a/apps/prairielearn/src/tests/helperCourse.js
+++ b/apps/prairielearn/src/tests/helperCourse.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { TEST_COURSE_PATH } = require('../lib/paths');
+import { TEST_COURSE_PATH } from '../lib/paths';
 const syncFromDisk = require('../sync/syncFromDisk');
 const { makeMockLogger } = require('./mockLogger');
 

--- a/apps/prairielearn/src/tests/helperCourse.js
+++ b/apps/prairielearn/src/tests/helperCourse.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { TEST_COURSE_PATH } from '../lib/paths';
-const syncFromDisk = require('../sync/syncFromDisk');
-const { makeMockLogger } = require('./mockLogger');
+import * as syncFromDisk from '../sync/syncFromDisk';
+import { makeMockLogger } from './mockLogger';
 
 async function syncCourse(courseDir = TEST_COURSE_PATH) {
   const { logger, getOutput } = makeMockLogger();

--- a/apps/prairielearn/src/tests/helperQuestionPreview.ts
+++ b/apps/prairielearn/src/tests/helperQuestionPreview.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import request = require('request');
-import helperQuestion = require('./helperQuestion');
+import * as helperQuestion from './helperQuestion';
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -3,7 +3,7 @@ const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
 const request = require('request');
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 const request = require('request');
 const cheerio = require('cheerio');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -9,7 +9,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperQuestion = require('./helperQuestion');
 const helperAttachFiles = require('./helperAttachFiles');
 

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -7,11 +7,12 @@ import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperQuestion = require('./helperQuestion');
-const helperAttachFiles = require('./helperAttachFiles');
+import * as helperQuestion from './helperQuestion';
+import * as helperAttachFiles from './helperAttachFiles';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -6,7 +6,7 @@ const request = require('request');
 const cheerio = require('cheerio');
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/homework.test.js
+++ b/apps/prairielearn/src/tests/homework.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const request = require('request');
 const cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/honorCode.test.js
+++ b/apps/prairielearn/src/tests/honorCode.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/honorCode.test.js
+++ b/apps/prairielearn/src/tests/honorCode.test.js
@@ -1,12 +1,12 @@
 // @ts-check
 import { assert } from 'chai';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam assessment response to `requireHonorCode`', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/honorCode.test.js
+++ b/apps/prairielearn/src/tests/honorCode.test.js
@@ -5,7 +5,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Exam assessment response to `requireHonorCode`', function () {

--- a/apps/prairielearn/src/tests/honorCode.test.js
+++ b/apps/prairielearn/src/tests/honorCode.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/honorCode.test.js
+++ b/apps/prairielearn/src/tests/honorCode.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/honorCode.test.js
+++ b/apps/prairielearn/src/tests/honorCode.test.js
@@ -6,7 +6,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Exam assessment response to `requireHonorCode`', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/instructorAssessment.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-var assert = require('chai').assert;
+import { assert } from 'chai';
 var request = require('request');
 var cheerio = require('cheerio');
 const _ = require('lodash');

--- a/apps/prairielearn/src/tests/instructorAssessment.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.js
@@ -5,8 +5,8 @@ import * as cheerio from 'cheerio';
 const _ = require('lodash');
 
 import * as helperServer from './helperServer';
-var helperQuestion = require('./helperQuestion');
-var helperExam = require('./helperExam');
+import * as helperQuestion from './helperQuestion';
+import * as helperExam from './helperExam';
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/instructorAssessment.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.js
@@ -2,7 +2,7 @@
 var assert = require('chai').assert;
 var request = require('request');
 var cheerio = require('cheerio');
-var _ = require('lodash');
+const _ = require('lodash');
 
 var helperServer = require('./helperServer');
 var helperQuestion = require('./helperQuestion');

--- a/apps/prairielearn/src/tests/instructorAssessment.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.js
@@ -1,10 +1,10 @@
 // @ts-check
 import { assert } from 'chai';
 var request = require('request');
-var cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 const _ = require('lodash');
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 var helperQuestion = require('./helperQuestion');
 var helperExam = require('./helperExam');
 

--- a/apps/prairielearn/src/tests/instructorAssessment.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-var request = require('request');
+const request = require('request');
 import * as cheerio from 'cheerio';
 const _ = require('lodash');
 

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
@@ -2,7 +2,7 @@
 const _ = require('lodash');
 import { assert } from 'chai';
 const request = require('request');
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 const { parse: csvParse } = require('csv-parse/sync');
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
@@ -3,11 +3,11 @@ const _ = require('lodash');
 import { assert } from 'chai';
 const request = require('request');
 import * as cheerio from 'cheerio';
-const { parse: csvParse } = require('csv-parse/sync');
+import { parse as csvParse } from 'csv-parse/sync';
 
 import * as helperServer from './helperServer';
-const helperQuestion = require('./helperQuestion');
-const helperExam = require('./helperExam');
+import * as helperQuestion from './helperQuestion';
+import * as helperExam from './helperExam';
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
@@ -5,7 +5,7 @@ const request = require('request');
 const cheerio = require('cheerio');
 const { parse: csvParse } = require('csv-parse/sync');
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperQuestion = require('./helperQuestion');
 const helperExam = require('./helperExam');
 

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const _ = require('lodash');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const request = require('request');
 const cheerio = require('cheerio');
 const { parse: csvParse } = require('csv-parse/sync');

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
-var request = require('request');
+const request = require('request');
 import * as cheerio from 'cheerio';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -10,7 +10,7 @@ var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
 var helperServer = require('./helperServer');
-const { idsEqual } = require('../lib/id');
+import { idsEqual } from '../lib/id';
 const { testFileDownloads, testQuestionPreviews } = require('./helperQuestionPreview');
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 var request = require('request');
 var cheerio = require('cheerio');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 var ERR = require('async-stacktrace');
-var _ = require('lodash');
+const _ = require('lodash');
 var assert = require('chai').assert;
 var request = require('request');
 var cheerio = require('cheerio');

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -6,7 +6,7 @@ var request = require('request');
 import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
-var sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -4,14 +4,14 @@ const _ = require('lodash');
 import { assert } from 'chai';
 var request = require('request');
 import * as cheerio from 'cheerio';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres');
-var sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import { idsEqual } from '../lib/id';
-const { testFileDownloads, testQuestionPreviews } = require('./helperQuestionPreview');
+import { testFileDownloads, testQuestionPreviews } from './helperQuestionPreview';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
-var assert = require('chai').assert;
+import { assert } from 'chai';
 var request = require('request');
 var cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-var ERR = require('async-stacktrace');
+const ERR = require('async-stacktrace');
 const _ = require('lodash');
 var assert = require('chai').assert;
 var request = require('request');

--- a/apps/prairielearn/src/tests/instructorQuestions.test.js
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.js
@@ -3,13 +3,13 @@ const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
 var request = require('request');
-var cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 import { idsEqual } from '../lib/id';
 const { testFileDownloads, testQuestionPreviews } = require('./helperQuestionPreview');
 

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 const cheerio = require('cheerio');
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -8,7 +8,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import fetch from 'node-fetch';
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const fetch = require('node-fetch').default;
 const cheerio = require('cheerio');
 const { step } = require('mocha-steps');

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -3,12 +3,13 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const fetch = require('node-fetch').default;
 const cheerio = require('cheerio');
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/issues.test.js
+++ b/apps/prairielearn/src/tests/issues.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const cheerio = require('cheerio');
 import { step } from 'mocha-steps';
 

--- a/apps/prairielearn/src/tests/jsonLoad.test.js
+++ b/apps/prairielearn/src/tests/jsonLoad.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const path = require('path');
-const jsonLoad = require('../lib/json-load');
+import * as jsonLoad from '../lib/json-load';
 
 const testfile = (filename) => path.join(__dirname, 'testJsonLoad', filename);
 

--- a/apps/prairielearn/src/tests/jsonLoad.test.js
+++ b/apps/prairielearn/src/tests/jsonLoad.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const path = require('path');
 const jsonLoad = require('../lib/json-load');
 

--- a/apps/prairielearn/src/tests/lti.test.js
+++ b/apps/prairielearn/src/tests/lti.test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 
 import { config } from '../lib/config';
 import * as helperServer from './helperServer';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const locals = {};
 
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/lti.test.js
+++ b/apps/prairielearn/src/tests/lti.test.js
@@ -4,7 +4,7 @@ const oauthSignature = require('oauth-signature');
 import { assert } from 'chai';
 
 import { config } from '../lib/config';
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const sqldb = require('@prairielearn/postgres');
 const locals = {};
 

--- a/apps/prairielearn/src/tests/lti.test.js
+++ b/apps/prairielearn/src/tests/lti.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const fetch = require('node-fetch').default;
 const oauthSignature = require('oauth-signature');
-const { assert } = require('chai');
+import { assert } from 'chai';
 
 const { config } = require('../lib/config');
 const helperServer = require('./helperServer');

--- a/apps/prairielearn/src/tests/lti.test.js
+++ b/apps/prairielearn/src/tests/lti.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const oauthSignature = require('oauth-signature');
 import { assert } from 'chai';
 

--- a/apps/prairielearn/src/tests/lti.test.js
+++ b/apps/prairielearn/src/tests/lti.test.js
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 const oauthSignature = require('oauth-signature');
 import { assert } from 'chai';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const helperServer = require('./helperServer');
 const sqldb = require('@prairielearn/postgres');
 const locals = {};

--- a/apps/prairielearn/src/tests/markdown.test.js
+++ b/apps/prairielearn/src/tests/markdown.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const markdown = require('../lib/markdown');
+import * as markdown from '../lib/markdown';
 import { assert } from 'chai';
 
 const testMarkdownQuestion = (question, expected) => {

--- a/apps/prairielearn/src/tests/markdown.test.js
+++ b/apps/prairielearn/src/tests/markdown.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const markdown = require('../lib/markdown');
-const assert = require('chai').assert;
+import { assert } from 'chai';
 
 const testMarkdownQuestion = (question, expected) => {
   const actual = markdown.processQuestion(question);

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 const cheerio = require('cheerio');
 
-const news_items = require('../news_items');
+import * as news_items from '../news_items';
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import fetch from 'node-fetch';
-const cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import * as news_items from '../news_items';
 import { config } from '../lib/config';

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -8,7 +8,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -2,13 +2,14 @@
 import { assert } from 'chai';
 import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import * as sqldb from '@prairielearn/postgres';
 
 import * as news_items from '../news_items';
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 const cheerio = require('cheerio');
 
 const news_items = require('../news_items');
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 
 const news_items = require('../news_items');
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 const cheerio = require('cheerio');
 
 const news_items = require('../news_items');

--- a/apps/prairielearn/src/tests/newsItems.test.js
+++ b/apps/prairielearn/src/tests/newsItems.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const fetch = require('node-fetch').default;
 const cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import { config } from '../../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 const { config } = require('../../lib/config');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-const { config } = require('../../lib/config');
+import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const helperServer = require('../helperServer');

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
-const helperServer = require('../helperServer');
+import * as helperServer from '../helperServer';
 const helperClient = require('../helperClient');
 
 async function checkPermissions(users) {

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -1,11 +1,13 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-import { config } from '../../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
+
+import { config } from '../../lib/config';
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 async function checkPermissions(users) {
   const result = await sqldb.queryAsync(sql.select_permissions, {

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -5,7 +5,7 @@ import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
-const helperClient = require('../helperClient');
+import * as helperClient from '../helperClient';
 
 async function checkPermissions(users) {
   const result = await sqldb.queryAsync(sql.select_permissions, {

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 const { config } = require('../../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
-const helperServer = require('../helperServer');
+import * as helperServer from '../helperServer';
 const helperClient = require('../helperClient');
 const { ensureEnrollment } = require('../../models/enrollment');
 

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -1,12 +1,14 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-import { config } from '../../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
+
+import { config } from '../../lib/config';
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';
 import { ensureEnrollment } from '../../models/enrollment';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('effective user', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import { config } from '../../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 const { config } = require('../../lib/config');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-const { config } = require('../../lib/config');
+import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const helperServer = require('../helperServer');

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -5,7 +5,7 @@ import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
-const helperClient = require('../helperClient');
+import * as helperClient from '../helperClient';
 const { ensureEnrollment } = require('../../models/enrollment');
 
 describe('effective user', function () {

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -6,7 +6,7 @@ import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';
-const { ensureEnrollment } = require('../../models/enrollment');
+import { ensureEnrollment } from '../../models/enrollment';
 
 describe('effective user', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 const { config } = require('../../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
-const helperServer = require('../helperServer');
+import * as helperServer from '../helperServer';
 const helperClient = require('../helperClient');
 const { ensureEnrollment } = require('../../models/enrollment');
 

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -1,12 +1,14 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-import { config } from '../../lib/config';
 import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
+
+import { config } from '../../lib/config';
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';
 import { ensureEnrollment } from '../../models/enrollment';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('student data access', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import { config } from '../../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 const { config } = require('../../lib/config');
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-const { config } = require('../../lib/config');
+import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 const helperServer = require('../helperServer');

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -6,7 +6,7 @@ import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
 import * as helperClient from '../helperClient';
-const { ensureEnrollment } = require('../../models/enrollment');
+import { ensureEnrollment } from '../../models/enrollment';
 
 describe('student data access', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -5,7 +5,7 @@ import { config } from '../../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 import * as helperServer from '../helperServer';
-const helperClient = require('../helperClient');
+import * as helperClient from '../helperClient';
 const { ensureEnrollment } = require('../../models/enrollment');
 
 describe('student data access', function () {

--- a/apps/prairielearn/src/tests/permissions/studentData.test.js
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 const { config } = require('../../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/publicQuestionPreview.test.ts
+++ b/apps/prairielearn/src/tests/publicQuestionPreview.test.ts
@@ -2,8 +2,8 @@ import { testQuestionPreviews } from './helperQuestionPreview';
 import { config } from '../lib/config';
 import { z } from 'zod';
 import { features } from '../lib/features/index';
-import sqldb = require('@prairielearn/postgres');
-import helperServer = require('./helperServer');
+import * as sqldb from '@prairielearn/postgres';
+import * as helperServer from './helperServer';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -3,13 +3,13 @@ import { step } from 'mocha-steps';
 import { config } from '../lib/config';
 import fetch from 'node-fetch';
 import { fetchCheerio } from './helperClient';
-import helperServer = require('./helperServer');
-import sqldb = require('@prairielearn/postgres');
+import * as helperServer from './helperServer';
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 import { features } from '../lib/features/index';
 import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths';
 
-import syncFromDisk = require('../sync/syncFromDisk');
+import * as syncFromDisk from '../sync/syncFromDisk';
 
 import { makeMockLogger } from './mockLogger';
 const { logger } = makeMockLogger();

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -7,7 +7,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Exam assessment with real-time grading disabled', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -6,7 +6,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Exam assessment with real-time grading disabled', function () {

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -1,13 +1,14 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam assessment with real-time grading disabled', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/schemas.test.js
+++ b/apps/prairielearn/src/tests/schemas.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const Ajv = require('ajv').default;
 import { assert } from 'chai';
-const schemas = require('../schemas');
+import * as schemas from '../schemas';
 
 const isObject = (a) => !!a && a.constructor === Object;
 
@@ -33,7 +33,10 @@ const validateRequiredRecursive = (obj, path = '') => {
 };
 
 for (const schemaName of Object.keys(schemas)) {
+  if (schemaName === 'default') continue;
+
   describe(`${schemaName} schema`, () => {
+    // eslint-disable-next-line import/namespace
     const schema = schemas[schemaName];
     it('compiles', () => {
       const ajv = new Ajv();

--- a/apps/prairielearn/src/tests/schemas.test.js
+++ b/apps/prairielearn/src/tests/schemas.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const Ajv = require('ajv').default;
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const schemas = require('../schemas');
 
 const isObject = (a) => !!a && a.constructor === Object;

--- a/apps/prairielearn/src/tests/schemas.test.js
+++ b/apps/prairielearn/src/tests/schemas.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const Ajv = require('ajv').default;
+import Ajv from 'ajv';
 import { assert } from 'chai';
 import * as schemas from '../schemas';
 

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -7,7 +7,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Exam assessment with showCloseAssessment access rule', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -6,7 +6,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Exam assessment with showCloseAssessment access rule', function () {

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam assessment with showCloseAssessment access rule', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -6,7 +6,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Exam assessment with showClosedAssessment AND showClosedAssessmentScore access rules', function () {

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Exam assessment with showClosedAssessment AND showClosedAssessmentScore access rules', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -7,7 +7,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Exam assessment with showClosedAssessment AND showClosedAssessmentScore access rules', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 
 const helperDb = require('../helperDb');

--- a/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 import * as helperDb from '../helperDb';
 

--- a/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 
 const helperDb = require('../helperDb');

--- a/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.js
+++ b/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 import * as helperDb from '../helperDb';
 

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.js
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.js
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const sqldb = require('@prairielearn/postgres');
 
 const helperDb = require('../helperDb');

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.js
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 import * as helperDb from '../helperDb';
 

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const sqldb = require('@prairielearn/postgres');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const sqldb = require('@prairielearn/postgres');
 import * as helperDb from '../helperDb';

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 
 import * as helperDb from '../helperDb';
-const util = require('./util');
+import * as util from './util';
 
 /**
  * Checks that the assessment set present in the database matches the data

--- a/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 const util = require('./util');
 
 /**

--- a/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 
 const helperDb = require('../helperDb');
 const util = require('./util');

--- a/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const chai = require('chai');
-const util = require('./util');
+import * as util from './util';
 import * as helperDb from '../helperDb';
 
 const { assert } = chai;

--- a/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const chai = require('chai');
 const util = require('./util');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 const { assert } = chai;
 

--- a/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.js
@@ -1,9 +1,7 @@
 // @ts-check
-const chai = require('chai');
+import { assert } from 'chai';
 import * as util from './util';
 import * as helperDb from '../helperDb';
-
-const { assert } = chai;
 
 /**
  * Checks that the assessment set present in the database matches the data

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 import { config } from '../../lib/config';
 const { features } = require('../../lib/features/index');
 import * as sqldb from '@prairielearn/postgres';
-const { idsEqual } = require('../../lib/id');
+import { idsEqual } from '../../lib/id';
 
 import * as util from './util';
 import * as helperDb from '../helperDb';

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra';
 const path = require('path');
 import { config } from '../../lib/config';
 const { features } = require('../../lib/features/index');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const { idsEqual } = require('../../lib/id');
 
 import * as util from './util';

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -8,7 +8,7 @@ const sqldb = require('@prairielearn/postgres');
 const { idsEqual } = require('../../lib/id');
 
 const util = require('./util');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -7,7 +7,7 @@ const { features } = require('../../lib/features/index');
 const sqldb = require('@prairielearn/postgres');
 const { idsEqual } = require('../../lib/id');
 
-const util = require('./util');
+import * as util from './util';
 import * as helperDb from '../helperDb';
 
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
-const { config } = require('../../lib/config');
+import { config } from '../../lib/config';
 const { features } = require('../../lib/features/index');
 const sqldb = require('@prairielearn/postgres');
 const { idsEqual } = require('../../lib/id');

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 const { config } = require('../../lib/config');
 const { features } = require('../../lib/features/index');

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const fs = require('fs-extra');
 const path = require('path');
 const { config } = require('../../lib/config');

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
 import { config } from '../../lib/config';
-const { features } = require('../../lib/features/index');
+import { features } from '../../lib/features/index';
 import * as sqldb from '@prairielearn/postgres';
 import { idsEqual } from '../../lib/id';
 

--- a/apps/prairielearn/src/tests/sync/courseDb.test.js
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.js
@@ -4,8 +4,8 @@ import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
 const path = require('path');
 
-const courseDb = require('../../sync/course-db');
-const infofile = require('../../sync/infofile');
+import * as courseDb from '../../sync/course-db';
+import * as infofile from '../../sync/infofile';
 
 /**
  * @param {(dir: string) => Promise<void>} callback

--- a/apps/prairielearn/src/tests/sync/courseDb.test.js
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const tmp = require('tmp-promise');
 const fs = require('fs-extra');
 const path = require('path');

--- a/apps/prairielearn/src/tests/sync/courseDb.test.js
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const tmp = require('tmp-promise');
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 
 const courseDb = require('../../sync/course-db');

--- a/apps/prairielearn/src/tests/sync/courseDb.test.js
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const tmp = require('tmp-promise');
+import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
 const path = require('path');
 

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 const util = require('./util');
 const helperDb = require('../helperDb');

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const fs = require('fs-extra');
 const path = require('path');
 const util = require('./util');

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra';
 const path = require('path');
 import * as util from './util';
 import * as helperDb from '../helperDb';
-const { idsEqual } = require('../../lib/id');
+import { idsEqual } from '../../lib/id';
 
 /**
  * Makes an empty course instance.

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
 const util = require('./util');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 const { idsEqual } = require('../../lib/id');
 
 /**

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
-const util = require('./util');
+import * as util from './util';
 import * as helperDb from '../helperDb';
 const { idsEqual } = require('../../lib/id');
 

--- a/apps/prairielearn/src/tests/sync/initialSync.test.js
+++ b/apps/prairielearn/src/tests/sync/initialSync.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const util = require('./util');
+import * as util from './util';
 import * as helperDb from '../helperDb';
 
 describe('Initial Sync', () => {

--- a/apps/prairielearn/src/tests/sync/initialSync.test.js
+++ b/apps/prairielearn/src/tests/sync/initialSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const util = require('./util');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 describe('Initial Sync', () => {
   before('set up testing database', helperDb.before);

--- a/apps/prairielearn/src/tests/sync/initialSync.test.js
+++ b/apps/prairielearn/src/tests/sync/initialSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const util = require('./util');
 const helperDb = require('../helperDb');
 

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra';
 const path = require('path');
 
 const util = require('./util');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 const { idsEqual } = require('../../lib/id');
 
 /**

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const fs = require('fs-extra');
 const path = require('path');
 

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 import * as util from './util';
 import * as helperDb from '../helperDb';
-const { idsEqual } = require('../../lib/id');
+import { idsEqual } from '../../lib/id';
 
 /**
  * Makes an empty question.

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as fs from 'fs-extra';
 const path = require('path');
 
-const util = require('./util');
+import * as util from './util';
 import * as helperDb from '../helperDb';
 const { idsEqual } = require('../../lib/id');
 

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const path = require('path');
 
 const util = require('./util');

--- a/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const util = require('./util');
+import * as util from './util';
 import * as helperDb from '../helperDb';
 
 /**

--- a/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const util = require('./util');
-const helperDb = require('../helperDb');
+import * as helperDb from '../helperDb';
 
 /**
  * Topics and tags are currently almost identical, so we test them together

--- a/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const util = require('./util');
 const helperDb = require('../helperDb');
 

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { promisify } from 'util';
 import * as fs from 'fs-extra';
-const tmp = require('tmp-promise');
+import * as tmp from 'tmp-promise';
 const path = require('path');
 import * as sqldb from '@prairielearn/postgres';
 const stringify = require('json-stable-stringify');

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -5,7 +5,7 @@ const tmp = require('tmp-promise');
 const path = require('path');
 const sqldb = require('@prairielearn/postgres');
 const stringify = require('json-stable-stringify');
-const { assert } = require('chai');
+import { assert } from 'chai';
 
 const syncFromDisk = require('../../sync/syncFromDisk');
 

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { promisify } = require('util');
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 const tmp = require('tmp-promise');
 const path = require('path');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -7,7 +7,7 @@ import * as sqldb from '@prairielearn/postgres';
 const stringify = require('json-stable-stringify');
 import { assert } from 'chai';
 
-const syncFromDisk = require('../../sync/syncFromDisk');
+import * as syncFromDisk from '../../sync/syncFromDisk';
 
 /**
  * @typedef {Object} CourseOptions

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -1,9 +1,9 @@
 // @ts-check
-const { promisify } = require('util');
+import { promisify } from 'util';
 import * as fs from 'fs-extra';
 const tmp = require('tmp-promise');
 const path = require('path');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const stringify = require('json-stable-stringify');
 import { assert } from 'chai';
 

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -226,11 +226,11 @@ const syncFromDisk = require('../../sync/syncFromDisk');
  * @param {CourseData} courseData - The course data to write to disk
  * @returns {Promise<string>} - The path to the directory containing the course data
  */
-module.exports.writeCourseToTempDirectory = async function (courseData) {
+export async function writeCourseToTempDirectory(courseData) {
   const { path: coursePath } = await tmp.dir({ unsafeCleanup: true });
-  await module.exports.writeCourseToDirectory(courseData, coursePath);
+  await writeCourseToDirectory(courseData, coursePath);
   return coursePath;
-};
+}
 
 /**
  * Accepts a CourseData object and writes it as a PrairieLearn course
@@ -240,7 +240,7 @@ module.exports.writeCourseToTempDirectory = async function (courseData) {
  * @param {CourseData} courseData - The course data to write to disk
  * @param {string} coursePath - The path to the directory to write to
  */
-module.exports.writeCourseToDirectory = async function (courseData, coursePath) {
+export async function writeCourseToDirectory(courseData, coursePath) {
   await fs.emptyDir(coursePath);
 
   // infoCourse.json
@@ -283,13 +283,13 @@ module.exports.writeCourseToDirectory = async function (courseData, coursePath) 
       await fs.writeJSON(assessmentInfoPath, courseInstance.assessments[assessmentName]);
     }
   }
-};
+}
 
-module.exports.QUESTION_ID = 'test';
-module.exports.ALTERNATIVE_QUESTION_ID = 'test2';
-module.exports.MANUAL_GRADING_QUESTION_ID = 'test_manual';
-module.exports.WORKSPACE_QUESTION_ID = 'workspace';
-module.exports.COURSE_INSTANCE_ID = 'Fa19';
+export const QUESTION_ID = 'test';
+export const ALTERNATIVE_QUESTION_ID = 'test2';
+export const MANUAL_GRADING_QUESTION_ID = 'test_manual';
+export const WORKSPACE_QUESTION_ID = 'workspace';
+export const COURSE_INSTANCE_ID = 'Fa19';
 
 /** @type {Course} */
 const course = {
@@ -357,21 +357,21 @@ const questions = {
     tags: ['test'],
     type: 'v3',
   },
-  [module.exports.QUESTION_ID]: {
+  [QUESTION_ID]: {
     uuid: 'f4ff2429-926e-4358-9e1f-d2f377e2036a',
     title: 'Test question',
     topic: 'Test',
     tags: ['test'],
     type: 'v3',
   },
-  [module.exports.ALTERNATIVE_QUESTION_ID]: {
+  [ALTERNATIVE_QUESTION_ID]: {
     uuid: '697a6188-8215-4806-92a1-592987342b9e',
     title: 'Another test question',
     topic: 'Test',
     tags: ['test'],
     type: 'Calculation',
   },
-  [module.exports.MANUAL_GRADING_QUESTION_ID]: {
+  [MANUAL_GRADING_QUESTION_ID]: {
     uuid: '2798b1ba-06e0-4ddf-9e5d-765fcca08a46',
     title: 'Test question',
     topic: 'Test',
@@ -379,7 +379,7 @@ const questions = {
     tags: ['test'],
     type: 'v3',
   },
-  [module.exports.WORKSPACE_QUESTION_ID]: {
+  [WORKSPACE_QUESTION_ID]: {
     uuid: '894927f7-19b3-451d-8ad1-75974ad2ffb7',
     title: 'Workspace test question',
     topic: 'Workspace',
@@ -397,7 +397,7 @@ const questions = {
 
 /** @type {{ [id: string]: CourseInstanceData }} */
 const courseInstances = {
-  [module.exports.COURSE_INSTANCE_ID]: {
+  [COURSE_INSTANCE_ID]: {
     assessments: {
       test: {
         uuid: '73432669-2663-444e-ade5-43f689a50dea',
@@ -439,7 +439,7 @@ const courseInstances = {
 /**
  * @returns {CourseData} - The base course data for syncing testing
  */
-module.exports.getCourseData = function () {
+export function getCourseData() {
   // Round-trip through JSON.stringify to ensure that mutations to nested
   // objects aren't reflected in the original objects.
   const courseData = {
@@ -448,16 +448,16 @@ module.exports.getCourseData = function () {
     courseInstances,
   };
   return JSON.parse(JSON.stringify(courseData));
-};
+}
 
-module.exports.getFakeLogger = function () {
+export function getFakeLogger() {
   return {
     verbose: () => {},
     debug: () => {},
     info: () => {},
     warn: () => {},
   };
-};
+}
 
 /**
  * Async wrapper for syncing course data from a directory. Also stubs out the
@@ -465,21 +465,21 @@ module.exports.getFakeLogger = function () {
  *
  * @param {string} courseDir - The path to the course directory
  */
-module.exports.syncCourseData = async function (courseDir) {
-  const logger = module.exports.getFakeLogger();
+export async function syncCourseData(courseDir) {
+  const logger = getFakeLogger();
   await promisify(syncFromDisk.syncOrCreateDiskToSql)(courseDir, logger);
-};
+}
 
-module.exports.createAndSyncCourseData = async function () {
-  const courseData = module.exports.getCourseData();
-  const courseDir = await module.exports.writeCourseToTempDirectory(courseData);
-  await module.exports.syncCourseData(courseDir);
+export async function createAndSyncCourseData() {
+  const courseData = getCourseData();
+  const courseDir = await writeCourseToTempDirectory(courseData);
+  await syncCourseData(courseDir);
 
   return {
     courseData,
     courseDir,
   };
-};
+}
 
 /**
  * Writes the given course data to a new temporary directory and returns the
@@ -488,11 +488,11 @@ module.exports.createAndSyncCourseData = async function () {
  * @param {CourseData} courseData - The course data to write and sync
  * @returns {Promise<string>} the path to the new temp directory
  */
-module.exports.writeAndSyncCourseData = async function (courseData) {
-  const courseDir = await module.exports.writeCourseToTempDirectory(courseData);
-  await module.exports.syncCourseData(courseDir);
+export async function writeAndSyncCourseData(courseData) {
+  const courseDir = await writeCourseToTempDirectory(courseData);
+  await syncCourseData(courseDir);
   return courseDir;
-};
+}
 
 /**
  * Overwrites the course data in the given directory and
@@ -500,10 +500,10 @@ module.exports.writeAndSyncCourseData = async function (courseData) {
  * @param {CourseData} courseData - The course data write and sync
  * @param {string} courseDir - The path to write the course data to
  */
-module.exports.overwriteAndSyncCourseData = async function (courseData, courseDir) {
-  await module.exports.writeCourseToDirectory(courseData, courseDir);
-  await module.exports.syncCourseData(courseDir);
-};
+export async function overwriteAndSyncCourseData(courseData, courseDir) {
+  await writeCourseToDirectory(courseData, courseDir);
+  await syncCourseData(courseDir);
+}
 
 /**
  * Returns an array of all records in a particular database table.
@@ -511,29 +511,29 @@ module.exports.overwriteAndSyncCourseData = async function (courseData, courseDi
  * @param {string} tableName - The name of the table to query
  * @return {Promise<Record<string, any>[]>} - The rows of the given table
  */
-module.exports.dumpTable = async function (tableName) {
+export async function dumpTable(tableName) {
   const res = await sqldb.queryAsync(`SELECT * FROM ${tableName};`, {});
   return res.rows;
-};
+}
 
-module.exports.captureDatabaseSnapshot = async function () {
+export async function captureDatabaseSnapshot() {
   return {
-    courseInstances: await module.exports.dumpTable('course_instances'),
-    assessments: await module.exports.dumpTable('assessments'),
-    assessmentSets: await module.exports.dumpTable('assessment_sets'),
-    topics: await module.exports.dumpTable('topics'),
-    tags: await module.exports.dumpTable('tags'),
-    courseInstanceAccessRules: await module.exports.dumpTable('course_instance_access_rules'),
-    assessmentAccessRules: await module.exports.dumpTable('assessment_access_rules'),
-    zones: await module.exports.dumpTable('zones'),
-    alternativeGroups: await module.exports.dumpTable('alternative_groups'),
-    assessmentQuestions: await module.exports.dumpTable('assessment_questions'),
-    questions: await module.exports.dumpTable('questions'),
-    questionTags: await module.exports.dumpTable('question_tags'),
-    users: await module.exports.dumpTable('users'),
-    enrollments: await module.exports.dumpTable('enrollments'),
+    courseInstances: await dumpTable('course_instances'),
+    assessments: await dumpTable('assessments'),
+    assessmentSets: await dumpTable('assessment_sets'),
+    topics: await dumpTable('topics'),
+    tags: await dumpTable('tags'),
+    courseInstanceAccessRules: await dumpTable('course_instance_access_rules'),
+    assessmentAccessRules: await dumpTable('assessment_access_rules'),
+    zones: await dumpTable('zones'),
+    alternativeGroups: await dumpTable('alternative_groups'),
+    assessmentQuestions: await dumpTable('assessment_questions'),
+    questions: await dumpTable('questions'),
+    questionTags: await dumpTable('question_tags'),
+    users: await dumpTable('users'),
+    enrollments: await dumpTable('enrollments'),
   };
-};
+}
 
 /**
  * Computes setA U setB.
@@ -569,7 +569,7 @@ function checkSetsSame(setA, setB) {
  * @param {{ [key: string]: any[] }} snapshotB - The second snapshot
  * @param {string[]} [ignoredKeys=[]] An optional list of keys to ignore
  */
-module.exports.assertSnapshotsMatch = function (snapshotA, snapshotB, ignoredKeys = []) {
+export function assertSnapshotsMatch(snapshotA, snapshotB, ignoredKeys = []) {
   // Sanity check - make sure both snapshots have the same keys
   assert(
     checkSetsSame(new Set(Object.keys(snapshotA)), new Set(Object.keys(snapshotB))),
@@ -582,7 +582,7 @@ module.exports.assertSnapshotsMatch = function (snapshotA, snapshotB, ignoredKey
     const setB = new Set(snapshotB[key].map((s) => stringify(s)));
     assert(checkSetsSame(setA, setB), `Snapshot of ${key} did not match`);
   }
-};
+}
 
 /**
  * Asserts that `snapshotA` is a subset of `snapshotB` using the same algorithm
@@ -592,7 +592,7 @@ module.exports.assertSnapshotsMatch = function (snapshotA, snapshotB, ignoredKey
  * @param {{ [key: string]: any[] }} snapshotB - The second snapshot
  * @param {string[]} [ignoredKeys=[]] An optional list of keys to ignore
  */
-module.exports.assertSnapshotSubset = function (snapshotA, snapshotB, ignoredKeys = []) {
+export function assertSnapshotSubset(snapshotA, snapshotB, ignoredKeys = []) {
   // Sanity check - make sure both snapshots have the same keys
   assert(
     checkSetsSame(new Set(Object.keys(snapshotA)), new Set(Object.keys(snapshotB))),
@@ -608,4 +608,4 @@ module.exports.assertSnapshotSubset = function (snapshotA, snapshotB, ignoredKey
       `Snapshot of ${key} is not a subset`,
     );
   }
-};
+}

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -4,7 +4,7 @@ import { step } from 'mocha-steps';
 const { v4: uuid } = require('uuid');
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -1,20 +1,21 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-const { v4: uuid } = require('uuid');
+import { v4 as uuid } from 'uuid';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
-const {
+import {
   getCourseData,
   COURSE_INSTANCE_ID,
   writeCourseToTempDirectory,
   overwriteAndSyncCourseData,
-} = require('./sync/util');
+} from './sync/util';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Course with assessments grouped by Set vs Module', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -7,7 +7,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 const {
   getCourseData,

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -8,7 +8,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 const {
   getCourseData,
   COURSE_INSTANCE_ID,

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 const { v4: uuid } = require('uuid');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 const { v4: uuid } = require('uuid');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 const { v4: uuid } = require('uuid');
 

--- a/apps/prairielearn/src/tests/testCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/testCourseQuestions.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 
 var helperServer = require('./helperServer');
 var helperQuestion = require('./helperQuestion');

--- a/apps/prairielearn/src/tests/testCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/testCourseQuestions.test.js
@@ -2,7 +2,7 @@
 import { config } from '../lib/config';
 
 import * as helperServer from './helperServer';
-var helperQuestion = require('./helperQuestion');
+import * as helperQuestion from './helperQuestion';
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/testCourseQuestions.test.js
+++ b/apps/prairielearn/src/tests/testCourseQuestions.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { config } from '../lib/config';
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 var helperQuestion = require('./helperQuestion');
 
 const locals = {};

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import { config } from '../lib/config';
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -1,13 +1,13 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
 import * as helperClient from './helperClient';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 describe('Assessment that forces students to complete questions in-order', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -7,7 +7,7 @@ const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';
-const helperClient = require('./helperClient');
+import * as helperClient from './helperClient';
 
 describe('Assessment that forces students to complete questions in-order', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const assert = require('chai').assert;
+import { assert } from 'chai';
 const { step } = require('mocha-steps');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -6,7 +6,7 @@ import { config } from '../lib/config';
 const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
-const helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 const helperClient = require('./helperClient');
 
 describe('Assessment that forces students to complete questions in-order', function () {

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.js
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { step } = require('mocha-steps');
+import { step } from 'mocha-steps';
 
 const { config } = require('../lib/config');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/utils/csrf.ts
+++ b/apps/prairielearn/src/tests/utils/csrf.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 
 export async function getCsrfToken(url: string) {

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -4,7 +4,7 @@ const { v4: uuidv4 } = require('uuid');
 const { z } = require('zod');
 import * as sqldb from '@prairielearn/postgres';
 
-const workspaceHostUtils = require('../lib/workspaceHost');
+import * as workspaceHostUtils from '../lib/workspaceHost';
 import * as helperDb from './helperDb';
 
 const WorkspaceHostSchema = z.object({

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 const { v4: uuidv4 } = require('uuid');
 const { z } = require('zod');
-const sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 const workspaceHostUtils = require('../lib/workspaceHost');
 import * as helperDb from './helperDb';

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 const { v4: uuidv4 } = require('uuid');
-const { z } = require('zod');
+import { z } from 'zod';
 import * as sqldb from '@prairielearn/postgres';
 
 import * as workspaceHostUtils from '../lib/workspaceHost';

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -5,7 +5,7 @@ const { z } = require('zod');
 const sqldb = require('@prairielearn/postgres');
 
 const workspaceHostUtils = require('../lib/workspaceHost');
-const helperDb = require('./helperDb');
+import * as helperDb from './helperDb';
 
 const WorkspaceHostSchema = z.object({
   id: z.string(),

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-const { assert } = require('chai');
+import { assert } from 'chai';
 const { v4: uuidv4 } = require('uuid');
 const { z } = require('zod');
 const sqldb = require('@prairielearn/postgres');

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const { v4: uuidv4 } = require('uuid');
+import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 var ERR = require('async-stacktrace');
-var _ = require('lodash');
+const _ = require('lodash');
 const { assert } = require('chai');
 const fetch = require('node-fetch').default;
 var cheerio = require('cheerio');

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -4,13 +4,13 @@ const _ = require('lodash');
 import { assert } from 'chai';
 import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
-import * as sqldb from '@prairielearn/postgres');
-var sql = sqldb.loadSqlEquiv(__filename);
-
 import * as helperServer from './helperServer';
-var helperQuestion = require('./helperQuestion');
+import * as helperQuestion from './helperQuestion';
+
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
-const { assert } = require('chai');
+import { assert } from 'chai';
 const fetch = require('node-fetch').default;
 var cheerio = require('cheerio');
 

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -3,13 +3,13 @@ const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
 import fetch from 'node-fetch';
-var cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
-var helperServer = require('./helperServer');
+import * as helperServer from './helperServer';
 var helperQuestion = require('./helperQuestion');
 
 const locals = {};

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import { assert } from 'chai';
-const fetch = require('node-fetch').default;
+import fetch from 'node-fetch';
 var cheerio = require('cheerio');
 
 const { config } = require('../lib/config');

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -1,5 +1,5 @@
 // @ts-check
-var ERR = require('async-stacktrace');
+const ERR = require('async-stacktrace');
 const _ = require('lodash');
 const { assert } = require('chai');
 const fetch = require('node-fetch').default;

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -6,7 +6,7 @@ import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 
 import { config } from '../lib/config';
-var sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 
 import * as helperServer from './helperServer';

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 var cheerio = require('cheerio');
 
-const { config } = require('../lib/config');
+import { config } from '../lib/config';
 var sqldb = require('@prairielearn/postgres');
 var sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/tests/zoneGradingHomework.test.js
+++ b/apps/prairielearn/src/tests/zoneGradingHomework.test.js
@@ -1,16 +1,16 @@
 // @ts-check
-var ERR = require('async-stacktrace');
-var _ = require('lodash');
-const { assert } = require('chai');
-const fetch = require('node-fetch').default;
-var cheerio = require('cheerio');
+const ERR = require('async-stacktrace');
+const _ = require('lodash');
+import { assert } from 'chai';
+import fetch from 'node-fetch';
+import * as cheerio from 'cheerio';
+import * as sqldb from '@prairielearn/postgres';
 
-const { config } = require('../lib/config');
-var sqldb = require('@prairielearn/postgres');
-var sql = sqldb.loadSqlEquiv(__filename);
+import { config } from '../lib/config';
+import * as helperServer from './helperServer';
+import * as helperQuestion from './helperQuestion';
 
-var helperServer = require('./helperServer');
-var helperQuestion = require('./helperQuestion');
+const sql = sqldb.loadSqlEquiv(__filename);
 
 const locals = {};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3233,6 +3233,7 @@ __metadata:
     "@types/jquery": ^3.5.29
     "@types/js-cookie": ^3.0.6
     "@types/jsdom": ^21.1.6
+    "@types/json-stable-stringify": ^1.0.36
     "@types/json-stringify-safe": ^5.0.3
     "@types/klaw": ^3.0.6
     "@types/lodash": ^4.14.202
@@ -4936,6 +4937,13 @@ __metadata:
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
   checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
+  languageName: node
+  linkType: hard
+
+"@types/json-stable-stringify@npm:^1.0.36":
+  version: 1.0.36
+  resolution: "@types/json-stable-stringify@npm:1.0.36"
+  checksum: 765b07589e11a3896c3d06bb9e3a9be681e7edd95adf27370df0647a91bd2bfcfaf0e091fd4a13729343b388973f73f7e789d6cc62ab988240518a2d27c4a4e2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3340,7 +3340,6 @@ __metadata:
     morphdom: ^2.7.1
     multer: ^1.4.5-lts.1
     mustache: ^4.2.0
-    ncp: ^2.0.0
     node-fetch: ^2.7.0
     node-jose: ^2.2.0
     nodemon: ^3.0.2
@@ -12865,7 +12864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ncp@npm:^2.0.0, ncp@npm:~2.0.0":
+"ncp@npm:~2.0.0":
   version: 2.0.0
   resolution: "ncp@npm:2.0.0"
   bin:


### PR DESCRIPTION
This PR converts all files in `apps/prairielearn/src/tests` to ESM as much as possible. The remaining `require(...)` calls are for modules whose types declare `export = ...` and thus can't be imported until we switch to native ESM and enable `allowSyntheticDefaultImports`.