### PR TITLE
Fix handling of rubric settings with no items

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -452,6 +452,7 @@ function deleteRow(event) {
     table.querySelector('.js-no-rubric-item-note').classList.remove('d-none');
   }
   updateRubricItemOrderField();
+  checkRubricItemTotals();
 }
 
 function rowDragStart(event) {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -139,18 +139,20 @@ const PostBodySchema = z.union([
       .literal('true')
       .optional()
       .transform((val) => val === 'true'),
-    rubric_item: z.record(
-      z.string(),
-      z.object({
-        id: z.string().optional(),
-        order: z.coerce.number(),
-        points: z.coerce.number(),
-        description: z.string(),
-        explanation: z.string().optional(),
-        grader_note: z.string().optional(),
-        always_show_to_students: z.string().transform((val) => val === 'true'),
-      }),
-    ),
+    rubric_item: z
+      .record(
+        z.string(),
+        z.object({
+          id: z.string().optional(),
+          order: z.coerce.number(),
+          points: z.coerce.number(),
+          description: z.string(),
+          explanation: z.string().optional(),
+          grader_note: z.string().optional(),
+          always_show_to_students: z.string().transform((val) => val === 'true'),
+        }),
+      )
+      .default({}),
   }),
   z.object({
     __action: z.custom<`reassign_${string}`>(

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -221,7 +221,7 @@ router.post(
           body.starting_points,
           body.min_points,
           body.max_extra_points,
-          Object.values(body.rubric_item || {}), // rubric items
+          Object.values(body.rubric_item), // rubric items
           body.tag_for_manual_grading,
           res.locals.authn_user.user_id,
         );


### PR DESCRIPTION
When rubric settings are set, if there are no rubric items, an error is supposed to show "No rubric items were provided". Due to a Zod issue, though, this error was not properly shown, rather a "System error" was returned with an issue being reported in Sentry. This PR fixes the Zod schema so that the error can be properly handled by the custom check instead of the Zod handler.