### PR TITLE
Fix flaky tests

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -2026,6 +2026,17 @@ module.exports.startServer = async () => {
 module.exports.stopServer = function (callback) {
   if (!server) return callback(new Error('cannot stop an undefined server'));
   if (!server.listening) return callback(null);
+
+  // This exists mostly for tests, where we might have dangling connections
+  // from `fetch()` requests whose bodies we never read. `server.close()` won't
+  // actually stop the server until all connections are closed, so we need to
+  // manually close said connections.
+  //
+  // In production environments, PrairieLearn should always be deployed behind
+  // a load balancer that will drain and close any open connections before
+  // PrairieLearn is stopped.
+  server.closeAllConnections();
+
   server.close(function (err) {
     if (ERR(err, callback)) return;
     callback(null);

--- a/apps/prairielearn/src/tests/helperServer.ts
+++ b/apps/prairielearn/src/tests/helperServer.ts
@@ -103,14 +103,14 @@ export async function after(): Promise<void> {
     debug('after(): stop server');
     await promisify(server.stopServer)();
 
+    debug('after(): close socket server');
+    await socketServer.close();
+
     debug('after(): close load estimators');
     load.close();
 
     debug('after(): stop cron');
     await cron.stop();
-
-    debug('after(): close socket server');
-    await socketServer.close();
 
     debug('after(): close server jobs');
     await serverJobs.stop();


### PR DESCRIPTION
This PR aims to fix flaky tests that we've observed since upgrading to Node 20.

As best as I can tell, our `helperServer.after` function would hang on actually closing the HTTP server. `HttpServer#close` waits for all connections to close before actually closing the server, but in our tests, there are a lot of scenarios where we `fetch()` something and never actually do anything with the response body. Non-deterministically, this results in the connection staying open, which in turn keeps the server from stopping immediately. It will eventually stop after `keepAliveTimeout` elapses (65 seconds), but this isn't fast enough to complete before Mocha decides that our shutdown step exceeded its timeout.

I honestly can't say why this only started happening after upgrading to Node 20. It's possible that this is due to Node 19 enabling HTTP keep-alive by default, or there could have been another change to the way the HTTP server works.

Either way, I tested this with the following command:

```sh
cd apps/prairielearn
yarn mocha src/tests/groupExamRolePermissions.test.ts src/tests/groupRolePermissions.test.ts
```

Without this change, those tests regularly fail. With this change, they consistently passed for me. I'm hoping this extends to all tests in CI.