### PR TITLE
Define testpaths for pytest in pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,7 @@ test-js: start-support
 test-js-dist: start-support
 	@yarn turbo run test:dist
 test-python:
-# `pl_unit_test.py` has an unfortunate file name - it matches the pattern that
-# pytest uses to discover tests, but it isn't actually a test file itself. We
-# explicitly exclude it here.
-	@python3 -m pytest --ignore graders/python/python_autograder/pl_unit_test.py --cov=apps
+	@python3 -m pytest
 test-prairielearn: start-support
 	@yarn workspace @prairielearn/prairielearn run test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,9 @@ include = [
 extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
 reportUnnecessaryTypeIgnoreComment = "error"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "apps/prairielearn/elements",
+    "apps/prairielearn/python",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ pythonVersion = "3.10"
 reportUnnecessaryTypeIgnoreComment = "error"
 
 [tool.pytest.ini_options]
+addopts = "--cov=apps"
 testpaths = [
     "apps/prairielearn/elements",
     "apps/prairielearn/python",


### PR DESCRIPTION
This has two benefits:

- Discovering tests is now basically instantaneous. Before, it took quite a while, presumably because it was searching in every single directory.
- This appears to solve the module resolution issues we were facing with pytest 8 (https://github.com/PrairieLearn/PrairieLearn/pull/9508). I don't entirely understand why; maybe `testpaths` gets added to `PYTHON_PATH` somehow?