### PR TITLE
Move institution admin pages under administrator prefix

### DIFF
--- a/apps/prairielearn/src/ee/pages/institutionAdminCourse/institutionAdminCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourse/institutionAdminCourse.html.ts
@@ -42,7 +42,7 @@ export function InstitutionAdminCourse({
         <nav class="container" aria-label="Breadcrumbs">
           <ol class="breadcrumb">
             <li class="breadcrumb-item">
-              <a href="/pl/institution/${institution.id}/admin/courses">Courses</a>
+              <a href="/pl/administrator/institution/${institution.id}/courses">Courses</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
               ${course.title} (${course.short_name})
@@ -143,7 +143,7 @@ export function InstitutionAdminCourse({
                     <tr>
                       <td>
                         <a
-                          href="/pl/institution/${institution.id}/admin/course_instance/${course_instance.id}"
+                          href="/pl/administrator/institution/${institution.id}/course_instance/${course_instance.id}"
                         >
                           ${course_instance.long_name ?? '—'}: ${course.short_name ?? '—'}
                         </a>

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourseInstance/institutionAdminCourseInstance.html.ts
@@ -44,10 +44,10 @@ export function InstitutionAdminCourseInstance({
         <nav class="container" aria-label="Breadcrumbs">
           <ol class="breadcrumb">
             <li class="breadcrumb-item">
-              <a href="/pl/institution/${institution.id}/admin/courses">Courses</a>
+              <a href="/pl/administrator/institution/${institution.id}/courses">Courses</a>
             </li>
             <li class="breadcrumb-item">
-              <a href="/pl/institution/${institution.id}/admin/course/${course.id}">
+              <a href="/pl/administrator/institution/${institution.id}/course/${course.id}">
                 ${course.title} (${course.short_name})
               </a>
             </li>

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.html.ts
@@ -43,7 +43,9 @@ export function InstitutionAdminCourses({
                   return html`
                     <tr>
                       <td>
-                        <a href="/pl/institution/${institution.id}/admin/course/${course.id}">
+                        <a
+                          href="/pl/administrator/institution/${institution.id}/course/${course.id}"
+                        >
                           ${course.short_name ?? '—'}: ${course.title ?? '—'}
                         </a>
                       </td>

--- a/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminLti13/institutionAdminLti13.ts
@@ -72,7 +72,7 @@ router.get(
     if (typeof req.params.unsafe_lti13_instance_id === 'undefined') {
       if (lti13Instances.length > 0) {
         return res.redirect(
-          `/pl/institution/${institution.id}/admin/lti13/${lti13Instances[0].id}`,
+          `/pl/administrator/institution/${institution.id}/lti13/${lti13Instances[0].id}`,
         );
       }
       // else continue through, the html.ts page handles the 0 instances case
@@ -194,7 +194,9 @@ router.post(
       );
       flash('success', `Instance #${new_li} added.`);
 
-      return res.redirect(`/pl/institution/${req.params.institution_id}/admin/lti13/${new_li}`);
+      return res.redirect(
+        `/pl/administrator/institution/${req.params.institution_id}/lti13/${new_li}`,
+      );
     } else if (req.body.__action === 'update_name') {
       await queryAsync(sql.update_name, {
         name: req.body.name,

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.ts
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.ts
@@ -95,7 +95,7 @@ export function AdministratorCourses({
                     return html`
                       <tr>
                         <td>
-                          <a href="/pl/institution/${course.institution.id}/admin">
+                          <a href="/pl/administrator/institution/${course.institution.id}">
                             ${course.institution.short_name}
                           </a>
                         </td>

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
@@ -152,7 +152,7 @@ export function AdministratorInstitutions({
                         <td>
                           ${isEnterprise()
                             ? html`
-                                <a href="/pl/institution/${institution.id}/admin">
+                                <a href="/pl/administrator/institution/${institution.id}">
                                   ${institution.short_name}
                                 </a>
                               `

--- a/apps/prairielearn/src/pages/partials/navbarInstitution.ejs
+++ b/apps/prairielearn/src/pages/partials/navbarInstitution.ejs
@@ -1,11 +1,11 @@
 <li class="nav-item">
-  <a class="nav-link" href="/pl/institution/<%= institution.id %>/admin">
-    <%= institution.short_name %>
+  <a class="nav-link" href="/pl/administrator/institutions">
+    Admin
   </a>
 </li>
 
 <li class="nav-item">
-  <a class="nav-link" href="/pl/institution/<%= institution.id %>/admin">
-    Admin
+  <a class="nav-link" href="/pl/administrator/institution/<%= institution.id %>">
+    <%= institution.short_name %>
   </a>
 </li>

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -858,13 +858,6 @@ module.exports.initExpress = function () {
 
   app.use('/pl/api/v1', require('./api/v1').default);
 
-  if (isEnterprise()) {
-    app.use(
-      '/pl/institution/:institution_id(\\d+)/admin',
-      require('./ee/routers/institutionAdmin').default,
-    );
-  }
-
   //////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////
@@ -1970,17 +1963,24 @@ module.exports.initExpress = function () {
     require('./pages/administratorQuery/administratorQuery').default,
   );
   app.use(
-    '/pl/administrator/jobSequence/',
+    '/pl/administrator/jobSequence',
     require('./pages/administratorJobSequence/administratorJobSequence').default,
   );
   app.use(
-    '/pl/administrator/courseRequests/',
+    '/pl/administrator/courseRequests',
     require('./pages/administratorCourseRequests/administratorCourseRequests').default,
   );
   app.use(
     '/pl/administrator/batchedMigrations',
     require('./pages/administratorBatchedMigrations/administratorBatchedMigrations').default,
   );
+
+  if (isEnterprise()) {
+    app.use(
+      '/pl/administrator/institution/:institution_id(\\d+)',
+      require('./ee/routers/institutionAdmin').default,
+    );
+  }
 
   //////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////

--- a/apps/prairielearn/src/tests/lti13.test.ts
+++ b/apps/prairielearn/src/tests/lti13.test.ts
@@ -55,27 +55,34 @@ describe('LTI 1.3', () => {
 
   step('create an LTI instance', async () => {
     // Load the LTI admin page.
-    const ltiInstancesResponse = await fetchCheerio(`${siteUrl}/pl/institution/1/admin/lti13`);
+    const ltiInstancesResponse = await fetchCheerio(
+      `${siteUrl}/pl/administrator/institution/1/lti13`,
+    );
     assert.equal(ltiInstancesResponse.status, 200);
 
     const newInstanceButton = ltiInstancesResponse.$('button:contains(Add a new LTI 1.3 instance)');
     const newInstanceForm = newInstanceButton.closest('form');
 
     // Create a new LTI instance.
-    const createInstanceResponse = await fetchCheerio(`${siteUrl}/pl/institution/1/admin/lti13`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        __csrf_token: newInstanceForm.find('input[name=__csrf_token]').val() as string,
-        __action: newInstanceButton.attr('value') as string,
-      }),
-    });
+    const createInstanceResponse = await fetchCheerio(
+      `${siteUrl}/pl/administrator/institution/1/lti13`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          __csrf_token: newInstanceForm.find('input[name=__csrf_token]').val() as string,
+          __action: newInstanceButton.attr('value') as string,
+        }),
+      },
+    );
     assert.equal(createInstanceResponse.status, 200);
 
     // Let's see how far we can get without customizing anything in the instance...
   });
 
   step('configure an LTI instance', async () => {
-    const ltiInstanceResponse = await fetchCheerio(`${siteUrl}/pl/institution/1/admin/lti13/1`);
+    const ltiInstanceResponse = await fetchCheerio(
+      `${siteUrl}/pl/administrator/institution/1/lti13/1`,
+    );
     assert.equal(ltiInstanceResponse.status, 200);
 
     const savePlatformOptionsButton = ltiInstanceResponse.$(
@@ -85,7 +92,7 @@ describe('LTI 1.3', () => {
 
     // Update the platform options.
     const updatePlatformOptionsResponse = await fetchCheerio(
-      `${siteUrl}/pl/institution/1/admin/lti13/1`,
+      `${siteUrl}/pl/administrator/institution/1/lti13/1`,
       {
         method: 'POST',
         body: new URLSearchParams({
@@ -108,18 +115,21 @@ describe('LTI 1.3', () => {
     const keystoreForm = addKeyButton.closest('form');
 
     // Create a key
-    const createKeyResponse = await fetchCheerio(`${siteUrl}/pl/institution/1/admin/lti13/1`, {
-      method: 'POST',
-      body: new URLSearchParams({
-        __csrf_token: keystoreForm.find('input[name=__csrf_token]').val() as string,
-        __action: addKeyButton.attr('value') as string,
-      }),
-    });
+    const createKeyResponse = await fetchCheerio(
+      `${siteUrl}/pl/administrator/institution/1/lti13/1`,
+      {
+        method: 'POST',
+        body: new URLSearchParams({
+          __csrf_token: keystoreForm.find('input[name=__csrf_token]').val() as string,
+          __action: addKeyButton.attr('value') as string,
+        }),
+      },
+    );
     assert.equal(createKeyResponse.status, 200);
   });
 
   step('enable LTI 1.3 as an authentication provider', async () => {
-    const ssoResponse = await fetchCheerio(`${siteUrl}/pl/institution/1/admin/sso`);
+    const ssoResponse = await fetchCheerio(`${siteUrl}/pl/administrator/institution/1/sso`);
     assert.equal(ssoResponse.status, 200);
 
     const saveButton = ssoResponse.$('button:contains(Save)');
@@ -127,7 +137,7 @@ describe('LTI 1.3', () => {
     const lti13Label = form.find('label:contains(LTI 1.3)');
     const lti13Input = lti13Label.closest('div').find('input');
 
-    const enableLtiResponse = await fetchCheerio(`${siteUrl}/pl/institution/1/admin/sso`, {
+    const enableLtiResponse = await fetchCheerio(`${siteUrl}/pl/administrator/institution/1/sso`, {
       method: 'POST',
       body: new URLSearchParams({
         __csrf_token: form.find('input[name=__csrf_token]').val() as string,


### PR DESCRIPTION
This prepares us for the introduction of a separate hierarchy of institution pages for institution (not global) administrators. For now, we're going to retain these existing pages for global use, and then introduce new, simplified pages for institutional admins that reflect what should actually be visible/editable to them.