### PR TITLE
Drop group_id and user_id from group_user_roles table

### DIFF
--- a/apps/prairielearn/src/lib/groups.sql
+++ b/apps/prairielearn/src/lib/groups.sql
@@ -109,7 +109,7 @@ WITH
   count_group_user_per_role AS (
     SELECT
       gur.group_role_id,
-      COUNT(gur.user_id) AS count
+      COUNT(gur.id) AS count
     FROM
       group_user_roles AS gur
       JOIN group_users AS gu ON gur.group_user_id = gu.id

--- a/apps/prairielearn/src/migrations/20231227124631__group_users__id__add.sql
+++ b/apps/prairielearn/src/migrations/20231227124631__group_users__id__add.sql
@@ -1,0 +1,27 @@
+ALTER TABLE group_users
+ADD UNIQUE (group_id, user_id),
+DROP CONSTRAINT group_users_pkey CASCADE,
+ADD COLUMN id BIGSERIAL PRIMARY KEY;
+
+DROP INDEX group_users_group_id_key;
+
+ALTER TABLE group_user_roles
+ADD COLUMN group_user_id BIGINT REFERENCES group_users (id) ON DELETE CASCADE;
+
+UPDATE group_user_roles gur
+SET
+  group_user_id = gu.id
+FROM
+  group_users gu
+WHERE
+  gu.group_id = gur.group_id
+  AND gu.user_id = gur.user_id;
+
+DELETE FROM group_user_roles
+WHERE
+  group_user_id IS NULL;
+
+ALTER TABLE group_user_roles
+ALTER COLUMN group_user_id
+SET NOT NULL,
+ADD UNIQUE (group_user_id, group_role_id);

--- a/apps/prairielearn/src/migrations/20231227134859__group_user_roles__group_id_user_id__drop.sql
+++ b/apps/prairielearn/src/migrations/20231227134859__group_user_roles__group_id_user_id__drop.sql
@@ -1,0 +1,3 @@
+ALTER TABLE group_user_roles
+DROP COLUMN group_id,
+DROP COLUMN user_id;

--- a/apps/prairielearn/src/sprocs/group_users_insert.sql
+++ b/apps/prairielearn/src/sprocs/group_users_insert.sql
@@ -14,6 +14,7 @@ DECLARE
     has_roles boolean;
     default_group_role_id bigint;
     min_roles_to_fill bigint;
+    new_group_user_id bigint;
 BEGIN
     -- find group id
     SELECT 
@@ -112,14 +113,15 @@ BEGIN
 
     -- join the group
     INSERT INTO group_users (user_id, group_id)
-    VALUES (arg_user_id, cur_group_id);
+    VALUES (arg_user_id, cur_group_id)
+    RETURNING id INTO new_group_user_id;
 
     -- assign the role, if appropriate
     IF has_roles THEN
         INSERT INTO group_user_roles
-            (user_id, group_id, group_role_id)
+            (user_group_id, group_role_id)
         VALUES
-            (arg_user_id, cur_group_id, default_group_role_id);
+            (new_group_user_id, default_group_role_id);
     END IF;
 
     -- log the join

--- a/apps/prairielearn/src/tests/groupRole.test.sql
+++ b/apps/prairielearn/src/tests/groupRole.test.sql
@@ -38,12 +38,13 @@ WHERE
 
 -- BLOCK select_group_user_roles
 SELECT
-  gur.user_id,
+  gu.user_id,
   gur.group_role_id
 FROM
-  group_user_roles AS gur
-  JOIN groups AS gr ON gur.group_id = gr.id
-  JOIN group_configs AS gc ON gc.id = gr.group_config_id
+  group_configs AS gc
+  JOIN groups AS g ON g.group_config_id = gc.id
+  JOIN group_users AS gu ON gu.group_id = g.id
+  JOIN group_user_roles AS gur ON gur.group_user_id = gu.id
 WHERE
   gc.assessment_id = $assessment_id;
 

--- a/database/tables/group_user_roles.pg
+++ b/database/tables/group_user_roles.pg
@@ -1,14 +1,17 @@
 columns
     group_id: bigint not null
     group_role_id: bigint not null
+    group_user_id: bigint not null
     id: bigint not null default nextval('group_user_roles_id_seq'::regclass)
     user_id: bigint not null
 
 indexes
     group_user_roles_pkey: PRIMARY KEY (id) USING btree (id)
     group_user_roles_group_id_user_id_group_role_id_key: UNIQUE USING btree (group_id, user_id, group_role_id)
+    group_user_roles_group_user_id_group_role_id_key: UNIQUE (group_user_id, group_role_id) USING btree (group_user_id, group_role_id)
 
 foreign-key constraints
     group_user_roles_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id)
     group_user_roles_group_role_id_fkey: FOREIGN KEY (group_role_id) REFERENCES group_roles(id)
+    group_user_roles_group_user_id_fkey: FOREIGN KEY (group_user_id) REFERENCES group_users(id) ON DELETE CASCADE
     group_user_roles_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id)

--- a/database/tables/group_user_roles.pg
+++ b/database/tables/group_user_roles.pg
@@ -1,17 +1,12 @@
 columns
-    group_id: bigint not null
     group_role_id: bigint not null
     group_user_id: bigint not null
     id: bigint not null default nextval('group_user_roles_id_seq'::regclass)
-    user_id: bigint not null
 
 indexes
     group_user_roles_pkey: PRIMARY KEY (id) USING btree (id)
-    group_user_roles_group_id_user_id_group_role_id_key: UNIQUE USING btree (group_id, user_id, group_role_id)
     group_user_roles_group_user_id_group_role_id_key: UNIQUE (group_user_id, group_role_id) USING btree (group_user_id, group_role_id)
 
 foreign-key constraints
-    group_user_roles_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id)
     group_user_roles_group_role_id_fkey: FOREIGN KEY (group_role_id) REFERENCES group_roles(id)
     group_user_roles_group_user_id_fkey: FOREIGN KEY (group_user_id) REFERENCES group_users(id) ON DELETE CASCADE
-    group_user_roles_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id)

--- a/database/tables/group_users.pg
+++ b/database/tables/group_users.pg
@@ -1,12 +1,16 @@
 columns
     group_id: bigint not null
+    id: bigint not null default nextval('group_users_id_seq'::regclass)
     user_id: bigint not null
 
 indexes
-    group_users_pkey: PRIMARY KEY (group_id, user_id) USING btree (group_id, user_id)
-    group_users_group_id_key: USING btree (group_id)
+    group_users_pkey: PRIMARY KEY (id) USING btree (id)
+    group_users_group_id_user_id_key: UNIQUE (group_id, user_id) USING btree (group_id, user_id)
     group_users_user_id_key: USING btree (user_id)
 
 foreign-key constraints
     group_users_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     group_users_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
+
+referenced by
+    group_user_roles: FOREIGN KEY (group_user_id) REFERENCES group_users(id) ON DELETE CASCADE

--- a/database/tables/groups.pg
+++ b/database/tables/groups.pg
@@ -19,7 +19,6 @@ foreign-key constraints
 
 referenced by
     assessment_instances: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_user_roles: FOREIGN KEY (group_id) REFERENCES groups(id)
     group_users: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     last_accesses: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     variants: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/users.pg
+++ b/database/tables/users.pg
@@ -43,7 +43,6 @@ referenced by
     grading_jobs: FOREIGN KEY (auth_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     grading_jobs: FOREIGN KEY (graded_by) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     grading_jobs: FOREIGN KEY (grading_request_canceled_by) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_user_roles: FOREIGN KEY (user_id) REFERENCES users(user_id)
     group_users: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     instance_questions: FOREIGN KEY (assigned_grader) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE SET NULL
     instance_questions: FOREIGN KEY (authn_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE


### PR DESCRIPTION
Follow-up to #9112, should only be merged after #9112 is deployed. Drops the group_id and user_id columns, which are replaced with group_user_id as a foreign key to group_users.