### PR TITLE
Fix race condition in workspace launching

### DIFF
--- a/apps/prairielearn/src/pages/error/error.js
+++ b/apps/prairielearn/src/pages/error/error.js
@@ -6,6 +6,8 @@ var jsonStringifySafe = require('json-stringify-safe');
 const { formatErrorStack, formatErrorStackSafe } = require('@prairielearn/error');
 const { logger } = require('@prairielearn/logger');
 
+const { config } = require('../../lib/config');
+
 /** @type {import('express').ErrorRequestHandler} */
 module.exports = function (err, req, res, _next) {
   const errorId = res.locals.error_id;
@@ -62,7 +64,7 @@ module.exports = function (err, req, res, _next) {
     id: errorId,
     referrer,
   };
-  if (req.app.get('env') === 'development') {
+  if (config.devMode) {
     // development error handler
     // will print stacktrace
     res.render(path.join(__dirname, 'error'), templateData);


### PR DESCRIPTION
With the race condition described in the inline comment, we'd end up hitting this bit of code:

https://github.com/PrairieLearn/PrairieLearn/blob/6e0957b5e380558b14bbace37b3efd55d09e5618/apps/prairielearn/src/server.js#L376

This would render a very ugly page to the user:

![Screenshot 2024-04-17 at 7 57 53 PM](https://github.com/PrairieLearn/PrairieLearn/assets/1476544/1eb5150c-56cc-42af-87d7-f16cc25b96dd)

Originally discussed on Slack: https://prairielearn.slack.com/archives/C266KEH9A/p1713409158958589