### PR TITLE
Cascade updates/deletes to group_user_roles table

### DIFF
--- a/apps/prairielearn/src/migrations/20240123213531_group_user_roles__cascade_deletes.sql
+++ b/apps/prairielearn/src/migrations/20240123213531_group_user_roles__cascade_deletes.sql
@@ -1,0 +1,32 @@
+-- Add new constraints that include cascading updates and deletes
+
+ALTER TABLE group_user_roles
+ADD CONSTRAINT group_user_roles_group_id_new_fkey FOREIGN KEY (group_id) REFERENCES groups (id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE group_user_roles
+ADD CONSTRAINT group_user_roles_group_role_id_new_fkey FOREIGN KEY (group_role_id) REFERENCES group_roles (id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE group_user_roles
+ADD CONSTRAINT group_user_roles_user_id_new_fkey FOREIGN KEY (user_id) REFERENCES users (user_id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+-- Drop the old constraints.
+
+ALTER TABLE group_user_roles
+DROP CONSTRAINT IF EXISTS group_user_roles_group_id_fkey;
+
+ALTER TABLE group_user_roles
+DROP CONSTRAINT IF EXISTS group_user_roles_group_role_id_fkey;
+
+ALTER TABLE group_user_roles
+DROP CONSTRAINT IF EXISTS group_user_roles_user_id_fkey;
+
+-- Rename the new constraints to the old names.
+
+ALTER TABLE group_user_roles
+RENAME CONSTRAINT group_user_roles_group_id_new_fkey TO group_user_roles_group_id_fkey;
+
+ALTER TABLE group_user_roles
+RENAME CONSTRAINT group_user_roles_group_role_id_new_fkey TO group_user_roles_group_role_id_fkey;
+
+ALTER TABLE group_user_roles
+RENAME CONSTRAINT group_user_roles_user_id_new_fkey TO group_user_roles_user_id_fkey;

--- a/apps/prairielearn/src/migrations/20240123213531_group_user_roles__cascade_deletes.sql
+++ b/apps/prairielearn/src/migrations/20240123213531_group_user_roles__cascade_deletes.sql
@@ -1,5 +1,4 @@
 -- Add new constraints that include cascading updates and deletes
-
 ALTER TABLE group_user_roles
 ADD CONSTRAINT group_user_roles_group_id_new_fkey FOREIGN KEY (group_id) REFERENCES groups (id) ON UPDATE CASCADE ON DELETE CASCADE;
 
@@ -10,7 +9,6 @@ ALTER TABLE group_user_roles
 ADD CONSTRAINT group_user_roles_user_id_new_fkey FOREIGN KEY (user_id) REFERENCES users (user_id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 -- Drop the old constraints.
-
 ALTER TABLE group_user_roles
 DROP CONSTRAINT IF EXISTS group_user_roles_group_id_fkey;
 
@@ -21,7 +19,6 @@ ALTER TABLE group_user_roles
 DROP CONSTRAINT IF EXISTS group_user_roles_user_id_fkey;
 
 -- Rename the new constraints to the old names.
-
 ALTER TABLE group_user_roles
 RENAME CONSTRAINT group_user_roles_group_id_new_fkey TO group_user_roles_group_id_fkey;
 

--- a/database/tables/group_roles.pg
+++ b/database/tables/group_roles.pg
@@ -17,4 +17,4 @@ foreign-key constraints
 
 referenced by
     assessment_question_role_permissions: FOREIGN KEY (group_role_id) REFERENCES group_roles(id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_user_roles: FOREIGN KEY (group_role_id) REFERENCES group_roles(id)
+    group_user_roles: FOREIGN KEY (group_role_id) REFERENCES group_roles(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/group_user_roles.pg
+++ b/database/tables/group_user_roles.pg
@@ -9,7 +9,7 @@ indexes
     group_user_roles_group_id_user_id_group_role_id_key: UNIQUE USING btree (group_id, user_id, group_role_id)
 
 foreign-key constraints
-    group_user_roles_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id)
+    group_user_roles_group_id_fkey: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     group_user_roles_group_id_user_id_fkey: FOREIGN KEY (group_id, user_id) REFERENCES group_users(group_id, user_id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_user_roles_group_role_id_fkey: FOREIGN KEY (group_role_id) REFERENCES group_roles(id)
-    group_user_roles_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id)
+    group_user_roles_group_role_id_fkey: FOREIGN KEY (group_role_id) REFERENCES group_roles(id) ON UPDATE CASCADE ON DELETE CASCADE
+    group_user_roles_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/groups.pg
+++ b/database/tables/groups.pg
@@ -19,7 +19,7 @@ foreign-key constraints
 
 referenced by
     assessment_instances: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_user_roles: FOREIGN KEY (group_id) REFERENCES groups(id)
+    group_user_roles: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     group_users: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     last_accesses: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE
     variants: FOREIGN KEY (group_id) REFERENCES groups(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/users.pg
+++ b/database/tables/users.pg
@@ -43,7 +43,7 @@ referenced by
     grading_jobs: FOREIGN KEY (auth_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     grading_jobs: FOREIGN KEY (graded_by) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     grading_jobs: FOREIGN KEY (grading_request_canceled_by) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
-    group_user_roles: FOREIGN KEY (user_id) REFERENCES users(user_id)
+    group_user_roles: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     group_users: FOREIGN KEY (user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE
     instance_questions: FOREIGN KEY (assigned_grader) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE SET NULL
     instance_questions: FOREIGN KEY (authn_user_id) REFERENCES users(user_id) ON UPDATE CASCADE ON DELETE CASCADE


### PR DESCRIPTION
Closes #9270.

I spot-checked all other group-related tables for missing `ON DELETE CASCADE` and didn't find any, so this should be all we need.