### PR TITLE
Add script to find candidates for conversion to ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-mocha": "^10.2.0",
     "eslint-plugin-no-floating-promise": "^1.0.2",
     "eslint-plugin-no-only-tests": "^3.1.0",
+    "globby": "^11.1.0",
     "htmlhint": "^1.1.4",
     "prettier": "3.1.0",
     "pyright": "^1.1.338",

--- a/tools/cjs-to-esm-candidates.mjs
+++ b/tools/cjs-to-esm-candidates.mjs
@@ -9,10 +9,18 @@ console.log(files);
 
 const CJS_ONLY_MODULES = new Set([
   'async-stacktrace',
+  'axe-core',
   'execa',
   'express-async-handler',
+  'express-list-endpoints',
+  'fetch-cookie',
+  'form-data',
+  'json-stable-stringify',
+  'klaw',
   'lodash',
+  'passport',
   'request',
+  'strip-ansi',
   'winston',
   'winston-transport',
 ]);

--- a/tools/cjs-to-esm-candidates.mjs
+++ b/tools/cjs-to-esm-candidates.mjs
@@ -1,0 +1,60 @@
+// @ts-check
+import fs from 'node:fs/promises';
+import globby from 'globby';
+import { parse } from '@typescript-eslint/parser';
+
+const files = await globby(['apps/*/src/**/*.{js,ts}']);
+
+console.log(files);
+
+const CJS_ONLY_MODULES = new Set([
+  'async-stacktrace',
+  'execa',
+  'express-async-handler',
+  'lodash',
+  'request',
+  'winston',
+  'winston-transport',
+]);
+
+function maybeLogLocation(path, node, modulePath) {
+  if (CJS_ONLY_MODULES.has(modulePath)) return;
+
+  console.log(`${path}:${node.loc.start.line}:${node.loc.start.column}: ${modulePath}`);
+}
+
+for (const file of files.sort()) {
+  const contents = await fs.readFile(file, 'utf-8');
+  const ast = parse(contents, {
+    range: true,
+    loc: true,
+    tokens: false,
+  });
+
+  ast.body.forEach((node) => {
+    // Handle `require()` calls.
+    if (node.type === 'VariableDeclaration') {
+      node.declarations.forEach((declaration) => {
+        if (
+          declaration.init?.type === 'CallExpression' &&
+          declaration.init.callee?.type === 'Identifier' &&
+          declaration.init.callee.name === 'require' &&
+          declaration.init.arguments[0].type === 'Literal'
+        ) {
+          const modulePath = declaration.init.arguments[0].value;
+          maybeLogLocation(file, node, modulePath);
+        }
+      });
+    }
+
+    // Handle `import ... = require(...)` statements.
+    if (
+      node.type === 'TSImportEqualsDeclaration' &&
+      node.moduleReference.type === 'TSExternalModuleReference' &&
+      node.moduleReference.expression.type === 'Literal'
+    ) {
+      const modulePath = node.moduleReference.expression.value;
+      maybeLogLocation(file, node, modulePath);
+    }
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14054,6 +14054,7 @@ __metadata:
     eslint-plugin-mocha: ^10.2.0
     eslint-plugin-no-floating-promise: ^1.0.2
     eslint-plugin-no-only-tests: ^3.1.0
+    globby: ^11.1.0
     htmlhint: ^1.1.4
     prettier: 3.1.0
     pyright: ^1.1.338


### PR DESCRIPTION
This PR contains a small CLI utility to help us prepare for the migration to ESM. It finds and prints all places where we load code via `const ... = require(...)` or `import ... = require(...)`. It uses a manually-curated list of packages that use `export = ...` to avoid printing anything for packages that we can't yet import with native ESM syntax.

This PR doesn't yet do anything to detect `module.exports`, though it'll be easy to expand it to handle that in the future.