### PR TITLE
Fix manual grading assign to other grader button

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -5,6 +5,7 @@ import {
   ManualPointsSection,
   TotalPointsSection,
 } from './gradingPointsSection.html';
+import { type User } from '../../../lib/db-types';
 
 interface SubmissionOrGradingJob {
   feedback: Record<string, any> | null;
@@ -26,7 +27,7 @@ export function GradingPanel({
   resLocals: Record<string, any>;
   context: 'main' | 'existing' | 'conflicting';
   rubric_settings_visible?: boolean;
-  graders?: Record<string, any> | null;
+  graders?: User[] | null;
   disable?: boolean;
   hide_back_to_question?: boolean;
   skip_text?: string;
@@ -173,8 +174,8 @@ ${submission.feedback?.manual}</textarea
                       <span class="sr-only">Change assigned grader</span>
                     </button>
                     <div class="dropdown-menu dropdown-menu-right">
-                      ${(graders || []).forEach((grader) => {
-                        html`
+                      ${(graders || []).map(
+                        (grader) => html`
                           <button
                             type="submit"
                             class="dropdown-item"
@@ -183,8 +184,8 @@ ${submission.feedback?.manual}</textarea
                           >
                             Assign to: ${grader.name} (${grader.uid})
                           </button>
-                        `;
-                      })}
+                        `,
+                      )}
                       <button
                         type="submit"
                         class="dropdown-item"

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -73,7 +73,7 @@ export function InstanceQuestion({
               `
             : ''}
           ${conflict_grading_job
-            ? ConflictGradingJobModal({ resLocals, conflict_grading_job })
+            ? ConflictGradingJobModal({ resLocals, conflict_grading_job, graders })
             : ''}
           <div class="row">
             <div class="col-lg-8 col-12">
@@ -117,9 +117,11 @@ export function InstanceQuestion({
 function ConflictGradingJobModal({
   resLocals,
   conflict_grading_job,
+  graders,
 }: {
   resLocals: Record<string, any>;
   conflict_grading_job: GradingJobData;
+  graders: User[] | null;
 }) {
   return html`
     <div id="conflictGradingJobModal" class="modal fade">
@@ -175,6 +177,7 @@ function ConflictGradingJobModal({
                     custom_manual_points: conflict_grading_job.manual_points ?? 0,
                     grading_job: conflict_grading_job,
                     context: 'conflicting',
+                    graders,
                   })}
                 </div>
               </div>


### PR DESCRIPTION
As discussed on Slack. The type of the graders object was incorrect, and it was using the wrong function. This meant the page didn't list the buttons to assign a question to a different grader.

Also, the buttons to assign to a different grader is also added to the conflict modal, allowing a conflict to be handled by a different staff member more easily.