### PR TITLE
Fix handling of rubric grading with more than 22 selected items

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -176,6 +176,7 @@ router.post(
       // we don't want to double-handle, so we always receive an object and
       // convert it to an array if necessary
       // (https://github.com/ljharb/qs#parsing-arrays).
+      // The order of the items in arrays is never important, so using Object.values is fine.
       qs.parse(qs.stringify(req.body), { parseArrays: false }),
     );
     if (body.__action === 'add_manual_grade') {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -112,6 +112,9 @@ const PostBodySchema = z.union([
     submission_id: IdSchema,
     modified_at: z.string(),
     rubric_item_selected_manual: IdSchema.or(IdSchema.array())
+      // For 22+ items, qs will convert the array to an object. This converts it back.
+      // (https://github.com/ljharb/qs#parsing-arrays)
+      .or(z.record(z.string(), IdSchema).transform((val) => Object.values(val)))
       .nullish()
       .transform((val) => (val == null ? [] : Array.isArray(val) ? val : [val])),
     score_manual_adjust_points: z.coerce.number().nullish(),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -180,7 +180,6 @@ router.post(
       qs.parse(qs.stringify(req.body), { parseArrays: false }),
     );
     if (body.__action === 'add_manual_grade') {
-      console.log(req.body.rubric_item_selected_manual, body.rubric_item_selected_manual);
       const manual_rubric_data = res.locals.assessment_question.manual_rubric_id
         ? {
             rubric_id: res.locals.assessment_question.manual_rubric_id,


### PR DESCRIPTION
As reported on Slack. In situations with 22 or more rubric items are selected, a Zod error was shown. This was caused the library used to parse the body (`qs`), which will use an object instead of an array when the index is any number over 20.

While it is possible to change `qs` to increase the array limit, any specified limit would be arbitrary. Instead, objects were embraced with a direct transformation into an array using `Object.values` (given the order of the array elements is not important).