### PR TITLE
Remove references to the legacy CBTF scheduler

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -11,7 +11,6 @@ export const AssessmentAccessRulesSchema = z.object({
   time_limit: z.string(),
   password: z.string(),
   exam_uuid: z.string().nullable(),
-  ps_exam_id: z.string().nullable(),
   pt_course_id: z.string().nullable(),
   pt_course_name: z.string().nullable(),
   pt_exam_id: z.string().nullable(),
@@ -115,7 +114,7 @@ export function InstructorAssessmentAccess({
                                   ${access_rule.pt_course_name}: ${access_rule.pt_exam_name}
                                 </a>
                               `
-                            : access_rule.exam_uuid && !access_rule.ps_exam_id
+                            : access_rule.exam_uuid
                               ? resLocals.devMode
                                 ? access_rule.exam_uuid
                                 : html`

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
@@ -29,7 +29,6 @@ SELECT
     ELSE aar.password
   END AS password,
   aar.exam_uuid,
-  e.exam_id AS ps_exam_id,
   pt_c.id AS pt_course_id,
   pt_c.name AS pt_course_name,
   pt_x.id AS pt_exam_id,
@@ -42,8 +41,6 @@ FROM
   assessment_access_rules AS aar
   JOIN assessments AS a ON (a.id = aar.assessment_id)
   JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-  LEFT JOIN exams AS e ON (e.uuid = aar.exam_uuid)
-  LEFT JOIN courses AS ps_c ON (ps_c.course_id = e.course_id)
   LEFT JOIN pt_exams AS pt_x ON (pt_x.uuid = aar.exam_uuid)
   LEFT JOIN pt_courses AS pt_c ON (pt_c.id = pt_x.course_id)
 WHERE

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -197,7 +197,7 @@
           "enum": ["Public", "Exam", "SEB"]
         },
         "examUuid": {
-          "description": "The scheduler exam UUID for which a student must be registered.",
+          "description": "The PrairieTest exam UUID for which a student must be registered.",
           "type": "string",
           "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
         },

--- a/apps/prairielearn/src/sprocs/check_assessment_access_rule.sql
+++ b/apps/prairielearn/src/sprocs/check_assessment_access_rule.sql
@@ -9,8 +9,6 @@ CREATE FUNCTION
         OUT authorized boolean,
         OUT exam_access_end TIMESTAMP WITH TIME ZONE
     ) AS $$
-DECLARE
-    ps_linked boolean;
 BEGIN
     authorized := TRUE;
 
@@ -47,7 +45,7 @@ BEGIN
     -- ############################################################
     -- check access with PrairieTest
 
-    << schedule_access >>
+    << prairietest_access >>
     BEGIN
         -- is an exam_id hardcoded into the access rule? Check that first
         IF assessment_access_rule.exam_uuid IS NOT NULL THEN
@@ -55,7 +53,7 @@ BEGIN
             -- require exam mode
             IF check_assessment_access_rule.mode IS DISTINCT FROM 'Exam' THEN
                 authorized := FALSE;
-                EXIT schedule_access;
+                EXIT prairietest_access;
             END IF;
 
             -- is there a checked-in pt_reservation?
@@ -72,13 +70,13 @@ BEGIN
 
             IF FOUND THEN
                 -- we have a valid reservation, don't keep going to "authorized := FALSE"
-                EXIT schedule_access;
+                EXIT prairietest_access;
             END IF;
 
             -- we only get here if we don't have a reservation, so block access
             authorized := FALSE;
 
         END IF;
-    END schedule_access;
+    END prairietest_access;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/apps/prairielearn/src/sprocs/check_assessment_access_rule.sql
+++ b/apps/prairielearn/src/sprocs/check_assessment_access_rule.sql
@@ -45,7 +45,7 @@ BEGIN
     END IF;
 
     -- ############################################################
-    -- check access with schedulers
+    -- check access with PrairieTest
 
     << schedule_access >>
     BEGIN

--- a/apps/prairielearn/src/sprocs/ip_to_mode.sql
+++ b/apps/prairielearn/src/sprocs/ip_to_mode.sql
@@ -11,6 +11,7 @@ DECLARE
     v_location_id bigint;
     v_filter_networks boolean;
 BEGIN
+    -- Is the user accessing via an exam mode network?
     PERFORM *
     FROM exam_mode_networks
     WHERE ip <<= network AND date <@ during;
@@ -19,23 +20,6 @@ BEGIN
         mode := 'Exam';
     ELSE
         mode := 'Public';
-    END IF;
-
-    -- Does the user have an active online CBTF reservation, if so set mode to 'Exam'
-    PERFORM *
-    FROM
-        reservations AS r
-        JOIN exams AS e USING (exam_id)
-    WHERE
-        r.user_id = ip_to_mode.authn_user_id
-        AND r.delete_date IS NULL
-        AND r.checked_in IS NOT NULL
-        AND r.access_start IS NOT NULL
-        AND date BETWEEN r.access_start AND r.access_end
-        AND e.exam_type = 'online';
-
-    IF FOUND THEN
-        mode := 'Exam';
     END IF;
 
     -- Does the user have an active PT reservation?

--- a/apps/prairielearn/src/sync/fromDisk/assessments.js
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.js
@@ -332,7 +332,7 @@ export async function sync(courseId, courseInstanceId, assessments, questionIds)
         uuidAssessmentMap.get(uuid)?.forEach((tid) => {
           infofile.addWarning(
             assessments[tid],
-            `examUuid "${uuid}" not found. Ensure you copied the correct UUID from the scheduler.`,
+            `examUuid "${uuid}" not found. Ensure you copied the correct UUID from PrairieTest.`,
           );
         });
       }

--- a/apps/prairielearn/src/sync/fromDisk/assessments.sql
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.sql
@@ -6,14 +6,6 @@ SELECT
       SELECT
         1
       FROM
-        exams
-      WHERE
-        exams.uuid = exam_uuids.value::uuid
-    )
-    OR EXISTS (
-      SELECT
-        1
-      FROM
         pt_exams
       WHERE
         pt_exams.uuid = exam_uuids.value::uuid

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -99,7 +99,7 @@ The above example will give students 90 minutes for this exam, and they must sta
 
 ![Time limit illustrations](exam_timer.svg)
 
-**Note that time limits should not be set for exams in the CBTF (Computer-Based Testing Facility). Instead, such exams should set `"mode": "Exam"`, in which case `timeLimitMin` will have no effect and the time limits will be enforced by the CBTF scheduling software.**
+**Note that time limits should not be set for exams in the CBTF (Computer-Based Testing Facility). Instead, such exams should set `"mode": "Exam"`, in which case `timeLimitMin` will have no effect and the time limits will be enforced by PrairieTest.**
 
 ### Time limit adjustments for open assessments
 

--- a/docs/accessControl.md
+++ b/docs/accessControl.md
@@ -34,7 +34,7 @@ Each `accessRule` is an object that specifies a set of circumstances under which
 | [`credit`](#credit)                                                 |                | ✓          | Maximum credit as percentage of full credit (can be more than 100).                                        | `"credit": 100`                                         |
 | [`timeLimitMin`](#time-limits)                                      |                | ✓          | Time limit in minutes to complete an assessment (only for Exams).                                          | `"timeLimitMin": 60`                                    |
 | [`password`](#passwords)                                            |                | ✓          | Password required to start an assessment (only for Exams).                                                 | `"password": "mysecret"`                                |
-| [`examUuid`](#exam-uuids)                                           |                | ✓          | Exam scheduler UUID that students must register for.                                                       | `"examUuid": "5719ebfe-ad20-42b1-b0dc-c47f0f714871"`    |
+| [`examUuid`](#exam-uuids)                                           |                | ✓          | PrairieTest UUID for the exam that students must register for.                                             | `"examUuid": "5719ebfe-ad20-42b1-b0dc-c47f0f714871"`    |
 | [`showClosedAssessment`](#showinghiding-closed-assessments)         |                | ✓          | Whether to allow viewing of assessment contents when closed (default `true`).                              | `"showClosedAssessment": false`                         |
 | [`showClosedAssessmentScore`](#showinghiding-all-score-information) |                | ✓          | Whether to allow viewing of the score of a closed assessment (default `true`).                             | `"showClosedAssessmentScore": false`                    |
 | [`active`](#active-assessments)                                     |                | ✓          | Whether the student can create a new assessment instance and submit answers to questions (default `true`). | `"active": false`                                       |
@@ -136,7 +136,7 @@ Before a student can do the exam, a proctor will need to type the phrase `mysecr
 
 ## Exam UUIDs
 
-To require that students are taking a particular exam in the Computer-Based Testing Facility (CBTF), the `examUuid` should be set to the UUID value from the scheduler app. For example:
+To require that students are taking a particular exam in the Computer-Based Testing Facility (CBTF), the `examUuid` should be set to the UUID value from PrairieTest. For example:
 
 ```
 "allowAccess": [
@@ -148,7 +148,7 @@ To require that students are taking a particular exam in the Computer-Based Test
 ]
 ```
 
-Note that in this case the `startDate` and `endDate` should _NOT_ be specified. These will be automatically determined by the scheduler app and should not be set in PrairieLearn.
+Note that in this case the `startDate` and `endDate` should _NOT_ be specified. These will be automatically determined by PrairieTest and should not be set in PrairieLearn.
 
 ## Showing/hiding closed assessments
 

--- a/docs/remoteExams.md
+++ b/docs/remoteExams.md
@@ -20,7 +20,7 @@ If you are using the CBTF for remote proctoring then the access control should l
 
 Some notes about this configuration:
 
-- The `examUuid` parameter should be copied from the CBTF Scheduler website for the specific exam. Each exam has its own unique `examUuid` and it's vital that the correct value is used for each separate exam.
+- The `examUuid` parameter should be copied from PrairieTest for the specific exam. Each exam has its own unique `examUuid` and it's vital that the correct value is used for each separate exam.
 - Date restrictions and time limits must not be set for the exam. All limits will be automatically enforced by the CBTF on a per-student basis, taking into account conflict exams and disability accommodations.
 
 ## CBTF exams with a few students outside the CBTF

--- a/docs/workshop/lesson2.md
+++ b/docs/workshop/lesson2.md
@@ -142,7 +142,7 @@ When using [PrairieTest](https://us.prairietest.com/pt/docs/course/welcome) to s
   }
   ```
 
-You will be able to find the `examUuid` in the CBTF scheduler app.
+You will be able to find the `examUuid` in PrairieTest.
 
 ## Homework 2
 


### PR DESCRIPTION
I started cleaning up `ip_to_mode` for some unrelated changes; figured I'd do all the cleanup as long as I was at it.