### PR TITLE
Explicitly install util-linux in graders/python

### DIFF
--- a/graders/python/install.sh
+++ b/graders/python/install.sh
@@ -3,6 +3,7 @@
 dnf -y update
 
 dnf install -y \
+    util-linux \
     sudo \
     gcc \
     make \


### PR DESCRIPTION
The recent change to use AL2023 as the base image in #9373 meant that we were missing `su` and `uuidgen`. These are both provided by the `util-linux` package, which was installed as a dependency of one of other other installs in AL2, but not anymore in AL2023. This PR explicitly installs this package.

I've verified that we can successfully grade python questions with this change.