### PR TITLE
Update instructorGradebook.js: omit unused course_id

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
@@ -84,7 +84,6 @@ router.get(
 
     if (req.params.filename === csvFilename(res.locals)) {
       const assessmentsResult = await sqldb.queryAsync(sql.course_assessments, {
-        course_id: res.locals.course.id,
         course_instance_id: res.locals.course_instance.id,
       });
       const userScoresCursor = await sqldb.queryCursor(sql.user_scores, {


### PR DESCRIPTION
It seems that the `course_id` parameter is needed for the `user_scores` query but not the `course_assessments` query.