### PR TITLE
Add admin tool to decode SAML responses

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -175,6 +175,7 @@
     "unzipper": "^0.10.14",
     "uuid": "^9.0.1",
     "winston": "^3.13.0",
+    "xml-formatter": "^3.6.2",
     "xml2js": "^0.6.2",
     "yargs-parser": "^21.1.1",
     "zod": "^3.22.4"

--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -1,77 +1,93 @@
-import { MultiSamlStrategy } from '@node-saml/passport-saml';
+import { MultiSamlStrategy, type SamlConfig } from '@node-saml/passport-saml';
 
 import { getInstitutionSamlProvider } from '../../lib/institution';
+
+export async function getSamlOptions({
+  institution_id,
+  host,
+  strictMode,
+}: {
+  institution_id: string;
+  host: string | undefined;
+  strictMode: boolean;
+}): Promise<SamlConfig> {
+  const samlProvider = await getInstitutionSamlProvider(institution_id);
+  if (!samlProvider) throw new Error('No SAML provider found for given institution');
+
+  // It's most convenient if folks can pass in `req.headers.host` directly,
+  // but that's typed as `string | undefined`. So, we'll accept that type
+  // and throw an error on on the off-change it's undefined.
+  if (!host) throw new Error('Missing host header');
+
+  // This is also known as our Entity ID.
+  const issuer = `https://${host}/saml/institution/${institution_id}`;
+
+  return {
+    host,
+    protocol: 'https://',
+    path: `/pl/auth/institution/${institution_id}/saml/callback`,
+    entryPoint: samlProvider.sso_login_url,
+    issuer,
+    idpIssuer: samlProvider.issuer,
+
+    // TODO: once all existing IdPs are updated to use the stricter,
+    // more secure defaults, enable all these by default.
+    audience: samlProvider.validate_audience || strictMode ? issuer : false,
+    wantAssertionsSigned: samlProvider.want_assertions_signed || strictMode,
+    wantAuthnResponseSigned: samlProvider.want_authn_response_signed || strictMode,
+
+    // TODO: do these two need to be configurable?
+    signatureAlgorithm: 'sha256',
+    digestAlgorithm: 'sha256',
+
+    // Identity Provider's public key.
+    cert: samlProvider.certificate,
+
+    // Service Provider's private key.
+    privateKey: samlProvider.private_key,
+    decryptionPvk: samlProvider.private_key,
+
+    // By default, `node-saml` will include a `RequestedAuthnContext`
+    // element that requests password-based authentication. However,
+    // some institutions use passwordless auth, so we disable this and
+    // allow any authentication context.
+    disableRequestedAuthnContext: true,
+  };
+}
 
 export const strategy = new MultiSamlStrategy(
   {
     passReqToCallback: true,
     getSamlOptions(req, done) {
-      getInstitutionSamlProvider(req.params.institution_id)
-        .then((samlProvider) => {
-          if (!samlProvider) {
-            return done(new Error('No SAML provider found for given institution'));
-          }
+      // v4 of `@node-saml/node-saml` made some breaking changes that could
+      // result in broken logins if IdPs aren't configured correctly. In
+      // particular:
+      //
+      // - `wantAssertionsSigned` is now true by default
+      // - `wantAuthnResponseSigned` is now true by default
+      // - The audience of the SAML response is now validated by default
+      //
+      // To continue supporting existing IdPs, we introduced configuration
+      // options for SAML providers that default to the older, less strict
+      // behavior. However, we want to encourage IdPs to meet the more
+      // strict default behavior. We want to allow institutional IT folks
+      // to see if they can comply with the new defaults without changing
+      // our own configuration (which would risk breaking existing logins).
+      //
+      // To support this, we allow authentication requests to be made in
+      // an optional "strict" mode. This is done by including the value
+      // `strict` in the `RelayState` parameter of the SAML request, which
+      // will also be included in the SAML response.
+      const relayState = req.query?.RelayState || req.body?.RelayState || '';
+      const relayStateItems = relayState.split(',');
+      const strictMode = relayStateItems.includes('strict');
 
-          const host = req.headers.host;
-
-          // This is also known as our Entity ID.
-          const issuer = `https://${host}/saml/institution/${req.params.institution_id}`;
-
-          // v4 of `@node-saml/node-saml` made some breaking changes that could
-          // result in broken logins if IdPs aren't configured correctly. In
-          // particular:
-          //
-          // - `wantAssertionsSigned` is now true by default
-          // - `wantAuthnResponseSigned` is now true by default
-          // - The audience of the SAML response is now validated by default
-          //
-          // To continue supporting existing IdPs, we introduced configuration
-          // options for SAML providers that default to the older, less strict
-          // behavior. However, we want to encourage IdPs to meet the more
-          // strict default behavior. We want to allow institutional IT folks
-          // to see if they can comply with the new defaults without changing
-          // our own configuration (which would risk breaking existing logins).
-          //
-          // To support this, we allow authentication requests to be made in
-          // an optional "strict" mode. This is done by including the value
-          // `strict` in the `RelayState` parameter of the SAML request, which
-          // will also be included in the SAML response.
-          const relayState = req.query?.RelayState || req.body?.RelayState || '';
-          const relayStateItems = relayState.split(',');
-          const strictMode = relayStateItems.includes('strict');
-
-          done(null, {
-            host,
-            protocol: 'https://',
-            path: `/pl/auth/institution/${req.params.institution_id}/saml/callback`,
-            entryPoint: samlProvider.sso_login_url,
-            issuer,
-            idpIssuer: samlProvider.issuer,
-
-            // TODO: once all existing IdPs are updated to use the stricter,
-            // more secure defaults, enable all these by default.
-            audience: samlProvider.validate_audience || strictMode ? issuer : false,
-            wantAssertionsSigned: samlProvider.want_assertions_signed || strictMode,
-            wantAuthnResponseSigned: samlProvider.want_authn_response_signed || strictMode,
-
-            // TODO: do these two need to be configurable?
-            signatureAlgorithm: 'sha256',
-            digestAlgorithm: 'sha256',
-
-            // Identity Provider's public key.
-            cert: samlProvider.certificate,
-
-            // Service Provider's private key.
-            privateKey: samlProvider.private_key,
-            decryptionPvk: samlProvider.private_key,
-
-            // By default, `node-saml` will include a `RequestedAuthnContext`
-            // element that requests password-based authentication. However,
-            // some institutions use passwordless auth, so we disable this and
-            // allow any authentication context.
-            disableRequestedAuthnContext: true,
-          });
-        })
+      getSamlOptions({
+        institution_id: req.params.institution_id,
+        host: req.headers.host,
+        strictMode,
+      })
+        .then((options) => done(null, options))
         .catch((err) => done(err));
     },
   },

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -46,6 +46,8 @@ export function AdministratorInstitutionSaml({
           navPage: 'administrator_institution',
           navSubPage: 'saml',
         })}
+        ${DeleteSamlConfigurationModal({ csrfToken: resLocals.__csrf_token })}
+
         <main class="container mb-4">
           ${hasSamlProvider && !hasEnabledSaml
             ? html`
@@ -362,26 +364,6 @@ ${samlProvider?.certificate ?? ''}</textarea
             : ''}
         </main>
 
-        ${Modal({
-          id: 'deleteModal',
-          title: 'Confirm deletion',
-          body: html`
-            <p>
-              Are you sure you want to delete the SAML configuration? Users in your institution,
-              including yourself, may be unable to log in to PrairieLearn.
-            </p>
-          `,
-          footer: html`
-            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-            <form method="POST">
-              <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              <button class="btn btn-danger" type="submit" name="__action" value="delete">
-                Delete SAML configuration
-              </button>
-            </form>
-          `,
-        })}
-
         <script>
           (function () {
             // Show the configuration form when the button is clicked.
@@ -396,6 +378,28 @@ ${samlProvider?.certificate ?? ''}</textarea
       </body>
     </html>
   `.toString();
+}
+
+function DeleteSamlConfigurationModal({ csrfToken }: { csrfToken: string }) {
+  return Modal({
+    id: 'deleteModal',
+    title: 'Confirm deletion',
+    body: html`
+      <p>
+        Are you sure you want to delete the SAML configuration? Users in your institution, including
+        yourself, may be unable to log in to PrairieLearn.
+      </p>
+    `,
+    footer: html`
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+      <form method="POST">
+        <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+        <button class="btn btn-danger" type="submit" name="__action" value="delete">
+          Delete SAML configuration
+        </button>
+      </form>
+    `,
+  });
 }
 
 export function DecodedAssertion({ xml, profile }: { xml: string; profile: string }) {

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -348,10 +348,9 @@ ${samlProvider?.certificate ?? ''}</textarea
                   <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
                   <button
                     class="btn btn-primary"
-                    id="decodeAssertionButton"
                     type="button"
                     name="__action"
-                    value="decodeAssertion"
+                    value="decode_assertion"
                     hx-post="${resLocals.urlPrefix}/saml"
                     hx-target="#decodedAssertion"
                     hx-swap="innerHTML show:top"

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -385,6 +385,23 @@ export function DecodeAssertionModal({
           POST request from the IdP.
         </small>
       </div>
+
+      <div class="form-group form-check">
+        <input
+          type="checkbox"
+          class="form-check-input"
+          id="strictMode"
+          name="strict_mode"
+          value="1"
+          aria-describedBy="strictModeHelp"
+        />
+        <label class="form-check-label" for="strictMode">Strict mode</label>
+        <small id="strictModeHelp" class="form-text text-muted mt-0">
+          Forces "validate audience", "require signed assertions", and "require signed response" to
+          be enabled.
+        </small>
+      </div>
+
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
       <button
         class="btn btn-primary"

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -300,30 +300,68 @@ ${samlProvider?.certificate ?? ''}</textarea
 
                 <p>
                   <button
+                    class="btn btn-danger"
+                    type="button"
                     data-toggle="modal"
-                    data-target="#decodeAssertionModal"
-                    class="btn btn-link"
+                    data-target="#deleteModal"
                   >
-                    Decode SAML assertion</button
-                  >: Decode/decrypt a SAML assertion to see the attributes
+                    Delete SAML configuration
+                  </button>
                 </p>
 
-                <button
-                  class="btn btn-danger"
-                  type="button"
-                  data-toggle="modal"
-                  data-target="#deleteModal"
-                >
-                  Delete SAML configuration
-                </button>
+                <h2 class="h4">Decode SAML assertion</h2>
+
+                <form method="POST">
+                  <div class="form-group">
+                    <label for="encodedAssertion">Encoded assertion</label>
+                    <textarea
+                      class="form-control"
+                      id="encodedAssertion"
+                      rows="10"
+                      name="encoded_assertion"
+                      aria-describedby="encodedAssertionHelp"
+                    ></textarea>
+                    <small class="form-text text-muted">
+                      This should be raw base64-encoded data from the
+                      <code>SAMLResponse</code> parameter in the POST request from the IdP.
+                    </small>
+                  </div>
+
+                  <div class="form-group form-check">
+                    <input
+                      type="checkbox"
+                      class="form-check-input"
+                      id="strictMode"
+                      name="strict_mode"
+                      value="1"
+                      aria-describedBy="strictModeHelp"
+                    />
+                    <label class="form-check-label" for="strictMode">Strict mode</label>
+                    <small id="strictModeHelp" class="form-text text-muted mt-0">
+                      Forces "validate audience", "require signed assertions", and "require signed
+                      response" to be enabled.
+                    </small>
+                  </div>
+
+                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                  <button
+                    class="btn btn-primary"
+                    id="decodeAssertionButton"
+                    type="button"
+                    name="__action"
+                    value="decodeAssertion"
+                    hx-post="${resLocals.urlPrefix}/saml"
+                    hx-target="#decodedAssertion"
+                    hx-swap="innerHTML show:top"
+                  >
+                    Decode
+                  </button>
+                  <div id="decodedAssertion"></div>
+                </form>
               `
             : ''}
         </main>
 
-        ${DecodeAssertionModal({
-          urlPrefix: resLocals.urlPrefix,
-          csrfToken: resLocals.__csrf_token,
-        })}
         ${Modal({
           id: 'deleteModal',
           title: 'Confirm deletion',
@@ -360,71 +398,12 @@ ${samlProvider?.certificate ?? ''}</textarea
   `.toString();
 }
 
-export function DecodeAssertionModal({
-  urlPrefix,
-  csrfToken,
-}: {
-  urlPrefix: string;
-  csrfToken: string;
-}) {
-  return Modal({
-    id: 'decodeAssertionModal',
-    title: 'Decode SAML assertion',
-    body: html`
-      <div class="form-group">
-        <label for="encodedAssertion">Encoded assertion</label>
-        <textarea
-          class="form-control"
-          id="encodedAssertion"
-          rows="10"
-          name="encoded_assertion"
-          aria-describedby="encodedAssertionHelp"
-        ></textarea>
-        <small class="form-text text-muted">
-          This should be raw base64-encoded data from the <code>SAMLResponse</code> parameter in the
-          POST request from the IdP.
-        </small>
-      </div>
-
-      <div class="form-group form-check">
-        <input
-          type="checkbox"
-          class="form-check-input"
-          id="strictMode"
-          name="strict_mode"
-          value="1"
-          aria-describedBy="strictModeHelp"
-        />
-        <label class="form-check-label" for="strictMode">Strict mode</label>
-        <small id="strictModeHelp" class="form-text text-muted mt-0">
-          Forces "validate audience", "require signed assertions", and "require signed response" to
-          be enabled.
-        </small>
-      </div>
-
-      <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-      <button
-        class="btn btn-primary"
-        id="decodeAssertionButton"
-        type="button"
-        name="__action"
-        value="decodeAssertion"
-        hx-post="${urlPrefix}/saml"
-        hx-target="#decodedAssertion"
-      >
-        Decode
-      </button>
-      <div id="decodedAssertion"></div>
-    `,
-  });
-}
-
 export function DecodedAssertion({ xml, profile }: { xml: string; profile: string }) {
   return html`
-    <h2 class="mt-3">Decoded XML</h2>
+    <h3 class="h5 mt-3">Decoded XML</h2>
     <pre class="bg-dark text-white rounded p-3 mt-3 mb-0">${xml}</pre>
 
-    <h2 class="mt-3">Profile</h2>
+    <h3 class="h5 mt-3">Profile</h2>
     <pre class="bg-dark text-white rounded p-3 mt-3 mb-0">${profile}</pre>
   `.toString();
 }

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
@@ -135,7 +135,6 @@ router.post(
           SAMLResponse: req.body.encoded_assertion,
         })
         .catch((err) => {
-          console.error(err);
           return {
             error: err.message,
           };

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
@@ -110,7 +110,7 @@ router.post(
         authn_user_id: res.locals.authn_user.user_id,
       });
       res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'decodeAssertion') {
+    } else if (req.body.__action === 'decode_assertion') {
       const samlConfig = await getSamlOptions({
         institution_id: req.params.institution_id,
         host: req.headers.host,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3445,6 +3445,7 @@ __metadata:
     unzipper: ^0.10.14
     uuid: ^9.0.1
     winston: ^3.13.0
+    xml-formatter: ^3.6.2
     xml2js: ^0.6.2
     yargs-parser: ^21.1.1
     zod: ^3.22.4
@@ -17140,6 +17141,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-formatter@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "xml-formatter@npm:3.6.2"
+  dependencies:
+    xml-parser-xo: ^4.1.0
+  checksum: 6ca632b136d47f68b12be88e5543f859cdc754c9e1c1386c68b8c7803f9b894c8ec19f51bdcbfa957d782358aa19778b2ef46702f4120a78920661b683033290
+  languageName: node
+  linkType: hard
+
 "xml-name-validator@npm:^3.0.0":
   version: 3.0.0
   resolution: "xml-name-validator@npm:3.0.0"
@@ -17151,6 +17161,13 @@ __metadata:
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
   checksum: 86effcc7026f437701252fcc308b877b4bc045989049cfc79b0cc112cb365cf7b009f4041fab9fb7cd1795498722c3e9fe9651afc66dfa794c16628a639a4c45
+  languageName: node
+  linkType: hard
+
+"xml-parser-xo@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "xml-parser-xo@npm:4.1.1"
+  checksum: f726f4416d501eb9b197a7a34178aeaee9ba9a53babf61e78265240f8a6f44bd099a15c76d2610a9519c9d1dcc812bb773ae8a00df39019f911f24e1ecff0cdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Every few months, I end up needing to decode/decrypt a SAML response, which sends me down a rabbit hole of trying to piece together a Node script to do that. I've done this enough that I felt it was worth my time to build this into PL. This automatically applies the correct private key, configured validation options, etc.