### PR TITLE
Fix fs-extra imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,19 @@
+const NO_RESTRICTED_SYNTAX = [
+  {
+    selector:
+      'CallExpression[callee.type="MemberExpression"][callee.object.name="MathJax"][callee.property.name=/^(typeset|tex2chtml|tex2svg)$/]',
+    message: "Don't use the synchronous MathJax API; use a function like typesetPromise() instead.",
+  },
+  {
+    selector: 'MemberExpression[object.name="MathJax"][property.name="Hub"]',
+    message: 'Use MathJax.typesetPromise() instead of MathJax.Hub',
+  },
+  {
+    selector: 'ImportDeclaration[source.value="fs-extra"]:has(ImportNamespaceSpecifier)',
+    message: 'Use a default import instead of a namespace import for fs-extra',
+  },
+];
+
 module.exports = {
   env: {
     node: true,
@@ -38,19 +54,7 @@ module.exports = {
       '__filename',
       '__dirname',
     ],
-    'no-restricted-syntax': [
-      'error',
-      {
-        selector:
-          'CallExpression[callee.type="MemberExpression"][callee.object.name="MathJax"][callee.property.name=/^(typeset|tex2chtml|tex2svg)$/]',
-        message:
-          "Don't use the synchronous MathJax API; use a function like typesetPromise() instead.",
-      },
-      {
-        selector: 'MemberExpression[object.name="MathJax"][property.name="Hub"]',
-        message: 'Use MathJax.typesetPromise() instead of MathJax.Hub',
-      },
-    ],
+    'no-restricted-syntax': ['error', ...NO_RESTRICTED_SYNTAX],
     'object-shorthand': 'error',
 
     // This isn't super useful to use because we're using TypeScript.
@@ -96,6 +100,7 @@ module.exports = {
         'import/no-named-as-default-member': 'off',
         'no-restricted-syntax': [
           'error',
+          ...NO_RESTRICTED_SYNTAX,
           {
             selector: 'MemberExpression[object.name="module"][property.name="exports"]',
             message: 'module.exports should not be used in TypeScript files',

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -1,6 +1,6 @@
 // @ts-check
 import _ from 'lodash';
-import fsExtra from 'fs-extra';
+import fs from 'fs-extra';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'path';
 
@@ -40,18 +40,18 @@ export async function buildDirectory(dir, submission, variant, question, course)
     for (const file of question.external_grading_files ?? []) {
       const src = path.join(coursePath, 'serverFilesCourse', file);
       const dest = path.join(dir, 'serverFilesCourse', file);
-      await fsExtra.copy(src, dest);
+      await fs.copy(src, dest);
     }
 
     // This is temporary while /grade/shared is deprecated but still supported
     // TODO remove this when we remove support for /grade/shared
     const src = path.join(dir, 'serverFilesCourse');
     const dest = path.join(dir, 'shared');
-    await fsExtra.copy(src, dest);
+    await fs.copy(src, dest);
 
     if (question.directory != null) {
       const testsDir = path.join(coursePath, 'questions', question.directory, 'tests');
-      await fsExtra.copy(testsDir, path.join(dir, 'tests')).catch((err) => {
+      await fs.copy(testsDir, path.join(dir, 'tests')).catch((err) => {
         // Tests might not be specified, only copy them if they exist
         if (err.code !== 'ENOENT') throw err;
       });

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -1,6 +1,6 @@
 // @ts-check
 import _ from 'lodash';
-import * as fsExtra from 'fs-extra';
+import fsExtra from 'fs-extra';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'path';
 

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -1,9 +1,8 @@
 // @ts-check
 import fetch from 'node-fetch';
 import * as path from 'path';
-import * as fs from 'fs';
 import { promises as fsPromises } from 'fs';
-import fse from 'fs-extra';
+import fs from 'fs-extra';
 import * as async from 'async';
 import debugfn from 'debug';
 import archiver from 'archiver';
@@ -271,7 +270,7 @@ async function startup(workspace_id: string): Promise<void> {
         // could lead to unexpected behavior.
         try {
           const timestampSuffix = new Date().toISOString().replace(/[^a-zA-Z0-9]/g, '-');
-          await fse.move(
+          await fs.move(
             initializeResult.destinationPath,
             `${initializeResult.destinationPath}-bak-${timestampSuffix}`,
             { overwrite: true },
@@ -287,7 +286,7 @@ async function startup(workspace_id: string): Promise<void> {
         // Next, move the newly created directory into place. This will be
         // done with a lock held, so we shouldn't worry about other processes
         // trying to work with these directories at the same time.
-        await fse.move(initializeResult.sourcePath, initializeResult.destinationPath, {
+        await fs.move(initializeResult.sourcePath, initializeResult.destinationPath, {
           overwrite: true,
         });
       }
@@ -505,7 +504,7 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
   const destinationPath = path.join(root, remotePath);
   const sourcePath = `${destinationPath}-${uuidv4()}`;
 
-  await fse.ensureDir(sourcePath);
+  await fs.ensureDir(sourcePath);
   await fsPromises.chown(
     sourcePath,
     config.workspaceJobsDirectoryOwnerUid,
@@ -516,11 +515,11 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
     await async.eachSeries(allWorkspaceFiles, async (workspaceFile) => {
       const sourceFile = path.join(sourcePath, workspaceFile.name);
       try {
-        await fse.ensureDir(path.dirname(sourceFile));
+        await fs.ensureDir(path.dirname(sourceFile));
         if ('localPath' in workspaceFile) {
-          await fse.copy(workspaceFile.localPath, sourceFile);
+          await fs.copy(workspaceFile.localPath, sourceFile);
         } else {
-          await fse.writeFile(sourceFile, workspaceFile.buffer);
+          await fs.writeFile(sourceFile, workspaceFile.buffer);
         }
       } catch (err) {
         fileGenerationErrors.push({

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import * as path from 'path';
 import * as fs from 'fs';
 import { promises as fsPromises } from 'fs';
-import * as fse from 'fs-extra';
+import fse from 'fs-extra';
 import * as async from 'async';
 import debugfn from 'debug';
 import archiver from 'archiver';


### PR DESCRIPTION
This should close #9842. `import * as fs from 'fs-extra` doesn't work as expected for this module, even though the types say they do. `import fs from 'fs-extra'` works correctly, and is in fact [one of the documented ways](https://github.com/jprichardson/node-fs-extra?tab=readme-ov-file#esm) to use this library with native ESM.