### PR TITLE
Remove usages of require.main

### DIFF
--- a/apps/prairielearn/src/question-servers/calculation-worker.js
+++ b/apps/prairielearn/src/question-servers/calculation-worker.js
@@ -125,10 +125,6 @@ function getLineOnce(rl) {
   });
 }
 
-if (require.main !== module) {
-  throw new Error('This script is designed to be run as the main process');
-}
-
 // Redirect `stdout` to `stderr` so that we can ensure that no
 // user code can write to `stdout`; we need to use `stdout` to send results
 // instead.

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -2158,7 +2158,7 @@ export async function insertDevUser() {
   await sqldb.queryAsync(adminSql, { user_id });
 }
 
-if (config.startServer) {
+if (require.main === module && config.startServer) {
   async.series(
     [
       async () => {

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -78,13 +78,6 @@ process.on('warning', (e) => console.warn(e));
 
 const argv = yargsParser(process.argv.slice(2));
 
-// If there is only one argument and `server.js` is being executed directly,
-// legacy it into the config option.
-if (require.main === module && argv['_'].length === 1) {
-  argv['config'] = argv['_'][0];
-  argv['_'] = [];
-}
-
 if ('h' in argv || 'help' in argv) {
   var msg = `PrairieLearn command line options:
     -h, --help                          Display this help and exit
@@ -2165,7 +2158,7 @@ export async function insertDevUser() {
   await sqldb.queryAsync(adminSql, { user_id });
 }
 
-if (require.main === module && config.startServer) {
+if (config.startServer) {
   async.series(
     [
       async () => {


### PR DESCRIPTION
There is no direct replacement for `require.main` in ESM modules. There's always https://www.npmjs.com/package/es-main... but I'd rather not drag in another dependency when IMO we never actually really need this check.