### PR TITLE
Fix warning about external grading timeout limits

### DIFF
--- a/apps/prairielearn/src/sync/course-db.js
+++ b/apps/prairielearn/src/sync/course-db.js
@@ -1030,10 +1030,10 @@ async function validateQuestion(question) {
 
   if (question.externalGradingOptions?.timeout) {
     if (question.externalGradingOptions.timeout > config.externalGradingMaximumTimeout) {
-      question.externalGradingOptions.timeout = config.externalGradingMaximumTimeout;
       warnings.push(
         `External grading timeout value of ${question.externalGradingOptions.timeout} seconds exceeds the maximum value and has been limited to ${config.externalGradingMaximumTimeout} seconds.`,
       );
+      question.externalGradingOptions.timeout = config.externalGradingMaximumTimeout;
     }
   }
 


### PR DESCRIPTION
We need to read the old value to construct the error message before we update it, otherwise we always print the following, which doesn't make sense:

> External grading timeout value of 600 seconds exceeds the maximum value and has been limited to 600 seconds.