### PR TITLE
Show IDs in feature editor

### DIFF
--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -281,7 +281,7 @@ export function AddFeatureGrantModalBody({
                 value="${institution.id}"
                 ${institution.id === institution_id ? 'selected' : ''}
               >
-                ${institution.long_name} (${institution.short_name})
+                ${institution.long_name}: ${institution.short_name} (${institution.id})
               </option>
             `;
           })}
@@ -328,7 +328,7 @@ export function AddFeatureGrantModalBody({
                 value="${course_instance.id}"
                 ${course_instance.id === course_instance_id ? 'selected' : ''}
               >
-                ${course_instance.long_name} (${course_instance.short_name})
+                ${course_instance.long_name}: ${course_instance.short_name} (${course_instance.id})
               </option>
             `;
           })}

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -303,7 +303,7 @@ export function AddFeatureGrantModalBody({
           ${(courses ?? []).map((course) => {
             return html`
               <option value="${course.id}" ${course.id === course_id ? 'selected' : ''}>
-                ${course.short_name}: ${course.title} (${course.repository ?? course.path})
+                ${course.short_name}: ${course.title} (${course.id})
               </option>
             `;
           })}

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -281,7 +281,7 @@ export function AddFeatureGrantModalBody({
                 value="${institution.id}"
                 ${institution.id === institution_id ? 'selected' : ''}
               >
-                ${institution.long_name}: ${institution.short_name} (${institution.id})
+                ${institution.short_name}: ${institution.long_name} (${institution.id})
               </option>
             `;
           })}
@@ -328,7 +328,7 @@ export function AddFeatureGrantModalBody({
                 value="${course_instance.id}"
                 ${course_instance.id === course_instance_id ? 'selected' : ''}
               >
-                ${course_instance.long_name}: ${course_instance.short_name} (${course_instance.id})
+                ${course_instance.short_name}: ${course_instance.long_name} (${course_instance.id})
               </option>
             `;
           })}

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.sql
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.sql
@@ -33,6 +33,7 @@ SELECT
 FROM
   institutions
 ORDER BY
+  short_name,
   long_name,
   id;
 
@@ -46,6 +47,7 @@ WHERE
   AND deleted_at IS NULL
 ORDER BY
   short_name,
+  title,
   id;
 
 -- BLOCK select_course_instances_for_course
@@ -57,5 +59,6 @@ WHERE
   course_id = $course_id
   AND deleted_at IS NULL
 ORDER BY
+  short_name,
   long_name,
   id;


### PR DESCRIPTION
Followup to #9558. @mwest1066 pointed out on Slack that course ID is probably a better differentiator here, as it's guaranteed to be unique, doesn't require us to have remote repositories, and matches the fact that we anyways want to move course paths on disk to be based on the course ID.

While I was at it, I added ID display to institutions and course instances as well.