### PR TITLE
Fix group adding functionality in assessments with no group maximum

### DIFF
--- a/apps/prairielearn/src/lib/groups.ts
+++ b/apps/prairielearn/src/lib/groups.ts
@@ -82,7 +82,7 @@ interface GroupRoleAssignment {
 
 const GroupForUpdateSchema = GroupSchema.extend({
   cur_size: z.number(),
-  max_size: z.number(),
+  max_size: z.number().nullable(),
   has_roles: z.boolean(),
 });
 
@@ -250,7 +250,7 @@ export async function addUserToGroup({
       }
     }
 
-    if (enforceGroupSize && group.cur_size >= group.max_size) {
+    if (enforceGroupSize && group.max_size != null && group.cur_size >= group.max_size) {
       throw new GroupOperationError(`Group is already full.`);
     }
 


### PR DESCRIPTION
After #9106, add group functionality was sent to a single lib function. This function didn't properly handle cases where the group maximum is undefined (unlimited). This case was causing a Zod error, as reported on Slack. This PR changes this, and ensures that group maximums are not applied if they don't exist.