### PR TITLE
Modernize display of course settings

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ejs
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ejs
@@ -17,58 +17,147 @@
             });
         </script>
         <%- include('../partials/navbar'); %>
-        <main id="content" class="container-fluid">
+        <main id="content" class="container mb-5 px-0">
             <%- include('../partials/courseSyncErrorsAndWarnings'); %>
-            <div class="card mb-4">
-                <div class="card-header bg-primary text-white d-flex">
-                    Course <%= course.short_name %>
-                </div>
-                <table class="table table-sm table-hover two-column-description">
-                    <tbody>
-                        <tr><th>Short Name</th><td><%= course.short_name %></td></tr>
-                        <tr><th>Title</th><td><%= course.title %></td></tr>
-                        <tr><th>Institution</th><td><%= institution.short_name %> (<%= institution.long_name %>)</td></tr>
-                        <tr><th>Timezone</th><td><%= course.display_timezone %></td></tr>
-                        <tr><th>Path</th><td><%= course.path %></td></tr>
-                        <tr><th>Repository</th><td><%= course.repository %></td></tr>
-                        <tr><th>Configuration</th>
-                            <td>
-                                <% if (locals.needToSync) { %>
-                                    <% if (authz_data.has_course_permission_edit && (! course.example_course)) { %>
-                                        <span class="text-danger">You must <a href="<%= urlPrefix %>/<%= navPage %>/syncs">sync your course</a> before viewing or editing its configuration</span>
-                                    <% } else { %>
-                                        <span class="text-danger">A course editor must sync this course before anyone can view or edit its configuration</span>
-                                    <% } %>
-                                <% } else if (locals.noInfo) { %>
-                                    <span class="text-danger">Missing configuration file</span>
-                                    <% if (authz_data.has_course_permission_edit && (! course.example_course)) { %>
-                                        <form name="add-configuration-form" class="d-inline" method="POST">
-                                            <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
-                                            <button name="__action" value="add_configuration" class="btn btn-xs btn-secondary mx-2">
-                                                <i class="fa fa-edit"></i>
-                                                <span class="d-none d-sm-inline">Create infoCourse.json</span>
-                                            </button>
-                                        </form>
-                                    <% } %>
-                                <% } else { %>
-                                    <% if (authz_data.has_course_permission_view) { %>
-                                        <a href="<%= urlPrefix %>/<%= navPage %>/file_view/infoCourse.json">
-                                            infoCourse.json
-                                        </a>
-                                        <% if (authz_data.has_course_permission_edit && (! course.example_course)) { %>
-                                            <a tabindex="0" class="btn btn-xs btn-secondary mx-2" role="button" href="<%= urlPrefix %>/<%= navPage %>/file_edit/infoCourse.json">
-                                                <i class="fa fa-edit"></i>
-                                                <span>Edit</span>
-                                            </a>
-                                        <% } %>
-                                    <% } else { %>
-                                        infoCourse.json
-                                    <% } %>
-                                <% } %>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+            <div class="card">
+            <div class="card-header bg-primary text-white d-flex mb-2">
+                <h2 class="h4">
+                    Course Settings
+                </h2>
+            </div>
+            <form class="mb-3 mx-4">
+                <div class="form-group">
+                    <label for="short_name">Short Name</label>
+                    <input 
+                      type="text"
+                      class="form-control" 
+                      id="short_name" 
+                      name="short_name" 
+                      value="<%= course.short_name %>" 
+                      disabled
+                    >
+                    <small class="form-text text-muted">
+                        The short name of the course. Often this is the course rubric
+                        and number (e.g., "MATH 101" or "PHYS 440").
+                    </small>
+                  </div>
+                  <div class="form-group">
+                    <label for="title">Title</label>
+                    <input 
+                      type="text"
+                      class="form-control" 
+                      id="title" 
+                      name="title" 
+                      value="<%= course.title %>" 
+                      disabled
+                    >
+                    <small class="form-text text-muted">
+                        This is the official title of the course, as given in the course catalog.
+                    </small>
+                  </div>
+                  <div class="form-group">
+                    <label for="institution">Institution</label>
+                    <input 
+                      type="text"
+                      class="form-control" 
+                      id="institution" 
+                      name="institution" 
+                      value="<%= institution.short_name %> (<%= institution.long_name %>)" 
+                      disabled
+                    >
+                    <small class="form-text text-muted">
+                      This is your academic institution (e.g., "University of Illinois").
+                    </small>
+                  </div>
+                  <div class="form-group">
+                    <label for="display_timezone">Timezone</label>
+                    <input 
+                      type="text"
+                      class="form-control" 
+                      id="display_timezone" 
+                      name="display_timezone" 
+                      value="<%= course.display_timezone %>" 
+                      disabled
+                    >
+                    <small class="form-text text-muted">
+                      The allowable timezones are from the tz database. It's best to use
+                       a city-based timezone that has the same times as you.
+                    </small>
+                  </div>
+                  <div class="form-group">
+                    <label for="path">Path</label>
+                    <input 
+                      type="text"
+                      class="form-control" 
+                      id="path" 
+                      name="path" 
+                      value="<%= course.path %>" 
+                      disabled
+                    >
+                    <small class="form-text text-muted">
+                      The path where course files can be found. 
+                    </small>
+                  </div>
+                  <div class="form-group">
+                    <label for="repository">Repository</label>
+                    <input 
+                      type="text"
+                      class="form-control" 
+                      id="repository" 
+                      name="repository" 
+                      value="<%= course.repository %>" 
+                      disabled
+                    >
+                    <small class="form-text text-muted">
+                      The Github repository that can be used to sync course files. 
+                    </small>
+                  </div>
+                  <div class="form-group">
+                    <label for="configuration">Configuration</label>
+                    <div
+                      class="form-control" 
+                      id="configuration" 
+                      name="configuration" 
+                      value="infoCourse.json"
+                    >
+                      <% if (locals.needToSync) { %>
+                        <% if (authz_data.has_course_permission_edit && (! course.example_course)) { %>
+                            <span class="text-danger">You must <a href="<%= urlPrefix %>/<%= navPage %>/syncs">sync your course</a> before viewing or editing its configuration</span>
+                        <% } else { %>
+                            <span class="text-danger">A course editor must sync this course before anyone can view or edit its configuration</span>
+                        <% } %>
+                    <% } else if (locals.noInfo) { %>
+                        <span class="text-danger">Missing configuration file</span>
+                        <% if (authz_data.has_course_permission_edit && (! course.example_course)) { %>
+                            <form name="add-configuration-form" class="d-inline" method="POST">
+                                <input type="hidden" name="__csrf_token" value="<%= __csrf_token %>">
+                                <button name="__action" value="add_configuration" class="btn btn-xs btn-secondary mx-2">
+                                    <i class="fa fa-edit"></i>
+                                    <span class="d-none d-sm-inline">Create infoCourse.json</span>
+                                </button>
+                            </form>
+                        <% } %>
+                    <% } else { %>
+                        <% if (authz_data.has_course_permission_view) { %>
+                            <a href="<%= urlPrefix %>/<%= navPage %>/file_view/infoCourse.json">
+                                infoCourse.json
+                            </a>
+                            <% if (authz_data.has_course_permission_edit && (! course.example_course)) { %>
+                                <a tabindex="0" class="btn btn-xs btn-secondary mx-2" role="button" href="<%= urlPrefix %>/<%= navPage %>/file_edit/infoCourse.json">
+                                    <i class="fa fa-edit"></i>
+                                    <span>Edit</span>
+                                </a>
+                            <% } %>
+                        <% } else { %>
+                            infoCourse.json
+                        <% } %>
+                    <% } %> 
+                    </div>
+                    <small class="form-text text-muted">
+                      The configuration file for the course. 
+                    </small>
+                  </div>
+            </form>
             </div>
         </main>
     </body>


### PR DESCRIPTION
This PR is the first step in preparing to allow editing of course setting from an interface in the browser. This moves the currently displayed settings from the two-column table display into a form that will be editable in the future. This is more similar to layouts in the institution settings page or the request course page. Currently, the form fields are intentionally disabled until a future PR that introduces editing of these fields and the respective JSON files. 