### PR TITLE
Don't include res.locals or req.body in error messages

### DIFF
--- a/apps/prairielearn/src/api/v1/index.js
+++ b/apps/prairielearn/src/api/v1/index.js
@@ -11,9 +11,7 @@ const router = express.Router();
  */
 function authzHasCourseInstanceView(req, res, next) {
   if (!res.locals.authz_data.has_course_instance_permission_view) {
-    return next(
-      error.make(403, 'Requires student data view access'),
-    );
+    return next(error.make(403, 'Requires student data view access'));
   }
   next();
 }

--- a/apps/prairielearn/src/api/v1/index.js
+++ b/apps/prairielearn/src/api/v1/index.js
@@ -12,9 +12,7 @@ const router = express.Router();
 function authzHasCourseInstanceView(req, res, next) {
   if (!res.locals.authz_data.has_course_instance_permission_view) {
     return next(
-      error.make(403, 'Requires student data view access', {
-        locals: res.locals,
-      }),
+      error.make(403, 'Requires student data view access'),
     );
   }
   next();

--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
@@ -246,8 +246,6 @@ async function authenticate(req: Request, res: Response): Promise<any> {
         // is too small, like with the Canvas development keys. It triggers that error in PL here.
         reject(
           error.make(400, 'Authentication failed, before user validation.', {
-            err,
-            user,
             info_raw: info,
             info: info?.toString(),
           }),

--- a/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
@@ -218,7 +218,7 @@ router.post(
       flash('success', `Instance deleted.`);
       return res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
@@ -154,10 +154,7 @@ router.post(
         flash('success', `Key ${key.kid} deleted.`);
         return res.redirect(req.originalUrl);
       } else {
-        throw error.make(500, 'error removing key', {
-          locals: res.locals,
-          body: req.body,
-        });
+        throw error.make(500, 'error removing key');
       }
     } else if (req.body.__action === 'update_platform') {
       const url = getCanonicalHost(req);
@@ -221,10 +218,7 @@ router.post(
       flash('success', `Instance deleted.`);
       return res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.ts
@@ -76,10 +76,7 @@ router.post(
         authn_user_id: res.locals.authn_user.user_id,
       });
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
 
     res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminSaml/institutionAdminSaml.ts
@@ -76,7 +76,7 @@ router.post(
         authn_user_id: res.locals.authn_user.user_id,
       });
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
 
     res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/lib/file-paths.js
+++ b/apps/prairielearn/src/lib/file-paths.js
@@ -66,11 +66,7 @@ export async function questionFilePathAsync(
     };
     const result = await sqldb.queryZeroOrOneRowAsync(sql.select_question, params);
     if (result.rowCount === 0) {
-      throw error.make(
-        500,
-        `Could not find template question "${question.template_directory}" from question "${question.directory}"`,
-        { sql: sql.select_question, params: params },
-      );
+      throw error.make(500, `Could not find template question "${question.template_directory}" from question "${question.directory}"`);
     }
 
     const templateQuestion = result.rows[0];

--- a/apps/prairielearn/src/lib/file-paths.js
+++ b/apps/prairielearn/src/lib/file-paths.js
@@ -66,7 +66,10 @@ export async function questionFilePathAsync(
     };
     const result = await sqldb.queryZeroOrOneRowAsync(sql.select_question, params);
     if (result.rowCount === 0) {
-      throw error.make(500, `Could not find template question "${question.template_directory}" from question "${question.directory}"`);
+      throw error.make(
+        500,
+        `Could not find template question "${question.template_directory}" from question "${question.directory}"`,
+      );
     }
 
     const templateQuestion = result.rows[0];

--- a/apps/prairielearn/src/lib/questionPreview.js
+++ b/apps/prairielearn/src/lib/questionPreview.js
@@ -18,9 +18,7 @@ export function processSubmission(req, res, callback) {
     try {
       postData = JSON.parse(req.body.postData);
     } catch (e) {
-      return callback(
-        error.make(400, 'JSON parse failed on body.postData'),
-      );
+      return callback(error.make(400, 'JSON parse failed on body.postData'));
     }
     variant_id = postData.variant ? postData.variant.id : null;
     submitted_answer = postData.submittedAnswer;
@@ -55,9 +53,7 @@ export function processSubmission(req, res, callback) {
           callback(null, submission.variant_id);
         });
       } else {
-        callback(
-          error.make(400, `unknown __action: ${req.body.__action}`),
-        );
+        callback(error.make(400, `unknown __action: ${req.body.__action}`));
       }
     },
   );

--- a/apps/prairielearn/src/lib/questionPreview.js
+++ b/apps/prairielearn/src/lib/questionPreview.js
@@ -56,7 +56,7 @@ export function processSubmission(req, res, callback) {
         });
       } else {
         callback(
-          error.make(400, 'unknown __action'),
+          error.make(400, `unknown __action: ${req.body.__action}`),
         );
       }
     },

--- a/apps/prairielearn/src/lib/questionPreview.js
+++ b/apps/prairielearn/src/lib/questionPreview.js
@@ -12,17 +12,14 @@ export function processSubmission(req, res, callback) {
     submitted_answer = _.omit(req.body, ['__action', '__csrf_token', '__variant_id']);
   } else {
     if (!req.body.postData) {
-      return callback(error.make(400, 'No postData', { locals: res.locals, body: req.body }));
+      return callback(error.make(400, 'No postData'));
     }
     let postData;
     try {
       postData = JSON.parse(req.body.postData);
     } catch (e) {
       return callback(
-        error.make(400, 'JSON parse failed on body.postData', {
-          locals: res.locals,
-          body: req.body,
-        }),
+        error.make(400, 'JSON parse failed on body.postData'),
       );
     }
     variant_id = postData.variant ? postData.variant.id : null;
@@ -59,10 +56,7 @@ export function processSubmission(req, res, callback) {
         });
       } else {
         callback(
-          error.make(400, 'unknown __action', {
-            locals: res.locals,
-            body: req.body,
-          }),
+          error.make(400, 'unknown __action'),
         );
       }
     },

--- a/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.js
+++ b/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.js
@@ -9,9 +9,7 @@ module.exports = function (req, res, next) {
     !res.locals.authz_data.authn_has_course_instance_permission_view
   ) {
     return next(
-      error.make(403, 'Requires either course preview access or student data view access', {
-        locals: res.locals,
-      }),
+      error.make(403, 'Requires either course preview access or student data view access'),
     );
   }
   next();

--- a/apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.js
+++ b/apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.js
@@ -11,6 +11,6 @@ module.exports = function (req, res, next) {
   ) {
     return next();
   } else {
-    return next(error.make(403, 'Access denied', { locals: res.locals }));
+    return next(error.make(403, 'Access denied'));
   }
 };

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreview.js
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreview.js
@@ -2,7 +2,7 @@ const error = require('@prairielearn/error');
 
 module.exports = function (req, res, next) {
   if (!res.locals.authz_data.has_course_permission_preview) {
-    return next(error.make(403, 'Requires course preview access', { locals: res.locals }));
+    return next(error.make(403, 'Requires course preview access'));
   }
   next();
 };

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.js
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.js
@@ -9,9 +9,7 @@ module.exports = function (req, res, next) {
     !res.locals.authz_data.has_course_instance_permission_view
   ) {
     return next(
-      error.make(403, 'Requires either course preview access or student data view access', {
-        locals: res.locals,
-      }),
+      error.make(403, 'Requires either course preview access or student data view access'),
     );
   }
   next();

--- a/apps/prairielearn/src/middlewares/authzIsAdministrator.js
+++ b/apps/prairielearn/src/middlewares/authzIsAdministrator.js
@@ -3,9 +3,7 @@ const error = require('@prairielearn/error');
 module.exports = function (req, res, next) {
   if (!res.locals.is_administrator) {
     return next(
-      error.make(403, 'Requires administrator privileges', {
-        locals: res.locals,
-      }),
+      error.make(403, 'Requires administrator privileges'),
     );
   }
   next();

--- a/apps/prairielearn/src/middlewares/authzIsAdministrator.js
+++ b/apps/prairielearn/src/middlewares/authzIsAdministrator.js
@@ -2,9 +2,7 @@ const error = require('@prairielearn/error');
 
 module.exports = function (req, res, next) {
   if (!res.locals.is_administrator) {
-    return next(
-      error.make(403, 'Requires administrator privileges'),
-    );
+    return next(error.make(403, 'Requires administrator privileges'));
   }
   next();
 };

--- a/apps/prairielearn/src/middlewares/csrfToken.js
+++ b/apps/prairielearn/src/middlewares/csrfToken.js
@@ -26,11 +26,7 @@ module.exports = function (req, res, next) {
     debug(`POST: __csrf_token = ${__csrf_token}`);
     if (!checkSignedToken(__csrf_token, tokenData, config.secretKey)) {
       return next(
-        error.make(403, 'CSRF fail', {
-          locals: res.locals,
-          tokenData,
-          __csrf_token,
-        }),
+        error.make(403, 'CSRF fail'),
       );
     }
   }

--- a/apps/prairielearn/src/middlewares/csrfToken.js
+++ b/apps/prairielearn/src/middlewares/csrfToken.js
@@ -25,9 +25,7 @@ module.exports = function (req, res, next) {
       : req.body.__csrf_token;
     debug(`POST: __csrf_token = ${__csrf_token}`);
     if (!checkSignedToken(__csrf_token, tokenData, config.secretKey)) {
-      return next(
-        error.make(403, 'CSRF fail'),
-      );
+      return next(error.make(403, 'CSRF fail'));
     }
   }
   next();

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
@@ -35,7 +35,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', { locals: res.locals, body: req.body });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
@@ -35,7 +35,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.js
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.js
@@ -33,10 +33,7 @@ router.post(
     } else if (req.body.__action === 'create_course_from_request') {
       await createCourseFromRequest(req, res);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.js
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.js
@@ -33,7 +33,7 @@ router.post(
     } else if (req.body.__action === 'create_course_from_request') {
       await createCourseFromRequest(req, res);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.js
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.js
@@ -82,7 +82,7 @@ router.post(
     } else if (req.body.__action === 'create_course_from_request') {
       await createCourseFromRequest(req, res);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.js
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.js
@@ -82,10 +82,7 @@ router.post(
     } else if (req.body.__action === 'create_course_from_request') {
       await createCourseFromRequest(req, res);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
@@ -31,9 +31,7 @@ router.post(
         uid_regexp: req.body.uid_regexp.trim() || null,
       });
     } else {
-      throw error.make(400, 'Unknown action', {
-        body: req.body,
-      });
+      throw error.make(400, 'Unknown action');
     }
 
     res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -40,7 +40,7 @@ router.post(
       const jobSequenceId = await chunks.generateAllChunksForCourseList(course_ids, authn_user_id);
       res.redirect(res.locals.urlPrefix + '/administrator/jobSequence/' + jobSequenceId);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -40,7 +40,7 @@ router.post(
       const jobSequenceId = await chunks.generateAllChunksForCourseList(course_ids, authn_user_id);
       res.redirect(res.locals.urlPrefix + '/administrator/jobSequence/' + jobSequenceId);
     } else {
-      throw error.make(400, 'unknown __action', { locals: res.locals, body: req.body });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
+++ b/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
@@ -10,10 +10,7 @@ router.get('/*', function (req, res, next) {
   const filename = req.params[0];
   if (!filename) {
     return next(
-      error.make(400, 'No filename provided within clientFilesAssessment directory', {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'No filename provided within clientFilesAssessment directory'),
     );
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);

--- a/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
+++ b/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
@@ -9,9 +9,7 @@ const ERR = require('async-stacktrace');
 router.get('/*', function (req, res, next) {
   const filename = req.params[0];
   if (!filename) {
-    return next(
-      error.make(400, 'No filename provided within clientFilesAssessment directory'),
-    );
+    return next(error.make(400, 'No filename provided within clientFilesAssessment directory'));
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
   const chunk = {

--- a/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
+++ b/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
@@ -13,10 +13,7 @@ router.get(
   asyncHandler(async function (req, res) {
     const filename = req.params[0];
     if (!filename) {
-      throw error.make(400, 'No filename provided within clientFilesCourse directory', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'No filename provided within clientFilesCourse directory');
     }
     const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
     await chunks.ensureChunksForCourseAsync(res.locals.course.id, { type: 'clientFilesCourse' });

--- a/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
+++ b/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
@@ -10,10 +10,7 @@ router.get('/*', function (req, res, next) {
   const filename = req.params[0];
   if (!filename) {
     return next(
-      error.make(400, 'No filename provided within clientFilesCourseInstance directory', {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'No filename provided within clientFilesCourseInstance directory'),
     );
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);

--- a/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
+++ b/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
@@ -9,9 +9,7 @@ const ERR = require('async-stacktrace');
 router.get('/*', function (req, res, next) {
   const filename = req.params[0];
   if (!filename) {
-    return next(
-      error.make(400, 'No filename provided within clientFilesCourseInstance directory'),
-    );
+    return next(error.make(400, 'No filename provided within clientFilesCourseInstance directory'));
   }
   const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
   const chunk = {

--- a/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
+++ b/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
@@ -16,10 +16,7 @@ module.exports = function (options = { publicEndpoint: false }) {
     asyncHandler(async function (req, res) {
       const filename = req.params[0];
       if (!filename) {
-        throw error.make(400, 'No filename provided within clientFilesQuestion directory', {
-          locals: res.locals,
-          body: req.body,
-        });
+        throw error.make(400, 'No filename provided within clientFilesQuestion directory');
       }
 
       if (options.publicEndpoint) {

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
@@ -137,10 +137,7 @@ router.post(
       const jobSequenceId = await syncHelpers.ecrUpdate(images, res.locals);
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
@@ -137,7 +137,7 @@ router.post(
       const jobSequenceId = await syncHelpers.ecrUpdate(images, res.locals);
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/editError/editError.js
+++ b/apps/prairielearn/src/pages/editError/editError.js
@@ -93,9 +93,7 @@ router.post('/:job_sequence_id', (req, res, next) => {
       })
       .catch((err) => ERR(err, next));
   } else {
-    return next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    return next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/editError/editError.js
+++ b/apps/prairielearn/src/pages/editError/editError.js
@@ -94,10 +94,7 @@ router.post('/:job_sequence_id', (req, res, next) => {
       .catch((err) => ERR(err, next));
   } else {
     return next(
-      error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action'),
     );
   }
 });

--- a/apps/prairielearn/src/pages/editError/editError.js
+++ b/apps/prairielearn/src/pages/editError/editError.js
@@ -94,7 +94,7 @@ router.post('/:job_sequence_id', (req, res, next) => {
       .catch((err) => ERR(err, next));
   } else {
     return next(
-      error.make(400, 'unknown __action'),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/enroll/enroll.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.ts
@@ -102,10 +102,7 @@ router.post(
       flash('success', `You have left ${courseDisplayName}.`);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown action: ' + res.locals.__action, {
-        __action: req.body.__action,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown action: ' + res.locals.__action);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
@@ -173,10 +173,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.js
@@ -173,7 +173,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -223,9 +223,7 @@ router.post(
       });
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, `unknown __action: ${req.body.__action}`, {
-        body: req.body,
-      });
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
@@ -195,9 +195,7 @@ router.post(
       await sqldb.queryAsync(sql.set_time_limit_all, params);
       res.send(JSON.stringify({}));
     } else {
-      throw error.make(400, 'unknown __action', {
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
@@ -195,7 +195,7 @@ router.post(
       await sqldb.queryAsync(sql.set_time_limit_all, params);
       res.send(JSON.stringify({}));
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
@@ -111,9 +111,7 @@ router.post(
       }
       res.send({});
     } else {
-      return next(
-        error.make(400, `unknown __action: ${req.body.__action}`),
-      );
+      return next(error.make(400, `unknown __action: ${req.body.__action}`));
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
@@ -112,7 +112,7 @@ router.post(
       res.send({});
     } else {
       return next(
-        error.make(400, 'unknown __action'),
+        error.make(400, `unknown __action: ${req.body.__action}`),
       );
     }
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.js
@@ -112,10 +112,7 @@ router.post(
       res.send({});
     } else {
       return next(
-        error.make(400, 'unknown __action', {
-          locals: res.locals,
-          body: req.body,
-        }),
+        error.make(400, 'unknown __action'),
       );
     }
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -255,10 +255,7 @@ router.post(
         ),
       );
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -255,7 +255,7 @@ router.post(
         ),
       );
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
@@ -135,7 +135,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.js
@@ -135,10 +135,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.js
@@ -90,9 +90,7 @@ router.post(
       });
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, `unknown __action: ${req.body.__action}`, {
-        body: req.body,
-      });
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
@@ -44,7 +44,7 @@ router.post('/', function (req, res, next) {
     );
   } else {
     return next(
-      error.make(400, 'unknown __action'),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
@@ -43,9 +43,7 @@ router.post('/', function (req, res, next) {
       },
     );
   } else {
-    return next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    return next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.js
@@ -44,10 +44,7 @@ router.post('/', function (req, res, next) {
     );
   } else {
     return next(
-      error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action'),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
@@ -157,7 +157,7 @@ router.post('/', function (req, res, next) {
     }
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
@@ -156,9 +156,7 @@ router.post('/', function (req, res, next) {
       });
     }
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.js
@@ -157,10 +157,7 @@ router.post('/', function (req, res, next) {
     }
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.js
@@ -54,10 +54,7 @@ router.post(
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
     } else {
-      throw error.make(400, `unknown __action: ${req.body.__action}`, {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
@@ -195,7 +195,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
@@ -194,9 +194,7 @@ router.post('/', (req, res, next) => {
       });
     });
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
@@ -195,10 +195,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
@@ -96,9 +96,7 @@ router.post('/', (req, res, next) => {
       });
     });
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
@@ -97,10 +97,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.js
@@ -97,7 +97,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
@@ -73,9 +73,7 @@ router.post('/', (req, res, next) => {
       });
     });
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
@@ -74,10 +74,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.js
@@ -74,7 +74,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
@@ -94,10 +94,7 @@ router.post(
         course_id: res.locals.course.id,
       });
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
     res.redirect(req.originalUrl);
   }),

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
@@ -94,7 +94,7 @@ router.post(
         course_id: res.locals.course.id,
       });
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
     res.redirect(req.originalUrl);
   }),

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
@@ -379,7 +379,7 @@ ${given_cp_and_cip.join(',\n')}
       await sqldb.callAsync('course_instance_permissions_delete_all', params);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
@@ -379,10 +379,7 @@ ${given_cp_and_cip.join(',\n')}
       await sqldb.callAsync('course_instance_permissions_delete_all', params);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -126,9 +126,7 @@ router.post('/', function (req, res, next) {
     res.cookie('pl_requested_data_changed', 'true');
     res.redirect(req.originalUrl);
   } else {
-    return next(
-      error.make(400, 'unknown action: ' + res.locals.__action),
-    );
+    return next(error.make(400, 'unknown action: ' + res.locals.__action));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -127,10 +127,7 @@ router.post('/', function (req, res, next) {
     res.redirect(req.originalUrl);
   } else {
     return next(
-      error.make(400, 'unknown action: ' + res.locals.__action, {
-        __action: req.body.__action,
-        body: req.body,
-      }),
+      error.make(400, 'unknown action: ' + res.locals.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -64,9 +64,7 @@ router.get('/*', (req, res, next) => {
 
   // Do not allow users to edit the exampleCourse
   if (res.locals.course.example_course) {
-    return next(
-      error.make(400, `attempting to edit file inside example course: ${workingPath}`),
-    );
+    return next(error.make(400, `attempting to edit file inside example course: ${workingPath}`));
   }
 
   // Do not allow users to edit files outside the course
@@ -207,9 +205,7 @@ router.post('/*', (req, res, next) => {
 
   // Do not allow users to edit the exampleCourse
   if (res.locals.course.example_course) {
-    return next(
-      error.make(400, `attempting to edit file inside example course: ${workingPath}`),
-    );
+    return next(error.make(400, `attempting to edit file inside example course: ${workingPath}`));
   }
 
   // Do not allow users to edit files outside the course
@@ -233,7 +229,10 @@ router.post('/*', (req, res, next) => {
     fileEdit.editHash = getHash(fileEdit.editContents);
     if (fileEdit.editHash === fileEdit.origHash) {
       return next(
-        error.make(400, `attempting to save a file without having made any changes: ${workingPath}`),
+        error.make(
+          400,
+          `attempting to save a file without having made any changes: ${workingPath}`,
+        ),
       );
     }
 
@@ -293,9 +292,7 @@ router.post('/*', (req, res, next) => {
       },
     );
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -294,7 +294,7 @@ router.post('/*', (req, res, next) => {
     );
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -65,10 +65,7 @@ router.get('/*', (req, res, next) => {
   // Do not allow users to edit the exampleCourse
   if (res.locals.course.example_course) {
     return next(
-      error.make(400, `attempting to edit file inside example course: ${workingPath}`, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, `attempting to edit file inside example course: ${workingPath}`),
     );
   }
 
@@ -80,10 +77,7 @@ router.get('/*', (req, res, next) => {
   );
   if (!contains(fileEdit.coursePath, fullPath)) {
     return next(
-      error.make(400, `attempting to edit file outside course directory: ${workingPath}`, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, `attempting to edit file outside course directory: ${workingPath}`),
     );
   }
 
@@ -214,10 +208,7 @@ router.post('/*', (req, res, next) => {
   // Do not allow users to edit the exampleCourse
   if (res.locals.course.example_course) {
     return next(
-      error.make(400, `attempting to edit file inside example course: ${workingPath}`, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, `attempting to edit file inside example course: ${workingPath}`),
     );
   }
 
@@ -229,10 +220,7 @@ router.post('/*', (req, res, next) => {
   );
   if (!contains(fileEdit.coursePath, fullPath)) {
     return next(
-      error.make(400, `attempting to edit file outside course directory: ${workingPath}`, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, `attempting to edit file outside course directory: ${workingPath}`),
     );
   }
 
@@ -245,14 +233,7 @@ router.post('/*', (req, res, next) => {
     fileEdit.editHash = getHash(fileEdit.editContents);
     if (fileEdit.editHash === fileEdit.origHash) {
       return next(
-        error.make(
-          400,
-          `attempting to save a file without having made any changes: ${workingPath}`,
-          {
-            locals: res.locals,
-            body: req.body,
-          },
-        ),
+        error.make(400, `attempting to save a file without having made any changes: ${workingPath}`),
       );
     }
 
@@ -313,10 +294,7 @@ router.post('/*', (req, res, next) => {
     );
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
@@ -140,10 +140,7 @@ router.post('/', function (req, res, next) {
     });
   } else {
     return next(
-      error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action'),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
@@ -140,7 +140,7 @@ router.post('/', function (req, res, next) {
     });
   } else {
     return next(
-      error.make(400, 'unknown __action'),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
@@ -139,9 +139,7 @@ router.post('/', function (req, res, next) {
       );
     });
   } else {
-    return next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    return next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
@@ -72,9 +72,7 @@ router.post('/', function (req, res, next) {
       res.redirect(req.originalUrl);
     });
   } else {
-    return next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    return next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
@@ -73,7 +73,7 @@ router.post('/', function (req, res, next) {
     });
   } else {
     return next(
-      error.make(400, 'unknown __action'),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
@@ -73,10 +73,7 @@ router.post('/', function (req, res, next) {
     });
   } else {
     return next(
-      error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action'),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
@@ -146,7 +146,7 @@ router.post('/', function (req, res, next) {
     }
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
@@ -146,10 +146,7 @@ router.post('/', function (req, res, next) {
     }
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.js
@@ -145,9 +145,7 @@ router.post('/', function (req, res, next) {
       });
     }
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
@@ -258,7 +258,7 @@ router.post(
       await closeAllIssuesForCourse(res.locals.course.id, res.locals.authn_user.user_id);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
@@ -258,10 +258,7 @@ router.post(
       await closeAllIssuesForCourse(res.locals.course.id, res.locals.authn_user.user_id);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
@@ -68,10 +68,7 @@ router.post('/', function (req, res, next) {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
@@ -68,7 +68,7 @@ router.post('/', function (req, res, next) {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
@@ -67,9 +67,7 @@ router.post('/', function (req, res, next) {
       );
     });
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -76,10 +76,7 @@ router.post(
         throw new Error('Not supported for externally-graded questions');
       }
     } else {
-      throw error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action: ' + req.body.__action);
     }
   }),
 );
@@ -237,10 +234,7 @@ router.post('/', function (req, res, next) {
       .catch((err) => next(err));
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -233,9 +233,7 @@ router.post('/', function (req, res, next) {
       })
       .catch((err) => next(err));
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.js
@@ -76,7 +76,7 @@ router.post(
         throw new Error('Not supported for externally-graded questions');
       }
     } else {
-      throw error.make(400, 'unknown __action: ' + req.body.__action);
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );
@@ -234,7 +234,7 @@ router.post('/', function (req, res, next) {
       .catch((err) => next(err));
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -69,9 +69,7 @@ router.post('/', (req, res, next) => {
       });
     });
   } else {
-    next(
-      error.make(400, `unknown __action: ${req.body.__action}`),
-    );
+    next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -70,10 +70,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action, {
-        locals: res.locals,
-        body: req.body,
-      }),
+      error.make(400, 'unknown __action: ' + req.body.__action),
     );
   }
 });

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -70,7 +70,7 @@ router.post('/', (req, res, next) => {
     });
   } else {
     next(
-      error.make(400, 'unknown __action: ' + req.body.__action),
+      error.make(400, `unknown __action: ${req.body.__action}`),
     );
   }
 });

--- a/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
+++ b/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
@@ -23,10 +23,7 @@ router.get('/:filename', function (req, res, next) {
     if (ERR(err, next)) return;
     if (!result.rows[0].access_allowed) {
       return next(
-        error.make(403, 'Access denied', {
-          locals: res.locals,
-          filename: filename,
-        }),
+        error.make(403, 'Access denied'),
       );
     }
 

--- a/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
+++ b/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
@@ -22,9 +22,7 @@ router.get('/:filename', function (req, res, next) {
   sqldb.queryOneRow(sql.check_client_files, params, function (err, result) {
     if (ERR(err, next)) return;
     if (!result.rows[0].access_allowed) {
-      return next(
-        error.make(403, 'Access denied'),
-      );
+      return next(error.make(403, 'Access denied'));
     }
 
     const coursePath = chunks.getRuntimeDirectoryForCourse(course);

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -54,10 +54,7 @@ router.post('/', function (req, res, next) {
         res.redirect(req.originalUrl);
       } else {
         next(
-          error.make(400, 'unknown __action: ' + req.body.__action, {
-            locals: res.locals,
-            body: req.body,
-          }),
+          error.make(400, 'unknown __action: ' + req.body.__action),
         );
       }
     })

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -54,7 +54,7 @@ router.post('/', function (req, res, next) {
         res.redirect(req.originalUrl);
       } else {
         next(
-          error.make(400, 'unknown __action: ' + req.body.__action),
+          error.make(400, `unknown __action: ${req.body.__action}`),
         );
       }
     })

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -53,9 +53,7 @@ router.post('/', function (req, res, next) {
         // we currently don't report issues for public facing previews
         res.redirect(req.originalUrl);
       } else {
-        next(
-          error.make(400, `unknown __action: ${req.body.__action}`),
-        );
+        next(error.make(400, `unknown __action: ${req.body.__action}`));
       }
     })
     .catch((err) => next(err));

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
@@ -234,7 +234,7 @@ router.post(
       res.redirect(req.originalUrl);
     } else {
       return next(
-        error.make(400, 'unknown __action'),
+        error.make(400, `unknown __action: ${req.body.__action}`),
       );
     }
   }),

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
@@ -233,9 +233,7 @@ router.post(
       );
       res.redirect(req.originalUrl);
     } else {
-      return next(
-        error.make(400, `unknown __action: ${req.body.__action}`),
-      );
+      return next(error.make(400, `unknown __action: ${req.body.__action}`));
     }
   }),
 );

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
@@ -234,10 +234,7 @@ router.post(
       res.redirect(req.originalUrl);
     } else {
       return next(
-        error.make(400, 'unknown __action', {
-          locals: res.locals,
-          body: req.body,
-        }),
+        error.make(400, 'unknown __action'),
       );
     }
   }),

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
@@ -160,7 +160,7 @@ router.post(
         }
         closeExam = true;
       } else {
-        throw error.make(400, 'unknown __action');
+        throw error.make(400, `unknown __action: ${req.body.__action}`);
       }
       const requireOpen = true;
       await assessment.gradeAssessmentInstanceAsync(
@@ -198,7 +198,7 @@ router.post(
       res.redirect(req.originalUrl);
     } else {
       next(
-        error.make(400, 'unknown __action'),
+        error.make(400, `unknown __action: ${req.body.__action}`),
       );
     }
   }),

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
@@ -123,7 +123,7 @@ router.post(
       !res.locals.authz_result.authorized_edit &&
       !res.locals.authz_data.has_course_instance_permission_edit
     ) {
-      throw error.make(403, 'Not authorized', res.locals);
+      throw error.make(403, 'Not authorized');
     }
     if (
       !res.locals.authz_result.authorized_edit &&
@@ -131,7 +131,7 @@ router.post(
         req.body.__action,
       )
     ) {
-      throw error.make(403, 'Action is only permitted to students, not staff', res.locals);
+      throw error.make(403, 'Action is only permitted to students, not staff');
     }
 
     if (req.body.__action === 'attach_file') {
@@ -160,10 +160,7 @@ router.post(
         }
         closeExam = true;
       } else {
-        throw error.make(400, 'unknown __action', {
-          locals: res.locals,
-          body: req.body,
-        });
+        throw error.make(400, 'unknown __action');
       }
       const requireOpen = true;
       await assessment.gradeAssessmentInstanceAsync(
@@ -201,10 +198,7 @@ router.post(
       res.redirect(req.originalUrl);
     } else {
       next(
-        error.make(400, 'unknown __action', {
-          locals: res.locals,
-          body: req.body,
-        }),
+        error.make(400, 'unknown __action'),
       );
     }
   }),

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
@@ -197,9 +197,7 @@ router.post(
       );
       res.redirect(req.originalUrl);
     } else {
-      next(
-        error.make(400, `unknown __action: ${req.body.__action}`),
-      );
+      next(error.make(400, `unknown __action: ${req.body.__action}`));
     }
   }),
 );

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.js
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.js
@@ -44,18 +44,13 @@ function processSubmission(req, res, callback) {
     submitted_answer = _.omit(req.body, ['__action', '__csrf_token', '__variant_id']);
   } else {
     if (!req.body.postData) {
-      return callback(error.make(400, 'No postData', { locals: res.locals, body: req.body }));
+      return callback(error.make(400, 'No postData'));
     }
     let postData;
     try {
       postData = JSON.parse(req.body.postData);
     } catch (e) {
-      return callback(
-        error.make(400, 'JSON parse failed on body.postData', {
-          locals: res.locals,
-          body: req.body,
-        }),
-      );
+      return callback(error.make(400, 'JSON parse failed on body.postData'));
     }
     variant_id = postData.variant ? postData.variant.id : null;
     submitted_answer = postData.submittedAnswer;
@@ -99,12 +94,7 @@ function processSubmission(req, res, callback) {
           },
         );
       } else {
-        callback(
-          error.make(400, 'unknown __action', {
-            locals: res.locals,
-            body: req.body,
-          }),
-        );
+        callback(error.make(400, 'unknown __action'));
       }
     },
   );
@@ -112,7 +102,7 @@ function processSubmission(req, res, callback) {
 
 router.post('/', function (req, res, next) {
   if (!res.locals.authz_result.authorized_edit) {
-    return next(error.make(403, 'Not authorized', res.locals));
+    return next(error.make(403, 'Not authorized'));
   }
 
   if (req.body.__action === 'grade' || req.body.__action === 'save') {
@@ -222,12 +212,7 @@ router.post('/', function (req, res, next) {
       );
     });
   } else {
-    return next(
-      error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      }),
-    );
+    return next(error.make(400, 'unknown __action'));
   }
 });
 

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.js
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.js
@@ -94,7 +94,7 @@ function processSubmission(req, res, callback) {
           },
         );
       } else {
-        callback(error.make(400, 'unknown __action'));
+        callback(error.make(400, `unknown __action: ${req.body.__action}`));
       }
     },
   );
@@ -212,7 +212,7 @@ router.post('/', function (req, res, next) {
       );
     });
   } else {
-    return next(error.make(400, 'unknown __action'));
+    return next(error.make(400, `unknown __action: ${req.body.__action}`));
   }
 });
 

--- a/apps/prairielearn/src/pages/studentSEBConfig/studentSEBConfig.js
+++ b/apps/prairielearn/src/pages/studentSEBConfig/studentSEBConfig.js
@@ -89,7 +89,7 @@ router.get('/', function (req, res, next) {
   var data = getCheckedSignedTokenData(encodedData, config.secretKey);
 
   if (data === null) {
-    return next(error.make(403, 'Unrecognized config request, please try again', res.locals));
+    return next(error.make(403, 'Unrecognized config request, please try again'));
   }
 
   var params = {
@@ -104,7 +104,7 @@ router.get('/', function (req, res, next) {
   sqldb.queryZeroOrOneRow(sql.select_and_auth, params, function (err, result) {
     if (ERR(err, next)) return;
     if (result.rowCount === 0) {
-      return next(error.make(403, 'Unrecognized config request, please try again', res.locals));
+      return next(error.make(403, 'Unrecognized config request, please try again'));
     }
 
     _.assign(res.locals, result.rows[0]);

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -83,10 +83,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action', {
-        locals: res.locals,
-        body: req.body,
-      });
+      throw error.make(400, 'unknown __action');
     }
   }),
 );

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -83,7 +83,7 @@ router.post(
       ]);
       res.redirect(req.originalUrl);
     } else {
-      throw error.make(400, 'unknown __action');
+      throw error.make(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -808,12 +808,7 @@ WHERE
         res.redirect(req.originalUrl);
       });
     } else {
-      return next(
-        error.make(400, 'unknown __action', {
-          body: req.body,
-          locals: res.locals,
-        }),
-      );
+      return next(error.make(400, `unknown __action: ${req.body.__action}`));
     }
   });
   ```


### PR DESCRIPTION
As discussed on Slack, these values aren't actually useful in dev, they've just been copied/pasted around forever.