### PR TITLE
Don't show 'shared-as' if course sharing name hasn't been picked

### DIFF
--- a/apps/prairielearn/src/pages/partials/instructorInfoPanel.ejs
+++ b/apps/prairielearn/src/pages/partials/instructorInfoPanel.ejs
@@ -51,7 +51,7 @@
     </div>
   </div>
 
-  <% if (question_is_shared) { %>
+  <% if (question_is_shared && course.sharing_name) { %>
   <div class="d-flex flex-wrap">
     <div class="pr-1">Shared As:</div>
     <% if (question.shared_publicly) { %>


### PR DESCRIPTION
follow up fix to #9763