### PR TITLE
Update instance questions and points on assessment instance insert

### DIFF
--- a/apps/prairielearn/src/admin_queries/generate_assessment_instances.sql
+++ b/apps/prairielearn/src/admin_queries/generate_assessment_instances.sql
@@ -16,7 +16,6 @@ FROM
   JOIN enrollments AS e ON (e.course_instance_id = ci.id)
   JOIN users AS u ON (u.user_id = e.user_id)
   JOIN assessment_instances_insert (a.id, u.user_id, a.group_work, u.user_id, $mode) AS aii ON TRUE
-  LEFT JOIN assessment_instances_update (aii.assessment_instance_id, u.user_id) AS aiu ON (a.type = 'Homework')
 WHERE
   a.id = $assessment_id
 ORDER BY

--- a/apps/prairielearn/src/admin_queries/generate_assessment_instances_group.sql
+++ b/apps/prairielearn/src/admin_queries/generate_assessment_instances_group.sql
@@ -28,7 +28,6 @@ FROM
   ) AS lgu ON (TRUE)
   JOIN users AS u ON (u.user_id = lgu.user_id)
   JOIN assessment_instances_insert (a.id, u.user_id, a.group_work, u.user_id, $mode) AS aii ON TRUE
-  LEFT JOIN assessment_instances_update (aii.assessment_instance_id, u.user_id) AS aiu ON (a.type = 'Homework')
 WHERE
   a.id = $assessment_id
   AND g.deleted_at IS NULL

--- a/apps/prairielearn/src/sprocs/assessment_instances_insert.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_insert.sql
@@ -8,8 +8,7 @@ CREATE FUNCTION
         IN time_limit_min integer DEFAULT NULL,
         IN date timestamptz DEFAULT NULL,
         IN client_fingerprint_id bigint DEFAULT NULL,
-        OUT assessment_instance_id bigint,
-        OUT new_instance_question_ids bigint[]
+        OUT assessment_instance_id bigint
     )
 AS $$
 #variable_conflict use_column -- fix user_id reference in ON CONFLICT
@@ -130,13 +129,6 @@ BEGIN
 
     -- ######################################################################
     -- create new questions if necessary
-
-    IF assessment.type = 'Homework' THEN
-        new_instance_question_ids := array[]::bigint[];
-    ELSIF assessment.type = 'Exam' THEN
-        PERFORM assessment_instances_update(assessment_instance_id, authn_user_id);
-    ELSE
-        RAISE EXCEPTION 'invalid assessment.type: %', assessment.type;
-    END IF;
+    PERFORM assessment_instances_update(assessment_instance_id, authn_user_id);
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/apps/prairielearn/src/sprocs/assessment_instances_regrade.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_regrade.sql
@@ -30,8 +30,8 @@ BEGIN
     -- first update Homeworks
     updated := FALSE;
     IF assessment_type = 'Homework' THEN
-        SELECT updated INTO updated
-        FROM assessment_instances_update(assessment_instance_id, authn_user_id);
+        SELECT aiu.updated INTO updated
+        FROM assessment_instances_update(assessment_instance_id, authn_user_id) AS aiu;
     END IF;
 
     -- store old points/score_perc

--- a/apps/prairielearn/src/sprocs/assessment_instances_regrade.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_regrade.sql
@@ -16,7 +16,6 @@ DECLARE
     course_id bigint;
     course_instance_id bigint;
     assessment_instance_updated boolean;
-    new_instance_question_ids bigint[];
 BEGIN
     PERFORM assessment_instances_lock(assessment_instance_id);
 
@@ -31,8 +30,7 @@ BEGIN
     -- first update Homeworks
     updated := FALSE;
     IF assessment_type = 'Homework' THEN
-        SELECT *
-        INTO updated, new_instance_question_ids
+        SELECT updated INTO updated
         FROM assessment_instances_update(assessment_instance_id, authn_user_id);
     END IF;
 


### PR DESCRIPTION
In some very narrow scenarios it is plausible for a student to create an assessment instance and not open it right away (e.g., in case of network interruption between the new instance POST operation and the GET that first opens the assessment instance). For Homeworks, this could cause a scenario that does not have instance questions or points.

This PR causes the update operation (which creates instance questions and updates points) to always be executed on assessment instance creation, regardless of assessment type. This will have the minor inconvenience that the update operation will run twice on start (once when it's created during POST, once in the redirected GET), but the second update will in essence be a no-op, and as a bonus the assessment instance data will be retained from the middleware instead of being retrieved from a new query.

I also changed the related admin queries, since they no longer need to call update now. Also, `assessment_instances_insert` had an out parameter for new instance question IDs which was never used, so I removed it as well.