### PR TITLE
Show course repository/path in feature editor

### DIFF
--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -303,7 +303,7 @@ export function AddFeatureGrantModalBody({
           ${(courses ?? []).map((course) => {
             return html`
               <option value="${course.id}" ${course.id === course_id ? 'selected' : ''}>
-                ${course.short_name}: ${course.title}
+                ${course.short_name}: ${course.title} (${course.repository ?? course.path})
               </option>
             `;
           })}


### PR DESCRIPTION
We sometimes hit cases where an institution has multiple courses with the same `short_name` and `title`. This change will allow us to differentiate between them.

There are other bits of the UI where this change could be nice, e.g. the institution admin pages. I'm not going to touch those just yet.