### PR TITLE
Fix LTI 1.1 auth callback

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -943,3 +943,14 @@ export const JobSequenceSchema = z.object({
   type: z.string().nullable(),
   user_id: IdSchema.nullable(),
 });
+export type JobSequence = z.infer<typeof JobSequenceSchema>;
+
+export const LtiCredentialsSchema = z.object({
+  consumer_key: z.string().nullable(),
+  course_instance_id: z.string().nullable(),
+  created_at: DateFromISOString.nullable(),
+  deleted_at: DateFromISOString.nullable(),
+  id: IdSchema,
+  secret: z.string().nullable(),
+});
+export type LtiCredentials = z.infer<typeof LtiCredentialsSchema>;

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -51,9 +51,7 @@ router.post(
 
     const ltiResult = await sqldb.queryOptionalRow(
       sql.lookup_credential,
-      {
-        consumer_key: parameters.oauth_consumer_key,
-      },
+      { consumer_key: parameters.oauth_consumer_key },
       LtiCredentialsSchema,
     );
     if (!ltiResult) throw new HttpStatusError(403, 'Unknown consumer_key');
@@ -62,7 +60,7 @@ router.post(
       'POST',
       ltiRedirectUrl,
       parameters,
-      // TODO: column should be non-nullable
+      // TODO: column should be `NOT NULL`
       /** @type {string} */ (ltiResult.secret),
       undefined,
       { encodeSignature: false },

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -158,7 +158,7 @@ router.post(
       if ('lis_result_sourcedid' in parameters) {
         // Save outcomes here
         await sqldb.queryAsync(sql.upsert_outcome, {
-          user_id: userResult.rows[0].user_id,
+          user_id: userResult.user_id,
           assessment_id: linkResult.rows[0].assessment_id,
           lis_result_sourcedid: parameters.lis_result_sourcedid,
           lis_outcome_service_url: parameters.lis_outcome_service_url,

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -4,12 +4,14 @@ import { Router } from 'express';
 import _ from 'lodash';
 import oauthSignature from 'oauth-signature';
 import { cache } from '@prairielearn/cache';
+import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
 import { generateSignedToken } from '@prairielearn/signed-token';
 import { config } from '../../lib/config.js';
 import { shouldSecureCookie, setCookie } from '../../lib/cookie.js';
 import { HttpStatusError } from '@prairielearn/error';
+import { IdSchema, LtiCredentialsSchema } from '../../lib/db-types.js';
 
 const TIME_TOLERANCE_SEC = 3000;
 
@@ -47,18 +49,21 @@ router.post(
     // FIXME: could warn or throw an error if parameters.roles exists (no longer used)
     // FIXME: could add a parameter that allows setting course role or course instance role
 
-    const result = await sqldb.queryZeroOrOneRowAsync(sql.lookup_credential, {
-      consumer_key: parameters.oauth_consumer_key,
-    });
-    if (result.rowCount === 0) throw new HttpStatusError(403, 'Unknown consumer_key');
-
-    const ltiresult = result.rows[0];
+    const ltiResult = await sqldb.queryOptionalRow(
+      sql.lookup_credential,
+      {
+        consumer_key: parameters.oauth_consumer_key,
+      },
+      LtiCredentialsSchema,
+    );
+    if (!ltiResult) throw new HttpStatusError(403, 'Unknown consumer_key');
 
     const genSignature = oauthSignature.generate(
       'POST',
       ltiRedirectUrl,
       parameters,
-      ltiresult.secret,
+      // TODO: column should be non-nullable
+      /** @type {string} */ (ltiResult.secret),
       undefined,
       { encodeSignature: false },
     );
@@ -96,7 +101,7 @@ router.post(
     // Not using an email address (parameters.lis_person_contact_email_primary)
     // so that LTI doesn't conflict with other UIDs.
     const authUid =
-      parameters.user_id + '@' + parameters.context_id + '::ciid=' + ltiresult.course_instance_id;
+      parameters.user_id + '@' + parameters.context_id + '::ciid=' + ltiResult.course_instance_id;
 
     let fallbackName = 'LTI user';
     if (parameters.context_title) {
@@ -105,23 +110,32 @@ router.post(
     }
     const authName = parameters.lis_person_name_full || fallbackName;
 
-    const userResult = await sqldb.callAsync('users_select_or_insert_and_enroll_lti', [
-      authUid,
-      authName,
-      ltiresult.course_instance_id,
-      parameters.user_id,
-      parameters.context_id,
-      res.locals.req_date,
-    ]);
-    if (!userResult.rows[0].has_access) {
+    const userResult = await sqldb.callOptionalRow(
+      'users_select_or_insert_and_enroll_lti',
+      [
+        authUid,
+        authName,
+        ltiResult.course_instance_id,
+        parameters.user_id,
+        parameters.context_id,
+        res.locals.req_date,
+      ],
+      z.object({
+        user_id: IdSchema,
+        has_access: z.boolean(),
+      }),
+    );
+    if (!userResult?.has_access) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    const tokenData = {
-      user_id: result.rows[0].user_id,
-      authn_provider_name: 'LTI',
-    };
-    const pl_authn = generateSignedToken(tokenData, config.secretKey);
+    const pl_authn = generateSignedToken(
+      {
+        user_id: userResult.user_id,
+        authn_provider_name: 'LTI',
+      },
+      config.secretKey,
+    );
     setCookie(res, ['pl_authn', 'pl2_authn'], pl_authn, {
       maxAge: config.authnCookieMaxAgeMilliseconds,
       httpOnly: true,
@@ -130,11 +144,11 @@ router.post(
 
     // Dual-write information to the session so that we can start reading
     // it instead of the cookie in the future.
-    req.session.user_id = userResult.rows[0].user_id;
+    req.session.user_id = userResult.user_id;
     req.session.authn_provider_name = 'LTI';
 
     const linkResult = await sqldb.queryOneRowAsync(sql.upsert_current_link, {
-      course_instance_id: ltiresult.course_instance_id,
+      course_instance_id: ltiResult.course_instance_id,
       context_id: parameters.context_id,
       resource_link_id: parameters.resource_link_id,
       resource_link_title: parameters.resource_link_title || '',
@@ -146,23 +160,23 @@ router.post(
       if ('lis_result_sourcedid' in parameters) {
         // Save outcomes here
         await sqldb.queryAsync(sql.upsert_outcome, {
-          user_id: tokenData.user_id,
+          user_id: userResult.rows[0].user_id,
           assessment_id: linkResult.rows[0].assessment_id,
           lis_result_sourcedid: parameters.lis_result_sourcedid,
           lis_outcome_service_url: parameters.lis_outcome_service_url,
-          lti_credential_id: ltiresult.id,
+          lti_credential_id: ltiResult.id,
         });
       }
 
       res.redirect(
-        `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/assessment/${linkResult.rows[0].assessment_id}/`,
+        `${res.locals.urlPrefix}/course_instance/${ltiResult.course_instance_id}/assessment/${linkResult.rows[0].assessment_id}/`,
       );
     } else {
       // No linked assessment
 
       const instructorResult = await sqldb.callAsync('users_is_instructor_in_course_instance', [
-        tokenData.user_id,
-        ltiresult.course_instance_id,
+        userResult.user_id,
+        ltiResult.course_instance_id,
       ]);
 
       if (instructorResult.rowCount === 0) {
@@ -175,7 +189,7 @@ router.post(
       }
 
       res.redirect(
-        `${res.locals.urlPrefix}/course_instance/${ltiresult.course_instance_id}/instructor/instance_admin/lti`,
+        `${res.locals.urlPrefix}/course_instance/${ltiResult.course_instance_id}/instructor/instance_admin/lti`,
       );
     }
   }),


### PR DESCRIPTION
I broke this in #9384. There were multiple `results` variables shadowing each other, _and_ there wasn't type-checking in play, so this slipped through the cracks. This wasn't caught immediately and visibly in prod because `lti_outcomes` is one of our horrible old tables that lacks `NOT NULL` constraints, so we ended up with rows with null `user_id` columns, which broke things downstream.