### PR TITLE
Improve docs for the active property in access rules

### DIFF
--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -208,13 +208,13 @@ The `showClosedAssessmentScore` access rule restriction is often used in conjunc
 
 The `active` access rule restriction is useful for allowing students to see what assessments they have coming up. It should also be used when [returning exams to students](faq.md#how-do-i-give-students-access-to-view-their-exams-after-they-are-over).
 
-By default, the `active` property in an access rule is `true`. This means students can start the assessment, create new assessment instances, and submit answers to questions.
+By default, the `active` property in an access rule is `true`. This means that, if there is an access rule that applies at a particular time/context, students can start the assessment, create new assessment instances, and submit answers to questions.
 
 If `active` is set to `false` in an access rule, students will still be able to see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page.
 
 If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
 
-Note that when `"active": false` is used to allow student to review their work after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment. However, they will not be able to submit any changed workspace files for grading.
+Note that when `"active": false` is used to allow students to review their work after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment. However, they will not be able to submit any changed workspace files for grading.
 
 An example of the `active` access rule restriction is shown below:
 

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -206,11 +206,15 @@ The `showClosedAssessmentScore` access rule restriction is often used in conjunc
 
 ## Active assessments
 
-The `active` access rule restriction is useful for allowing students to see what assessments they have coming up. It should also be used when [returning exams to students](faq.md#how-do-i-give-students-access-to-view-their-exams-after-they-are-over). If `active` is set to `false`, students can see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page. The `active` property in an access rule is `true` by default.
+The `active` access rule restriction is useful for allowing students to see what assessments they have coming up. It should also be used when [returning exams to students](faq.md#how-do-i-give-students-access-to-view-their-exams-after-they-are-over).
+
+By default, the `active` property in an access rule is `true`. This means students can start the assessment, create new assessment instances, and submit answers to questions.
+
+If `active` is set to `false`, students will still be able to see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page.
 
 If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
 
-Note that when `"active": false` is used to make assessments visible to students after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment. However, they will not be able to submit any changed workspace files for grading.
+Note that when `"active": false` is used to allow student to review their work after they've finished the assessment, students can still access and modify files in any [workspaces](workspaces/index.md) associated with questions on the assessment. However, they will not be able to submit any changed workspace files for grading.
 
 An example of the `active` access rule restriction is shown below:
 

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -210,6 +210,8 @@ The `active` access rule restriction is useful for allowing students to see what
 
 By default, the `active` property in an access rule is `true`. This means that, if there is an access rule that applies at a particular time/context, students can start the assessment, create new assessment instances, and submit answers to questions.
 
+If there is no applicable access rule at a particular time/context, students will not be able to view the assessment, and it won't appear on their Assessments page. They will only be able to see their grade for the assessment in the gradebook.
+
 If `active` is set to `false` in an access rule, students will still be able to see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page.
 
 If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -210,7 +210,7 @@ The `active` access rule restriction is useful for allowing students to see what
 
 By default, the `active` property in an access rule is `true`. This means students can start the assessment, create new assessment instances, and submit answers to questions.
 
-If `active` is set to `false`, students will still be able to see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page.
+If `active` is set to `false` in an access rule, students will still be able to see the assessment on the Assessments page, but they cannot start the assessment, create a new assessment instance, or submit answers to questions. If an assessment is currently not active but will be in the future, students can see when the assessment will become active by looking at the `Available credit` column on the Assessments page.
 
 If `active` is set to `false` in an access rule, the available `credit` cannot be set to any value other than 0 (the default value).
 


### PR DESCRIPTION
This is based on feedback that this documentation wasn't as clear as it could be. Specifically, there was confusion regarding whether or not this controlled visibility of the assessment on the assessments page. I hope these new docs are a little clearer.