### PR TITLE
Add modified_at to assessment instance API

### DIFF
--- a/apps/prairielearn/src/api/v1/endpoints/queries.sql
+++ b/apps/prairielearn/src/api/v1/endpoints/queries.sql
@@ -62,6 +62,7 @@ WITH
       ai.score_perc,
       ai.number AS assessment_instance_number,
       ai.open,
+      format_date_iso8601 (ai.modified_at, ci.display_timezone) AS modified_at,
       gi.id AS group_id,
       gi.name AS group_name,
       gi.uid_list AS group_uids,


### PR DESCRIPTION
This change would expose the `modified_at` field of the `assessment_instances` table in the following endpoints:
- `/pl/api/v1/course_instances/:course_instance_id/assessments/:assessment_id/assessment_instances`
- `/pl/api/v1/course_instances/:course_instance_id/assessment_instances/:assessment_instance_id`

We have historically been fetching submissions multiple times a day using the assessment instance submissions API for our grade report system and we'd like to move to a more sustainable solution. 

This field should allow us to fetch only assessment instances that have been modified (i.e. changed scores) since the last time we fetched, and should significantly reduce the number of API calls needed to have up-to-date submission data.