### PR TITLE
Fix variable name in assessment questions page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ejs
@@ -189,7 +189,7 @@
                 </td>
                 <td class="text-center">
                   <% if (question.number_submissions_hist) { %>
-                    <div id="attemptsHist<%= i %>" class="miniHist">
+                    <div id="attemptsHist<%= iRow %>" class="miniHist">
 
                     </div>
                   <% } %>


### PR DESCRIPTION
As reported on Slack. This was causing issues on the assessment questions page for any assessment that had valid submissions and where stats had been calculated in some point (i.e., the histogram has values).