### PR TITLE
Don't allow submitted workspace file paths to contain backslashes

### DIFF
--- a/exampleCourse/questions/demo/workspace/dynamicFiles/question.html
+++ b/exampleCourse/questions/demo/workspace/dynamicFiles/question.html
@@ -2,3 +2,5 @@
   <p>This is a workspace question with an in-browser terminal (<a href="https://xtermjs.org/">xterm.js</a>) and dynamic files. These files are created using the <code>generate</code> function in <code>server.py</code>.</p>
   <pl-workspace></pl-workspace>
 </pl-question-panel>
+
+<pl-file-preview></pl-file-preview>

--- a/packages/workspace-utils/src/index.ts
+++ b/packages/workspace-utils/src/index.ts
@@ -87,6 +87,18 @@ export async function getWorkspaceGradedFiles(
     })
   ).filter((file) => contains(workspaceDir, path.join(workspaceDir, file.path)));
 
+  // We generally use `archiver` downstream of this, which does not elegantly
+  // handle file names with backslashes:
+  // https://github.com/archiverjs/node-archiver/issues/743
+  // To prevent downstream issues, we disallow any files with backslashes in
+  // their paths. We fail hard rather than silently dropping these files so
+  // that it's clear to the user what's happening.
+  const backslashPaths = files.filter((file) => file.path.includes('\\'));
+  if (backslashPaths.length > 0) {
+    const paths = backslashPaths.map((file) => file.path).join(', ');
+    throw new Error(`Cannot submit files with paths that contain backslashes: ${paths}`);
+  }
+
   if (files.length > limits.maxFiles) {
     throw new Error(`Cannot submit more than ${limits.maxFiles} files from the workspace.`);
   }


### PR DESCRIPTION
This is necessary because of https://github.com/archiverjs/node-archiver/issues/743. For as long as `archiver` doesn't correctly support backslashes in file names, we'll have to disallow them.