### PR TITLE
alt text to images in news items for accessibility, prettier'd this time

### DIFF
--- a/apps/prairielearn/src/news_items/006_manual_feedback/index.html
+++ b/apps/prairielearn/src/news_items/006_manual_feedback/index.html
@@ -72,7 +72,7 @@
       <tt>&lt;assessment&gt;_submissions_for_manual_grading.csv</tt>
     </div>
     <a href="csv_for_grading.png"
-      ><img src="csv_for_grading.png" class="card-img-top" style="max-width: 100%"
+      ><img src="csv_for_grading.png" alt="Screenshot of CSV for grading" class="card-img-top" style="max-width: 100%"
     /></a>
   </div>
 </div>

--- a/apps/prairielearn/src/news_items/006_manual_feedback/index.html
+++ b/apps/prairielearn/src/news_items/006_manual_feedback/index.html
@@ -72,7 +72,11 @@
       <tt>&lt;assessment&gt;_submissions_for_manual_grading.csv</tt>
     </div>
     <a href="csv_for_grading.png"
-      ><img src="csv_for_grading.png" alt="Screenshot of CSV for grading" class="card-img-top" style="max-width: 100%"
+      ><img
+        src="csv_for_grading.png"
+        alt="Screenshot of CSV for grading"
+        class="card-img-top"
+        style="max-width: 100%"
     /></a>
   </div>
 </div>

--- a/apps/prairielearn/src/news_items/041_element_question_writing/index.html
+++ b/apps/prairielearn/src/news_items/041_element_question_writing/index.html
@@ -41,7 +41,7 @@
         immediately, while the third is only shown after three valid submissions.
       </p>
 
-      <img class="border rounded" src="pl-hidden-hints.png" width="800px" />
+      <img class="border rounded" src="pl-hidden-hints.png" alt="Screenshot showing three hints" width="800px" />
 
       <p>
         For more information and examples, see the
@@ -62,9 +62,9 @@
         for technically correct but non-optimal answers.
       </p>
 
-      <img class="border rounded" src="pl-big-o-question.png" width="600px" />
-      <img class="border rounded" src="pl-big-o-incorrect.png" width="600px" />
-      <img class="border rounded" src="pl-big-o-correct.png" width="600px" />
+      <img class="border rounded" src="pl-big-o-question.png" alt="Screenshot of question" width="600px" />
+      <img class="border rounded" src="pl-big-o-incorrect.png" alt="Screenshot of incorrect response" width="600px" />
+      <img class="border rounded" src="pl-big-o-correct.png" alt="Screenshot of correct response" width="600px" />
 
       <p>
         For more information and examples, see the
@@ -87,7 +87,7 @@
         serialization.
       </p>
 
-      <img class="border rounded" src="pl-dataframe.png" width="600px" />
+      <img class="border rounded" src="pl-dataframe.png" alt="Screenshot of DataFrame" width="600px" />
 
       <p>
         For more information and examples, see the
@@ -114,7 +114,7 @@
       easier to print complex dictionaries and other nested data types.
     </p>
 
-    <img class="border rounded" src="pl-python-variable.png" width="800px" />
+    <img class="border rounded" src="pl-python-variable.png" alt="Screenshot displaying a complex dictionary" width="800px" />
 
     <p>
       For more information and examples, see the
@@ -156,7 +156,7 @@
       and now has support for displaying <a href="https://networkx.org/">NetworkX</a> graphs.
     </p>
 
-    <img class="border rounded" src="pl-graph.png" width="800px" />
+    <img class="border rounded" src="pl-graph.png" alt="Screenshot of a rendered graph" width="800px" />
 
     <p>
       For more information and examples, see the

--- a/apps/prairielearn/src/news_items/041_element_question_writing/index.html
+++ b/apps/prairielearn/src/news_items/041_element_question_writing/index.html
@@ -41,7 +41,12 @@
         immediately, while the third is only shown after three valid submissions.
       </p>
 
-      <img class="border rounded" src="pl-hidden-hints.png" alt="Screenshot showing three hints" width="800px" />
+      <img
+        class="border rounded"
+        src="pl-hidden-hints.png"
+        alt="Screenshot showing three hints"
+        width="800px"
+      />
 
       <p>
         For more information and examples, see the
@@ -62,9 +67,24 @@
         for technically correct but non-optimal answers.
       </p>
 
-      <img class="border rounded" src="pl-big-o-question.png" alt="Screenshot of question" width="600px" />
-      <img class="border rounded" src="pl-big-o-incorrect.png" alt="Screenshot of incorrect response" width="600px" />
-      <img class="border rounded" src="pl-big-o-correct.png" alt="Screenshot of correct response" width="600px" />
+      <img
+        class="border rounded"
+        src="pl-big-o-question.png"
+        alt="Screenshot of question"
+        width="600px"
+      />
+      <img
+        class="border rounded"
+        src="pl-big-o-incorrect.png"
+        alt="Screenshot of incorrect response"
+        width="600px"
+      />
+      <img
+        class="border rounded"
+        src="pl-big-o-correct.png"
+        alt="Screenshot of correct response"
+        width="600px"
+      />
 
       <p>
         For more information and examples, see the
@@ -87,7 +107,12 @@
         serialization.
       </p>
 
-      <img class="border rounded" src="pl-dataframe.png" alt="Screenshot of DataFrame" width="600px" />
+      <img
+        class="border rounded"
+        src="pl-dataframe.png"
+        alt="Screenshot of DataFrame"
+        width="600px"
+      />
 
       <p>
         For more information and examples, see the
@@ -114,7 +139,12 @@
       easier to print complex dictionaries and other nested data types.
     </p>
 
-    <img class="border rounded" src="pl-python-variable.png" alt="Screenshot displaying a complex dictionary" width="800px" />
+    <img
+      class="border rounded"
+      src="pl-python-variable.png"
+      alt="Screenshot displaying a complex dictionary"
+      width="800px"
+    />
 
     <p>
       For more information and examples, see the
@@ -156,7 +186,12 @@
       and now has support for displaying <a href="https://networkx.org/">NetworkX</a> graphs.
     </p>
 
-    <img class="border rounded" src="pl-graph.png" alt="Screenshot of a rendered graph" width="800px" />
+    <img
+      class="border rounded"
+      src="pl-graph.png"
+      alt="Screenshot of a rendered graph"
+      width="800px"
+    />
 
     <p>
       For more information and examples, see the

--- a/apps/prairielearn/src/news_items/043_units_element/index.html
+++ b/apps/prairielearn/src/news_items/043_units_element/index.html
@@ -35,22 +35,22 @@
   submissions like <code>100 cm</code> or <code>1000 mm</code> are also accepted.
 </p>
 
-<img class="border rounded" src="pl-units-input.png" width="800px" />
+<img class="border rounded" src="pl-units-input.png" alt="Screenshot of a problem requring units" width="800px" />
 
 <p>
   Below are submission panels for correct answers. For the second one, the comparison was performed
   independent of units and within the given tolerance (1cm).
 </p>
 
-<img class="border rounded" src="pl-units-input-correct.png" width="400px" />
-<img class="border rounded" src="pl-units-input-correct-2.png" width="400px" />
+<img class="border rounded" src="pl-units-input-correct.png" alt="Screenshot of submission of 1m" width="400px" />
+<img class="border rounded" src="pl-units-input-correct-2.png" alt="Screenshot of submission of 1001mm" width="400px" />
 
 <p>
   In the following example, the student used an incompatible unit (<code>cm^3</code> instead of
   <code>m</code>), resulting in an answer tagged as incorrect.
 </p>
 
-<img class="border rounded" src="pl-units-input-incorrect.png" width="600px" />
+<img class="border rounded" src="pl-units-input-incorrect.png" alt="Screenshot of submission with an incompatible unit" width="600px" />
 
 <p>
   Additional comparison methods are available without this automated conversion, along with other

--- a/apps/prairielearn/src/news_items/043_units_element/index.html
+++ b/apps/prairielearn/src/news_items/043_units_element/index.html
@@ -35,22 +35,42 @@
   submissions like <code>100 cm</code> or <code>1000 mm</code> are also accepted.
 </p>
 
-<img class="border rounded" src="pl-units-input.png" alt="Screenshot of a problem requring units" width="800px" />
+<img
+  class="border rounded"
+  src="pl-units-input.png"
+  alt="Screenshot of a problem requring units"
+  width="800px"
+/>
 
 <p>
   Below are submission panels for correct answers. For the second one, the comparison was performed
   independent of units and within the given tolerance (1cm).
 </p>
 
-<img class="border rounded" src="pl-units-input-correct.png" alt="Screenshot of submission of 1m" width="400px" />
-<img class="border rounded" src="pl-units-input-correct-2.png" alt="Screenshot of submission of 1001mm" width="400px" />
+<img
+  class="border rounded"
+  src="pl-units-input-correct.png"
+  alt="Screenshot of submission of 1m"
+  width="400px"
+/>
+<img
+  class="border rounded"
+  src="pl-units-input-correct-2.png"
+  alt="Screenshot of submission of 1001mm"
+  width="400px"
+/>
 
 <p>
   In the following example, the student used an incompatible unit (<code>cm^3</code> instead of
   <code>m</code>), resulting in an answer tagged as incorrect.
 </p>
 
-<img class="border rounded" src="pl-units-input-incorrect.png" alt="Screenshot of submission with an incompatible unit" width="600px" />
+<img
+  class="border rounded"
+  src="pl-units-input-incorrect.png"
+  alt="Screenshot of submission with an incompatible unit"
+  width="600px"
+/>
 
 <p>
   Additional comparison methods are available without this automated conversion, along with other

--- a/apps/prairielearn/src/news_items/043_units_element/index.html
+++ b/apps/prairielearn/src/news_items/043_units_element/index.html
@@ -38,7 +38,7 @@
 <img
   class="border rounded"
   src="pl-units-input.png"
-  alt="Screenshot of a problem requring units"
+  alt="Screenshot of a problem requiring units"
   width="800px"
 />
 


### PR DESCRIPTION
Alt text added to screenshot images included with three news items to satisfy WCAG 2.1 level A 1.1.1 Non-text Content ("Image missing a text alternative").

Files formatted with prettier.