### PR TITLE
Modernize performance sync library

### DIFF
--- a/apps/prairielearn/src/sync/performance.ts
+++ b/apps/prairielearn/src/sync/performance.ts
@@ -3,7 +3,7 @@ const scopedData: Record<string, Record<string, number>> = {};
 interface Performance {
   start: (name: string) => void;
   end: (name: string) => void;
-  timedAsync: <T>(name: string, asyncFunc: () => Promise<T>) => Promise<T>;
+  timed: <T>(name: string, asyncFunc: () => Promise<T>) => Promise<T>;
 }
 
 export function makePerformance(scopeName: string): Performance {
@@ -23,7 +23,7 @@ export function makePerformance(scopeName: string): Performance {
     }
   }
 
-  async function timedAsync<T>(name: string, asyncFunc: () => Promise<T>): Promise<T> {
+  async function timed<T>(name: string, asyncFunc: () => Promise<T>): Promise<T> {
     start(name);
     try {
       return await asyncFunc();
@@ -32,5 +32,5 @@ export function makePerformance(scopeName: string): Performance {
     }
   }
 
-  return { start, end, timedAsync };
+  return { start, end, timed };
 }

--- a/apps/prairielearn/src/sync/performance.ts
+++ b/apps/prairielearn/src/sync/performance.ts
@@ -25,13 +25,11 @@ export function makePerformance(scopeName: string): Performance {
 
   async function timedAsync<T>(name: string, asyncFunc: () => Promise<T>): Promise<T> {
     start(name);
-    let res: T;
     try {
-      res = await asyncFunc();
+      return await asyncFunc();
     } finally {
       end(name);
     }
-    return res;
   }
 
   return { start, end, timedAsync };

--- a/apps/prairielearn/src/sync/performance.ts
+++ b/apps/prairielearn/src/sync/performance.ts
@@ -1,4 +1,3 @@
-// @ts-check
 const scopedData = {};
 
 /**

--- a/apps/prairielearn/src/sync/performance.ts
+++ b/apps/prairielearn/src/sync/performance.ts
@@ -13,14 +13,14 @@ export function makePerformance(scopeName) {
   /**
    * @param {string} name
    */
-  function start(name) {
+  function start(name: string): void {
     scope[name] = new Date();
   }
 
   /**
    * @param {string} name
    */
-  function end(name) {
+  function end(name: string): void {
     if (!(name in scope)) {
       return;
     }
@@ -30,6 +30,7 @@ export function makePerformance(scopeName) {
   }
 
   /**
+   * @deprecated
    * @param {string} name
    * @param {(callback: (err: Error | null) => void) => void} func
    * @param {*} callback
@@ -48,7 +49,7 @@ export function makePerformance(scopeName) {
    * @param {() => Promise<T>} asyncFunc
    * @returns {Promise<T>}
    */
-  async function timedAsync(name, asyncFunc) {
+  async function timedAsync<T>(name: string, asyncFunc: () => Promise<T>): Promise<T> {
     start(name);
     let res;
     try {

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -39,29 +39,27 @@ export async function syncDiskToSqlWithLock(
   logger.info('Loading info.json files from course repository');
   perf.start('sync');
 
-  const courseData = await perf.timedAsync('loadCourseData', () =>
+  const courseData = await perf.timed('loadCourseData', () =>
     courseDB.loadFullCourse(courseId, courseDir),
   );
   logger.info('Syncing info to database');
-  await perf.timedAsync('syncCourseInfo', () => syncCourseInfo.sync(courseData, courseId));
-  const courseInstanceIds = await perf.timedAsync('syncCourseInstances', () =>
+  await perf.timed('syncCourseInfo', () => syncCourseInfo.sync(courseData, courseId));
+  const courseInstanceIds = await perf.timed('syncCourseInstances', () =>
     syncCourseInstances.sync(courseId, courseData),
   );
-  await perf.timedAsync('syncTopics', () => syncTopics.sync(courseId, courseData));
-  const questionIds = await perf.timedAsync('syncQuestions', () =>
+  await perf.timed('syncTopics', () => syncTopics.sync(courseId, courseData));
+  const questionIds = await perf.timed('syncQuestions', () =>
     syncQuestions.sync(courseId, courseData),
   );
 
-  await perf.timedAsync('syncTags', () => syncTags.sync(courseId, courseData, questionIds));
-  await perf.timedAsync('syncAssessmentSets', () => syncAssessmentSets.sync(courseId, courseData));
-  await perf.timedAsync('syncAssessmentModules', () =>
-    syncAssessmentModules.sync(courseId, courseData),
-  );
+  await perf.timed('syncTags', () => syncTags.sync(courseId, courseData, questionIds));
+  await perf.timed('syncAssessmentSets', () => syncAssessmentSets.sync(courseId, courseData));
+  await perf.timed('syncAssessmentModules', () => syncAssessmentModules.sync(courseId, courseData));
   perf.start('syncAssessments');
   await Promise.all(
     Object.entries(courseData.courseInstances).map(async ([ciid, courseInstanceData]) => {
       const courseInstanceId = courseInstanceIds[ciid];
-      await perf.timedAsync(`syncAssessments${ciid}`, () =>
+      await perf.timed(`syncAssessments${ciid}`, () =>
         syncAssessments.sync(
           courseId,
           courseInstanceId,


### PR DESCRIPTION
Follow-up to #9421. Adds better types, removes unnecessary JSDoc comments, removes deprecated (and unused) callback function.