### PR TITLE
Add types to InstructorAssessmentInstance page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -62,7 +62,7 @@ const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
   zone_best_questions: z.number().nullable(),
   zone_has_best_questions: z.boolean(),
   zone_has_max_points: z.boolean(),
-  zone_id: IdSchema.nullable(),
+  zone_id: IdSchema,
   zone_max_points: z.number().nullable(),
   zone_title: z.string().nullable(),
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -47,7 +47,7 @@ const DateDurationResultSchema = z.object({
 });
 
 const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
-  instructor_question_number: z.string().nullable(),
+  instructor_question_number: z.string(),
   manual_rubric_id: IdSchema.nullable(),
   max_auto_points: z.number().nullable(),
   max_manual_points: z.number().nullable(),
@@ -55,9 +55,9 @@ const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
   modified_at: z.string(),
   qid: z.string().nullable(),
   question_id: IdSchema,
-  question_number: z.string().nullable(),
+  question_number: z.string(),
   question_title: z.string().nullable(),
-  row_order: z.number().nullable(),
+  row_order: z.number(),
   start_new_zone: z.boolean(),
   zone_best_questions: z.number().nullable(),
   zone_has_best_questions: z.boolean(),

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -47,9 +47,24 @@ const DateDurationResultSchema = z.object({
 });
 
 const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
+  instructor_question_number: z.string().nullable(),
+  manual_rubric_id: IdSchema.nullable(),
+  max_auto_points: z.number().nullable(),
+  max_manual_points: z.number().nullable(),
+  max_points: z.number().nullable(),
   modified_at: z.string(),
   qid: z.string().nullable(),
+  question_id: IdSchema,
   question_number: z.string().nullable(),
+  question_title: z.string().nullable(),
+  row_order: z.number().nullable(),
+  start_new_zone: z.boolean(),
+  zone_best_questions: z.number().nullable(),
+  zone_has_best_questions: z.boolean(),
+  zone_has_max_points: z.boolean(),
+  zone_id: IdSchema.nullable(), 
+  zone_max_points: z.number().nullable(),
+  zone_title: z.string().nullable(),
 });
 
 const logCsvFilename = (locals) => {
@@ -101,7 +116,7 @@ router.get(
       },
       InstanceQuestionRowSchema,
     );
-
+    
     res.locals.log = await selectAssessmentInstanceLog(res.locals.assessment_instance.id, false);
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.js
@@ -62,7 +62,7 @@ const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
   zone_best_questions: z.number().nullable(),
   zone_has_best_questions: z.boolean(),
   zone_has_max_points: z.boolean(),
-  zone_id: IdSchema.nullable(), 
+  zone_id: IdSchema.nullable(),
   zone_max_points: z.number().nullable(),
   zone_title: z.string().nullable(),
 });
@@ -116,7 +116,7 @@ router.get(
       },
       InstanceQuestionRowSchema,
     );
-    
+
     res.locals.log = await selectAssessmentInstanceLog(res.locals.assessment_instance.id, false);
 
     res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);


### PR DESCRIPTION
In PR #9072, we added zod-validation to our queries and add schemas to validate the data. However, as pointed out #9246, there were columns from the `select_instance_questions` query that were not included int he `InstanceQuestionRowSchema`. Thus, there were bugs and features missing from the page. This PR intends to add those missing types to the Zod schema and restore features to the page. Closes #9246.