### PR TITLE
Update installing.md - clarify instructions for Linux and ARM Macs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -103,9 +103,7 @@ mkdir "$HOME/pl_ag_jobs"
 
 #### Running Docker with the extended features
 
-Now, we can run PrairieLearn as usual, but with additional options to allow the external grading or workspaces features. We require these extra options so that Docker can spawn additional containers alongside the main PrairieLearn container.
-
-For example, if your course directory is in `$HOME/pl-tam212` and the jobs directory created above is in `$HOME/pl_ag_jobs`, the new command is as follows:
+Now, we can run PrairieLearn with additional options to allow the external grading or workspaces features. For example, if your course directory is in `$HOME/pl-tam212` and the jobs directory created above is in `$HOME/pl_ag_jobs`, the new command is as follows:
 
 ```sh
 docker run -it --rm -p 3000:3000 \

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -129,9 +129,13 @@ docker run -it --rm -p 3000:3000 \
     -v "$HOME/pl_ag_jobs:/jobs" `# Map jobs directory into /jobs` \
     -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
     -v /var/run/docker.sock:/var/run/docker.sock `# Mount docker into itself so container can spawn others` \
-    --add-host=host.docker.internal:172.17.0.1 `# Ensure network connectivity (may need a different port if you have changed docker's defaults)` \
+    --add-host=host.docker.internal:172.17.0.1 `# Ensure network connectivity` \
     prairielearn/prairielearn
 ```
+
+###### Troubleshooting the --add-host option on Linux and Windows
+
+If you are an advanced Docker user, or if your organization's network policies require it, then you might have previously adjusted the address pool used by Docker. If this conflicts with the Docker defaults, you might get a network timeout error when attempting to launch a workspace locally. In that case, you might need to adjust the IP address for the `--add-host=` option. You can find more technical details here: [PL issue #9805](https://github.com/PrairieLearn/PrairieLearn/issues/9805#issuecomment-2093299949), [moby/moby PR 29376](https://github.com/moby/moby/pull/29376), [docker/docs issue 8663](https://github.com/docker/docs/issues/8663).
 
 ## Upgrading your Docker's version of PrairieLearn
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -60,9 +60,9 @@ Once that message shows up, open a web browser and connect to [http://localhost:
 
 When you are finished with PrairieLearn, type Control-C on the terminal where you ran the server to stop it.
 
-### Running on Apple Silicon and other ARM64 hardware
+### Running on Apple silicon and other ARM64 hardware
 
-If you're using an Apple Silicon Mac (M1, M2, etc.) or another ARM-based machine, you may see an error like the following when you try to run the PrairieLearn Docker image:
+If you're using an Apple silicon Mac (M-series chips, etc.) or another ARM-based machine, you may see an error like the following when you try to run the PrairieLearn Docker image:
 
 ```
 no matching manifest for linux/arm64/v8 in the manifest list entries

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -119,7 +119,7 @@ docker run -it --rm -p 3000:3000 \
     prairielearn/prairielearn
 ```
 
-##### Linux or Windows WSL2
+##### Linux or Windows WSL 2
 
 If you are on **Linux**, or if you are on **Windows** using the WSL 2 shell, you can use the following command:
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -101,13 +101,11 @@ To run PrairieLearn locally with external grader and workspace support, create a
 mkdir "$HOME/pl_ag_jobs"
 ```
 
-#### Platform-specific invocations
+#### Running Docker with the extended features
 
-Now, run PrairieLearn as usual, but with additional options. For example, if your course directory is in `$HOME/pl-tam212` and the jobs directory created above is in `$HOME/pl_ag_jobs`, the new command is as follows, depending on your operating system:
+Now, we can run PrairieLearn as usual, but with additional options to allow the external grading or workspaces features. We require these extra options so that Docker can spawn additional containers alongside the main PrairieLearn container.
 
-##### macOS
-
-If you are on **macOS**, use this invocation, which includes the "platform" flag mentioned above to avoid problems on Apple ARM chips. (This does require Rosetta emulation to be enabled as described above.)
+For example, if your course directory is in `$HOME/pl-tam212` and the jobs directory created above is in `$HOME/pl_ag_jobs`, the new command is as follows:
 
 ```sh
 docker run -it --rm -p 3000:3000 \
@@ -116,26 +114,15 @@ docker run -it --rm -p 3000:3000 \
     -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
     -v /var/run/docker.sock:/var/run/docker.sock `# Mount docker into itself so container can spawn others` \
     --platform linux/amd64 `# Ensure the emulated amd64 version is used on ARM chips` \
-    prairielearn/prairielearn
-```
-
-##### Linux or Windows WSL 2
-
-If you are on **Linux**, or if you are on **Windows** using the WSL 2 shell, you can use the following command:
-
-```sh
-docker run -it --rm -p 3000:3000 \
-    -v "$HOME/pl-tam212:/course" `# Replace the path with your course directory` \
-    -v "$HOME/pl_ag_jobs:/jobs" `# Map jobs directory into /jobs` \
-    -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
-    -v /var/run/docker.sock:/var/run/docker.sock `# Mount docker into itself so container can spawn others` \
     --add-host=host.docker.internal:172.17.0.1 `# Ensure network connectivity` \
     prairielearn/prairielearn
 ```
 
-###### Troubleshooting the --add-host option on Linux and Windows
+###### Troubleshooting the --add-host option and network timeouts
 
 If you are an advanced Docker user, or if your organization's network policies require it, then you might have previously adjusted the address pool used by Docker. If this conflicts with the Docker defaults, you might get a network timeout error when attempting to launch a workspace locally. In that case, you might need to adjust the IP address for the `--add-host=` option. You can find more technical details here: [PL issue #9805](https://github.com/PrairieLearn/PrairieLearn/issues/9805#issuecomment-2093299949), [moby/moby PR 29376](https://github.com/moby/moby/pull/29376), [docker/docs issue 8663](https://github.com/docker/docs/issues/8663).
+
+If you are using macOS, then you may be able to remove the `--add-host` option entirely without any problems.
 
 ## Upgrading your Docker's version of PrairieLearn
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -60,7 +60,7 @@ Once that message shows up, open a web browser and connect to [http://localhost:
 
 When you are finished with PrairieLearn, type Control-C on the terminal where you ran the server to stop it.
 
-### Running on Apple M1 and other ARM64 hardware
+### Running on Apple Silicon and other ARM64 hardware
 
 If you're using an Apple Silicon Mac (M1, M2, etc.) or another ARM-based machine, you may see an error like the following when you try to run the PrairieLearn Docker image:
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -129,7 +129,7 @@ docker run -it --rm -p 3000:3000 \
     -v "$HOME/pl_ag_jobs:/jobs" `# Map jobs directory into /jobs` \
     -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
     -v /var/run/docker.sock:/var/run/docker.sock `# Mount docker into itself so container can spawn others` \
-    --add-host=host.docker.internal:172.17.0.1 `# Ensure network connectivity` \
+    --add-host=host.docker.internal:172.17.0.1 `# Ensure network connectivity (may need a different port if you have changed docker's defaults)` \
     prairielearn/prairielearn
 ```
 


### PR DESCRIPTION
The network tweak for Linux, and the fix for ARM Macs, were missing from the extended workspace invocations.