### PR TITLE
Allow any authentication context for SAML auth

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -29,6 +29,11 @@ export const strategy = new MultiSamlStrategy(
             // Service Provider's private key.
             privateKey: samlProvider.private_key,
             decryptionPvk: samlProvider.private_key,
+            // By default, `node-saml` will include a `RequestedAuthnContext`
+            // element that requests password-based authentication. However,
+            // some institutions use passwordless auth, so we disable this and
+            // allow any authentication context.
+            disableRequestedAuthnContext: true,
           });
         })
         .catch((err) => done(err));


### PR DESCRIPTION
This allows institutions using passwordless auth to authenticate. I'll test this with UIUC's auth on staging first.