### PR TITLE
Rename Sharing Set Info type to avoid type name duplication

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -21,12 +21,12 @@ export const SelectedAssessmentsSchema = z.object({
 });
 type SelectedAssessments = z.infer<typeof SelectedAssessmentsSchema>;
 
-export const SharingSetSchema = z.object({
+export const SharingSetRowSchema = z.object({
   id: IdSchema,
   name: z.string(),
   in_set: z.boolean(),
 });
-type SharingSet = z.infer<typeof SharingSetSchema>;
+type SharingSetRow = z.infer<typeof SharingSetRowSchema>;
 
 export function InstructorQuestionSettings({
   resLocals,
@@ -48,8 +48,8 @@ export function InstructorQuestionSettings({
   qids: string[];
   assessmentsWithQuestion: SelectedAssessments[];
   sharingEnabled: boolean;
-  sharingSetsIn: SharingSet[];
-  sharingSetsOther: SharingSet[];
+  sharingSetsIn: SharingSetRow[];
+  sharingSetsOther: SharingSetRow[];
   editableCourses: CourseWithPermissions[];
   infoPath: string;
 }) {

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -20,7 +20,7 @@ import { IdSchema } from '../../lib/db-types';
 import {
   InstructorQuestionSettings,
   SelectedAssessmentsSchema,
-  SharingSetSchema,
+  SharingSetRowSchema,
 } from './instructorQuestionSettings.html';
 
 const router = express.Router();
@@ -251,7 +251,7 @@ router.get(
           question_id: res.locals.question.id,
           course_id: res.locals.course.id,
         },
-        SharingSetSchema,
+        SharingSetRowSchema,
       );
       sharingSetsIn = result.filter((row) => row.in_set);
       sharingSetsOther = result.filter((row) => !row.in_set);


### PR DESCRIPTION
The type had the same name as the one of the types in db-types, I renamed to avoid confusion.