### PR TITLE
Drop legacy scheduler columns

### DIFF
--- a/apps/prairielearn/src/migrations/20240206175554_users__drop_scheduler_columns.sql
+++ b/apps/prairielearn/src/migrations/20240206175554_users__drop_scheduler_columns.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users
+DROP COLUMN IF EXISTS receive_email;
+
+ALTER TABLE users
+DROP COLUMN IF EXISTS receive_sms;
+
+ALTER TABLE users
+DROP COLUMN IF EXISTS sms_number;


### PR DESCRIPTION
These columns were added to PrairieLearn tables by the legacy CBTF scheduler in some of our production environments. Let's get rid of them!