### PR TITLE
Require workspace dynamic files to set contents explicitly

### DIFF
--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -464,6 +464,15 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
             };
           }
 
+          if (!('contents' in file)) {
+            fileGenerationErrors.push({
+              file: file.name,
+              msg: `Dynamic workspace file has neither "contents" nor "questionFile". File ignored.`,
+              data: file,
+            });
+            return null;
+          }
+
           // Discard encodings outside of explicit list of allowed encodings
           if (file.encoding && !['utf-8', 'base64', 'hex'].includes(file.encoding)) {
             fileGenerationErrors.push({

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -454,6 +454,7 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
                 msg: 'Dynamic workspace file points to a local file outside the question directory. File ignored.',
                 data: file,
               });
+              return null;
             }
             // To avoid race conditions, no check if file exists here, rather an exception is
             // captured when attempting to copy.

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -454,7 +454,6 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
                 msg: 'Dynamic workspace file points to a local file outside the question directory. File ignored.',
                 data: file,
               });
-              return null;
             }
             // To avoid race conditions, no check if file exists here, rather an exception is
             // captured when attempting to copy.
@@ -462,15 +461,6 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
               name: file.name,
               localPath,
             };
-          }
-
-          if (!('contents' in file)) {
-            fileGenerationErrors.push({
-              file: file.name,
-              msg: `Dynamic workspace file has neither "contents" nor "questionFile". File ignored.`,
-              data: file,
-            });
-            return null;
           }
 
           // Discard encodings outside of explicit list of allowed encodings
@@ -482,6 +472,15 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
             });
             return null;
           }
+
+          if (!('contents' in file)) {
+            fileGenerationErrors.push({
+              file: file.name,
+              msg: `Dynamic workspace file has neither "contents" nor "questionFile". Blank file created.`,
+              data: file,
+            });
+          }
+
           return {
             name: file.name,
             buffer: Buffer.from(file.contents ?? '', file.encoding || 'utf-8'),

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -206,10 +206,12 @@ def generate(data):
         },
         # A question file can also be added by using its path in the question instead of its contents
         {"name": "provided.txt", "questionFile": "clientFilesQuestion/provided.txt"},
+        # To make an empty file, set `contents` to None or an empty string
+        {"name": "empty.txt", "contents": None}
     ]
 ```
 
-By default, `contents` is expected to be a string in UTF-8 format. To provide binary content, the value must be encoded using base64 or hex, as shown in the example above. In this case, the `encoding` property must also be provided. Only one of `questionFile` and `contents` may be provided. If neither `questionFile` nor `contents` are provided, an empty file is created.
+By default, `contents` is expected to be a string in UTF-8 format. To provide binary content, the value must be encoded using base64 or hex, as shown in the example above. In this case, the `encoding` property must also be provided. Either `questionFile` or `contents` must be provided, but not both. If an empty file is expected, `contents` may be set to `None` or an empty string.
 
 If a file name appears in multiple locations, the following precedence takes effect:
 


### PR DESCRIPTION
Currently workspace dynamic files without either a "contents" property or a "questionFile" cause the file to be an empty file. This, however, is subject to silent errors, as instructors may mistakenly miss the contents property (a recent case saw a typo in this property), which causes a silent issue.

This PR changes the process to create an issue in this context. The file is still created to ensure anyone that relies on this behaviour still has a working question.

This is a potentially breaking change, though affected cases are expected to be minimal (I don't expect many people to have empty files as dynamic files), and the "break", if it happens, causes at most new issues to be raised, with a simple fix of setting content to None/blank to avoid the issue.