### PR TITLE
Forbid returning different data object in zygote

### DIFF
--- a/apps/prairielearn/python/question_phases.py
+++ b/apps/prairielearn/python/question_phases.py
@@ -148,6 +148,16 @@ def process(
                 if result is not None:
                     raise Exception("Another element already returned a file")
                 result = element_value
+            else:
+                if element_value is not None and element_value is not data:
+                    # TODO: Once this has been running in production for a while,
+                    # change this to raise an exception.
+                    sys.stderr.write(
+                        f"Function {str(phase)}() in {str(element_controller)} returned a data object other than the one that was passed in.\n\n"
+                        + "There is no need to return a value, as the data object is mutable and can be modified in place.\n\n"
+                        + "For now, the return value will be used instead of the data object that was passed in.\n\n"
+                        + "In the future, returning a different object will trigger a fatal error."
+                    )
         except Exception:
             raise Exception(f"Error processing element {element.tag}")
 

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -320,11 +320,11 @@ def worker_loop() -> None:
                 # Any function that is not 'file' or 'render' will modify 'data' and
                 # should not be returning anything (because 'data' is mutable).
                 if (fcn != "file") and (fcn != "render"):
-                    if val is None:
+                    if val is None or val is args[-1]:
                         json_outp = try_dumps(
                             {"present": True, "val": args[-1]}, allow_nan=False
                         )
-                    elif args[-1] is not val:
+                    else:
                         # We'll only actually complain if the function returned
                         # a completely different object than the one passed in.
                         # Otherwise, we'll just silently ignore the return value

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -325,13 +325,23 @@ def worker_loop() -> None:
                             {"present": True, "val": args[-1]}, allow_nan=False
                         )
                     else:
+                        json_outp = try_dumps(
+                            {"present": True, "val": val}, allow_nan=False
+                        )
+
                         # We'll only actually complain if the function returned
                         # a completely different object than the one passed in.
                         # Otherwise, we'll just silently ignore the return value
                         # and use the passed-in object (which should in fact be
                         # the same object).
-                        raise Exception(
-                            f"Function {str(fcn)} in file {str(file)} returned a data object other than the one that was passed in"
+                        #
+                        # TODO: Once this has been running in production for a while,
+                        # change this to raise an exception.
+                        sys.stderr.write(
+                            f"Function {str(fcn)} in file {str(file)} returned a data object other than the one that was passed in.\n\n"
+                            + "There is no need to return a value, as the data object is mutable and can be modified in place.\n\n"
+                            + "For now, the return value will be used instead of the data object that was passed in.\n\n"
+                            + "In the future, returning a different object will trigger a fatal error."
                         )
                 else:
                     json_outp = try_dumps(

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -338,7 +338,7 @@ def worker_loop() -> None:
                         # TODO: Once this has been running in production for a while,
                         # change this to raise an exception.
                         sys.stderr.write(
-                            f"Function {str(fcn)} in file {str(file)} returned a data object other than the one that was passed in.\n\n"
+                            f"Function {str(fcn)}() in {str(file + '.py')} returned a data object other than the one that was passed in.\n\n"
                             + "There is no need to return a value, as the data object is mutable and can be modified in place.\n\n"
                             + "For now, the return value will be used instead of the data object that was passed in.\n\n"
                             + "In the future, returning a different object will trigger a fatal error."

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -324,31 +324,15 @@ def worker_loop() -> None:
                         json_outp = try_dumps(
                             {"present": True, "val": args[-1]}, allow_nan=False
                         )
-                    else:
-                        json_outp_passed = try_dumps(
-                            {"present": True, "val": args[-1]},
-                            sort_keys=True,
-                            allow_nan=False,
+                    elif args[-1] is not val:
+                        # We'll only actually complain if the function returned
+                        # a completely different object than the one passed in.
+                        # Otherwise, we'll just silently ignore the return value
+                        # and use the passed-in object (which should in fact be
+                        # the same object).
+                        raise Exception(
+                            f"Function {str(fcn)} in file {str(file)} returned a data object other than the one that was passed in"
                         )
-                        json_outp = try_dumps(
-                            {"present": True, "val": val},
-                            sort_keys=True,
-                            allow_nan=False,
-                        )
-                        if json_outp_passed != json_outp:
-                            sys.stderr.write(
-                                'WARNING: Passed and returned value of "data" differ in the function '
-                                + str(fcn)
-                                + "() in the file "
-                                + str(cwd)
-                                + "/"
-                                + str(file)
-                                + ".py.\n\n passed:\n  "
-                                + str(args[-1])
-                                + "\n\n returned:\n  "
-                                + str(val)
-                                + '\n\nThere is no need to be returning "data" at all (it is mutable, i.e., passed by reference). In future, this code will throw a fatal error. For now, the returned value of "data" was used and the passed value was discarded.'
-                            )
                 else:
                     json_outp = try_dumps(
                         {"present": True, "val": val}, allow_nan=False

--- a/exampleCourse/elements/course-element/course-element.py
+++ b/exampleCourse/elements/course-element/course-element.py
@@ -5,7 +5,6 @@ import chevron
 
 def prepare(element_html, data):
     data["params"]["random_number"] = random.random()
-    return data
 
 
 def render(element_html, data):

--- a/exampleCourse/questions/demo/annotated/engMarkovBrewing/server.py
+++ b/exampleCourse/questions/demo/annotated/engMarkovBrewing/server.py
@@ -35,5 +35,3 @@ def generate(data):
             "type": "1d array",
         },
     ]
-
-    return data

--- a/exampleCourse/questions/demo/computeRotationMatrix/server.py
+++ b/exampleCourse/questions/demo/computeRotationMatrix/server.py
@@ -20,4 +20,3 @@ def generate(data):
         data["params"]["b"] = "R_{\\frac{\\pi}{" + str(a) + "}}"
     M = np.around(M, 5)
     data["correct_answers"]["M"] = pl.to_json(M)
-    return data

--- a/exampleCourse/questions/demo/drawing/centroid/server.py
+++ b/exampleCourse/questions/demo/drawing/centroid/server.py
@@ -36,5 +36,3 @@ def generate(data):
     data["params"]["yD"] = yD
     data["params"]["base_rectangle"] = base_rectangle
     data["params"]["height_rectangle"] = height_rectangle
-
-    return data

--- a/exampleCourse/questions/demo/drawing/collarRod/server.py
+++ b/exampleCourse/questions/demo/drawing/collarRod/server.py
@@ -50,5 +50,3 @@ def generate(data):
 
     width_arrow = 60
     data["params"]["width_arrow"] = width_arrow
-
-    return data

--- a/exampleCourse/questions/demo/drawing/frame-exploded/server.py
+++ b/exampleCourse/questions/demo/drawing/frame-exploded/server.py
@@ -37,5 +37,3 @@ def generate(data):
     # shift over x coordinates to fit all exploded FBDs
     for key in ["x" + str(i) for i in range(1, 11)]:
         x[key + "exp"] = x[key] - 75
-
-    return data

--- a/exampleCourse/questions/demo/drawing/gradeVector/server.py
+++ b/exampleCourse/questions/demo/drawing/gradeVector/server.py
@@ -5,5 +5,3 @@ def generate(data):
     alpha = int(np.random.choice([-1, 1]) * np.random.choice([30, 45, 60, 120, 150]))
     data["params"]["angle"] = alpha
     data["params"]["grade_angle"] = -alpha
-
-    return data

--- a/exampleCourse/questions/demo/drawing/inclinedPlane-reaction/server.py
+++ b/exampleCourse/questions/demo/drawing/inclinedPlane-reaction/server.py
@@ -77,5 +77,3 @@ def generate(data):
 
     width_arrow = 60
     data["params"]["width_arrow"] = width_arrow
-
-    return data

--- a/exampleCourse/questions/demo/drawing/inclinedPlane/server.py
+++ b/exampleCourse/questions/demo/drawing/inclinedPlane/server.py
@@ -68,5 +68,3 @@ def generate(data):
 
     width_arrow = 60
     data["params"]["width_arrow"] = width_arrow
-
-    return data

--- a/exampleCourse/questions/demo/drawing/liftingMechanism/server.py
+++ b/exampleCourse/questions/demo/drawing/liftingMechanism/server.py
@@ -93,5 +93,3 @@ def generate(data):
     data["params"]["wbox"] = wbox
     data["params"]["xbox"] = xbox
     data["params"]["ybox"] = ybox
-
-    return data

--- a/exampleCourse/questions/demo/drawing/pulley/server.py
+++ b/exampleCourse/questions/demo/drawing/pulley/server.py
@@ -71,7 +71,3 @@ def generate(data):
     data["params"]["off2"] = hbox / 2
 
     data["params"]["height_canvas"] = height_canvas
-
-    # data["correct_answers"]["Mx"] = 10
-
-    return data

--- a/exampleCourse/questions/demo/drawing/simpleTutorial/server.py
+++ b/exampleCourse/questions/demo/drawing/simpleTutorial/server.py
@@ -141,5 +141,3 @@ def generate(data):
         data["params"]["visible0"] = "true"
 
     data["params"]["text"] = text
-
-    return data

--- a/exampleCourse/questions/demo/drawing/vmDiagrams/server.py
+++ b/exampleCourse/questions/demo/drawing/vmDiagrams/server.py
@@ -187,5 +187,3 @@ def generate(data):
     sup_line = sup_line.rstrip(",")
     sup_line += "]"
     data["params"]["sup_line_M"] = sup_line
-
-    return data

--- a/exampleCourse/questions/demo/randomCheckbox/server.py
+++ b/exampleCourse/questions/demo/randomCheckbox/server.py
@@ -16,4 +16,3 @@ def generate(data):
         X = np.random.rand(M, M)
         name = "M" + str(i + 1)
         data["params"][name] = pl.to_json(X)
-    return data

--- a/exampleCourse/questions/element/drawingGallery/server.py
+++ b/exampleCourse/questions/element/drawingGallery/server.py
@@ -1,5 +1,3 @@
 def generate(data):
     polygon = '[{"x": 40, "y": 40}, {"x": 140,"y": 80}, {"x": 100,"y": 160}, {"x": 80,"y": 140}]'
     data["params"]["polygon"] = polygon
-
-    return data

--- a/exampleCourse/questions/element/dropdown/server.py
+++ b/exampleCourse/questions/element/dropdown/server.py
@@ -6,5 +6,3 @@ def generate(data):
         {"tag": "false", "ans": "part"},
         {"tag": "false", "ans": "inverse"},
     ]
-
-    return data

--- a/exampleCourse/questions/element/matrixComponentInput/server.py
+++ b/exampleCourse/questions/element/matrixComponentInput/server.py
@@ -22,5 +22,3 @@ def generate(data):
     data["correct_answers"]["out4"] = pl.to_json(long_matrix)
     data["correct_answers"]["out5"] = pl.to_json(y)
     data["correct_answers"]["out6"] = pl.to_json(I)
-
-    return data

--- a/exampleCourse/questions/element/matrixLatex/server.py
+++ b/exampleCourse/questions/element/matrixLatex/server.py
@@ -27,5 +27,3 @@ def generate(data):
     data["params"]["myNumber"] = pl.to_json(myNumber)
     data["params"]["b"] = pl.to_json(br)
     data["params"]["c"] = pl.to_json(bc)
-
-    return data

--- a/exampleCourse/questions/workshop/Lesson3_example3/server.py
+++ b/exampleCourse/questions/workshop/Lesson3_example3/server.py
@@ -6,4 +6,3 @@ def generate(data):
     ans = "{0:b}".format(a)
     data["params"]["a"] = a
     data["correct_answers"]["b"] = ans
-    return data

--- a/exampleCourse/questions/workshop/Lesson5_example3/server.py
+++ b/exampleCourse/questions/workshop/Lesson5_example3/server.py
@@ -25,5 +25,3 @@ def generate(data):
     else:
         data["params"]["alpha"] = -alpha
         data["params"]["direction"] = "counter-clockwise"
-
-    return data

--- a/testCourse/elements/course-element/course-element.py
+++ b/testCourse/elements/course-element/course-element.py
@@ -5,7 +5,6 @@ import chevron
 
 def prepare(element_html, data):
     data["params"]["random_number"] = random.random()
-    return data
 
 
 def render(element_html, data):

--- a/testCourse/questions/prairieDrawFigure/server.py
+++ b/testCourse/questions/prairieDrawFigure/server.py
@@ -19,5 +19,3 @@ def generate(data):
     data["params"]["shape_c"] = shape_c
     data["params"]["shape_x1"] = shape_x1
     data["params"]["shape_x2"] = shape_x2
-
-    return data


### PR DESCRIPTION
I'm doing this ahead of #9715. Skipping unnecessary JSON serialization will help with performance, even when using `orjson`.