### PR TITLE
Fix rendering of submission panel for external grading

### DIFF
--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -596,7 +596,7 @@ export function renderPanelsForSubmission(
           submission.submission_number = submission_index;
           const submissions = [submission];
 
-          const htmls = await util.promisify(render)(
+          const htmls = await render(
             renderSelection,
             variant,
             question,


### PR DESCRIPTION
Fixes error introduced by #9085. A helper function was converted to async, but one of its calls was still promisifying the already promisified function.