### PR TITLE
Upgrade lxml to 5.2.1

### DIFF
--- a/graders/c/requirements.txt
+++ b/graders/c/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib==3.8.3
 numpy==1.26.4
 sympy==1.12
-lxml==5.2.0
+lxml==5.2.1

--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -8,7 +8,7 @@ flake8-isort==6.1.1
 Flake8-pyproject==1.2.3
 flake8==7.0.0
 isort==5.13.2
-lxml==5.2.0
+lxml==5.2.1
 matplotlib==3.8.3
 networkx==3.2.1
 nltk==3.8.1


### PR DESCRIPTION
5.2.0 would produce a `SIGILL` when running under Rosetta x86 emulation.: https://bugs.launchpad.net/lxml/+bug/2059910. This is fixed in 5.2.1.