### PR TITLE
Simplify ensureEnrollment function

### DIFF
--- a/apps/prairielearn/src/models/enrollment.sql
+++ b/apps/prairielearn/src/models/enrollment.sql
@@ -1,26 +1,9 @@
 -- BLOCK ensure_enrollment
-WITH
-  new_enrollment AS (
-    INSERT INTO
-      enrollments (user_id, course_instance_id)
-    VALUES
-      ($user_id, $course_instance_id)
-    ON CONFLICT DO NOTHING
-    RETURNING
-      *
-  )
-SELECT
-  *
-FROM
-  new_enrollment
-UNION ALL
-SELECT
-  *
-FROM
-  enrollments
-WHERE
-  user_id = $user_id
-  AND course_instance_id = $course_instance_id;
+INSERT INTO
+  enrollments (user_id, course_instance_id)
+VALUES
+  ($user_id, $course_instance_id)
+ON CONFLICT DO NOTHING;
 
 -- BLOCK select_enrollment_for_user_in_course_instance
 SELECT

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -1,5 +1,5 @@
 import { Response } from 'express';
-import { loadSqlEquiv, queryOptionalRow, queryRow } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryAsync, queryOptionalRow } from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
 
 import { CourseInstance, Enrollment, EnrollmentSchema, Institution } from '../lib/db-types';
@@ -18,8 +18,8 @@ export async function ensureEnrollment({
 }: {
   course_instance_id: string;
   user_id: string;
-}): Promise<Enrollment> {
-  return await queryRow(sql.ensure_enrollment, { course_instance_id, user_id }, EnrollmentSchema);
+}): Promise<void> {
+  await queryAsync(sql.ensure_enrollment, { course_instance_id, user_id });
 }
 
 /**


### PR DESCRIPTION
The return value of `ensureEnrollment` was never used, so we don't need all the complexity associated with returning either the new or existing enrollment.