### PR TITLE
Improve error handling when getting workspace graded files

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -301,7 +301,6 @@ const ConfigSchema = z.object({
   workspaceAuthzCookieMaxAgeMilliseconds: z.number().default(60 * 1000),
   workspaceJobsDirectoryOwnerUid: z.number().default(0),
   workspaceJobsDirectoryOwnerGid: z.number().default(0),
-  workspaceJobsParallelLimit: z.number().default(5),
   workspaceHeartbeatIntervalSec: z.number().default(60),
   workspaceHeartbeatTimeoutSec: z.number().default(10 * 60),
   workspaceVisibilityTimeoutSec: z.number().default(30 * 60),


### PR DESCRIPTION
The issue behind #9563 was made much worse by the fact that the error actually crashed the server because we weren't handling `error` events correctly. This PR improves that so if we get another similar error, it will at least fail somewhat gracefully and show _some_ kind of error to the user instead of just 502ing.