### PR TITLE
symbolic: add a more specific error if someone tries to do `cos*x`

### DIFF
--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -199,7 +199,7 @@ class HasInvalidVariableError(BaseSympyError):
     text: str
 
 @dataclass
-class HasFunctionConfusedForVariableError(BaseSympyError):
+class FunctionNameUsedWithoutArguments(BaseSympyError):
     offset: int
     text: str
 
@@ -258,7 +258,7 @@ class CheckVariables(ast.NodeVisitor):
                 if node.id not in self.variables:
                     err_node = get_parent_with_location(node)
                     if node.id in self.functions:
-                        raise HasFunctionConfusedForVariableError(
+                        raise FunctionNameUsedWithoutArguments(
                             err_node.col_offset, err_node.id
                         )
                     else:
@@ -668,9 +668,10 @@ def validate_string_as_sympy(
             f"<br><br><pre>{point_to_error(expr, err.offset)}</pre>"
             "Note that the location of the syntax error is approximate."
         )
-    except HasFunctionConfusedForVariableError as err:
+    except FunctionNameUsedWithoutArguments as err:
         return (
-            f'Your answer tries to use the function "{err.text}" like a variable. '
+            f'Your answer mentions the function "{err.text}" without '
+            'applying it to anything. '
             f"<br><br><pre>{point_to_error(expr, err.offset)}</pre>"
             "Note that the location of the syntax error is approximate."
         )

--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -198,10 +198,12 @@ class HasInvalidVariableError(BaseSympyError):
     offset: int
     text: str
 
+
 @dataclass
 class FunctionNameUsedWithoutArguments(BaseSympyError):
     offset: int
     text: str
+
 
 @dataclass
 class HasParseError(BaseSympyError):
@@ -308,7 +310,9 @@ def ast_check(expr: str, locals_for_eval: LocalsForEval) -> None:
     CheckFunctions(locals_for_eval["functions"]).visit(root)
 
     # Disallow variables that are not in locals_for_eval
-    CheckVariables(locals_for_eval["variables"], locals_for_eval["functions"]).visit(root)
+    CheckVariables(locals_for_eval["variables"], locals_for_eval["functions"]).visit(
+        root
+    )
 
     # Disallow AST nodes that are not in whitelist
     #
@@ -671,7 +675,7 @@ def validate_string_as_sympy(
     except FunctionNameUsedWithoutArguments as err:
         return (
             f'Your answer mentions the function "{err.text}" without '
-            'applying it to anything. '
+            "applying it to anything. "
             f"<br><br><pre>{point_to_error(expr, err.offset)}</pre>"
             "Note that the location of the syntax error is approximate."
         )

--- a/apps/prairielearn/python/python_helper_sympy.py
+++ b/apps/prairielearn/python/python_helper_sympy.py
@@ -241,10 +241,9 @@ class CheckFunctions(ast.NodeVisitor):
         self.functions = functions
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Name):
-            if node.func.id not in self.functions:
-                err_node = get_parent_with_location(node)
-                raise HasInvalidFunctionError(err_node.col_offset, err_node.func.id)
+        if isinstance(node.func, ast.Name) and node.func.id not in self.functions:
+            err_node = get_parent_with_location(node)
+            raise HasInvalidFunctionError(err_node.col_offset, err_node.func.id)
         self.generic_visit(node)
 
 
@@ -255,16 +254,16 @@ class CheckVariables(ast.NodeVisitor):
         self.functions = functions
 
     def visit_Name(self, node: ast.Name) -> None:
-        if isinstance(node.ctx, ast.Load):
-            if not is_name_of_function(node):
-                if node.id not in self.variables:
-                    err_node = get_parent_with_location(node)
-                    if node.id in self.functions:
-                        raise FunctionNameUsedWithoutArguments(
-                            err_node.col_offset, err_node.id
-                        )
-                    else:
-                        raise HasInvalidVariableError(err_node.col_offset, err_node.id)
+        if (
+            isinstance(node.ctx, ast.Load)
+            and not is_name_of_function(node)
+            and node.id not in self.variables
+        ):
+            err_node = get_parent_with_location(node)
+            if node.id in self.functions:
+                raise FunctionNameUsedWithoutArguments(err_node.col_offset, err_node.id)
+            else:
+                raise HasInvalidVariableError(err_node.col_offset, err_node.id)
         self.generic_visit(node)
 
 

--- a/apps/prairielearn/python/python_helper_sympy_test.py
+++ b/apps/prairielearn/python/python_helper_sympy_test.py
@@ -279,6 +279,7 @@ class TestExceptions:
     INVALID_EXPRESSION_CASES = ["5==5", "5!=5", "5>5", "5<5", "5>=5", "5<=5"]
     INVALID_FUNCTION_CASES = ["eval(n)", "f(n)", "g(n)+cos(n)", "dir(n)", "sin(f(n))"]
     INVALID_VARIABLE_CASES = ["x", "y", "z*n"]
+    FUNCTION_AS_VARIABLE_CASES = ["2/exp", "cos*n"]
     INVALID_PARSE_CASES = ["(", "n**", "n**2+", "!"]
     INVALID_ESCAPE_CASES = ["\\", "n + 2 \\", "2 \\"]
     INVALID_COMMENT_CASES = ["#", "n + 2 # comment", "# x"]
@@ -317,6 +318,11 @@ class TestExceptions:
     @pytest.mark.parametrize("a_sub", INVALID_VARIABLE_CASES)
     def test_invalid_variable(self, a_sub: str) -> None:
         with pytest.raises(phs.HasInvalidSymbolError):
+            phs.convert_string_to_sympy(a_sub, self.VARIABLES)
+
+    @pytest.mark.parametrize("a_sub", FUNCTION_AS_VARIABLE_CASES)
+    def test_invalid_variable(self, a_sub: str) -> None:
+        with pytest.raises(phs.HasFunctionConfusedForVariableError):
             phs.convert_string_to_sympy(a_sub, self.VARIABLES)
 
     @pytest.mark.parametrize("a_sub", INVALID_PARSE_CASES)

--- a/apps/prairielearn/python/python_helper_sympy_test.py
+++ b/apps/prairielearn/python/python_helper_sympy_test.py
@@ -278,8 +278,8 @@ class TestExceptions:
     NO_FLOATS_CASES = ["3.5", "4.2n", "3.5*n", "3.14159*n**2", "sin(2.3)"]
     INVALID_EXPRESSION_CASES = ["5==5", "5!=5", "5>5", "5<5", "5>=5", "5<=5"]
     INVALID_FUNCTION_CASES = ["eval(n)", "f(n)", "g(n)+cos(n)", "dir(n)", "sin(f(n))"]
-    INVALID_VARIABLE_CASES = ["x", "y", "z*n"]
-    FUNCTION_AS_VARIABLE_CASES = ["2/exp", "cos*n"]
+    INVALID_VARIABLE_CASES = ["x", "exp(y)", "z*n"]
+    FUNCTION_NOT_CALLED_CASES = ["2+exp", "cos*n"]
     INVALID_PARSE_CASES = ["(", "n**", "n**2+", "!"]
     INVALID_ESCAPE_CASES = ["\\", "n + 2 \\", "2 \\"]
     INVALID_COMMENT_CASES = ["#", "n + 2 # comment", "# x"]
@@ -317,12 +317,12 @@ class TestExceptions:
 
     @pytest.mark.parametrize("a_sub", INVALID_VARIABLE_CASES)
     def test_invalid_variable(self, a_sub: str) -> None:
-        with pytest.raises(phs.HasInvalidSymbolError):
+        with pytest.raises((phs.HasInvalidSymbolError, phs.HasInvalidVariableError)):
             phs.convert_string_to_sympy(a_sub, self.VARIABLES)
 
-    @pytest.mark.parametrize("a_sub", FUNCTION_AS_VARIABLE_CASES)
-    def test_invalid_variable(self, a_sub: str) -> None:
-        with pytest.raises(phs.HasFunctionConfusedForVariableError):
+    @pytest.mark.parametrize("a_sub", FUNCTION_NOT_CALLED_CASES)
+    def test_function_not_called(self, a_sub: str) -> None:
+        with pytest.raises(phs.FunctionNameUsedWithoutArguments):
             phs.convert_string_to_sympy(a_sub, self.VARIABLES)
 
     @pytest.mark.parametrize("a_sub", INVALID_PARSE_CASES)


### PR DESCRIPTION
This is the better solution to the student confusion that sparked #9322 (oh well):

In my case, I had a custom function `B(x)`. Two students who didn't really understand what was going on tried to write things like `1/B * x` in their answer, and were confused by the error message that `B` was an invalid variable name ("how am I supposed to write the answer???"). This makes it clearer.

(Not super happy with either the class name or the wording of the error message, very happy to hear better suggestions.)