### PR TITLE
Add ESLint config to order imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,6 +60,24 @@ module.exports = {
     // This isn't super useful to use because we're using TypeScript.
     'import/no-named-as-default-member': 'off',
 
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+        },
+        pathGroups: [
+          {
+            pattern: '@prairielearn/**',
+            group: 'external',
+            position: 'after',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['builtin'],
+      },
+    ],
+
     // The recommended Mocha rules are too strict for us; we'll only enable
     // these two rules.
     'mocha/no-exclusive-tests': 'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -63,7 +63,7 @@ module.exports = {
     'import/order': [
       'error',
       {
-        'newlines-between': 'always-and-inside-groups',
+        'newlines-between': 'always',
         alphabetize: {
           order: 'asc',
         },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -63,7 +63,7 @@ module.exports = {
     'import/order': [
       'error',
       {
-        'newlines-between': 'always',
+        'newlines-between': 'always-and-inside-groups',
         alphabetize: {
           order: 'asc',
         },

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,6 @@ b5ee36cebacd8c3192dd0e2457ab472cc185a055
 
 # Format YML/CSS/HTML/MJS files with Prettier
 57adaf8cac3ad7f5d8e1fc3d1614f2bd8ac9e881
+
+# Order all imports with the `import/order` ESLint rule
+1b3268b50c71ac447d4f7885259c2a9164cef461

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+/* eslint-disable import/order */
 // IMPORTANT: this must come first so that it can properly instrument our
 // dependencies like `pg` and `express`.
 import * as opentelemetry from '@prairielearn/opentelemetry';
@@ -8,6 +9,7 @@ import * as Sentry from '@prairielearn/sentry';
 // `@sentry/tracing` must be imported before `@sentry/profiling-node`.
 import '@sentry/tracing';
 import { ProfilingIntegration } from '@sentry/profiling-node';
+/* eslint-enable import/order */
 
 import * as fs from 'node:fs';
 import * as http from 'node:http';


### PR DESCRIPTION
This copies our `import/order` config from PrairieTest. This will be merged after #9857.