### PR TITLE
Fix getPaths for instructor file editor

### DIFF
--- a/apps/prairielearn/src/lib/instructorFiles.js
+++ b/apps/prairielearn/src/lib/instructorFiles.js
@@ -184,5 +184,5 @@ export function getPathsCallback(req, res, callback) {
     callback(err);
     return;
   }
-  callback(paths);
+  callback(null, paths);
 }

--- a/apps/prairielearn/src/lib/instructorFiles.js
+++ b/apps/prairielearn/src/lib/instructorFiles.js
@@ -9,8 +9,11 @@ import { encodePath, decodePath } from './uri-util';
  * For the file path of the current page, this function returns rich
  * information about higher folders up to a certain level determined by
  * the navPage. Created for use in instructor file views.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
  */
-export function getPaths(req, res, callback) {
+export function getPaths(req, res) {
   let paths = {
     coursePath: res.locals.course.path,
     courseId: res.locals.course.id,
@@ -59,14 +62,14 @@ export function getPaths(req, res, callback) {
     paths.testsDir = path.join(paths.rootPath, 'tests');
     paths.urlPrefix = `${res.locals.urlPrefix}/question/${res.locals.question.id}`;
   } else {
-    return callback(new Error(`Invalid navPage: ${res.locals.navPage}`));
+    throw new Error(`Invalid navPage: ${res.locals.navPage}`);
   }
 
   if (req.params[0]) {
     try {
       paths.workingPath = path.join(res.locals.course.path, decodePath(req.params[0]));
     } catch (err) {
-      return callback(new Error(`Invalid path: ${req.params[0]}`));
+      throw new Error(`Invalid path: ${req.params[0]}`);
     }
   } else {
     paths.workingPath = paths.rootPath;
@@ -163,5 +166,23 @@ export function getPaths(req, res, callback) {
       }
     });
 
-  callback(null, paths);
+  return paths;
+}
+
+/**
+ * Wrapper around {@link getPaths} to support callback-based usage.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {(err: Error | null | undefined, paths?: any) => void} callback
+ */
+export function getPathsCallback(req, res, callback) {
+  let paths;
+  try {
+    paths = getPaths(req, res);
+  } catch (err) {
+    callback(err);
+    return;
+  }
+  callback(paths);
 }

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -17,7 +17,7 @@ const { encodePath } = require('../../lib/uri-util');
 const editorUtil = require('../../lib/editorUtil');
 const { default: AnsiUp } = require('ansi_up');
 const { getCourseOwners } = require('../../lib/course');
-const { getPaths } = require('../../lib/instructorFiles');
+const { getPathsCallback } = require('../../lib/instructorFiles');
 
 function isHidden(item) {
   return item[0] === '.';
@@ -217,7 +217,7 @@ router.get('/*', function (req, res, next) {
     [
       (callback) => {
         debug('get paths');
-        getPaths(req, res, (err, paths) => {
+        getPathsCallback(req, res, (err, paths) => {
           if (ERR(err, callback)) return;
           file_browser.paths = paths;
           callback(null);
@@ -271,7 +271,7 @@ router.post('/*', function (req, res, next) {
   if (!res.locals.authz_data.has_course_permission_edit) {
     return next(error.make(403, 'Access denied (must be a course Editor)'));
   }
-  getPaths(req, res, (err, paths) => {
+  getPathsCallback(req, res, (err, paths) => {
     if (ERR(err, next)) return;
     const container = {
       rootPath: paths.rootPath,

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -30,7 +30,7 @@ import * as modelist from 'ace-code/src/ext/modelist';
 import { decodePath } from '../../lib/uri-util';
 import { updateChunksForCourse, logChunkChangesToJob } from '../../lib/chunks';
 import { idsEqual } from '../../lib/id';
-import { getPaths } from '../../lib/instructorFiles';
+import { getPathsCallback } from '../../lib/instructorFiles';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(__filename);
@@ -165,7 +165,7 @@ router.get('/*', (req, res, next) => {
         fileEdit.origHash = fileEdit.diskHash;
       }
 
-      getPaths(req, res, (err, paths) => {
+      getPathsCallback(req, res, (err, paths) => {
         if (ERR(err, next)) return;
         res.locals.fileEdit = fileEdit;
         res.locals.fileEdit.paths = paths;


### PR DESCRIPTION
When `getPaths` threw an error, it would crash the entire server, as there was nothing to catch the error. This is because it was designed for callback usage, which expects functions to only pass errors to the callback instead of throwing them. At some point, we refactored `getPaths` to sometimes throw errors, which slipped through review.

Rather than changing the whole function back to just callbacks, I opted to introduce a wrapper that handles propagating errors back to callbacks. As we refactor the callsites of `getPathsCallback`, we can replace it with plain `getPaths`.