### PR TITLE
Fix rubric keyboard binding for rubrics with more than 10 items

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -235,7 +235,7 @@ VALUES
     $explanation,
     $grader_note,
     CASE
-      WHEN $number > 10 THEN NULL
+      WHEN $number >= 10 THEN NULL
       ELSE MOD($number + 1, 10)
     END,
     $always_show_to_students

--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -203,7 +203,7 @@ SET
   explanation = COALESCE($explanation, explanation),
   grader_note = COALESCE($grader_note, grader_note),
   key_binding = CASE
-    WHEN $number > 10 THEN NULL
+    WHEN $number >= 10 THEN NULL
     ELSE MOD($number + 1, 10)
   END,
   always_show_to_students = COALESCE($always_show_to_students, always_show_to_students),


### PR DESCRIPTION
Fixes #9231. This is a simple off-by-one error. The check uses `$number` to determine if there have been 10 entries with keyboard shortcuts, but `$number` is zero-based, so if `$number` is 10 this is the 11th rubric item.