### PR TITLE
Handle missing images when reporting image sizes

### DIFF
--- a/packages/actions-report-image-sizes/src/index.ts
+++ b/packages/actions-report-image-sizes/src/index.ts
@@ -76,6 +76,18 @@ async function getImageManifest(
   });
 
   if (manifestResponse.status === 404) {
+    console.log(`No manifest found for ${image}:${reference}`);
+    return null;
+  }
+
+  if (manifestResponse.status === 401) {
+    // This can happen if the image does not yet exist in the registry. When we
+    // request an auth token with pull permissions for a repository that does
+    // not exist, Docker Hub returns a token that silently doesn't include any
+    // access permissions at all, and when we go to read the manifest, it fails
+    // with an authorization error instead of a 404. We'll treat authorization
+    // errors as if the image does not exist.
+    console.log(`Authorization error when reading manifest for ${image}:${reference}, skipping...`);
     return null;
   }
 
@@ -85,7 +97,6 @@ async function getImageManifest(
   if (!digest) {
     throw new Error(`Missing Docker-Content-Digest header for ${url}`);
   }
-  console.log(rawManifest);
   return { manifest, digest };
 }
 
@@ -262,8 +273,6 @@ async function main() {
     // report the size of the new images.
     const oldImages = await getAllImagesFromRegistry(image, 'latest');
 
-    console.log(newImages, oldImages);
-
     for (const newImage of newImages) {
       // Find the old image with the same platform. If there isn't a match
       // and the new image doesn't have a platform, try to find an old image for
@@ -274,10 +283,8 @@ async function main() {
       // TODO: Build `prairielearn/prairielearn` with buildx and remove this hack.
       let oldImage = oldImages?.find((image) => image.platform === newImage.platform);
       if (!oldImage && newImage.platform === null) {
-        console.log('finding old image');
         oldImage = oldImages?.find((image) => image.platform === 'linux/amd64');
       }
-      console.log(newImage, oldImage);
       changedImages.push({
         name: image,
         platform: newImage.platform ?? oldImage?.platform ?? null,

--- a/packages/actions-report-image-sizes/src/index.ts
+++ b/packages/actions-report-image-sizes/src/index.ts
@@ -91,6 +91,11 @@ async function getImageManifest(
     return null;
   }
 
+  if (!manifestResponse.ok) {
+    const status = `${manifestResponse.status} ${manifestResponse.statusText}`;
+    throw new Error(`Failed to fetch manifest for ${image}:${reference}: ${status}`);
+  }
+
   const rawManifest = await manifestResponse.json();
   const manifest = DockerApiImageManifestSchema.parse(rawManifest);
   const digest = manifestResponse.headers.get('Docker-Content-Digest');


### PR DESCRIPTION
Fixes the issue described here: https://github.com/PrairieLearn/PrairieLearn/pull/9302#issuecomment-1977227141

See the inline comment for more details. It's unfortunate that Docker Hub responds with a 401 instead of a 404 in this case.