### PR TITLE
Document the need for Rosetta emulation on Apple Silicon

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -74,7 +74,9 @@ To fix this, add `--platform linux/amd64` before the image in any `docker run` c
 docker run -it --rm -p 3000:3000 --platform linux/amd64 prairielearn/prairielearn
 ```
 
-Note that the use of R in `server.py` is not currently supported on ARM64 hardware.
+When running the image, you may get an error like `pg_ctl: could not start server`. To fix this, open Docker Desktop settings, click on "General", check "Use Rosetta for x86/amd64 emulation on Apple Silicon", and click "Apply & Restart". After Docker Desktop restarts, try the above `docker run ...` command again.
+
+_Note that the use of R in `server.py` is not currently supported on ARM64 hardware._
 
 ### Support for external graders and workspaces
 


### PR DESCRIPTION
It seems like QEMU emulation isn't working will with the copy of Postgres that's embedded in our image, as Postgres fails to start with the following error:

```
pg_ctl: could not start server
```

Enabling Rosetta emulation has helped in several of these cases, so I figured I'd add it to our docs.