### PR TITLE
Fix HTML for instructor navbar

### DIFF
--- a/apps/prairielearn/src/pages/partials/navbarInstructor.ejs
+++ b/apps/prairielearn/src/pages/partials/navbarInstructor.ejs
@@ -1,8 +1,11 @@
 
     <%# Course admin %> 
     <li class="nav-item btn-group" id="navbar-course-switcher">
-        <a class="nav-link" <% if (navPage == "course_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "issues" || navSubPage == "questions" || navSubPage == "syncs"))) { %>active<% } %> <% if (! authz_data.has_course_permission_view) { %> disabled <% } %>"
-         href="<%= urlPrefix %>/course_admin" role="button">
+        <a
+            class="nav-link <% if (navPage == 'course_admin' && !(typeof navSubPage !== 'undefined' && (navSubPage == 'issues' || navSubPage == 'questions' || navSubPage == 'syncs'))) { %> active <% } %> <% if (!authz_data.has_course_permission_view) { %> disabled <% } %>"
+            href="<%= urlPrefix %>/course_admin"
+            role="button"
+        >
             <%= course.short_name %>
         </a>
         <a


### PR DESCRIPTION
I noticed while looking at a page's HTML that we had unbalanced double quotes here. Specifically, there was a double quote after `class="nav-link"`, but there shouldn't have been because the following two conditional that add `active` and `disabled` should have been included in the class list.