### PR TITLE
Convert more files to ESM

### DIFF
--- a/apps/prairielearn/src/ee/routers/lti13.ts
+++ b/apps/prairielearn/src/ee/routers/lti13.ts
@@ -6,7 +6,7 @@ import lti13Auth from '../auth/lti13/lti13Auth';
 import lti13CourseNavigation from '../pages/lti13CourseNavigation/lti13CourseNavigation';
 import { features } from '../../lib/features';
 import middlewareAuthn = require('../../middlewares/authn');
-import csrfToken = require('../../middlewares/csrfToken');
+import csrfToken from '../../middlewares/csrfToken';
 import { selectLti13Instance } from '../models/lti13Instance';
 
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/routers/lti13.ts
+++ b/apps/prairielearn/src/ee/routers/lti13.ts
@@ -5,7 +5,7 @@ import lti13InstancePages from '../pages/lti13Instance/lti13Instance';
 import lti13Auth from '../auth/lti13/lti13Auth';
 import lti13CourseNavigation from '../pages/lti13CourseNavigation/lti13CourseNavigation';
 import { features } from '../../lib/features';
-import middlewareAuthn = require('../../middlewares/authn');
+import authnMiddleware from '../../middlewares/authn';
 import csrfToken from '../../middlewares/csrfToken';
 import { selectLti13Instance } from '../models/lti13Instance';
 
@@ -30,7 +30,7 @@ router.use(
 router.use('/:lti13_instance_id/auth', lti13Auth);
 router.use(
   '/:lti13_instance_id/course_navigation',
-  middlewareAuthn, // authentication, set res.locals.authn_user
+  authnMiddleware, // authentication, set res.locals.authn_user
   csrfToken,
   lti13CourseNavigation,
 );

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -8,7 +8,7 @@ import * as compiledAssets from '@prairielearn/compiled-assets';
 import { config } from './config';
 import { APP_ROOT_PATH } from './paths';
 import staticNodeModules from '../middlewares/staticNodeModules';
-import elementFiles = require('../pages/elementFiles/elementFiles');
+import elementFiles from '../pages/elementFiles/elementFiles';
 import { HtmlSafeString } from '@prairielearn/html';
 
 let assetsPrefix: string | null = null;

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -1050,7 +1050,6 @@ export async function ensureChunksForCourseAsync(courseId: string, chunks: Chunk
     }),
   );
 }
-export const ensureChunksForCourse = util.callbackify(ensureChunksForCourseAsync);
 
 interface QuestionWithTemplateDirectory {
   id: string;

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -1063,7 +1063,7 @@ interface QuestionWithTemplateDirectory {
  * @param question A question object.
  * @returns Array of question IDs that are (recursive) templates for the given question (may be an empty array).
  */
-export async function getTemplateQuestionIdsAsync(
+export async function getTemplateQuestionIds(
   question: QuestionWithTemplateDirectory,
 ): Promise<string[]> {
   if (!question.template_directory) return [];
@@ -1073,7 +1073,6 @@ export async function getTemplateQuestionIdsAsync(
   const questionIds = result.rows.map((r) => r.id);
   return questionIds;
 }
-export const getTemplateQuestionIds = util.callbackify(getTemplateQuestionIdsAsync);
 
 /**
  * Logs the changes to chunks for a given job.

--- a/apps/prairielearn/src/lib/file-paths.js
+++ b/apps/prairielearn/src/lib/file-paths.js
@@ -73,7 +73,7 @@ export async function questionFilePath(
     }
 
     const templateQuestion = result.rows[0];
-    return questionFilePath(
+    return await questionFilePath(
       filename,
       templateQuestion.directory,
       coursePath,

--- a/apps/prairielearn/src/lib/file-paths.js
+++ b/apps/prairielearn/src/lib/file-paths.js
@@ -35,7 +35,7 @@ const QUESTION_DEFAULTS_PATH = path.resolve(APP_ROOT_PATH, 'v2-question-servers'
  * @param {number} nTemplates
  * @returns {Promise<QuestionFilePathInfo>}
  */
-export async function questionFilePathAsync(
+export async function questionFilePath(
   filename,
   questionDirectory,
   coursePath,
@@ -73,7 +73,7 @@ export async function questionFilePathAsync(
     }
 
     const templateQuestion = result.rows[0];
-    return questionFilePathAsync(
+    return questionFilePath(
       filename,
       templateQuestion.directory,
       coursePath,
@@ -119,14 +119,4 @@ export async function questionFilePathAsync(
       }
     }
   }
-}
-
-export function questionFilePath(filename, questionDirectory, coursePath, question, callback) {
-  questionFilePathAsync(filename, questionDirectory, coursePath, question)
-    .then(({ fullPath, effectiveFilename, rootPath }) => {
-      callback(null, fullPath, effectiveFilename, rootPath);
-    })
-    .catch((err) => {
-      callback(err);
-    });
 }

--- a/apps/prairielearn/src/middlewares/authn.js
+++ b/apps/prairielearn/src/middlewares/authn.js
@@ -1,17 +1,17 @@
 // @ts-check
 const asyncHandler = require('express-async-handler');
-const sqldb = require('@prairielearn/postgres');
-const { getCheckedSignedTokenData } = require('@prairielearn/signed-token');
+import * as sqldb from '@prairielearn/postgres';
+import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
 
-const { config } = require('../lib/config');
-const authnLib = require('../lib/authn');
-const { clearCookie, setCookie } = require('../lib/cookie');
+import { config } from '../lib/config';
+import * as authnLib from '../lib/authn';
+import { clearCookie, setCookie } from '../lib/cookie';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
 const UUID_REGEXP = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
-module.exports = asyncHandler(async (req, res, next) => {
+export default asyncHandler(async (req, res, next) => {
   res.locals.is_administrator = false;
   res.locals.news_item_notification_count = 0;
 
@@ -40,7 +40,7 @@ module.exports = asyncHandler(async (req, res, next) => {
     });
 
     if (!data || !data.uuid || typeof data.uuid !== 'string' || !data.uuid.match(UUID_REGEXP)) {
-      return next(new Error('invalid load_test_token'));
+      throw new Error('invalid load_test_token');
     }
 
     const uuid = data.uuid;
@@ -195,5 +195,5 @@ module.exports = asyncHandler(async (req, res, next) => {
     pl_authn_cookie: true,
   });
 
-  return next();
+  next();
 });

--- a/apps/prairielearn/src/middlewares/authnToken.js
+++ b/apps/prairielearn/src/middlewares/authnToken.js
@@ -1,11 +1,13 @@
-const ERR = require('async-stacktrace');
-const crypto = require('crypto');
-const sqldb = require('@prairielearn/postgres');
-const { logger } = require('@prairielearn/logger');
+// @ts-check
+const asyncHandler = require('express-async-handler');
+import * as crypto from 'node:crypto';
+import * as sqldb from '@prairielearn/postgres';
+import { logger } from '@prairielearn/logger';
+import * as Sentry from '@prairielearn/sentry';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
-module.exports = (req, res, next) => {
+export default asyncHandler(async (req, res, next) => {
   let token;
   if (req.query.private_token !== undefined) {
     // Token was provided in a query param
@@ -21,32 +23,37 @@ module.exports = (req, res, next) => {
     return;
   }
 
-  const params = {
+  if (typeof token !== 'string') {
+    res.status(401).send({
+      message: 'The provided authentication token was invalid',
+    });
+    return;
+  }
+
+  const result = await sqldb.queryZeroOrOneRowAsync(sql.select_user_from_token_hash, {
     token_hash: crypto.createHash('sha256').update(token, 'utf8').digest('hex'),
-  };
-
-  sqldb.queryZeroOrOneRow(sql.select_user_from_token_hash, params, (err, result) => {
-    if (ERR(err, next)) return;
-    if (result.rows.length === 0) {
-      // Invalid token received
-      res.status(401).send({
-        message: 'The provided authentication token was invalid',
-      });
-    } else {
-      // Nice, we got a user
-      res.locals.authn_user = result.rows[0].user;
-      res.locals.is_administrator = result.rows[0].is_administrator;
-
-      // Let's note that this token was used, but don't wait for this
-      // to continue handling the request
-      next();
-
-      const lastUsedParams = {
-        token_id: result.rows[0].token_id,
-      };
-      sqldb.query(sql.update_token_last_used, lastUsedParams, (err) => {
-        if (ERR(err, (e) => logger.error('Error in sql.update_token_last_used', e)));
-      });
-    }
   });
-};
+  if (result.rows.length === 0) {
+    // Invalid token received
+    res.status(401).send({
+      message: 'The provided authentication token was invalid',
+    });
+    return;
+  }
+
+  res.locals.authn_user = result.rows[0].user;
+  res.locals.is_administrator = result.rows[0].is_administrator;
+
+  // Let's note that this token was used, but don't wait for this
+  // to continue handling the request
+  next();
+
+  sqldb
+    .queryAsync(sql.update_token_last_used, {
+      token_id: result.rows[0].token_id,
+    })
+    .catch((err) => {
+      Sentry.captureException(err);
+      logger.error('Error in sql.update_token_last_used', err);
+    });
+});

--- a/apps/prairielearn/src/middlewares/authzWorkspace.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspace.js
@@ -1,20 +1,20 @@
 // @ts-check
-const _ = require('lodash');
+import * as _ from 'lodash';
 const asyncHandler = require('express-async-handler');
 
-const sqldb = require('@prairielearn/postgres');
-const error = require('@prairielearn/error');
+import * as sqldb from '@prairielearn/postgres';
 
-const { isEnterprise } = require('../lib/license');
-const { authzCourseOrInstance } = require('./authzCourseOrInstance');
-const { selectAndAuthzInstanceQuestion } = require('./selectAndAuthzInstanceQuestion');
-const { selectAndAuthzAssessmentInstance } = require('./selectAndAuthzAssessmentInstance');
-const { selectAndAuthzInstructorQuestion } = require('./selectAndAuthzInstructorQuestion');
-const { authzHasCoursePreviewOrInstanceView } = require('./authzHasCoursePreviewOrInstanceView');
+import { isEnterprise } from '../lib/license';
+import { authzCourseOrInstance } from './authzCourseOrInstance';
+import { selectAndAuthzInstanceQuestion } from './selectAndAuthzInstanceQuestion';
+import { selectAndAuthzAssessmentInstance } from './selectAndAuthzAssessmentInstance';
+import { selectAndAuthzInstructorQuestion } from './selectAndAuthzInstructorQuestion';
+import { authzHasCoursePreviewOrInstanceView } from './authzHasCoursePreviewOrInstanceView';
+import { HttpStatusError } from '@prairielearn/error';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
-module.exports = asyncHandler(async (req, res, next) => {
+export default asyncHandler(async (req, res, next) => {
   // We rely on having res.locals.workspace_id already set to the correct value here
   const result = await sqldb.queryZeroOrOneRowAsync(sql.select_auth_data_from_workspace, {
     workspace_id: res.locals.workspace_id,
@@ -27,7 +27,7 @@ module.exports = asyncHandler(async (req, res, next) => {
     //
     // We use a 403 instead of a 404 to avoid leaking information about the existence
     // of particular workspace IDs.
-    throw new error.HttpStatusError(403, 'Access denied');
+    throw new HttpStatusError(403, 'Access denied');
   }
 
   _.assign(res.locals, result.rows[0]);
@@ -45,7 +45,7 @@ module.exports = asyncHandler(async (req, res, next) => {
       if (!hasPlanGrants) {
         // TODO: Show a fancier error page explaining what happened and prompting
         // the user to contact their instructor.
-        throw new error.HttpStatusError(403, 'Access denied');
+        throw new HttpStatusError(403, 'Access denied');
       }
     }
 

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieCheck.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieCheck.js
@@ -1,8 +1,10 @@
-const { getCheckedSignedTokenData } = require('@prairielearn/signed-token');
-const { config } = require('../lib/config');
-const { idsEqual } = require('../lib/id');
+// @ts-check
+const asyncHandler = require('express-async-handler');
+import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
+import { config } from '../lib/config';
+import { idsEqual } from '../lib/id';
 
-module.exports = (req, res, next) => {
+export default asyncHandler(async (req, res, next) => {
   // This middleware looks for a workspace_id-specific cookie and,
   // if found, skips the rest of authn/authz. The special cookie is
   // set by middlewares/authzWorkspaceCookieSet.js
@@ -23,4 +25,4 @@ module.exports = (req, res, next) => {
 
   // otherwise we fall through and proceed to the full authn/authz stack
   next();
-};
+});

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
@@ -1,3 +1,4 @@
+// @ts-check
 const asyncHandler = require('express-async-handler');
 import { generateSignedToken } from '@prairielearn/signed-token';
 import { config } from '../lib/config';

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
@@ -1,8 +1,9 @@
-const { generateSignedToken } = require('@prairielearn/signed-token');
-const { config } = require('../lib/config');
-const { shouldSecureCookie, setCookie } = require('../lib/cookie');
+const asyncHandler = require('express-async-handler');
+import { generateSignedToken } from '@prairielearn/signed-token';
+import { config } from '../lib/config';
+import { shouldSecureCookie, setCookie } from '../lib/cookie';
 
-module.exports = (req, res, next) => {
+export default asyncHandler(async (req, res, next) => {
   // We should only have arrived here if we passed authn/authz and
   // are authorized to access res.locals.workspace_id. We will set a
   // short-lived cookie specific to this workspace_id that will let
@@ -22,4 +23,4 @@ module.exports = (req, res, next) => {
     secure: shouldSecureCookie(req),
   });
   next();
-};
+});

--- a/apps/prairielearn/src/middlewares/csrfToken.js
+++ b/apps/prairielearn/src/middlewares/csrfToken.js
@@ -1,18 +1,18 @@
 // @ts-check
-const path = require('path');
-const debug = require('debug')('prairielearn:' + path.basename(__filename, '.js'));
+const asyncHandler = require('express-async-handler');
+import { config } from '../lib/config';
+import { HttpStatusError } from '@prairielearn/error';
+import { generateSignedToken, checkSignedToken } from '@prairielearn/signed-token';
 
-const { config } = require('../lib/config');
-const error = require('@prairielearn/error');
-const { generateSignedToken, checkSignedToken } = require('@prairielearn/signed-token');
-
-module.exports = function (req, res, next) {
-  var tokenData = {
+export default asyncHandler(async (req, res, next) => {
+  const tokenData = {
     url: req.originalUrl,
   };
+
   if (res.locals.authn_user && res.locals.authn_user.user_id) {
     tokenData.authn_user_id = res.locals.authn_user.user_id;
   }
+
   res.locals.__csrf_token = generateSignedToken(tokenData, config.secretKey);
 
   if (req.method === 'POST') {
@@ -20,13 +20,12 @@ module.exports = function (req, res, next) {
     // upload, you may have forgotten to special-case the file upload path.
     // Search for "upload.single('file')" in server.js, for example.
 
-    var __csrf_token = req.headers['x-csrf-token']
+    const __csrf_token = req.headers['x-csrf-token']
       ? req.headers['x-csrf-token']
       : req.body.__csrf_token;
-    debug(`POST: __csrf_token = ${__csrf_token}`);
     if (!checkSignedToken(__csrf_token, tokenData, config.secretKey)) {
-      return next(new error.HttpStatusError(403, 'CSRF fail'));
+      throw new HttpStatusError(403, 'CSRF fail');
     }
   }
   next();
-};
+});

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
@@ -1,20 +1,18 @@
-var _ = require('lodash');
-const util = require('util');
-
-var sqldb = require('@prairielearn/postgres');
-const error = require('@prairielearn/error');
+const asyncHandler = require('express-async-handler');
+import * as _ from 'lodash';
+import * as sqldb from '@prairielearn/postgres';
+import { HttpStatusError } from '@prairielearn/error';
 
 var sql = sqldb.loadSqlEquiv(__filename);
 
-module.exports = util.callbackify(async (req, res) => {
-  var params = {
+export default asyncHandler(async (req, res) => {
+  const result = await sqldb.queryAsync(sql.select_and_auth, {
     assessment_question_id: req.params.assessment_question_id,
     assessment_id: res.locals.assessment.id,
     course_instance_id: res.locals.course_instance.id,
     authz_data: res.locals.authz_data,
     req_date: res.locals.req_date,
-  };
-  const result = await sqldb.queryAsync(sql.select_and_auth, params);
-  if (result.rowCount === 0) throw new error.HttpStatusError(403, 'Access denied');
+  });
+  if (result.rowCount === 0) throw new HttpStatusError(403, 'Access denied');
   _.assign(res.locals, result.rows[0]);
 });

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
@@ -1,3 +1,4 @@
+// @ts-check
 const asyncHandler = require('express-async-handler');
 import * as _ from 'lodash';
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
@@ -6,7 +6,7 @@ import { HttpStatusError } from '@prairielearn/error';
 
 var sql = sqldb.loadSqlEquiv(__filename);
 
-export default asyncHandler(async (req, res) => {
+export default asyncHandler(async (req, res, next) => {
   const result = await sqldb.queryAsync(sql.select_and_auth, {
     assessment_question_id: req.params.assessment_question_id,
     assessment_id: res.locals.assessment.id,
@@ -16,4 +16,5 @@ export default asyncHandler(async (req, res) => {
   });
   if (result.rowCount === 0) throw new HttpStatusError(403, 'Access denied');
   _.assign(res.locals, result.rows[0]);
+  next();
 });

--- a/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
+++ b/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
@@ -1,12 +1,12 @@
 // @ts-check
-const express = require('express');
+import { Router } from 'express';
 const asyncHandler = require('express-async-handler');
-const error = require('@prairielearn/error');
+import * as error from '@prairielearn/error';
 
-const authnLib = require('../../lib/authn');
-const { config } = require('../../lib/config');
+import * as authnLib from '../../lib/authn';
+import { config } from '../../lib/config';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',
@@ -15,9 +15,9 @@ router.get(
       throw new error.HttpStatusError(404, 'Shibboleth login is not enabled');
     }
 
-    var uid = req.get('x-trust-auth-uid') ?? null;
-    var name = req.get('x-trust-auth-name') ?? null;
-    var uin = req.get('x-trust-auth-uin') ?? null;
+    const uid = req.get('x-trust-auth-uid') ?? null;
+    const name = req.get('x-trust-auth-name') ?? null;
+    const uin = req.get('x-trust-auth-uin') ?? null;
 
     if (!uid) throw new Error('No authUid');
 
@@ -39,4 +39,4 @@ router.get(
   }),
 );
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
+++ b/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
@@ -1,43 +1,38 @@
 // @ts-check
-const ERR = require('async-stacktrace');
-const express = require('express');
-const { OAuth2Client } = require('google-auth-library');
-const { logger } = require('@prairielearn/logger');
-const error = require('@prairielearn/error');
+const asyncHandler = require('express-async-handler');
+import { Router } from 'express';
+import { OAuth2Client } from 'google-auth-library';
+import { HttpStatusError } from '@prairielearn/error';
 
-const { config } = require('../../lib/config');
+import { config } from '../../lib/config';
 
-const router = express.Router();
+const router = Router();
 
-router.get('/', function (req, res, next) {
-  if (
-    !config.hasOauth ||
-    !config.googleClientId ||
-    !config.googleClientSecret ||
-    !config.googleRedirectUrl
-  ) {
-    return next(new error.HttpStatusError(404, 'Google login is not enabled'));
-  }
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    if (
+      !config.hasOauth ||
+      !config.googleClientId ||
+      !config.googleClientSecret ||
+      !config.googleRedirectUrl
+    ) {
+      throw new HttpStatusError(404, 'Google login is not enabled');
+    }
 
-  let url;
-  try {
     const oauth2Client = new OAuth2Client(
       config.googleClientId,
       config.googleClientSecret,
       config.googleRedirectUrl,
     );
-    url = oauth2Client.generateAuthUrl({
+    const url = oauth2Client.generateAuthUrl({
       access_type: 'online',
       scope: ['openid', 'profile', 'email'],
       prompt: 'select_account',
       // FIXME: should add some state here to avoid CSRF
     });
-  } catch (err) {
-    ERR(err, next);
-    return;
-  }
-  logger.verbose('Google auth URL redirect: ' + url);
-  res.redirect(url);
-});
+    res.redirect(url);
+  }),
+);
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/authPassword/authPassword.js
+++ b/apps/prairielearn/src/pages/authPassword/authPassword.js
@@ -1,11 +1,10 @@
 // @ts-check
-const express = require('express');
-const { generateSignedToken } = require('@prairielearn/signed-token');
-const { config } = require('../../lib/config');
-const { shouldSecureCookie, setCookie } = require('../../lib/cookie');
-const { clearCookie } = require('../../lib/cookie');
+import { Router } from 'express';
+import { generateSignedToken } from '@prairielearn/signed-token';
+import { config } from '../../lib/config';
+import { shouldSecureCookie, setCookie, clearCookie } from '../../lib/cookie';
 
-const router = express.Router();
+const router = Router();
 
 router.get('/', function (req, res) {
   res.locals.passwordInvalid = 'pl_assessmentpw' in req.cookies;
@@ -25,4 +24,5 @@ router.post('/', function (req, res) {
   clearCookie(res, ['pl_pw_origUrl', 'pl2_pw_original_url']);
   return res.redirect(redirectUrl);
 });
-module.exports = router;
+
+export default router;

--- a/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
+++ b/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
@@ -1,26 +1,32 @@
-const path = require('path');
-const express = require('express');
-const router = express.Router();
+// @ts-check
+const asyncHandler = require('express-async-handler');
+import * as path from 'node:path';
+import { Router } from 'express';
 
-const error = require('@prairielearn/error');
-const chunks = require('../../lib/chunks');
-const ERR = require('async-stacktrace');
+import * as error from '@prairielearn/error';
+import * as chunks from '../../lib/chunks';
 
-router.get('/*', function (req, res, next) {
-  const filename = req.params[0];
-  if (!filename) {
-    return next(
-      new error.HttpStatusError(400, 'No filename provided within clientFilesAssessment directory'),
-    );
-  }
-  const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
-  const chunk = {
-    type: 'clientFilesAssessment',
-    courseInstanceId: res.locals.course_instance.id,
-    assessmentId: res.locals.assessment.id,
-  };
-  chunks.ensureChunksForCourse(res.locals.course.id, chunk, (err) => {
-    if (ERR(err, next)) return;
+const router = Router();
+
+router.get(
+  '/*',
+  asyncHandler(async (req, res) => {
+    const filename = req.params[0];
+    if (!filename) {
+      throw new error.HttpStatusError(
+        400,
+        'No filename provided within clientFilesAssessment directory',
+      );
+    }
+
+    const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
+    /** @type {chunks.Chunk} */
+    const chunk = {
+      type: 'clientFilesAssessment',
+      courseInstanceId: res.locals.course_instance.id,
+      assessmentId: res.locals.assessment.id,
+    };
+    await chunks.ensureChunksForCourseAsync(res.locals.course.id, chunk);
 
     const clientFilesDir = path.join(
       coursePath,
@@ -31,7 +37,7 @@ router.get('/*', function (req, res, next) {
       'clientFilesAssessment',
     );
     res.sendFile(filename, { root: clientFilesDir });
-  });
-});
+  }),
+);
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
+++ b/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
@@ -1,12 +1,12 @@
 // @ts-check
 const asyncHandler = require('express-async-handler');
-const path = require('path');
-const express = require('express');
+import * as path from 'node:path';
+import { Router } from 'express';
 
-const error = require('@prairielearn/error');
-const chunks = require('../../lib/chunks');
+import * as error from '@prairielearn/error';
+import * as chunks from '../../lib/chunks';
 
-const router = express.Router({ mergeParams: true });
+const router = Router({ mergeParams: true });
 
 router.get(
   '/*',
@@ -26,4 +26,4 @@ router.get(
   }),
 );
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
+++ b/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
@@ -10,7 +10,7 @@ const router = Router();
 
 router.get(
   '/*',
-  asyncHandler(async (req, res, next) => {
+  asyncHandler(async (req, res) => {
     const filename = req.params[0];
     if (!filename) {
       throw new error.HttpStatusError(

--- a/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
+++ b/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
@@ -1,28 +1,31 @@
-const path = require('path');
-const express = require('express');
-const router = express.Router();
+// @ts-check
+const asyncHandler = require('express-async-handler');
+import * as path from 'node:path';
+import { Router } from 'express';
 
-const error = require('@prairielearn/error');
-const chunks = require('../../lib/chunks');
-const ERR = require('async-stacktrace');
+import * as error from '@prairielearn/error';
+import * as chunks from '../../lib/chunks';
 
-router.get('/*', function (req, res, next) {
-  const filename = req.params[0];
-  if (!filename) {
-    return next(
-      new error.HttpStatusError(
+const router = Router();
+
+router.get(
+  '/*',
+  asyncHandler(async (req, res, next) => {
+    const filename = req.params[0];
+    if (!filename) {
+      throw new error.HttpStatusError(
         400,
         'No filename provided within clientFilesCourseInstance directory',
-      ),
-    );
-  }
-  const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
-  const chunk = {
-    type: 'clientFilesCourseInstance',
-    courseInstanceId: res.locals.course_instance.id,
-  };
-  chunks.ensureChunksForCourse(res.locals.course.id, chunk, (err) => {
-    if (ERR(err, next)) return;
+      );
+    }
+
+    const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
+    /** @type {chunks.Chunk} */
+    const chunk = {
+      type: 'clientFilesCourseInstance',
+      courseInstanceId: res.locals.course_instance.id,
+    };
+    await chunks.ensureChunksForCourseAsync(res.locals.course.id, chunk);
 
     const clientFilesDir = path.join(
       coursePath,
@@ -31,7 +34,7 @@ router.get('/*', function (req, res, next) {
       'clientFilesCourseInstance',
     );
     res.sendFile(filename, { root: clientFilesDir });
-  });
-});
+  }),
+);
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
+++ b/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
@@ -1,25 +1,22 @@
 // @ts-check
 const asyncHandler = require('express-async-handler');
-const path = require('path');
-const express = require('express');
+import * as path from 'node:path';
+import { Router } from 'express';
 
-const error = require('@prairielearn/error');
-const chunks = require('../../lib/chunks');
-const { getQuestionCourse } = require('../../lib/question-variant');
-const { selectCourseById } = require('../../models/course');
-const { selectQuestionById } = require('../../models/question');
+import * as chunks from '../../lib/chunks';
+import { getQuestionCourse } from '../../lib/question-variant';
+import { selectCourseById } from '../../models/course';
+import { selectQuestionById } from '../../models/question';
+import { HttpStatusError } from '@prairielearn/error';
 
-module.exports = function (options = { publicEndpoint: false }) {
-  const router = express.Router({ mergeParams: true });
+export default function (options = { publicEndpoint: false }) {
+  const router = Router({ mergeParams: true });
   router.get(
     '/*',
     asyncHandler(async function (req, res) {
       const filename = req.params[0];
       if (!filename) {
-        throw new error.HttpStatusError(
-          400,
-          'No filename provided within clientFilesQuestion directory',
-        );
+        throw new HttpStatusError(400, 'No filename provided within clientFilesQuestion directory');
       }
 
       if (options.publicEndpoint) {
@@ -30,7 +27,7 @@ module.exports = function (options = { publicEndpoint: false }) {
           !res.locals.question.shared_publicly ||
           res.locals.course.id !== res.locals.question.course_id
         ) {
-          throw new error.HttpStatusError(404, 'Not Found');
+          throw new HttpStatusError(404, 'Not Found');
         }
       }
 
@@ -52,4 +49,4 @@ module.exports = function (options = { publicEndpoint: false }) {
     }),
   );
   return router;
-};
+}

--- a/apps/prairielearn/src/pages/elementFiles/elementFiles.js
+++ b/apps/prairielearn/src/pages/elementFiles/elementFiles.js
@@ -1,12 +1,14 @@
-const path = require('path');
-const express = require('express');
-const router = express.Router({ mergeParams: true });
-const _ = require('lodash');
+// @ts-check
+const asyncHandler = require('express-async-handler');
+import * as path from 'node:path';
+import { Router } from 'express';
 
-const chunks = require('../../lib/chunks');
-const { config } = require('../../lib/config');
-const { APP_ROOT_PATH } = require('../../lib/paths');
-const ERR = require('async-stacktrace');
+import * as chunks from '../../lib/chunks';
+import { config } from '../../lib/config';
+import { APP_ROOT_PATH } from '../../lib/paths';
+import { HttpStatusError } from '@prairielearn/error';
+
+const router = Router({ mergeParams: true });
 
 /**
  * Serves scripts and styles for v3 elements. Only serves .js and .css files, or any
@@ -16,52 +18,50 @@ const ERR = require('async-stacktrace');
 const EXTENSION_WHITELIST = ['.js', '.css'];
 const CLIENT_FOLDER = 'clientFilesElement';
 
-router.get('/*', function (req, res, next) {
-  const filename = req.params[0];
-  const pathSpl = path.normalize(filename).split('/');
-  const valid =
-    pathSpl[1] === CLIENT_FOLDER ||
-    _.some(EXTENSION_WHITELIST, (extension) => filename.endsWith(extension));
-  if (!valid) {
-    res.status(404);
-    const err = new Error('Unable to serve that file');
-    err.status = 404;
-    return next(err);
-  }
+router.get(
+  '/*',
+  asyncHandler(async (req, res) => {
+    const filename = req.params[0];
+    const pathSpl = path.normalize(filename).split('/');
+    const valid =
+      pathSpl[1] === CLIENT_FOLDER ||
+      EXTENSION_WHITELIST.some((extension) => filename.endsWith(extension));
+    if (!valid) {
+      throw new HttpStatusError(404, 'Unable to serve that file');
+    }
 
-  // If the route includes a `cachebuster` param, we'll set the `immutable`
-  // and `maxAge` options on the `Cache-Control` header. This router is
-  // mounted twice - one with the cachebuster in the URL, and once without it
-  // for backwards compatibility. See `server.js` for more details.
-  //
-  // As with `/assets/`, we assume that element files are likely to change
-  // when running in dev mode, so we skip caching entirely in that case.
-  const isCached = !!req.params.cachebuster && !config.devMode;
-  const sendFileOptions = {
-    immutable: isCached,
-    maxAge: isCached ? '31536000s' : 0,
-  };
+    // If the route includes a `cachebuster` param, we'll set the `immutable`
+    // and `maxAge` options on the `Cache-Control` header. This router is
+    // mounted twice - one with the cachebuster in the URL, and once without it
+    // for backwards compatibility. See `server.js` for more details.
+    //
+    // As with `/assets/`, we assume that element files are likely to change
+    // when running in dev mode, so we skip caching entirely in that case.
+    const isCached = !!req.params.cachebuster && !config.devMode;
+    const sendFileOptions = {
+      immutable: isCached,
+      maxAge: isCached ? '31536000s' : 0,
+    };
 
-  if (isCached) {
-    // `middlewares/cors.js` disables caching for all routes by default.
-    // We need to remove this header so that `res.sendFile` can set it
-    // correctly.
-    res.removeHeader('Cache-Control');
-  }
+    if (isCached) {
+      // `middlewares/cors.js` disables caching for all routes by default.
+      // We need to remove this header so that `res.sendFile` can set it
+      // correctly.
+      res.removeHeader('Cache-Control');
+    }
 
-  let elementFilesDir;
-  if (res.locals.course) {
-    // Files should be served from the course directory
-    const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
-    chunks.ensureChunksForCourse(res.locals.course.id, { type: 'elements' }, (err) => {
-      if (ERR(err, next)) return;
+    let elementFilesDir;
+    if (res.locals.course) {
+      // Files should be served from the course directory
+      const coursePath = chunks.getRuntimeDirectoryForCourse(res.locals.course);
+      await chunks.ensureChunksForCourseAsync(res.locals.course.id, { type: 'elements' });
       elementFilesDir = path.join(coursePath, 'elements');
       res.sendFile(filename, { root: elementFilesDir, ...sendFileOptions });
-    });
-  } else {
-    elementFilesDir = path.join(APP_ROOT_PATH, 'elements');
-    res.sendFile(filename, { root: elementFilesDir, ...sendFileOptions });
-  }
-});
+    } else {
+      elementFilesDir = path.join(APP_ROOT_PATH, 'elements');
+      res.sendFile(filename, { root: elementFilesDir, ...sendFileOptions });
+    }
+  }),
+);
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
+++ b/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
@@ -1,17 +1,17 @@
 // @ts-check
 const asyncHandler = require('express-async-handler');
-const error = require('@prairielearn/error');
-var express = require('express');
+import { Router } from 'express';
+import * as sqldb from '@prairielearn/postgres';
 
-const { getDynamicFile } = require('../../lib/question-variant');
-const { selectCourseById } = require('../../models/course');
-const { selectQuestionById } = require('../../models/question');
-var sqldb = require('@prairielearn/postgres');
+import { getDynamicFile } from '../../lib/question-variant';
+import { selectCourseById } from '../../models/course';
+import { selectQuestionById } from '../../models/question';
+import { HttpStatusError } from '@prairielearn/error';
 
 var sql = sqldb.loadSqlEquiv(__filename);
 
-module.exports = function (options = { publicEndpoint: false }) {
-  const router = express.Router({ mergeParams: true });
+export default function (options = { publicEndpoint: false }) {
+  const router = Router({ mergeParams: true });
   router.get(
     '/variant/:variant_id(\\d+)/*',
     asyncHandler(async function (req, res) {
@@ -23,7 +23,7 @@ module.exports = function (options = { publicEndpoint: false }) {
           !res.locals.question.shared_publicly ||
           res.locals.course.id !== res.locals.question.course_id
         ) {
-          throw new error.HttpStatusError(404, 'Not Found');
+          throw new HttpStatusError(404, 'Not Found');
         }
       }
 
@@ -51,4 +51,4 @@ module.exports = function (options = { publicEndpoint: false }) {
     }),
   );
   return router;
-};
+}

--- a/apps/prairielearn/src/pages/legacyQuestionText/legacyQuestionText.js
+++ b/apps/prairielearn/src/pages/legacyQuestionText/legacyQuestionText.js
@@ -15,7 +15,7 @@ router.get(
     const filename = 'text/' + req.params.filename;
     const coursePath = chunks.getRuntimeDirectoryForCourse(course);
 
-    const questionIds = await chunks.getTemplateQuestionIdsAsync(question);
+    const questionIds = await chunks.getTemplateQuestionIds(question);
 
     /** @type {chunks.Chunk[]} */
     const templateQuestionChunks = questionIds.map((id) => ({
@@ -32,7 +32,7 @@ router.get(
       ]).concat(templateQuestionChunks);
     await chunks.ensureChunksForCourseAsync(course.id, chunksToLoad);
 
-    const { rootPath, effectiveFilename } = await filePaths.questionFilePathAsync(
+    const { rootPath, effectiveFilename } = await filePaths.questionFilePath(
       filename,
       question.directory,
       coursePath,

--- a/apps/prairielearn/src/pages/legacyQuestionText/legacyQuestionText.js
+++ b/apps/prairielearn/src/pages/legacyQuestionText/legacyQuestionText.js
@@ -1,43 +1,46 @@
-var ERR = require('async-stacktrace');
-var express = require('express');
-var router = express.Router();
+// @ts-check
+import { Router } from 'express';
+const asyncHandler = require('express-async-handler');
 
-const chunks = require('../../lib/chunks');
-var filePaths = require('../../lib/file-paths');
+import * as chunks from '../../lib/chunks';
+import * as filePaths from '../../lib/file-paths';
 
-router.get('/:filename', function (req, res, next) {
-  const question = res.locals.question;
-  const course = res.locals.course;
-  const filename = 'text/' + req.params.filename;
-  const coursePath = chunks.getRuntimeDirectoryForCourse(course);
+const router = Router();
 
-  chunks.getTemplateQuestionIds(question, (err, questionIds) => {
-    if (ERR(err, next)) return;
+router.get(
+  '/:filename',
+  asyncHandler(async (req, res) => {
+    const question = res.locals.question;
+    const course = res.locals.course;
+    const filename = 'text/' + req.params.filename;
+    const coursePath = chunks.getRuntimeDirectoryForCourse(course);
 
+    const questionIds = await chunks.getTemplateQuestionIdsAsync(question);
+
+    /** @type {chunks.Chunk[]} */
     const templateQuestionChunks = questionIds.map((id) => ({
       type: 'question',
       questionId: id,
     }));
-    const chunksToLoad = [
-      {
-        type: 'question',
-        questionId: question.id,
-      },
-    ].concat(templateQuestionChunks);
-    chunks.ensureChunksForCourse(course.id, chunksToLoad, (err) => {
-      if (ERR(err, next)) return;
-      filePaths.questionFilePath(
-        filename,
-        question.directory,
-        coursePath,
-        question,
-        function (err, fullPath, effectiveFilename, rootPath) {
-          if (ERR(err, next)) return;
-          res.sendFile(effectiveFilename, { root: rootPath });
+    const chunksToLoad =
+      /** @type {chunks.Chunk[]} */
+      ([
+        {
+          type: 'question',
+          questionId: question.id,
         },
-      );
-    });
-  });
-});
+      ]).concat(templateQuestionChunks);
+    await chunks.ensureChunksForCourseAsync(course.id, chunksToLoad);
 
-module.exports = router;
+    const { rootPath, effectiveFilename } = await filePaths.questionFilePathAsync(
+      filename,
+      question.directory,
+      coursePath,
+      question,
+    );
+
+    res.sendFile(effectiveFilename, { root: rootPath });
+  }),
+);
+
+export default router;

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.js
@@ -1,13 +1,13 @@
 // @ts-check
-const express = require('express');
-const router = express.Router();
+import { Router } from 'express';
 const asyncHandler = require('express-async-handler');
 
-const error = require('@prairielearn/error');
-const sqldb = require('@prairielearn/postgres');
-const fileStore = require('../../lib/file-store');
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+import * as fileStore from '../../lib/file-store';
 
 const sql = sqldb.loadSqlEquiv(__filename);
+const router = Router();
 
 router.get(
   '/:unsafe_file_id(\\d+)/:unsafe_display_filename',
@@ -22,7 +22,7 @@ router.get(
     // filename matches, and that the file is not deleted.
     const result = await sqldb.queryZeroOrOneRowAsync(sql.select_file, params);
     if (result.rows.length === 0) {
-      return next(new error.HttpStatusError(404, 'File not found'));
+      throw new error.HttpStatusError(404, 'File not found');
     }
 
     const { id: fileId, display_filename: displayFilename } = result.rows[0];
@@ -34,4 +34,4 @@ router.get(
   }),
 );
 
-module.exports = router;
+export default router;

--- a/apps/prairielearn/src/pages/submissionFile/submissionFile.js
+++ b/apps/prairielearn/src/pages/submissionFile/submissionFile.js
@@ -1,12 +1,12 @@
 // @ts-check
-const express = require('express');
+import { Router } from 'express';
 const asyncHandler = require('express-async-handler');
-const { isBinaryFile } = require('isbinaryfile');
-const mime = require('mime');
-const sqldb = require('@prairielearn/postgres');
+import { isBinaryFile } from 'isbinaryfile';
+import * as mime from 'mime';
+import * as sqldb from '@prairielearn/postgres';
 
-const { selectCourseById } = require('../../models/course');
-const { selectQuestionById } = require('../../models/question');
+import { selectCourseById } from '../../models/course';
+import { selectQuestionById } from '../../models/question';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
@@ -29,8 +29,8 @@ async function guessMimeType(name, buffer) {
   return isBinary ? 'application/octet-stream' : 'text/plain';
 }
 
-module.exports = function (options = { publicEndpoint: false }) {
-  const router = express.Router({ mergeParams: true });
+export default function (options = { publicEndpoint: false }) {
+  const router = Router({ mergeParams: true });
 
   router.get(
     '/*',
@@ -44,6 +44,7 @@ module.exports = function (options = { publicEndpoint: false }) {
           res.locals.course.id !== res.locals.question.course_id
         ) {
           res.sendStatus(404);
+          return;
         }
       }
 
@@ -79,4 +80,4 @@ module.exports = function (options = { publicEndpoint: false }) {
     }),
   );
   return router;
-};
+}

--- a/apps/prairielearn/src/question-servers/calculation-subprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.js
@@ -12,7 +12,7 @@ import { withCodeCaller } from '../lib/code-caller';
 /** @typedef {import('../lib/chunks').Chunk} Chunk */
 
 async function prepareChunksIfNeeded(question, course) {
-  const questionIds = await chunks.getTemplateQuestionIdsAsync(question);
+  const questionIds = await chunks.getTemplateQuestionIds(question);
 
   /** @type {Chunk[]} */
   const templateQuestionChunks = questionIds.map((id) => ({ type: 'question', questionId: id }));
@@ -53,7 +53,7 @@ async function callFunction(func, question_course, question, inputData) {
   const courseHostPath = chunks.getRuntimeDirectoryForCourse(question_course);
   const courseRuntimePath = config.workersExecutionMode === 'native' ? courseHostPath : '/course';
 
-  const { fullPath: questionServerPath } = await filePaths.questionFilePathAsync(
+  const { fullPath: questionServerPath } = await filePaths.questionFilePath(
     'server.js',
     question.directory,
     courseHostPath,

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1191,7 +1191,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/edit_error',
-    require('./pages/editError/editError'),
+    require('./pages/editError/editError').default,
   );
 
   // course instance - course admin pages
@@ -1704,7 +1704,7 @@ module.exports.initExpress = function () {
     require('./pages/instructorFileTransfer/instructorFileTransfer').default,
   ]);
 
-  app.use('/pl/course/:course_id(\\d+)/edit_error', require('./pages/editError/editError'));
+  app.use('/pl/course/:course_id(\\d+)/edit_error', require('./pages/editError/editError').default);
 
   app.use(/^(\/pl\/course\/[0-9]+\/course_admin)\/?$/, (req, res, _next) => {
     res.redirect(`${req.params[0]}/instances`);

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -799,15 +799,15 @@ module.exports.initExpress = function () {
   // files to be treated as immutable in production and cached aggressively.
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/cacheableElements/:cachebuster',
-    require('./pages/elementFiles/elementFiles'),
+    require('./pages/elementFiles/elementFiles').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/cacheableElements/:cachebuster',
-    require('./pages/elementFiles/elementFiles'),
+    require('./pages/elementFiles/elementFiles').default,
   );
   app.use(
     '/pl/course/:course_id(\\d+)/cacheableElements/:cachebuster',
-    require('./pages/elementFiles/elementFiles'),
+    require('./pages/elementFiles/elementFiles').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/cacheableElementExtensions/:cachebuster',
@@ -828,16 +828,19 @@ module.exports.initExpress = function () {
   // traffic in the future, we can delete these.
   //
   // TODO: the only internal usage of this is in the `pl-drawing` element. Fix that.
-  app.use('/pl/static/elements', require('./pages/elementFiles/elementFiles'));
+  app.use('/pl/static/elements', require('./pages/elementFiles/elementFiles').default);
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/elements',
-    require('./pages/elementFiles/elementFiles'),
+    require('./pages/elementFiles/elementFiles').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/elements',
-    require('./pages/elementFiles/elementFiles'),
+    require('./pages/elementFiles/elementFiles').default,
   );
-  app.use('/pl/course/:course_id(\\d+)/elements', require('./pages/elementFiles/elementFiles'));
+  app.use(
+    '/pl/course/:course_id(\\d+)/elements',
+    require('./pages/elementFiles/elementFiles').default,
+  );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/elementExtensions',
     require('./pages/elementExtensionFiles/elementExtensionFiles').default,

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1046,7 +1046,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/clientFilesQuestion',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion').default,
-      require('./pages/clientFilesQuestion/clientFilesQuestion')(),
+      require('./pages/clientFilesQuestion/clientFilesQuestion').default(),
     ],
   );
 
@@ -1417,7 +1417,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/clientFilesQuestion',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/clientFilesQuestion/clientFilesQuestion')(),
+      require('./pages/clientFilesQuestion/clientFilesQuestion').default(),
     ],
   );
 
@@ -1596,7 +1596,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/clientFilesQuestion',
-    require('./pages/clientFilesQuestion/clientFilesQuestion')(),
+    require('./pages/clientFilesQuestion/clientFilesQuestion').default(),
   );
 
   // generatedFiles
@@ -1843,7 +1843,7 @@ module.exports.initExpress = function () {
   );
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/clientFilesQuestion', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,
-    require('./pages/clientFilesQuestion/clientFilesQuestion')(),
+    require('./pages/clientFilesQuestion/clientFilesQuestion').default(),
   ]);
 
   // generatedFiles
@@ -1912,7 +1912,7 @@ module.exports.initExpress = function () {
   // Client files for questions
   app.use(
     '/pl/public/course/:course_id(\\d+)/question/:question_id(\\d+)/clientFilesQuestion',
-    require('./pages/clientFilesQuestion/clientFilesQuestion')({ publicEndpoint: true }),
+    require('./pages/clientFilesQuestion/clientFilesQuestion').default({ publicEndpoint: true }),
   );
 
   // generatedFiles

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -413,7 +413,7 @@ module.exports.initExpress = function () {
     // sub-router by finding the cookie, or by running regular
     // authn/authz.
 
-    require('./middlewares/authzWorkspaceCookieCheck'), // short-circuits if we have the workspace-authz cookie
+    require('./middlewares/authzWorkspaceCookieCheck').default, // short-circuits if we have the workspace-authz cookie
     require('./middlewares/date').default,
     require('./middlewares/authn'), // jumps to error handler if authn fails
     require('./middlewares/authzWorkspace'), // jumps to error handler if authz fails

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -510,7 +510,7 @@ module.exports.initExpress = function () {
   app.use(require('./middlewares/date').default);
   app.use(require('./middlewares/effectiveRequestChanged').default);
 
-  app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2'));
+  app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2').default);
   app.use('/pl/oauth2callback', require('./pages/authCallbackOAuth2/authCallbackOAuth2'));
   app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib').default);
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1401,7 +1401,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/assessment/:assessment_id(\\d+)/clientFilesAssessment',
     [
       require('./middlewares/selectAndAuthzAssessment').default,
-      require('./pages/clientFilesAssessment/clientFilesAssessment'),
+      require('./pages/clientFilesAssessment/clientFilesAssessment').default,
     ],
   );
 
@@ -1582,7 +1582,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzAssessment').default,
       require('./middlewares/studentAssessmentAccess').default,
-      require('./pages/clientFilesAssessment/clientFilesAssessment'),
+      require('./pages/clientFilesAssessment/clientFilesAssessment').default,
     ],
   );
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -417,7 +417,7 @@ module.exports.initExpress = function () {
     require('./middlewares/date').default,
     require('./middlewares/authn'), // jumps to error handler if authn fails
     require('./middlewares/authzWorkspace'), // jumps to error handler if authz fails
-    require('./middlewares/authzWorkspaceCookieSet'), // sets the workspace-authz cookie
+    require('./middlewares/authzWorkspaceCookieSet').default, // sets the workspace-authz cookie
   ]);
   app.use('/pl/workspace/:workspace_id(\\d+)/container', [
     cookieParser(),

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1059,7 +1059,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/file',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion').default,
-      require('./pages/legacyQuestionFile/legacyQuestionFile'),
+      require('./pages/legacyQuestionFile/legacyQuestionFile').default,
     ],
   );
   app.use(
@@ -1442,14 +1442,14 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/file',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/legacyQuestionFile/legacyQuestionFile'),
+      require('./pages/legacyQuestionFile/legacyQuestionFile').default,
     ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/preview/file',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/legacyQuestionFile/legacyQuestionFile'),
+      require('./pages/legacyQuestionFile/legacyQuestionFile').default,
     ],
   );
   app.use(
@@ -1611,7 +1611,7 @@ module.exports.initExpress = function () {
   // legacy client file paths
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/file',
-    require('./pages/legacyQuestionFile/legacyQuestionFile'),
+    require('./pages/legacyQuestionFile/legacyQuestionFile').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/text',
@@ -1862,11 +1862,11 @@ module.exports.initExpress = function () {
   // handle routes with and without /preview/ in them to handle URLs with and without trailing slashes
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/file', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,
-    require('./pages/legacyQuestionFile/legacyQuestionFile'),
+    require('./pages/legacyQuestionFile/legacyQuestionFile').default,
   ]);
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/preview/file', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,
-    require('./pages/legacyQuestionFile/legacyQuestionFile'),
+    require('./pages/legacyQuestionFile/legacyQuestionFile').default,
   ]);
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/text', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -416,7 +416,7 @@ module.exports.initExpress = function () {
     require('./middlewares/authzWorkspaceCookieCheck').default, // short-circuits if we have the workspace-authz cookie
     require('./middlewares/date').default,
     require('./middlewares/authn').default, // jumps to error handler if authn fails
-    require('./middlewares/authzWorkspace'), // jumps to error handler if authz fails
+    require('./middlewares/authzWorkspace').default, // jumps to error handler if authz fails
     require('./middlewares/authzWorkspaceCookieSet').default, // sets the workspace-authz cookie
   ]);
   app.use('/pl/workspace/:workspace_id(\\d+)/container', [
@@ -646,7 +646,7 @@ module.exports.initExpress = function () {
       res.locals.workspace_id = req.params.workspace_id;
       next();
     },
-    require('./middlewares/authzWorkspace'),
+    require('./middlewares/authzWorkspace').default,
   ]);
   app.use('/pl/workspace/:workspace_id(\\d+)', require('./pages/workspace/workspace').default);
   app.use(

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -596,7 +596,7 @@ module.exports.initExpress = function () {
       res.locals.navPage = 'password';
       next();
     },
-    require('./pages/authPassword/authPassword'),
+    require('./pages/authPassword/authPassword').default,
   ]);
   app.use('/pl/news_items', [
     function (req, res, next) {

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1503,7 +1503,7 @@ module.exports.initExpress = function () {
       require('./middlewares/studentAssessmentAccess').default,
       require('./middlewares/clientFingerprint').default,
       require('./middlewares/logPageView').default('studentAssessmentInstanceFile'),
-      require('./pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile'),
+      require('./pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile').default,
     ],
   );
   app.use(

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1054,7 +1054,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/generatedFilesQuestion',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion').default,
-      require('./pages/generatedFilesQuestion/generatedFilesQuestion')(),
+      require('./pages/generatedFilesQuestion/generatedFilesQuestion').default(),
     ],
   );
 
@@ -1426,7 +1426,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/generatedFilesQuestion',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/generatedFilesQuestion/generatedFilesQuestion')(),
+      require('./pages/generatedFilesQuestion/generatedFilesQuestion').default(),
     ],
   );
 
@@ -1602,7 +1602,7 @@ module.exports.initExpress = function () {
   // generatedFiles
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/generatedFilesQuestion',
-    require('./pages/generatedFilesQuestion/generatedFilesQuestion')(),
+    require('./pages/generatedFilesQuestion/generatedFilesQuestion').default(),
   );
 
   // Submission files
@@ -1849,7 +1849,7 @@ module.exports.initExpress = function () {
   // generatedFiles
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/generatedFilesQuestion', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,
-    require('./pages/generatedFilesQuestion/generatedFilesQuestion')(),
+    require('./pages/generatedFilesQuestion/generatedFilesQuestion').default(),
   ]);
 
   // Submission files
@@ -1918,7 +1918,9 @@ module.exports.initExpress = function () {
   // generatedFiles
   app.use(
     '/pl/public/course/:course_id(\\d+)/question/:question_id(\\d+)/generatedFilesQuestion',
-    require('./pages/generatedFilesQuestion/generatedFilesQuestion')({ publicEndpoint: true }),
+    require('./pages/generatedFilesQuestion/generatedFilesQuestion').default({
+      publicEndpoint: true,
+    }),
   );
 
   // Submission files

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1066,7 +1066,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/text',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion').default,
-      require('./pages/legacyQuestionText/legacyQuestionText'),
+      require('./pages/legacyQuestionText/legacyQuestionText').default,
     ],
   );
 
@@ -1456,14 +1456,14 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/text',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/legacyQuestionText/legacyQuestionText'),
+      require('./pages/legacyQuestionText/legacyQuestionText').default,
     ],
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/preview/text',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/legacyQuestionText/legacyQuestionText'),
+      require('./pages/legacyQuestionText/legacyQuestionText').default,
     ],
   );
 
@@ -1615,7 +1615,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/text',
-    require('./pages/legacyQuestionText/legacyQuestionText'),
+    require('./pages/legacyQuestionText/legacyQuestionText').default,
   );
 
   //////////////////////////////////////////////////////////////////////
@@ -1870,11 +1870,11 @@ module.exports.initExpress = function () {
   ]);
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/text', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,
-    require('./pages/legacyQuestionText/legacyQuestionText'),
+    require('./pages/legacyQuestionText/legacyQuestionText').default,
   ]);
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/preview/text', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,
-    require('./pages/legacyQuestionText/legacyQuestionText'),
+    require('./pages/legacyQuestionText/legacyQuestionText').default,
   ]);
 
   //////////////////////////////////////////////////////////////////////

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -811,15 +811,15 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/cacheableElementExtensions/:cachebuster',
-    require('./pages/elementExtensionFiles/elementExtensionFiles'),
+    require('./pages/elementExtensionFiles/elementExtensionFiles').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/cacheableElementExtensions/:cachebuster',
-    require('./pages/elementExtensionFiles/elementExtensionFiles'),
+    require('./pages/elementExtensionFiles/elementExtensionFiles').default,
   );
   app.use(
     '/pl/course/:course_id(\\d+)/cacheableElementExtensions/:cachebuster',
-    require('./pages/elementExtensionFiles/elementExtensionFiles'),
+    require('./pages/elementExtensionFiles/elementExtensionFiles').default,
   );
 
   // For backwards compatibility, we continue to serve the non-cached element
@@ -840,15 +840,15 @@ module.exports.initExpress = function () {
   app.use('/pl/course/:course_id(\\d+)/elements', require('./pages/elementFiles/elementFiles'));
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/elementExtensions',
-    require('./pages/elementExtensionFiles/elementExtensionFiles'),
+    require('./pages/elementExtensionFiles/elementExtensionFiles').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/elementExtensions',
-    require('./pages/elementExtensionFiles/elementExtensionFiles'),
+    require('./pages/elementExtensionFiles/elementExtensionFiles').default,
   );
   app.use(
     '/pl/course/:course_id(\\d+)/elementExtensions',
-    require('./pages/elementExtensionFiles/elementExtensionFiles'),
+    require('./pages/elementExtensionFiles/elementExtensionFiles').default,
   );
 
   //////////////////////////////////////////////////////////////////////

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1037,7 +1037,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/clientFilesQuestion',
@@ -1381,7 +1381,7 @@ module.exports.initExpress = function () {
   // Global client files
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/clientFilesCourseInstance',
@@ -1391,7 +1391,7 @@ module.exports.initExpress = function () {
   // Client files for assessments
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/assessment/:assessment_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/assessment/:assessment_id(\\d+)/clientFilesCourseInstance',
@@ -1408,7 +1408,7 @@ module.exports.initExpress = function () {
   // Client files for questions
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/clientFilesQuestion',
@@ -1553,7 +1553,7 @@ module.exports.initExpress = function () {
   // Global client files
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourseInstance',
@@ -1566,7 +1566,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzAssessment').default,
       require('./middlewares/studentAssessmentAccess').default,
-      require('./pages/clientFilesCourse/clientFilesCourse'),
+      require('./pages/clientFilesCourse/clientFilesCourse').default,
     ],
   );
   app.use(
@@ -1589,7 +1589,7 @@ module.exports.initExpress = function () {
   // Client files for questions
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/clientFilesQuestion',
@@ -1830,13 +1830,13 @@ module.exports.initExpress = function () {
   // Global client files
   app.use(
     '/pl/course/:course_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
 
   // Client files for questions
   app.use(
     '/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/clientFilesCourse',
-    require('./pages/clientFilesCourse/clientFilesCourse'),
+    require('./pages/clientFilesCourse/clientFilesCourse').default,
   );
   app.use('/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/clientFilesQuestion', [
     require('./middlewares/selectAndAuthzInstructorQuestion').default,

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -542,7 +542,7 @@ module.exports.initExpress = function () {
   // disable SEB until we can fix the mcrypt issues
   // app.use('/pl/downloadSEBConfig', require('./pages/studentSEBConfig/studentSEBConfig'));
   app.use(require('./middlewares/authn')); // authentication, set res.locals.authn_user
-  app.use('/pl/api', require('./middlewares/authnToken')); // authn for the API, set res.locals.authn_user
+  app.use('/pl/api', require('./middlewares/authnToken').default); // authn for the API, set res.locals.authn_user
 
   // Must come after the authentication middleware, as we need to read the
   // `authn_is_administrator` property from the response locals.

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -512,7 +512,7 @@ module.exports.initExpress = function () {
 
   app.use('/pl/oauth2login', require('./pages/authLoginOAuth2/authLoginOAuth2'));
   app.use('/pl/oauth2callback', require('./pages/authCallbackOAuth2/authCallbackOAuth2'));
-  app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib'));
+  app.use(/\/pl\/shibcallback/, require('./pages/authCallbackShib/authCallbackShib').default);
 
   if (isEnterprise()) {
     if (config.hasAzure) {

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -415,7 +415,7 @@ module.exports.initExpress = function () {
 
     require('./middlewares/authzWorkspaceCookieCheck').default, // short-circuits if we have the workspace-authz cookie
     require('./middlewares/date').default,
-    require('./middlewares/authn'), // jumps to error handler if authn fails
+    require('./middlewares/authn').default, // jumps to error handler if authn fails
     require('./middlewares/authzWorkspace'), // jumps to error handler if authz fails
     require('./middlewares/authzWorkspaceCookieSet').default, // sets the workspace-authz cookie
   ]);
@@ -541,7 +541,7 @@ module.exports.initExpress = function () {
   ]);
   // disable SEB until we can fix the mcrypt issues
   // app.use('/pl/downloadSEBConfig', require('./pages/studentSEBConfig/studentSEBConfig'));
-  app.use(require('./middlewares/authn')); // authentication, set res.locals.authn_user
+  app.use(require('./middlewares/authn').default); // authentication, set res.locals.authn_user
   app.use('/pl/api', require('./middlewares/authnToken').default); // authn for the API, set res.locals.authn_user
 
   // Must come after the authentication middleware, as we need to read the

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1018,7 +1018,7 @@ module.exports.initExpress = function () {
         res.locals.navSubPage = 'manual_grading';
         next();
       },
-      require('./middlewares/selectAndAuthzAssessmentQuestion'),
+      require('./middlewares/selectAndAuthzAssessmentQuestion').default,
       require('./pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion')
         .default,
     ],

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1385,7 +1385,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/clientFilesCourseInstance',
-    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance'),
+    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance').default,
   );
 
   // Client files for assessments
@@ -1395,7 +1395,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/assessment/:assessment_id(\\d+)/clientFilesCourseInstance',
-    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance'),
+    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance').default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/assessment/:assessment_id(\\d+)/clientFilesAssessment',
@@ -1557,7 +1557,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourseInstance',
-    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance'),
+    require('./pages/clientFilesCourseInstance/clientFilesCourseInstance').default,
   );
 
   // Client files for assessments
@@ -1574,7 +1574,7 @@ module.exports.initExpress = function () {
     [
       require('./middlewares/selectAndAuthzAssessment').default,
       require('./middlewares/studentAssessmentAccess').default,
-      require('./pages/clientFilesCourseInstance/clientFilesCourseInstance'),
+      require('./pages/clientFilesCourseInstance/clientFilesCourseInstance').default,
     ],
   );
   app.use(

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -562,7 +562,7 @@ module.exports.initExpress = function () {
     enterpriseOnlyMiddleware(() => require('./ee/webhooks/stripe').default),
   );
 
-  app.use(require('./middlewares/csrfToken')); // sets and checks res.locals.__csrf_token
+  app.use(require('./middlewares/csrfToken').default); // sets and checks res.locals.__csrf_token
   app.use(require('./middlewares/logRequest').default);
 
   // load accounting for authenticated accesses

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1078,7 +1078,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_question/:instance_question_id(\\d+)/submission/:submission_id(\\d+)/file',
     [
       require('./middlewares/selectAndAuthzInstanceQuestion').default,
-      require('./pages/submissionFile/submissionFile')(),
+      require('./pages/submissionFile/submissionFile').default(),
     ],
   );
 
@@ -1435,7 +1435,7 @@ module.exports.initExpress = function () {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/question/:question_id(\\d+)/submission/:submission_id(\\d+)/file',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/submissionFile/submissionFile')(),
+      require('./pages/submissionFile/submissionFile').default(),
     ],
   );
 
@@ -1608,7 +1608,7 @@ module.exports.initExpress = function () {
   // Submission files
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/submission/:submission_id(\\d+)/file',
-    require('./pages/submissionFile/submissionFile')(),
+    require('./pages/submissionFile/submissionFile').default(),
   );
 
   // legacy client file paths
@@ -1857,7 +1857,7 @@ module.exports.initExpress = function () {
     '/pl/course/:course_id(\\d+)/question/:question_id(\\d+)/submission/:submission_id(\\d+)/file',
     [
       require('./middlewares/selectAndAuthzInstructorQuestion').default,
-      require('./pages/submissionFile/submissionFile')(),
+      require('./pages/submissionFile/submissionFile').default(),
     ],
   );
 
@@ -1926,7 +1926,7 @@ module.exports.initExpress = function () {
   // Submission files
   app.use(
     '/pl/public/course/:course_id(\\d+)/question/:question_id(\\d+)/submission/:submission_id(\\d+)/file',
-    [require('./pages/submissionFile/submissionFile')({ publicEndpoint: true })],
+    [require('./pages/submissionFile/submissionFile').default({ publicEndpoint: true })],
   );
 
   //////////////////////////////////////////////////////////////////////

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -614,7 +614,7 @@ module.exports.initExpress = function () {
       res.locals.navSubPage = 'news_item';
       next();
     },
-    require('./pages/news_item/news_item'),
+    require('./pages/news_item/news_item').default,
   ]);
   app.use(
     '/pl/request_course',
@@ -730,7 +730,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/news_item',
-    require('./pages/news_item/news_item'),
+    require('./pages/news_item/news_item').default,
   );
 
   // Some course instance student pages only require the authn user to have permissions
@@ -764,7 +764,7 @@ module.exports.initExpress = function () {
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/news_item',
-    require('./pages/news_item/news_item'),
+    require('./pages/news_item/news_item').default,
   );
 
   // All other course instance student pages require the effective user to have permissions
@@ -1627,7 +1627,7 @@ module.exports.initExpress = function () {
     res.redirect(res.locals.urlPrefix + '/course_admin');
   }); // redirect plain course URL to overview page
 
-  // Some course pages only require the authn user to have permission (aleady checked)
+  // Some course pages only require the authn user to have permission (already checked)
   app.use(
     '/pl/course/:course_id(\\d+)/effectiveUser',
     require('./pages/instructorEffectiveUser/instructorEffectiveUser').default,
@@ -1636,7 +1636,7 @@ module.exports.initExpress = function () {
     '/pl/course/:course_id(\\d+)/news_items',
     require('./pages/news_items/news_items').default,
   );
-  app.use('/pl/course/:course_id(\\d+)/news_item', require('./pages/news_item/news_item'));
+  app.use('/pl/course/:course_id(\\d+)/news_item', require('./pages/news_item/news_item').default);
 
   // All other course pages require the effective user to have permission
   app.use('/pl/course/:course_id(\\d+)', require('./middlewares/authzHasCoursePreview').default);


### PR DESCRIPTION
This brings us down to only 16 files using CJS!

```
Summary (16 files):
apps/prairielearn/src/executor.js: 3
apps/prairielearn/src/question-servers/calculation-worker.js: 3
apps/prairielearn/src/lib/require-frontend.js: 5
apps/prairielearn/src/pages/error/error.js: 5
apps/prairielearn/src/lib/ltiOutcomes.js: 7
apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js: 7
apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js: 7
apps/prairielearn/src/lib/code-caller/code-caller-native.js: 8
apps/prairielearn/src/lib/markdown.js: 9
apps/prairielearn/src/pages/studentSEBConfig/studentSEBConfig.js: 9
apps/prairielearn/src/pages/courseSyncs/courseSyncs.js: 10
apps/prairielearn/src/schemas/index.js: 14
apps/prairielearn/src/lib/code-caller/index.js: 15
apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js: 16
apps/prairielearn/src/lib/code-caller/code-caller-container.js: 18
apps/prairielearn/src/server.js: 59
```