### PR TITLE
Add missing version to workspace logs

### DIFF
--- a/apps/prairielearn/src/lib/workspaceHost.sql
+++ b/apps/prairielearn/src/lib/workspaceHost.sql
@@ -80,9 +80,10 @@ WITH
   ),
   workspace_log AS (
     INSERT INTO
-      workspace_logs (workspace_id, state, message)
+      workspace_logs (workspace_id, version, state, message)
     SELECT
       uw.id,
+      uw.version,
       uw.state,
       'Assigned to host ' || uwh.id
     FROM


### PR DESCRIPTION
For reasons that I cannot fathom, `workspace_logs.version` defaults to 1, so this silently took that default instead of failing 🙃 