### PR TITLE
Backfill workspace disk usage

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
@@ -1,0 +1,28 @@
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { queryOneRowAsync, queryRows } from '@prairielearn/postgres';
+import { updateWorkspaceDiskUsage } from '@prairielearn/workspace-utils';
+
+import { config } from '../lib/config';
+import { WorkspaceSchema } from '../lib/db-types';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const result = await queryOneRowAsync('SELECT MAX(id) as max from workspaces;', {});
+    return {
+      min: 1n,
+      max: result.rows[0].max,
+      batchSize: 100,
+    };
+  },
+  async execute(min: bigint, max: bigint): Promise<void> {
+    const workspaces = await queryRows(
+      'SELECT * FROM workspaces WHERE id >= $min AND id <= $max',
+      { min, max },
+      WorkspaceSchema,
+    );
+
+    for (const workspace of workspaces) {
+      await updateWorkspaceDiskUsage(workspace.id, config.workspaceHomeDirRoot);
+    }
+  },
+});

--- a/apps/prairielearn/src/batched-migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
@@ -15,16 +15,14 @@ export default makeBatchedMigration({
     };
   },
   async execute(min: bigint, max: bigint): Promise<void> {
+    // We skip all workspaces that already have a disk usage value.
     const workspaces = await queryRows(
-      'SELECT * FROM workspaces WHERE id >= $min AND id <= $max',
+      'SELECT * FROM workspaces WHERE id >= $min AND id <= $max AND disk_usage_bytes IS NULL',
       { min, max },
       WorkspaceSchema,
     );
 
     for (const workspace of workspaces) {
-      // We may have already computed the disk usage for this workspace.
-      if (workspace.disk_usage_bytes !== null) continue;
-
       await updateWorkspaceDiskUsage(workspace.id, config.workspaceHomeDirRoot);
     }
   },

--- a/apps/prairielearn/src/batched-migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
@@ -22,6 +22,9 @@ export default makeBatchedMigration({
     );
 
     for (const workspace of workspaces) {
+      // We may have already computed the disk usage for this workspace.
+      if (workspace.disk_usage_bytes !== null) continue;
+
       await updateWorkspaceDiskUsage(workspace.id, config.workspaceHomeDirRoot);
     }
   },

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -239,6 +239,7 @@ export type Question = z.infer<typeof QuestionSchema>;
 
 export const WorkspaceSchema = z.object({
   created_at: DateFromISOString,
+  disk_usage_bytes: z.coerce.number().nullable(), // This is BIGINT, but always fits a number
   heartbeat_at: DateFromISOString.nullable(),
   hostname: z.string().nullable(),
   id: IdSchema,

--- a/apps/prairielearn/src/migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
+++ b/apps/prairielearn/src/migrations/20240320000007_workspaces__disk_usage_bytes__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20240320000007_workspaces__disk_usage_bytes__backfill');
+}


### PR DESCRIPTION
Followup to #9576 to backfill `workspaces.disk_usage_bytes` for all existing rows.