### PR TITLE
Fix computation of grading phase durations in submission info box

### DIFF
--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -555,7 +555,7 @@ function buildGradingJobStats(job) {
       reportDuration: formatDiff(job.grading_finished_at, job.graded_at),
       totalDuration: formatDiff(job.grading_requested_at, job.graded_at, false),
     };
-    const totalDuration = durations.reduce((a, b) => a + (b ?? 0), 0) || 1;
+    const totalDuration = durations.reduce((a, b) => (a ?? 0) + (b ?? 0), 0) || 1;
 
     return {
       ...stats,

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -560,9 +560,8 @@ function buildGradingJobStats(job) {
     return {
       ...stats,
       phases: durations.map(
-        (duration) =>
-          // Round down to avoid width being greater than 100% with floating point errors
-          Math.floor(((duration ?? 0) * 1000) / totalDuration) / 10,
+        // Round down to avoid width being greater than 100% with floating point errors
+        (duration) => Math.floor(((duration ?? 0) * 1000) / totalDuration) / 10,
       ),
     };
   }

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -534,34 +534,36 @@ export async function getAndRenderVariant(variant_id, variant_seed, locals) {
   }
 }
 
+/**
+ * @param {import('./db-types').GradingJob | null} job
+ */
 function buildGradingJobStats(job) {
   if (job) {
-    const phases = [];
-    const totalDuration = differenceInMilliseconds(
-      DateFromISOString.parse(job.graded_at),
-      DateFromISOString.parse(job.grading_requested_at),
-    );
+    /** @type {(number | null)[]} */
+    const durations = [];
     const formatDiff = (start, end, addToPhases = true) => {
-      const duration = differenceInMilliseconds(
-        DateFromISOString.parse(end),
-        DateFromISOString.parse(start),
-      );
-      if (addToPhases) {
-        const percentage = duration / totalDuration;
-        // Round down to avoid width being greater than 100% with floating point errors
-        phases.push(Math.floor(percentage * 1000) / 10);
-      }
-      return (duration / 1000).toFixed(3).replace(/\.?0+$/, '');
+      const duration = end == null || start == null ? null : differenceInMilliseconds(end, start);
+      if (addToPhases) durations.push(duration);
+      return duration == null ? '\u2212' : (duration / 1000).toFixed(3).replace(/\.?0+$/, '') + 's';
     };
 
-    return {
+    const stats = {
       submitDuration: formatDiff(job.grading_requested_at, job.grading_submitted_at),
       queueDuration: formatDiff(job.grading_submitted_at, job.grading_received_at),
       prepareDuration: formatDiff(job.grading_received_at, job.grading_started_at),
       runDuration: formatDiff(job.grading_started_at, job.grading_finished_at),
       reportDuration: formatDiff(job.grading_finished_at, job.graded_at),
       totalDuration: formatDiff(job.grading_requested_at, job.graded_at, false),
-      phases,
+    };
+    const totalDuration = durations.reduce((a, b) => (a ?? 0) + (b ?? 0), 0) || 1;
+
+    return {
+      ...stats,
+      phases: durations.map(
+        (duration) =>
+          // Round down to avoid width being greater than 100% with floating point errors
+          Math.floor(((duration ?? 0) * 1000) / totalDuration) / 10,
+      ),
     };
   }
 

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -2,7 +2,7 @@
 import * as async from 'async';
 import * as path from 'path';
 import * as ejs from 'ejs';
-import { differenceInMilliseconds, parseISO } from 'date-fns';
+import { differenceInMilliseconds } from 'date-fns';
 import * as util from 'util';
 import { z } from 'zod';
 
@@ -538,11 +538,14 @@ function buildGradingJobStats(job) {
   if (job) {
     const phases = [];
     const totalDuration = differenceInMilliseconds(
-      parseISO(job.graded_at),
-      parseISO(job.grading_requested_at),
+      DateFromISOString.parse(job.graded_at),
+      DateFromISOString.parse(job.grading_requested_at),
     );
     const formatDiff = (start, end, addToPhases = true) => {
-      const duration = differenceInMilliseconds(parseISO(end), parseISO(start));
+      const duration = differenceInMilliseconds(
+        DateFromISOString.parse(end),
+        DateFromISOString.parse(start),
+      );
       if (addToPhases) {
         const percentage = duration / totalDuration;
         // Round down to avoid width being greater than 100% with floating point errors

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -555,7 +555,7 @@ function buildGradingJobStats(job) {
       reportDuration: formatDiff(job.grading_finished_at, job.graded_at),
       totalDuration: formatDiff(job.grading_requested_at, job.graded_at, false),
     };
-    const totalDuration = durations.reduce((a, b) => (a ?? 0) + (b ?? 0), 0) || 1;
+    const totalDuration = durations.reduce((a, b) => a + (b ?? 0), 0) || 1;
 
     return {
       ...stats,

--- a/apps/prairielearn/src/pages/partials/submissionInfoModal.ejs
+++ b/apps/prairielearn/src/pages/partials/submissionInfoModal.ejs
@@ -17,43 +17,43 @@
           <tbody>
             <tr>
               <th>Submission time</th>
-              <td><%- submission.formatted_date %></td>
+              <td><%= submission.formatted_date %></td>
             </tr>
             <% if (question.grading_method == 'External') { %>
             <tr>
               <th><span class="text-dark mr-2">&bull;</span>Submit duration</th>
-              <td><%- submission.grading_job_stats.submitDuration %>s</td>
+              <td><%= submission.grading_job_stats.submitDuration %></td>
             </tr>
             <tr>
               <th><span class="text-warning mr-2">&bull;</span>Queue duration</th>
-              <td><%- submission.grading_job_stats.queueDuration %>s</td>
+              <td><%= submission.grading_job_stats.queueDuration %></td>
             </tr>
             <tr>
               <th><span class="text-primary mr-2">&bull;</span>Prepare duration</th>
-              <td><%- submission.grading_job_stats.prepareDuration %>s</td>
+              <td><%= submission.grading_job_stats.prepareDuration %></td>
             </tr>
             <tr>
               <th><span class="text-success mr-2">&bull;</span>Run duration</th>
-              <td><%- submission.grading_job_stats.runDuration %>s</td>
+              <td><%= submission.grading_job_stats.runDuration %></td>
             </tr>
             <tr>
               <th><span class="text-danger mr-2">&bull;</span>Report duration</th>
-              <td><%- submission.grading_job_stats.reportDuration %>s</td>
+              <td><%= submission.grading_job_stats.reportDuration %></td>
             </tr>
             <tr>
               <th>Total duration</th>
-              <td><%- submission.grading_job_stats.totalDuration %>s</td>
+              <td><%= submission.grading_job_stats.totalDuration %></td>
             </tr>
             <% } %>
           </tbody>
         </table>
         <% if (question.grading_method == 'External') { %>
         <div class="d-flex mt-2 mb-2">
-          <span style="display: inline-block; width: <%- submission.grading_job_stats.phases[0] %>%; height: 10px;" class="bg-dark m-0"></span>
-          <span style="display: inline-block; width: <%- submission.grading_job_stats.phases[1] %>%; height: 10px;" class="bg-warning m-0"></span>
-          <span style="display: inline-block; width: <%- submission.grading_job_stats.phases[2] %>%; height: 10px;" class="bg-primary m-0"></span>
-          <span style="display: inline-block; width: <%- submission.grading_job_stats.phases[3] %>%; height: 10px;" class="bg-success m-0"></span>
-          <span style="display: inline-block; width: <%- submission.grading_job_stats.phases[4] %>%; height: 10px;" class="bg-danger m-0"></span>
+          <span style="display: inline-block; width: <%= submission.grading_job_stats.phases[0] %>%; height: 10px;" class="bg-dark m-0"></span>
+          <span style="display: inline-block; width: <%= submission.grading_job_stats.phases[1] %>%; height: 10px;" class="bg-warning m-0"></span>
+          <span style="display: inline-block; width: <%= submission.grading_job_stats.phases[2] %>%; height: 10px;" class="bg-primary m-0"></span>
+          <span style="display: inline-block; width: <%= submission.grading_job_stats.phases[3] %>%; height: 10px;" class="bg-success m-0"></span>
+          <span style="display: inline-block; width: <%= submission.grading_job_stats.phases[4] %>%; height: 10px;" class="bg-danger m-0"></span>
         </div>
         <% if (typeof course_instance != 'undefined' && course_instance != null) { %>
         <a class="btn btn-primary mt-2" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/grading_job/<%= submission.grading_job_id %>">View grading job <%= submission.grading_job_id %></a>


### PR DESCRIPTION
Fixes #9403. The code assumed that the dates were strings, and explicitly parsed them, but recent updates caused Zod parsing to convert them to dates instead. ~~This is solved by parsing using `DateFromISOString`, which will properly parse if the value is string and use the Date object itself if it had already been parsed.~~ Given all cases where this function is called are already parsed with Zod, no additional parsing is needed.

This PR also fixes the handling of this box when there are timestamps still set at null. Before:

![image](https://github.com/PrairieLearn/PrairieLearn/assets/1004907/44ebf747-c31f-47f7-a50a-50ca3fa2da25)

After:

![image](https://github.com/PrairieLearn/PrairieLearn/assets/1004907/2a2c422a-010e-4c7a-b3e7-b5ce404f7a22)
