### PR TITLE
Show disabled button for inactive multi-instance assessment

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ejs
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ejs
@@ -77,18 +77,22 @@
               </td>
               <td class="text-center align-middle">
                 <% if (row.multiple_instance_header) { %>
-                <a href="<%= urlPrefix %><%= row.link %>" class="btn btn-primary btn-sm" role="button">New instance</a>
-                <% } else { // multiple_instance_header %>
-                <% if (row.assessment_instance_id) { %>
-                <% if(row.show_closed_assessment_score) { %>
-                <%- include('../partials/scorebar', {score: row.assessment_instance_score_perc}) %>
+                  <% if (row.active) { %>
+                    <a href="<%= urlPrefix %><%= row.link %>" class="btn btn-primary btn-sm" role="button">New instance</a>
+                  <% } else { %>
+                    <button type="button" disabled class="btn btn-primary btn-sm">New instance</button>
+                  <% } %>
                 <% } else { %>
-                Score not shown
+                  <% if (row.assessment_instance_id) { %>
+                    <% if (row.show_closed_assessment_score) { %>
+                    <%- include('../partials/scorebar', {score: row.assessment_instance_score_perc}) %>
+                    <% } else { %>
+                    Score not shown
+                    <% } %>
+                  <% } else { %>
+                    Not started
+                  <% } %>
                 <% } %>
-                <% } else { %>
-                Not started
-                <% } %>
-                <% } // multiple_instance_header %>
               </td>
             </tr>
             <% }); %>


### PR DESCRIPTION
Closes #9214. The other approach is to hide the button entirely, but as discussed on that other issue, I think that's best only after we've implemented something like #2185.