### PR TITLE
Allow null items in instance_question.variants_points_list

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -559,7 +559,7 @@ export const InstanceQuestionSchema = z.object({
     .nullable(),
   submission_score_array: z.array(z.number().nullable()).nullable(),
   used_for_grade: z.boolean().nullable(),
-  variants_points_list: z.array(z.number()),
+  variants_points_list: z.array(z.number().nullable()),
 });
 export type InstanceQuestion = z.infer<typeof InstanceQuestionSchema>;
 


### PR DESCRIPTION
This is based on an observed error in our production environment: https://prairielearn-inc.sentry.io/issues/5023961427

Here's the relevant instance question and variant: https://us.prairielearn.com/pl/course_instance/147365/instance_question/361768852?variant_id=90904775

I haven't yet spent much time trying to understand exactly why this ended up with null entries, or if that's a valid state. It's possible that we actually _don't_ want to allow null items, in which case we should trace down where the null item came from and fix that.

From a quick look at the question, there was an error in v2 question grading code, and it's plausible that this could've resulted in a `null` value being introduced and passed around.