### PR TITLE
Convert sync performance util to TypeScript

### DIFF
--- a/apps/prairielearn/src/sync/performance.ts
+++ b/apps/prairielearn/src/sync/performance.ts
@@ -1,4 +1,3 @@
-// @ts-check
 const scopedData = {};
 
 /**

--- a/apps/prairielearn/src/sync/performance.ts
+++ b/apps/prairielearn/src/sync/performance.ts
@@ -13,14 +13,14 @@ export function makePerformance(scopeName) {
   /**
    * @param {string} name
    */
-  function start(name) {
+  function start(name: string): void {
     scope[name] = new Date();
   }
 
   /**
    * @param {string} name
    */
-  function end(name) {
+  function end(name: string): void {
     if (!(name in scope)) {
       return;
     }
@@ -30,6 +30,7 @@ export function makePerformance(scopeName) {
   }
 
   /**
+   * @deprecated
    * @param {string} name
    * @param {(callback: (err: Error | null) => void) => void} func
    * @param {*} callback
@@ -48,7 +49,7 @@ export function makePerformance(scopeName) {
    * @param {() => Promise<T>} asyncFunc
    * @returns {Promise<T>}
    */
-  async function timedAsync(name, asyncFunc) {
+  async function timedAsync<T>(name: string, asyncFunc: () => Promise<T>): Promise<T> {
     start(name);
     let res;
     try {


### PR DESCRIPTION
This PR only renames the file and adds enough typing to allow typechecks to pass. A follow-up PR will change the content. This is done to preserve rename history.