### PR TITLE
Fix real-time rendering of question score panel

### DIFF
--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -101,6 +101,9 @@ const SubmissionInfoSchema = z.object({
   user_uid: z.string().nullable(),
   submission_index: z.coerce.number(),
   submission_count: z.coerce.number(),
+  previous_variants: z
+    .array(z.object({ variant_id: IdSchema, max_submission_score: z.number() }))
+    .nullable(),
 });
 
 /**
@@ -622,6 +625,7 @@ export async function renderPanelsForSubmission({
 
   const {
     variant,
+    previous_variants,
     submission,
     instance_question,
     next_instance_question,
@@ -737,6 +741,10 @@ export async function renderPanelsForSubmission({
         submission,
         __csrf_token: csrfToken,
         authz_result: { authorized_edit: authorizedEdit },
+        urlPrefix,
+        instance_question_info: {
+          previous_variants,
+        },
       };
       const templatePath = path.join(
         import.meta.dirname,

--- a/apps/prairielearn/src/lib/question-render.sql
+++ b/apps/prairielearn/src/lib/question-render.sql
@@ -166,6 +166,40 @@ WITH
       gj.id DESC
     LIMIT
       1
+  ),
+  -- The following two CTEs are copied from `selectAndAuthzInstanceQuestion`.
+  variant_max_submission_scores AS (
+    SELECT
+      v.id AS variant_id,
+      max(s.score) AS max_submission_score
+    FROM
+      variants AS v
+      JOIN submissions AS s ON (s.variant_id = v.id)
+    WHERE
+      v.instance_question_id = $instance_question_id
+      AND s.score IS NOT NULL
+    GROUP BY
+      v.id
+  ),
+  instance_question_variants AS (
+    SELECT
+      jsonb_agg(
+        jsonb_build_object(
+          'variant_id',
+          v.id,
+          'max_submission_score',
+          COALESCE(vmss.max_submission_score, 0)
+        )
+        ORDER BY
+          v.date
+      ) AS variants
+    FROM
+      variants AS v
+      LEFT JOIN variant_max_submission_scores AS vmss ON (vmss.variant_id = v.id)
+    WHERE
+      v.instance_question_id = $instance_question_id
+      AND NOT v.open
+      AND NOT v.broken
   )
 SELECT
   to_jsonb(lgj) AS grading_job,
@@ -209,7 +243,8 @@ SELECT
       submissions AS s2
     WHERE
       s2.variant_id = s.variant_id
-  ) AS submission_count
+  ) AS submission_count,
+  iqv.variants AS previous_variants
 FROM
   submissions AS s
   JOIN variants AS v ON (v.id = s.variant_id)
@@ -226,6 +261,7 @@ FROM
   JOIN LATERAL instance_questions_next_allowed_grade (iq.id) AS iqnag ON TRUE
   LEFT JOIN next_iq ON (next_iq.current_id = iq.id)
   LEFT JOIN users AS u ON (s.auth_user_id = u.user_id)
+  LEFT JOIN instance_question_variants AS iqv ON (TRUE)
 WHERE
   s.id = $submission_id
   AND q.id = $question_id


### PR DESCRIPTION
This fixes a regression from #6105.

To reproduce the error on master:

- Open an external grading question in student view (I used "External Grading: Alpine Linux smoke test" on HW9 in `testCourse`
- Submit an answer
- Observe that the page doesn't update in real time
- Observe the error in the logs

Repeat with this branch to see things working correctly.

Long-term, this will all by TypeScript, and we'll be able to have `tsc` tell us whenever we mess this up (because we mess this up pretty regularly!).