### PR TITLE
Document that workspaces aren't affected by active: false

### DIFF
--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -208,6 +208,10 @@ The `showClosedAssessmentScore` access rule restriction is often used in conjunc
 
 The `active` access rule restriction is useful for allowing students to see what assessments they have coming up. It should also be used when [returning exams to students](faq.md#how-do-i-give-students-access-to-view-their-exams-after-they-are-over). If `active` is set to `false`, students can see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page. The `active` property in an access rule is `true` by default.
 
+If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
+
+Note that when `"active": false` is used to make assessments visible to students after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment.
+
 An example of the `active` access rule restriction is shown below:
 
 ```json
@@ -227,10 +231,6 @@ An example of the `active` access rule restriction is shown below:
 ```
 
 In the example above, from January 1st to February 15th, students can see the assessment on the Assessments page but cannot begin the assessment. They will see a message saying that the assessment will be available on February 16th. The first access rule applies on February 16th, and since `active` is `true` (by default), students can start the assessment and submit answers to questions on that day.
-
-If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
-
-Note that when `"active": false` is used to make assessments visible to students after they've finished the assessment, students can still access and modify files in [workspaces](workspaces/index.md) associated with questions on the assessment.
 
 ## Course instance example
 

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -210,7 +210,7 @@ The `active` access rule restriction is useful for allowing students to see what
 
 If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
 
-Note that when `"active": false` is used to make assessments visible to students after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment.
+Note that when `"active": false` is used to make assessments visible to students after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment. However, they will not be able to submit any changed workspace files for grading.
 
 An example of the `active` access rule restriction is shown below:
 

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -208,8 +208,6 @@ The `showClosedAssessmentScore` access rule restriction is often used in conjunc
 
 The `active` access rule restriction is useful for allowing students to see what assessments they have coming up. It should also be used when [returning exams to students](faq.md#how-do-i-give-students-access-to-view-their-exams-after-they-are-over). If `active` is set to `false`, students can see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page. The `active` property in an access rule is `true` by default.
 
-**Note**: if `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
-
 An example of the `active` access rule restriction is shown below:
 
 ```json
@@ -229,6 +227,10 @@ An example of the `active` access rule restriction is shown below:
 ```
 
 In the example above, from January 1st to February 15th, students can see the assessment on the Assessments page but cannot begin the assessment. They will see a message saying that the assessment will be available on February 16th. The first access rule applies on February 16th, and since `active` is `true` (by default), students can start the assessment and submit answers to questions on that day.
+
+If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
+
+Note that when `"active": false` is used to make assessments visible to students after they've finished the assessment, students can still access and modify files in [workspaces](workspaces/index.md) associated with questions on the assessment.
 
 ## Course instance example
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,7 +31,7 @@ To allow students to see their entire exam after it is over, you can add an [acc
 
 Students who took the exam will then have public access to their exams after the `startDate` until the end of the course instance, while students who did not take the exam will not be able to view it. Students will not be able to answer questions for further credit (due to `"active": false`), but they will be able to see the entire exam in exactly the same state as when they were doing the exam originally. Because students have public access to the exam, it should be assumed that all the questions will be posted to websites such as Chegg and Course Hero. To let students see their exams with some additional security, consider only allowing [limited access post-exam under controlled conditions](faq.md#should-students-be-able-to-review-their-exams-after-they-are-over) (although this requires in-person access by students and doesn't work online).
 
-Note that when granting access via `"active": false`, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment.
+Note that when granting access via `"active": false`, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment. However, they will not be able to submit any changed workspace files for grading.
 
 ## How can question pool development be managed over semesters?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,6 +31,8 @@ To allow students to see their entire exam after it is over, you can add an [acc
 
 Students who took the exam will then have public access to their exams after the `startDate` until the end of the course instance, while students who did not take the exam will not be able to view it. Students will not be able to answer questions for further credit (due to `"active": false`), but they will be able to see the entire exam in exactly the same state as when they were doing the exam originally. Because students have public access to the exam, it should be assumed that all the questions will be posted to websites such as Chegg and Course Hero. To let students see their exams with some additional security, consider only allowing [limited access post-exam under controlled conditions](faq.md#should-students-be-able-to-review-their-exams-after-they-are-over) (although this requires in-person access by students and doesn't work online).
 
+Note that when granting access via `"active": false`, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment.
+
 ## How can question pool development be managed over semesters?
 
 Writing and maintaining a large pool of questions is a lot of work. There are many strategies for managing this process. The approach taken by the TAM 2XX courses (Introductory Mechanics sequence) at Illinois is:


### PR DESCRIPTION
We briefly considered changing the behavior to make workspaces inaccessible when `"active": false` is in effect, but we realized that some courses actually rely on the current behavior for review sessions. So, we're opting to explicitly document the current behavior for now.

In the future, we may consider adding something like `"workspacesAccessible": false` to `allowAccess` to allow instructors to explicitly control the behavior.