### PR TITLE
Add CI test for external grader socket results

### DIFF
--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -120,12 +120,16 @@ function fetchResults(socket: Socket, submissionId: string) {
       // the instance question is part of the current user's
       // assessment instance (authorized_edit==true) or because the
       // question is open in preview mode (authz_result==undefined)
-      authorized_edit: authorizedEdit,
+      authorized_edit: authorizedEdit === 'true',
     },
     function (msg: any) {
       // We're done with the socket for this incarnation of the page
       socket.close();
-      updateDynamicPanels(msg, submissionId);
+      if (msg) {
+        updateDynamicPanels(msg, submissionId);
+      } else {
+        console.error('Error retrieving results for submission ' + submissionId);
+      }
       // Restore modal state if need be
       if (wasModalOpen) {
         $('#submissionInfoModal-' + submissionId).modal('show');

--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -128,7 +128,7 @@ function fetchResults(socket: Socket, submissionId: string) {
       if (msg) {
         updateDynamicPanels(msg, submissionId);
       } else {
-        console.error('Error retrieving results for submission ' + submissionId);
+        console.error(`Error retrieving results for submission ${submissionId}`);
       }
       // Restore modal state if need be
       if (wasModalOpen) {

--- a/apps/prairielearn/src/lib/externalGradingSocket.js
+++ b/apps/prairielearn/src/lib/externalGradingSocket.js
@@ -59,6 +59,7 @@ export function connection(socket) {
         'url_prefix',
         'question_context',
         'csrf_token',
+        'authorized_edit',
       ])
     ) {
       return callback(null);
@@ -93,6 +94,7 @@ export function connection(socket) {
       (err) => {
         logger.error('Error rendering panels for submission', err);
         Sentry.captureException(err);
+        callback(null);
       },
     );
   });

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -303,28 +303,26 @@ describe('Grading method(s)', function () {
           assert.isNotNull(socketResult.submissionPanel);
 
           const $submissionPanel = cheerio.load(socketResult.submissionPanel);
-          const scoreBadge = $submissionPanel('[data-testid="submission-status"] .badge');
-          assert.lengthOf(scoreBadge, 1);
-          assert.equal(scoreBadge.text().trim(), '100%');
-          const externalGraderResults = $submissionPanel('.pl-external-grader-results');
-          assert.lengthOf(externalGraderResults, 1);
-
-          // reload QuestionsPage to simplify further checks
-          questionsPage = await (await fetch(iqUrl)).text();
-          $questionsPage = cheerio.load(questionsPage);
+          assert.lengthOf($submissionPanel('[data-testid="submission-block"]'), 1);
+          assert.equal(getLatestSubmissionStatus($submissionPanel), '100%');
+          assert.lengthOf($submissionPanel('.pl-external-grader-results'), 1);
+          assert.lengthOf($submissionPanel('.grading-block:not(.d-none)'), 0);
         });
 
         it('should result in 1 grading jobs', async () => {
           const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
           assert.lengthOf(grading_jobs, 1);
         });
-        it('should result in 1 "submission-block" component being rendered', () => {
+        it('should result in 1 "submission-block" component being rendered', async () => {
+          // reload QuestionsPage to also check behaviour when results are ready on load
+          questionsPage = await (await fetch(iqUrl)).text();
+          $questionsPage = cheerio.load(questionsPage);
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
         it('should display submission status', async () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), '100%');
         });
-        it('should result in 1 "grading-block" component being displayed', () => {
+        it('should NOT result in "grading-block" component being displayed', () => {
           assert.lengthOf($questionsPage('.grading-block:not(.d-none)'), 0);
         });
       });


### PR DESCRIPTION
Resolves #9852. Also adds some basic functionality in the question page, to make sure a console message is printed and the socket is closed if the panel rendering has any exception.