### PR TITLE
Add option to close related issues on manual grading

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -118,7 +118,7 @@ ${submission.feedback?.manual}</textarea
             </small>
           </label>
         </li>
-        ${open_issues.length > 0
+        ${open_issues.length > 0 && context !== 'existing'
           ? html`
               <li class="form-group list-group-item">
                 <div class="form-check">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -5,7 +5,7 @@ import {
   ManualPointsSection,
   TotalPointsSection,
 } from './gradingPointsSection.html';
-import { type User } from '../../../lib/db-types';
+import { type Issue, type User } from '../../../lib/db-types';
 
 interface SubmissionOrGradingJob {
   feedback: Record<string, any> | null;
@@ -39,6 +39,7 @@ export function GradingPanel({
   const points = custom_points ?? resLocals.instance_question.points ?? 0;
   const submission = grading_job ?? resLocals.submission;
   const assessment_question_url = `${resLocals.urlPrefix}/assessment/${resLocals.assessment_instance.assessment_id}/manual_grading/assessment_question/${resLocals.instance_question.assessment_question_id}`;
+  const open_issues: Issue[] = resLocals.issues.filter((issue) => issue.open);
   disable = disable || !resLocals.authz_data.has_course_instance_permission_edit;
   skip_text = skip_text || (disable ? 'Next' : 'Skip');
 
@@ -117,6 +118,28 @@ ${submission.feedback?.manual}</textarea
             </small>
           </label>
         </li>
+        ${open_issues.length > 0
+          ? html`
+              <li class="form-group list-group-item">
+                <div class="form-check">
+                  ${open_issues.map(
+                    (issue) => html`
+                      <input
+                        type="checkbox"
+                        id="close-issue-checkbox-${issue.id}"
+                        class="form-check-input"
+                        name="unsafe_issue_ids_close"
+                        value="${issue.id}"
+                      />
+                      <label class="w-100 form-check-label" for="close-issue-checkbox-${issue.id}">
+                        Close issue #${issue.id}
+                      </label>
+                    `,
+                  )}
+                </div>
+              </li>
+            `
+          : ''}
         <li class="list-group-item d-flex align-items-center">
           ${!hide_back_to_question
             ? html`


### PR DESCRIPTION
Closes #9678. Given many cases of manual grading involve resolving an issue raised by a student, this change allows the issue to be closed as the manual grading is submitted.

I chose to close the issue outside of the manual grading transaction, though I'm open to moving the logic to the manual grading process if that makes sense.

![image](https://github.com/PrairieLearn/PrairieLearn/assets/1004907/ae800fe8-551b-4344-8b17-596585680029)
