### PR TITLE
Remove git restore --staged --worktree from syncing process

### DIFF
--- a/apps/prairielearn/src/lib/course.ts
+++ b/apps/prairielearn/src/lib/course.ts
@@ -139,9 +139,6 @@ export async function pullAndUpdateCourse({
           job.info('Fetch from remote git repository');
           await job.exec('git', ['fetch'], gitOptions);
 
-          job.info('Restore staged and unstaged changes');
-          await job.exec('git', ['restore', '--staged', '--worktree'], gitOptions);
-
           job.info('Clean local files not in remote git repository');
           await job.exec('git', ['clean', '-fdx'], gitOptions);
 


### PR DESCRIPTION
This broke syncing with the following error:

```
fatal: you must specify path(s) to restore
```

I'm removing this until @mwest1066 can chime in with what the correct command is (I imagine we just need to add a `.` at the end, but I'm not familiar with this particular version of `git restore` so I'm not entirely sure).