### PR TITLE
Improve TypeScript coverage

### DIFF
--- a/apps/prairielearn/src/middlewares/date.js
+++ b/apps/prairielearn/src/middlewares/date.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { config } from '../lib/config';
 
 /**

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
@@ -1,3 +1,4 @@
+// @ts-check
 const asyncHandler = require('express-async-handler');
 import * as express from 'express';
 
@@ -66,7 +67,7 @@ router.get(
           res.locals.start = groupInfo.start;
           res.locals.rolesInfo = groupInfo.rolesInfo;
 
-          if (groupConfig.hasRoles) {
+          if (groupConfig.has_roles) {
             res.locals.userCanAssignRoles = canUserAssignGroupRoles(
               groupInfo,
               res.locals.user.user_id,


### PR DESCRIPTION
This PR adds a few missing `// @ts-check` comments. I found these files with the following command:

```sh
grep -r -L "// @ts-check" apps/ | grep "\.js$" | grep -v "dist" | grep -v "prairielearn/public" | grep -v "prairielearn/v2-question-server" | grep -v "prairielearn/elements"
```