### PR TITLE
Rewrite import-equals to use native ESM syntax where possible

### DIFF
--- a/apps/prairielearn/src/cron/autoFinishExams.ts
+++ b/apps/prairielearn/src/cron/autoFinishExams.ts
@@ -1,10 +1,10 @@
 import ERR = require('async-stacktrace');
-import async = require('async');
-import error = require('@prairielearn/error');
+import * as async from 'async';
+import * as error from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
-import assessment = require('../lib/assessment');
+import * as assessment from '../lib/assessment';
 import { config } from '../lib/config';
 
 /**

--- a/apps/prairielearn/src/cron/cleanTimeSeries.ts
+++ b/apps/prairielearn/src/cron/cleanTimeSeries.ts
@@ -1,6 +1,6 @@
 import { callbackify } from 'util';
 import { logger } from '@prairielearn/logger';
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
 

--- a/apps/prairielearn/src/cron/workspaceHostTransitions.ts
+++ b/apps/prairielearn/src/cron/workspaceHostTransitions.ts
@@ -1,4 +1,4 @@
-import async = require('async');
+import * as async from 'async';
 import { EC2 } from '@aws-sdk/client-ec2';
 import { callbackify } from 'util';
 import fetch from 'node-fetch';
@@ -8,8 +8,8 @@ import { loadSqlEquiv, queryAsync, queryRows } from '@prairielearn/postgres';
 
 import { config } from '../lib/config';
 import { makeAwsClientConfig } from '../lib/aws';
-import workspaceHelper = require('../lib/workspace');
-import workspaceHostUtils = require('../lib/workspaceHost');
+import * as workspaceHelper from '../lib/workspace';
+import * as workspaceHostUtils from '../lib/workspaceHost';
 
 const sql = loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/cron/workspaceTimeoutStop.ts
+++ b/apps/prairielearn/src/cron/workspaceTimeoutStop.ts
@@ -1,8 +1,8 @@
-import util = require('util');
+import * as util from 'node:util';
 import { logger } from '@prairielearn/logger';
 import { metrics, getCounter, ValueType } from '@prairielearn/opentelemetry';
-import sqldb = require('@prairielearn/postgres');
-import workspaceUtils = require('@prairielearn/workspace-utils');
+import * as sqldb from '@prairielearn/postgres';
+import * as workspaceUtils from '@prairielearn/workspace-utils';
 
 import { config } from '../lib/config';
 

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -2,7 +2,7 @@ import ERR = require('async-stacktrace');
 import asyncHandler = require('express-async-handler');
 import { Router } from 'express';
 import passport = require('passport');
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 
 import * as authnLib from '../../../lib/authn';
 

--- a/apps/prairielearn/src/ee/cron/workspaceHostLoads.ts
+++ b/apps/prairielearn/src/ee/cron/workspaceHostLoads.ts
@@ -5,7 +5,7 @@ import { loadSqlEquiv, queryAsync, callOneRowAsync } from '@prairielearn/postgre
 
 import { makeAwsClientConfig } from '../../lib/aws';
 import { config } from '../../lib/config';
-import workspaceHostUtils = require('../../lib/workspaceHost');
+import * as workspaceHostUtils from '../../lib/workspaceHost';
 
 const sql = loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/ee/lib/billing/plans.test.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plans.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 
-import helperServer = require('../../../tests/helperServer');
-import helperDb = require('../../../tests/helperDb');
+import * as helperServer from '../../../tests/helperServer';
+import * as helperDb from '../../../tests/helperDb';
 import {
   getPlanGrantsForContext,
   getPlanGrantsForPartialContexts,

--- a/apps/prairielearn/src/ee/models/enrollment.test.ts
+++ b/apps/prairielearn/src/ee/models/enrollment.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 
-import helperDb = require('../../tests/helperDb');
-import helperCourse = require('../../tests/helperCourse');
+import * as helperDb from '../../tests/helperDb';
+import * as helperCourse from '../../tests/helperCourse';
 import { ensureEnrollment } from '../../models/enrollment';
 import {
   getEnrollmentCountsForCourseInstance,

--- a/apps/prairielearn/src/ee/models/plan-grants.test.ts
+++ b/apps/prairielearn/src/ee/models/plan-grants.test.ts
@@ -1,4 +1,4 @@
-import helperDb = require('../../tests/helperDb');
+import * as helperDb from '../../tests/helperDb';
 import { getOrCreateUser } from '../../tests/utils/auth';
 import { ensurePlanGrant } from './plan-grants';
 

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import asyncHandler = require('express-async-handler');
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 import { flash } from '@prairielearn/flash';
 

--- a/apps/prairielearn/src/ee/pages/institutionAdminGeneral/institutionAdminGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminGeneral/institutionAdminGeneral.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import asyncHandler = require('express-async-handler');
 import { loadSqlEquiv, queryRow, runInTransactionAsync } from '@prairielearn/postgres';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 
 import {

--- a/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 import asyncHandler = require('express-async-handler');
-import jose = require('node-jose');
+import * as jose from 'node-jose';
 import { z } from 'zod';
 import { sortBy } from 'lodash';
 
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryAsync, queryRows } from '@prairielearn/postgres';
 import { flash } from '@prairielearn/flash';
 

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.test.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.test.ts
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
-import cheerio = require('cheerio');
+import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 import { queryAsync } from '@prairielearn/postgres';
 
 import { enableEnterpriseEdition, withoutEnterpriseEdition } from '../../tests/ee-helpers';
-import helperServer = require('../../../tests/helperServer');
+import * as helperServer from '../../../tests/helperServer';
 import {
   reconcilePlanGrantsForCourseInstance,
   reconcilePlanGrantsForInstitution,

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.ts
@@ -2,7 +2,7 @@ import { Router, type Response } from 'express';
 import asyncHandler = require('express-async-handler');
 import { z } from 'zod';
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 
 import {
   EnrollmentLimitSource,

--- a/apps/prairielearn/src/ee/pages/lti13Instance/lti13Instance.ts
+++ b/apps/prairielearn/src/ee/pages/lti13Instance/lti13Instance.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import asyncHandler = require('express-async-handler');
-import jose = require('node-jose');
+import * as jose from 'node-jose';
 import { getCanonicalHost } from '../../../lib/url';
 import { URL } from 'url';
 import { selectLti13Instance } from '../../models/lti13Instance';

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 
 import { config } from '../../../lib/config';
-import helperServer = require('../../../tests/helperServer');
+import * as helperServer from '../../../tests/helperServer';
 import { enableEnterpriseEdition } from '../../tests/ee-helpers';
 import {
   reconcilePlanGrantsForCourseInstance,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import asyncHandler = require('express-async-handler');
 import type Stripe from 'stripe';
 import { z } from 'zod';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
 
 import {

--- a/apps/prairielearn/src/ee/webhooks/stripe/index.ts
+++ b/apps/prairielearn/src/ee/webhooks/stripe/index.ts
@@ -1,7 +1,7 @@
 import express = require('express');
 import asyncHandler = require('express-async-handler');
 import Stripe from 'stripe';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
 
 import { config } from '../../../lib/config';

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -1,9 +1,9 @@
-import crypto = require('crypto');
+import * as crypto from 'node:crypto';
 import express = require('express');
-import fs = require('fs');
-import path = require('path');
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { hashElement, type HashElementNode } from 'folder-hash';
-import compiledAssets = require('@prairielearn/compiled-assets');
+import * as compiledAssets from '@prairielearn/compiled-assets';
 
 import { config } from './config';
 import { APP_ROOT_PATH } from './paths';

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -1,21 +1,21 @@
 import { S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
-import async = require('async');
-import child_process = require('child_process');
-import fs = require('fs-extra');
-import path = require('path');
+import * as async from 'async';
+import * as child_process from 'child_process';
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import { PassThrough as PassThroughStream } from 'stream';
-import tar = require('tar');
-import util = require('util');
+import * as tar from 'tar';
+import * as util from 'util';
 import { v4 as uuidv4 } from 'uuid';
 
-import namedLocks = require('@prairielearn/named-locks');
-import sqldb = require('@prairielearn/postgres');
+import * as namedLocks from '@prairielearn/named-locks';
+import * as sqldb from '@prairielearn/postgres';
 
-import aws = require('./aws');
+import * as aws from './aws';
 import { chalk, chalkDim } from './chalk';
 import { createServerJob, ServerJob } from './server-jobs';
-import courseDB = require('../sync/course-db');
+import * as courseDB from '../sync/course-db';
 import type { CourseData } from '../sync/course-db';
 import { config } from './config';
 import { contains } from '@prairielearn/path-utils';

--- a/apps/prairielearn/src/lib/copy-question.ts
+++ b/apps/prairielearn/src/lib/copy-question.ts
@@ -1,6 +1,6 @@
 import { type Response } from 'express';
-import fs = require('fs-extra');
-import path = require('node:path');
+import * as fs from 'fs-extra';
+import * as path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/lib/node-metrics.ts
+++ b/apps/prairielearn/src/lib/node-metrics.ts
@@ -1,6 +1,6 @@
 import loopbench = require('loopbench');
 import { CloudWatch, type Dimension } from '@aws-sdk/client-cloudwatch';
-import Sentry = require('@prairielearn/sentry');
+import * as Sentry from '@prairielearn/sentry';
 import { logger } from '@prairielearn/logger';
 
 import { makeAwsClientConfig } from './aws';

--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -6,8 +6,8 @@ import { logger } from '@prairielearn/logger';
 import { loadSqlEquiv, queryAsync, queryValidatedOneRow, queryRows } from '@prairielearn/postgres';
 
 import { chalk, chalkDim } from './chalk';
-import serverJobs = require('./server-jobs-legacy');
-import socketServer = require('./socket-server');
+import * as serverJobs from './server-jobs-legacy';
+import * as socketServer from './socket-server';
 import { Job, JobSchema } from './db-types';
 
 const sql = loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/lib/session-store.test.ts
+++ b/apps/prairielearn/src/lib/session-store.test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
-import helperDb = require('../tests/helperDb');
+import * as helperDb from '../tests/helperDb';
 import { PostgresSessionStore } from './session-store';
 import { UserSchema, UserSessionSchema } from './db-types';
 

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { loadSqlEquiv, queryOptionalRow, queryRow } from '@prairielearn/postgres';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 
 import { CourseInstance, Enrollment, EnrollmentSchema, Institution } from '../lib/db-types';
 import { isEnterprise } from '../lib/license';

--- a/apps/prairielearn/src/models/questions.ts
+++ b/apps/prairielearn/src/models/questions.ts
@@ -1,4 +1,4 @@
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 import AnsiUp from 'ansi_up';
 import {
   TopicSchema,

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
@@ -1,8 +1,8 @@
 import asyncHandler = require('express-async-handler');
 import express = require('express');
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { AdministratorAdmins } from './administratorAdmins.html';
 import { UserSchema } from '../../lib/db-types';
 

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.ts
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import asyncHandler = require('express-async-handler');
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import {
   selectAllBatchedMigrations,
   selectBatchedMigration,

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -1,7 +1,7 @@
 import asyncHandler = require('express-async-handler');
 import { Router } from 'express';
 import { loadSqlEquiv, queryValidatedRows, queryRows } from '@prairielearn/postgres';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { z } from 'zod';
 
 import { FeatureName, features } from '../../lib/features';

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
@@ -1,6 +1,6 @@
 import asyncHandler = require('express-async-handler');
 import express = require('express');
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 import { AdministratorInstitutions, InstitutionRowSchema } from './administratorInstitutions.html';
 

--- a/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.ts
+++ b/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.ts
@@ -1,7 +1,7 @@
 import express = require('express');
 import asyncHandler = require('express-async-handler');
 
-import serverJobs = require('../../lib/server-jobs-legacy');
+import * as serverJobs from '../../lib/server-jobs-legacy';
 import { AdministratorJobSequence } from './administratorJobSequence.html';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
@@ -1,14 +1,14 @@
 import express = require('express');
 const router = express.Router();
 import asyncHandler = require('express-async-handler');
-import fsPromises = require('node:fs/promises');
-import path = require('path');
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import hljs from 'highlight.js';
 import { stringify } from '@prairielearn/csv';
 import { z } from 'zod';
 
-import jsonLoad = require('../../lib/json-load');
-import sqldb = require('@prairielearn/postgres');
+import * as jsonLoad from '../../lib/json-load';
+import * as sqldb from '@prairielearn/postgres';
 import {
   AdministratorQuery,
   AdministratorQuerySchema,
@@ -32,7 +32,7 @@ router.get(
     const info = AdministratorQuerySchema.parse(
       await jsonLoad.readJSON(path.join(queriesDir, jsonFilename)),
     );
-    const querySql = await fsPromises.readFile(path.join(queriesDir, sqlFilename), {
+    const querySql = await fs.readFile(path.join(queriesDir, sqlFilename), {
       encoding: 'utf8',
     });
     const sqlHighlighted = hljs.highlight(querySql, {
@@ -96,7 +96,7 @@ router.post(
     const sqlFilename = req.params.query + '.sql';
 
     const info = await jsonLoad.readJSON(path.join(queriesDir, jsonFilename));
-    const querySql = await fsPromises.readFile(path.join(queriesDir, sqlFilename), {
+    const querySql = await fs.readFile(path.join(queriesDir, sqlFilename), {
       encoding: 'utf8',
     });
 

--- a/apps/prairielearn/src/pages/enroll/enroll.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.ts
@@ -1,7 +1,7 @@
 import asyncHandler = require('express-async-handler');
 import express = require('express');
 import { z } from 'zod';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import {
   loadSqlEquiv,
   queryOneRowAsync,

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express';
 import asyncHandler = require('express-async-handler');
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { InstructorSharing } from './instructorCourseAdminSharing.html';
 import { z } from 'zod';
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 
 const router = Router();
 const sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -1,10 +1,10 @@
 import ERR = require('async-stacktrace');
 import { Router } from 'express';
-import error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
-import sqldb = require('@prairielearn/postgres');
+import * as sqldb from '@prairielearn/postgres';
 import { QuestionAddEditor } from '../../lib/editors';
-import fs = require('fs-extra');
+import * as fs from 'fs-extra';
 import { QuestionsPage } from './instructorQuestions.html';
 import { QuestionsPageDataAnsified, selectQuestionsForCourse } from '../../models/questions';
 import asyncHandler = require('express-async-handler');

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -1,14 +1,14 @@
+import ERR = require('async-stacktrace');
+import { Router } from 'express';
+import * as async from 'async';
+import * as path from 'path';
+import * as error from '@prairielearn/error';
+import { z } from 'zod';
+
 import { selectQuestionById } from '../../models/question';
 import { selectCourseById } from '../../models/course';
 import { processSubmission } from '../../lib/questionPreview';
 import { IdSchema, UserSchema } from '../../lib/db-types';
-import { z } from 'zod';
-
-import ERR = require('async-stacktrace');
-import { Router } from 'express';
-import async = require('async');
-import path = require('path');
-import error = require('@prairielearn/error');
 import LogPageView = require('../../middlewares/logPageView');
 import {
   getAndRenderVariant,

--- a/apps/prairielearn/src/pages/publicQuestions/publicQuestions.ts
+++ b/apps/prairielearn/src/pages/publicQuestions/publicQuestions.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
+import asyncHandler = require('express-async-handler');
+import * as error from '@prairielearn/error';
 import { QuestionsPage } from './publicQuestions.html';
 import { selectPublicQuestionsForCourse } from '../../models/questions';
 import { selectCourseById } from '../../models/course';
-import asyncHandler = require('express-async-handler');
 import { features } from '../../lib/features/index';
-import error = require('@prairielearn/error');
+
 const router = Router({ mergeParams: true });
 
 router.get(

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -1,9 +1,9 @@
 import express = require('express');
 import asyncHandler = require('express-async-handler');
-import crypto = require('crypto');
+import * as crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
-import error = require('@prairielearn/error');
-import sqldb = require('@prairielearn/postgres');
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
 import { AccessTokenSchema, UserSettings } from './userSettings.html';
 import { InstitutionSchema, UserSchema } from '../../lib/db-types';

--- a/apps/prairielearn/src/tests/mockLogger.ts
+++ b/apps/prairielearn/src/tests/mockLogger.ts
@@ -1,4 +1,4 @@
-import stream = require('stream');
+import * as stream from 'stream';
 import winston = require('winston');
 
 interface MockLogger {

--- a/apps/prairielearn/src/webhooks/terminate.ts
+++ b/apps/prairielearn/src/webhooks/terminate.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import jose = require('jose');
-import crypto = require('crypto');
+import * as jose from 'jose';
+import * as crypto from 'crypto';
 import { logger } from '@prairielearn/logger';
 
 import { config } from '../lib/config';

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
@@ -19,7 +19,7 @@
     "zones": [
         {
             "questions": [
-                {"id": "demo/annotated/mathNumberInput","points": [3,1]}
+                {"id": "demo/calculation"}
             ]
         },
         {

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
@@ -19,7 +19,7 @@
     "zones": [
         {
             "questions": [
-                {"id": "demo/calculation"}
+                {"id": "demo/annotated/mathNumberInput","points": [3,1]}
             ]
         },
         {


### PR DESCRIPTION
I used the tool introduced in #9058 to find all the instances of `import ... = require(...)` that could be rewritten to use `import * as ... from ...` instead.

```
node tools/cjs-to-esm-candidates.mjs --import-equals-only
```

This PR makes all necessary changes to that that command produces zero results. This is valuable because we'll have to do this eventually for our conversion to ESM anyways.