### PR TITLE
Fix duplicate answers in template/multiple-choice question

### DIFF
--- a/exampleCourse/questions/template/multiple-choice/numeric/server.py
+++ b/exampleCourse/questions/template/multiple-choice/numeric/server.py
@@ -2,8 +2,8 @@ import random
 
 
 def generate(data):
-    # Sample a random decimal number in the tenths place between 1.1 and 5.
-    a = round(random.uniform(1.1, 5), 1)
+    # Sample a random decimal number in the tenths place between 2 and 5.
+    a = round(random.uniform(2, 5), 1)
 
     # Sample an integer number between 6 and 11.
     b = random.randint(6, 11)


### PR DESCRIPTION
If we were (un)lucky enough to select $a = 1.8$ and $b = 9$, we'd end up in a situation where the first two distractors were $7.2$. The easiest way to fix this was to adjust the range. I used the following code to verify that there weren't any more duplicate distractors:

```py
import numpy as np

for a in np.arange(2, 5.1, 0.1):
    for b in np.arange(6, 12):
        correct = round(a * b, 4)
        distractor_1 = round((a - 1) * b, 4)
        distractor_2 = round(b - a, 4)
        distractor_3 = round((a + 1) * b, 4)

        count_set = set()
        count_set.add(correct)
        count_set.add(distractor_1)
        count_set.add(distractor_2)
        count_set.add(distractor_3)

        if len(count_set) != 4:
            print("Duplicate found")
            print(f"a: {a}, b: {b}")
            print(f"correct: {correct}")
            print(f"distractor_1: {distractor_1}")
            print(f"distractor_2: {distractor_2}")
            print(f"distractor_3: {distractor_3}")
```