### PR TITLE
Fix `group_info.sql` to not return NULL users

### DIFF
--- a/apps/prairielearn/src/sprocs/group_info.sql
+++ b/apps/prairielearn/src/sprocs/group_info.sql
@@ -19,6 +19,7 @@ BEGIN
             array_agg(users_get_displayed_role(u.user_id, a.course_instance_id)) as user_roles_list
         FROM
             group_configs AS gc
+            JOIN assessments AS a ON (a.id = gc.assessment_id)
             JOIN groups AS g ON (g.group_config_id = gc.id)
             JOIN group_users AS gu ON (gu.group_id = g.id)
             JOIN users AS u ON (u.user_id = gu.user_id)
@@ -42,8 +43,6 @@ BEGIN
     WHERE
         gc.assessment_id = group_info.assessment_id
         AND gc.deleted_at IS NULL
-        AND g.deleted_at IS NULL
-    GROUP BY
-        g.id;
+        AND g.deleted_at IS NULL;
 END
 $$ LANGUAGE plpgsql STABLE;

--- a/apps/prairielearn/src/sprocs/group_info.sql
+++ b/apps/prairielearn/src/sprocs/group_info.sql
@@ -11,22 +11,38 @@ CREATE FUNCTION
 AS $$
 BEGIN
     RETURN QUERY
+    WITH group_user_lists AS (
+        SELECT
+            g.id as id,
+            array_agg(u.uid) AS uid_list,
+            array_agg(u.name) AS user_name_list,
+            array_agg(users_get_displayed_role(u.user_id, a.course_instance_id)) as user_roles_list
+        FROM
+            group_configs AS gc
+            JOIN groups AS g ON (g.group_config_id = gc.id)
+            JOIN group_users AS gu ON (gu.group_id = g.id)
+            JOIN users AS u ON (u.user_id = gu.user_id)
+        WHERE
+            gc.assessment_id = group_info.assessment_id
+            AND gc.deleted_at IS NULL
+            AND g.deleted_at IS NULL
+        GROUP BY
+            g.id
+    )
     SELECT
         g.id AS id,
         g.name AS name,
-        array_agg(u.uid) AS uid_list,
-        array_agg(u.name) AS user_name_list,
-        array_agg(users_get_displayed_role(u.user_id, a.course_instance_id)) as user_roles_list
+        coalesce(gul.uid_list, '{}'::text[]) AS uid_list,
+        coalesce(gul.user_name_list, '{}'::text[]) AS user_name_list,
+        coalesce(gul.user_roles_list, '{}'::text[]) AS user_roles_list
     FROM
         group_configs AS gc
         JOIN groups AS g ON (g.group_config_id = gc.id)
-        JOIN assessments as a ON (a.id = gc.assessment_id)
-        LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
-        LEFT JOIN users AS u ON (u.user_id = gu.user_id)
+        LEFT JOIN group_user_lists AS gul ON (gul.id = g.id)
     WHERE
-        gc.deleted_at IS NULL
+        gc.assessment_id = group_info.assessment_id
+        AND gc.deleted_at IS NULL
         AND g.deleted_at IS NULL
-        AND gc.assessment_id = group_info.assessment_id
     GROUP BY
         g.id;
 END


### PR DESCRIPTION
**WARNING: Currently untested!**

Fixes #9228

The problem was that the `group_info` query used a simple LEFT JOIN and so it returns `uid_list = [NULL]` when there aren't any group users. This PR changes to a two-stage query so that it will return `uid_list = []` in this case.

This function is only used in two files:
1. `instructorAssessmentInstances.sql`, which triggered the bug in #9228: https://github.com/PrairieLearn/PrairieLearn/blob/4158b0dc07463ad82c560b30529ec94ac705c607/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql#L93
2. the API in two places: https://github.com/PrairieLearn/PrairieLearn/blob/4158b0dc07463ad82c560b30529ec94ac705c607/apps/prairielearn/src/api/v1/endpoints/queries.sql#L96 and https://github.com/PrairieLearn/PrairieLearn/blob/4158b0dc07463ad82c560b30529ec94ac705c607/apps/prairielearn/src/api/v1/endpoints/queries.sql#L356

None of the above calls rely on the old behavior.