### PR TITLE
Fix issue badge processing in assessment questions page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -228,6 +228,7 @@ function AssessmentQuestionsTable({
                         `}
                     ${question.title}
                     ${renderEjs(__filename, "<%- include('../partials/issueBadge') %>", {
+                      urlPrefix,
                       count: question.open_issue_count,
                       issueQid: question.qid,
                     })}


### PR DESCRIPTION
As reported by @firasm on Slack. The EJS file was missing a variable.