### PR TITLE
Fix misuses of role="button"

### DIFF
--- a/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.html.ts
+++ b/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.html.ts
@@ -27,7 +27,7 @@ export function AdministratorJobSequence({
         <main id="content" class="container-fluid">
           <div class="row">
             <div class="col-12">
-              <a class="btn btn-primary mb-4" href="javascript:history.back();" role="button">
+              <a class="btn btn-primary mb-4" href="javascript:history.back();">
                 <i class="fa fa-arrow-left" aria-hidden="true"></i>
                 Back to previous page
               </a>

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -242,14 +242,12 @@ export function AdministratorQuery({
                             </span>
                             <a
                               href="${`?query_run_id=${query_run_id}&format=json`}"
-                              role="button"
                               class="btn btn-sm btn-light"
                             >
                               <i class="fas fa-download" aria-hidden="true"></i> JSON
                             </a>
                             <a
                               href="${`?query_run_id=${query_run_id}&format=csv`}"
-                              role="button"
                               class="btn btn-sm btn-light"
                             >
                               <i class="fas fa-download" aria-hidden="true"></i> CSV

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -135,7 +135,7 @@ function LoginPageContainer({
 
 function ShibLoginButton() {
   return html`
-    <a class="btn btn-shib d-block position-relative" href="/pl/shibcallback" role="button">
+    <a class="btn btn-shib d-block position-relative" href="/pl/shibcallback">
       ${config.shibLinkLogo != null
         ? html`<img src="${config.shibLinkLogo}" class="social-icon" />`
         : html`<span class="social-icon"></span>`}
@@ -146,7 +146,7 @@ function ShibLoginButton() {
 
 function GoogleLoginButton() {
   return html`
-    <a class="btn btn-primary d-block position-relative" href="/pl/oauth2login" role="button">
+    <a class="btn btn-primary d-block position-relative" href="/pl/oauth2login">
       <img src="${assetPath('/images/google_logo.svg')}" class="social-icon" />
       <span class="font-weight-bold">Sign in with Google</span>
     </a>
@@ -155,7 +155,7 @@ function GoogleLoginButton() {
 
 function MicrosoftLoginButton() {
   return html`
-    <a class="btn btn-dark d-block position-relative" href="/pl/azure_login" role="button">
+    <a class="btn btn-dark d-block position-relative" href="/pl/azure_login">
       <img src="${assetPath('/images/ms_logo.svg')}" class="social-icon" />
       <span class="font-weight-bold">Sign in with Microsoft</span>
     </a>
@@ -299,7 +299,7 @@ export function AuthLoginUnsupportedProvider({
 
 function DevModeBypass() {
   return html`
-    <a class="btn btn-success w-100" href="/pl/dev_login" role="button">
+    <a class="btn btn-success w-100" href="/pl/dev_login">
       <span class="font-weight-bold">Dev Mode Bypass</span>
     </a>
     <small class="text-muted">You will be authenticated as <tt>${config.authUid}</tt>.</small>

--- a/apps/prairielearn/src/pages/editError/editError.ejs
+++ b/apps/prairielearn/src/pages/editError/editError.ejs
@@ -25,7 +25,7 @@
                         Edit Failure
                     </div>
                     <div class="col-auto">
-                        <a class="btn btn-light btn-sm" data-toggle="collapse" href="#results-some-uuid" role="button" id="results-some-uuid-button">Show detail</a>
+                        <button type="button" class="btn btn-light btn-sm" data-toggle="collapse" data-target="#results-some-uuid" id="results-some-uuid-button">Show detail</a>
                     </div>
                 </div>
             </h5>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -120,7 +120,7 @@ ${submission.feedback?.manual}</textarea
         <li class="list-group-item d-flex align-items-center">
           ${!hide_back_to_question
             ? html`
-                <a role="button" class="btn btn-primary" href="${assessment_question_url}">
+                <a class="btn btn-primary" href="${assessment_question_url}">
                   <i class="fas fa-arrow-left"></i>
                   Back to Question
                 </a>
@@ -141,7 +141,6 @@ ${submission.feedback?.manual}</textarea
               : ''}
             <div class="btn-group">
               <a
-                role="button"
                 class="btn btn-secondary"
                 href="${assessment_question_url}/next_ungraded?prior_instance_question_id=${resLocals
                   .instance_question.id}"

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ejs
@@ -87,7 +87,7 @@
                                     infoAssessment.json
                                 </a>
                                 <% if ((authz_data.has_course_permission_edit) && (! course.example_course)) { %>
-                                    <a tabindex="0" class="btn btn-xs btn-secondary mx-2" role="button" href="<%= urlPrefix %>/assessment/<%= assessment.id %>/file_edit/<%= infoAssessmentPath %>">
+                                    <a class="btn btn-xs btn-secondary mx-2" href="<%= urlPrefix %>/assessment/<%= assessment.id %>/file_edit/<%= infoAssessmentPath %>">
                                         <i class="fa fa-edit"></i>
                                         <span>Edit</span>
                                     </a>

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ejs
@@ -97,7 +97,7 @@
               <% } %>
               <tr id="row-<%= row.id %>">
                 <td class="align-middle" style="width: 1%">
-                  <a href="<%= urlPrefix %>/assessment/<%= row.id %>/" class="badge color-<%= row.color %> color-hover" role="button">
+                  <a href="<%= urlPrefix %>/assessment/<%= row.id %>/" class="badge color-<%= row.color %> color-hover">
                     <%= row.label %></a>
                 </td>
                 <td class="align-middle">

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -183,7 +183,7 @@ export const InstructorSharing = ({
                     <form name="sharing-id-regenerate" method="POST" class="d-inline">
                       <input type="hidden" name="__action" value="sharing_token_regenerate" />
                       <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                      <button role="button" type="submit" class="btn btn-xs btn-secondary">
+                      <button type="submit" class="btn btn-xs btn-secondary">
                         <i class="fa fa-rotate"></i>
                         <span>Regenerate</span>
                       </button>

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ejs
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ejs
@@ -74,7 +74,7 @@
                   <i class="fa fa-edit"></i>
                   <span>Edit</span>
                 </a>
-                <button id="instructorFileUploadForm-<%= file_browser.file.id %>" tabindex="0" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: file_browser.file}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!file_browser.file.canUpload) { %>disabled<% } %>>
+                <button type="button" id="instructorFileUploadForm-<%= file_browser.file.id %>" tabindex="0" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: file_browser.file}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!file_browser.file.canUpload) { %>disabled<% } %>>
                   <i class="fa fa-arrow-up"></i>
                   <span>Upload</span>
                 </button>
@@ -143,13 +143,13 @@
               <tr>
                 <td>
                   <% if (f.sync_errors) { %>
-                  <button class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Errors"
+                  <button type="button" class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Errors"
                           data-html="true" data-container="body" data-trigger="hover"
                           data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3&quot;><%= f.sync_errors_ansified %></pre>">
                     <i class="fa fa-times text-danger" aria-hidden="true"></i>
                   </button>
                   <% } else if (f.sync_warnings) { %>
-                  <button class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Warnings"
+                  <button type="button" class="btn btn-xs mr-1" data-toggle="popover" data-title="Sync Warnings"
                           data-html="true" data-container="body" data-trigger="hover"
                           data-content="<pre style=&quot;background-color: black&quot; class=&quot;text-white rounded p-3&quot;><%= f.sync_warnings_ansified %></pre>">
                     <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
@@ -163,23 +163,23 @@
                   <% } %>
                 </td>
                 <td>
-                  <a tabindex="0" class="btn btn-xs btn-secondary <% if (!f.canEdit) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_edit/<%= f.encodedPath %>">
+                  <a class="btn btn-xs btn-secondary <% if (!f.canEdit) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_edit/<%= f.encodedPath %>">
                     <i class="fa fa-edit"></i>
                     <span>Edit</span>
                   </a>
-                  <button id="instructorFileUploadForm-<%= f.id %>" tabindex="0" class="btn btn-xs btn-secondary" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: f}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!f.canUpload) { %>disabled<% } %>>
+                  <button type="button" id="instructorFileUploadForm-<%= f.id %>" class="btn btn-xs btn-secondary" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: f}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!f.canUpload) { %>disabled<% } %>>
                     <i class="fa fa-arrow-up"></i>
                     <span>Upload</span>
                   </button>
-                  <a tabindex="0" class="btn btn-xs btn-secondary <% if (!f.canDownload) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_download/<%= f.encodedPath %>?attachment=<%= f.encodedName %>">
+                  <a class="btn btn-xs btn-secondary <% if (!f.canDownload) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_download/<%= f.encodedPath %>?attachment=<%= f.encodedName %>">
                     <i class="fa fa-arrow-down"></i>
                     <span>Download</span>
                   </a>
-                  <button id="instructorFileRenameForm-<%= f.id %>" tabindex="0" class="btn btn-xs btn-secondary" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Rename file" data-content="<%= include('instructorFileRenameForm', {file: f}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!f.canRename) { %>disabled<% } %>>
+                  <button type="button" id="instructorFileRenameForm-<%= f.id %>"class="btn btn-xs btn-secondary" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Rename file" data-content="<%= include('instructorFileRenameForm', {file: f}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!f.canRename) { %>disabled<% } %>>
                     <i class="fa fa-i-cursor"></i>
                     <span>Rename</span>
                   </button>
-                  <button id="instructorFileDeleteForm-<%= f.id %>" tabindex="0" class="btn btn-xs btn-secondary" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Confirm delete" data-content="<%= include('instructorFileDeleteForm', {file: f}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!f.canDelete) { %>disabled<% } %>>
+                  <button type="button" id="instructorFileDeleteForm-<%= f.id %>" class="btn btn-xs btn-secondary" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Confirm delete" data-content="<%= include('instructorFileDeleteForm', {file: f}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!f.canDelete) { %>disabled<% } %>>
                     <i class="far fa-trash-alt"></i>
                     <span>Delete</span>
                   </button>

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ejs
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ejs
@@ -70,7 +70,7 @@
                 <% if (file_browser.isFile) { %>
 
                 <%# File head %>
-                <a tabindex="0" class="btn btn-sm btn-light <% if (!file_browser.file.canEdit) { %>disabled<% } %>" role="button" href="<%= file_browser.paths.urlPrefix %>/file_edit/<%= file_browser.file.encodedPath %>">
+                <a tabindex="0" class="btn btn-sm btn-light <% if (!file_browser.file.canEdit) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_edit/<%= file_browser.file.encodedPath %>">
                   <i class="fa fa-edit"></i>
                   <span>Edit</span>
                 </a>
@@ -78,15 +78,15 @@
                   <i class="fa fa-arrow-up"></i>
                   <span>Upload</span>
                 </button>
-                <a tabindex="0" class="btn btn-sm btn-light <% if (!file_browser.file.canDownload) { %>disabled<% } %>" role="button" href="<%= file_browser.paths.urlPrefix %>/file_download/<%= file_browser.file.encodedPath %>?attachment=<%= file_browser.file.encodedName %>">
+                <a class="btn btn-sm btn-light <% if (!file_browser.file.canDownload) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_download/<%= file_browser.file.encodedPath %>?attachment=<%= file_browser.file.encodedName %>">
                   <i class="fa fa-arrow-down"></i>
                   <span>Download</span>
                 </a>
-                <button id="instructorFileRenameForm-<%= file_browser.file.id %>" tabindex="0" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Rename file" data-content="<%= include('instructorFileRenameForm', {file: file_browser.file}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!file_browser.file.canRename) { %>disabled<% } %>>
+                <button type="button" id="instructorFileRenameForm-<%= file_browser.file.id %>" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Rename file" data-content="<%= include('instructorFileRenameForm', {file: file_browser.file}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!file_browser.file.canRename) { %>disabled<% } %>>
                   <i class="fa fa-i-cursor"></i>
                   <span>Rename</span>
                 </button>
-                <button id="instructorFileDeleteForm-<%= file_browser.file.id %>" tabindex="0" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Confirm delete" data-content="<%= include('instructorFileDeleteForm', {file: file_browser.file}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!file_browser.file.canDelete) { %>disabled<% } %>>
+                <button type="button" id="instructorFileDeleteForm-<%= file_browser.file.id %>" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Confirm delete" data-content="<%= include('instructorFileDeleteForm', {file: file_browser.file}) %>" data-trigger="manual" onclick="$(this).popover('show')" <% if (!file_browser.file.canDelete) { %>disabled<% } %>>
                   <i class="far fa-trash-alt"></i>
                   <span>Delete</span>
                 </button>
@@ -97,13 +97,13 @@
                 <% if ((authz_data.has_course_permission_edit) && (! course.example_course)) { %>
                 <% if (file_browser.paths.specialDirs) { %>
                   <% file_browser.paths.specialDirs.forEach((d) => { %>
-                    <button id="instructorFileUploadForm-New<%= d.label %>" tabindex="0" class="btn btn-sm btn-light" role="button" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: {id: 'New' + d.label, info: d.info, working_path: d.path}}) %>" data-trigger="manual" onclick="$(this).popover('show')">
+                    <button type="button" id="instructorFileUploadForm-New<%= d.label %>" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: {id: 'New' + d.label, info: d.info, working_path: d.path}}) %>" data-trigger="manual" onclick="$(this).popover('show')">
                       <i class="fa fa-plus"></i>
                       <span>Add new <%= d.label.toLowerCase() %> file</span>
                     </button>
                   <% }); %>
                 <% } %>
-                <button id="instructorFileUploadForm-New" tabindex="0" class="btn btn-sm btn-light" role="button" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: {id: 'New', working_path: file_browser.paths.workingPath}}) %>" data-trigger="manual" onclick="$(this).popover('show')">
+                <button type="button" id="instructorFileUploadForm-New" class="btn btn-sm btn-light" data-toggle="popover" data-container="body" data-html="true" data-placement="auto" title="Upload file" data-content="<%= include('instructorFileUploadForm', {file: {id: 'New', working_path: file_browser.paths.workingPath}}) %>" data-trigger="manual" onclick="$(this).popover('show')">
                   <i class="fa fa-plus"></i>
                   <span>Add new file</span>
                 </button>
@@ -163,7 +163,7 @@
                   <% } %>
                 </td>
                 <td>
-                  <a tabindex="0" class="btn btn-xs btn-secondary <% if (!f.canEdit) { %>disabled<% } %>" role="button" href="<%= file_browser.paths.urlPrefix %>/file_edit/<%= f.encodedPath %>">
+                  <a tabindex="0" class="btn btn-xs btn-secondary <% if (!f.canEdit) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_edit/<%= f.encodedPath %>">
                     <i class="fa fa-edit"></i>
                     <span>Edit</span>
                   </a>
@@ -171,7 +171,7 @@
                     <i class="fa fa-arrow-up"></i>
                     <span>Upload</span>
                   </button>
-                  <a tabindex="0" class="btn btn-xs btn-secondary <% if (!f.canDownload) { %>disabled<% } %>" role="button" href="<%= file_browser.paths.urlPrefix %>/file_download/<%= f.encodedPath %>?attachment=<%= f.encodedName %>">
+                  <a tabindex="0" class="btn btn-xs btn-secondary <% if (!f.canDownload) { %>disabled<% } %>" href="<%= file_browser.paths.urlPrefix %>/file_download/<%= f.encodedPath %>?attachment=<%= f.encodedName %>">
                     <i class="fa fa-arrow-down"></i>
                     <span>Download</span>
                   </a>

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ejs
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ejs
@@ -147,13 +147,15 @@
                             </span>
                         </div>
                         <div class="col-auto collapse <% if ((!fileEdit.failedPush) && (!fileEdit.alertChoice)) { %>show<% } %>" id="buttons-<%= fileEdit.uuid %>">
-                            <a id="help-<%= fileEdit.uuid %>-button"
-                               class="btn btn-light btn-sm"
-                               data-toggle="collapse" href="#help-<%= fileEdit.uuid %>"
-                               role="button" aria-expanded="false">
+                            <button
+                                id="help-<%= fileEdit.uuid %>-button"
+                                class="btn btn-light btn-sm"
+                                data-toggle="collapse"
+                                data-target="#help-<%= fileEdit.uuid %>"
+                                aria-expanded="false">
                                 <i class="far fa-question-circle" aria-hidden="true"></i>
                                 <span id="help-<%= fileEdit.uuid %>-button-label">Show help</span>
-                            </a>
+                            </button>
                             <button id="file-editor-<%= fileEdit.uuid %>-save-button" name="__action" value="save_and_sync" class="btn btn-light btn-sm" disabled>
                                 <i class="fas fa-save" aria-hidden="true"></i>
                                 Save and sync
@@ -190,7 +192,7 @@
                                 </div>
                                 <% if (fileEdit.jobSequenceId != null) { %>
                                 <div class="col-auto">
-                                    <a class="btn btn-secondary btn-sm" data-toggle="collapse" href="#results-<%= fileEdit.uuid %>" role="button" id="results-<%= fileEdit.uuid %>-button">Show detail</a>
+                                    <button type="button" class="btn btn-secondary btn-sm" data-toggle="collapse" data-target="#results-<%= fileEdit.uuid %>" id="results-<%= fileEdit.uuid %>-button">Show detail</button>
                                 </div>
                                 <% } %>
                                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ejs
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ejs
@@ -148,6 +148,7 @@
                         </div>
                         <div class="col-auto collapse <% if ((!fileEdit.failedPush) && (!fileEdit.alertChoice)) { %>show<% } %>" id="buttons-<%= fileEdit.uuid %>">
                             <button
+                                type="button"
                                 id="help-<%= fileEdit.uuid %>-button"
                                 class="btn btn-light btn-sm"
                                 data-toggle="collapse"

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ejs
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ejs
@@ -67,7 +67,7 @@
                                     infoCourseInstance.json
                                 </a>
                                 <% if ((authz_data.has_course_permission_edit) && (! course.example_course)) { %>
-                                    <a tabindex="0" class="btn btn-xs btn-secondary mx-2" role="button" href="<%= urlPrefix %>/<%= navPage %>/file_edit/<%= infoCourseInstancePath %>">
+                                    <a class="btn btn-xs btn-secondary mx-2" href="<%= urlPrefix %>/<%= navPage %>/file_edit/<%= infoCourseInstancePath %>">
                                         <i class="fa fa-edit"></i>
                                         <span>Edit</span>
                                     </a>

--- a/apps/prairielearn/src/pages/instructorJobSequence/instructorJobSequence.ejs
+++ b/apps/prairielearn/src/pages/instructorJobSequence/instructorJobSequence.ejs
@@ -8,7 +8,7 @@
     <%- include('../partials/navbar', {navPage: ''}); %>
     <main id="content" class="container-fluid">
       <div class="row"><div class="col-12">
-        <a class="btn btn-primary mb-4" href="javascript:history.back();" role="button">
+        <a class="btn btn-primary mb-4" href="javascript:history.back();">
           <i class="fa fa-arrow-left" aria-hidden="true"></i>
           Back to previous page
         </a>

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ejs
@@ -54,7 +54,7 @@
                     info.json
                   </a>
                   <% if ((authz_data.has_course_permission_edit) && (!course.example_course)) { %>
-                    <a role="button" class="btn btn-xs btn-secondary mx-2" href="<%= urlPrefix %>/question/<%= question.id %>/file_edit/<%= infoPath %>">
+                    <a class="btn btn-xs btn-secondary mx-2" href="<%= urlPrefix %>/question/<%= question.id %>/file_edit/<%= infoPath %>">
                       <i class="fa fa-edit"></i>
                       <span>Edit</span>
                     </a>

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs
@@ -50,7 +50,7 @@
                   <%= row.course_instance_short_name %>
               </td>
               <td style="width: 1%">
-                <a href="/pl/course_instance/<%= row.course_instance_id %>/instructor/assessment/<%= row.assessment_id %>/" class="badge color-<%= row.assessment_color %> color-hover" role="button"><%= row.assessment_label %></a>
+                <a href="/pl/course_instance/<%= row.course_instance_id %>/instructor/assessment/<%= row.assessment_id %>/" class="badge color-<%= row.assessment_color %> color-hover"><%= row.assessment_label %></a>
               </td>
               <td class="text-center">
                   <%= formatFloat(row.mean_question_score, 1) %>

--- a/apps/prairielearn/src/pages/news_item/news_item.ejs
+++ b/apps/prairielearn/src/pages/news_item/news_item.ejs
@@ -8,7 +8,7 @@
     <main id="content" class="container">
       <article>
         <header>
-          <a class="btn btn-primary mb-4" href="<%= urlPrefix %>/news_items" role="button">
+          <a class="btn btn-primary mb-4" href="<%= urlPrefix %>/news_items">
             <i class="fa fa-arrow-left" aria-hidden="true"></i>
             Back to news list
           </a>

--- a/apps/prairielearn/src/pages/partials/assessmentSyncErrorsAndWarnings.ejs
+++ b/apps/prairielearn/src/pages/partials/assessmentSyncErrorsAndWarnings.ejs
@@ -10,7 +10,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- assessment.sync_errors_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/assessment/<%= assessment.id %>/file_edit/courseInstances/<%= course_instance.short_name %>/assessments/<%= assessment.tid %>/infoAssessment.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/assessment/<%= assessment.id %>/file_edit/courseInstances/<%= course_instance.short_name %>/assessments/<%= assessment.tid %>/infoAssessment.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit infoAssessment.json to fix this error</span>
     </a>
@@ -26,7 +26,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- assessment.sync_warnings_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/assessment/<%= assessment.id %>/file_edit/courseInstances/<%= course_instance.short_name %>/assessments/<%= assessment.tid %>/infoAssessment.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/assessment/<%= assessment.id %>/file_edit/courseInstances/<%= course_instance.short_name %>/assessments/<%= assessment.tid %>/infoAssessment.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit infoAssessment.json to fix this warning</span>
     </a>

--- a/apps/prairielearn/src/pages/partials/courseInstanceSyncErrorsAndWarnings.ejs
+++ b/apps/prairielearn/src/pages/partials/courseInstanceSyncErrorsAndWarnings.ejs
@@ -10,7 +10,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- course_instance.sync_errors_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/instance_admin/file_edit/courseInstances/<%= course_instance.short_name %>/infoCourseInstance.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/instance_admin/file_edit/courseInstances/<%= course_instance.short_name %>/infoCourseInstance.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit infoCourseInstance.json to fix this error</span>
     </a>
@@ -26,7 +26,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- course_instance.sync_warnings_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/instance_admin/file_edit/courseInstances/<%= course_instance.short_name %>/infoCourseInstance.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/instance_admin/file_edit/courseInstances/<%= course_instance.short_name %>/infoCourseInstance.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit infoCourseInstance.json to fix this warning</span>
     </a>

--- a/apps/prairielearn/src/pages/partials/courseSyncErrorsAndWarnings.ejs
+++ b/apps/prairielearn/src/pages/partials/courseSyncErrorsAndWarnings.ejs
@@ -10,7 +10,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- course.sync_errors_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/course_admin/file_edit/infoCourse.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/course_admin/file_edit/infoCourse.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit infoCourse.json to fix this error</span>
     </a>
@@ -26,7 +26,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- course.sync_warnings_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/course_admin/file_edit/infoCourse.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/course_admin/file_edit/infoCourse.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit infoCourse.json to fix this warning</span>
     </a>

--- a/apps/prairielearn/src/pages/partials/navbarInstructor.ejs
+++ b/apps/prairielearn/src/pages/partials/navbarInstructor.ejs
@@ -4,7 +4,6 @@
         <a
             class="nav-link <% if (navPage == 'course_admin' && !(typeof navSubPage !== 'undefined' && (navSubPage == 'issues' || navSubPage == 'questions' || navSubPage == 'syncs'))) { %> active <% } %> <% if (!authz_data.has_course_permission_view) { %> disabled <% } %>"
             href="<%= urlPrefix %>/course_admin"
-            role="button"
         >
             <%= course.short_name %>
         </a>
@@ -46,7 +45,7 @@
         <%# Instance admin %> 
         <li class="navbar-text mx-2 no-select">/</li>
         <li class="nav-item btn-group" id="navbar-course-instance-switcher">
-            <a class="nav-link <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin" role="button">
+            <a class="nav-link <% if (navPage == "instance_admin" && !(typeof navSubPage !== 'undefined' && (navSubPage == "assessments" || navSubPage == "gradebook"))) { %>active<% } %>" href="<%= plainUrlPrefix %>/course_instance/<%= course_instance.id %>/instructor/instance_admin">
                 <%= course_instance.short_name %>
             </a>
             <a
@@ -79,7 +78,7 @@
         <% if (typeof assessment_label != 'undefined' && typeof assessment != 'undefined') { %>
             <li class="navbar-text mx-2 no-select">/</li>
             <li class="nav-item btn-group">
-                <a class="nav-link <% if (navPage == "assessment") { %>active<% } %>" href="<%= urlPrefix %>/assessment/<%= assessment.id %>" role="button">
+                <a class="nav-link <% if (navPage == "assessment") { %>active<% } %>" href="<%= urlPrefix %>/assessment/<%= assessment.id %>">
                     <%= assessment_label %>
                 </a>
                 <% if (typeof assessments != 'undefined') { %>

--- a/apps/prairielearn/src/pages/partials/navbarPublic.ejs
+++ b/apps/prairielearn/src/pages/partials/navbarPublic.ejs
@@ -1,5 +1,5 @@
 <li class="nav-item btn-group">
-  <a class="nav-link" role="button" aria-label="Link to page showing all public questions for the course." href="<%= urlPrefix %>/questions">
+  <a class="nav-link" aria-label="Link to page showing all public questions for the course." href="<%= urlPrefix %>/questions">
     <% if (locals.course) { %>
       <%= course.short_name %>
     <% } %>

--- a/apps/prairielearn/src/pages/partials/questionSyncErrorsAndWarnings.ejs
+++ b/apps/prairielearn/src/pages/partials/questionSyncErrorsAndWarnings.ejs
@@ -10,7 +10,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- question.sync_errors_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/question/<%= question.id %>/file_edit/questions/<%= question.qid %>/info.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/question/<%= question.id %>/file_edit/questions/<%= question.qid %>/info.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit info.json to fix this error</span>
     </a>
@@ -26,7 +26,7 @@
     </p>
     <pre class="text-white rounded p-3 <% if (locals.course.example_course) { %>mb-0<% } %>" style="background-color: black;"><code><%- question.sync_warnings_ansified %></code></pre>
     <% if (!locals.course.example_course) { %>
-    <a class="btn btn-primary" role="button" href="<%= urlPrefix %>/question/<%= question.id %>/file_edit/questions/<%= question.qid %>/info.json">
+    <a class="btn btn-primary" href="<%= urlPrefix %>/question/<%= question.id %>/file_edit/questions/<%= question.qid %>/info.json">
       <i class="fa fa-edit"></i>
       <span class="d-none d-sm-inline">Edit info.json to fix this warning</span>
     </a>

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ejs
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ejs
@@ -78,7 +78,7 @@
               <td class="text-center align-middle">
                 <% if (row.multiple_instance_header) { %>
                   <% if (row.active) { %>
-                    <a href="<%= urlPrefix %><%= row.link %>" class="btn btn-primary btn-sm" role="button">New instance</a>
+                    <a href="<%= urlPrefix %><%= row.link %>" class="btn btn-primary btn-sm">New instance</a>
                   <% } else { %>
                     <button type="button" disabled class="btn btn-primary btn-sm">New instance</button>
                   <% } %>


### PR DESCRIPTION
Adding `role="button"` to links isn't advisable because it misrepresents the element to screen readers.