### PR TITLE
Wrap pl-matrix-input answer/submission

### DIFF
--- a/apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -74,7 +74,7 @@
 {{/error}}
 {{^error}}
 {{#label}}<span>{{{label}}}</span>{{/label}}
-<code class="user-output">{{a_sub}}</code>
+<code class="user-output" style="white-space: break-spaces;">{{a_sub}}</code>
 {{#correct}}<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
 {{#partial}}<span class="badge badge-warning"><i class="fa fa-circle-o" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
 {{#incorrect}}<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
@@ -100,7 +100,7 @@
             <div role="tabpanel" class="tab-pane {{#default_is_matlab}}active{{/default_is_matlab}}" id="matlab-{{uuid}}">
                 <p>
                     {{#label}}<span>{{{label}}}</span>{{/label}}
-                    <code class="user-output" id="matlab-data-{{uuid}}">{{matlab_data}}</code>
+                    <code class="user-output" style="white-space: break-spaces;" id="matlab-data-{{uuid}}">{{matlab_data}}</code>
                 </p>
                 <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#matlab-data-{{uuid}}">
                     copy this answer
@@ -109,7 +109,7 @@
             <div role="tabpanel" class="tab-pane {{#default_is_python}}active{{/default_is_python}}" id="python-{{uuid}}">
                 <p>
                     {{#label}}<span>{{{label}}}</span>{{/label}}
-                    <code class="user-output" id="python-data-{{uuid}}">{{python_data}}</code>
+                    <code class="user-output" style="white-space: break-spaces;" id="python-data-{{uuid}}">{{python_data}}</code>
                 </p>
                 <button type="button" class="btn btn-secondary btn-sm copy-button" data-clipboard-target="#python-data-{{uuid}}">
                     copy this answer


### PR DESCRIPTION
Before:

<img width="953" alt="Screenshot 2024-02-22 at 15 37 15" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/00c643bf-47f4-423f-aedc-bda8a30dfe3b">

After:

<img width="859" alt="Screenshot 2024-02-22 at 15 56 14" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/3682fc62-30ec-4d25-97d0-e429c71fd2e9">

An alternative would be to add horizontal scrolling, but IMO this works better, especially on smaller viewports.