### PR TITLE
Fix manual grading instances.json

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.sql
@@ -3,7 +3,7 @@ WITH
   issue_count AS (
     SELECT
       i.instance_question_id AS instance_question_id,
-      count(*) AS open_issue_count
+      count(*)::integer AS open_issue_count
     FROM
       issues AS i
     WHERE


### PR DESCRIPTION
The Zod schema declares this is a `z.number().nullable()`, which will reject the string `bigint` that `count(...)` produces by default.