### PR TITLE
Use correct base images in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,17 +236,25 @@ jobs:
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
           no-cache: true
           tags: prairielearn/plbase:${{ env.COMMIT_SHA }}
+        
+      # This ensures that the `prairielearn/prairielearn` image is built with the
+      # correct version of `prairielearn/plbase`. We'll only tag this as `latest`
+      # if we actually built it; if it wasn't built, we don't tag it, so Docker will
+      # correctly fall back to pulling the `latest` version from the registry.
+      - name: Tag plbase image as latest
+        if: ${{ env.images_plbase_modified }}
+        run: docker tag prairielearn/plbase:${{ env.COMMIT_SHA }} prairielearn/plbase:latest
 
       - name: Build the prairielearn docker image
         run: docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} .
-        env:
-          PRAIRIELEARN_IMAGE_TAG: ${{ env.COMMIT_SHA }}
+      
+      # This ensures that the `prairielearn/executor` image is built with the
+      # correct version of `prairielearn/prairielearn`.
       - name: Tag prairielearn image as latest
         run: docker tag prairielearn/prairielearn:${{ env.COMMIT_SHA }} prairielearn/prairielearn:latest
+
       - name: Build executor image
         run: docker build ./images/executor --tag prairielearn/executor:${{ env.COMMIT_SHA }}
-        env:
-          PRAIRIELEARN_IMAGE_TAG: ${{ env.COMMIT_SHA }}
       - name: Tag executor image as latest
         run: docker tag prairielearn/executor:${{ env.COMMIT_SHA }} prairielearn/executor:latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,7 +236,7 @@ jobs:
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
           no-cache: true
           tags: prairielearn/plbase:${{ env.COMMIT_SHA }}
-        
+
       # This ensures that the `prairielearn/prairielearn` image is built with the
       # correct version of `prairielearn/plbase`. We'll only tag this as `latest`
       # if we actually built it; if it wasn't built, we don't tag it, so Docker will
@@ -247,7 +247,7 @@ jobs:
 
       - name: Build the prairielearn docker image
         run: docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} .
-      
+
       # This ensures that the `prairielearn/executor` image is built with the
       # correct version of `prairielearn/prairielearn`.
       - name: Tag prairielearn image as latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:master-labs
 
-FROM prairielearn/plbase:${PRAIRIELEARN_IMAGE_TAG:-latest}
+FROM prairielearn/plbase:latest
 
 ENV PATH="/PrairieLearn/node_modules/.bin:$PATH"
 

--- a/images/executor/Dockerfile
+++ b/images/executor/Dockerfile
@@ -1,4 +1,4 @@
-FROM prairielearn/prairielearn:${PRAIRIELEARN_IMAGE_TAG:-latest}
+FROM prairielearn/prairielearn:latest
 WORKDIR /PrairieLearn/
 
 # Create our unprivileged user


### PR DESCRIPTION
My usage of `PRAIRIELEARN_IMAGE_TAG` before was just flat-out wrong, so we were always defaulting to `latest` in the Dockerfiles changed here. In practice, we never really noticed a difference, but the change here is still objectively the correct thing to do.