### PR TITLE
Add a Content-Security-Policy header

### DIFF
--- a/apps/prairielearn/src/middlewares/content-security-policy.ts
+++ b/apps/prairielearn/src/middlewares/content-security-policy.ts
@@ -3,7 +3,10 @@ import { Router } from 'express';
 const router = Router();
 
 router.all('/*', function (req, res, next) {
-  // Prevent PrairieLearn from being rendered in an iframe.
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+  //
+  // Currently, we only use CSP to prevent PrairieLearn from being rendered in
+  // an iframe.
   res.header('Content-Security-Policy', "frame-ancestors: 'none';");
 
   next();

--- a/apps/prairielearn/src/middlewares/content-security-policy.ts
+++ b/apps/prairielearn/src/middlewares/content-security-policy.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.all('/*', function (req, res, next) {
+  // Prevent PrairieLearn from being rendered in an iframe.
+  res.header('Content-Security-Policy', "frame-ancestors: 'none';");
+
+  next();
+});
+
+export default router;

--- a/apps/prairielearn/src/middlewares/content-security-policy.ts
+++ b/apps/prairielearn/src/middlewares/content-security-policy.ts
@@ -9,6 +9,9 @@ router.all('/*', function (req, res, next) {
   // an iframe.
   res.header('Content-Security-Policy', "frame-ancestors: 'none';");
 
+  // Added for backwards compatibility with older browsers.
+  res.header('X-Frame-Options', 'DENY');
+
   next();
 });
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -483,6 +483,7 @@ module.exports.initExpress = function () {
   });
   app.use(require('./middlewares/logResponse')); // defers to end of response
   app.use(require('./middlewares/cors'));
+  app.use(require('./middlewares/content-security-policy').default);
   app.use(require('./middlewares/date'));
   app.use(require('./middlewares/effectiveRequestChanged'));
   app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2'));


### PR DESCRIPTION
This should not be merged until we've transitioned beta users of LTI 1.3 to opening PrairieLearn in a new tab instead of an iframe in Canvas.