### PR TITLE
Remove all references to access rule role columns

### DIFF
--- a/apps/prairielearn/src/admin_queries/upcoming_exams.sql
+++ b/apps/prairielearn/src/admin_queries/upcoming_exams.sql
@@ -27,10 +27,6 @@ WITH
       AND (
         aar.end_date BETWEEN (now() - interval '1 hour') AND (now() + interval '14 days')
       )
-      AND (
-        aar.role IS NULL
-        OR aar.role = 'Student'
-      )
       AND aar.credit >= 100
       AND a.type = 'Exam'
       AND a.deleted_at IS NULL

--- a/apps/prairielearn/src/models/course-instances.sql
+++ b/apps/prairielearn/src/models/course-instances.sql
@@ -44,7 +44,6 @@ FROM
       course_instance_access_rules AS ar
     WHERE
       ar.course_instance_id = ci.id
-      AND ((ar.role > 'Student') IS NOT TRUE)
   ) AS d
 WHERE
   c.id = $course_id

--- a/apps/prairielearn/src/pages/enroll/enroll.sql
+++ b/apps/prairielearn/src/pages/enroll/enroll.sql
@@ -23,7 +23,6 @@ FROM
       course_instance_access_rules AS ar
     WHERE
       ar.course_instance_id = ci.id
-      AND ((ar.role > 'Student') IS NOT TRUE)
   ) AS d
 WHERE
   u.user_id = $user_id

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -31,7 +31,6 @@ WITH
           course_instance_access_rules AS ar
         WHERE
           ar.course_instance_id = ci.id
-          AND ((ar.role > 'Student') IS NOT TRUE)
       ) AS d
     WHERE
       c.deleted_at IS NULL
@@ -75,7 +74,6 @@ WITH
           course_instance_access_rules AS ar
         WHERE
           ar.course_instance_id = ci.id
-          AND ((ar.role > 'Student') IS NOT TRUE)
       ) AS d
     WHERE
       c.deleted_at IS NULL
@@ -162,7 +160,6 @@ WITH
           course_instance_access_rules AS ar
         WHERE
           ar.course_instance_id = ci.id
-          AND ((ar.role > 'Student') IS NOT TRUE)
       ) AS d
     WHERE
       u.user_id = $user_id

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
@@ -45,6 +45,5 @@ FROM
   LEFT JOIN pt_courses AS pt_c ON (pt_c.id = pt_x.course_id)
 WHERE
   a.id = $assessment_id
-  AND ((aar.role > 'Student') IS NOT TRUE)
 ORDER BY
   aar.number;

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.sql
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.sql
@@ -58,7 +58,6 @@ FROM
       course_instance_access_rules AS ar
     WHERE
       ar.course_instance_id = ci.id
-      AND ((ar.role > 'Student') IS NOT TRUE)
   ) AS d
 WHERE
   cp.course_id = $course_id

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.sql
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.sql
@@ -21,6 +21,5 @@ FROM
   JOIN course_instances AS ci ON (ci.id = ciar.course_instance_id)
 WHERE
   ciar.course_instance_id = $course_instance_id
-  AND ((ciar.role > 'Student') IS NOT TRUE)
 ORDER BY
   ciar.number;

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.sql
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.sql
@@ -26,7 +26,6 @@ FROM
       course_instance_access_rules AS ar
     WHERE
       ar.course_instance_id = ci.id
-      AND ((ar.role > 'Student') IS NOT TRUE)
   ) AS d
 WHERE
   aq.question_id = $question_id

--- a/apps/prairielearn/src/sprocs/check_assessment_access.sql
+++ b/apps/prairielearn/src/sprocs/check_assessment_access.sql
@@ -76,7 +76,6 @@ BEGIN
     WHERE
         aar.assessment_id = check_assessment_access.assessment_id
         AND caar.authorized
-        AND ((aar.role > 'Student') IS NOT TRUE)
     ORDER BY
         aar.credit DESC NULLS LAST,
         aar.number
@@ -114,7 +113,6 @@ BEGIN
             AND aar.active
             AND aar.start_date > check_assessment_access.date
             AND caar.authorized
-            AND ((aar.role > 'Student') IS NOT TRUE)
         ORDER BY
             aar.start_date,
             aar.credit DESC NULLS LAST,
@@ -168,7 +166,6 @@ BEGIN
             check_assessment_access.user_id, check_assessment_access.uid, NULL, FALSE) AS caar ON TRUE
     WHERE
         aar.assessment_id = check_assessment_access.assessment_id
-        AND ((aar.role > 'Student') IS NOT TRUE)
         AND (
             (aar.active AND caar.authorized)
             OR (course_role >= 'Previewer' OR course_instance_role >= 'Student Data Viewer') -- Override for instructors

--- a/apps/prairielearn/src/sprocs/check_assessment_access_rule.sql
+++ b/apps/prairielearn/src/sprocs/check_assessment_access_rule.sql
@@ -12,11 +12,6 @@ CREATE FUNCTION
 BEGIN
     authorized := TRUE;
 
-    IF assessment_access_rule.role > 'Student' THEN
-        authorized := FALSE;
-        RETURN;
-    END IF;
-
     IF (assessment_access_rule.mode IS NOT NULL
         AND assessment_access_rule.mode != 'SEB') THEN
         IF mode IS NULL OR mode != assessment_access_rule.mode THEN

--- a/apps/prairielearn/src/sprocs/check_course_instance_access.sql
+++ b/apps/prairielearn/src/sprocs/check_course_instance_access.sql
@@ -22,6 +22,5 @@ FROM
     course_instance_access_rules AS ciar,
     selected_course
 WHERE
-    ciar.course_instance_id = check_course_instance_access.course_instance_id
-    AND ((ciar.role > 'Student') IS NOT TRUE);
+    ciar.course_instance_id = check_course_instance_access.course_instance_id;
 $$ LANGUAGE SQL STABLE;

--- a/apps/prairielearn/src/sprocs/check_course_instance_access_rule.sql
+++ b/apps/prairielearn/src/sprocs/check_course_instance_access_rule.sql
@@ -10,11 +10,6 @@ DECLARE
     available boolean := TRUE;
     user_result record;
 BEGIN
-    IF course_instance_access_rule.role > 'Student' THEN
-        available := FALSE;
-        RETURN available;
-    END IF;
-
     IF course_instance_access_rule.uids IS NOT NULL THEN
         IF uid != ALL (course_instance_access_rule.uids) THEN
             available := FALSE;

--- a/apps/prairielearn/src/sprocs/sync_assessments.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessments.sql
@@ -259,7 +259,6 @@ BEGIN
                 assessment_id,
                 number,
                 mode,
-                role,
                 credit,
                 uids,
                 time_limit_min,
@@ -276,7 +275,6 @@ BEGIN
                     new_assessment_id,
                     (access_rule->>'number')::integer,
                     (access_rule->>'mode')::enum_mode,
-                    'Student'::enum_role,
                     (access_rule->>'credit')::integer,
                     jsonb_array_to_text_array(access_rule->'uids'),
                     (access_rule->>'time_limit_min')::integer,
@@ -297,7 +295,6 @@ BEGIN
             ON CONFLICT (number, assessment_id) DO UPDATE
             SET
                 mode = EXCLUDED.mode,
-                role = EXCLUDED.role,
                 credit = EXCLUDED.credit,
                 time_limit_min = EXCLUDED.time_limit_min,
                 password = EXCLUDED.password,

--- a/apps/prairielearn/src/sprocs/sync_course_instances.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_instances.sql
@@ -161,7 +161,6 @@ BEGIN
         INSERT INTO course_instance_access_rules (
             course_instance_id,
             number,
-            role,
             uids,
             start_date,
             end_date,
@@ -169,7 +168,6 @@ BEGIN
         ) SELECT
             syncing_course_instance_id,
             number,
-            'Student'::enum_role,
             CASE
                 WHEN access_rule->'uids' = null::JSONB THEN NULL
                 ELSE jsonb_array_to_text_array(access_rule->'uids')
@@ -181,7 +179,6 @@ BEGIN
             JSONB_ARRAY_ELEMENTS(valid_course_instance.data->'access_rules') WITH ORDINALITY AS t(access_rule, number)
         ON CONFLICT (number, course_instance_id) DO UPDATE
         SET
-            role = EXCLUDED.role,
             uids = EXCLUDED.uids,
             start_date = EXCLUDED.start_date,
             end_date = EXCLUDED.end_date,


### PR DESCRIPTION
Contains the same changes as #4659, just without the migration that removes the columns. We can only safely apply that once nothing is reading from these columns.