### PR TITLE
Stop reads/writes for submissions.regradable

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -585,7 +585,6 @@ export const SubmissionSchema = z.object({
   params: z.record(z.string(), z.any()).nullable(),
   partial_scores: z.record(z.string(), z.any()).nullable(),
   raw_submitted_answer: z.record(z.string(), z.any()).nullable(),
-  regradable: z.boolean().nullable(),
   score: z.number().nullable(),
   submitted_answer: z.record(z.string(), z.any()).nullable(),
   true_answer: z.record(z.string(), z.any()).nullable(),

--- a/apps/prairielearn/src/lib/grading.ts
+++ b/apps/prairielearn/src/lib/grading.ts
@@ -122,7 +122,6 @@ export async function saveSubmissionAsync(
       hasFatalIssue,
       data.true_answer,
       data.feedback,
-      false, // regradable
       submission.credit,
       submission.mode,
       submission.variant_id,

--- a/apps/prairielearn/src/lib/question-render.sql
+++ b/apps/prairielearn/src/lib/question-render.sql
@@ -60,7 +60,6 @@ SELECT
   s.id,
   s.mode,
   s.override_score,
-  s.regradable,
   s.score,
   s.v2_score,
   s.variant_id,

--- a/apps/prairielearn/src/lib/question-testing.js
+++ b/apps/prairielearn/src/lib/question-testing.js
@@ -75,7 +75,6 @@ function createTestSubmission(
           // sproc.
           variant.true_answer,
           null, // feedback
-          true, // regradable
           null, // credit
           null, // mode
           variant.id,

--- a/apps/prairielearn/src/sprocs/submissions_insert.sql
+++ b/apps/prairielearn/src/sprocs/submissions_insert.sql
@@ -7,7 +7,6 @@ CREATE FUNCTION
         IN broken boolean,
         IN new_true_answer jsonb,
         IN feedback jsonb,
-        IN regradable boolean,
         IN credit integer,
         IN mode enum_mode,
         IN variant_id bigint,
@@ -99,9 +98,9 @@ BEGIN
 
     INSERT INTO submissions
             (variant_id, auth_user_id, raw_submitted_answer, submitted_answer, format_errors,
-            credit, mode, duration, params, true_answer, feedback, gradable, broken, regradable, client_fingerprint_id)
+            credit, mode, duration, params, true_answer, feedback, gradable, broken, client_fingerprint_id)
     VALUES  (variant_id, authn_user_id, raw_submitted_answer, submitted_answer, format_errors,
-            credit, mode, delta, variant.params, variant.true_answer, feedback, gradable, broken, regradable, client_fingerprint_id)
+            credit, mode, delta, variant.params, variant.true_answer, feedback, gradable, broken, client_fingerprint_id)
     RETURNING id
     INTO submission_id;
 

--- a/apps/prairielearn/src/sprocs/variants_select_submission_for_grading.sql
+++ b/apps/prairielearn/src/sprocs/variants_select_submission_for_grading.sql
@@ -49,11 +49,6 @@ BEGIN
         RAISE EXCEPTION 'check_submission_id mismatch: % vs %', check_submission_id, submission.id USING ERRCODE = 'ST400';
     END IF;
 
-    -- mark submission as regradable
-    UPDATE submissions AS s
-    SET regradable = TRUE
-    WHERE s.id = submission.id;
-
     -- does the most recent submission actually need grading?
     IF submission.score IS NOT NULL THEN RETURN; END IF; -- already graded
     IF submission.grading_requested_at IS NOT NULL THEN RETURN; END IF; -- grading is in progress


### PR DESCRIPTION
Part of #9205. Once we're no longer reading from or writing to this column in production, we can drop the column entirely.

AFAICT, we never actually do anything with the read value of this column, so I believe it's safe to stop writing to it before all servers would have necessarily stopped reading from it. Let me know if you think that's not the case.