### PR TITLE
Add missing column to question statistics page

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ejs
@@ -56,6 +56,9 @@
                   <%= formatFloat(row.mean_question_score, 1) %>
               </td>
               <td class="text-center">
+                  <%= formatFloat(row.median_question_score, 1) %>
+              </td>
+              <td class="text-center">
                   <%= formatFloat(row.question_score_variance, 1) %>
               </td>
               <td class="text-center">


### PR DESCRIPTION
Followup to #9625. Although this column was missing from each row, it was present in the table header, so all following columns were under the wrong header.