### PR TITLE
Fix formatting of Content-Security-Policy header

### DIFF
--- a/apps/prairielearn/src/middlewares/content-security-policy.ts
+++ b/apps/prairielearn/src/middlewares/content-security-policy.ts
@@ -7,7 +7,7 @@ router.all('/*', function (req, res, next) {
   //
   // Currently, we only use CSP to prevent PrairieLearn from being rendered in
   // an iframe.
-  res.header('Content-Security-Policy', "frame-ancestors: 'none';");
+  res.header('Content-Security-Policy', "frame-ancestors 'none';");
 
   // Added for backwards compatibility with older browsers.
   res.header('X-Frame-Options', 'DENY');


### PR DESCRIPTION
This semicolon was added accidentally; it's unnecessary and in fact causes problems. CSP docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors