### PR TITLE
Fix handling of user_sessions.user_id during conflicts

### DIFF
--- a/apps/prairielearn/src/lib/session-store.sql
+++ b/apps/prairielearn/src/lib/session-store.sql
@@ -22,6 +22,7 @@ VALUES
 ON CONFLICT (session_id) DO
 UPDATE
 SET
+  user_id = $user_id,
   data = $data::jsonb,
   updated_at = now(),
   expires_at = $expires_at;


### PR DESCRIPTION
While investigating another issue, I discovered that a lot of our `user_sessions` rows have a null `user_id` despite having a value in `data->>'user_id'`. The issue here should be obvious.

Once this is deployed, I'll introduce a batched migration to backfill all the empty `user_id` values.

We aren't currently relying exclusively on this value anywhere, so this wouldn't have had any observable impact to end users. However, it's important that we get this fixed in preparation for dropping the `pl_authn` cookie.