### PR TITLE
Upgrade pandas, install pyarrow

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -12,10 +12,11 @@ networkx==3.2.1
 nltk==3.8.1
 numpy==1.26.3
 openpyxl==3.1.2
-pandas==2.1.4
+pandas==2.2.0
 Pillow==10.2.0
 PuLP==2.8.0
 Pygments==2.17.2
+pyarrow==15.0.0
 pygraphviz==1.6
 requests==2.31.0
 scikit-image==0.22.0

--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -16,12 +16,13 @@ nltk==3.8.1
 numpy==1.26.3
 openpyxl==3.1.2
 pandas-stubs==2.1.4.231227
-pandas==2.1.4
+pandas==2.2.0
 Pint==0.23
 psutil==5.9.8
 PuLP==2.8.0
 pycryptodome==3.20.0
 Pygments==2.17.2
+pyarrow==15.0.0
 pygments-ansi-color==0.3.0
 pygraphviz==1.6
 pyquaternion==0.9.9

--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -13,10 +13,11 @@ networkx==3.2.1
 nltk==3.8.1
 numpy==1.26.3
 openpyxl==3.1.2
-pandas==2.1.4
+pandas==2.2.0
 Pillow==10.2.0
 PuLP==2.8.0
 Pygments==2.17.2
+pyarrow==15.0.0
 pygraphviz==1.12
 requests==2.31.0
 scikit-image==0.22.0


### PR DESCRIPTION
Pandas now prints a deprecation warning if `pyarrow` is not installed, as it will become a required dependency in Pandas 3.