### PR TITLE
Converts question server functions to async

### DIFF
--- a/apps/prairielearn/src/lib/grading.js
+++ b/apps/prairielearn/src/lib/grading.js
@@ -249,10 +249,12 @@ export function gradeVariant(
             (err, ret_courseIssues, ret_data) => {
               if (ERR(err, callback)) return;
               courseIssues = ret_courseIssues;
-              data = ret_data;
               const hasFatalIssue = _.some(_.map(courseIssues, 'fatal'));
-              if (hasFatalIssue) data.gradable = false;
-              data.broken = hasFatalIssue;
+              data = {
+                ...ret_data,
+                gradable: ret_data.gradable && !hasFatalIssue,
+                broken: hasFatalIssue,
+              };
               debug('_gradeVariant()', 'completed grade()', 'hasFatalIssue:', hasFatalIssue);
               callback(null);
             },

--- a/apps/prairielearn/src/lib/grading.js
+++ b/apps/prairielearn/src/lib/grading.js
@@ -43,7 +43,9 @@ export function saveSubmission(submission, variant, question, variant_course, ca
   debug('saveSubmission()');
   submission.raw_submitted_answer = submission.submitted_answer;
   submission.gradable = true;
-  let questionModule, question_course, courseIssues, data, submission_id, workspace_id, zipPath;
+  /** @type {questionServers.QuestionServer} */
+  let questionModule;
+  let question_course, courseIssues, data, submission_id, workspace_id, zipPath;
   async.series(
     [
       (callback) => {
@@ -96,15 +98,8 @@ export function saveSubmission(submission, variant, question, variant_course, ca
         }
         await fs.promises.unlink(zipPath);
       },
-      (callback) => {
-        questionServers.getModule(question.type, (err, ret_questionModule) => {
-          if (ERR(err, callback)) return;
-          questionModule = ret_questionModule;
-          debug('saveSubmission()', 'loaded questionModule');
-          callback(null);
-        });
-      },
       async () => {
+        questionModule = questionServers.getModule(question.type);
         question_course = await getQuestionCourse(question, variant_course);
       },
       (callback) => {
@@ -196,7 +191,9 @@ export function gradeVariant(
   callback,
 ) {
   debug('_gradeVariant()');
-  let questionModule, question_course, courseIssues, data, submission, grading_job;
+  /** @type {questionServers.QuestionServer} */
+  let questionModule;
+  let question_course, courseIssues, data, submission, grading_job;
   async.series(
     [
       async () => {
@@ -237,13 +234,8 @@ export function gradeVariant(
           callback(null);
         });
       },
-      (callback) => {
-        questionServers.getModule(question.type, (err, ret_questionModule) => {
-          if (ERR(err, callback)) return;
-          questionModule = ret_questionModule;
-          debug('_gradeVariant()', 'loaded questionModule');
-          callback(null);
-        });
+      async () => {
+        questionModule = questionServers.getModule(question.type);
       },
       (callback) => {
         if (question.grading_method !== 'External') {

--- a/apps/prairielearn/src/lib/issues.ts
+++ b/apps/prairielearn/src/lib/issues.ts
@@ -1,5 +1,4 @@
 import * as async from 'async';
-import { callbackify } from 'util';
 
 import * as sqldb from '@prairielearn/postgres';
 import { recursivelyTruncateStrings } from '@prairielearn/sanitize';
@@ -83,7 +82,7 @@ export async function insertIssueForError(
  * @param studentMessage - The message to display to the student.
  * @param courseData - Arbitrary data to be associated with the issues.
  */
-export async function writeCourseIssuesAsync(
+export async function writeCourseIssues(
   courseIssues: ErrorMaybeWithData[],
   variant: Variant,
   authn_user_id: string | null,
@@ -99,4 +98,3 @@ export async function writeCourseIssuesAsync(
     });
   });
 }
-export const writeCourseIssues = callbackify(writeCourseIssuesAsync);

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -4,7 +4,6 @@ const ERR = require('async-stacktrace');
 const _ = require('lodash');
 import * as async from 'async';
 import * as path from 'path';
-import debugfn from 'debug';
 import * as ejs from 'ejs';
 import { differenceInMilliseconds, parseISO } from 'date-fns';
 import * as util from 'util';
@@ -19,7 +18,6 @@ import * as error from '@prairielearn/error';
 import { getQuestionCourse, ensureVariant } from './question-variant';
 import { writeCourseIssues } from './issues';
 
-const debug = debugfn('prairielearn:' + path.basename(__filename, '.js'));
 const sql = sqldb.loadSqlEquiv(__filename);
 
 /**
@@ -41,9 +39,8 @@ const MAX_RECENT_SUBMISSIONS = 3;
  * @param {Object} question_course - The course for the question.
  * @param {Object} course_instance - The course_instance for the variant.
  * @param {Object} locals - The current locals for the page response.
- * @param {function} callback - A callback(err, courseIssues, htmls) function.
  */
-function render(
+async function render(
   renderSelection,
   variant,
   question,
@@ -53,47 +50,26 @@ function render(
   question_course,
   course_instance,
   locals,
-  callback,
 ) {
-  /** @type {questionServers.QuestionServer} */
-  let questionModule;
-  let htmls;
-  async.series(
-    [
-      async () => {
-        questionModule = questionServers.getModule(question.type);
-      },
-      (callback) => {
-        questionModule.render(
-          renderSelection,
-          variant,
-          question,
-          submission,
-          submissions,
-          question_course,
-          course_instance,
-          locals,
-          (err, courseIssues, ret_htmls) => {
-            if (ERR(err, callback)) return;
+  const questionModule = questionServers.getModule(question.type);
 
-            const studentMessage = 'Error rendering question';
-            const courseData = { variant, question, submission, course: variant_course };
-            htmls = ret_htmls;
-            // locals.authn_user may not be populated when rendering a panel
-            const user_id = locals && locals.authn_user ? locals.authn_user.user_id : null;
-            writeCourseIssues(courseIssues, variant, user_id, studentMessage, courseData, (err) => {
-              if (ERR(err, callback)) return;
-              return callback(null);
-            });
-          },
-        );
-      },
-    ],
-    (err) => {
-      if (ERR(err, callback)) return;
-      callback(null, htmls);
-    },
+  const { courseIssues, data } = await questionModule.render(
+    renderSelection,
+    variant,
+    question,
+    submission,
+    submissions,
+    question_course,
+    course_instance,
+    locals,
   );
+
+  const studentMessage = 'Error rendering question';
+  const courseData = { variant, question, submission, course: variant_course };
+  // locals.authn_user may not be populated when rendering a panel
+  const user_id = locals && locals.authn_user ? locals.authn_user.user_id : null;
+  await writeCourseIssues(courseIssues, variant, user_id, studentMessage, courseData);
+  return data;
 }
 
 /**
@@ -291,15 +267,14 @@ export function getAndRenderVariant(variant_id, variant_seed, locals, callback) 
       async () => {
         locals.question_course = await getQuestionCourse(locals.question, locals.course);
       },
-      (callback) => {
+      async () => {
         if (variant_id != null) {
-          const params = [variant_id, locals.question.id, locals.instance_question?.id];
-          sqldb.callOneRow('variants_select', params, (err, result) => {
-            if (ERR(err, callback)) return;
-            debug('variants_select', result.rows[0].variant);
-            _.assign(locals, result.rows[0]);
-            callback(null);
-          });
+          const result = await sqldb.callOneRowAsync('variants_select', [
+            variant_id,
+            locals.question.id,
+            locals.instance_question?.id,
+          ]);
+          _.assign(locals, result.rows[0]);
         } else {
           const require_open = locals.assessment && locals.assessment.type !== 'Exam';
           const instance_question_id = locals.instance_question
@@ -313,7 +288,7 @@ export function getAndRenderVariant(variant_id, variant_seed, locals, callback) 
             variant_seed,
           };
           const assessmentGroupWork = locals.assessment ? locals.assessment.group_work : false;
-          ensureVariant(
+          locals.variant = await ensureVariant(
             locals.question.id,
             instance_question_id,
             locals.user.user_id,
@@ -325,11 +300,6 @@ export function getAndRenderVariant(variant_id, variant_seed, locals, callback) 
             options,
             require_open,
             locals.client_fingerprint_id,
-            (err, variant) => {
-              if (ERR(err, callback)) return;
-              locals.variant = variant;
-              callback(null);
-            },
           );
         }
       },
@@ -421,14 +391,14 @@ export function getAndRenderVariant(variant_id, variant_seed, locals, callback) 
           locals.question.type,
         );
       },
-      (callback) => {
+      async () => {
         const renderSelection = {
           header: true,
           question: true,
           submissions: locals.showSubmissions,
           answer: locals.showTrueAnswer,
         };
-        render(
+        const htmls = await render(
           renderSelection,
           locals.variant,
           locals.question,
@@ -438,15 +408,11 @@ export function getAndRenderVariant(variant_id, variant_seed, locals, callback) 
           locals.question_course,
           locals.course_instance,
           locals,
-          (err, htmls) => {
-            if (ERR(err, callback)) return;
-            locals.extraHeadersHtml = htmls.extraHeadersHtml;
-            locals.questionHtml = htmls.questionHtml;
-            locals.submissionHtmls = htmls.submissionHtmls;
-            locals.answerHtml = htmls.answerHtml;
-            callback(null);
-          },
         );
+        locals.extraHeadersHtml = htmls.extraHeadersHtml;
+        locals.questionHtml = htmls.questionHtml;
+        locals.submissionHtmls = htmls.submissionHtmls;
+        locals.answerHtml = htmls.answerHtml;
       },
       async () => {
         // Load issues last in case there are issues from rendering.

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -55,31 +55,45 @@ function render(
   locals,
   callback,
 ) {
-  questionServers.getModule(question.type, (err, questionModule) => {
-    if (ERR(err, callback)) return;
-    questionModule.render(
-      renderSelection,
-      variant,
-      question,
-      submission,
-      submissions,
-      question_course,
-      course_instance,
-      locals,
-      (err, courseIssues, htmls) => {
-        if (ERR(err, callback)) return;
-
-        const studentMessage = 'Error rendering question';
-        const courseData = { variant, question, submission, course: variant_course };
-        // locals.authn_user may not be populated when rendering a panel
-        const user_id = locals && locals.authn_user ? locals.authn_user.user_id : null;
-        writeCourseIssues(courseIssues, variant, user_id, studentMessage, courseData, (err) => {
-          if (ERR(err, callback)) return;
-          return callback(null, htmls);
-        });
+  /** @type {questionServers.QuestionServer} */
+  let questionModule;
+  let htmls;
+  async.series(
+    [
+      async () => {
+        questionModule = questionServers.getModule(question.type);
       },
-    );
-  });
+      (callback) => {
+        questionModule.render(
+          renderSelection,
+          variant,
+          question,
+          submission,
+          submissions,
+          question_course,
+          course_instance,
+          locals,
+          (err, courseIssues, ret_htmls) => {
+            if (ERR(err, callback)) return;
+
+            const studentMessage = 'Error rendering question';
+            const courseData = { variant, question, submission, course: variant_course };
+            htmls = ret_htmls;
+            // locals.authn_user may not be populated when rendering a panel
+            const user_id = locals && locals.authn_user ? locals.authn_user.user_id : null;
+            writeCourseIssues(courseIssues, variant, user_id, studentMessage, courseData, (err) => {
+              if (ERR(err, callback)) return;
+              return callback(null);
+            });
+          },
+        );
+      },
+    ],
+    (err) => {
+      if (ERR(err, callback)) return;
+      callback(null, htmls);
+    },
+  );
 }
 
 /**
@@ -402,12 +416,10 @@ export function getAndRenderVariant(variant_id, variant_seed, locals, callback) 
           }
         }
       },
-      (callback) => {
-        questionServers.getEffectiveQuestionType(locals.question.type, (err, eqt) => {
-          if (ERR(err, callback)) return;
-          locals.effectiveQuestionType = eqt;
-          callback(null);
-        });
+      async () => {
+        locals.effectiveQuestionType = questionServers.getEffectiveQuestionType(
+          locals.question.type,
+        );
       },
       (callback) => {
         const renderSelection = {

--- a/apps/prairielearn/src/lib/question-testing.js
+++ b/apps/prairielearn/src/lib/question-testing.js
@@ -26,7 +26,7 @@ const sql = sqldb.loadSqlEquiv(__filename);
  * @param {Object} variant - The variant to submit to.
  * @param {Object} question - The question for the variant.
  * @param {Object} variant_course - The course for the variant.
- * @param {string} test_type - The type of test to run.  Should be one of 'correct', 'incorrect', or 'invalid'.
+ * @param {'correct' | 'incorrect' | 'invalid'} test_type - The type of test to run.
  * @param {string} authn_user_id - The currently authenticated user.
  * @param {function} callback - A callback(err, submission_id) function.
  */
@@ -40,22 +40,17 @@ function createTestSubmission(
 ) {
   debug('_createTestSubmission()');
   if (question.type !== 'Freeform') return callback(new Error('question.type must be Freeform'));
-  let questionModule, question_course, courseIssues, data, submission_id, grading_job;
+  /** @type {questionServers.QuestionServer} */
+  let questionModule;
+  let question_course, courseIssues, data, submission_id, grading_job;
   async.series(
     [
-      (callback) => {
-        questionServers.getModule(question.type, (err, ret_questionModule) => {
-          if (ERR(err, callback)) return;
-          questionModule = ret_questionModule;
-          debug('_createTestSubmission()', 'loaded questionModule');
-          callback(null);
-        });
-      },
       async () => {
+        questionModule = questionServers.getModule(question.type);
         question_course = await getQuestionCourse(question, variant_course);
       },
       (callback) => {
-        questionModule.test(
+        questionModule.test?.(
           variant,
           question,
           question_course,
@@ -208,7 +203,7 @@ function compareSubmissions(expected_submission, test_submission, callback) {
  * @param {Object} variant - The variant to submit to.
  * @param {Object} question - The question for the variant.
  * @param {Object} course - The course for the variant.
- * @param {string} test_type - The type of test to run.  Should be one of 'correct', 'incorrect', or 'invalid'.
+ * @param {'correct' | 'incorrect' | 'invalid'} test_type - The type of test to run.
  * @param {string} authn_user_id - The currently authenticated user.
  * @param {function} callback - A callback(err) function.
  */
@@ -300,7 +295,7 @@ function testVariant(variant, question, course, test_type, authn_user_id, callba
  * @param {boolean} group_work - If the assessment will support group work.
  * @param {Object} variant_course - The course for the variant.
  * @param {string} authn_user_id - The currently authenticated user.
- * @param {string} test_type - The type of test to run.  Should be one of 'correct', 'incorrect', or 'invalid'.
+ * @param {'correct' | 'incorrect' | 'invalid'} test_type - The type of test to run.
  * @param {function} callback - A callback(err, variant) function.
  */
 function testQuestion(
@@ -423,7 +418,7 @@ function testQuestion(
  * @param {Object} question - The question for the variant.
  * @param {boolean} group_work - If the assessment will support group work.
  * @param {Object} course - The course for the variant.
- * @param {string} test_type - The type of test to run.  Should be one of 'correct', 'incorrect', or 'invalid'.
+ * @param {'correct' | 'incorrect' | 'invalid'} test_type - The type of test to run.
  * @param {string} authn_user_id - The currently authenticated user.
  */
 async function runTest(
@@ -531,7 +526,7 @@ export async function startTestQuestion(
   authn_user_id,
 ) {
   let success = true;
-  const test_types = ['correct', 'incorrect', 'invalid'];
+  const test_types = /** @type {const} */ (['correct', 'incorrect', 'invalid']);
 
   const serverJob = await createServerJob({
     courseId: course.id,

--- a/apps/prairielearn/src/lib/question-testing.js
+++ b/apps/prairielearn/src/lib/question-testing.js
@@ -58,9 +58,8 @@ function createTestSubmission(
           (err, ret_courseIssues, ret_data) => {
             if (ERR(err, callback)) return;
             courseIssues = ret_courseIssues;
-            data = ret_data;
             const hasFatalIssue = _.some(_.map(courseIssues, 'fatal'));
-            data.broken = hasFatalIssue;
+            data = { ...ret_data, broken: hasFatalIssue };
             debug('_createTestSubmission()', 'completed test()');
             callback(null);
           },

--- a/apps/prairielearn/src/lib/question-variant.js
+++ b/apps/prairielearn/src/lib/question-variant.js
@@ -1,7 +1,5 @@
 // @ts-check
 const _ = require('lodash');
-import * as path from 'path';
-import debugfn from 'debug';
 import * as fg from 'fast-glob';
 
 import { workspaceFastGlobDefaultOptions } from '@prairielearn/workspace-utils';
@@ -12,8 +10,6 @@ import { writeCourseIssues } from './issues';
 import { selectCourseById } from '../models/course';
 import { selectQuestionById, selectQuestionByInstanceQuestionId } from '../models/question';
 
-const debug = debugfn('prairielearn:' + path.basename(__filename, '.js'));
-
 /**
  * Internal function, do not call directly. Create a variant object, do not write to DB.
  * @protected
@@ -23,14 +19,12 @@ const debug = debugfn('prairielearn:' + path.basename(__filename, '.js'));
  * @param {Object} options - Options controlling the creation: options = {variant_seed}
  */
 async function makeVariant(question, course, options) {
-  debug('_makeVariant()');
   var variant_seed;
   if (_(options).has('variant_seed') && options.variant_seed != null) {
     variant_seed = options.variant_seed;
   } else {
     variant_seed = Math.floor(Math.random() * Math.pow(2, 32)).toString(36);
   }
-  debug(`_makeVariant(): question_id = ${question.id}`);
   let courseIssues, variant;
 
   const questionModule = questionServers.getModule(question.type);
@@ -181,7 +175,6 @@ async function makeAndInsertVariant(
     client_fingerprint_id,
   ]);
   const variant = result.rows[0].variant;
-  debug('variants_insert', variant);
 
   const studentMessage = 'Error creating question variant';
   const courseData = { variant, question, course: variant_course };

--- a/apps/prairielearn/src/lib/question-variant.js
+++ b/apps/prairielearn/src/lib/question-variant.js
@@ -3,7 +3,6 @@ const _ = require('lodash');
 import * as path from 'path';
 import debugfn from 'debug';
 import * as fg from 'fast-glob';
-import * as util from 'util';
 
 import { workspaceFastGlobDefaultOptions } from '@prairielearn/workspace-utils';
 import * as sqldb from '@prairielearn/postgres';
@@ -93,7 +92,7 @@ async function makeVariant(question, course, options) {
  * @param {string} authn_user_id - The current authenticated user.
  * @returns {Promise<Buffer>}
  */
-export async function getFileAsync(filename, variant, question, variant_course, authn_user_id) {
+export async function getDynamicFile(filename, variant, question, variant_course, authn_user_id) {
   const question_course = await getQuestionCourse(question, variant_course);
   const questionModule = questionServers.getModule(question.type);
   if (!questionModule.file) {
@@ -111,7 +110,6 @@ export async function getFileAsync(filename, variant, question, variant_course, 
   await writeCourseIssues(courseIssues, variant, authn_user_id, studentMessage, courseData);
   return fileData;
 }
-export const getFile = util.callbackify(getFileAsync);
 
 /**
  * Internal function, do not call directly. Get a question by either question_id or instance_question_id.

--- a/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
+++ b/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
@@ -2,9 +2,8 @@
 const asyncHandler = require('express-async-handler');
 const error = require('@prairielearn/error');
 var express = require('express');
-const { promisify } = require('util');
 
-var question = require('../../lib/question-variant');
+const { getDynamicFile } = require('../../lib/question-variant');
 const { selectCourseById } = require('../../models/course');
 const { selectQuestionById } = require('../../models/question');
 var sqldb = require('@prairielearn/postgres');
@@ -40,7 +39,7 @@ module.exports = function (options = { publicEndpoint: false }) {
       });
       const variant = result.rows[0];
 
-      const fileData = await promisify(question.getFile)(
+      const fileData = await getDynamicFile(
         filename,
         variant,
         res.locals.question,

--- a/apps/prairielearn/src/question-servers/calculation-subprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.js
@@ -95,18 +95,12 @@ async function callFunction(func, question_course, question, inputData) {
   }
 }
 
-export function generate(question, course, variant_seed, callback) {
-  callFunction('generate', course, question, { variant_seed }).then(
-    ({ data, courseIssues }) => callback(null, courseIssues, data),
-    (err) => callback(err),
-  );
+export async function generate(question, course, variant_seed) {
+  return await callFunction('generate', course, question, { variant_seed });
 }
 
-export function grade(submission, variant, question, question_course, callback) {
-  callFunction('grade', question_course, question, { submission, variant }).then(
-    ({ data, courseIssues }) => callback(null, courseIssues, data),
-    (err) => callback(err),
-  );
+export async function grade(submission, variant, question, question_course) {
+  return await callFunction('grade', question_course, question, { submission, variant });
 }
 
 export function getFile(filename, variant, question, course, callback) {
@@ -124,43 +118,43 @@ export function getFile(filename, variant, question, course, callback) {
 // The following functions don't do anything for v2 questions; they're just
 // here to satisfy the question server interface.
 
-export function render(
-  renderSelection,
-  variant,
-  question,
-  submission,
+export async function render(
+  _renderSelection,
+  _variant,
+  _question,
+  _submission,
   submissions,
-  course,
-  course_instance,
-  locals,
-  callback,
+  _course,
+  _course_instance,
+  _locals,
 ) {
-  const htmls = {
+  const data = {
     extraHeadersHtml: '',
     questionHtml: '',
     submissionHtmls: _.map(submissions, () => ''),
     answerHtml: '',
   };
-  callback(null, [], htmls);
+  return { courseIssues: [], data };
 }
 
-export function prepare(question, course, variant, callback) {
+export async function prepare(_question, _course, variant) {
   const data = {
     params: variant.params,
     true_answer: variant.true_answer,
     options: variant.options,
   };
-  callback(null, [], data);
+  return { courseIssues: [], data };
 }
 
-export function parse(submission, variant, question, course, callback) {
+export async function parse(submission, variant, _question, _course) {
   const data = {
-    params: variant.params,
-    true_answer: variant.true_answer,
-    submitted_answer: submission.submitted_answer,
-    raw_submitted_answer: submission.raw_submitted_answer,
+    params: variant.params ?? {},
+    true_answer: variant.true_answer ?? {},
+    submitted_answer: submission.submitted_answer ?? {},
+    raw_submitted_answer: submission.raw_submitted_answer ?? {},
+    feedback: {},
     format_errors: {},
     gradable: true,
   };
-  callback(null, [], data);
+  return { courseIssues: [], data };
 }

--- a/apps/prairielearn/src/question-servers/calculation-subprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.js
@@ -103,18 +103,6 @@ export async function grade(submission, variant, question, question_course) {
   return await callFunction('grade', question_course, question, { submission, variant });
 }
 
-export function getFile(filename, variant, question, course, callback) {
-  callFunction('getFile', course, question, { filename, variant }).then(
-    ({ data, courseIssues }) => {
-      // We need to "unwrap" buffers if needed
-      const isBuffer = data.type === 'buffer';
-      const unwrappedData = isBuffer ? Buffer.from(data.data, 'base64') : data.data;
-      callback(null, courseIssues, unwrappedData);
-    },
-    (err) => callback(err),
-  );
-}
-
 // The following functions don't do anything for v2 questions; they're just
 // here to satisfy the question server interface.
 

--- a/apps/prairielearn/src/question-servers/calculation-worker.js
+++ b/apps/prairielearn/src/question-servers/calculation-worker.js
@@ -70,24 +70,6 @@ function generate(server, coursePath, question, variant_seed) {
   };
 }
 
-function getFile(server, coursePath, filename, variant, question) {
-  const vid = variant.variant_seed;
-  const params = variant.params;
-  const trueAnswer = variant.true_answer;
-  const options = variant.options;
-  const questionDir = path.join(coursePath, 'questions', question.directory);
-  const fileData = server.getFile(filename, vid, params, trueAnswer, options, questionDir);
-
-  // If `getFile` returns a Buffer, we need to handle that specially, since
-  // Buffers can't be losslessly round-tripped through `JSON.stringify` and
-  // `JSON.parse`.
-  const isBuffer = Buffer.isBuffer(fileData);
-  return {
-    type: isBuffer ? 'buffer' : 'unknown',
-    data: isBuffer ? fileData.toString('base64') : fileData,
-  };
-}
-
 function grade(server, coursePath, submission, variant, question) {
   const vid = variant.variant_seed;
   const params = variant.params;
@@ -189,8 +171,6 @@ if (require.main === module) {
     let data;
     if (func === 'generate') {
       data = generate(server, coursePath, question, variant_seed);
-    } else if (func === 'getFile') {
-      data = getFile(server, coursePath, filename, variant, question);
     } else if (func === 'grade') {
       data = grade(server, coursePath, submission, variant, question);
     } else {

--- a/apps/prairielearn/src/question-servers/calculation-worker.js
+++ b/apps/prairielearn/src/question-servers/calculation-worker.js
@@ -161,7 +161,6 @@ if (require.main === module) {
       // Depending on which function is being invoked, these may or may not
       // be present.
       variant_seed,
-      filename,
       variant,
       submission,
     } = input;

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1284,7 +1284,6 @@ export async function render(
     locals.question_renderer = context.renderer;
 
     return withCodeCaller(context.course_dir_host, async (codeCaller) => {
-      // FIXME: support 'header'
       if (renderSelection.question) {
         const {
           courseIssues: newCourseIssues,

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1723,7 +1723,7 @@ export async function parse(submission, variant, question, course) {
   });
 }
 
-export async function gradeAsync(submission, variant, question, question_course) {
+export async function grade(submission, variant, question, question_course) {
   return instrumented('freeform.grade', async () => {
     debug('grade()');
     if (variant.broken) throw new Error('attemped to grade broken variant');

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1783,7 +1783,7 @@ export async function test(variant, question, course, test_type) {
       partial_scores: {},
       score: 0,
       feedback: {},
-      variant_seed: parseInt(variant.variant_seed ?? '0', 36),
+      variant_seed: parseInt(variant.variant_seed, 36),
       options: _.get(variant, 'options', {}),
       raw_submitted_answers: {},
       gradable: true,

--- a/apps/prairielearn/src/question-servers/index.ts
+++ b/apps/prairielearn/src/question-servers/index.ts
@@ -3,14 +3,56 @@ import { Question, Course, Variant, Submission, CourseInstance } from '../lib/db
 export type QuestionType = Question['type'];
 export type EffectiveQuestionType = 'Calculation' | 'Freeform';
 
-type QuestionServerCallback = (err: Error | null, courseIssues: Error[], data: any) => void;
+type QuestionServerCallback<T> = (err: Error | null, courseIssues: Error[], data: T) => void;
+
+export interface GenerateResultData {
+  params: Record<string, any>;
+  true_answer: Record<string, any>;
+  options?: Record<string, any> | null;
+}
+export type PrepareResultData = GenerateResultData;
+export interface RenderResultData {
+  extraHeadersHtml: string;
+  questionHtml: string;
+  submissionHtmls: string[];
+  answerHtml: string;
+}
+export interface ParseResultData {
+  params: Record<string, any>;
+  true_answer: Record<string, any>;
+  submitted_answer: Record<string, any>;
+  feedback: Record<string, any>;
+  raw_submitted_answer: Record<string, any>;
+  format_errors: Record<string, any>;
+  gradable: boolean;
+}
+export interface GradeResultData {
+  params: Record<string, any>;
+  true_answer: Record<string, any>;
+  submitted_answer: Record<string, any>;
+  format_errors: Record<string, any>;
+  raw_submitted_answer: Record<string, any>;
+  partial_scores: Record<string, any>;
+  score: number;
+  feedback: Record<string, any>;
+  gradable: boolean;
+}
+export interface TestResultData {
+  params: Record<string, any>;
+  true_answer: Record<string, any>;
+  format_errors: Record<string, any>;
+  raw_submitted_answer: Record<string, any>;
+  partial_scores: Record<string, any>;
+  score: number;
+  gradable: boolean;
+}
 
 export interface QuestionServer {
   generate: (
     question: Question,
     course: Course,
     variant_seed: string,
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<GenerateResultData>,
   ) => void;
   prepare: (
     question: Question,
@@ -22,7 +64,7 @@ export interface QuestionServer {
       options: Record<string, any>;
       broken: boolean;
     },
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<PrepareResultData>,
   ) => void;
   render: (
     renderSelection: { question: boolean; answer: boolean; submissions: boolean },
@@ -33,35 +75,35 @@ export interface QuestionServer {
     course: Course,
     course_instance: CourseInstance,
     locals: Record<string, any>,
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<RenderResultData>,
   ) => void;
   parse: (
     submission: Submission,
     variant: Variant,
     question: Question,
     course: Course,
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<ParseResultData>,
   ) => void;
   grade: (
     submission: Submission,
     variant: Variant,
     question: Question,
     course: Course,
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<GradeResultData>,
   ) => void;
   file?: (
     filename: string,
     variant: Variant,
     question: Question,
     course: Course,
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<Buffer>,
   ) => void;
   test?: (
     variant: Variant,
     question: Question,
     course: Course,
     test_type: 'correct' | 'incorrect' | 'invalid',
-    callback: QuestionServerCallback,
+    callback: QuestionServerCallback<TestResultData>,
   ) => void;
 }
 

--- a/apps/prairielearn/src/question-servers/index.ts
+++ b/apps/prairielearn/src/question-servers/index.ts
@@ -10,13 +10,16 @@ export interface GenerateResultData {
   true_answer: Record<string, any>;
   options?: Record<string, any> | null;
 }
+
 export type PrepareResultData = GenerateResultData;
+
 export interface RenderResultData {
   extraHeadersHtml: string;
   questionHtml: string;
   submissionHtmls: string[];
   answerHtml: string;
 }
+
 export interface ParseResultData {
   params: Record<string, any>;
   true_answer: Record<string, any>;
@@ -26,6 +29,7 @@ export interface ParseResultData {
   format_errors: Record<string, any>;
   gradable: boolean;
 }
+
 export interface GradeResultData {
   params: Record<string, any>;
   true_answer: Record<string, any>;
@@ -37,6 +41,7 @@ export interface GradeResultData {
   feedback: Record<string, any>;
   gradable: boolean;
 }
+
 export interface TestResultData {
   params: Record<string, any>;
   true_answer: Record<string, any>;

--- a/apps/prairielearn/src/question-servers/index.ts
+++ b/apps/prairielearn/src/question-servers/index.ts
@@ -3,7 +3,7 @@ import { Question, Course, Variant, Submission, CourseInstance } from '../lib/db
 export type QuestionType = Question['type'];
 export type EffectiveQuestionType = 'Calculation' | 'Freeform';
 
-type QuestionServerCallback<T> = (err: Error | null, courseIssues: Error[], data: T) => void;
+type QuestionServerReturnValue<T> = Promise<{ courseIssues: Error[]; data: T }>;
 
 export interface GenerateResultData {
   params: Record<string, any>;
@@ -57,8 +57,7 @@ export interface QuestionServer {
     question: Question,
     course: Course,
     variant_seed: string,
-    callback: QuestionServerCallback<GenerateResultData>,
-  ) => void;
+  ) => QuestionServerReturnValue<GenerateResultData>;
   prepare: (
     question: Question,
     course: Course,
@@ -69,8 +68,7 @@ export interface QuestionServer {
       options: Record<string, any>;
       broken: boolean;
     },
-    callback: QuestionServerCallback<PrepareResultData>,
-  ) => void;
+  ) => QuestionServerReturnValue<PrepareResultData>;
   render: (
     renderSelection: { question: boolean; answer: boolean; submissions: boolean },
     variant: Variant,
@@ -80,36 +78,31 @@ export interface QuestionServer {
     course: Course,
     course_instance: CourseInstance,
     locals: Record<string, any>,
-    callback: QuestionServerCallback<RenderResultData>,
-  ) => void;
+  ) => QuestionServerReturnValue<RenderResultData>;
   parse: (
     submission: Submission,
     variant: Variant,
     question: Question,
     course: Course,
-    callback: QuestionServerCallback<ParseResultData>,
-  ) => void;
+  ) => QuestionServerReturnValue<ParseResultData>;
   grade: (
     submission: Submission,
     variant: Variant,
     question: Question,
     course: Course,
-    callback: QuestionServerCallback<GradeResultData>,
-  ) => void;
+  ) => QuestionServerReturnValue<GradeResultData>;
   file?: (
     filename: string,
     variant: Variant,
     question: Question,
     course: Course,
-    callback: QuestionServerCallback<Buffer>,
-  ) => void;
+  ) => QuestionServerReturnValue<Buffer>;
   test?: (
     variant: Variant,
     question: Question,
     course: Course,
     test_type: 'correct' | 'incorrect' | 'invalid',
-    callback: QuestionServerCallback<TestResultData>,
-  ) => void;
+  ) => QuestionServerReturnValue<TestResultData>;
 }
 
 const questionModules: Record<EffectiveQuestionType, QuestionServer> = {

--- a/apps/prairielearn/src/question-servers/index.ts
+++ b/apps/prairielearn/src/question-servers/index.ts
@@ -1,20 +1,76 @@
-import _ = require('lodash');
+import { Question, Course, Variant, Submission, CourseInstance } from '../lib/db-types';
 
-/**
- * Question servers module.
- * @module question-servers
- */
+export type QuestionType = Question['type'];
+export type EffectiveQuestionType = 'Calculation' | 'Freeform';
 
-const questionModules = {
+type QuestionServerCallback = (err: Error | null, courseIssues: Error[], data: any) => void;
+
+export interface QuestionServer {
+  generate: (
+    question: Question,
+    course: Course,
+    variant_seed: string,
+    callback: QuestionServerCallback,
+  ) => void;
+  prepare: (
+    question: Question,
+    course: Course,
+    variant: {
+      variant_seed: string;
+      params: Record<string, any>;
+      true_answer: Record<string, any>;
+      options: Record<string, any>;
+      broken: boolean;
+    },
+    callback: QuestionServerCallback,
+  ) => void;
+  render: (
+    renderSelection: { question: boolean; answer: boolean; submissions: boolean },
+    variant: Variant,
+    question: Question,
+    submission: Submission,
+    submissions: Submission[],
+    course: Course,
+    course_instance: CourseInstance,
+    locals: Record<string, any>,
+    callback: QuestionServerCallback,
+  ) => void;
+  parse: (
+    submission: Submission,
+    variant: Variant,
+    question: Question,
+    course: Course,
+    callback: QuestionServerCallback,
+  ) => void;
+  grade: (
+    submission: Submission,
+    variant: Variant,
+    question: Question,
+    course: Course,
+    callback: QuestionServerCallback,
+  ) => void;
+  file?: (
+    filename: string,
+    variant: Variant,
+    question: Question,
+    course: Course,
+    callback: QuestionServerCallback,
+  ) => void;
+  test?: (
+    variant: Variant,
+    question: Question,
+    course: Course,
+    test_type: 'correct' | 'incorrect' | 'invalid',
+    callback: QuestionServerCallback,
+  ) => void;
+}
+
+const questionModules: Record<EffectiveQuestionType, QuestionServer> = {
   Calculation: require('./calculation-subprocess'),
-  File: require('./calculation-subprocess'),
-  Checkbox: require('./calculation-subprocess'),
-  MultipleChoice: require('./calculation-subprocess'),
-  MultipleTrueFalse: require('./calculation-subprocess'),
   Freeform: require('./freeform'),
 };
 
-const effectiveQuestionTypes = {
+const effectiveQuestionTypes: Record<QuestionType, EffectiveQuestionType> = {
   Calculation: 'Calculation',
   File: 'Calculation',
   Checkbox: 'Calculation',
@@ -23,18 +79,14 @@ const effectiveQuestionTypes = {
   Freeform: 'Freeform',
 };
 
-export function getEffectiveQuestionType(type, callback) {
-  if (_.has(effectiveQuestionTypes, type)) {
-    callback(null, effectiveQuestionTypes[type]);
+export function getEffectiveQuestionType(type: QuestionType): EffectiveQuestionType {
+  if (type in effectiveQuestionTypes) {
+    return effectiveQuestionTypes[type];
   } else {
-    callback(new Error('Unknown question type: ' + type));
+    throw new Error('Unknown question type: ' + type);
   }
 }
 
-export function getModule(type, callback) {
-  if (_.has(questionModules, type)) {
-    callback(null, questionModules[type]);
-  } else {
-    callback(new Error('Unknown question type: ' + type));
-  }
+export function getModule(type: QuestionType): QuestionServer {
+  return questionModules[getEffectiveQuestionType(type)];
 }

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -23,33 +23,6 @@ import { EXAMPLE_COURSE_PATH } from '../../lib/paths';
 const SITE_URL = 'http://localhost:' + config.serverPort;
 
 /**
- * Several pages have very large DOMs or attributes that AXE runs very slow on.
- * None of these elements have accessibility components, so we'll special-case these
- * and remove them before running AXE.
- *
- * @param {import('jsdom').JSDOM} page
- */
-function cleanLargePages(url, page) {
-  if (url === '/pl/course_instance/1/instructor/course_admin/questions') {
-    // This attribute is very large, which somehow corresponds to a long running
-    // time for AXE. It's irrelevant for our checks, so we just remove it.
-    page.window.document.querySelector('#questionsTable')?.removeAttribute('data-data');
-  }
-
-  if (
-    url === '/pl/course_instance/1/instructor/instance_admin/settings' ||
-    /\/pl\/course_instance\/1\/instructor\/assessment\/\d+\/settings/.test(url)
-  ) {
-    // The SVG for the QR code contains many elements, which in turn makes AXE
-    // run very slow. We don't need to check the accessibility of the QR code
-    // itself, so we'll remove the children.
-    page.window.document
-      .querySelectorAll('#js-student-link-qrcode svg > *')
-      .forEach((e) => e.remove());
-  }
-}
-
-/**
  * Loads the given URL into a JSDOM object.
  *
  * @param {string} url
@@ -72,8 +45,9 @@ async function loadPageJsdom(url) {
  */
 async function checkPage(url) {
   const page = await loadPageJsdom(SITE_URL + url);
-  cleanLargePages(url, page);
-  const results = await axe.run(page.window.document.documentElement);
+  const results = await axe.run(page.window.document.documentElement, {
+    resultTypes: ['violations', 'incomplete'],
+  });
   A11yError.checkAndThrow(results.violations);
 }
 

--- a/apps/prairielearn/src/tests/accessibility/index.test.js
+++ b/apps/prairielearn/src/tests/accessibility/index.test.js
@@ -331,7 +331,7 @@ describe('accessibility', () => {
   after('shut down testing server', helperServer.after);
 
   test('All pages pass accessibility checks', async function () {
-    this.timeout(120_000);
+    this.timeout(240_000);
 
     const missingParamsEndpoints = [];
     const failingEndpoints = [];


### PR DESCRIPTION
Changes the question server functions to async functions. The implementation was already using async, only the calls were still through callbacks, so the server implementation itself was not affected.

Also rewrites some of the functions involved in question generation/grading/testing/rendering to async, where the change was relatively simple. Within this change, since all references to `writeCourseIssues` were converted to async, got rid of the callback version of this function.

~~Note: this PR includes/overrides the changes in #9083 and #9079, so it's up to you if you want to review those two first and have this one merged on top of them, or to skip those altogether and review only this one.~~

Diff best viewed with spaces ignored. ~~particularly if #9083 is not merged first~~