### PR TITLE
Print batched migration error to console

### DIFF
--- a/packages/migrations/src/batched-migrations/batched-migration-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.ts
@@ -177,6 +177,11 @@ export class BatchedMigrationRunner {
       }
 
       if (error) {
+        console.error('Error running the batched migration job: ');
+        console.error(error);
+        console.error(
+          'To re-run the migration job, open the Admin Panel and click "Retry Failed Jobs"',
+        );
         await this.finishJob(nextJob, 'failed', { error: serializeError(error) });
       } else {
         await this.finishJob(nextJob, 'succeeded');


### PR DESCRIPTION
The current implementation of batched migration fails silently on dev mode, since in most situations in dev mode we don't need to open the Batched Migrations tab on Admin to run the migration. An error on the console will alert the user that the migration failed.