### PR TITLE
Fix submissions.gradable for v2 questions

### DIFF
--- a/apps/prairielearn/src/lib/grading.ts
+++ b/apps/prairielearn/src/lib/grading.ts
@@ -366,7 +366,7 @@ export async function gradeVariant(
         null, // finish_time
         data.submitted_answer,
         data.format_errors,
-        data.gradable && !hasFatalIssue,
+        !!data.gradable && !hasFatalIssue, // gradable
         hasFatalIssue, // broken
         data.params,
         data.true_answer,

--- a/apps/prairielearn/src/lib/grading.ts
+++ b/apps/prairielearn/src/lib/grading.ts
@@ -229,7 +229,7 @@ export async function saveSubmission(
   return await insertSubmission({
     ...submission,
     ...data,
-    gradable: data.gradable && !hasFatalIssue,
+    gradable: !!data.gradable && !hasFatalIssue, // gradable
     broken: hasFatalIssue,
   });
 }


### PR DESCRIPTION
This PR addresses the root cause of #9487 that allowed `instance_questions.variants_points_list` to end up with `NULL` entries.

When a v2 question errors out during grading, we hit this branch:

https://github.com/PrairieLearn/PrairieLearn/blob/e55b8fefa68802c6ad819b192864606ffaad42d5/apps/prairielearn/src/question-servers/calculation-subprocess.js#L94

Later, we go to read the `gradable` property here:

https://github.com/PrairieLearn/PrairieLearn/blob/e55b8fefa68802c6ad819b192864606ffaad42d5/apps/prairielearn/src/lib/grading.ts#L369

`undefined && true === undefined`, but we really want a `true`/`false` value there, hence the fixes in this PR.

Going deeper, that value gets passed to `grading_jobs_update_after_grading` and used here:

https://github.com/PrairieLearn/PrairieLearn/blob/e55b8fefa68802c6ad819b192864606ffaad42d5/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql#L152-L167

Because `new_gradable` was not `FALSE`, we enter the `ELSE` clause there, which calls `instance_questions_grade`:

https://github.com/PrairieLearn/PrairieLearn/blob/e55b8fefa68802c6ad819b192864606ffaad42d5/apps/prairielearn/src/sprocs/instance_questions_grade.sql#L34-L35

Which in turn calls `instance_question_points_homework`:

https://github.com/PrairieLearn/PrairieLearn/blob/e55b8fefa68802c6ad819b192864606ffaad42d5/apps/prairielearn/src/sprocs/instance_questions_points.sql#L43-L45

Which is what ultimately updates `variants_points_list`:

https://github.com/PrairieLearn/PrairieLearn/blob/e55b8fefa68802c6ad819b192864606ffaad42d5/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql#L47-L58