### PR TITLE
Fix rpy2 with libstdc++ symlink

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -65,6 +65,26 @@ else
     python3 -m pip install --no-cache-dir -r /py_req_no_r.txt
 fi
 
+# `pyarrow` and `rpy2` conflict in a horrible way:
+#
+# - `pyarrow` will load `/usr/lib64/libstdc++.so.6.0.29`
+# - `rpy2` will load `/usr/local/lib/libstdc++.so.6.0.32`
+#
+# `pyarrow` gets autoloaded by `pandas`, which we in turn load in the zygote.
+# If someone then tries to load `rpy2` in question code, it will fail to load
+# with the following error:
+#
+# cannot load library '/usr/local/lib/R/lib/libR.so': /lib64/libstdc++.so.6: version `GLIBCXX_3.4.30' not found
+#
+# This is because `rpy2` needs a version of `libstdc++` that supports libstd++ 3.4.30,
+# but `pyarrow` has already loaded a version of `libstdc++` that only supports up to 3.4.29.
+#
+# We work around that by setting up a symlink to the newer version of `libstdc++`.
+#
+# TODO: We can probably undo this change once we're removed R and `rpy2`.
+# TODO: We could also probably remove this when Amazon Linux picks up a newer version of the `gcc` suite.
+ln -s /usr/local/lib/libstdc++.so.6 /usr/lib64/libstdc++.so.6
+
 # Clear various caches to minimize the final image size.
 dnf clean all
 conda clean --all

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -83,7 +83,7 @@ fi
 #
 # TODO: We can probably undo this change once we're removed R and `rpy2`.
 # TODO: We could also probably remove this when Amazon Linux picks up a newer version of the `gcc` suite.
-ln -s /usr/local/lib/libstdc++.so.6 /usr/lib64/libstdc++.so.6
+ln -sf /usr/local/lib/libstdc++.so.6 /usr/lib64/libstdc++.so.6
 
 # Clear various caches to minimize the final image size.
 dnf clean all


### PR DESCRIPTION
See inline comment for the majority of the details.

For posterity: another approach we considered was setting `LD_LIBRARY_PATH` in the PrairieLearn `Dockerfile`:

```
ENV LD_LIBRARY_PATH="/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:/lib64:/lib"
```

However, we felt this was much riskier than this more targeted approach. Famous last words, but this change should be very safe, as version `6.0.32` of the `libstdc++` supports all of the the same `GLIBCXX` symbols as `6.0.29`, in addition to the newer ones that `rpy2` relies on.

I'll test the built image before we merge this.