### PR TITLE
Add apps/prairielearn/server.log to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@
 .yarn/install-state.gz
 !pyproject.toml
 !apps/
+apps/prairielearn/server.log
 !database/
 !docs/
 !docker/


### PR DESCRIPTION
This file gets really big when PL runs for a long time during development (3.5GB for me). Trying to run `docker build ...` results in this file needlessly being included in the image. This PR ensures it isn't.