### PR TITLE
Remove ShortAnswer question type

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -217,7 +217,6 @@ export const QuestionSchema = z.object({
   topic_id: IdSchema.nullable(),
   type: z.enum([
     'Calculation',
-    'ShortAnswer',
     'MultipleChoice',
     'Checkbox',
     'File',

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -19,7 +19,6 @@
       "description": "Type of the question.",
       "enum": [
         "Calculation",
-        "ShortAnswer",
         "MultipleChoice",
         "Checkbox",
         "File",

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -17,14 +17,7 @@
     },
     "type": {
       "description": "Type of the question.",
-      "enum": [
-        "Calculation",
-        "MultipleChoice",
-        "Checkbox",
-        "File",
-        "MultipleTrueFalse",
-        "v3"
-      ]
+      "enum": ["Calculation", "MultipleChoice", "Checkbox", "File", "MultipleTrueFalse", "v3"]
     },
     "title": {
       "description": "The title of the question (e.g., 'Addition of vectors in Cartesian coordinates').",

--- a/apps/prairielearn/src/sync/course-db.js
+++ b/apps/prairielearn/src/sync/course-db.js
@@ -395,7 +395,7 @@ const FILE_UUID_REGEX =
  * @property {any} id
  * @property {string} qid
  * @property {string} uuid
- * @property {"Calculation" | "ShortAnswer" | "MultipleChoice" | "Checkbox" | "File" | "MultipleTrueFalse" | "v3"} type
+ * @property {"Calculation" | "MultipleChoice" | "Checkbox" | "File" | "MultipleTrueFalse" | "v3"} type
  * @property {string} title
  * @property {string} topic
  * @property {string[]} tags

--- a/apps/prairielearn/src/tests/sync/util.js
+++ b/apps/prairielearn/src/tests/sync/util.js
@@ -200,7 +200,7 @@ import * as syncFromDisk from '../../sync/syncFromDisk';
 /**
  * @typedef {Object} Question
  * @property {string} uuid
- * @property {"Calculation" | "ShortAnswer" | "MultipleChoice" | "Checkbox" | "File" | "MultipleTrueFalse" | "v3"} type
+ * @property {"Calculation" | "MultipleChoice" | "Checkbox" | "File" | "MultipleTrueFalse" | "v3"} type
  * @property {string} title
  * @property {string} topic
  * @property {string[]} [tags]


### PR DESCRIPTION
This type was supported in the schema but not in the question modules.

The database enum was not modified, as changing the enum is not an easy migration, and there is no harm in keeping the enum values as they are in the DB.