### PR TITLE
Always check out configured branch when syncing course

### DIFF
--- a/apps/prairielearn/src/lib/course.ts
+++ b/apps/prairielearn/src/lib/course.ts
@@ -139,6 +139,9 @@ export async function pullAndUpdateCourse({
           job.info('Fetch from remote git repository');
           await job.exec('git', ['fetch'], gitOptions);
 
+          job.info('Restore staged and unstaged changes');
+          await job.exec('git', ['restore', '--staged', '--worktree'], gitOptions);
+
           job.info('Clean local files not in remote git repository');
           await job.exec('git', ['clean', '-fdx'], gitOptions);
 

--- a/apps/prairielearn/src/lib/course.ts
+++ b/apps/prairielearn/src/lib/course.ts
@@ -142,6 +142,9 @@ export async function pullAndUpdateCourse({
           job.info('Clean local files not in remote git repository');
           await job.exec('git', ['clean', '-fdx'], gitOptions);
 
+          job.info('Check out current branch');
+          await job.exec('git', ['checkout', branch], gitOptions);
+
           job.info('Reset state to remote git repository');
           await job.exec('git', ['reset', '--hard', `origin/${branch}`], gitOptions);
         }


### PR DESCRIPTION
This allows us (or instructors) to get back to a known good state if we ever change the branch for their course. Previously, this would require manual intervention on disk by an admin.