### PR TITLE
Remove redundant index for role permissions table

### DIFF
--- a/apps/prairielearn/src/migrations/20231223101924_assessment_question_role_permissions__drop_index.sql
+++ b/apps/prairielearn/src/migrations/20231223101924_assessment_question_role_permissions__drop_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS assessment_question_role_permissions_assessment_question_id_key;

--- a/database/tables/assessment_question_role_permissions.pg
+++ b/database/tables/assessment_question_role_permissions.pg
@@ -6,7 +6,6 @@ columns
 
 indexes
     assessment_question_role_permissions_pkey: PRIMARY KEY (assessment_question_id, group_role_id) USING btree (assessment_question_id, group_role_id)
-    assessment_question_role_permissions_assessment_question_id_key: UNIQUE USING btree (assessment_question_id, group_role_id)
     assessment_question_role_permissions_group_role_id_key: USING btree (group_role_id)
 
 foreign-key constraints


### PR DESCRIPTION
This index matches exactly the primary key, so it's redundant.