### PR TITLE
Allow copying template course questions from public sharing page

### DIFF
--- a/apps/prairielearn/src/pages/partials/question.ejs
+++ b/apps/prairielearn/src/pages/partials/question.ejs
@@ -107,7 +107,7 @@
         <% } %>
         <% // Show even when question_copy_targets is empty. %>
         <% // We'll show a CTA to request a course if the user isn't an editor of any course. %>
-        <% if (course.template_course && question_context != 'manual_grading') { %>
+        <% if (typeof question_copy_targets !== 'undefined' && course.template_course && question_context != 'manual_grading') { %>
           <button class="btn btn-light btn-sm ml-auto" type="button" data-toggle="modal" data-target="#copyQuestionModal">
             <i class="fa fa-clone"></i>
             Copy question

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -16,6 +16,7 @@ import {
   setRendererHeader,
 } from '../../lib/question-render';
 import { PublicQuestionPreview } from './publicQuestionPreview.html';
+import { setQuestionCopyTargets } from '../../lib/copy-question';
 
 const logPageView = promisify(LogPageView(path.basename(__filename, '.ts')));
 
@@ -80,6 +81,7 @@ router.get(
     const variant_id = req.query.variant_id ? IdSchema.parse(req.query.variant_id) : null;
     await getAndRenderVariant(variant_id, variant_seed, res.locals);
     await logPageView(req, res);
+    await setQuestionCopyTargets(res);
     setRendererHeader(res);
     res.send(PublicQuestionPreview({ resLocals: res.locals }));
   }),


### PR DESCRIPTION
The public question preview page was showing the "Copy question" button for template courses, but the button wasn't actually doing anything because `question_copy_targets` wasn't defined. This PR makes the button work.