### PR TITLE
Add autocorrect attribute to text-based input elements

### DIFF
--- a/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.mustache
+++ b/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.mustache
@@ -23,6 +23,7 @@
                     name="{{name}}"
                     type="text"
                     autocomplete="off"
+                    autocorrect="off"
                     class="form-control big-o-input-input"
                     size="{{size}}"
                     {{^editable}}disabled{{/editable}}

--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.mustache
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.mustache
@@ -21,6 +21,7 @@
             type="text"
             inputmode={{#use_numeric}}"numeric"{{/use_numeric}}{{^use_numeric}}"text"{{/use_numeric}}
             autocomplete="off"
+            autocorrect="off"
             class="form-control pl-integer-input-input"
             size="{{size}}"
             {{^editable}}disabled{{/editable}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -22,6 +22,7 @@
           type="text"
           inputmode="text"
           autocomplete="off"
+          autocorrect="off"
           class="form-control pl-number-input-input"
           size="{{size}}"
           {{^editable}}disabled{{/editable}}

--- a/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
+++ b/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
@@ -23,6 +23,7 @@
             class="form-control pl-string-input-input"
             size="{{size}}"
             autocomplete="off"
+            autocorrect="off"
             {{^editable}}disabled{{/editable}}
             {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
             aria-describedby="pl-symbolic-input-{{uuid}}-label pl-symbolic-input-{{uuid}}-suffix"

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -20,6 +20,7 @@
             name="{{name}}"
             type="text"
             autocomplete="off"
+            autocorrect="off"
             class="form-control pl-symbolic-input-input"
             size="{{size}}"
             {{^editable}}disabled{{/editable}}

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
@@ -20,6 +20,7 @@
         <input
             name={{name}}
             autocomplete="off"
+            autocorrect="off"
             type="text"
             class="form-control pl-units-input-input"
             size="{{size}}"


### PR DESCRIPTION
Added `autocorrect="off"` attribute to elements: 
- pl-big-o-input 
- pl-integer-input 
- pl-number-input 
- pl-string-input
- pl-symbolic-input
- pl-units-input

as discussed on #9729.