### PR TITLE
Replace deprecated configureScope with getCurrentScope

### DIFF
--- a/.changeset/shiny-gifts-smell.md
+++ b/.changeset/shiny-gifts-smell.md
@@ -1,0 +1,5 @@
+---
+"@prairielearn/sentry": minor
+---
+
+Export `getCurrentScope` function

--- a/.changeset/shiny-gifts-smell.md
+++ b/.changeset/shiny-gifts-smell.md
@@ -1,5 +1,5 @@
 ---
-"@prairielearn/sentry": minor
+'@prairielearn/sentry': minor
 ---
 
 Export `getCurrentScope` function

--- a/apps/prairielearn/src/lib/sentry.ts
+++ b/apps/prairielearn/src/lib/sentry.ts
@@ -5,66 +5,64 @@ export function enrichSentryEventMiddleware(req: Request, res: Response, next: N
   // This will ensure that this middleware is always run in an isolated
   // context so that we don't accidentally leak data between requests.
   Sentry.runWithAsyncContext(() => {
-    const hub = Sentry.getCurrentHub();
+    const scope = Sentry.getCurrentScope();
 
-    hub.configureScope((scope) => {
-      // This event processor will run whenever an event is captured by Sentry.
-      // It will use as much context as it can, but will gracefully handle the
-      // case where context is missing.
-      scope.addEventProcessor((event) => {
-        event.tags ??= {};
+    // This event processor will run whenever an event is captured by Sentry.
+    // It will use as much context as it can, but will gracefully handle the
+    // case where context is missing.
+    scope.addEventProcessor((event) => {
+      event.tags ??= {};
 
-        event.tags.response_id = res.locals.response_id;
-        event.tags.method = req.method;
-        event.tags.url = req.originalUrl;
+      event.tags.response_id = res.locals.response_id;
+      event.tags.method = req.method;
+      event.tags.url = req.originalUrl;
 
-        if (res.locals.error_id) {
-          event.tags.error_id = res.locals.error_id;
-        }
+      if (res.locals.error_id) {
+        event.tags.error_id = res.locals.error_id;
+      }
 
-        if (res.locals.authn_user?.user_id) {
-          event.user = {
-            id: res.locals.authn_user.user_id.toString(),
-            // To comply with GDPR and other data protection laws, you can
-            // configure Sentry to not store IP addresses. Sentry will then
-            // only use the IP address to compute a country code and
-            // immediately discard it.
-            ip_address: req.ip,
-          };
-        }
+      if (res.locals.authn_user?.user_id) {
+        event.user = {
+          id: res.locals.authn_user.user_id.toString(),
+          // To comply with GDPR and other data protection laws, you can
+          // configure Sentry to not store IP addresses. Sentry will then
+          // only use the IP address to compute a country code and
+          // immediately discard it.
+          ip_address: req.ip,
+        };
+      }
 
-        if (res.locals?.course?.id) {
-          event.tags['course.id'] = res.locals.course?.id;
-          event.tags['course.short_name'] = res.locals.course?.short_name;
-          event.tags['course.title'] = res.locals.course?.title;
-        }
+      if (res.locals?.course?.id) {
+        event.tags['course.id'] = res.locals.course?.id;
+        event.tags['course.short_name'] = res.locals.course?.short_name;
+        event.tags['course.title'] = res.locals.course?.title;
+      }
 
-        if (res.locals?.course_instance?.id) {
-          event.tags['course_instance.id'] = res.locals.course_instance?.id;
-          event.tags['course_instance.short_name'] = res.locals.course_instance?.short_name;
-          event.tags['course_instance.long_name'] = res.locals.course_instance?.long_name;
-        }
+      if (res.locals?.course_instance?.id) {
+        event.tags['course_instance.id'] = res.locals.course_instance?.id;
+        event.tags['course_instance.short_name'] = res.locals.course_instance?.short_name;
+        event.tags['course_instance.long_name'] = res.locals.course_instance?.long_name;
+      }
 
-        if (res.locals?.assessment?.id) {
-          event.tags['assessment.id'] = res.locals.assessment?.id;
-          event.tags['assessment.directory'] = res.locals.assessment?.directory;
-        }
+      if (res.locals?.assessment?.id) {
+        event.tags['assessment.id'] = res.locals.assessment?.id;
+        event.tags['assessment.directory'] = res.locals.assessment?.directory;
+      }
 
-        if (res.locals?.assessment_instance?.id) {
-          event.tags['assessment_instance.id'] = res.locals.assessment_instance?.id;
-        }
+      if (res.locals?.assessment_instance?.id) {
+        event.tags['assessment_instance.id'] = res.locals.assessment_instance?.id;
+      }
 
-        if (res.locals?.question?.id) {
-          event.tags['question.id'] = res.locals.question?.id;
-          event.tags['question.directory'] = res.locals.question?.directory;
-        }
+      if (res.locals?.question?.id) {
+        event.tags['question.id'] = res.locals.question?.id;
+        event.tags['question.directory'] = res.locals.question?.directory;
+      }
 
-        if (res.locals?.instance_question?.id) {
-          event.tags['instance_question.id'] = res.locals.instance_question?.id;
-        }
+      if (res.locals?.instance_question?.id) {
+        event.tags['instance_question.id'] = res.locals.instance_question?.id;
+      }
 
-        return event;
-      });
+      return event;
     });
 
     next();

--- a/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -44,11 +44,10 @@ router.get(
         // This is probably a detailed error from the Google API client. We'll
         // pick off the useful bits and attach them to the Sentry scope so that
         // they'll be included with the error event.
-        Sentry.configureScope((scope) => {
-          scope.setContext('OAuth', {
-            code: err.code,
-            data: err.response.data,
-          });
+        const scope = Sentry.getCurrentScope();
+        scope.setContext('OAuth', {
+          code: err.code,
+          data: err.response.data,
         });
       }
       throw err;

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -82,4 +82,5 @@ export {
   Integrations,
   Handlers,
   runWithAsyncContext,
+  getCurrentScope,
 } from '@sentry/node';


### PR DESCRIPTION
I noticed that `configureScope` was flagged as deprecated in my editor while reviewing the OAuth code.