### PR TITLE
Remove usage of legacy queryValidated functions

### DIFF
--- a/apps/prairielearn/src/ee/lib/billing/plans.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plans.ts
@@ -107,7 +107,7 @@ export function getPlanNamesFromPlanGrants(planGrants: PlanGrant[]): PlanName[] 
 export async function getRequiredPlansForCourseInstance(
   course_instance_id: string,
 ): Promise<PlanName[]> {
-  return queryRows(
+  return await queryRows(
     sql.select_required_plans_for_course_instance,
     { course_instance_id },
     z.enum(PLAN_NAMES),
@@ -230,7 +230,7 @@ export function planGrantsSatisfyRequiredPlans(planGrants: PlanGrant[], required
 }
 
 async function getInstitutionForCourseInstance(course_instance_id: string): Promise<Institution> {
-  return queryRow(
+  return await queryRow(
     sql.select_institution_for_course_instance,
     { course_instance_id },
     InstitutionSchema,

--- a/apps/prairielearn/src/lib/features/manager.ts
+++ b/apps/prairielearn/src/lib/features/manager.ts
@@ -1,4 +1,4 @@
-import { loadSqlEquiv, queryAsync, queryValidatedSingleColumnOneRow } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 import { z } from 'zod';
 import { AsyncLocalStorage } from 'node:async_hooks';
 
@@ -91,7 +91,7 @@ export class FeatureManager<FeatureName extends string> {
     // Allow config to globally override a feature.
     if (name in config.features) return config.features[name];
 
-    const featureIsEnabled = await queryValidatedSingleColumnOneRow(
+    const featureIsEnabled = await queryRow(
       sql.is_feature_enabled,
       {
         name,

--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -3,7 +3,7 @@ import execa = require('execa');
 import { z } from 'zod';
 import * as Sentry from '@prairielearn/sentry';
 import { logger } from '@prairielearn/logger';
-import { loadSqlEquiv, queryAsync, queryValidatedOneRow, queryRows } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryAsync, queryRow, queryRows } from '@prairielearn/postgres';
 
 import { chalk, chalkDim } from './chalk';
 import * as serverJobs from './server-jobs-legacy';
@@ -225,7 +225,7 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
  * Creates a job sequence with a single job.
  */
 export async function createServerJob(options: CreateServerJobOptions): Promise<ServerJobExecutor> {
-  const { job_sequence_id, job_id } = await queryValidatedOneRow(
+  const { job_sequence_id, job_id } = await queryRow(
     sql.insert_job_sequence,
     {
       course_id: options.courseId,

--- a/apps/prairielearn/src/lib/timezones.ts
+++ b/apps/prairielearn/src/lib/timezones.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { loadSqlEquiv, queryValidatedRows } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 const sql = loadSqlEquiv(__filename);
 
@@ -14,7 +14,7 @@ let memoizedAvailableTimezones: Timezone[] | null = null;
 let memoizedAvailableTimezonesByName: Map<string, Timezone> | null = null;
 
 async function getAvailableTimezonesFromDB(): Promise<Timezone[]> {
-  const availableTimezones = await queryValidatedRows(sql.select_timezones, [], TimezoneCodec);
+  const availableTimezones = await queryRows(sql.select_timezones, [], TimezoneCodec);
   return availableTimezones;
 }
 

--- a/apps/prairielearn/src/lib/workspaceHost.ts
+++ b/apps/prairielearn/src/lib/workspaceHost.ts
@@ -83,7 +83,7 @@ export async function findTerminableWorkspaceHosts(
   unhealthy_timeout_sec: number,
   launch_timeout_sec: number,
 ): Promise<WorkspaceHost[]> {
-  return queryRows(
+  return await queryRows(
     sql.find_terminable_hosts,
     {
       unhealthy_timeout_sec,
@@ -104,7 +104,7 @@ export async function findTerminableWorkspaceHosts(
 export async function terminateWorkspaceHostsIfNotLaunching(
   instanceIds: string[],
 ): Promise<WorkspaceLog[]> {
-  return queryRows(
+  return await queryRows(
     sql.terminate_hosts_if_not_launching,
     { instance_ids: instanceIds },
     WorkspaceLogSchema,

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -1,6 +1,6 @@
 import asyncHandler = require('express-async-handler');
 import { Router } from 'express';
-import { loadSqlEquiv, queryValidatedRows, queryRows } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
 import { z } from 'zod';
 
@@ -78,16 +78,16 @@ const AddFeatureGrantModalParamsSchema = z.object({
 type AddFeatureGrantModalParams = z.infer<typeof AddFeatureGrantModalParamsSchema>;
 
 async function getEntitiesFromParams(params: AddFeatureGrantModalParams) {
-  const institutions = await queryValidatedRows(sql.select_institutions, {}, InstitutionSchema);
+  const institutions = await queryRows(sql.select_institutions, {}, InstitutionSchema);
   const courses = params.institution_id
-    ? await queryValidatedRows(
+    ? await queryRows(
         sql.select_courses_for_institution,
         { institution_id: params.institution_id },
         CourseSchema,
       )
     : [];
   const course_instances = params.course_id
-    ? await queryValidatedRows(
+    ? await queryRows(
         sql.select_course_instances_for_course,
         { course_id: params.course_id },
         CourseInstanceSchema,

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -43,7 +43,7 @@ const COURSE = {
 };
 
 function getAllChunksForCourse(course_id) {
-  return sqldb.queryValidatedRows(
+  return sqldb.queryRows(
     sql.select_all_chunks,
     {
       course_id,

--- a/apps/prairielearn/src/tests/chunks.test.js
+++ b/apps/prairielearn/src/tests/chunks.test.js
@@ -42,8 +42,8 @@ const COURSE = {
   },
 };
 
-function getAllChunksForCourse(course_id) {
-  return sqldb.queryRows(
+async function getAllChunksForCourse(course_id) {
+  return await sqldb.queryRows(
     sql.select_all_chunks,
     {
       course_id,

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
-import { callValidatedRows, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+import { callRows, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
 import * as helperServer from './helperServer';
 import { extractAndSaveCSRFToken, fetchCheerio, getCSRFToken } from './helperClient';
@@ -28,7 +28,7 @@ describe('Instructor group controls', () => {
   });
 
   step('enroll random users', async () => {
-    users = await callValidatedRows(
+    users = await callRows(
       'users_randomly_generate',
       [
         // Generate 5 users

--- a/apps/prairielearn/src/tests/utils/auth.ts
+++ b/apps/prairielearn/src/tests/utils/auth.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { callValidatedOneRow, queryRow } from '@prairielearn/postgres';
+import { callRow, queryRow } from '@prairielearn/postgres';
 import { config } from '../../lib/config';
 import { IdSchema, User, UserSchema } from '../../lib/db-types';
 
@@ -40,7 +40,7 @@ export async function getConfiguredUser(): Promise<User> {
 }
 
 export async function getOrCreateUser(authUser: AuthUser): Promise<User> {
-  const user = await callValidatedOneRow(
+  const user = await callRow(
     'users_select_or_insert',
     [authUser.uid, authUser.name, authUser.uin, 'dev'],
     z.object({ user_id: IdSchema }),

--- a/apps/prairielearn/src/tests/utils/auth.ts
+++ b/apps/prairielearn/src/tests/utils/auth.ts
@@ -43,6 +43,7 @@ export async function getOrCreateUser(authUser: AuthUser): Promise<User> {
   const user = await callRow(
     'users_select_or_insert',
     [authUser.uid, authUser.name, authUser.uin, 'dev'],
+    // The sproc returns multiple columns, but we only use the ID.
     z.object({ user_id: IdSchema }),
   );
   return await queryRow(

--- a/apps/prairielearn/src/tests/workspaceHost.test.js
+++ b/apps/prairielearn/src/tests/workspaceHost.test.js
@@ -34,7 +34,7 @@ const WorkspaceLogsSchema = z.object({
 });
 
 async function insertWorkspaceHost(id, state = 'launching') {
-  return sqldb.queryValidatedOneRow(
+  return sqldb.queryRow(
     'INSERT INTO workspace_hosts (id, instance_id, state) VALUES ($id, $instance_id, $state) RETURNING *;',
     {
       id,
@@ -50,7 +50,7 @@ async function insertWorkspaceHost(id, state = 'launching') {
  * @param {string | number | null | undefined} hostId
  */
 async function insertWorkspace(id, hostId = null) {
-  return sqldb.queryValidatedOneRow(
+  return sqldb.queryRow(
     'INSERT INTO workspaces (id, state, workspace_host_id) VALUES ($id, $state, $workspace_host_id) RETURNING *;',
     {
       id,
@@ -62,7 +62,7 @@ async function insertWorkspace(id, hostId = null) {
 }
 
 async function selectWorkspaceHost(id) {
-  return sqldb.queryValidatedOneRow(
+  return sqldb.queryRow(
     'SELECT * FROM workspace_hosts WHERE id = $id;',
     { id },
     WorkspaceHostSchema,
@@ -70,11 +70,7 @@ async function selectWorkspaceHost(id) {
 }
 
 async function selectWorkspace(id) {
-  return sqldb.queryValidatedOneRow(
-    'SELECT * FROM workspaces WHERE id = $id;',
-    { id },
-    WorkspaceSchema,
-  );
+  return sqldb.queryRow('SELECT * FROM workspaces WHERE id = $id;', { id }, WorkspaceSchema);
 }
 
 /**
@@ -83,7 +79,7 @@ async function selectWorkspace(id) {
  * @param {string | number} id
  */
 async function getWorkspaceHostLogs(id) {
-  return sqldb.queryValidatedRows(
+  return sqldb.queryRows(
     'SELECT * FROM workspace_host_logs WHERE workspace_host_id = $id;',
     { id },
     WorkspaceHostLogsSchema,
@@ -91,7 +87,7 @@ async function getWorkspaceHostLogs(id) {
 }
 
 async function getWorkspaceLogs(id) {
-  return sqldb.queryValidatedRows(
+  return sqldb.queryRows(
     'SELECT * FROM workspace_logs WHERE workspace_id = $id;',
     { id },
     WorkspaceLogsSchema,

--- a/packages/migrations/src/batched-migrations/batched-migration-job.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-job.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { loadSqlEquiv, queryValidatedRows } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 const sql = loadSqlEquiv(__filename);
 
@@ -26,7 +26,7 @@ export async function selectRecentJobsWithStatus(
   status: BatchedMigrationJobStatus,
   limit: number,
 ): Promise<BatchedMigrationJobRow[]> {
-  return queryValidatedRows(
+  return await queryRows(
     sql.select_recent_jobs_with_status,
     { batched_migration_id: batchedMigrationId, status, limit },
     BatchedMigrationJobRowSchema,

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
@@ -1,10 +1,5 @@
 import { assert } from 'chai';
-import {
-  makePostgresTestUtils,
-  queryAsync,
-  queryValidatedOneRow,
-  queryValidatedRows,
-} from '@prairielearn/postgres';
+import { makePostgresTestUtils, queryAsync, queryRow, queryRows } from '@prairielearn/postgres';
 import * as namedLocks from '@prairielearn/named-locks';
 import * as error from '@prairielearn/error';
 
@@ -54,7 +49,7 @@ function makeTestBatchMigration() {
 }
 
 async function getBatchedMigration(migrationId: string) {
-  return queryValidatedOneRow(
+  return await queryRow(
     'SELECT * FROM batched_migrations WHERE id = $id;',
     { id: migrationId },
     BatchedMigrationRowSchema,
@@ -62,7 +57,7 @@ async function getBatchedMigration(migrationId: string) {
 }
 
 async function getBatchedMigrationJobs(migrationId: string) {
-  return queryValidatedRows(
+  return await queryRows(
     'SELECT * FROM batched_migration_jobs WHERE batched_migration_id = $batched_migration_id ORDER BY id ASC;',
     { batched_migration_id: migrationId },
     BatchedMigrationJobRowSchema,

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.ts
@@ -1,10 +1,4 @@
-import {
-  loadSqlEquiv,
-  queryAsync,
-  queryValidatedOneRow,
-  queryValidatedSingleColumnOneRow,
-  queryValidatedZeroOrOneRow,
-} from '@prairielearn/postgres';
+import { loadSqlEquiv, queryAsync, queryRow, queryOptionalRow } from '@prairielearn/postgres';
 import { logger } from '@prairielearn/logger';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';
@@ -52,7 +46,7 @@ export class BatchedMigrationRunner {
   }
 
   private async hasIncompleteJobs(migration: BatchedMigrationRow): Promise<boolean> {
-    return queryValidatedSingleColumnOneRow(
+    return await queryRow(
       sql.batched_migration_has_incomplete_jobs,
       { batched_migration_id: migration.id },
       z.boolean(),
@@ -60,7 +54,7 @@ export class BatchedMigrationRunner {
   }
 
   private async hasFailedJobs(migration: BatchedMigrationRow): Promise<boolean> {
-    return queryValidatedSingleColumnOneRow(
+    return await queryRow(
       sql.batched_migration_has_failed_jobs,
       { batched_migration_id: migration.id },
       z.boolean(),
@@ -68,7 +62,7 @@ export class BatchedMigrationRunner {
   }
 
   private async refreshMigrationStatus(migration: BatchedMigrationRow) {
-    this.migrationStatus = await queryValidatedSingleColumnOneRow(
+    this.migrationStatus = await queryRow(
       sql.get_migration_status,
       {
         id: migration.id,
@@ -94,7 +88,7 @@ export class BatchedMigrationRunner {
   private async getNextBatchBounds(
     migration: BatchedMigrationRow,
   ): Promise<null | [bigint, bigint]> {
-    const lastJob = await queryValidatedZeroOrOneRow(
+    const lastJob = await queryOptionalRow(
       sql.select_last_batched_migration_job,
       { batched_migration_id: migration.id },
       BatchedMigrationJobRowSchema,
@@ -144,7 +138,7 @@ export class BatchedMigrationRunner {
   ): Promise<BatchedMigrationJobRow | null> {
     const nextBatchBounds = await this.getNextBatchBounds(migration);
     if (nextBatchBounds) {
-      return queryValidatedOneRow(
+      return await queryRow(
         sql.insert_batched_migration_job,
         {
           batched_migration_id: migration.id,
@@ -157,7 +151,7 @@ export class BatchedMigrationRunner {
       // Pick up any old pending jobs from this migration. These will only exist if
       // an admin manually elected to retry all failed jobs; we'll never automatically
       // transition failed jobs back to pending.
-      return queryValidatedZeroOrOneRow(
+      return await queryOptionalRow(
         sql.select_first_pending_batched_migration_job,
         { batched_migration_id: migration.id },
         BatchedMigrationJobRowSchema,

--- a/packages/migrations/src/batched-migrations/batched-migration.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration.ts
@@ -1,9 +1,9 @@
 import {
   loadSqlEquiv,
   queryAsync,
-  queryValidatedOneRow,
-  queryValidatedRows,
-  queryValidatedZeroOrOneRow,
+  queryRow,
+  queryRows,
+  queryOptionalRow,
 } from '@prairielearn/postgres';
 import { z } from 'zod';
 
@@ -76,37 +76,25 @@ type NewBatchedMigration = Pick<
 export async function insertBatchedMigration(
   migration: NewBatchedMigration,
 ): Promise<BatchedMigrationRow | null> {
-  return queryValidatedZeroOrOneRow(
-    sql.insert_batched_migration,
-    migration,
-    BatchedMigrationRowSchema,
-  );
+  return await queryOptionalRow(sql.insert_batched_migration, migration, BatchedMigrationRowSchema);
 }
 
 export async function selectAllBatchedMigrations(project: string) {
-  return queryValidatedRows(
-    sql.select_all_batched_migrations,
-    { project },
-    BatchedMigrationRowSchema,
-  );
+  return await queryRows(sql.select_all_batched_migrations, { project }, BatchedMigrationRowSchema);
 }
 
 export async function selectBatchedMigration(
   project: string,
   id: string,
 ): Promise<BatchedMigrationRow> {
-  return queryValidatedOneRow(
-    sql.select_batched_migration,
-    { project, id },
-    BatchedMigrationRowSchema,
-  );
+  return await queryRow(sql.select_batched_migration, { project, id }, BatchedMigrationRowSchema);
 }
 
 export async function selectBatchedMigrationForTimestamp(
   project: string,
   timestamp: string,
 ): Promise<BatchedMigrationRow> {
-  return queryValidatedOneRow(
+  return await queryRow(
     sql.select_batched_migration_for_timestamp,
     { project, timestamp },
     BatchedMigrationRowSchema,
@@ -117,7 +105,7 @@ export async function updateBatchedMigrationStatus(
   id: string,
   status: BatchedMigrationStatus,
 ): Promise<BatchedMigrationRow> {
-  return queryValidatedOneRow(
+  return await queryRow(
     sql.update_batched_migration_status,
     { id, status },
     BatchedMigrationRowSchema,
@@ -125,5 +113,5 @@ export async function updateBatchedMigrationStatus(
 }
 
 export async function retryFailedBatchedMigrationJobs(project: string, id: string): Promise<void> {
-  await queryAsync(sql.retry_failed_jobs, { project, id });
+  await await queryAsync(sql.retry_failed_jobs, { project, id });
 }

--- a/packages/migrations/src/batched-migrations/batched-migration.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration.ts
@@ -113,5 +113,5 @@ export async function updateBatchedMigrationStatus(
 }
 
 export async function retryFailedBatchedMigrationJobs(project: string, id: string): Promise<void> {
-  await await queryAsync(sql.retry_failed_jobs, { project, id });
+  await queryAsync(sql.retry_failed_jobs, { project, id });
 }

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'node:events';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { loadSqlEquiv, queryValidatedZeroOrOneRow } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
 import { doWithLock, tryWithLock } from '@prairielearn/named-locks';
 
 import { MigrationFile, readAndValidateMigrationsFromDirectories } from '../load-migrations';
@@ -205,14 +205,14 @@ export class BatchedMigrationsRunner extends EventEmitter {
 
   private async getOrStartMigration(): Promise<BatchedMigrationRow | null> {
     return tryWithLock(this.lockName, {}, async () => {
-      let migration = await queryValidatedZeroOrOneRow(
+      let migration = await queryOptionalRow(
         sql.select_running_migration,
         { project: this.options.project },
         BatchedMigrationRowSchema,
       );
 
       if (!migration) {
-        migration = await queryValidatedZeroOrOneRow(
+        migration = await queryOptionalRow(
           sql.start_next_pending_migration,
           { project: this.options.project },
           BatchedMigrationRowSchema,


### PR DESCRIPTION
This sets us up to remove `queryValidated*` and `callValidated*` in a future PR.