### PR TITLE
Fix Zod schema in assessment regrading

### DIFF
--- a/apps/prairielearn/src/lib/regrading.js
+++ b/apps/prairielearn/src/lib/regrading.js
@@ -20,7 +20,7 @@ export async function regradeAssessmentInstance(assessment_instance_id, user_id,
     { assessment_instance_id },
     z.object({
       assessment_instance_label: z.string(),
-      user_uid: z.string().optional(),
+      user_uid: z.string().nullable(),
       group_name: z.string().nullable(),
       assessment_id: IdSchema,
       course_instance_id: IdSchema,

--- a/apps/prairielearn/src/lib/regrading.sql
+++ b/apps/prairielearn/src/lib/regrading.sql
@@ -13,7 +13,7 @@ FROM
   JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
   JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
   JOIN pl_courses AS c ON (c.id = ci.course_id)
-  LEFT JOIN users AS u USING (user_id)
+  LEFT JOIN users AS u ON (u.user_id = ai.user_id)
   LEFT JOIN groups AS g ON (g.id = ai.group_id)
 WHERE
   ai.id = $assessment_instance_id


### PR DESCRIPTION
This was incorrectly declared as `.optional()` instead of `.nullable()`, meaning we errored out if someone tried to regrade a group assessment instance (which doesn't have an associated user).