### PR TITLE
Upgrade to pygraphviz 1.12

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -17,7 +17,7 @@ Pillow==10.2.0
 PuLP==2.8.0
 Pygments==2.17.2
 pyarrow==15.0.0
-pygraphviz==1.6
+pygraphviz==1.12
 requests==2.31.0
 scikit-image==0.22.0
 scikit-learn==1.4.0

--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -23,7 +23,7 @@ pycryptodome==3.20.0
 Pygments==2.17.2
 pyarrow==15.0.0
 pygments-ansi-color==0.3.0
-pygraphviz==1.6
+pygraphviz==1.12
 pyquaternion==0.9.9
 pytest-cov==4.1.0
 pytest-repeat==0.9.3


### PR DESCRIPTION
Now that we're using Amazon Linux 2023 everywhere, we can safely upgrade to this latest version everywhere.