### PR TITLE
Convert external grader common library to async

### DIFF
--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -1,8 +1,7 @@
 // @ts-check
-const ERR = require('async-stacktrace');
 import * as _ from 'lodash';
-import * as async from 'async';
-import * as fs from 'fs-extra';
+import * as fsExtra from 'fs-extra';
+import * as fsPromises from 'node:fs/promises';
 import * as path from 'path';
 
 import { logger } from '@prairielearn/logger';
@@ -21,169 +20,91 @@ export function getJobDirectory(jobId) {
  * Constructs a directory of files to be used for grading.
  *
  * @param {string} dir
- * @param {any} submission
- * @param {any} variant
- * @param {any} question
- * @param {any} course
+ * @param {import('./db-types').Submission} submission
+ * @param {import('./db-types').Variant} variant
+ * @param {import('./db-types').Question} question
+ * @param {import('./db-types').Course} course
  */
-export function buildDirectory(dir, submission, variant, question, course, callback) {
+export async function buildDirectory(dir, submission, variant, question, course) {
   const coursePath = getRuntimeDirectoryForCourse(course);
-  async.series(
-    [
-      (callback) => {
-        // Attempt to remove existing directory first
-        fs.remove(dir, () => {
-          // Ignore error for now
-          callback(null);
-        });
-      },
-      (callback) => {
-        fs.mkdirs(dir, (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        fs.mkdir(path.join(dir, 'serverFilesCourse'), (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        fs.mkdir(path.join(dir, 'tests'), (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        fs.mkdir(path.join(dir, 'student'), (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        fs.mkdir(path.join(dir, 'data'), (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        // Copy all specified files/directories into serverFilesCourse/
-        if (question.external_grading_files) {
-          async.each(
-            question.external_grading_files,
-            (file, callback) => {
-              const src = path.join(coursePath, 'serverFilesCourse', file);
-              const dest = path.join(dir, 'serverFilesCourse', file);
-              fs.copy(src, dest, (err) => {
-                if (ERR(err, callback)) return;
-                callback(null);
-              });
-            },
-            (err) => {
-              if (ERR(err, callback)) return;
-              callback(null);
-            },
-          );
-        } else {
-          callback(null);
-        }
-      },
-      (callback) => {
-        // This is temporary while /grade/shared is deprecated but still supported
-        // TODO remove this when we remove support for /grade/shared
-        const src = path.join(dir, 'serverFilesCourse');
-        const dest = path.join(dir, 'shared');
-        fs.copy(src, dest, (err) => {
-          if (ERR(err, callback)) return;
-          callback(null);
-        });
-      },
-      (callback) => {
-        // Tests might not be specified, only copy them if they exist
-        const testsDir = path.join(coursePath, 'questions', question.directory, 'tests');
-        fs.access(testsDir, fs.constants.R_OK, (err) => {
-          if (!err) {
-            fs.copy(testsDir, path.join(dir, 'tests'), (err) => {
-              if (ERR(err, callback)) return;
-              callback(null);
-            });
-          } else {
-            logger.warn(
-              `No tests directory found for ${question.qid}; maybe you meant to specify some?`,
-            );
-            callback(null);
-          }
-        });
-      },
-      (callback) => {
-        if (submission.submitted_answer._files) {
-          async.each(
-            submission.submitted_answer._files,
-            (file, callback) => {
-              if (!file.name) {
-                return callback(new Error("File was missing 'name' property."));
-              }
-              if (file.contents == null) {
-                return callback(new Error("File was missing 'contents' property."));
-              }
+  try {
+    // Attempt to remove existing directory first
+    await fsPromises.rm(dir, { force: true, recursive: true });
+    await fsPromises.mkdir(dir, { recursive: true });
+    await fsPromises.mkdir(path.join(dir, 'serverFilesCourse'));
+    await fsPromises.mkdir(path.join(dir, 'tests'));
+    await fsPromises.mkdir(path.join(dir, 'student'));
+    await fsPromises.mkdir(path.join(dir, 'data'));
 
-              // Files are expected to be base-64 encoded
-              let decodedContents = Buffer.from(file.contents, 'base64');
-              // Check that the file name does not try to navigate up in
-              // the directory hierarchy
-              const fullPath = path.join(dir, 'student', file.name);
-              if (!contains(path.join(dir, 'student'), fullPath)) {
-                callback(new Error('Invalid filename'));
-                return;
-              }
-              // The version of ensureDir provided by fs-extra
-              // automatically creates intermediate paths recursively.
-              const targetDir = path.dirname(fullPath);
-              fs.ensureDir(targetDir, (err) => {
-                if (ERR(err, callback)) return;
-                fs.writeFile(fullPath, decodedContents, (err) => {
-                  if (ERR(err, callback)) return;
-                  callback(null);
-                });
-              });
-            },
-            function (err) {
-              if (ERR(err, callback)) return;
-              callback(null);
-            },
+    // Copy all specified files/directories into serverFilesCourse/
+    for (const file of question.external_grading_files ?? []) {
+      const src = path.join(coursePath, 'serverFilesCourse', file);
+      const dest = path.join(dir, 'serverFilesCourse', file);
+      await fsExtra.copy(src, dest);
+    }
+
+    // This is temporary while /grade/shared is deprecated but still supported
+    // TODO remove this when we remove support for /grade/shared
+    const src = path.join(dir, 'serverFilesCourse');
+    const dest = path.join(dir, 'shared');
+    await fsExtra.copy(src, dest);
+
+    if (question.directory != null) {
+      // Tests might not be specified, only copy them if they exist
+      const testsDir = path.join(coursePath, 'questions', question.directory, 'tests');
+      await fsExtra.copy(testsDir, path.join(dir, 'tests')).catch((err) => {
+        if (err.code === 'ENOENT') {
+          logger.warn(
+            `No tests directory found for ${question.qid}; maybe you meant to specify some?`,
           );
         } else {
-          callback(null);
+          throw err;
         }
-      },
-      (callback) => {
-        // This uses the same fields passed v3's server.grade functions
-        const data = {
-          params: variant.params,
-          correct_answers: variant.true_answer,
-          submitted_answers: submission.submitted_answer,
-          format_errors: submission.format_errors,
-          partial_scores: submission.partial_scores == null ? {} : submission.partial_scores,
-          score: submission.score == null ? 0 : submission.score,
-          feedback: submission.feedback == null ? {} : submission.feedback,
-          variant_seed: parseInt(variant.variant_seed, 36),
-          options: variant.options || {},
-          raw_submitted_answers: submission.raw_submitted_answer,
-          gradable: submission.gradable,
-        };
-        fs.writeJSON(path.join(dir, 'data', 'data.json'), data, callback);
-      },
-    ],
-    (err) => {
-      if (ERR(err, callback)) {
-        return logger.error(`Error setting up ${dir}`);
+      });
+    }
+
+    for (const file of submission.submitted_answer?._files ?? []) {
+      if (!file.name) {
+        throw new Error("File was missing 'name' property.");
+      }
+      if (file.contents == null) {
+        throw new Error("File was missing 'contents' property.");
       }
 
-      logger.verbose(`Successfully set up ${dir}`);
-      callback(null);
-    },
-  );
+      // Files are expected to be base-64 encoded
+      let decodedContents = Buffer.from(file.contents, 'base64');
+      // Check that the file name does not try to navigate up in
+      // the directory hierarchy
+      const fullPath = path.join(dir, 'student', file.name);
+      if (!contains(path.join(dir, 'student'), fullPath)) {
+        throw new Error('Invalid filename');
+      }
+
+      await fsPromises.mkdir(path.dirname(fullPath), { recursive: true });
+      await fsPromises.writeFile(fullPath, decodedContents);
+    }
+
+    // This uses the same fields passed v3's server.grade functions
+    const data = {
+      params: variant.params,
+      correct_answers: variant.true_answer,
+      submitted_answers: submission.submitted_answer,
+      format_errors: submission.format_errors,
+      partial_scores: submission.partial_scores ?? {},
+      score: submission.score ?? 0,
+      feedback: submission.feedback ?? {},
+      variant_seed: parseInt(variant.variant_seed ?? '0', 36),
+      options: variant.options || {},
+      raw_submitted_answers: submission.raw_submitted_answer,
+      gradable: submission.gradable,
+    };
+    await fsPromises.writeFile(path.join(dir, 'data', 'data.json'), JSON.stringify(data));
+
+    logger.verbose(`Successfully set up ${dir}`);
+  } catch (err) {
+    logger.error(`Error setting up ${dir}`);
+    throw err;
+  }
 }
 
 /**

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -50,16 +50,10 @@ export async function buildDirectory(dir, submission, variant, question, course)
     await fsExtra.copy(src, dest);
 
     if (question.directory != null) {
-      // Tests might not be specified, only copy them if they exist
       const testsDir = path.join(coursePath, 'questions', question.directory, 'tests');
       await fsExtra.copy(testsDir, path.join(dir, 'tests')).catch((err) => {
-        if (err.code === 'ENOENT') {
-          logger.warn(
-            `No tests directory found for ${question.qid}; maybe you meant to specify some?`,
-          );
-        } else {
-          throw err;
-        }
+        // Tests might not be specified, only copy them if they exist
+        if (err.code !== 'ENOENT') throw err;
       });
     }
 

--- a/apps/prairielearn/src/lib/externalGraderLocal.js
+++ b/apps/prairielearn/src/lib/externalGraderLocal.js
@@ -11,7 +11,6 @@ import { logger } from '@prairielearn/logger';
 import { buildDirectory, makeGradingResult } from './externalGraderCommon';
 import { config } from './config';
 import * as sqldb from '@prairielearn/postgres';
-import { promisify } from 'util';
 
 const sql = sqldb.loadSqlEquiv(__filename);
 
@@ -43,7 +42,7 @@ export class ExternalGraderLocal {
       results.received_time = new Date().toISOString();
       emitter.emit('received', results.received_time);
 
-      await promisify(buildDirectory)(dir, submission, variant, question, course);
+      await buildDirectory(dir, submission, variant, question, course);
 
       if (question.external_grading_entrypoint.includes('serverFilesCourse')) {
         // Mark the entrypoint as executable if it lives in serverFilesCourse.

--- a/apps/prairielearn/src/lib/externalGraderSqs.js
+++ b/apps/prairielearn/src/lib/externalGraderSqs.js
@@ -33,17 +33,10 @@ export class ExternalGraderSqs {
       [
         async () => {
           await buildDirectory(dir, submission, variant, question, course);
-        },
-        async () => {
+
           // Now that we've built up our directory, let's zip it up and send
           // it off to S3
-          let tarball = tar.create(
-            {
-              gzip: true,
-              cwd: dir,
-            },
-            ['.'],
-          );
+          let tarball = tar.create({ gzip: true, cwd: dir }, ['.']);
 
           const passthrough = new PassThrough();
           tarball.pipe(passthrough);
@@ -55,14 +48,10 @@ export class ExternalGraderSqs {
           };
 
           const s3 = new S3(makeS3ClientConfig());
-          await new Upload({
-            client: s3,
-            params,
-          }).done();
-        },
-        async () => {
+          await new Upload({ client: s3, params }).done();
+
           // Store S3 info for this job
-          sqldb.queryAsync(sql.update_s3_info, {
+          await sqldb.queryAsync(sql.update_s3_info, {
             grading_job_id: grading_job.id,
             s3_bucket: config.externalGradingS3Bucket,
             s3_root_key: s3RootKey,

--- a/apps/prairielearn/src/lib/externalGraderSqs.js
+++ b/apps/prairielearn/src/lib/externalGraderSqs.js
@@ -31,8 +31,8 @@ export class ExternalGraderSqs {
 
     async.series(
       [
-        (callback) => {
-          buildDirectory(dir, submission, variant, question, course, callback);
+        async () => {
+          await buildDirectory(dir, submission, variant, question, course);
         },
         async () => {
           // Now that we've built up our directory, let's zip it up and send


### PR DESCRIPTION
Also replaced calls to `fsExtra` functions to `fsPromises` where an appropriate alternative exists. `fsExtra.copy` was kept because [`fsPromises.cp` is still tagged as experimental](https://nodejs.org/api/fs.html#fscpsrc-dest-options-callback).

Review hiding whitespaces.