### PR TITLE
Properly export retryFailedBatchedMigrationJobs function

### DIFF
--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.ts
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.ts
@@ -5,13 +5,13 @@ import {
   selectAllBatchedMigrations,
   selectBatchedMigration,
   selectRecentJobsWithStatus,
+  retryFailedBatchedMigrationJobs,
 } from '@prairielearn/migrations';
 
 import {
   AdministratorBatchedMigrations,
   AdministratorBatchedMigration,
 } from './administratorBatchedMigrations.html';
-import { retryFailedBatchedMigrationJobs } from '@prairielearn/migrations/dist/batched-migrations';
 
 const router = Router({ mergeParams: true });
 

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -17,6 +17,7 @@ export {
   selectBatchedMigration,
   selectBatchedMigrationForTimestamp,
   selectRecentJobsWithStatus,
+  retryFailedBatchedMigrationJobs,
 } from './batched-migrations';
 
 export const SCHEMA_MIGRATIONS_PATH = path.resolve(__dirname, '..', 'schema-migrations');


### PR DESCRIPTION
Reaching into `dist/` in a package isn't a best practice and actually causes issues with coming ESM changes.