### PR TITLE
Respond with 404 if Shibboleth/OAuth login disabled

### DIFF
--- a/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -5,6 +5,7 @@ const express = require('express');
 const asyncHandler = require('express-async-handler');
 const { OAuth2Client } = require('google-auth-library');
 const { logger } = require('@prairielearn/logger');
+const error = require('@prairielearn/error');
 
 const authnLib = require('../../lib/authn');
 const { config } = require('../../lib/config');
@@ -20,7 +21,7 @@ router.get(
       !config.googleClientSecret ||
       !config.googleRedirectUrl
     ) {
-      throw new Error('Google login is not enabled');
+      throw error.make(404, 'Google login is not enabled');
     }
 
     const code = req.query.code;

--- a/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
+++ b/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
@@ -2,16 +2,12 @@
 const express = require('express');
 const router = express.Router();
 const asyncHandler = require('express-async-handler');
-const error = require('@prairielearn/error');
 
 const authnLib = require('../../lib/authn');
-const { config } = require('../../lib/config');
 
 router.get(
   '/',
   asyncHandler(async (req, res, _next) => {
-    if (!config.hasShib) throw error.make(404, 'Shibboleth login is not enabled');
-
     var uid = req.get('x-trust-auth-uid') ?? null;
     var name = req.get('x-trust-auth-name') ?? null;
     var uin = req.get('x-trust-auth-uin') ?? null;

--- a/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
+++ b/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
@@ -1,13 +1,20 @@
 // @ts-check
 const express = require('express');
-const router = express.Router();
 const asyncHandler = require('express-async-handler');
+const error = require('@prairielearn/error');
 
 const authnLib = require('../../lib/authn');
+const { config } = require('../../lib/config');
+
+const router = express.Router();
 
 router.get(
   '/',
   asyncHandler(async (req, res, _next) => {
+    if (!config.hasShib) {
+      throw error.make(404, 'Shibboleth login is not enabled');
+    }
+
     var uid = req.get('x-trust-auth-uid') ?? null;
     var name = req.get('x-trust-auth-name') ?? null;
     var uin = req.get('x-trust-auth-uin') ?? null;

--- a/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
+++ b/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const asyncHandler = require('express-async-handler');
+const error = require('@prairielearn/error');
 
 const authnLib = require('../../lib/authn');
 const { config } = require('../../lib/config');
@@ -9,7 +10,7 @@ const { config } = require('../../lib/config');
 router.get(
   '/',
   asyncHandler(async (req, res, _next) => {
-    if (!config.hasShib) throw new Error('Shibboleth login is not enabled');
+    if (!config.hasShib) throw error.make(404, 'Shibboleth login is not enabled');
 
     var uid = req.get('x-trust-auth-uid') ?? null;
     var name = req.get('x-trust-auth-name') ?? null;

--- a/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
+++ b/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
@@ -1,12 +1,13 @@
 // @ts-check
 const ERR = require('async-stacktrace');
 const express = require('express');
-const router = express.Router();
-
+const { OAuth2Client } = require('google-auth-library');
 const { logger } = require('@prairielearn/logger');
+const error = require('@prairielearn/error');
+
 const { config } = require('../../lib/config');
 
-const { OAuth2Client } = require('google-auth-library');
+const router = express.Router();
 
 router.get('/', function (req, res, next) {
   if (
@@ -15,7 +16,7 @@ router.get('/', function (req, res, next) {
     !config.googleClientSecret ||
     !config.googleRedirectUrl
   ) {
-    return next(new Error('Google login is not enabled'));
+    return next(error.make(404, 'Google login is not enabled'));
   }
 
   let url;

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -486,9 +486,13 @@ module.exports.initExpress = function () {
   app.use(require('./middlewares/content-security-policy').default);
   app.use(require('./middlewares/date'));
   app.use(require('./middlewares/effectiveRequestChanged'));
+
   app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2'));
   app.use('/pl/oauth2callback', require('./pages/authCallbackOAuth2/authCallbackOAuth2'));
-  app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
+
+  if (config.hasShib) {
+    app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
+  }
 
   if (isEnterprise()) {
     if (config.hasAzure) {

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -489,10 +489,7 @@ module.exports.initExpress = function () {
 
   app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2'));
   app.use('/pl/oauth2callback', require('./pages/authCallbackOAuth2/authCallbackOAuth2'));
-
-  if (config.hasShib) {
-    app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
-  }
+  app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
 
   if (isEnterprise()) {
     if (config.hasAzure) {


### PR DESCRIPTION
This keeps these errors out of Sentry and our load balancer error metrics.