### PR TITLE
Use --parents flag for Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,16 @@
+# syntax=docker/dockerfile-upstream:master-labs
+
 FROM prairielearn/plbase:${PRAIRIELEARN_IMAGE_TAG:-latest}
 
 ENV PATH="/PrairieLearn/node_modules/.bin:$PATH"
 
-# Note that we have to copy the `packages` and `apps` directories into the
-# image so that `yarn` can resolve the workspaces inside them and set up
-# symlinks correctly.
-#
-# This is suboptimal, as a change to any file in these directories will
-# invalidate this layer's cache, but it's the best option we have for now.
-# The alternative is to use a separate `COPY` step for each package/app, but
-# this is inexplicably slow on GitHub Actions, taking about 2.5 minutes just to
-# execute the `COPY` steps. If Docker implements `COPY --parents` as described
-# in https://github.com/moby/moby/issues/35639, we can use that and copy globs
-# instead, which should give us the best of both worlds.
+# This copies in all the `package.json` files in `apps` and `packages`, which
+# Yarn needs to correctly install all dependencies in our workspaces.
+# The `--parents` flag is used to preserve parent directories for the sources.
 #
 # We also need to copy both the `.yarn` directory and the `.yarnrc.yml` file,
 # both of which are necessary for Yarn to correctly install dependencies.
-COPY .yarn/ /PrairieLearn/.yarn/
-COPY package.json yarn.lock .yarnrc.yml /PrairieLearn/
-COPY packages/ /PrairieLearn/packages/
-COPY apps/ /PrairieLearn/apps/
+COPY --parents .yarn/ yarn.lock .yarnrc.yml **/package.json /PrairieLearn/
 
 # Install Node dependencies.
 RUN cd /PrairieLearn && yarn install --immutable  && yarn cache clean


### PR DESCRIPTION
This PR uses the new `--parents` flag introduced in https://github.com/moby/buildkit/pull/3001 to improve our Docker builds. Now, if `package.json`/`yarn.lock` and friends don't change in a PR, we can reuse the image layers that include the dependencies, which should save a fair amount of time when it comes to pushing the image.

This is technically still a "labs" feature, hence the `# syntax` magic comment that tells Docker to use the latest version of the Dockerfile syntax. Hopefully it graduates into stable Docker soon!