### PR TITLE
Use consistent import/require syntax per file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,12 @@ module.exports = {
       },
     ],
 
+    // This gives false positives for `fs-extra`, which re-exports everything
+    // from `fs`. We'll disable it for now.
+    //
+    // TODO: file an issue upstream with `eslint-plugin-import`.
+    'import/namespace': 'off',
+
     // The recommended Mocha rules are too strict for us; we'll only enable
     // these two rules.
     'mocha/no-exclusive-tests': 'error',

--- a/apps/prairielearn/src/lib/aws.js
+++ b/apps/prairielearn/src/lib/aws.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { Upload } from '@aws-sdk/lib-storage';
 import { S3 } from '@aws-sdk/client-s3';
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 import * as util from 'util';
 import * as async from 'async';
 import * as path from 'path';

--- a/apps/prairielearn/src/lib/editors.js
+++ b/apps/prairielearn/src/lib/editors.js
@@ -18,7 +18,7 @@ const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'
 import * as error from '@prairielearn/error';
 import * as fs from 'fs-extra';
 import * as async from 'async';
-const { v4: uuidv4 } = require('uuid');
+import { v4 as uuidv4 } from 'uuid';
 const sha256 = require('crypto-js/sha256');
 import { updateChunksForCourse, logChunkChangesToJob } from './chunks';
 import { EXAMPLE_COURSE_PATH } from './paths';

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import * as async from 'async';
-const fs = require('fs-extra');
+import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { logger } from '@prairielearn/logger';

--- a/apps/prairielearn/src/lib/externalGraderSqs.js
+++ b/apps/prairielearn/src/lib/externalGraderSqs.js
@@ -6,13 +6,13 @@ import * as tar from 'tar';
 const _ = require('lodash');
 import { Upload } from '@aws-sdk/lib-storage';
 import { S3 } from '@aws-sdk/client-s3';
-const PassThroughStream = require('stream').PassThrough;
+import { PassThrough } from 'stream';
 import { SQSClient, GetQueueUrlCommand, SendMessageCommand } from '@aws-sdk/client-sqs';
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 
 import { makeAwsClientConfig, makeS3ClientConfig } from './aws';
-const { config: globalConfig } = require('./config');
+import { config as globalConfig } from './config';
 import { getJobDirectory, buildDirectory } from './externalGraderCommon';
 
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -45,7 +45,7 @@ export class ExternalGraderSqs {
             ['.'],
           );
 
-          const passthrough = new PassThroughStream();
+          const passthrough = new PassThrough();
           tarball.pipe(passthrough);
 
           const params = {

--- a/apps/prairielearn/src/lib/externalGradingSocket.js
+++ b/apps/prairielearn/src/lib/externalGradingSocket.js
@@ -8,7 +8,7 @@ import * as Sentry from '@prairielearn/sentry';
 
 import { config } from './config';
 import { renderPanelsForSubmission } from './question-render';
-const socketServer = require('./socket-server');
+import * as socketServer from './socket-server';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/lib/file-store.js
+++ b/apps/prairielearn/src/lib/file-store.js
@@ -2,7 +2,7 @@
 import * as path from 'path';
 import * as fsPromises from 'fs/promises';
 import * as fs from 'fs';
-const { v4: uuidv4 } = require('uuid');
+import { v4 as uuidv4 } from 'uuid';
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 import * as sqldb from '@prairielearn/postgres';
 import { config } from './config';

--- a/apps/prairielearn/src/lib/github.js
+++ b/apps/prairielearn/src/lib/github.js
@@ -11,8 +11,8 @@ import { syncDiskToSqlAsync } from '../sync/syncFromDisk';
 import { sendCourseRequestMessage } from './opsbot';
 import { logChunkChangesToJob, updateChunksForCourse } from './chunks';
 import { createServerJob } from './server-jobs';
+import * as sqldb from '@prairielearn/postgres';
 
-const sqldb = require('@prairielearn/postgres');
 const sql = sqldb.loadSqlEquiv(__filename);
 
 /*

--- a/apps/prairielearn/src/lib/server-jobs-legacy.js
+++ b/apps/prairielearn/src/lib/server-jobs-legacy.js
@@ -4,8 +4,8 @@ const _ = require('lodash');
 import * as util from 'util';
 import * as async from 'async';
 import * as child_process from 'child_process';
-const { default: AnsiUp } = require('ansi_up');
-const { setTimeout: sleep } = require('node:timers/promises');
+import AnsiUp from 'ansi_up';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 import { logger } from '@prairielearn/logger';
 import * as socketServer from './socket-server';

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -6,7 +6,7 @@ import { logger } from '@prairielearn/logger';
 import * as path from 'path';
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 
-const { config } = require('./config');
+import { config } from './config';
 
 /**
  * @param {Redis} client

--- a/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
+++ b/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
@@ -1,7 +1,4 @@
 // @ts-check
-import { selectCourseById } from '../../models/course';
-import { selectQuestionById } from '../../models/question';
-
 const asyncHandler = require('express-async-handler');
 const path = require('path');
 const express = require('express');
@@ -9,6 +6,8 @@ const express = require('express');
 const error = require('@prairielearn/error');
 const chunks = require('../../lib/chunks');
 const { getQuestionCourse } = require('../../lib/question-variant');
+const { selectCourseById } = require('../../models/course');
+const { selectQuestionById } = require('../../models/question');
 
 module.exports = function (options = { publicEndpoint: false }) {
   const router = express.Router({ mergeParams: true });

--- a/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
+++ b/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
@@ -1,13 +1,12 @@
 // @ts-check
-import { selectCourseById } from '../../models/course';
-import { selectQuestionById } from '../../models/question';
-import { promisify } from 'util';
-
 const asyncHandler = require('express-async-handler');
 const error = require('@prairielearn/error');
 var express = require('express');
+const { promisify } = require('util');
 
 var question = require('../../lib/question-variant');
+const { selectCourseById } = require('../../models/course');
+const { selectQuestionById } = require('../../models/question');
 var sqldb = require('@prairielearn/postgres');
 
 var sql = sqldb.loadSqlEquiv(__filename);

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.js
@@ -4,7 +4,7 @@ import * as express from 'express';
 import * as path from 'path';
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 const _ = require('lodash');
-const { default: AnsiUp } = require('ansi_up');
+import AnsiUp from 'ansi_up';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 import * as express from 'express';
 const asyncHandler = require('express-async-handler');
-const { default: AnsiUp } = require('ansi_up');
+import AnsiUp from 'ansi_up';
 import * as error from '@prairielearn/error';
 const debug = require('debug')('prairielearn:instructorAssessments');
 import { logger } from '@prairielearn/logger';

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
@@ -3,7 +3,7 @@ import * as express from 'express';
 import * as path from 'path';
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 import * as fs from 'fs-extra';
-const async = require('async');
+import * as async from 'async';
 const ERR = require('async-stacktrace');
 import { CourseInfoEditor } from '../../lib/editors';
 import { logger } from '@prairielearn/logger';

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
@@ -1,5 +1,3 @@
-import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances';
-
 const asyncHandler = require('express-async-handler');
 const express = require('express');
 const router = express.Router();
@@ -10,6 +8,7 @@ const { logger } = require('@prairielearn/logger');
 const error = require('@prairielearn/error');
 const sqldb = require('@prairielearn/postgres');
 const { idsEqual } = require('../../lib/id');
+const { selectCourseInstancesWithStaffAccess } = require('../../models/course-instances');
 
 const path = require('path');
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -1,12 +1,12 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 import * as express from 'express';
-const async = require('async');
-const error = require('@prairielearn/error');
-const sqldb = require('@prairielearn/postgres');
-const fs = require('fs-extra');
-const path = require('path');
-const { v4: uuidv4 } = require('uuid');
+import * as async from 'async';
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 const debug = require('debug')('prairielearn:instructorFileEditor');
 import { contains } from '@prairielearn/path-utils';
 import * as serverJobs from '../../lib/server-jobs-legacy';
@@ -21,7 +21,7 @@ import {
 } from '../../models/course';
 import { config } from '../../lib/config';
 import { getErrorsAndWarningsForFilePath } from '../../lib/editorUtil';
-const { default: AnsiUp } = require('ansi_up');
+import AnsiUp from 'ansi_up';
 const sha256 = require('crypto-js/sha256');
 import { b64EncodeUnicode, b64DecodeUnicode } from '../../lib/base64-util';
 import { deleteFile, getFile, uploadFile } from '../../lib/file-store';

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
@@ -1,5 +1,3 @@
-import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances';
-
 const asyncHandler = require('express-async-handler');
 const _ = require('lodash');
 const { parseISO, formatDistance } = require('date-fns');
@@ -11,6 +9,7 @@ const error = require('@prairielearn/error');
 const paginate = require('../../lib/paginate');
 const sqldb = require('@prairielearn/postgres');
 const { idsEqual } = require('../../lib/id');
+const { selectCourseInstancesWithStaffAccess } = require('../../models/course-instances');
 
 const sql = sqldb.loadSqlEquiv(__filename);
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -1,5 +1,3 @@
-import { selectCoursesWithEditAccess } from '../../models/course';
-
 // @ts-check
 const ERR = require('async-stacktrace');
 const asyncHandler = require('express-async-handler');
@@ -28,6 +26,7 @@ const { flash } = require('@prairielearn/flash');
 const { features } = require('../../lib/features/index');
 const { getCanonicalHost } = require('../../lib/url');
 const { isEnterprise } = require('../../lib/license');
+const { selectCoursesWithEditAccess } = require('../../models/course');
 
 router.post(
   '/test',

--- a/apps/prairielearn/src/pages/shared/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/shared/studentAssessmentInstance.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 import { uploadFile, deleteFile } from '../../lib/file-store';
-const { idsEqual } = require('../../lib/id');
+import { idsEqual } from '../../lib/id';
 
 module.exports.processFileUpload = async (req, res) => {
   if (!res.locals.assessment_instance.open) throw new Error(`Assessment is not open`);

--- a/apps/prairielearn/src/pages/shared/studentInstanceQuestion.js
+++ b/apps/prairielearn/src/pages/shared/studentInstanceQuestion.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
-const sqldb = require('@prairielearn/postgres');
-const error = require('@prairielearn/error');
+import * as sqldb from '@prairielearn/postgres';
+import * as error from '@prairielearn/error';
 
 import { uploadFile, deleteFile } from '../../lib/file-store';
-const { idsEqual } = require('../../lib/id');
-const issues = require('../../lib/issues');
+import { idsEqual } from '../../lib/id';
+import * as issues from '../../lib/issues';
 
 /*
  * Get a validated variant_id from a request, or throw an exception.

--- a/apps/prairielearn/src/pages/workspace/workspace.js
+++ b/apps/prairielearn/src/pages/workspace/workspace.js
@@ -5,9 +5,9 @@ const router = express.Router();
 const asyncHandler = require('express-async-handler');
 const sqldb = require('@prairielearn/postgres');
 const workspaceUtils = require('@prairielearn/workspace-utils');
-import { generateSignedToken } from '@prairielearn/signed-token';
 
 const { config } = require('../../lib/config');
+const { generateSignedToken } = require('@prairielearn/signed-token');
 
 const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
 const error = require('@prairielearn/error');

--- a/apps/prairielearn/src/sync/course-db.js
+++ b/apps/prairielearn/src/sync/course-db.js
@@ -1,5 +1,5 @@
 // @ts-check
-const path = require('path');
+import * as path from 'path';
 const _ = require('lodash');
 import * as fs from 'fs-extra';
 import * as async from 'async';

--- a/apps/prairielearn/src/tests/assets.test.js
+++ b/apps/prairielearn/src/tests/assets.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
-const fs = require('node:fs/promises');
-const path = require('node:path');
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config';

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 import { z } from 'zod';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/tests/courseEditor.test.js
+++ b/apps/prairielearn/src/tests/courseEditor.test.js
@@ -2,7 +2,7 @@
 const ERR = require('async-stacktrace');
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 import * as async from 'async';
 import * as cheerio from 'cheerio';
 import { exec } from 'child_process';

--- a/apps/prairielearn/src/tests/courseElementExtension.test.js
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.js
@@ -5,7 +5,7 @@ import * as fs from 'fs-extra';
 import { config } from '../lib/config';
 import * as sqldb from '@prairielearn/postgres';
 const _ = require('lodash');
-const path = require('path');
+import * as path from 'path';
 import * as freeform from '../question-servers/freeform.js';
 import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths';
 import { promisify } from 'util';

--- a/apps/prairielearn/src/tests/database.test.js
+++ b/apps/prairielearn/src/tests/database.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 const _ = require('lodash');
-const path = require('node:path');
+import * as path from 'node:path';
 import { describeDatabase, diffDirectoryAndDatabase } from '@prairielearn/postgres-tools';
 
 import { REPOSITORY_ROOT_PATH } from '../lib/paths';

--- a/apps/prairielearn/src/tests/fileEditor.test.js
+++ b/apps/prairielearn/src/tests/fileEditor.test.js
@@ -4,7 +4,7 @@ const request = require('request');
 import { assert } from 'chai';
 import { readFileSync } from 'node:fs';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 import * as async from 'async';
 import * as cheerio from 'cheerio';
 import * as tmp from 'tmp';

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const util = require('node:util');
+import * as util from 'node:util';
 import * as sqldb from '@prairielearn/postgres';
 import { step } from 'mocha-steps';
 

--- a/apps/prairielearn/src/tests/groupRole.test.js
+++ b/apps/prairielearn/src/tests/groupRole.test.js
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/tests/jsonLoad.test.js
+++ b/apps/prairielearn/src/tests/jsonLoad.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { assert } from 'chai';
-const path = require('path');
+import * as path from 'path';
 import * as jsonLoad from '../lib/json-load';
 
 const testfile = (filename) => path.join(__dirname, 'testJsonLoad', filename);

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 import { config } from '../../lib/config';
 import { features } from '../../lib/features/index';
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/tests/sync/courseDb.test.js
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.js
@@ -2,7 +2,7 @@
 import { assert } from 'chai';
 import * as tmp from 'tmp-promise';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 
 import * as courseDb from '../../sync/course-db';
 import * as infofile from '../../sync/infofile';

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 import * as util from './util';
 import * as helperDb from '../helperDb';
 import { idsEqual } from '../../lib/id';

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.js
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { assert } from 'chai';
 import * as fs from 'fs-extra';
-const path = require('path');
+import * as path from 'path';
 
 import * as util from './util';
 import * as helperDb from '../helperDb';

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -2,7 +2,7 @@
 import { promisify } from 'util';
 import * as fs from 'fs-extra';
 import * as tmp from 'tmp-promise';
-const path = require('path');
+import * as path from 'path';
 import * as sqldb from '@prairielearn/postgres';
 const stringify = require('json-stable-stringify');
 import { assert } from 'chai';

--- a/tools/cjs-to-esm-candidates.mjs
+++ b/tools/cjs-to-esm-candidates.mjs
@@ -14,6 +14,7 @@ const CJS_ONLY_MODULES = new Set([
   'fetch-cookie',
   'form-data',
   'json-stable-stringify',
+  'json-stringify-safe',
   'klaw',
   'lodash',
   'passport',
@@ -30,6 +31,7 @@ function maybeLogLocation(path, node, modulePath) {
 }
 
 const importEqualsOnly = process.argv.includes('--import-equals-only');
+const filesWithImportsOnly = process.argv.includes('--files-with-imports-only');
 
 const files = await globby(['apps/*/src/**/*.{js,ts}']);
 
@@ -40,6 +42,15 @@ for (const file of files.sort()) {
     loc: true,
     tokens: false,
   });
+
+  const fileHasImports = ast.body.some(
+    (node) =>
+      node.type === 'ImportDeclaration' ||
+      (node.type === 'TSImportEqualsDeclaration' &&
+        node.moduleReference.type === 'TSExternalModuleReference'),
+  );
+
+  if (filesWithImportsOnly && !fileHasImports) continue;
 
   ast.body.forEach((node) => {
     // Handle `require()` calls.

--- a/tools/cjs-to-esm-candidates.mjs
+++ b/tools/cjs-to-esm-candidates.mjs
@@ -6,8 +6,13 @@ import { parse } from '@typescript-eslint/parser';
 // These modules have their types declared as `export = ...`, so we can't use
 // `import` to load them until we're using native ESM.
 const CJS_ONLY_MODULES = new Set([
+  'archiver',
   'async-stacktrace',
   'axe-core',
+  'byline',
+  'crypto-js/sha256',
+  'dockerode',
+  'events',
   'execa',
   'express-async-handler',
   'express-list-endpoints',
@@ -17,6 +22,7 @@ const CJS_ONLY_MODULES = new Set([
   'json-stringify-safe',
   'klaw',
   'lodash',
+  'oauth-signature',
   'passport',
   'request',
   'strip-ansi',


### PR DESCRIPTION
Complements #9059. This PR aligns files to use either `import` or `require` exclusively (with the exception of modules that can only be loaded with `require` at the moment.