### PR TITLE
Fix validation of cookieDomain in config

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -69,23 +69,7 @@ const ConfigSchema = z.object({
   authnCookieMaxAgeMilliseconds: z.number().default(30 * 24 * 60 * 60 * 1000),
   sessionStoreExpireSeconds: z.number().default(86400),
   sessionCookieSameSite: z.string().default(process.env.NODE_ENV === 'production' ? 'none' : 'lax'),
-  cookieDomain: z
-    .string()
-    .nullable()
-    .default(null)
-    .refine(
-      (val) => {
-        // In production environments, require that the the cookie domain is truthy.
-        if (process.env.NODE_ENV === 'production') return !!val;
-
-        // Allow any value in non-production environments, including null values.
-        return true;
-      },
-      { message: 'must be a non-empty string in production environments' },
-    )
-    .refine((val) => val?.startsWith('.') || val === null, {
-      message: 'must start with a dot, e.g. ".example.com"',
-    }),
+  cookieDomain: z.string().nullable().default(null),
   serverType: z.enum(['http', 'https']).default('http'),
   serverPort: z.string().default('3000'),
   serverTimeout: z.number().default(10 * 60 * 1000), // 10 minutes
@@ -538,11 +522,25 @@ export async function loadConfig(paths: string[]) {
     makeImdsConfigSource(),
     makeSecretsManagerConfigSource('ConfSecret'),
   ]);
+
   if (config.questionRenderCacheType !== null) {
     logger.warn(
       'The field "questionRenderCacheType" is deprecated. Please move the cache type configuration to the field "cacheType".',
     );
     config.cacheType = config.questionRenderCacheType;
+  }
+
+  // `cookieDomain` defaults to null, so we can't do these checks via `refine()`
+  // since we parse the schema to get defaults. Instead, we do the checks here
+  // after the config has been completely loaded.
+  if (process.env.NODE_ENV === 'production') {
+    if (!config.cookieDomain) {
+      throw new Error('cookieDomain must be set in production environments');
+    }
+
+    if (!config.cookieDomain.startsWith('.')) {
+      throw new Error('cookieDomain must start with a dot, e.g. ".example.com"');
+    }
   }
 }
 


### PR DESCRIPTION
Using `.refine()` didn't work because we parse an empty object to get default values:

https://github.com/PrairieLearn/PrairieLearn/blob/0208d4cc37d68deb8503eb54cfdf607b52c2ee2e/packages/config/src/index.ts#L96-L99

This means that we'd try to validate `null` before we got a chance to load any value from our config sources.