### PR TITLE
Handle API errors with Sentry

### DIFF
--- a/apps/prairielearn/src/api/v1/index.js
+++ b/apps/prairielearn/src/api/v1/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 
 const error = require('@prairielearn/error');
+const Sentry = require('@prairielearn/sentry');
 
 const router = express.Router();
 
@@ -58,7 +59,10 @@ router.use(
 // If no earlier routes matched, 404 the route
 router.use(require('./notFound'));
 
-// Handle errors independently from the normal PL eror handling
+// The Sentry error handler must come before our own.
+router.use(Sentry.Handlers.errorHandler());
+
+// Handle errors independently from the normal PL error handling
 router.use(require('./error'));
 
 module.exports = router;

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1953,9 +1953,9 @@ module.exports.initExpress = function () {
     next(err);
   });
 
+  // The Sentry error handler must come before our own.
   app.use(Sentry.Handlers.errorHandler());
 
-  // Note that the Sentry error handler should come before our error page.
   app.use(require('./pages/error/error'));
 
   return app;


### PR DESCRIPTION
Our API router terminates the error-handling process, so our usual Sentry error handle would never be used. This PR inserts the handler such that it'll also run for API errors.