### PR TITLE
Add missing column to question stats CSV

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.js
@@ -69,6 +69,7 @@ router.get(
             record.qid,
             record.question_title,
             record.mean_question_score,
+            record.median_question_score,
             record.question_score_variance,
             record.discrimination,
             record.some_submission_perc,


### PR DESCRIPTION
This is the same change as #9704, just for the CSV download instead of the HTML table.