### PR TITLE
Improve admin display of course and course instance names

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -45,7 +45,7 @@ export function AdministratorInstitutionCourse({
               <a href="/pl/administrator/institution/${institution.id}/courses">Courses</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
-              ${course.title} (${course.short_name})
+              ${course.short_name}: ${course.title}
             </li>
           </ol>
         </nav>
@@ -145,7 +145,7 @@ export function AdministratorInstitutionCourse({
                         <a
                           href="/pl/administrator/institution/${institution.id}/course_instance/${course_instance.id}"
                         >
-                          ${course_instance.long_name ?? '—'}: ${course_instance.short_name ?? '—'}
+                          ${course_instance.short_name ?? '—'}: ${course_instance.long_name ?? '—'}
                         </a>
                       </td>
                       <td>${enrollment_count}</td>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -145,7 +145,7 @@ export function AdministratorInstitutionCourse({
                         <a
                           href="/pl/administrator/institution/${institution.id}/course_instance/${course_instance.id}"
                         >
-                          ${course_instance.long_name ?? '—'}: ${course.short_name ?? '—'}
+                          ${course_instance.long_name ?? '—'}: ${course_instance.short_name ?? '—'}
                         </a>
                       </td>
                       <td>${enrollment_count}</td>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
@@ -48,11 +48,11 @@ export function AdministratorInstitutionCourseInstance({
             </li>
             <li class="breadcrumb-item">
               <a href="/pl/administrator/institution/${institution.id}/course/${course.id}">
-                ${course.title} (${course.short_name})
+                ${course.short_name}: ${course.title}
               </a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
-              ${course_instance.long_name} (${course_instance.short_name})
+              ${course_instance.short_name}: ${course_instance.long_name}
             </li>
           </ol>
         </nav>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
@@ -52,7 +52,7 @@ export function AdministratorInstitutionCourseInstance({
               </a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
-              ${course_instance.short_name}: ${course_instance.long_name}
+              ${course_instance.short_name ?? '—'}: ${course_instance.long_name ?? '—'}
             </li>
           </ol>
         </nav>


### PR DESCRIPTION
I noticed that we were accidentally rendering `course.short_name` instead of `course_instance.short_name` in the admin pages. This PR fixes that.

I also opted to standardize on rendering course/instance names as `SHORT: LONG`:

<img width="481" alt="Screenshot 2024-04-19 at 14 18 33" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/cd220d07-b1da-40ef-bac2-79a33ebdac82">

This matches how we displayed things on the courses/instances admin pages.