### PR TITLE
Set default role permissions to all permissions

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/assessments.js
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.js
@@ -122,8 +122,9 @@ function getParamsForAssessment(assessmentInfoFile, questionIds) {
 
   let alternativeGroupNumber = 0;
   let assessmentQuestionNumber = 0;
-  let assessmentCanView = assessment?.canView ?? [];
-  let assessmentCanSubmit = assessment?.canSubmit ?? [];
+  let allRoleNames = (assessment.groupRoles ?? []).map((role) => role.name);
+  let assessmentCanView = assessment?.canView ?? allRoleNames;
+  let assessmentCanSubmit = assessment?.canSubmit ?? allRoleNames;
   assessmentParams.alternativeGroups = zones.map((zone) => {
     let zoneGradeRateMinutes = _.has(zone, 'gradeRateMinutes')
       ? zone.gradeRateMinutes


### PR DESCRIPTION
Currently, if no questions set `canView` and `canSubmit` when roles are in play, all roles are set to not allow viewing and submitting. This PR changes that default to allowing all roles to view and submit unless explicitly set otherwise.