### PR TITLE
Add allow-rpy2 feature flag

### DIFF
--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -4,10 +4,12 @@ const featureNames = [
   'manual-grading-rubrics',
   'course-instance-billing',
   'enforce-plan-grants-for-questions',
-  'lti13',
   // Can only be applied to courses/institutions.
+  'allow-rpy2',
   'process-questions-in-worker',
   'question-sharing',
+  // Can only be applied to institutions.
+  'lti13',
 ] as const;
 
 const features = new FeatureManager(featureNames);


### PR DESCRIPTION
This feature flag is currently a no-op. I'm adding it independently so that we can get the appropriate feature grants in place before we make it actually do anything.