### PR TITLE
Fix RStudio workspace Nginx proxy

### DIFF
--- a/workspaces/rstudio/Dockerfile
+++ b/workspaces/rstudio/Dockerfile
@@ -2,6 +2,7 @@
 # PrairieLearn RStudio workspace template
 # 20210831 Eric Huber - Initial version
 # 20240123 Eric Huber - Modify service file to provide server-user argument
+# 20240126 Eric Huber - Pin base image version for future diagnostics
 
 # Maintainer notes:
 
@@ -22,7 +23,8 @@
 # as a limited user without hacks, but it may not be worth the maintenance
 # burden if there is no added benefit.
 
-FROM rocker/rstudio
+# Latest as of 20240126
+FROM rocker/rstudio:4.3.2
 
 # On PL, we need to use 1001:1001 for the default user account. We adjust the
 # pre-existing rstudio user which is typically uid 1000 otherwise.

--- a/workspaces/rstudio/rstudio-nginx.conf
+++ b/workspaces/rstudio/rstudio-nginx.conf
@@ -1,5 +1,12 @@
 
-# This configuration file is based on the default nginx.conf file included
+# This Nginx reverse proxy configuration is intended for the RStudio
+# PrairieLearn workspace environment. We rewrite the base URL (since RStudio
+# Server does not have this feature yet), as well as pinning the scheme on
+# the URL in a way necessary to support both local testing over HTTP and
+# deployment on PL, where the PL server uses HTTPS, but internally the
+# container uses HTTP.
+
+# The original template was based on the default nginx.conf file included
 # with Nginx, which is distributed under the following license, as found at
 # the URL: https://nginx.org/LICENSE
 
@@ -75,6 +82,11 @@ http {
     error_log /var/log/nginx/error.log;
     # error_log /var/log/nginx/error.log debug;
 
+    # Log the http/https scheme when debugging PrairieLearn redirect issues
+    # Inspired by: https://docs.nginx.com/nginx/admin-guide/monitoring/logging/
+    # log_format scheme_debug 'Scheme: $scheme Referer: $http_referer Heaviest: $heaviest_scheme Cookie: $cookie_heaviest_scheme - $ssl_protocol $ssl_cipher $remote_addr "$http_user_agent"';
+    # access_log /tmp/scheme_debug.log scheme_debug;
+
     ##
     # Gzip Settings
     ##
@@ -100,12 +112,13 @@ http {
         ''      close;
     }
 
-    # This section was added for PrairieLearn Workspaces. RStudio wants to
-    # cycle through a few pages when establishing the no-authentication
-    # session. We set a cookie to help make sure http or https is used
-    # consistently; this can smooth over issues in local testing. The
-    # TRIMMED_BASE_URL variable is dynamically replaced in this file when the
-    # container is started.
+    # The TRIMMED_BASE_URL variable is dynamically replaced in this file when
+    # the container is started, and it already has any initial or final
+    # slashes removed. The contents will match the base URL that has been
+    # communicated by the PL server through an environment variable. To avoid
+    # issues switching between HTTP and HTTPS incorrectly when Nginx and
+    # RStudio handle redirects, we always force the redirect destination to
+    # match the referer.
     server {
         listen 3939;
 
@@ -113,23 +126,22 @@ http {
 
         location /$TRIMMED_BASE_URL/ {
             set $heaviest_scheme "http";
-            if ($cookie_heaviest_scheme = https) {
-                set $heaviest_scheme "https";
-            }
             if ($http_referer ~ ^https) {
                 set $heaviest_scheme "https";
             }
 
-            add_header Set-Cookie "heaviest_scheme=$heaviest_scheme; Path=/; SameSite=strict; HttpOnly";
+            # This cookie is no longer necessary, but might be useful in the
+            # future. Not very reliable.
+            # add_header Set-Cookie "heaviest_scheme=$heaviest_scheme; Path=/; SameSite=strict; HttpOnly";
 
             proxy_hide_header X-Frame-Options;
             proxy_set_header X-RSC-Request $heaviest_scheme://$host:$server_port$request_uri;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            proxy_read_timeout 20d;
-            rewrite ^/$TRIMMED_BASE_URL/(.*)$ /$1 break;
-            proxy_pass http://localhost:8787;
+            proxy_read_timeout 120s;
+            rewrite /$TRIMMED_BASE_URL/(.*)$ /$1 break;
+            proxy_pass http://localhost:8787/;
             proxy_redirect http://localhost:8787/ $heaviest_scheme://$http_host/$TRIMMED_BASE_URL/;
         }
     }


### PR DESCRIPTION
There was a subtle problem with the Nginx reverse proxy for the RStudio workspace, giving sporadic startup failures. I'm removing the logic that had made use of a cookie to trip a flag. After a few edits and testing locally with https and launching the workspace as 1001:1001, it seems to work reliably again. The default local development settings (http, 0:0) also seem to be working again.

The root issue is that RStudio Server does not let you set the base URL (so we have to rewrite it ourselves), and RStudio Server does a redirect when the user first loads the page that is not predictably http or https. This causes problems if the redirect goes to the wrong URL scheme at the wrong time. People also need to be able to test locally with the defaults in the PL Docker (which don't quite match the deployment). If problems persist, we could put something even more explicitly hard-coded to behave one way in deployment and another way locally.

I will mark this a draft until I can sync it on a test course tomorrow and try it "for real".

@eddelbuettel - Please try it again too.