### PR TITLE
fix: make test no longer looks for test.js files

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon --exec \"yarn dev:no-watch\" --",
     "start-executor": "node dist/executor.js",
     "start": "node dist/server.js",
-    "test": "mocha --parallel src/**/*.test.{js,ts}",
+    "test": "mocha --parallel src/**/*.test.ts",
     "test:dist": "mocha --parallel dist/**/*.test.js"
   },
   "dependencies": {


### PR DESCRIPTION
After #9274 we no longer have non-typescript tests in `tests`:

```
✔ ~/git/PrairieLearn/apps/prairielearn [PL-packagejson-test-only-ts|⚑ 4]
12:27 discovery$ find src -name \*.test.js
✔ ~/git/PrairieLearn/apps/prairielearn [PL-packagejson-test-only-ts|⚑ 4]
```

Mocha throws a warning that it doesn't find any tests.js files, so let's remove them from the testing config.