### PR TITLE
Use import/order ESLint rule to automatically order imports

### DIFF
--- a/apps/grader-host/src/index.js
+++ b/apps/grader-host/src/index.js
@@ -1,33 +1,35 @@
 // @ts-check
+import { exec } from 'child_process';
+import { pipeline } from 'node:stream/promises';
 import * as util from 'node:util';
-import ERR from 'async-stacktrace';
-import fs from 'fs-extra';
-import * as async from 'async';
-import * as tmp from 'tmp';
-import Docker from 'dockerode';
+import * as path from 'path';
+
+import { ECRClient } from '@aws-sdk/client-ecr';
 import { S3 } from '@aws-sdk/client-s3';
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
-import { ECRClient } from '@aws-sdk/client-ecr';
 import { Upload } from '@aws-sdk/lib-storage';
-import { exec } from 'child_process';
-import * as path from 'path';
+import * as async from 'async';
+import ERR from 'async-stacktrace';
 import byline from 'byline';
-import { pipeline } from 'node:stream/promises';
-import * as Sentry from '@prairielearn/sentry';
+import Docker from 'dockerode';
+import fs from 'fs-extra';
+import * as tmp from 'tmp';
+
+import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
 import * as sqldb from '@prairielearn/postgres';
 import { sanitizeObject } from '@prairielearn/sanitize';
-import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
+import * as Sentry from '@prairielearn/sentry';
 
-import globalLogger from './lib/logger.js';
-import { makeJobLogger } from './lib/jobLogger.js';
+import { makeAwsClientConfig, makeS3ClientConfig } from './lib/aws.js';
 import { config, loadConfig } from './lib/config.js';
 import * as healthCheck from './lib/healthCheck.js';
+import { makeJobLogger } from './lib/jobLogger.js';
 import * as lifecycle from './lib/lifecycle.js';
+import * as load from './lib/load.js';
+import globalLogger from './lib/logger.js';
 import pullImages from './lib/pullImages.js';
 import receiveFromQueue from './lib/receiveFromQueue.js';
 import * as timeReporter from './lib/timeReporter.js';
-import * as load from './lib/load.js';
-import { makeAwsClientConfig, makeS3ClientConfig } from './lib/aws.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/grader-host/src/lib/aws.ts
+++ b/apps/grader-host/src/lib/aws.ts
@@ -1,4 +1,5 @@
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+
 import { makeAwsConfigProvider } from '@prairielearn/aws';
 
 import { config } from './config.js';

--- a/apps/grader-host/src/lib/config.ts
+++ b/apps/grader-host/src/lib/config.ts
@@ -1,6 +1,7 @@
-import { SQSClient, GetQueueUrlCommand } from '@aws-sdk/client-sqs';
 import { AutoScaling } from '@aws-sdk/client-auto-scaling';
+import { SQSClient, GetQueueUrlCommand } from '@aws-sdk/client-sqs';
 import { z } from 'zod';
+
 import {
   ConfigLoader,
   makeImdsConfigSource,

--- a/apps/grader-host/src/lib/healthCheck.js
+++ b/apps/grader-host/src/lib/healthCheck.js
@@ -1,10 +1,11 @@
 // @ts-check
 import * as http from 'node:http';
+
 import Docker from 'dockerode';
 
-import globalLogger from './logger.js';
 import { config } from './config.js';
 import * as lifecycle from './lifecycle.js';
+import globalLogger from './logger.js';
 
 /**
  * Stores our current status. Once we transition to an unhealthy state, there's

--- a/apps/grader-host/src/lib/jobLogger.ts
+++ b/apps/grader-host/src/lib/jobLogger.ts
@@ -1,6 +1,7 @@
+import { Writable, type WritableOptions } from 'node:stream';
+
 import winston from 'winston';
 import Transport from 'winston-transport';
-import { Writable, type WritableOptions } from 'node:stream';
 
 import { config } from './config.js';
 

--- a/apps/grader-host/src/lib/lifecycle.js
+++ b/apps/grader-host/src/lib/lifecycle.js
@@ -1,10 +1,11 @@
 // @ts-check
 import * as assert from 'node:assert';
+
 import { AutoScaling } from '@aws-sdk/client-auto-scaling';
 
-import logger from './logger.js';
-import { config } from './config.js';
 import { makeAwsClientConfig } from './aws.js';
+import { config } from './config.js';
+import logger from './logger.js';
 
 /**
  * Stores our current state. We do one-way transitions:

--- a/apps/grader-host/src/lib/load.js
+++ b/apps/grader-host/src/lib/load.js
@@ -1,9 +1,10 @@
 // @ts-check
 import * as sqldb from '@prairielearn/postgres';
-import logger from './logger.js';
+
 import { config } from './config.js';
-import * as lifecycle from './lifecycle.js';
 import * as healthCheck from './healthCheck.js';
+import * as lifecycle from './lifecycle.js';
+import logger from './logger.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/grader-host/src/lib/logger.js
+++ b/apps/grader-host/src/lib/logger.js
@@ -1,6 +1,6 @@
 // @ts-check
-import winston from 'winston';
 import { format } from 'logform';
+import winston from 'winston';
 
 const consoleTransport = new winston.transports.Console({
   level: 'info',

--- a/apps/grader-host/src/lib/pullImages.js
+++ b/apps/grader-host/src/lib/pullImages.js
@@ -1,14 +1,15 @@
 // @ts-check
-import ERR from 'async-stacktrace';
-import * as async from 'async';
-import Docker from 'dockerode';
 import { ECRClient } from '@aws-sdk/client-ecr';
-import * as sqldb from '@prairielearn/postgres';
-import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
+import * as async from 'async';
+import ERR from 'async-stacktrace';
+import Docker from 'dockerode';
 
-import logger from './logger.js';
-import { config } from './config.js';
+import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
+import * as sqldb from '@prairielearn/postgres';
+
 import { makeAwsClientConfig } from './aws.js';
+import { config } from './config.js';
+import logger from './logger.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/grader-host/src/lib/receiveFromQueue.js
+++ b/apps/grader-host/src/lib/receiveFromQueue.js
@@ -1,19 +1,21 @@
 // @ts-check
-import ERR from 'async-stacktrace';
-import * as async from 'async';
-import fs from 'fs-extra';
+import { setTimeout as sleep } from 'node:timers/promises';
 import * as path from 'path';
-import { Ajv } from 'ajv';
+
 import {
   ReceiveMessageCommand,
   ChangeMessageVisibilityCommand,
   DeleteMessageCommand,
 } from '@aws-sdk/client-sqs';
-import * as Sentry from '@prairielearn/sentry';
-import { setTimeout as sleep } from 'node:timers/promises';
+import { Ajv } from 'ajv';
+import * as async from 'async';
+import ERR from 'async-stacktrace';
+import fs from 'fs-extra';
 
-import globalLogger from './logger.js';
+import * as Sentry from '@prairielearn/sentry';
+
 import { config } from './config.js';
+import globalLogger from './logger.js';
 
 let messageSchema = null;
 

--- a/apps/grader-host/src/tests/receiveFromQueue.test.js
+++ b/apps/grader-host/src/tests/receiveFromQueue.test.js
@@ -1,11 +1,11 @@
 // @ts-check
-import { assert } from 'chai';
-import sinon from 'sinon';
 import {
   ReceiveMessageCommand,
   ChangeMessageVisibilityCommand,
   DeleteMessageCommand,
 } from '@aws-sdk/client-sqs';
+import { assert } from 'chai';
+import sinon from 'sinon';
 
 import { config } from '../lib/config.js';
 import queueReceiver from '../lib/receiveFromQueue.js';

--- a/apps/prairielearn/assets/scripts/administratorInstitutionLti13Client.ts
+++ b/apps/prairielearn/assets/scripts/administratorInstitutionLti13Client.ts
@@ -1,4 +1,5 @@
 import { onDocumentReady, decodeData } from '@prairielearn/browser-utils';
+
 import { type LTI13InstancePlatforms } from '../../src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.types.js';
 
 onDocumentReady(() => {

--- a/apps/prairielearn/assets/scripts/examTimeLimitCountdown.ts
+++ b/apps/prairielearn/assets/scripts/examTimeLimitCountdown.ts
@@ -1,7 +1,8 @@
-import { setupCountdown } from './lib/countdown.js';
-import { saveQuestionFormData } from './lib/confirmOnUnload.js';
 import { onDocumentReady, decodeData, parseHTMLElement } from '@prairielearn/browser-utils';
 import { html } from '@prairielearn/html';
+
+import { saveQuestionFormData } from './lib/confirmOnUnload.js';
+import { setupCountdown } from './lib/countdown.js';
 
 onDocumentReady(() => {
   const timeLimitData = decodeData<{

--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -1,4 +1,5 @@
 import ClipboardJS from 'clipboard';
+
 import { mathjaxTypeset } from './lib/mathjax.js';
 
 $(() => {

--- a/apps/prairielearn/assets/scripts/instructorCourseAdminSettingsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorCourseAdminSettingsClient.ts
@@ -1,4 +1,5 @@
 import { onDocumentReady } from '@prairielearn/browser-utils';
+
 import { saveButtonEnabling } from './lib/saveButtonEnabling.js';
 
 onDocumentReady(() => {

--- a/apps/prairielearn/assets/scripts/instructorInstanceAdminBillingClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorInstanceAdminBillingClient.ts
@@ -1,4 +1,5 @@
 import morphdom from 'morphdom';
+
 import { decodeData, onDocumentReady } from '@prairielearn/browser-utils';
 
 import {

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -1,6 +1,7 @@
 /* eslint-env browser, jquery */
 
 import _ from 'lodash';
+
 import { onDocumentReady, decodeData } from '@prairielearn/browser-utils';
 import { html } from '@prairielearn/html';
 

--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -1,8 +1,9 @@
 import './lib/htmx';
 import 'htmx.org/dist/ext/loading-states.js';
 
-import { onDocumentReady } from '@prairielearn/browser-utils';
 import CookiesModule from 'js-cookie';
+
+import { onDocumentReady } from '@prairielearn/browser-utils';
 
 const COOKIE_EXPIRATION_DAYS = 30;
 

--- a/apps/prairielearn/assets/scripts/popover.ts
+++ b/apps/prairielearn/assets/scripts/popover.ts
@@ -1,5 +1,6 @@
-import { onDocumentReady } from '@prairielearn/browser-utils';
 import { on } from 'delegated-events';
+
+import { onDocumentReady } from '@prairielearn/browser-utils';
 
 /**
  * By default, Bootstrap popovers click when a user clicks inside the body of a popover. This

--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -1,9 +1,10 @@
 import { Socket, io } from 'socket.io-client';
+
 import { onDocumentReady, decodeData } from '@prairielearn/browser-utils';
 
-import { mathjaxTypeset } from './lib/mathjax.js';
-import { setupCountdown } from './lib/countdown.js';
 import { confirmOnUnload } from './lib/confirmOnUnload.js';
+import { setupCountdown } from './lib/countdown.js';
+import { mathjaxTypeset } from './lib/mathjax.js';
 
 onDocumentReady(() => {
   const questionContainer = document.querySelector<HTMLElement>('.question-container');

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAccessRules/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAccessRules/index.js
@@ -1,7 +1,8 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.js
@@ -1,10 +1,12 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
-import * as assessment from '../../../../lib/assessment.js';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
+
+import * as assessment from '../../../../lib/assessment.js';
 
 const sql = sqldb.loadSql(path.join(import.meta.dirname, '..', 'queries.sql'));
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessments/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessments/index.js
@@ -1,7 +1,8 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.js
@@ -1,6 +1,6 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceInfo/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceInfo/index.js
@@ -1,7 +1,8 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceSubmissions/index.js
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceSubmissions/index.js
@@ -1,7 +1,8 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/api/v1/error.js
+++ b/apps/prairielearn/src/api/v1/error.js
@@ -1,6 +1,7 @@
 // @ts-check
-import { logger } from '@prairielearn/logger';
 import status from 'http-status';
+
+import { logger } from '@prairielearn/logger';
 
 export default function (err, req, res, _next) {
   logger.error('API Error', err);

--- a/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
+++ b/apps/prairielearn/src/batched-migrations/20230913181816_pl_courses_created_at.ts
@@ -1,6 +1,7 @@
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { z } from 'zod';
+
 import { makeBatchedMigration } from '@prairielearn/migrations';
 import { loadSqlEquiv, queryOneRowAsync, queryOptionalRow, queryRow } from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -1,9 +1,10 @@
-import { html, HtmlSafeString } from '@prairielearn/html';
 import { EncodedData } from '@prairielearn/browser-utils';
-import { type CourseInstance } from '../lib/db-types.js';
-import { QuestionsPageDataAnsified } from '../models/questions.js';
+import { html, HtmlSafeString } from '@prairielearn/html';
+
 import { nodeModulesAssetPath, compiledScriptTag, compiledStylesheetTag } from '../lib/assets.js';
+import { type CourseInstance } from '../lib/db-types.js';
 import { idsEqual } from '../lib/id.js';
+import { QuestionsPageDataAnsified } from '../models/questions.js';
 
 export function QuestionsTableHead() {
   // Importing javascript using <script> tags as below is *not* the preferred method, it is better to directly use 'import'

--- a/apps/prairielearn/src/cron/externalGraderLoad.ts
+++ b/apps/prairielearn/src/cron/externalGraderLoad.ts
@@ -1,6 +1,7 @@
-import _ from 'lodash';
 import { AutoScaling } from '@aws-sdk/client-auto-scaling';
 import { CloudWatch } from '@aws-sdk/client-cloudwatch';
+import _ from 'lodash';
+
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -1,12 +1,14 @@
-import _ from 'lodash';
-import debugfn from 'debug';
-import { v4 as uuidv4 } from 'uuid';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { trace, context, suppressTracing, SpanStatusCode } from '@prairielearn/opentelemetry';
-import * as Sentry from '@prairielearn/sentry';
+
+import debugfn from 'debug';
+import _ from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
+
 import { logger } from '@prairielearn/logger';
 import * as namedLocks from '@prairielearn/named-locks';
+import { trace, context, suppressTracing, SpanStatusCode } from '@prairielearn/opentelemetry';
 import * as sqldb from '@prairielearn/postgres';
+import * as Sentry from '@prairielearn/sentry';
 
 import { config } from '../lib/config.js';
 import { isEnterprise } from '../lib/license.js';

--- a/apps/prairielearn/src/cron/sendExternalGraderDeadLetters.ts
+++ b/apps/prairielearn/src/cron/sendExternalGraderDeadLetters.ts
@@ -1,10 +1,11 @@
-import * as async from 'async';
 import {
   SQSClient,
   GetQueueUrlCommand,
   ReceiveMessageCommand,
   DeleteMessageCommand,
 } from '@aws-sdk/client-sqs';
+import * as async from 'async';
+
 import { logger } from '@prairielearn/logger';
 
 import { makeAwsClientConfig } from '../lib/aws.js';

--- a/apps/prairielearn/src/cron/sendExternalGraderStats.ts
+++ b/apps/prairielearn/src/cron/sendExternalGraderStats.ts
@@ -1,7 +1,8 @@
-import { config } from '../lib/config.js';
 import { logger } from '@prairielearn/logger';
-import * as opsbot from '../lib/opsbot.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
+import * as opsbot from '../lib/opsbot.js';
 
 export async function run() {
   if (!opsbot.canSendMessages()) return;

--- a/apps/prairielearn/src/cron/sendUnfinishedCronWarnings.ts
+++ b/apps/prairielearn/src/cron/sendUnfinishedCronWarnings.ts
@@ -1,6 +1,7 @@
 import { logger } from '@prairielearn/logger';
-import * as opsbot from '../lib/opsbot.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import * as opsbot from '../lib/opsbot.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/cron/serverLoad.ts
+++ b/apps/prairielearn/src/cron/serverLoad.ts
@@ -1,5 +1,6 @@
-import * as async from 'async';
 import { CloudWatch } from '@aws-sdk/client-cloudwatch';
+import * as async from 'async';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { makeAwsClientConfig } from '../lib/aws.js';

--- a/apps/prairielearn/src/cron/serverUsage.ts
+++ b/apps/prairielearn/src/cron/serverUsage.ts
@@ -1,5 +1,6 @@
 // @ts-check
 import { CloudWatch } from '@aws-sdk/client-cloudwatch';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { makeAwsClientConfig } from '../lib/aws.js';

--- a/apps/prairielearn/src/cron/workspaceHostTransitions.ts
+++ b/apps/prairielearn/src/cron/workspaceHostTransitions.ts
@@ -1,13 +1,14 @@
-import * as async from 'async';
 import { EC2 } from '@aws-sdk/client-ec2';
+import * as async from 'async';
 import fetch from 'node-fetch';
 import { z } from 'zod';
+
 import { logger } from '@prairielearn/logger';
 import { loadSqlEquiv, queryAsync, queryRows } from '@prairielearn/postgres';
 import * as workspaceUtils from '@prairielearn/workspace-utils';
 
-import { config } from '../lib/config.js';
 import { makeAwsClientConfig } from '../lib/aws.js';
+import { config } from '../lib/config.js';
 import * as workspaceHostUtils from '../lib/workspaceHost.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/cron/workspaceTimeoutWarn.ts
+++ b/apps/prairielearn/src/cron/workspaceTimeoutWarn.ts
@@ -1,7 +1,8 @@
-import { config } from '../lib/config.js';
 import { logger } from '@prairielearn/logger';
-import * as workspaceUtils from '@prairielearn/workspace-utils';
 import * as sqldb from '@prairielearn/postgres';
+import * as workspaceUtils from '@prairielearn/workspace-utils';
+
+import { config } from '../lib/config.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/auth/azure/callback.ts
+++ b/apps/prairielearn/src/ee/auth/azure/callback.ts
@@ -1,6 +1,6 @@
-import passport from 'passport';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+import passport from 'passport';
 
 import * as authnLib from '../../../lib/authn.js';
 

--- a/apps/prairielearn/src/ee/auth/azure/login.ts
+++ b/apps/prairielearn/src/ee/auth/azure/login.ts
@@ -1,5 +1,5 @@
-import passport from 'passport';
 import { Router } from 'express';
+import passport from 'passport';
 
 const router = Router();
 

--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.html.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.html.ts
@@ -1,7 +1,8 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { Lti13Instance } from '../../../lib/db-types.js';
+
 import { LoadUserAuth } from '../../../lib/authn.js';
+import { Lti13Instance } from '../../../lib/db-types.js';
 
 export const Lti13Test = ({
   resLocals,

--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
@@ -1,20 +1,23 @@
+import * as crypto from 'crypto';
+import { URL } from 'url';
+import { callbackify } from 'util';
+
 import { Router, type Request, Response, NextFunction } from 'express';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 import { Issuer, Strategy, type TokenSet } from 'openid-client';
 import * as passport from 'passport';
 import { z } from 'zod';
-import _ from 'lodash';
-import { callbackify } from 'util';
-import * as crypto from 'crypto';
-import { URL } from 'url';
 
-import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
 import { cache } from '@prairielearn/cache';
+import * as error from '@prairielearn/error';
+import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
+
 import * as authnLib from '../../../lib/authn.js';
-import { selectLti13Instance } from '../../models/lti13Instance.js';
-import { Lti13Test } from './lti13Auth.html.js';
 import { getCanonicalHost } from '../../../lib/url.js';
+import { selectLti13Instance } from '../../models/lti13Instance.js';
+
+import { Lti13Test } from './lti13Auth.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/auth/prairietest.ts
+++ b/apps/prairielearn/src/ee/auth/prairietest.ts
@@ -1,12 +1,14 @@
-import asyncHandler from 'express-async-handler';
-import { Router } from 'express';
-import * as jose from 'jose';
 import * as crypto from 'node:crypto';
 
+import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+import * as jose from 'jose';
+
 import { config } from '../../lib/config.js';
-import { AuthPrairieTest } from './prairietest.html.js';
 import { isEnterprise } from '../../lib/license.js';
 import { redirectToTermsPageIfNeeded } from '../lib/terms.js';
+
+import { AuthPrairieTest } from './prairietest.html.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -1,14 +1,16 @@
 import ERR from 'async-stacktrace';
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 import passport from 'passport';
+
 import * as error from '@prairielearn/error';
 
 import * as authnLib from '../../../lib/authn.js';
+import { getInstitutionSamlProvider } from '../../lib/institution.js';
+
+import { SamlTest } from './router.html.js';
 
 import { strategy } from './index.js';
-import { SamlTest } from './router.html.js';
-import { getInstitutionSamlProvider } from '../../lib/institution.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/ee/cron/chunksHostAutoScaling.ts
+++ b/apps/prairielearn/src/ee/cron/chunksHostAutoScaling.ts
@@ -1,5 +1,5 @@
-import { CloudWatch, type Dimension } from '@aws-sdk/client-cloudwatch';
 import { AutoScaling } from '@aws-sdk/client-auto-scaling';
+import { CloudWatch, type Dimension } from '@aws-sdk/client-cloudwatch';
 import _ from 'lodash';
 
 import { makeAwsClientConfig } from '../../lib/aws.js';

--- a/apps/prairielearn/src/ee/cron/workspaceHostLoads.ts
+++ b/apps/prairielearn/src/ee/cron/workspaceHostLoads.ts
@@ -1,5 +1,6 @@
 import { CloudWatch } from '@aws-sdk/client-cloudwatch';
 import { EC2 } from '@aws-sdk/client-ec2';
+
 import { loadSqlEquiv, queryAsync, callOneRowAsync } from '@prairielearn/postgres';
 
 import { makeAwsClientConfig } from '../../lib/aws.js';

--- a/apps/prairielearn/src/ee/lib/billing/components/InstructorInstanceAdminBillingForm.html.ts
+++ b/apps/prairielearn/src/ee/lib/billing/components/InstructorInstanceAdminBillingForm.html.ts
@@ -1,5 +1,6 @@
-import { html } from '@prairielearn/html';
 import { EncodedData } from '@prairielearn/browser-utils';
+import { html } from '@prairielearn/html';
+
 import { PlanName, planGrantsMatchPlanFeatures } from '../plans-types.js';
 
 interface InstructorInstanceAdminBillingInput {

--- a/apps/prairielearn/src/ee/lib/billing/components/PlanGrantsEditor.html.ts
+++ b/apps/prairielearn/src/ee/lib/billing/components/PlanGrantsEditor.html.ts
@@ -1,7 +1,7 @@
 import { html } from '@prairielearn/html';
 
-import { PLANS, PLAN_NAMES, PlanName } from '../plans-types.js';
 import { type PlanGrant } from '../../../../lib/db-types.js';
+import { PLANS, PLAN_NAMES, PlanName } from '../plans-types.js';
 import { type DesiredPlan } from '../plans.js';
 
 export function PlanGrantsEditor({

--- a/apps/prairielearn/src/ee/lib/billing/components/UserSettingsPurchasesCard.html.ts
+++ b/apps/prairielearn/src/ee/lib/billing/components/UserSettingsPurchasesCard.html.ts
@@ -1,8 +1,8 @@
 import { html } from '@prairielearn/html';
 
+import { StripeCheckoutSession } from '../../../../lib/db-types.js';
 import { type Purchase } from '../purchases.js';
 import { formatStripePrice } from '../stripe.js';
-import { StripeCheckoutSession } from '../../../../lib/db-types.js';
 
 export function UserSettingsPurchasesCard({ purchases }: { purchases: Purchase[] }) {
   return html`

--- a/apps/prairielearn/src/ee/lib/billing/plan-grants.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plan-grants.ts
@@ -8,14 +8,15 @@ import {
   QuestionSchema,
   UserSchema,
 } from '../../../lib/db-types.js';
+import { features } from '../../../lib/features/index.js';
 import {
   getPlanGrantsForPartialContexts,
   getPlanNamesFromPlanGrants,
   getRequiredPlansForCourseInstance,
   planGrantsMatchFeatures,
 } from '../../lib/billing/plans.js';
+
 import { PlanFeatureName, planGrantsMatchPlanFeatures } from './plans-types.js';
-import { features } from '../../../lib/features/index.js';
 
 type ResLocals = Record<string, any>;
 

--- a/apps/prairielearn/src/ee/lib/billing/plans.test.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plans.test.ts
@@ -1,7 +1,9 @@
 import { assert } from 'chai';
 
-import * as helperServer from '../../../tests/helperServer.js';
 import * as helperDb from '../../../tests/helperDb.js';
+import * as helperServer from '../../../tests/helperServer.js';
+import { ensurePlanGrant } from '../../models/plan-grants.js';
+
 import {
   getPlanGrantsForContext,
   getPlanGrantsForPartialContexts,
@@ -12,7 +14,6 @@ import {
   reconcilePlanGrantsForInstitution,
   updateRequiredPlansForCourseInstance,
 } from './plans.js';
-import { ensurePlanGrant } from '../../models/plan-grants.js';
 
 describe('plans', () => {
   before(helperServer.before());

--- a/apps/prairielearn/src/ee/lib/billing/plans.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plans.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
+
 import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
+
 import {
   EnumPlanGrantType,
   Institution,
@@ -7,13 +9,14 @@ import {
   PlanGrant,
   PlanGrantSchema,
 } from '../../../lib/db-types.js';
-import { PLAN_NAMES, PlanFeatureName, PlanName, getFeaturesForPlans } from './plans-types.js';
-import { ensurePlanGrant, updatePlanGrant, deletePlanGrant } from '../../models/plan-grants.js';
+import { WithRequiredKeys } from '../../../lib/types.js';
 import {
   insertCourseInstanceRequiredPlan,
   deleteCourseInstanceRequiredPlan,
 } from '../../models/course-instance-required-plans.js';
-import { WithRequiredKeys } from '../../../lib/types.js';
+import { ensurePlanGrant, updatePlanGrant, deletePlanGrant } from '../../models/plan-grants.js';
+
+import { PLAN_NAMES, PlanFeatureName, PlanName, getFeaturesForPlans } from './plans-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/lib/billing/purchases.ts
+++ b/apps/prairielearn/src/ee/lib/billing/purchases.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 import {

--- a/apps/prairielearn/src/ee/lib/billing/stripe.ts
+++ b/apps/prairielearn/src/ee/lib/billing/stripe.ts
@@ -1,9 +1,11 @@
 import Stripe from 'stripe';
-import { loadSqlEquiv, queryAsync, runInTransactionAsync } from '@prairielearn/postgres';
 
 import { cache } from '@prairielearn/cache';
+import { loadSqlEquiv, queryAsync, runInTransactionAsync } from '@prairielearn/postgres';
+
 import { config } from '../../../lib/config.js';
 import { selectAndLockUserById, selectUserById } from '../../../models/user.js';
+
 import { PlanName } from './plans-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
+++ b/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
-import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
-import { AdministratorSchema, type Institution, InstitutionSchema } from '../../lib/db-types.js';
+
 import { HttpStatusError } from '@prairielearn/error';
+import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
+
+import { AdministratorSchema, type Institution, InstitutionSchema } from '../../lib/db-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/lib/terms.ts
+++ b/apps/prairielearn/src/ee/lib/terms.ts
@@ -1,10 +1,11 @@
 import { type Response } from 'express';
+
 import { callRow } from '@prairielearn/postgres';
 
-import { ModeSchema, type User } from '../../lib/db-types.js';
-import { HttpRedirect } from '../../lib/redirect.js';
 import { setCookie } from '../../lib/cookie.js';
+import { ModeSchema, type User } from '../../lib/db-types.js';
 import { features } from '../../lib/features/index.js';
+import { HttpRedirect } from '../../lib/redirect.js';
 
 function hasUserAcceptedTerms(user: User): boolean {
   // At the moment, we only have one revision of our terms and conditions, so

--- a/apps/prairielearn/src/ee/models/course-instance-required-plans.ts
+++ b/apps/prairielearn/src/ee/models/course-instance-required-plans.ts
@@ -1,7 +1,8 @@
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
-import { PlanName } from '../lib/billing/plans-types.js';
+
 import { CourseInstanceRequiredPlanSchema, IdSchema } from '../../lib/db-types.js';
 import { insertAuditLog } from '../../models/audit-log.js';
+import { PlanName } from '../lib/billing/plans-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/models/enrollment.test.ts
+++ b/apps/prairielearn/src/ee/models/enrollment.test.ts
@@ -1,17 +1,19 @@
 import { assert } from 'chai';
 
-import * as helperDb from '../../tests/helperDb.js';
-import * as helperCourse from '../../tests/helperCourse.js';
+import { queryRow } from '@prairielearn/postgres';
+
+import { CourseInstanceSchema } from '../../lib/db-types.js';
 import { ensureEnrollment } from '../../models/enrollment.js';
+import * as helperCourse from '../../tests/helperCourse.js';
+import * as helperDb from '../../tests/helperDb.js';
+import { getOrCreateUser } from '../../tests/utils/auth.js';
+
 import {
   getEnrollmentCountsForCourse,
   getEnrollmentCountsForCourseInstance,
   getEnrollmentCountsForInstitution,
 } from './enrollment.js';
-import { getOrCreateUser } from '../../tests/utils/auth.js';
 import { ensurePlanGrant } from './plan-grants.js';
-import { queryRow } from '@prairielearn/postgres';
-import { CourseInstanceSchema } from '../../lib/db-types.js';
 
 describe('getEnrollmentCountsForInstitution', () => {
   beforeEach(async function () {

--- a/apps/prairielearn/src/ee/models/enrollment.ts
+++ b/apps/prairielearn/src/ee/models/enrollment.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+
 import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
 
 import { Institution, Course, CourseInstance } from '../../lib/db-types.js';
 import { checkPlanGrants } from '../lib/billing/plan-grants.js';
-import { getPlanGrantsForContext, getPlanNamesFromPlanGrants } from '../lib/billing/plans.js';
 import { planGrantsMatchPlanFeatures } from '../lib/billing/plans-types.js';
+import { getPlanGrantsForContext, getPlanNamesFromPlanGrants } from '../lib/billing/plans.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/models/lti13Instance.ts
+++ b/apps/prairielearn/src/ee/models/lti13Instance.ts
@@ -1,4 +1,5 @@
 import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
+
 import { Lti13Instance, Lti13InstanceSchema } from '../../lib/db-types.js';
 import { getInstitutionAuthenticationProviders } from '../lib/institution.js';
 

--- a/apps/prairielearn/src/ee/models/plan-grants.test.ts
+++ b/apps/prairielearn/src/ee/models/plan-grants.test.ts
@@ -1,5 +1,6 @@
 import * as helperDb from '../../tests/helperDb.js';
 import { getOrCreateUser } from '../../tests/utils/auth.js';
+
 import { ensurePlanGrant } from './plan-grants.js';
 
 describe('plan-grants', () => {

--- a/apps/prairielearn/src/ee/models/plan-grants.ts
+++ b/apps/prairielearn/src/ee/models/plan-grants.ts
@@ -1,8 +1,8 @@
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
-import { insertAuditLog } from '../../models/audit-log.js';
 import { PlanGrant, PlanGrantSchema, EnumPlanGrantType } from '../../lib/db-types.js';
 import { WithRequiredKeys } from '../../lib/types.js';
+import { insertAuditLog } from '../../models/audit-log.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/models/stripe-checkout-sessions.ts
+++ b/apps/prairielearn/src/ee/models/stripe-checkout-sessions.ts
@@ -1,7 +1,9 @@
-import { loadSqlEquiv, queryAsync, queryOptionalRow, queryRow } from '@prairielearn/postgres';
 import type Stripe from 'stripe';
-import { PlanName } from '../lib/billing/plans-types.js';
+
+import { loadSqlEquiv, queryAsync, queryOptionalRow, queryRow } from '@prairielearn/postgres';
+
 import { type StripeCheckoutSession, StripeCheckoutSessionSchema } from '../../lib/db-types.js';
+import { PlanName } from '../lib/billing/plans-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 import { type Institution, type Course, CourseInstanceSchema } from '../../../lib/db-types.js';
 

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
@@ -1,16 +1,18 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
+import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
+
 import { CourseSchema } from '../../../lib/db-types.js';
+import { insertAuditLog } from '../../../models/audit-log.js';
+import { getInstitution } from '../../lib/institution.js';
+
 import {
   CourseInstanceRowSchema,
   AdministratorInstitutionCourse,
 } from './administratorInstitutionCourse.html.js';
-import { getInstitution } from '../../lib/institution.js';
-import { insertAuditLog } from '../../../models/audit-log.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
@@ -1,5 +1,7 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
+import { compiledScriptTag } from '../../../lib/assets.js';
 import {
   type Course,
   type CourseInstance,
@@ -7,7 +9,6 @@ import {
   type PlanGrant,
 } from '../../../lib/db-types.js';
 import { PlanGrantsEditor } from '../../lib/billing/components/PlanGrantsEditor.html.js';
-import { compiledScriptTag } from '../../../lib/assets.js';
 
 export function AdministratorInstitutionCourseInstance({
   institution,

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.ts
@@ -1,18 +1,20 @@
 import { Router } from 'express';
-import { z } from 'zod';
 import asyncHandler from 'express-async-handler';
-import * as error from '@prairielearn/error';
-import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
-import { flash } from '@prairielearn/flash';
+import { z } from 'zod';
 
-import { getInstitution } from '../../lib/institution.js';
+import * as error from '@prairielearn/error';
+import { flash } from '@prairielearn/flash';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
 import { CourseInstanceSchema, CourseSchema } from '../../../lib/db-types.js';
-import { AdministratorInstitutionCourseInstance } from './administratorInstitutionCourseInstance.html.js';
+import { parseDesiredPlanGrants } from '../../lib/billing/components/PlanGrantsEditor.html.js';
 import {
   getPlanGrantsForCourseInstance,
   reconcilePlanGrantsForCourseInstance,
 } from '../../lib/billing/plans.js';
-import { parseDesiredPlanGrants } from '../../lib/billing/components/PlanGrantsEditor.html.js';
+import { getInstitution } from '../../lib/institution.js';
+
+import { AdministratorInstitutionCourseInstance } from './administratorInstitutionCourseInstance.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourses/administratorInstitutionCourses.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourses/administratorInstitutionCourses.html.ts
@@ -1,5 +1,6 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { type Course, type Institution } from '../../../lib/db-types.js';
 
 export function AdministratorInstitutionCourses({

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourses/administratorInstitutionCourses.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourses/administratorInstitutionCourses.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
-import { getInstitution } from '../../lib/institution.js';
-import { AdministratorInstitutionCourses } from './administratorInstitutionCourses.html.js';
+
 import { CourseSchema } from '../../../lib/db-types.js';
+import { getInstitution } from '../../lib/institution.js';
+
+import { AdministratorInstitutionCourses } from './administratorInstitutionCourses.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.html.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
+
 import { compiledScriptTag } from '@prairielearn/compiled-assets';
 import { html, type HtmlValue } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
 import { type PlanGrant, type Institution } from '../../../lib/db-types.js';
-import { PlanGrantsEditor } from '../../lib/billing/components/PlanGrantsEditor.html.js';
 import { formatTimezone, Timezone } from '../../../lib/timezones.js';
+import { PlanGrantsEditor } from '../../lib/billing/components/PlanGrantsEditor.html.js';
 
 export const InstitutionStatisticsSchema = z.object({
   course_count: z.number(),

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
@@ -1,22 +1,24 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import { loadSqlEquiv, queryRow, runInTransactionAsync } from '@prairielearn/postgres';
+
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
+import { loadSqlEquiv, queryRow, runInTransactionAsync } from '@prairielearn/postgres';
+
+import { InstitutionSchema } from '../../../lib/db-types.js';
+import { getAvailableTimezones } from '../../../lib/timezones.js';
+import { insertAuditLog } from '../../../models/audit-log.js';
+import { parseDesiredPlanGrants } from '../../lib/billing/components/PlanGrantsEditor.html.js';
+import {
+  getPlanGrantsForContext,
+  reconcilePlanGrantsForInstitution,
+} from '../../lib/billing/plans.js';
+import { getInstitution } from '../../lib/institution.js';
 
 import {
   AdministratorInstitutionGeneral,
   InstitutionStatisticsSchema,
 } from './administratorInstitutionGeneral.html.js';
-import { getInstitution } from '../../lib/institution.js';
-import {
-  getPlanGrantsForContext,
-  reconcilePlanGrantsForInstitution,
-} from '../../lib/billing/plans.js';
-import { InstitutionSchema } from '../../../lib/db-types.js';
-import { insertAuditLog } from '../../../models/audit-log.js';
-import { parseDesiredPlanGrants } from '../../lib/billing/components/PlanGrantsEditor.html.js';
-import { getAvailableTimezones } from '../../../lib/timezones.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
@@ -1,10 +1,11 @@
+import { EncodedData } from '@prairielearn/browser-utils';
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { type Institution, type Lti13Instance } from '../../../lib/db-types.js';
-import { LTI13InstancePlatforms } from './administratorInstitutionLti13.types.js';
 
-import { EncodedData } from '@prairielearn/browser-utils';
 import { compiledScriptTag } from '../../../lib/assets.js';
+import { type Institution, type Lti13Instance } from '../../../lib/db-types.js';
+
+import { LTI13InstancePlatforms } from './administratorInstitutionLti13.types.js';
 
 export function AdministratorInstitutionLti13({
   institution,

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -1,18 +1,19 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 import jose from 'node-jose';
 import { z } from 'zod';
-import _ from 'lodash';
 
 import * as error from '@prairielearn/error';
-import { loadSqlEquiv, queryAsync, queryRows } from '@prairielearn/postgres';
 import { flash } from '@prairielearn/flash';
+import { loadSqlEquiv, queryAsync, queryRows } from '@prairielearn/postgres';
 
-import { getInstitution } from '../../lib/institution.js';
-import { AdministratorInstitutionLti13 } from './administratorInstitutionLti13.html.js';
+import { config } from '../../../lib/config.js';
 import { Lti13Instance, Lti13InstanceSchema } from '../../../lib/db-types.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import { config } from '../../../lib/config.js';
+import { getInstitution } from '../../lib/institution.js';
+
+import { AdministratorInstitutionLti13 } from './administratorInstitutionLti13.html.js';
 import { LTI13InstancePlatforms } from './administratorInstitutionLti13.types.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -1,7 +1,8 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { type AuthnProvider, type Institution, type SamlProvider } from '../../../lib/db-types.js';
+
 import { Modal } from '../../../components/Modal.html.js';
+import { type AuthnProvider, type Institution, type SamlProvider } from '../../../lib/db-types.js';
 
 export function AdministratorInstitutionSaml({
   institution,

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
@@ -1,25 +1,27 @@
+import { SAML } from '@node-saml/passport-saml';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 // We import from this instead of `pem` directly because the latter includes
 // code that messes up the display of source maps in dev mode:
 // https://github.com/Dexus/pem/issues/389#issuecomment-2043258753
 import * as pem from 'pem/lib/pem.js';
-import { SAML } from '@node-saml/passport-saml';
+import formatXml from 'xml-formatter';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryAsync, runInTransactionAsync } from '@prairielearn/postgres';
-import formatXml from 'xml-formatter';
 
-import {
-  AdministratorInstitutionSaml,
-  DecodedAssertion,
-} from './administratorInstitutionSaml.html.js';
+import { getSamlOptions } from '../../auth/saml/index.js';
 import {
   getInstitution,
   getInstitutionSamlProvider,
   getInstitutionAuthenticationProviders,
 } from '../../lib/institution.js';
-import { getSamlOptions } from '../../auth/saml/index.js';
+
+import {
+  AdministratorInstitutionSaml,
+  DecodedAssertion,
+} from './administratorInstitutionSaml.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.html.ts
@@ -1,5 +1,6 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { type AuthnProvider, type Institution, type SamlProvider } from '../../../lib/db-types.js';
 
 export const AdministratorInstitutionSso = ({

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.ts
@@ -4,13 +4,14 @@ import { z } from 'zod';
 
 import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
 
-import { AdministratorInstitutionSso } from './administratorInstitutionSso.html.js';
 import {
   getInstitution,
   getSupportedAuthenticationProviders,
   getInstitutionAuthenticationProviders,
   getInstitutionSamlProvider,
 } from '../../lib/institution.js';
+
+import { AdministratorInstitutionSso } from './administratorInstitutionSso.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/institutionAdminAdmins/institutionAdminAdmins.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminAdmins/institutionAdminAdmins.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { selectAndAuthzInstitutionAsAdmin } from '../../lib/selectAndAuthz.js';
+
 import { InstitutionAdminAdmins } from './institutionAdminAdmins.html.js';
 
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminCourses/institutionAdminCourses.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
-import { selectAndAuthzInstitutionAsAdmin } from '../../lib/selectAndAuthz.js';
-import { InstitutionAdminCourses } from './institutionAdminCourses.html.js';
 import { CourseSchema } from '../../../lib/db-types.js';
+import { selectAndAuthzInstitutionAsAdmin } from '../../lib/selectAndAuthz.js';
+
+import { InstitutionAdminCourses } from './institutionAdminCourses.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.html.ts
@@ -1,6 +1,7 @@
 import { compiledScriptTag } from '@prairielearn/compiled-assets';
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { InstructorInstanceAdminBillingForm } from '../../lib/billing/components/InstructorInstanceAdminBillingForm.html.js';
 import { PlanName } from '../../lib/billing/plans-types.js';
 

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.test.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.test.ts
@@ -1,19 +1,20 @@
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
+
 import { queryAsync } from '@prairielearn/postgres';
 
-import { enableEnterpriseEdition, withoutEnterpriseEdition } from '../../tests/ee-helpers.js';
+import { config } from '../../../lib/config.js';
+import { features } from '../../../lib/features/index.js';
 import * as helperServer from '../../../tests/helperServer.js';
+import { getCsrfToken } from '../../../tests/utils/csrf.js';
+import { enrollRandomUsers } from '../../../tests/utils/enrollments.js';
 import {
   reconcilePlanGrantsForCourseInstance,
   reconcilePlanGrantsForInstitution,
   updateRequiredPlansForCourseInstance,
 } from '../../lib/billing/plans.js';
-import { config } from '../../../lib/config.js';
-import { features } from '../../../lib/features/index.js';
-import { enrollRandomUsers } from '../../../tests/utils/enrollments.js';
-import { getCsrfToken } from '../../../tests/utils/csrf.js';
+import { enableEnterpriseEdition, withoutEnterpriseEdition } from '../../tests/ee-helpers.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const pageUrl = siteUrl + '/pl/course_instance/1/instructor/instance_admin/billing';

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.ts
@@ -1,20 +1,22 @@
 import { Router, type Response } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
-import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
 
-import {
-  EnrollmentLimitSource,
-  InstructorCourseInstanceBilling,
-} from './instructorInstanceAdminBilling.html.js';
+import * as error from '@prairielearn/error';
+import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+
+import { instructorInstanceAdminBillingState } from '../../lib/billing/components/InstructorInstanceAdminBillingForm.html.js';
 import { PlanName } from '../../lib/billing/plans-types.js';
 import {
   getPlanGrantsForContext,
   getRequiredPlansForCourseInstance,
   updateRequiredPlansForCourseInstance,
 } from '../../lib/billing/plans.js';
-import { instructorInstanceAdminBillingState } from '../../lib/billing/components/InstructorInstanceAdminBillingForm.html.js';
+
+import {
+  EnrollmentLimitSource,
+  InstructorCourseInstanceBilling,
+} from './instructorInstanceAdminBilling.html.js';
 
 const router = Router({ mergeParams: true });
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/ee/pages/lti13Instance/lti13Instance.ts
+++ b/apps/prairielearn/src/ee/pages/lti13Instance/lti13Instance.ts
@@ -1,10 +1,12 @@
+import { URL } from 'url';
+
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import jose from 'node-jose';
-import { getCanonicalHost } from '../../../lib/url.js';
-import { URL } from 'url';
-import { selectLti13Instance } from '../../models/lti13Instance.js';
 import _ from 'lodash';
+import jose from 'node-jose';
+
+import { getCanonicalHost } from '../../../lib/url.js';
+import { selectLti13Instance } from '../../models/lti13Instance.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -1,9 +1,9 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { PlanName } from '../../lib/billing/plans-types.js';
 import { compiledScriptTag } from '../../../lib/assets.js';
 import { Course, CourseInstance } from '../../../lib/db-types.js';
+import { PlanName } from '../../lib/billing/plans-types.js';
 import { formatStripePrice } from '../../lib/billing/stripe.js';
 
 export function StudentCourseInstanceUpgrade({

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -2,20 +2,20 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 
 import { config } from '../../../lib/config.js';
+import { ensureEnrollment } from '../../../models/enrollment.js';
 import * as helperServer from '../../../tests/helperServer.js';
-import { enableEnterpriseEdition } from '../../tests/ee-helpers.js';
-import {
-  reconcilePlanGrantsForCourseInstance,
-  reconcilePlanGrantsForCourseInstanceUser,
-  updateRequiredPlansForCourseInstance,
-} from '../../lib/billing/plans.js';
 import {
   withUser,
   type AuthUser,
   getConfiguredUser,
   getOrCreateUser,
 } from '../../../tests/utils/auth.js';
-import { ensureEnrollment } from '../../../models/enrollment.js';
+import {
+  reconcilePlanGrantsForCourseInstance,
+  reconcilePlanGrantsForCourseInstanceUser,
+  updateRequiredPlansForCourseInstance,
+} from '../../lib/billing/plans.js';
+import { enableEnterpriseEdition } from '../../tests/ee-helpers.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
 const assessmentsUrl = `${siteUrl}/pl/course_instance/1/assessments`;

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -2,40 +2,42 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import type Stripe from 'stripe';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
 
-import {
-  CourseInstanceStudentUpdateSuccess,
-  StudentCourseInstanceUpgrade,
-} from './studentCourseInstanceUpgrade.html.js';
-import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
-import {
-  getMissingPlanGrants,
-  getPlanGrantsForPartialContexts,
-  getRequiredPlansForCourseInstance,
-} from '../../lib/billing/plans.js';
-import { ensurePlanGrant } from '../../models/plan-grants.js';
+import { config } from '../../../lib/config.js';
 import {
   CourseInstanceSchema,
   CourseSchema,
   InstitutionSchema,
   UserSchema,
 } from '../../../lib/db-types.js';
+import { getCanonicalHost } from '../../../lib/url.js';
+import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
+import {
+  getMissingPlanGrants,
+  getPlanGrantsForPartialContexts,
+  getRequiredPlansForCourseInstance,
+} from '../../lib/billing/plans.js';
 import {
   getOrCreateStripeCustomerId,
   getPriceForPlan,
   getPricesForPlans,
   getStripeClient,
 } from '../../lib/billing/stripe.js';
-import { config } from '../../../lib/config.js';
+import { ensurePlanGrant } from '../../models/plan-grants.js';
 import {
   getStripeCheckoutSessionByStripeObjectId,
   insertStripeCheckoutSessionForUserInCourseInstance,
   markStripeCheckoutSessionCompleted,
   updateStripeCheckoutSessionData,
 } from '../../models/stripe-checkout-sessions.js';
-import { getCanonicalHost } from '../../../lib/url.js';
+
+import {
+  CourseInstanceStudentUpdateSuccess,
+  StudentCourseInstanceUpgrade,
+} from './studentCourseInstanceUpgrade.html.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/ee/pages/terms/terms.ts
+++ b/apps/prairielearn/src/ee/pages/terms/terms.ts
@@ -1,10 +1,12 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
 
-import { Terms } from './terms.html.js';
 import { clearCookie } from '../../../lib/cookie.js';
+
+import { Terms } from './terms.html.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/ee/routers/administratorInstitution.ts
+++ b/apps/prairielearn/src/ee/routers/administratorInstitution.ts
@@ -1,15 +1,15 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
+import { features } from '../../lib/features/index.js';
 import authzIsAdministrator from '../../middlewares/authzIsAdministrator.js';
-import generalRouter from '../pages/administratorInstitutionGeneral/administratorInstitutionGeneral.js';
-import coursesRouter from '../pages/administratorInstitutionCourses/administratorInstitutionCourses.js';
 import courseRouter from '../pages/administratorInstitutionCourse/administratorInstitutionCourse.js';
 import courseInstanceRouter from '../pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.js';
-import ssoRouter from '../pages/administratorInstitutionSso/administratorInstitutionSso.js';
-import samlRouter from '../pages/administratorInstitutionSaml/administratorInstitutionSaml.js';
+import coursesRouter from '../pages/administratorInstitutionCourses/administratorInstitutionCourses.js';
+import generalRouter from '../pages/administratorInstitutionGeneral/administratorInstitutionGeneral.js';
 import lti13Router from '../pages/administratorInstitutionLti13/administratorInstitutionLti13.js';
-import { features } from '../../lib/features/index.js';
+import samlRouter from '../pages/administratorInstitutionSaml/administratorInstitutionSaml.js';
+import ssoRouter from '../pages/administratorInstitutionSso/administratorInstitutionSso.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/ee/routers/lti13.ts
+++ b/apps/prairielearn/src/ee/routers/lti13.ts
@@ -1,13 +1,15 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
-import lti13InstancePages from '../pages/lti13Instance/lti13Instance.js';
-import lti13Auth from '../auth/lti13/lti13Auth.js';
-import lti13CourseNavigation from '../pages/lti13CourseNavigation/lti13CourseNavigation.js';
+
 import { features } from '../../lib/features/index.js';
 import authnMiddleware from '../../middlewares/authn.js';
 import csrfToken from '../../middlewares/csrfToken.js';
+import lti13Auth from '../auth/lti13/lti13Auth.js';
 import { selectLti13Instance } from '../models/lti13Instance.js';
+import lti13CourseNavigation from '../pages/lti13CourseNavigation/lti13CourseNavigation.js';
+import lti13InstancePages from '../pages/lti13Instance/lti13Instance.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/ee/webhooks/stripe/index.ts
+++ b/apps/prairielearn/src/ee/webhooks/stripe/index.ts
@@ -1,18 +1,19 @@
 import express from 'express';
 import asyncHandler from 'express-async-handler';
 import Stripe from 'stripe';
+
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
 
 import { config } from '../../../lib/config.js';
+import { selectInstitutionForCourseInstance } from '../../../models/institution.js';
 import { clearStripeProductCache, getStripeClient } from '../../lib/billing/stripe.js';
+import { ensurePlanGrant } from '../../models/plan-grants.js';
 import {
   getStripeCheckoutSessionByStripeObjectId,
   markStripeCheckoutSessionCompleted,
   updateStripeCheckoutSessionData,
 } from '../../models/stripe-checkout-sessions.js';
-import { ensurePlanGrant } from '../../models/plan-grants.js';
-import { selectInstitutionForCourseInstance } from '../../../models/institution.js';
 
 const router = express.Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/executor.js
+++ b/apps/prairielearn/src/executor.js
@@ -1,7 +1,8 @@
 // @ts-check
 import { createInterface } from 'node:readline';
-import { FunctionMissingError } from './lib/code-caller/index.js';
+
 import { CodeCallerNative } from './lib/code-caller/code-caller-native.js';
+import { FunctionMissingError } from './lib/code-caller/index.js';
 
 /**
  * @typedef {Object} Request

--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -1,13 +1,11 @@
 import * as async from 'async';
-import * as ejs from 'ejs';
 import debugfn from 'debug';
+import * as ejs from 'ejs';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
-import { gradeVariant } from './grading.js';
 import * as sqldb from '@prairielearn/postgres';
-import * as ltiOutcomes from './ltiOutcomes.js';
-import { createServerJob } from './server-jobs.js';
+
 import {
   CourseSchema,
   IdSchema,
@@ -16,6 +14,9 @@ import {
   ClientFingerprintSchema,
   AssessmentInstanceSchema,
 } from './db-types.js';
+import { gradeVariant } from './grading.js';
+import * as ltiOutcomes from './ltiOutcomes.js';
+import { createServerJob } from './server-jobs.js';
 
 const debug = debugfn('prairielearn:assessment');
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -1,16 +1,19 @@
 import * as crypto from 'node:crypto';
-import express from 'express';
 import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
+
+import express from 'express';
 import { hashElement, type HashElementNode } from 'folder-hash';
+
 import * as compiledAssets from '@prairielearn/compiled-assets';
+import { HtmlSafeString } from '@prairielearn/html';
+
+import staticNodeModules from '../middlewares/staticNodeModules.js';
+import elementFiles from '../pages/elementFiles/elementFiles.js';
 
 import { config } from './config.js';
 import { APP_ROOT_PATH } from './paths.js';
-import staticNodeModules from '../middlewares/staticNodeModules.js';
-import elementFiles from '../pages/elementFiles/elementFiles.js';
-import { HtmlSafeString } from '@prairielearn/html';
-import { createRequire } from 'node:module';
 
 let assetsPrefix: string | null = null;
 let elementsHash: HashElementNode | null = null;

--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -1,14 +1,16 @@
 // @ts-check
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 import { generateSignedToken } from '@prairielearn/signed-token';
 
-import { config } from './config.js';
-import { clearCookie, setCookie, shouldSecureCookie } from '../lib/cookie.js';
-import { InstitutionSchema, UserSchema } from './db-types.js';
-import { HttpRedirect } from './redirect.js';
-import { isEnterprise } from './license.js';
 import { redirectToTermsPageIfNeeded } from '../ee/lib/terms.js';
+import { clearCookie, setCookie, shouldSecureCookie } from '../lib/cookie.js';
+
+import { config } from './config.js';
+import { InstitutionSchema, UserSchema } from './db-types.js';
+import { isEnterprise } from './license.js';
+import { HttpRedirect } from './redirect.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/aws.js
+++ b/apps/prairielearn/src/lib/aws.js
@@ -1,14 +1,16 @@
 // @ts-check
-import { Upload } from '@aws-sdk/lib-storage';
-import { S3 } from '@aws-sdk/client-s3';
-import fs from 'fs-extra';
-import * as path from 'path';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import debugfn from 'debug';
 import { pipeline } from 'node:stream/promises';
-import { makeAwsConfigProvider } from '@prairielearn/aws';
+import * as path from 'path';
 
+import { S3 } from '@aws-sdk/client-s3';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { Upload } from '@aws-sdk/lib-storage';
+import debugfn from 'debug';
+import fs from 'fs-extra';
+
+import { makeAwsConfigProvider } from '@prairielearn/aws';
 import { logger } from '@prairielearn/logger';
+
 import { config } from './config.js';
 
 const debug = debugfn('prairielearn:aws');

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -1,25 +1,27 @@
+import * as child_process from 'child_process';
+import * as path from 'path';
+import { PassThrough as PassThroughStream } from 'stream';
+import * as util from 'util';
+
 import { S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import * as async from 'async';
-import * as child_process from 'child_process';
 import fs from 'fs-extra';
-import * as path from 'path';
-import { PassThrough as PassThroughStream } from 'stream';
 import * as tar from 'tar';
-import * as util from 'util';
 import { v4 as uuidv4 } from 'uuid';
 
 import * as namedLocks from '@prairielearn/named-locks';
+import { contains } from '@prairielearn/path-utils';
 import * as sqldb from '@prairielearn/postgres';
+
+import { getLockNameForCoursePath } from '../models/course.js';
+import * as courseDB from '../sync/course-db.js';
+import { CourseData } from '../sync/course-db.js';
 
 import { downloadFromS3, makeS3ClientConfig } from './aws.js';
 import { chalk, chalkDim } from './chalk.js';
-import { createServerJob, ServerJob } from './server-jobs.js';
-import * as courseDB from '../sync/course-db.js';
-import { CourseData } from '../sync/course-db.js';
 import { config } from './config.js';
-import { contains } from '@prairielearn/path-utils';
-import { getLockNameForCoursePath } from '../models/course.js';
+import { createServerJob, ServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.js
@@ -1,24 +1,27 @@
 // @ts-check
+import * as os from 'node:os';
 import * as path from 'node:path';
+
+import { ECRClient } from '@aws-sdk/client-ecr';
+import { Mutex } from 'async-mutex';
 import debugfn from 'debug';
-import { v4 as uuidv4 } from 'uuid';
 import Docker from 'dockerode';
+import { execa } from 'execa';
+import fs from 'fs-extra';
 import MemoryStream from 'memorystream';
 import * as tmp from 'tmp-promise';
-import { Mutex } from 'async-mutex';
-import * as os from 'node:os';
-import fs from 'fs-extra';
-import { execa } from 'execa';
-import { ECRClient } from '@aws-sdk/client-ecr';
+import { v4 as uuidv4 } from 'uuid';
+
 import * as bindMount from '@prairielearn/bind-mount';
-import { instrumented } from '@prairielearn/opentelemetry';
 import { setupDockerAuth } from '@prairielearn/docker-utils';
 import { logger } from '@prairielearn/logger';
+import { instrumented } from '@prairielearn/opentelemetry';
 
-import { config } from '../config.js';
-import { FunctionMissingError } from './code-caller-shared.js';
-import { deferredPromise } from '../deferred.js';
 import { makeAwsClientConfig } from '../aws.js';
+import { config } from '../config.js';
+import { deferredPromise } from '../deferred.js';
+
+import { FunctionMissingError } from './code-caller-shared.js';
 
 /** @typedef {typeof CREATED | typeof WAITING | typeof IN_CALL | typeof EXITING | typeof EXITED} CallerState */
 const CREATED = Symbol('CREATED');

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native-types.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native-types.ts
@@ -1,5 +1,5 @@
-import { Readable, Writable } from 'stream';
 import { ChildProcess } from 'child_process';
+import { Readable, Writable } from 'stream';
 
 export interface CodeCallerNativeChildProcess extends ChildProcess {
   stdio: [Writable, Readable, Readable, Readable, Readable];

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.js
@@ -1,14 +1,17 @@
 // @ts-check
-import _ from 'lodash';
-import * as path from 'node:path';
 import * as child_process from 'node:child_process';
-import { v4 as uuidv4 } from 'uuid';
-import debugfn from 'debug';
+import * as path from 'node:path';
 
-import { FunctionMissingError } from './code-caller-shared.js';
+import debugfn from 'debug';
+import _ from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
+
 import { logger } from '@prairielearn/logger';
+
 import { deferredPromise } from '../deferred.js';
 import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from '../paths.js';
+
+import { FunctionMissingError } from './code-caller-shared.js';
 
 const debug = debugfn('prairielearn:code-caller-native');
 

--- a/apps/prairielearn/src/lib/code-caller/index.js
+++ b/apps/prairielearn/src/lib/code-caller/index.js
@@ -1,16 +1,19 @@
 // @ts-check
 import * as os from 'node:os';
-import { createPool } from 'generic-pool';
-import { v4 as uuidv4 } from 'uuid';
-import * as Sentry from '@prairielearn/sentry';
-import debugfn from 'debug';
 import { setTimeout as sleep } from 'node:timers/promises';
 
+import debugfn from 'debug';
+import { createPool } from 'generic-pool';
+import { v4 as uuidv4 } from 'uuid';
+
 import { logger } from '@prairielearn/logger';
-import { config } from '../config.js';
+import * as Sentry from '@prairielearn/sentry';
+
 import * as chunks from '../chunks.js';
+import { config } from '../config.js';
 import { features } from '../features/index.js';
 import * as load from '../load.js';
+
 import { CodeCallerContainer, init as initCodeCallerDocker } from './code-caller-container.js';
 import { CodeCallerNative } from './code-caller-native.js';
 import { FunctionMissingError } from './code-caller-shared.js';

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -1,4 +1,6 @@
+import { filesize } from 'filesize';
 import { z } from 'zod';
+
 import {
   ConfigLoader,
   makeFileConfigSource,
@@ -6,7 +8,6 @@ import {
   makeSecretsManagerConfigSource,
 } from '@prairielearn/config';
 import { logger } from '@prairielearn/logger';
-import { filesize } from 'filesize';
 
 import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from './paths.js';
 

--- a/apps/prairielearn/src/lib/copy-question.ts
+++ b/apps/prairielearn/src/lib/copy-question.ts
@@ -1,14 +1,17 @@
+import * as path from 'node:path';
+
 import { type Response } from 'express';
 import fs from 'fs-extra';
-import * as path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
+import { generateSignedToken } from '@prairielearn/signed-token';
+
+import { selectCoursesWithEditAccess } from '../models/course.js';
 
 import { config } from './config.js';
-import { generateSignedToken } from '@prairielearn/signed-token';
 import { Course, Question } from './db-types.js';
-import { selectCoursesWithEditAccess } from '../models/course.js';
 import { idsEqual } from './id.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/course-request.ts
+++ b/apps/prairielearn/src/lib/course-request.ts
@@ -1,6 +1,7 @@
-import { loadSqlEquiv, queryRows, queryAsync } from '@prairielearn/postgres';
 import { z } from 'zod';
+
 import { logger } from '@prairielearn/logger';
+import { loadSqlEquiv, queryRows, queryAsync } from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 
 import { DateFromISOString, IdSchema } from '../lib/db-types.js';

--- a/apps/prairielearn/src/lib/course.ts
+++ b/apps/prairielearn/src/lib/course.ts
@@ -1,13 +1,9 @@
 import fs from 'fs-extra';
+
+import { HttpStatusError } from '@prairielearn/error';
 import * as namedLocks from '@prairielearn/named-locks';
 import * as sqldb from '@prairielearn/postgres';
-import { HttpStatusError } from '@prairielearn/error';
 
-import { createServerJob } from './server-jobs.js';
-import { config } from './config.js';
-import * as chunks from './chunks.js';
-import { syncDiskToSqlWithLock } from '../sync/syncFromDisk.js';
-import { IdSchema, User, UserSchema } from './db-types.js';
 import {
   getCourseCommitHash,
   getLockNameForCoursePath,
@@ -15,6 +11,12 @@ import {
   selectCourseById,
   updateCourseCommitHash,
 } from '../models/course.js';
+import { syncDiskToSqlWithLock } from '../sync/syncFromDisk.js';
+
+import * as chunks from './chunks.js';
+import { config } from './config.js';
+import { IdSchema, User, UserSchema } from './db-types.js';
+import { createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
 import parsePostgresInterval from 'postgres-interval';
+import { z } from 'zod';
 
 const INTERVAL_MS_PER_SECOND = 1000;
 const INTERVAL_MS_PER_MINUTE = 60 * INTERVAL_MS_PER_SECOND;

--- a/apps/prairielearn/src/lib/editorUtil.js
+++ b/apps/prairielearn/src/lib/editorUtil.js
@@ -1,6 +1,7 @@
 // @ts-check
 // const sqldb = require('@prairielearn/postgres')
 import * as path from 'path';
+
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/editors.js
+++ b/apps/prairielearn/src/lib/editors.js
@@ -1,30 +1,34 @@
 // @ts-check
+import * as path from 'path';
+
+import * as async from 'async';
+import sha256 from 'crypto-js/sha256.js';
+import debugfn from 'debug';
+import fs from 'fs-extra';
 import _ from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
+
+import { AugmentedError, HttpStatusError } from '@prairielearn/error';
+import { html } from '@prairielearn/html';
 import { logger } from '@prairielearn/logger';
-import { contains } from '@prairielearn/path-utils';
-import { createServerJob } from './server-jobs.js';
 import * as namedLocks from '@prairielearn/named-locks';
-import * as syncFromDisk from '../sync/syncFromDisk.js';
+import { contains } from '@prairielearn/path-utils';
+import * as sqldb from '@prairielearn/postgres';
+import { escapeRegExp } from '@prairielearn/sanitize';
+
+import * as b64Util from '../lib/base64-util.js';
 import {
   getLockNameForCoursePath,
   getCourseCommitHash,
   updateCourseCommitHash,
   getOrUpdateCourseCommitHash,
 } from '../models/course.js';
-import { config } from './config.js';
-import * as path from 'path';
-import debugfn from 'debug';
-import { AugmentedError, HttpStatusError } from '@prairielearn/error';
-import fs from 'fs-extra';
-import * as async from 'async';
-import { v4 as uuidv4 } from 'uuid';
-import sha256 from 'crypto-js/sha256.js';
+import * as syncFromDisk from '../sync/syncFromDisk.js';
+
 import { updateChunksForCourse, logChunkChangesToJob } from './chunks.js';
+import { config } from './config.js';
 import { EXAMPLE_COURSE_PATH } from './paths.js';
-import { escapeRegExp } from '@prairielearn/sanitize';
-import * as sqldb from '@prairielearn/postgres';
-import * as b64Util from '../lib/base64-util.js';
-import { html } from '@prairielearn/html';
+import { createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:editors');

--- a/apps/prairielearn/src/lib/externalGrader.ts
+++ b/apps/prairielearn/src/lib/externalGrader.ts
@@ -1,17 +1,15 @@
+import assert from 'node:assert';
+import type { EventEmitter } from 'node:events';
+
+import _ from 'lodash';
 import { z } from 'zod';
+
+import * as error from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
-import * as error from '@prairielearn/error';
-import assert from 'node:assert';
-import _ from 'lodash';
-import type { EventEmitter } from 'node:events';
 
-import * as ltiOutcomes from './ltiOutcomes.js';
 import { config } from './config.js';
-import * as externalGradingSocket from './externalGradingSocket.js';
-import { ExternalGraderSqs } from './externalGraderSqs.js';
-import { ExternalGraderLocal } from './externalGraderLocal.js';
 import {
   IdSchema,
   CourseSchema,
@@ -25,6 +23,10 @@ import {
   type Question,
   type Course,
 } from './db-types.js';
+import { ExternalGraderLocal } from './externalGraderLocal.js';
+import { ExternalGraderSqs } from './externalGraderSqs.js';
+import * as externalGradingSocket from './externalGradingSocket.js';
+import * as ltiOutcomes from './ltiOutcomes.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/externalGraderCommon.js
+++ b/apps/prairielearn/src/lib/externalGraderCommon.js
@@ -1,11 +1,13 @@
 // @ts-check
-import _ from 'lodash';
-import fs from 'fs-extra';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'path';
 
+import fs from 'fs-extra';
+import _ from 'lodash';
+
 import { logger } from '@prairielearn/logger';
 import { contains } from '@prairielearn/path-utils';
+
 import { getRuntimeDirectoryForCourse } from './chunks.js';
 
 /**

--- a/apps/prairielearn/src/lib/externalGraderLocal.js
+++ b/apps/prairielearn/src/lib/externalGraderLocal.js
@@ -1,16 +1,18 @@
 // @ts-check
-import * as path from 'path';
-import Docker from 'dockerode';
-import * as os from 'os';
 import EventEmitter from 'events';
-import fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
 import byline from 'byline';
+import Docker from 'dockerode';
 import { execa } from 'execa';
+import fs from 'fs-extra';
 
 import { logger } from '@prairielearn/logger';
-import { buildDirectory, makeGradingResult } from './externalGraderCommon.js';
-import { config } from './config.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import { config } from './config.js';
+import { buildDirectory, makeGradingResult } from './externalGraderCommon.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/externalGraderResults.js
+++ b/apps/prairielearn/src/lib/externalGraderResults.js
@@ -6,6 +6,7 @@ import {
   ReceiveMessageCommand,
   DeleteMessageCommand,
 } from '@aws-sdk/client-sqs';
+
 import * as error from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
@@ -13,10 +14,10 @@ import * as Sentry from '@prairielearn/sentry';
 
 import { makeS3ClientConfig, makeAwsClientConfig } from './aws.js';
 import { config } from './config.js';
-import { gradingJobStatusUpdated } from './externalGradingSocket.js';
+import { deferredPromise } from './deferred.js';
 import { processGradingResult } from './externalGrader.js';
 import * as externalGraderCommon from './externalGraderCommon.js';
-import { deferredPromise } from './deferred.js';
+import { gradingJobStatusUpdated } from './externalGradingSocket.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/externalGraderSqs.js
+++ b/apps/prairielearn/src/lib/externalGraderSqs.js
@@ -1,13 +1,15 @@
 // @ts-check
-import * as async from 'async';
 import { EventEmitter } from 'events';
-import fs from 'fs-extra';
-import * as tar from 'tar';
-import _ from 'lodash';
-import { Upload } from '@aws-sdk/lib-storage';
-import { S3 } from '@aws-sdk/client-s3';
 import { PassThrough } from 'stream';
+
+import { S3 } from '@aws-sdk/client-s3';
 import { SQSClient, GetQueueUrlCommand, SendMessageCommand } from '@aws-sdk/client-sqs';
+import { Upload } from '@aws-sdk/lib-storage';
+import * as async from 'async';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import * as tar from 'tar';
+
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/lib/externalGradingSocket.js
+++ b/apps/prairielearn/src/lib/externalGradingSocket.js
@@ -1,10 +1,11 @@
 // @ts-check
 import ERR from 'async-stacktrace';
 import _ from 'lodash';
-import { checkSignedToken } from '@prairielearn/signed-token';
+
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
+import { checkSignedToken } from '@prairielearn/signed-token';
 
 import { config } from './config.js';
 import { renderPanelsForSubmission } from './question-render.js';

--- a/apps/prairielearn/src/lib/features/manager.ts
+++ b/apps/prairielearn/src/lib/features/manager.ts
@@ -1,6 +1,8 @@
-import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
-import { z } from 'zod';
 import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { z } from 'zod';
+
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 
 import { config } from '../config.js';
 

--- a/apps/prairielearn/src/lib/features/middleware.ts
+++ b/apps/prairielearn/src/lib/features/middleware.ts
@@ -1,8 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 
-import { features } from './index.js';
 import { FeatureOverrides } from './manager.js';
+
+import { features } from './index.js';
 
 type AuthFunction = (req: Request, res: Response) => boolean;
 

--- a/apps/prairielearn/src/lib/file-paths.js
+++ b/apps/prairielearn/src/lib/file-paths.js
@@ -1,6 +1,8 @@
 // @ts-check
-import fs from 'fs-extra';
 import * as path from 'path';
+
+import fs from 'fs-extra';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/lib/file-store.js
+++ b/apps/prairielearn/src/lib/file-store.js
@@ -1,14 +1,16 @@
 // @ts-check
-import * as path from 'path';
-import * as fsPromises from 'fs/promises';
 import * as fs from 'fs';
-import { v4 as uuidv4 } from 'uuid';
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
+
 import debugfn from 'debug';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as sqldb from '@prairielearn/postgres';
 
-import { config } from './config.js';
 import { uploadToS3, getFromS3 } from '../lib/aws.js';
+
+import { config } from './config.js';
 import { IdSchema } from './db-types.js';
 
 const debug = debugfn('prairielearn:socket-server');

--- a/apps/prairielearn/src/lib/github.js
+++ b/apps/prairielearn/src/lib/github.js
@@ -1,17 +1,20 @@
 // @ts-check
-import { Octokit } from '@octokit/rest';
-import { v4 as uuidv4 } from 'uuid';
-import * as Sentry from '@prairielearn/sentry';
 import { setTimeout as sleep } from 'node:timers/promises';
 
-import { config } from './config.js';
+import { Octokit } from '@octokit/rest';
+import { v4 as uuidv4 } from 'uuid';
+
 import { logger } from '@prairielearn/logger';
+import * as sqldb from '@prairielearn/postgres';
+import * as Sentry from '@prairielearn/sentry';
+
 import { updateCourseCommitHash } from '../models/course.js';
 import { syncDiskToSql } from '../sync/syncFromDisk.js';
-import { sendCourseRequestMessage } from './opsbot.js';
+
 import { logChunkChangesToJob, updateChunksForCourse } from './chunks.js';
+import { config } from './config.js';
+import { sendCourseRequestMessage } from './opsbot.js';
 import { createServerJob } from './server-jobs.js';
-import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/grading.ts
+++ b/apps/prairielearn/src/lib/grading.ts
@@ -1,16 +1,13 @@
 import * as fs from 'fs';
+
 import * as unzipper from 'unzipper';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
-
-import * as externalGrader from './externalGrader.js';
-import * as ltiOutcomes from './ltiOutcomes.js';
-import { writeCourseIssues } from './issues.js';
-import { getQuestionCourse } from './question-variant.js';
 import * as sqldb from '@prairielearn/postgres';
+
 import * as questionServers from '../question-servers/index.js';
-import * as workspaceHelper from './workspace.js';
+
 import {
   Course,
   DateFromISOString,
@@ -24,7 +21,12 @@ import {
   Variant,
   VariantSchema,
 } from './db-types.js';
+import * as externalGrader from './externalGrader.js';
 import { idsEqual } from './id.js';
+import { writeCourseIssues } from './issues.js';
+import * as ltiOutcomes from './ltiOutcomes.js';
+import { getQuestionCourse } from './question-variant.js';
+import * as workspaceHelper from './workspace.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/group-update.ts
+++ b/apps/prairielearn/src/lib/group-update.ts
@@ -1,6 +1,8 @@
+import csvtojson from 'csvtojson';
 import _ from 'lodash';
 import * as streamifier from 'streamifier';
-import csvtojson from 'csvtojson';
+import { z } from 'zod';
+
 import * as namedLocks from '@prairielearn/named-locks';
 import {
   loadSqlEquiv,
@@ -9,11 +11,10 @@ import {
   queryOptionalRow,
   runInTransactionAsync,
 } from '@prairielearn/postgres';
-import { z } from 'zod';
 
 import { IdSchema, UserSchema } from './db-types.js';
-import { createServerJob } from './server-jobs.js';
 import { GroupOperationError, createGroup, createOrAddToGroup } from './groups.js';
+import { createServerJob } from './server-jobs.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/groups.ts
+++ b/apps/prairielearn/src/lib/groups.ts
@@ -1,9 +1,12 @@
-import * as error from '@prairielearn/error';
-import { z } from 'zod';
 import _ from 'lodash';
+import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
-import { idsEqual } from './id.js';
+
+import { getEnrollmentForUserInCourseInstance } from '../models/enrollment.js';
+import { selectUserByUid } from '../models/user.js';
+
 import {
   GroupSchema,
   IdSchema,
@@ -14,8 +17,7 @@ import {
   GroupRoleSchema,
   type GroupUserRole,
 } from './db-types.js';
-import { getEnrollmentForUserInCourseInstance } from '../models/enrollment.js';
-import { selectUserByUid } from '../models/user.js';
+import { idsEqual } from './id.js';
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 export class GroupOperationError extends Error {

--- a/apps/prairielearn/src/lib/instructorFiles.js
+++ b/apps/prairielearn/src/lib/instructorFiles.js
@@ -1,8 +1,10 @@
 // @ts-check
 import * as path from 'path';
-import { contains } from '@prairielearn/path-utils';
-import { html } from '@prairielearn/html';
+
 import * as error from '@prairielearn/error';
+import { html } from '@prairielearn/html';
+import { contains } from '@prairielearn/path-utils';
+
 import { encodePath, decodePath } from './uri-util.js';
 
 /**

--- a/apps/prairielearn/src/lib/issues.ts
+++ b/apps/prairielearn/src/lib/issues.ts
@@ -2,6 +2,7 @@ import * as async from 'async';
 
 import * as sqldb from '@prairielearn/postgres';
 import { recursivelyTruncateStrings } from '@prairielearn/sanitize';
+
 import { Variant } from './db-types.js';
 
 interface IssueForErrorData {

--- a/apps/prairielearn/src/lib/json-load.js
+++ b/apps/prairielearn/src/lib/json-load.js
@@ -1,7 +1,8 @@
 // @ts-check
 import * as fs from 'fs/promises';
-import jju from 'jju';
+
 import { Ajv } from 'ajv';
+import jju from 'jju';
 
 // We use a single global instance so that schemas aren't recompiled every time they're used
 // https://github.com/ajv-validator/ajv/issues/2132

--- a/apps/prairielearn/src/lib/lifecycle-hooks.js
+++ b/apps/prairielearn/src/lib/lifecycle-hooks.js
@@ -4,6 +4,7 @@ import {
   CompleteLifecycleActionCommand,
   DescribeAutoScalingInstancesCommand,
 } from '@aws-sdk/client-auto-scaling';
+
 import { logger } from '@prairielearn/logger';
 
 import { makeAwsClientConfig } from './aws.js';

--- a/apps/prairielearn/src/lib/load.js
+++ b/apps/prairielearn/src/lib/load.js
@@ -1,9 +1,10 @@
 // @ts-check
-import _ from 'lodash';
 import debugfn from 'debug';
+import _ from 'lodash';
 
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
+
 import { config } from './config.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/ltiOutcomes.js
+++ b/apps/prairielearn/src/lib/ltiOutcomes.js
@@ -1,11 +1,11 @@
 // @ts-check
+import debugfn from 'debug';
+import _ from 'lodash';
 import request from 'request';
 import * as xml2js from 'xml2js';
-import _ from 'lodash';
-import debugfn from 'debug';
 
-import * as sqldb from '@prairielearn/postgres';
 import { logger } from '@prairielearn/logger';
+import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:ltiOutcomes');

--- a/apps/prairielearn/src/lib/manualGrading.ts
+++ b/apps/prairielearn/src/lib/manualGrading.ts
@@ -1,12 +1,10 @@
 import * as async from 'async';
-import mustache from 'mustache';
 import _ from 'lodash';
+import mustache from 'mustache';
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
-import { idsEqual } from './id.js';
-import * as markdown from './markdown.js';
-import * as ltiOutcomes from './ltiOutcomes.js';
 import {
   AssessmentQuestionSchema,
   IdSchema,
@@ -16,6 +14,9 @@ import {
   RubricItemSchema,
   RubricSchema,
 } from './db-types.js';
+import { idsEqual } from './id.js';
+import * as ltiOutcomes from './ltiOutcomes.js';
+import * as markdown from './markdown.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/markdown.js
+++ b/apps/prairielearn/src/lib/markdown.js
@@ -1,12 +1,12 @@
 // @ts-check
-import { unified } from 'unified';
-import markdown from 'remark-parse';
 import raw from 'rehype-raw';
-import gfm from 'remark-gfm';
-import remark2rehype from 'remark-rehype';
-import math from 'remark-math';
-import stringify from 'rehype-stringify';
 import sanitize from 'rehype-sanitize';
+import stringify from 'rehype-stringify';
+import gfm from 'remark-gfm';
+import math from 'remark-math';
+import markdown from 'remark-parse';
+import remark2rehype from 'remark-rehype';
+import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 
 // The ? symbol is used to make the match non-greedy (i.e., match the shortest

--- a/apps/prairielearn/src/lib/node-metrics.ts
+++ b/apps/prairielearn/src/lib/node-metrics.ts
@@ -1,7 +1,8 @@
-import loopbench from 'loopbench';
 import { CloudWatch, type Dimension } from '@aws-sdk/client-cloudwatch';
-import * as Sentry from '@prairielearn/sentry';
+import loopbench from 'loopbench';
+
 import { logger } from '@prairielearn/logger';
+import * as Sentry from '@prairielearn/sentry';
 
 import { makeAwsClientConfig } from './aws.js';
 import { config } from './config.js';

--- a/apps/prairielearn/src/lib/opsbot.ts
+++ b/apps/prairielearn/src/lib/opsbot.ts
@@ -1,7 +1,9 @@
-import * as error from '@prairielearn/error';
-import { config } from './config.js';
-import { logger } from '@prairielearn/logger';
 import fetch, { Response } from 'node-fetch';
+
+import * as error from '@prairielearn/error';
+import { logger } from '@prairielearn/logger';
+
+import { config } from './config.js';
 
 export function canSendMessages(): boolean {
   return !!config.secretSlackOpsBotEndpoint;

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -1,21 +1,20 @@
 // @ts-check
-import * as async from 'async';
 import * as path from 'path';
-import * as ejs from 'ejs';
-import { differenceInMilliseconds } from 'date-fns';
 import * as util from 'util';
+
+import * as async from 'async';
+import { differenceInMilliseconds } from 'date-fns';
+import * as ejs from 'ejs';
 import { z } from 'zod';
 
 import { EncodedData } from '@prairielearn/browser-utils';
-import { generateSignedToken } from '@prairielearn/signed-token';
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+import { generateSignedToken } from '@prairielearn/signed-token';
+
+import * as questionServers from '../question-servers/index.js';
 
 import { config, setLocalsFromConfig } from './config.js';
-import * as manualGrading from './manualGrading.js';
-import * as questionServers from '../question-servers/index.js';
-import { getQuestionCourse, ensureVariant } from './question-variant.js';
-import { writeCourseIssues } from './issues.js';
 import {
   AssessmentInstanceSchema,
   AssessmentQuestionSchema,
@@ -33,6 +32,9 @@ import {
   SubmissionSchema,
   VariantSchema,
 } from './db-types.js';
+import { writeCourseIssues } from './issues.js';
+import * as manualGrading from './manualGrading.js';
+import { getQuestionCourse, ensureVariant } from './question-variant.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/question-submission.ts
+++ b/apps/prairielearn/src/lib/question-submission.ts
@@ -1,12 +1,13 @@
-import _ from 'lodash';
 import { type Request, type Response } from 'express';
+import _ from 'lodash';
 
 import * as error from '@prairielearn/error';
 
+import { selectVariantById } from '../models/variant.js';
+
+import { type Variant } from './db-types.js';
 import { saveAndGradeSubmission, saveSubmission } from './grading.js';
 import { idsEqual } from './id.js';
-import { selectVariantById } from '../models/variant.js';
-import { type Variant } from './db-types.js';
 
 export async function validateVariantAgainstQuestion(
   unsafe_variant_id: string,

--- a/apps/prairielearn/src/lib/question-testing.ts
+++ b/apps/prairielearn/src/lib/question-testing.ts
@@ -1,14 +1,12 @@
-import _ from 'lodash';
 import * as async from 'async';
 import jsonStringifySafe from 'json-stringify-safe';
+import _ from 'lodash';
+import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
+
 import * as questionServers from '../question-servers/index.js';
-import { type ServerJob, createServerJob } from './server-jobs.js';
-import { saveSubmission, gradeVariant, insertSubmission } from './grading.js';
-import { getQuestionCourse, ensureVariant } from './question-variant.js';
-import { getAndRenderVariant } from './question-render.js';
-import { writeCourseIssues } from './issues.js';
+
 import {
   GradingJobSchema,
   SubmissionSchema,
@@ -18,7 +16,11 @@ import {
   type Course,
   type CourseInstance,
 } from './db-types.js';
-import { z } from 'zod';
+import { saveSubmission, gradeVariant, insertSubmission } from './grading.js';
+import { writeCourseIssues } from './issues.js';
+import { getAndRenderVariant } from './question-render.js';
+import { getQuestionCourse, ensureVariant } from './question-variant.js';
+import { type ServerJob, createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/question-variant.ts
+++ b/apps/prairielearn/src/lib/question-variant.ts
@@ -1,18 +1,19 @@
-import _ from 'lodash';
 import fg from 'fast-glob';
+import _ from 'lodash';
 import { z } from 'zod';
 
-import { workspaceFastGlobDefaultOptions } from '@prairielearn/workspace-utils';
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+import { workspaceFastGlobDefaultOptions } from '@prairielearn/workspace-utils';
 
-import * as questionServers from '../question-servers/index.js';
-import { writeCourseIssues } from './issues.js';
+import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectCourseById } from '../models/course.js';
 import { selectQuestionById, selectQuestionByInstanceQuestionId } from '../models/question.js';
+import * as questionServers from '../question-servers/index.js';
+
 import { Course, IdSchema, Question, Variant, VariantSchema } from './db-types.js';
 import { idsEqual } from './id.js';
-import { selectCourseInstanceById } from '../models/course-instances.js';
+import { writeCourseIssues } from './issues.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/regrading.ts
+++ b/apps/prairielearn/src/lib/regrading.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 
-import { createServerJob } from './server-jobs.js';
-import * as ltiOutcomes from './ltiOutcomes.js';
 import { IdSchema } from './db-types.js';
+import * as ltiOutcomes from './ltiOutcomes.js';
+import { createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/require-frontend.js
+++ b/apps/prairielearn/src/lib/require-frontend.js
@@ -5,9 +5,10 @@
  * Note: Do not use to require backend modules, as they should be CommonJS
  * modules and not AMD modules.
  */
-import requirejs from 'requirejs';
-import * as path from 'node:path';
 import { createRequire } from 'node:module';
+import * as path from 'node:path';
+
+import requirejs from 'requirejs';
 
 import { logger } from '@prairielearn/logger';
 

--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -1,13 +1,14 @@
+import csvtojson from 'csvtojson';
 import _ from 'lodash';
 import * as streamifier from 'streamifier';
-import csvtojson from 'csvtojson';
-import * as sqldb from '@prairielearn/postgres';
 import { z } from 'zod';
 
-import { createServerJob } from './server-jobs.js';
-import * as manualGrading from './manualGrading.js';
-import { IdSchema } from './db-types.js';
+import * as sqldb from '@prairielearn/postgres';
+
 import { updateAssessmentInstancePoints, updateAssessmentInstanceScore } from './assessment.js';
+import { IdSchema } from './db-types.js';
+import * as manualGrading from './manualGrading.js';
+import { createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/sentry.ts
+++ b/apps/prairielearn/src/lib/sentry.ts
@@ -1,5 +1,6 @@
-import * as Sentry from '@prairielearn/sentry';
 import type { NextFunction, Request, Response } from 'express';
+
+import * as Sentry from '@prairielearn/sentry';
 
 export function enrichSentryEventMiddleware(req: Request, res: Response, next: NextFunction) {
   // This will ensure that this middleware is always run in an isolated

--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -1,18 +1,19 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
 import { AnsiUp } from 'ansi_up';
 import { execa } from 'execa';
-import { z } from 'zod';
-import { setTimeout as sleep } from 'node:timers/promises';
 import _ from 'lodash';
+import { z } from 'zod';
 
-import * as Sentry from '@prairielearn/sentry';
 import { logger } from '@prairielearn/logger';
 import { loadSqlEquiv, queryAsync, queryRow, queryRows } from '@prairielearn/postgres';
+import * as Sentry from '@prairielearn/sentry';
 import { checkSignedToken, generateSignedToken } from '@prairielearn/signed-token';
 
 import { chalk, chalkDim } from './chalk.js';
-import * as socketServer from './socket-server.js';
-import { IdSchema, Job, JobSchema, JobSequenceSchema, UserSchema } from './db-types.js';
 import { config } from './config.js';
+import { IdSchema, Job, JobSchema, JobSequenceSchema, UserSchema } from './db-types.js';
+import * as socketServer from './socket-server.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/session-store.test.ts
+++ b/apps/prairielearn/src/lib/session-store.test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
+
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
 import * as helperDb from '../tests/helperDb.js';
-import { PostgresSessionStore } from './session-store.js';
+
 import { UserSchema, UserSessionSchema } from './db-types.js';
+import { PostgresSessionStore } from './session-store.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/session-store.ts
+++ b/apps/prairielearn/src/lib/session-store.ts
@@ -1,6 +1,6 @@
-import { SessionStore } from '@prairielearn/session';
-import { loadSqlEquiv, queryAsync, queryOptionalRow } from '@prairielearn/postgres';
 import * as opentelemetry from '@prairielearn/opentelemetry';
+import { loadSqlEquiv, queryAsync, queryOptionalRow } from '@prairielearn/postgres';
+import { SessionStore } from '@prairielearn/session';
 
 import { UserSessionSchema } from './db-types.js';
 

--- a/apps/prairielearn/src/lib/socket-server.js
+++ b/apps/prairielearn/src/lib/socket-server.js
@@ -1,9 +1,10 @@
 // @ts-check
-import { Server } from 'socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
-import { Redis } from 'ioredis';
-import { logger } from '@prairielearn/logger';
 import debugfn from 'debug';
+import { Redis } from 'ioredis';
+import { Server } from 'socket.io';
+
+import { logger } from '@prairielearn/logger';
 
 import { config } from './config.js';
 

--- a/apps/prairielearn/src/lib/telemetry/socket-activity-metrics.ts
+++ b/apps/prairielearn/src/lib/telemetry/socket-activity-metrics.ts
@@ -1,4 +1,5 @@
 import { type Socket } from 'node:net';
+
 import * as opentelemetry from '@prairielearn/opentelemetry';
 
 export class SocketActivityMetrics {

--- a/apps/prairielearn/src/lib/uri-util.js
+++ b/apps/prairielearn/src/lib/uri-util.js
@@ -1,6 +1,7 @@
 // @ts-check
-import { logger } from '@prairielearn/logger';
 import * as path from 'path';
+
+import { logger } from '@prairielearn/logger';
 
 export function encodePath(originalPath) {
   try {

--- a/apps/prairielearn/src/lib/user.test.ts
+++ b/apps/prairielearn/src/lib/user.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+
 import { parseUidsString } from './user.js';
 
 describe('user utilities', () => {

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -1,33 +1,31 @@
 // @ts-check
-import fetch from 'node-fetch';
-import * as path from 'path';
 import { promises as fsPromises } from 'fs';
-import fs from 'fs-extra';
+import { ok as assert } from 'node:assert';
+import { setTimeout as sleep } from 'node:timers/promises';
+import * as path from 'path';
+
+import archiver from 'archiver';
 import * as async from 'async';
 import debugfn from 'debug';
-import archiver from 'archiver';
-import klaw from 'klaw';
-import { v4 as uuidv4 } from 'uuid';
-import * as tmp from 'tmp-promise';
-import mustache from 'mustache';
-import { setTimeout as sleep } from 'node:timers/promises';
-import { z } from 'zod';
-import { ok as assert } from 'node:assert';
-import type { Socket } from 'socket.io';
 import type { Entry } from 'fast-glob';
+import fs from 'fs-extra';
+import klaw from 'klaw';
+import mustache from 'mustache';
+import fetch from 'node-fetch';
+import type { Socket } from 'socket.io';
+import * as tmp from 'tmp-promise';
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
 
-import * as sqldb from '@prairielearn/postgres';
-import * as workspaceUtils from '@prairielearn/workspace-utils';
-import { contains } from '@prairielearn/path-utils';
-import { checkSignedToken } from '@prairielearn/signed-token';
 import { logger } from '@prairielearn/logger';
+import { contains } from '@prairielearn/path-utils';
+import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
+import { checkSignedToken } from '@prairielearn/signed-token';
+import * as workspaceUtils from '@prairielearn/workspace-utils';
 
-import { config } from './config.js';
-import * as socketServer from './socket-server.js';
 import * as chunks from './chunks.js';
-import * as workspaceHostUtils from './workspaceHost.js';
-import * as issues from './issues.js';
+import { config } from './config.js';
 import {
   CourseSchema,
   DateFromISOString,
@@ -36,6 +34,9 @@ import {
   WorkspaceHostSchema,
   WorkspaceSchema,
 } from './db-types.js';
+import * as issues from './issues.js';
+import * as socketServer from './socket-server.js';
+import * as workspaceHostUtils from './workspaceHost.js';
 
 const debug = debugfn('prairielearn:workspace');
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/workspaceHost.ts
+++ b/apps/prairielearn/src/lib/workspaceHost.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import {
   loadSqlEquiv,
   queryAsync,
@@ -6,6 +7,7 @@ import {
   queryRow,
   queryRows,
 } from '@prairielearn/postgres';
+
 import {
   WorkspaceHostSchema,
   WorkspaceLogSchema,

--- a/apps/prairielearn/src/middlewares/authn.js
+++ b/apps/prairielearn/src/middlewares/authn.js
@@ -1,10 +1,11 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
 
-import { config } from '../lib/config.js';
 import * as authnLib from '../lib/authn.js';
+import { config } from '../lib/config.js';
 import { clearCookie, setCookie } from '../lib/cookie.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/middlewares/authnToken.js
+++ b/apps/prairielearn/src/middlewares/authnToken.js
@@ -1,8 +1,10 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as crypto from 'node:crypto';
-import * as sqldb from '@prairielearn/postgres';
+
+import asyncHandler from 'express-async-handler';
+
 import { logger } from '@prairielearn/logger';
+import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
@@ -1,15 +1,17 @@
 // @ts-check
-import _ from 'lodash';
-import asyncHandler from 'express-async-handler';
-import debugfn from 'debug';
 import { parseISO, isValid } from 'date-fns';
-import { config } from '../lib/config.js';
+import debugfn from 'debug';
+import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
+
 import { AugmentedError, HttpStatusError } from '@prairielearn/error';
-import * as sqldb from '@prairielearn/postgres';
 import { html } from '@prairielearn/html';
-import { idsEqual } from '../lib/id.js';
-import { features } from '../lib/features/index.js';
+import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
 import { clearCookie } from '../lib/cookie.js';
+import { features } from '../lib/features/index.js';
+import { idsEqual } from '../lib/id.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:authzCourseOrInstance');

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.js
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.js
@@ -1,6 +1,7 @@
 // @ts-check
-import * as error from '@prairielearn/error';
 import asyncHandler from 'express-async-handler';
+
+import * as error from '@prairielearn/error';
 
 export async function authzHasCoursePreviewOrInstanceView(req, res) {
   if (

--- a/apps/prairielearn/src/middlewares/authzWorkspace.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspace.js
@@ -1,16 +1,17 @@
 // @ts-check
-import _ from 'lodash';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 
+import { HttpStatusError } from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import { isEnterprise } from '../lib/license.js';
+
 import { authzCourseOrInstance } from './authzCourseOrInstance.js';
-import { selectAndAuthzInstanceQuestion } from './selectAndAuthzInstanceQuestion.js';
-import { selectAndAuthzAssessmentInstance } from './selectAndAuthzAssessmentInstance.js';
-import { selectAndAuthzInstructorQuestion } from './selectAndAuthzInstructorQuestion.js';
 import { authzHasCoursePreviewOrInstanceView } from './authzHasCoursePreviewOrInstanceView.js';
-import { HttpStatusError } from '@prairielearn/error';
+import { selectAndAuthzAssessmentInstance } from './selectAndAuthzAssessmentInstance.js';
+import { selectAndAuthzInstanceQuestion } from './selectAndAuthzInstanceQuestion.js';
+import { selectAndAuthzInstructorQuestion } from './selectAndAuthzInstructorQuestion.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieCheck.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieCheck.js
@@ -1,6 +1,8 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
+
 import { config } from '../lib/config.js';
 import { idsEqual } from '../lib/id.js';
 

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.js
@@ -1,6 +1,8 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import { generateSignedToken } from '@prairielearn/signed-token';
+
 import { config } from '../lib/config.js';
 import { shouldSecureCookie, setCookie } from '../lib/cookie.js';
 

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,4 +1,5 @@
 import asyncHandler from 'express-async-handler';
+
 import { idsEqual } from '../lib/id.js';
 import { ensureCheckedEnrollment } from '../models/enrollment.js';
 

--- a/apps/prairielearn/src/middlewares/clientFingerprint.ts
+++ b/apps/prairielearn/src/middlewares/clientFingerprint.ts
@@ -1,9 +1,11 @@
 // @ts-check
+import { Request, Response } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
+
 import { IdSchema } from '../lib/db-types.js';
 import { idsEqual } from '../lib/id.js';
-import { Request, Response } from 'express';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/middlewares/csrfToken.js
+++ b/apps/prairielearn/src/middlewares/csrfToken.js
@@ -1,8 +1,10 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
-import { config } from '../lib/config.js';
+
 import { HttpStatusError } from '@prairielearn/error';
 import { generateSignedToken, checkSignedToken } from '@prairielearn/signed-token';
+
+import { config } from '../lib/config.js';
 
 export default asyncHandler(async (req, res, next) => {
   const tokenData = {

--- a/apps/prairielearn/src/middlewares/logPageView.js
+++ b/apps/prairielearn/src/middlewares/logPageView.js
@@ -1,5 +1,6 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessment.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessment.js
@@ -2,8 +2,8 @@
 import asyncHandler from 'express-async-handler';
 import _ from 'lodash';
 
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.js
@@ -1,9 +1,9 @@
 // @ts-check
-import _ from 'lodash';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
 var sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentQuestion.js
@@ -1,8 +1,9 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
 import _ from 'lodash';
-import * as sqldb from '@prairielearn/postgres';
+
 import { HttpStatusError } from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
 var sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.js
@@ -1,8 +1,8 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
 
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
 import { getGroupConfig, getGroupInfo, getQuestionGroupPermissions } from '../lib/groups.js';
 

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstructorQuestion.js
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstructorQuestion.js
@@ -1,9 +1,9 @@
 // @ts-check
-import _ from 'lodash';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/middlewares/selectAssessments.js
+++ b/apps/prairielearn/src/middlewares/selectAssessments.js
@@ -1,5 +1,6 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/middlewares/selectOpenIssueCount.js
+++ b/apps/prairielearn/src/middlewares/selectOpenIssueCount.js
@@ -1,5 +1,6 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
 var sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/middlewares/staticNodeModules.js
+++ b/apps/prairielearn/src/middlewares/staticNodeModules.js
@@ -1,6 +1,7 @@
 // @ts-check
-import * as express from 'express';
 import * as path from 'node:path';
+
+import * as express from 'express';
 
 import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from '../lib/paths.js';
 

--- a/apps/prairielearn/src/middlewares/studentAssessmentAccess.js
+++ b/apps/prairielearn/src/middlewares/studentAssessmentAccess.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 import { logger } from '@prairielearn/logger';
 import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
+
 import { config } from '../lib/config.js';
 import { setCookie } from '../lib/cookie.js';
 

--- a/apps/prairielearn/src/middlewares/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/middlewares/studentAssessmentInstance.js
@@ -1,5 +1,6 @@
 // @ts-check
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
 var sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/models/course-instances.ts
+++ b/apps/prairielearn/src/models/course-instances.ts
@@ -1,5 +1,7 @@
-import { loadSqlEquiv, queryOptionalRow, queryRows } from '@prairielearn/postgres';
 import { z } from 'zod';
+
+import { loadSqlEquiv, queryOptionalRow, queryRows } from '@prairielearn/postgres';
+
 import { type CourseInstance, CourseInstanceSchema } from '../lib/db-types.js';
 import { idsEqual } from '../lib/id.js';
 

--- a/apps/prairielearn/src/models/course-permissions.ts
+++ b/apps/prairielearn/src/models/course-permissions.ts
@@ -1,3 +1,4 @@
+import * as error from '@prairielearn/error';
 import {
   loadSqlEquiv,
   queryAsync,
@@ -5,7 +6,6 @@ import {
   queryRows,
   runInTransactionAsync,
 } from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
 
 import {
   type User,
@@ -14,6 +14,7 @@ import {
   type CourseInstancePermission,
   CourseInstancePermissionSchema,
 } from '../lib/db-types.js';
+
 import { selectOrInsertUserByUid } from './user.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/models/course.ts
+++ b/apps/prairielearn/src/models/course.ts
@@ -1,8 +1,10 @@
-import { promisify } from 'util';
 import { exec } from 'child_process';
+import { promisify } from 'util';
+
 import { z } from 'zod';
-import { loadSqlEquiv, queryRow, queryAsync, queryRows } from '@prairielearn/postgres';
+
 import * as error from '@prairielearn/error';
+import { loadSqlEquiv, queryRow, queryAsync, queryRows } from '@prairielearn/postgres';
 
 import { Course, CourseSchema } from '../lib/db-types.js';
 

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -1,6 +1,10 @@
-import { loadSqlEquiv, queryAsync, queryOptionalRow } from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import { loadSqlEquiv, queryAsync, queryOptionalRow } from '@prairielearn/postgres';
 
+import {
+  PotentialEnterpriseEnrollmentStatus,
+  checkPotentialEnterpriseEnrollment,
+} from '../ee/models/enrollment.js';
 import {
   Course,
   CourseInstance,
@@ -9,12 +13,8 @@ import {
   Institution,
 } from '../lib/db-types.js';
 import { isEnterprise } from '../lib/license.js';
-import {
-  PotentialEnterpriseEnrollmentStatus,
-  checkPotentialEnterpriseEnrollment,
-} from '../ee/models/enrollment.js';
-import { assertNever } from '../lib/types.js';
 import { HttpRedirect } from '../lib/redirect.js';
+import { assertNever } from '../lib/types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/models/question.ts
+++ b/apps/prairielearn/src/models/question.ts
@@ -1,4 +1,5 @@
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+
 import { Question, QuestionSchema } from '../lib/db-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/models/questions.ts
+++ b/apps/prairielearn/src/models/questions.ts
@@ -1,12 +1,14 @@
-import * as sqldb from '@prairielearn/postgres';
 import { AnsiUp } from 'ansi_up';
+import { z } from 'zod';
+
+import * as sqldb from '@prairielearn/postgres';
+
 import {
   TopicSchema,
   SharingSetSchema,
   AssessmentsFormatForQuestionSchema,
   TagSchema,
 } from '../lib/db-types.js';
-import { z } from 'zod';
 import { idsEqual } from '../lib/id.js';
 
 const QuestionsPageDataSchema = z.object({

--- a/apps/prairielearn/src/models/variant.ts
+++ b/apps/prairielearn/src/models/variant.ts
@@ -1,4 +1,5 @@
 import { loadSqlEquiv, queryAsync, queryOptionalRow } from '@prairielearn/postgres';
+
 import { Variant, VariantSchema } from '../lib/db-types.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/news_items/index.js
+++ b/apps/prairielearn/src/news_items/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 import * as fs from 'node:fs/promises';
 import * as path from 'path';
+
 import _ from 'lodash';
 
 import { logger } from '@prairielearn/logger';
@@ -8,8 +9,8 @@ import * as namedLocks from '@prairielearn/named-locks';
 import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 
-import * as schemas from '../schemas/index.js';
 import * as jsonLoad from '../lib/json-load.js';
+import * as schemas from '../schemas/index.js';
 
 const DIRECTORY_REGEX = /^([0-9]+)_.+$/;
 

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.ts
@@ -1,5 +1,6 @@
 import { html, escapeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { User } from '../../lib/db-types.js';
 
 export function AdministratorAdmins({

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
@@ -1,10 +1,12 @@
-import asyncHandler from 'express-async-handler';
 import express from 'express';
-import * as sqldb from '@prairielearn/postgres';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
-import { AdministratorAdmins } from './administratorAdmins.html.js';
+import * as sqldb from '@prairielearn/postgres';
+
 import { UserSchema } from '../../lib/db-types.js';
+
+import { AdministratorAdmins } from './administratorAdmins.html.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.ts
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 import {
   selectAllBatchedMigrations,

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.html.ts
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.html.ts
@@ -1,8 +1,9 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { Institution } from '../../lib/db-types.js';
-import { CourseRequestRow } from '../../lib/course-request.js';
+
 import { CourseRequestsTable } from '../../components/CourseRequestsTable.html.js';
+import { CourseRequestRow } from '../../lib/course-request.js';
+import { Institution } from '../../lib/db-types.js';
 
 export function AdministratorCourseRequests({
   rows,

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.ts
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.ts
@@ -1,5 +1,6 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 
 import { config } from '../../lib/config.js';
@@ -9,6 +10,7 @@ import {
   updateCourseRequest,
 } from '../../lib/course-request.js';
 import { selectAllInstitutions } from '../../models/institution.js';
+
 import { AdministratorCourseRequests } from './administratorCourseRequests.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.ts
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
+
 import { escapeHtml, html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
+import { CourseRequestsTable } from '../../components/CourseRequestsTable.html.js';
+import { config } from '../../lib/config.js';
 import { CourseRequestRow } from '../../lib/course-request.js';
 import { CourseSchema, Institution, InstitutionSchema } from '../../lib/db-types.js';
-import { config } from '../../lib/config.js';
-import { CourseRequestsTable } from '../../components/CourseRequestsTable.html.js';
 
 export const CourseWithInstitutionSchema = CourseSchema.extend({
   institution: InstitutionSchema,

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.ts
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.ts
@@ -1,5 +1,5 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
@@ -11,6 +11,7 @@ import {
   updateCourseRequest,
 } from '../../lib/course-request.js';
 import { selectAllInstitutions } from '../../models/institution.js';
+
 import { AdministratorCourses, CourseWithInstitutionSchema } from './administratorCourses.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
+
+import { compiledScriptTag } from '@prairielearn/compiled-assets';
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { Modal } from '../../components/Modal.html.js';
 import { Course, CourseInstance, Institution } from '../../lib/db-types.js';
-import { compiledScriptTag } from '@prairielearn/compiled-assets';
 
 export const FeatureGrantRowSchema = z.object({
   id: z.string(),

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -1,23 +1,25 @@
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
-import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
-import { FeatureName, features } from '../../lib/features/index.js';
+import * as error from '@prairielearn/error';
+import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+
 import { config } from '../../lib/config.js';
-import {
-  AdministratorFeatures,
-  AdministratorFeature,
-  FeatureGrantRowSchema,
-  AddFeatureGrantModalBody,
-} from './administratorFeatures.html.js';
 import {
   CourseInstanceSchema,
   CourseSchema,
   IdSchema,
   InstitutionSchema,
 } from '../../lib/db-types.js';
+import { FeatureName, features } from '../../lib/features/index.js';
+
+import {
+  AdministratorFeatures,
+  AdministratorFeature,
+  FeatureGrantRowSchema,
+  AddFeatureGrantModalBody,
+} from './administratorFeatures.html.js';
 
 const router = Router();
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { isEnterprise } from '../../lib/license.js';
-import { InstitutionSchema } from '../../lib/db-types.js';
-import { type Timezone, formatTimezone } from '../../lib/timezones.js';
+
 import { Modal } from '../../components/Modal.html.js';
+import { InstitutionSchema } from '../../lib/db-types.js';
+import { isEnterprise } from '../../lib/license.js';
+import { type Timezone, formatTimezone } from '../../lib/timezones.js';
 
 export const InstitutionRowSchema = z.object({
   institution: InstitutionSchema,

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
@@ -1,13 +1,15 @@
-import asyncHandler from 'express-async-handler';
 import express from 'express';
-import * as sqldb from '@prairielearn/postgres';
+import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
+import { getAvailableTimezones } from '../../lib/timezones.js';
 
 import {
   AdministratorInstitutions,
   InstitutionRowSchema,
 } from './administratorInstitutions.html.js';
-import { getAvailableTimezones } from '../../lib/timezones.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.html.ts
+++ b/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.html.ts
@@ -1,5 +1,6 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { nodeModulesAssetPath } from '../../lib/assets.js';
 
 export function AdministratorJobSequence({

--- a/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.ts
+++ b/apps/prairielearn/src/pages/administratorJobSequence/administratorJobSequence.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { getJobSequenceWithFormattedOutput } from '../../lib/server-jobs.js';
+
 import { AdministratorJobSequence } from './administratorJobSequence.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.js
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.js
@@ -1,7 +1,8 @@
 // @ts-check
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import _ from 'lodash';
-import { Router } from 'express';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { AdministratorNetworks } from './administratorNetworks.html.js';

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 export const AdministratorQueryJsonParamsSchema = z.object({
   name: z.string(),

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.ts
@@ -1,9 +1,11 @@
-import * as express from 'express';
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'path';
+
+import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as jsonLoad from '../../lib/json-load.js';
+
 import { AdministratorQueries, AdministratorQueryJsonSchema } from './administratorQueries.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 import { nodeModulesAssetPath } from '../../lib/assets.js';
 

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
@@ -1,14 +1,16 @@
-import express from 'express';
-const router = express.Router();
-import asyncHandler from 'express-async-handler';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+
+import express from 'express';
+import asyncHandler from 'express-async-handler';
 import hljs from 'highlight.js';
-import { stringify } from '@prairielearn/csv';
 import { z } from 'zod';
 
-import * as jsonLoad from '../../lib/json-load.js';
+import { stringify } from '@prairielearn/csv';
 import * as sqldb from '@prairielearn/postgres';
+
+import * as jsonLoad from '../../lib/json-load.js';
+
 import {
   AdministratorQuery,
   AdministratorQuerySchema,
@@ -17,6 +19,7 @@ import {
   AdministratorQueryQueryRun,
 } from './administratorQuery.html.js';
 
+const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const queriesDir = path.resolve(import.meta.dirname, '..', '..', 'admin_queries');

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -1,11 +1,13 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
-import { cache } from '@prairielearn/cache';
+import asyncHandler from 'express-async-handler';
 
+import { cache } from '@prairielearn/cache';
 import * as error from '@prairielearn/error';
+
 import * as chunks from '../../lib/chunks.js';
-import { AdministratorSettings } from './administratorSettings.html.js';
 import { IdSchema } from '../../lib/db-types.js';
+
+import { AdministratorSettings } from './administratorSettings.html.js';
 
 const router = express.Router();
 

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 import { WorkspaceHostSchema, IdSchema } from '../../lib/db-types.js';
 

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.ts
@@ -1,8 +1,10 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
+
 import { AdministratorWorkspaces, WorkspaceHostRowSchema } from './administratorWorkspaces.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.js
@@ -1,16 +1,17 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 import _ from 'lodash';
 import oauthSignature from 'oauth-signature';
-import { cache } from '@prairielearn/cache';
 import { z } from 'zod';
 
+import { cache } from '@prairielearn/cache';
+import { HttpStatusError } from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 import { generateSignedToken } from '@prairielearn/signed-token';
+
 import { config } from '../../lib/config.js';
 import { shouldSecureCookie, setCookie } from '../../lib/cookie.js';
-import { HttpStatusError } from '@prairielearn/error';
 import { IdSchema, LtiCredentialsSchema } from '../../lib/db-types.js';
 
 const TIME_TOLERANCE_SEC = 3000;

--- a/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
+++ b/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js
@@ -1,13 +1,14 @@
 // @ts-check
-import * as Sentry from '@prairielearn/sentry';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { OAuth2Client } from 'google-auth-library';
+
+import { HttpStatusError } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
+import * as Sentry from '@prairielearn/sentry';
 
 import * as authnLib from '../../lib/authn.js';
 import { config } from '../../lib/config.js';
-import { HttpStatusError } from '@prairielearn/error';
 
 const router = Router();
 

--- a/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
+++ b/apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 
 import * as authnLib from '../../lib/authn.js';

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -1,8 +1,8 @@
 import { html, type HtmlValue } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { config } from '../../lib/config.js';
 import { assetPath } from '../../lib/assets.js';
+import { config } from '../../lib/config.js';
 import { isEnterprise } from '../../lib/license.js';
 
 export interface InstitutionAuthnProvider {

--- a/apps/prairielearn/src/pages/authLogin/authLogin.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.ts
@@ -1,16 +1,18 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+
+import * as authLib from '../../lib/authn.js';
+import { config } from '../../lib/config.js';
 
 import {
   AuthLogin,
   AuthLoginUnsupportedProvider,
   type InstitutionAuthnProvider,
 } from './authLogin.html.js';
-import { config } from '../../lib/config.js';
-import * as authLib from '../../lib/authn.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();

--- a/apps/prairielearn/src/pages/authLoginDev/authLoginDev.js
+++ b/apps/prairielearn/src/pages/authLoginDev/authLoginDev.js
@@ -2,8 +2,8 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { config } from '../../lib/config.js';
 import * as authnLib from '../../lib/authn.js';
+import { config } from '../../lib/config.js';
 
 const router = Router();
 

--- a/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
+++ b/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js
@@ -1,7 +1,8 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 import { OAuth2Client } from 'google-auth-library';
+
 import { HttpStatusError } from '@prairielearn/error';
 
 import { config } from '../../lib/config.js';

--- a/apps/prairielearn/src/pages/authPassword/authPassword.js
+++ b/apps/prairielearn/src/pages/authPassword/authPassword.js
@@ -1,6 +1,8 @@
 // @ts-check
 import { Router } from 'express';
+
 import { generateSignedToken } from '@prairielearn/signed-token';
+
 import { config } from '../../lib/config.js';
 import { shouldSecureCookie, setCookie, clearCookie } from '../../lib/cookie.js';
 

--- a/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
+++ b/apps/prairielearn/src/pages/clientFilesAssessment/clientFilesAssessment.js
@@ -1,9 +1,11 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
+
 import * as chunks from '../../lib/chunks.js';
 
 const router = Router();

--- a/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
+++ b/apps/prairielearn/src/pages/clientFilesCourse/clientFilesCourse.js
@@ -1,9 +1,11 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
+
 import * as chunks from '../../lib/chunks.js';
 
 const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
+++ b/apps/prairielearn/src/pages/clientFilesCourseInstance/clientFilesCourseInstance.js
@@ -1,9 +1,11 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
+
 import * as chunks from '../../lib/chunks.js';
 
 const router = Router();

--- a/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
+++ b/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.js
@@ -1,13 +1,15 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { HttpStatusError } from '@prairielearn/error';
 
 import * as chunks from '../../lib/chunks.js';
 import { getQuestionCourse } from '../../lib/question-variant.js';
 import { selectCourseById } from '../../models/course.js';
 import { selectQuestionById } from '../../models/question.js';
-import { HttpStatusError } from '@prairielearn/error';
 
 export default function (options = { publicEndpoint: false }) {
   const router = Router({ mergeParams: true });

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.js
@@ -1,17 +1,18 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import _ from 'lodash';
 import { ECR } from '@aws-sdk/client-ecr';
 import * as async from 'async';
 import { formatISO } from 'date-fns';
 import { Router } from 'express';
-import * as sqldb from '@prairielearn/postgres';
-import { DockerName } from '@prairielearn/docker-utils';
+import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 
-import * as syncHelpers from '../shared/syncHelpers.js';
+import { DockerName } from '@prairielearn/docker-utils';
+import { HttpStatusError } from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
 import { makeAwsClientConfig } from '../../lib/aws.js';
 import { config } from '../../lib/config.js';
-import { HttpStatusError } from '@prairielearn/error';
+import * as syncHelpers from '../shared/syncHelpers.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const router = Router();

--- a/apps/prairielearn/src/pages/editError/editError.js
+++ b/apps/prairielearn/src/pages/editError/editError.js
@@ -1,10 +1,12 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
 import { HttpStatusError } from '@prairielearn/error';
+import { logger } from '@prairielearn/logger';
+
 import { getJobSequenceWithFormattedOutput } from '../../lib/server-jobs.js';
 import * as syncHelpers from '../shared/syncHelpers.js';
-import { logger } from '@prairielearn/logger';
 
 const router = Router();
 

--- a/apps/prairielearn/src/pages/elementExtensionFiles/elementExtensionFiles.js
+++ b/apps/prairielearn/src/pages/elementExtensionFiles/elementExtensionFiles.js
@@ -1,11 +1,13 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
-import { Router } from 'express';
 
-import { config } from '../../lib/config.js';
-import * as chunks from '../../lib/chunks.js';
+import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
 import { HttpStatusError } from '@prairielearn/error';
+
+import * as chunks from '../../lib/chunks.js';
+import { config } from '../../lib/config.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/pages/elementFiles/elementFiles.js
+++ b/apps/prairielearn/src/pages/elementFiles/elementFiles.js
@@ -1,12 +1,14 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { HttpStatusError } from '@prairielearn/error';
 
 import * as chunks from '../../lib/chunks.js';
 import { config } from '../../lib/config.js';
 import { APP_ROOT_PATH } from '../../lib/paths.js';
-import { HttpStatusError } from '@prairielearn/error';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/pages/enroll/enroll.html.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.html.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 

--- a/apps/prairielearn/src/pages/enroll/enroll.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.ts
@@ -1,7 +1,9 @@
-import asyncHandler from 'express-async-handler';
 import express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
+import { flash } from '@prairielearn/flash';
 import {
   loadSqlEquiv,
   queryOneRowAsync,
@@ -9,17 +11,17 @@ import {
   queryRows,
   queryZeroOrOneRowAsync,
 } from '@prairielearn/postgres';
-import { flash } from '@prairielearn/flash';
 
 import { InstitutionSchema, CourseInstanceSchema, CourseSchema } from '../../lib/db-types.js';
+import { authzCourseOrInstance } from '../../middlewares/authzCourseOrInstance.js';
+import { ensureCheckedEnrollment } from '../../models/enrollment.js';
+
 import {
   Enroll,
   EnrollLtiMessage,
   CourseInstanceRowSchema,
   EnrollmentLimitExceededMessage,
 } from './enroll.html.js';
-import { ensureCheckedEnrollment } from '../../models/enrollment.js';
-import { authzCourseOrInstance } from '../../middlewares/authzCourseOrInstance.js';
 
 const router = express.Router();
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/error/error.js
+++ b/apps/prairielearn/src/pages/error/error.js
@@ -1,7 +1,8 @@
 // @ts-check
-import _ from 'lodash';
 import * as path from 'path';
+
 import jsonStringifySafe from 'json-stringify-safe';
+import _ from 'lodash';
 
 import { formatErrorStack, formatErrorStackSafe } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';

--- a/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
+++ b/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.js
@@ -1,12 +1,13 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { HttpStatusError } from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import { getDynamicFile } from '../../lib/question-variant.js';
 import { selectCourseById } from '../../models/course.js';
 import { selectQuestionById } from '../../models/question.js';
-import { HttpStatusError } from '@prairielearn/error';
 
 var sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/pages/home/home.js
+++ b/apps/prairielearn/src/pages/home/home.js
@@ -1,11 +1,12 @@
 // @ts-check
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
+import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
 import { config } from '../../lib/config.js';
 import { isEnterprise } from '../../lib/license.js';
-import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 export const AssessmentAccessRulesSchema = z.object({
   mode: z.string(),

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
@@ -1,8 +1,10 @@
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
+
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
+
 import {
   InstructorAssessmentAccess,
   AssessmentAccessRulesSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -1,13 +1,16 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
-import archiver from 'archiver';
-import { stringifyStream } from '@prairielearn/csv';
 import { pipeline } from 'node:stream/promises';
 
-import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
+import archiver from 'archiver';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { stringifyStream } from '@prairielearn/csv';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
+
 import { getGroupConfig } from '../../lib/groups.js';
+import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
+
 import { InstructorAssessmentDownloads, Filenames } from './instructorAssessmentDownloads.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -1,9 +1,11 @@
+import { z } from 'zod';
+
 import { html, escapeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
+import { Modal } from '../../components/Modal.html.js';
 import { nodeModulesAssetPath } from '../../lib/assets.js';
 import { GroupConfig, IdSchema, UserSchema } from '../../lib/db-types.js';
-import { z } from 'zod';
-import { Modal } from '../../components/Modal.html.js';
 
 export const GroupUsersRowSchema = z.object({
   group_id: IdSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -1,11 +1,13 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 
-import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
+import { GroupConfigSchema } from '../../lib/db-types.js';
+import { uploadInstanceGroups, autoGroups } from '../../lib/group-update.js';
 import {
   GroupOperationError,
   addUserToGroup,
@@ -14,13 +16,13 @@ import {
   deleteGroup,
   leaveGroup,
 } from '../../lib/groups.js';
-import { uploadInstanceGroups, autoGroups } from '../../lib/group-update.js';
-import { GroupConfigSchema } from '../../lib/db-types.js';
+import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
+import { parseUidsString } from '../../lib/user.js';
+
 import {
   InstructorAssessmentGroups,
   GroupUsersRowSchema,
 } from './instructorAssessmentGroups.html.js';
-import { parseUidsString } from '../../lib/user.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -1,11 +1,12 @@
-import { escapeHtml, html } from '@prairielearn/html';
-import { renderEjs } from '@prairielearn/html-ejs';
 import { z } from 'zod';
 
-import { IdSchema, InstanceQuestionSchema } from '../../lib/db-types.js';
+import { escapeHtml, html } from '@prairielearn/html';
+import { renderEjs } from '@prairielearn/html-ejs';
+
+import { Modal } from '../../components/Modal.html.js';
 import { InstanceLogEntry } from '../../lib/assessment.js';
 import { nodeModulesAssetPath, compiledScriptTag } from '../../lib/assets.js';
-import { Modal } from '../../components/Modal.html.js';
+import { IdSchema, InstanceQuestionSchema } from '../../lib/db-types.js';
 import { formatFloat } from '../../lib/format.js';
 
 export const AssessmentInstanceStatsSchema = z.object({

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -1,21 +1,24 @@
-import * as express from 'express';
 import { pipeline } from 'node:stream/promises';
+
+import * as express from 'express';
 import asyncHandler from 'express-async-handler';
-import * as error from '@prairielearn/error';
-import * as sqldb from '@prairielearn/postgres';
-import { stringifyStream } from '@prairielearn/csv';
 import { z } from 'zod';
 
-import { assessmentFilenamePrefix, sanitizeString } from '../../lib/sanitize-name.js';
-import * as ltiOutcomes from '../../lib/ltiOutcomes.js';
-import { updateInstanceQuestionScore } from '../../lib/manualGrading.js';
+import { stringifyStream } from '@prairielearn/csv';
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
 import {
   selectAssessmentInstanceLog,
   selectAssessmentInstanceLogCursor,
   updateAssessmentInstancePoints,
   updateAssessmentInstanceScore,
 } from '../../lib/assessment.js';
+import * as ltiOutcomes from '../../lib/ltiOutcomes.js';
+import { updateInstanceQuestionScore } from '../../lib/manualGrading.js';
+import { assessmentFilenamePrefix, sanitizeString } from '../../lib/sanitize-name.js';
 import { resetVariantsForInstanceQuestion } from '../../models/variant.js';
+
 import {
   InstructorAssessmentInstance,
   AssessmentInstanceStatsSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.js
@@ -1,10 +1,11 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
-import { regradeAssessmentInstance } from '../../lib/regrading.js';
+import * as sqldb from '@prairielearn/postgres';
+
 import {
   checkBelongs,
   gradeAssessmentInstance,
@@ -12,8 +13,8 @@ import {
   deleteAllAssessmentInstancesForAssessment,
   deleteAssessmentInstance,
 } from '../../lib/assessment.js';
-import * as sqldb from '@prairielearn/postgres';
 import { IdSchema } from '../../lib/db-types.js';
+import { regradeAssessmentInstance } from '../../lib/regrading.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
+
 import { HtmlValue, html, joinHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { AssessmentQuestionSchema } from '../../../lib/db-types.js';
 import { idsEqual } from '../../../lib/id.js';
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
@@ -1,7 +1,9 @@
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
-import * as sqldb from '@prairielearn/postgres';
+
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
 import { ManualGradingAssessment, ManualGradingQuestionSchema } from './assessment.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -1,11 +1,12 @@
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryAsync, queryRows } from '@prairielearn/postgres';
 
-import * as manualGrading from '../../../lib/manualGrading.js';
 import { InstanceQuestionSchema } from '../../../lib/db-types.js';
-import { z } from 'zod';
+import * as manualGrading from '../../../lib/manualGrading.js';
 
 const router = express.Router();
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -1,11 +1,13 @@
 import { html } from '@prairielearn/html';
-import { RubricInputSection } from './rubricInputSection.html.js';
+
+import { type Issue, type User } from '../../../lib/db-types.js';
+
 import {
   AutoPointsSection,
   ManualPointsSection,
   TotalPointsSection,
 } from './gradingPointsSection.html.js';
-import { type Issue, type User } from '../../../lib/db-types.js';
+import { RubricInputSection } from './rubricInputSection.html.js';
 
 interface SubmissionOrGradingJob {
   feedback: Record<string, any> | null;

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -1,9 +1,11 @@
-import { html, unsafeHtml } from '@prairielearn/html';
 import { z } from 'zod';
+
+import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { GradingJobSchema, User } from '../../../lib/db-types.js';
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../../lib/assets.js';
+import { GradingJobSchema, User } from '../../../lib/db-types.js';
+
 import { GradingPanel } from './gradingPanel.html.js';
 import { RubricSettingsModal } from './rubricSettingsModal.html.js';
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -2,14 +2,16 @@ import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 import * as qs from 'qs';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
-import { getAndRenderVariant, renderPanelsForSubmission } from '../../../lib/question-render.js';
-import * as manualGrading from '../../../lib/manualGrading.js';
 import { IdSchema, UserSchema } from '../../../lib/db-types.js';
-import { GradingJobData, GradingJobDataSchema, InstanceQuestion } from './instanceQuestion.html.js';
+import * as manualGrading from '../../../lib/manualGrading.js';
+import { getAndRenderVariant, renderPanelsForSubmission } from '../../../lib/question-render.js';
+
 import { GradingPanel } from './gradingPanel.html.js';
+import { GradingJobData, GradingJobDataSchema, InstanceQuestion } from './instanceQuestion.html.js';
 import { RubricSettingsModal } from './rubricSettingsModal.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
@@ -1,4 +1,5 @@
 import { html, unsafeHtml } from '@prairielearn/html';
+
 import { RubricData, RubricGradingData } from '../../../lib/manualGrading.js';
 
 export function RubricInputSection({

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.html.ts
@@ -1,4 +1,5 @@
 import { html } from '@prairielearn/html';
+
 import { RubricData } from '../../../lib/manualGrading.js';
 
 export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, any> }) {

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.html.ts
@@ -1,7 +1,9 @@
-import { html, unsafeHtml } from '@prairielearn/html';
-import { renderEjs } from '@prairielearn/html-ejs';
 import { z } from 'zod';
 
+import { html, unsafeHtml } from '@prairielearn/html';
+import { renderEjs } from '@prairielearn/html-ejs';
+
+import { Modal } from '../../components/Modal.html.js';
 import { assetPath, nodeModulesAssetPath } from '../../lib/assets.js';
 import {
   AlternativeGroupSchema,
@@ -15,7 +17,6 @@ import {
 } from '../../lib/db-types.js';
 import { formatFloat } from '../../lib/format.js';
 import { STAT_DESCRIPTIONS } from '../shared/assessmentStatDescriptions.js';
-import { Modal } from '../../components/Modal.html.js';
 
 export const AssessmentQuestionStatsRowSchema = AssessmentQuestionSchema.extend({
   course_short_name: CourseSchema.shape.short_name,

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.ts
@@ -1,21 +1,24 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
 import { pipeline } from 'node:stream/promises';
-import * as error from '@prairielearn/error';
-import * as sqldb from '@prairielearn/postgres';
-import { stringifyStream } from '@prairielearn/csv';
+
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
-import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
+import { stringifyStream } from '@prairielearn/csv';
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
 import {
   updateAssessmentQuestionStatsForAssessment,
   updateAssessmentStatistics,
 } from '../../lib/assessment.js';
+import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
+import { STAT_DESCRIPTIONS } from '../shared/assessmentStatDescriptions.js';
+
 import {
   AssessmentQuestionStatsRowSchema,
   InstructorAssessmentQuestionStatistics,
 } from './instructorAssessmentQuestionStatistics.html.js';
-import { STAT_DESCRIPTIONS } from '../shared/assessmentStatDescriptions.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -1,6 +1,9 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
+
+import { Modal } from '../../components/Modal.html.js';
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
 import {
   AlternativeGroupSchema,
@@ -11,7 +14,6 @@ import {
   TopicSchema,
   ZoneSchema,
 } from '../../lib/db-types.js';
-import { Modal } from '../../components/Modal.html.js';
 
 export const AssessmentQuestionRowSchema = AssessmentQuestionSchema.extend({
   alternative_group_number_choose: AlternativeGroupSchema.shape.number_choose,

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ts
@@ -1,10 +1,12 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
 import { AnsiUp } from 'ansi_up';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
 import { queryRows, loadSqlEquiv } from '@prairielearn/postgres';
+
 import { resetVariantsForAssessmentQuestion } from '../../models/variant.js';
+
 import {
   InstructorAssessmentQuestions,
   AssessmentQuestionRowSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
@@ -1,9 +1,10 @@
-import { html } from '@prairielearn/html';
-import { renderEjs } from '@prairielearn/html-ejs';
 import { z } from 'zod';
 
-import { JobSequenceSchema, UserSchema } from '../../lib/db-types.js';
+import { html } from '@prairielearn/html';
+import { renderEjs } from '@prairielearn/html-ejs';
+
 import { Modal } from '../../components/Modal.html.js';
+import { JobSequenceSchema, UserSchema } from '../../lib/db-types.js';
 
 export const RegradingJobSequenceSchema = z.object({
   job_sequence: JobSequenceSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
@@ -2,8 +2,10 @@ import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
-import { regradeAllAssessmentInstances } from '../../lib/regrading.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import { regradeAllAssessmentInstances } from '../../lib/regrading.js';
+
 import {
   InstructorAssessmentRegrading,
   RegradingJobSequenceSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -1,8 +1,8 @@
 import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { nodeModulesAssetPath } from '../../lib/assets.js';
 import { Modal } from '../../components/Modal.html.js';
+import { nodeModulesAssetPath } from '../../lib/assets.js';
 
 export function InstructorAssessmentSettings({
   resLocals,

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -1,12 +1,15 @@
+import * as path from 'path';
+
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
-import * as path from 'path';
 import QR from 'qrcode-svg';
-import { flash } from '@prairielearn/flash';
-import * as sqldb from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
+import { flash } from '@prairielearn/flash';
+import * as sqldb from '@prairielearn/postgres';
+
+import { IdSchema } from '../../lib/db-types.js';
 import {
   AssessmentCopyEditor,
   AssessmentRenameEditor,
@@ -14,7 +17,7 @@ import {
 } from '../../lib/editors.js';
 import { encodePath } from '../../lib/uri-util.js';
 import { getCanonicalHost } from '../../lib/url.js';
-import { IdSchema } from '../../lib/db-types.js';
+
 import { InstructorAssessmentSettings } from './instructorAssessmentSettings.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.js
@@ -1,12 +1,13 @@
 // @ts-check
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
-import { stringify } from '@prairielearn/csv';
 
+import { stringify } from '@prairielearn/csv';
 import * as error from '@prairielearn/error';
-import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
 import * as sqldb from '@prairielearn/postgres';
+
 import { updateAssessmentStatistics } from '../../lib/assessment.js';
+import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.js
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.js
@@ -1,15 +1,16 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
-import * as error from '@prairielearn/error';
-import * as sqldb from '@prairielearn/postgres';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
+import { JobSequenceSchema, UserSchema } from '../../lib/db-types.js';
 import {
   uploadInstanceQuestionScores,
   uploadAssessmentInstanceScores,
 } from '../../lib/score-upload.js';
-import { JobSequenceSchema, UserSchema } from '../../lib/db-types.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.js
@@ -1,19 +1,21 @@
 // @ts-check
-import * as express from 'express';
-import asyncHandler from 'express-async-handler';
-import { AnsiUp } from 'ansi_up';
-import * as error from '@prairielearn/error';
-import debugfn from 'debug';
-import { stringifyStream } from '@prairielearn/csv';
-import * as sqldb from '@prairielearn/postgres';
 import { pipeline } from 'node:stream/promises';
 
-import { courseInstanceFilenamePrefix } from '../../lib/sanitize-name.js';
-import { AssessmentAddEditor } from '../../lib/editors.js';
+import { AnsiUp } from 'ansi_up';
+import debugfn from 'debug';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
+import { stringifyStream } from '@prairielearn/csv';
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
 import {
   updateAssessmentStatistics,
   updateAssessmentStatisticsForCourseInstance,
 } from '../../lib/assessment.js';
+import { AssessmentAddEditor } from '../../lib/editors.js';
+import { courseInstanceFilenamePrefix } from '../../lib/sanitize-name.js';
 
 const router = express.Router();
 const ansiUp = new AnsiUp();

--- a/apps/prairielearn/src/pages/instructorCopyTemplateCourseQuestion/instructorCopyTemplateCourseQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorCopyTemplateCourseQuestion/instructorCopyTemplateCourseQuestion.ts
@@ -1,12 +1,13 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
 import { copyQuestionBetweenCourses } from '../../lib/copy-question.js';
-import { idsEqual } from '../../lib/id.js';
 import { CourseSchema, QuestionSchema } from '../../lib/db-types.js';
+import { idsEqual } from '../../lib/id.js';
 
 const router = Router();
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
@@ -1,14 +1,16 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
-import * as sqldb from '@prairielearn/postgres';
-import * as error from '@prairielearn/error';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+
+import { CourseInstanceSchema, IdSchema } from '../../lib/db-types.js';
 import { CourseInstanceAddEditor } from '../../lib/editors.js';
 import { idsEqual } from '../../lib/id.js';
 import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
-import { CourseInstanceSchema, IdSchema } from '../../lib/db-types.js';
+
 import {
   InstructorCourseAdminInstances,
   CourseInstanceAuthzRow,

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.ts
@@ -1,9 +1,10 @@
+import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import * as express from 'express';
-
 import * as sqldb from '@prairielearn/postgres';
+
 import { AssessmentSetSchema } from '../../lib/db-types.js';
+
 import { InstructorCourseAdminSets } from './instructorCourseAdminSets.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -1,8 +1,8 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { formatTimezone, type Timezone } from '../../lib/timezones.js';
 import { compiledScriptTag } from '../../lib/assets.js';
+import { formatTimezone, type Timezone } from '../../lib/timezones.js';
 
 export function InstructorCourseAdminSettings({
   resLocals,

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -1,17 +1,20 @@
-import * as express from 'express';
 import * as path from 'path';
+
+import sha256 from 'crypto-js/sha256.js';
+import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
-import { CourseInfoCreateEditor, FileModifyEditor } from '../../lib/editors.js';
-import * as error from '@prairielearn/error';
-import { flash } from '@prairielearn/flash';
-import sha256 from 'crypto-js/sha256.js';
 import { v4 as uuidv4 } from 'uuid';
 
-import { InstructorCourseAdminSettings } from './instructorCourseAdminSettings.html.js';
-import { getAvailableTimezones } from '../../lib/timezones.js';
-import { getPaths } from '../../lib/instructorFiles.js';
+import * as error from '@prairielearn/error';
+import { flash } from '@prairielearn/flash';
+
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
+import { CourseInfoCreateEditor, FileModifyEditor } from '../../lib/editors.js';
+import { getPaths } from '../../lib/instructorFiles.js';
+import { getAvailableTimezones } from '../../lib/timezones.js';
+
+import { InstructorCourseAdminSettings } from './instructorCourseAdminSettings.html.js';
 
 const router = express.Router();
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import * as error from '@prairielearn/error';
-import { InstructorSharing } from './instructorCourseAdminSharing.html.js';
 import { z } from 'zod';
+
+import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
+
 import { getCanonicalHost } from '../../lib/url.js';
+
+import { InstructorSharing } from './instructorCourseAdminSharing.html.js';
 
 const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.js
@@ -1,16 +1,23 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
 import * as async from 'async';
 import debugfn from 'debug';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
 import { html } from '@prairielearn/html';
 import { logger } from '@prairielearn/logger';
-import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
+import {
+  CourseInstancePermissionSchema,
+  CourseInstanceSchema,
+  CoursePermissionSchema,
+  UserSchema,
+} from '../../lib/db-types.js';
 import { idsEqual } from '../../lib/id.js';
+import { parseUidsString } from '../../lib/user.js';
 import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
 import {
   deleteAllCourseInstancePermissionsForCourse,
@@ -23,13 +30,6 @@ import {
   updateCourseInstancePermissionsRole,
   updateCoursePermissionsRole,
 } from '../../models/course-permissions.js';
-import { parseUidsString } from '../../lib/user.js';
-import {
-  CourseInstancePermissionSchema,
-  CourseInstanceSchema,
-  CoursePermissionSchema,
-  UserSchema,
-} from '../../lib/db-types.js';
 
 const debug = debugfn('prairielearn:instructorCourseAdminStaff');
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
@@ -1,5 +1,6 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { Tag } from '../../lib/db-types.js';
 
 export function InstructorCourseAdminTags({

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.ts
@@ -1,9 +1,10 @@
+import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 
-import * as express from 'express';
-
 import * as sqldb from '@prairielearn/postgres';
+
 import { TagSchema } from '../../lib/db-types.js';
+
 import { InstructorCourseAdminTags } from './instructorCourseAdminTags.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.ts
@@ -1,8 +1,10 @@
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
+
 import { TopicSchema } from '../../lib/db-types.js';
+
 import { InstructorCourseAdminTopics } from './instructorCourseAdminTopics.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.js
@@ -1,13 +1,14 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import _ from 'lodash';
-import * as express from 'express';
-import debugfn from 'debug';
 import { parseISO, isValid } from 'date-fns';
 import { format, toZonedTime } from 'date-fns-tz';
+import debugfn from 'debug';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
+import { z } from 'zod';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
-import { z } from 'zod';
 
 import { clearCookie, setCookie } from '../../lib/cookie.js';
 import {

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -1,21 +1,23 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import { Router } from 'express';
-import * as error from '@prairielearn/error';
-
 import * as path from 'node:path';
-import { FileDeleteEditor, FileRenameEditor, FileUploadEditor } from '../../lib/editors.js';
-import { contains } from '@prairielearn/path-utils';
-import fs from 'fs-extra';
-import * as async from 'async';
-import hljs from 'highlight.js';
-import { fileTypeFromFile } from 'file-type';
-import { isBinaryFile } from 'isbinaryfile';
-import { encodePath } from '../../lib/uri-util.js';
-import * as editorUtil from '../../lib/editorUtil.js';
+
 import { AnsiUp } from 'ansi_up';
+import * as async from 'async';
+import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+import { fileTypeFromFile } from 'file-type';
+import fs from 'fs-extra';
+import hljs from 'highlight.js';
+import { isBinaryFile } from 'isbinaryfile';
+
+import * as error from '@prairielearn/error';
+import { contains } from '@prairielearn/path-utils';
+
 import { getCourseOwners } from '../../lib/course.js';
+import * as editorUtil from '../../lib/editorUtil.js';
+import { FileDeleteEditor, FileRenameEditor, FileUploadEditor } from '../../lib/editors.js';
 import { getPaths } from '../../lib/instructorFiles.js';
+import { encodePath } from '../../lib/uri-util.js';
 
 const router = Router();
 

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.js
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.js
@@ -1,6 +1,7 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 
 import { decodePath } from '../../lib/uri-util.js';

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -1,25 +1,28 @@
 // @ts-check
-import * as express from 'express';
-import asyncHandler from 'express-async-handler';
-import * as error from '@prairielearn/error';
-import * as sqldb from '@prairielearn/postgres';
-import fs from 'fs-extra';
 import * as path from 'path';
-import { v4 as uuidv4 } from 'uuid';
-import debugfn from 'debug';
-import { getJobSequenceWithFormattedOutput } from '../../lib/server-jobs.js';
-import { getErrorsAndWarningsForFilePath } from '../../lib/editorUtil.js';
+
+import * as modelist from 'ace-code/src/ext/modelist.js';
 import { AnsiUp } from 'ansi_up';
 import sha256 from 'crypto-js/sha256.js';
-import { b64EncodeUnicode, b64DecodeUnicode } from '../../lib/base64-util.js';
-import { deleteFile, getFile, uploadFile } from '../../lib/file-store.js';
+import debugfn from 'debug';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+import fs from 'fs-extra';
 import { isBinaryFile } from 'isbinaryfile';
-import * as modelist from 'ace-code/src/ext/modelist.js';
+import { v4 as uuidv4 } from 'uuid';
+
+import * as error from '@prairielearn/error';
+import { logger } from '@prairielearn/logger';
+import * as sqldb from '@prairielearn/postgres';
+
+import { b64EncodeUnicode, b64DecodeUnicode } from '../../lib/base64-util.js';
+import { getCourseOwners } from '../../lib/course.js';
+import { getErrorsAndWarningsForFilePath } from '../../lib/editorUtil.js';
+import { FileModifyEditor } from '../../lib/editors.js';
+import { deleteFile, getFile, uploadFile } from '../../lib/file-store.js';
 import { idsEqual } from '../../lib/id.js';
 import { getPaths } from '../../lib/instructorFiles.js';
-import { getCourseOwners } from '../../lib/course.js';
-import { logger } from '@prairielearn/logger';
-import { FileModifyEditor } from '../../lib/editors.js';
+import { getJobSequenceWithFormattedOutput } from '../../lib/server-jobs.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
@@ -1,12 +1,15 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
 import * as path from 'path';
+
 import debugfn from 'debug';
-import * as sqldb from '@prairielearn/postgres';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
 import { flash } from '@prairielearn/flash';
-import { QuestionTransferEditor } from '../../lib/editors.js';
+import * as sqldb from '@prairielearn/postgres';
+
 import { config } from '../../lib/config.js';
+import { QuestionTransferEditor } from '../../lib/editors.js';
 import { idsEqual } from '../../lib/id.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.js
@@ -1,18 +1,20 @@
 // @ts-check
+import { pipeline } from 'node:stream/promises';
+
+import * as express from 'express';
 import asyncHandler from 'express-async-handler';
 import _ from 'lodash';
-import * as express from 'express';
+
 import { stringifyStream } from '@prairielearn/csv';
-import { pipeline } from 'node:stream/promises';
 import { HttpStatusError } from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
+import { updateAssessmentInstanceScore } from '../../lib/assessment.js';
 import {
   getCourseOwners,
   checkAssessmentInstanceBelongsToCourseInstance,
 } from '../../lib/course.js';
 import { courseInstanceFilenamePrefix } from '../../lib/sanitize-name.js';
-import { updateAssessmentInstanceScore } from '../../lib/assessment.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 import { IdSchema } from '../../lib/db-types.js';
 

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
@@ -1,12 +1,15 @@
-import * as express from 'express';
+import type * as stream from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+
 import { S3, NoSuchKey } from '@aws-sdk/client-s3';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
-import asyncHandler from 'express-async-handler';
-import type * as stream from 'node:stream';
 
 import { makeS3ClientConfig } from '../../lib/aws.js';
+
 import { InstructorGradingJob, GradingJobQueryResultSchema } from './instructorGradingJob.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.js
@@ -1,6 +1,6 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.js
@@ -1,11 +1,12 @@
 // @ts-check
 import ERR from 'async-stacktrace';
-import _ from 'lodash';
 import * as express from 'express';
+import _ from 'lodash';
 
-import { getCourseOwners } from '../../lib/course.js';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
+
+import { getCourseOwners } from '../../lib/course.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -1,8 +1,8 @@
 import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { nodeModulesAssetPath } from '../../lib/assets.js';
 import { Modal } from '../../components/Modal.html.js';
+import { nodeModulesAssetPath } from '../../lib/assets.js';
 
 export function InstructorInstanceAdminSettings({
   resLocals,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -1,12 +1,15 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
-import QR from 'qrcode-svg';
-import { flash } from '@prairielearn/flash';
-import * as sqldb from '@prairielearn/postgres';
 import * as path from 'path';
-import * as error from '@prairielearn/error';
+
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+import QR from 'qrcode-svg';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
+import { flash } from '@prairielearn/flash';
+import * as sqldb from '@prairielearn/postgres';
+
+import { IdSchema } from '../../lib/db-types.js';
 import {
   CourseInstanceCopyEditor,
   CourseInstanceRenameEditor,
@@ -14,7 +17,7 @@ import {
 } from '../../lib/editors.js';
 import { encodePath } from '../../lib/uri-util.js';
 import { getCanonicalHost } from '../../lib/url.js';
-import { IdSchema } from '../../lib/db-types.js';
+
 import { InstructorInstanceAdminSettings } from './instructorInstanceAdminSettings.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.js
@@ -1,18 +1,19 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import _ from 'lodash';
 import { parseISO, formatDistance } from 'date-fns';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 import SearchString from 'search-string';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
-import * as paginate from '../../lib/paginate.js';
-import * as sqldb from '@prairielearn/postgres';
 import { flash } from '@prairielearn/flash';
-import { idsEqual } from '../../lib/id.js';
-import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
+import * as sqldb from '@prairielearn/postgres';
+
 import { IdSchema } from '../../lib/db-types.js';
+import { idsEqual } from '../../lib/id.js';
+import * as paginate from '../../lib/paginate.js';
+import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorJobSequence/instructorJobSequence.js
+++ b/apps/prairielearn/src/pages/instructorJobSequence/instructorJobSequence.js
@@ -1,6 +1,7 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
 import { HttpStatusError } from '@prairielearn/error';
 
 import { getJobSequenceWithFormattedOutput } from '../../lib/server-jobs.js';

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.js
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.js
@@ -1,16 +1,17 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import * as async from 'async';
-import fs from 'fs-extra';
 import * as path from 'path';
-import * as express from 'express';
 
+import * as async from 'async';
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+import fs from 'fs-extra';
+
+import { chalk } from '../../lib/chalk.js';
+import * as chunks from '../../lib/chunks.js';
 import { config } from '../../lib/config.js';
+import { REPOSITORY_ROOT_PATH } from '../../lib/paths.js';
 import { createServerJob } from '../../lib/server-jobs.js';
 import * as syncFromDisk from '../../sync/syncFromDisk.js';
-import * as chunks from '../../lib/chunks.js';
-import { chalk } from '../../lib/chalk.js';
-import { REPOSITORY_ROOT_PATH } from '../../lib/paths.js';
 
 const router = express.Router();
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.js
@@ -1,24 +1,24 @@
 // @ts-check
-import _ from 'lodash';
 import * as express from 'express';
-import { z } from 'zod';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
+import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 
+import { setQuestionCopyTargets } from '../../lib/copy-question.js';
+import { IdSchema } from '../../lib/db-types.js';
+import * as issues from '../../lib/issues.js';
 import {
   getAndRenderVariant,
   renderPanelsForSubmission,
   setRendererHeader,
 } from '../../lib/question-render.js';
-import * as issues from '../../lib/issues.js';
-import { logPageView } from '../../middlewares/logPageView.js';
-import { setQuestionCopyTargets } from '../../lib/copy-question.js';
 import {
   processSubmission,
   validateVariantAgainstQuestion,
 } from '../../lib/question-submission.js';
-import { IdSchema } from '../../lib/db-types.js';
+import { logPageView } from '../../middlewares/logPageView.js';
 
 const router = express.Router();
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -1,12 +1,13 @@
+import { z } from 'zod';
+
 import { escapeHtml, html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 import { Modal } from '../../components/Modal.html.js';
 import { IdSchema } from '../../lib/db-types.js';
-import { CourseWithPermissions } from '../../models/course.js';
-import { isEnterprise } from '../../lib/license.js';
 import { idsEqual } from '../../lib/id.js';
+import { isEnterprise } from '../../lib/license.js';
+import { CourseWithPermissions } from '../../models/course.js';
 
 export const SelectedAssessmentsSchema = z.object({
   title: z.string(),

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -1,26 +1,29 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
-import * as error from '@prairielearn/error';
-import { startTestQuestion } from '../../lib/question-testing.js';
-import * as sqldb from '@prairielearn/postgres';
 import * as path from 'path';
+
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
+import * as error from '@prairielearn/error';
+import { flash } from '@prairielearn/flash';
+import * as sqldb from '@prairielearn/postgres';
+import { generateSignedToken } from '@prairielearn/signed-token';
+
+import { config } from '../../lib/config.js';
+import { copyQuestionBetweenCourses } from '../../lib/copy-question.js';
+import { IdSchema } from '../../lib/db-types.js';
 import {
   QuestionRenameEditor,
   QuestionDeleteEditor,
   QuestionCopyEditor,
 } from '../../lib/editors.js';
-import { config } from '../../lib/config.js';
-import { encodePath } from '../../lib/uri-util.js';
-import { idsEqual } from '../../lib/id.js';
-import { generateSignedToken } from '@prairielearn/signed-token';
-import { copyQuestionBetweenCourses } from '../../lib/copy-question.js';
-import { flash } from '@prairielearn/flash';
 import { features } from '../../lib/features/index.js';
+import { idsEqual } from '../../lib/id.js';
+import { startTestQuestion } from '../../lib/question-testing.js';
+import { encodePath } from '../../lib/uri-util.js';
 import { getCanonicalHost } from '../../lib/url.js';
 import { selectCoursesWithEditAccess } from '../../models/course.js';
-import { IdSchema } from '../../lib/db-types.js';
+
 import {
   InstructorQuestionSettings,
   SelectedAssessmentsSchema,

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
 
 import { assetPath, nodeModulesAssetPath } from '../../lib/assets.js';
 import {

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ts
@@ -1,16 +1,19 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
 import { pipeline } from 'node:stream/promises';
+
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
 import { stringifyStream } from '@prairielearn/csv';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import { questionFilenamePrefix } from '../../lib/sanitize-name.js';
+import { STAT_DESCRIPTIONS } from '../shared/assessmentStatDescriptions.js';
+
 import {
   AssessmentQuestionStatsRowSchema,
   InstructorQuestionStatistics,
 } from './instructorQuestionStatistics.html.js';
-import { STAT_DESCRIPTIONS } from '../shared/assessmentStatDescriptions.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.html.ts
@@ -1,7 +1,8 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { type CourseInstance } from '../../lib/db-types.js';
+
 import { QuestionsTable, QuestionsTableHead } from '../../components/QuestionsTable.html.js';
+import { type CourseInstance } from '../../lib/db-types.js';
 import { QuestionsPageDataAnsified } from '../../models/questions.js';
 
 export const QuestionsPage = ({

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+import fs from 'fs-extra';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
+
 import { QuestionAddEditor } from '../../lib/editors.js';
-import fs from 'fs-extra';
-import { QuestionsPage } from './instructorQuestions.html.js';
-import { QuestionsPageDataAnsified, selectQuestionsForCourse } from '../../models/questions.js';
-import asyncHandler from 'express-async-handler';
 import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
+import { QuestionsPageDataAnsified, selectQuestionsForCourse } from '../../models/questions.js';
+
+import { QuestionsPage } from './instructorQuestions.html.js';
 
 const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -1,6 +1,8 @@
+import { z } from 'zod';
+
 import { HtmlValue, html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
-import { z } from 'zod';
+
 import { CourseRequestSchema, UserSchema } from '../../lib/db-types.js';
 
 export const CourseRequestRowSchema = z.object({

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
@@ -1,17 +1,19 @@
-import asyncHandler from 'express-async-handler';
-import * as express from 'express';
 import * as path from 'path';
+
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import { flash } from '@prairielearn/flash';
-import { loadSqlEquiv, queryRow, queryRows } from '@prairielearn/postgres';
 import { logger } from '@prairielearn/logger';
+import { loadSqlEquiv, queryRow, queryRows } from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 
-import * as opsbot from '../../lib/opsbot.js';
-import * as github from '../../lib/github.js';
 import { config } from '../../lib/config.js';
 import { IdSchema } from '../../lib/db-types.js';
+import * as github from '../../lib/github.js';
+import * as opsbot from '../../lib/opsbot.js';
+
 import { RequestCourse, CourseRequestRowSchema } from './instructorRequestCourse.html.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
+++ b/apps/prairielearn/src/pages/legacyQuestionFile/legacyQuestionFile.js
@@ -1,6 +1,7 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/pages/navbarCourseInstanceSwitcher/navbarCourseInstanceSwitcher.ts
+++ b/apps/prairielearn/src/pages/navbarCourseInstanceSwitcher/navbarCourseInstanceSwitcher.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import { NavbarCourseInstanceSwitcher } from './navbarCourseInstanceSwitcher.html.js';
+
 import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
+
+import { NavbarCourseInstanceSwitcher } from './navbarCourseInstanceSwitcher.html.js';
 
 const router = Router();
 

--- a/apps/prairielearn/src/pages/navbarCourseSwitcher/navbarCourseSwitcher.ts
+++ b/apps/prairielearn/src/pages/navbarCourseSwitcher/navbarCourseSwitcher.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import { NavbarCourseSwitcher } from './navbarCourseSwitcher.html.js';
+
 import { selectCoursesWithStaffAccess } from '../../models/course.js';
+
+import { NavbarCourseSwitcher } from './navbarCourseSwitcher.html.js';
 
 const router = Router();
 

--- a/apps/prairielearn/src/pages/news_item/news_item.js
+++ b/apps/prairielearn/src/pages/news_item/news_item.js
@@ -1,8 +1,9 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
-import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/pages/news_items/news_items.js
+++ b/apps/prairielearn/src/pages/news_items/news_items.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.html.ts
@@ -1,6 +1,7 @@
 import { compiledScriptTag } from '@prairielearn/compiled-assets';
 import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { assetPath, nodeModulesAssetPath } from '../../lib/assets.js';
 
 export function PublicQuestionPreview({ resLocals }: { resLocals: Record<string, any> }) {

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -1,20 +1,22 @@
 import { Router } from 'express';
-import * as error from '@prairielearn/error';
-import { z } from 'zod';
 import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
 
-import { selectQuestionById } from '../../models/question.js';
-import { selectCourseById } from '../../models/course.js';
-import { processSubmission } from '../../lib/question-submission.js';
+import * as error from '@prairielearn/error';
+
+import { setQuestionCopyTargets } from '../../lib/copy-question.js';
 import { IdSchema, UserSchema } from '../../lib/db-types.js';
-import { logPageView } from '../../middlewares/logPageView.js';
 import {
   getAndRenderVariant,
   renderPanelsForSubmission,
   setRendererHeader,
 } from '../../lib/question-render.js';
+import { processSubmission } from '../../lib/question-submission.js';
+import { logPageView } from '../../middlewares/logPageView.js';
+import { selectCourseById } from '../../models/course.js';
+import { selectQuestionById } from '../../models/question.js';
+
 import { PublicQuestionPreview } from './publicQuestionPreview.html.js';
-import { setQuestionCopyTargets } from '../../lib/copy-question.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/pages/publicQuestions/publicQuestions.html.ts
+++ b/apps/prairielearn/src/pages/publicQuestions/publicQuestions.html.ts
@@ -1,5 +1,6 @@
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { QuestionsTable, QuestionsTableHead } from '../../components/QuestionsTable.html.js';
 import { QuestionsPageData } from '../../models/questions.js';
 

--- a/apps/prairielearn/src/pages/publicQuestions/publicQuestions.ts
+++ b/apps/prairielearn/src/pages/publicQuestions/publicQuestions.ts
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as error from '@prairielearn/error';
-import { QuestionsPage } from './publicQuestions.html.js';
-import { selectPublicQuestionsForCourse } from '../../models/questions.js';
-import { selectCourseById } from '../../models/course.js';
+
 import { features } from '../../lib/features/index.js';
+import { selectCourseById } from '../../models/course.js';
+import { selectPublicQuestionsForCourse } from '../../models/questions.js';
+
+import { QuestionsPage } from './publicQuestions.html.js';
 
 const router = Router({ mergeParams: true });
 

--- a/apps/prairielearn/src/pages/shared/syncHelpers.js
+++ b/apps/prairielearn/src/pages/shared/syncHelpers.js
@@ -8,13 +8,14 @@ import {
 } from '@aws-sdk/client-ecr';
 import * as async from 'async';
 import Docker from 'dockerode';
+
 import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
 import * as Sentry from '@prairielearn/sentry';
 
 import { makeAwsClientConfig } from '../../lib/aws.js';
 import { config } from '../../lib/config.js';
-import { createServerJob } from '../../lib/server-jobs.js';
 import { pullAndUpdateCourse } from '../../lib/course.js';
+import { createServerJob } from '../../lib/server-jobs.js';
 
 const docker = new Docker();
 

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.js
@@ -1,12 +1,11 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
-import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
 import { flash } from '@prairielearn/flash';
+import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
 
-import { checkPasswordOrRedirect } from '../../middlewares/studentAssessmentAccess.js';
 import { makeAssessmentInstance } from '../../lib/assessment.js';
 import {
   joinGroup,
@@ -20,6 +19,7 @@ import {
   canUserAssignGroupRoles,
 } from '../../lib/groups.js';
 import { getClientFingerprintId } from '../../middlewares/clientFingerprint.js';
+import { checkPasswordOrRedirect } from '../../middlewares/studentAssessmentAccess.js';
 
 const router = express.Router();
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.js
@@ -1,12 +1,19 @@
 // @ts-check
-import asyncHandler from 'express-async-handler';
 import * as express from 'express';
+import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRow, queryRows } from '@prairielearn/postgres';
 
 import * as assessment from '../../lib/assessment.js';
+import {
+  AssessmentInstanceSchema,
+  DateFromISOString,
+  IdSchema,
+  InstanceQuestionSchema,
+} from '../../lib/db-types.js';
+import { uploadFile, deleteFile } from '../../lib/file-store.js';
 import {
   canUserAssignGroupRoles,
   getGroupConfig,
@@ -15,13 +22,6 @@ import {
   leaveGroup,
   updateGroupRoles,
 } from '../../lib/groups.js';
-import {
-  AssessmentInstanceSchema,
-  DateFromISOString,
-  IdSchema,
-  InstanceQuestionSchema,
-} from '../../lib/db-types.js';
-import { uploadFile, deleteFile } from '../../lib/file-store.js';
 import { idsEqual } from '../../lib/id.js';
 
 const router = express.Router();

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.js
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.js
@@ -4,6 +4,7 @@ import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
+
 import * as fileStore from '../../lib/file-store.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.js
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.js
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
+
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.js
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.js
@@ -1,28 +1,28 @@
 // @ts-check
-import _ from 'lodash';
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
 
-import * as sqldb from '@prairielearn/postgres';
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
 
-import { logPageView } from '../../middlewares/logPageView.js';
+import { gradeAssessmentInstance } from '../../lib/assessment.js';
+import { setQuestionCopyTargets } from '../../lib/copy-question.js';
+import { IdSchema } from '../../lib/db-types.js';
+import { uploadFile, deleteFile } from '../../lib/file-store.js';
+import { getQuestionGroupPermissions } from '../../lib/groups.js';
+import { idsEqual } from '../../lib/id.js';
+import { insertIssue } from '../../lib/issues.js';
 import {
   getAndRenderVariant,
   renderPanelsForSubmission,
   setRendererHeader,
 } from '../../lib/question-render.js';
-import { gradeAssessmentInstance } from '../../lib/assessment.js';
-import { setQuestionCopyTargets } from '../../lib/copy-question.js';
-import { getQuestionGroupPermissions } from '../../lib/groups.js';
-import { uploadFile, deleteFile } from '../../lib/file-store.js';
-import { idsEqual } from '../../lib/id.js';
-import { insertIssue } from '../../lib/issues.js';
 import {
   processSubmission,
   validateVariantAgainstQuestion,
 } from '../../lib/question-submission.js';
-import { IdSchema } from '../../lib/db-types.js';
+import { logPageView } from '../../middlewares/logPageView.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/pages/submissionFile/submissionFile.js
+++ b/apps/prairielearn/src/pages/submissionFile/submissionFile.js
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { isBinaryFile } from 'isbinaryfile';
 import mime from 'mime';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { selectCourseById } from '../../models/course.js';

--- a/apps/prairielearn/src/pages/userSettings/userSettings.html.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.html.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
-import { IdSchema, Institution, User } from '../../lib/db-types.js';
-import { type Purchase } from '../../ee/lib/billing/purchases.js';
-import { isEnterprise } from '../../lib/license.js';
 import { UserSettingsPurchasesCard } from '../../ee/lib/billing/components/UserSettingsPurchasesCard.html.js';
+import { type Purchase } from '../../ee/lib/billing/purchases.js';
+import { IdSchema, Institution, User } from '../../lib/db-types.js';
+import { isEnterprise } from '../../lib/license.js';
 
 export const AccessTokenSchema = z.object({
   created_at: z.string(),

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -1,14 +1,17 @@
+import * as crypto from 'crypto';
+
 import express from 'express';
 import asyncHandler from 'express-async-handler';
-import * as crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
+
 import { HttpStatusError } from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
-import { AccessTokenSchema, UserSettings } from './userSettings.html.js';
+import { getPurchasesForUser } from '../../ee/lib/billing/purchases.js';
 import { InstitutionSchema, ModeSchema, UserSchema } from '../../lib/db-types.js';
 import { isEnterprise } from '../../lib/license.js';
-import { getPurchasesForUser } from '../../ee/lib/billing/purchases.js';
+
+import { AccessTokenSchema, UserSettings } from './userSettings.html.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/pages/workspace/workspace.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.ts
@@ -1,12 +1,13 @@
 import * as express from 'express';
 import asyncHandler from 'express-async-handler';
-import * as sqldb from '@prairielearn/postgres';
-import * as workspaceUtils from '@prairielearn/workspace-utils';
+
 import * as error from '@prairielearn/error';
+import * as sqldb from '@prairielearn/postgres';
+import { generateSignedToken } from '@prairielearn/signed-token';
+import * as workspaceUtils from '@prairielearn/workspace-utils';
 
 import { config } from '../../lib/config.js';
 import { selectVariantIdForWorkspace } from '../../models/workspace.js';
-import { generateSignedToken } from '@prairielearn/signed-token';
 
 import { Workspace } from './workspace.html.js';
 

--- a/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.html.ts
+++ b/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.html.ts
@@ -1,7 +1,9 @@
+import { z } from 'zod';
+
 import { html } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
+
 import { WorkspaceLogSchema } from '../../lib/db-types.js';
-import { z } from 'zod';
 
 export const WorkspaceLogRowSchema = WorkspaceLogSchema.extend({
   date_formatted: z.string(),

--- a/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.ts
+++ b/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.ts
@@ -1,12 +1,14 @@
+import { S3 } from '@aws-sdk/client-s3';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fetch from 'node-fetch';
-import { S3 } from '@aws-sdk/client-s3';
+
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import { makeS3ClientConfig } from '../../lib/aws.js';
 import { config } from '../../lib/config.js';
+
 import {
   WorkspaceLogRow,
   WorkspaceLogRowSchema,

--- a/apps/prairielearn/src/question-servers/calculation-subprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.js
@@ -1,13 +1,15 @@
 // @ts-check
-import _ from 'lodash';
 import * as path from 'node:path';
+
+import _ from 'lodash';
+
 import { contains } from '@prairielearn/path-utils';
 
-import { config } from '../lib/config.js';
 import * as chunks from '../lib/chunks.js';
+import { withCodeCaller } from '../lib/code-caller/index.js';
+import { config } from '../lib/config.js';
 import * as filePaths from '../lib/file-paths.js';
 import { REPOSITORY_ROOT_PATH } from '../lib/paths.js';
-import { withCodeCaller } from '../lib/code-caller/index.js';
 
 /** @typedef {import('../lib/chunks.js').Chunk} Chunk */
 

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1,31 +1,32 @@
 // @ts-check
 
-import * as async from 'async';
-import _ from 'lodash';
-import fs from 'fs-extra';
 import * as path from 'path';
-import mustache from 'mustache';
+
+import * as async from 'async';
 // Use slim export, which relies on htmlparser2 instead of parse5. This provides
 // support for questions with legacy renderer.
 import * as cheerio from 'cheerio/lib/slim';
-import * as parse5 from 'parse5';
 import debugfn from 'debug';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import mustache from 'mustache';
 import objectHash from 'object-hash';
+import * as parse5 from 'parse5';
 
-import { instrumented, metrics, instrumentedWithMetrics } from '@prairielearn/opentelemetry';
-import { logger } from '@prairielearn/logger';
 import { cache } from '@prairielearn/cache';
+import { logger } from '@prairielearn/logger';
+import { instrumented, metrics, instrumentedWithMetrics } from '@prairielearn/opentelemetry';
 
-import * as schemas from '../schemas/index.js';
-import { config } from '../lib/config.js';
-import { withCodeCaller, FunctionMissingError } from '../lib/code-caller/index.js';
-import * as jsonLoad from '../lib/json-load.js';
-import { getOrUpdateCourseCommitHash } from '../models/course.js';
-import * as markdown from '../lib/markdown.js';
-import * as chunks from '../lib/chunks.js';
 import * as assets from '../lib/assets.js';
-import { APP_ROOT_PATH } from '../lib/paths.js';
+import * as chunks from '../lib/chunks.js';
+import { withCodeCaller, FunctionMissingError } from '../lib/code-caller/index.js';
+import { config } from '../lib/config.js';
 import { features } from '../lib/features/index.js';
+import * as jsonLoad from '../lib/json-load.js';
+import * as markdown from '../lib/markdown.js';
+import { APP_ROOT_PATH } from '../lib/paths.js';
+import { getOrUpdateCourseCommitHash } from '../models/course.js';
+import * as schemas from '../schemas/index.js';
 
 const debug = debugfn('prairielearn:freeform');
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-/* eslint-disable import/order */
 // IMPORTANT: this must come first so that it can properly instrument our
 // dependencies like `pg` and `express`.
 import * as opentelemetry from '@prairielearn/opentelemetry';
@@ -9,7 +8,6 @@ import * as Sentry from '@prairielearn/sentry';
 // `@sentry/tracing` must be imported before `@sentry/profiling-node`.
 import '@sentry/tracing';
 import { ProfilingIntegration } from '@sentry/profiling-node';
-/* eslint-enable import/order */
 
 import * as fs from 'node:fs';
 import * as http from 'node:http';

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1,79 +1,83 @@
 // @ts-check
 
+/* eslint-disable import/order */
 // IMPORTANT: this must come first so that it can properly instrument our
 // dependencies like `pg` and `express`.
 import * as opentelemetry from '@prairielearn/opentelemetry';
-
 import * as Sentry from '@prairielearn/sentry';
+
 // `@sentry/tracing` must be imported before `@sentry/profiling-node`.
 import '@sentry/tracing';
 import { ProfilingIntegration } from '@sentry/profiling-node';
+/* eslint-enable import/order */
 
-import asyncHandler from 'express-async-handler';
 import * as fs from 'node:fs';
-import * as util from 'node:util';
-import * as path from 'node:path';
-import favicon from 'serve-favicon';
-import * as async from 'async';
-import express from 'express';
-import bodyParser from 'body-parser';
-import cookieParser from 'cookie-parser';
-import passport from 'passport';
-import Bowser from 'bowser';
 import * as http from 'node:http';
 import * as https from 'node:https';
+import * as path from 'node:path';
+import * as util from 'node:util';
+import * as url from 'url';
+
+import * as async from 'async';
 import blocked from 'blocked';
 import blockedAt from 'blocked-at';
+import bodyParser from 'body-parser';
+import Bowser from 'bowser';
+import cookieParser from 'cookie-parser';
+import esMain from 'es-main';
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import _ from 'lodash';
+import multer from 'multer';
 import onFinished from 'on-finished';
+import passport from 'passport';
+import favicon from 'serve-favicon';
 import { v4 as uuidv4 } from 'uuid';
 import yargsParser from 'yargs-parser';
-import multer from 'multer';
-import * as url from 'url';
-import { createProxyMiddleware } from 'http-proxy-middleware';
+
+import { EncodedData } from '@prairielearn/browser-utils';
+import { cache } from '@prairielearn/cache';
+import * as error from '@prairielearn/error';
+import { flashMiddleware, flash } from '@prairielearn/flash';
+import { logger, addFileLogging } from '@prairielearn/logger';
+import * as migrations from '@prairielearn/migrations';
 import {
   SCHEMA_MIGRATIONS_PATH,
   initBatchedMigrations,
   startBatchedMigrations,
   stopBatchedMigrations,
 } from '@prairielearn/migrations';
-import _ from 'lodash';
-import esMain from 'es-main';
+import * as namedLocks from '@prairielearn/named-locks';
+import * as sqldb from '@prairielearn/postgres';
+import { createSessionMiddleware } from '@prairielearn/session';
 
-import { logger, addFileLogging } from '@prairielearn/logger';
+import * as cron from './cron/index.js';
+import * as assets from './lib/assets.js';
+import * as codeCaller from './lib/code-caller/index.js';
 import { config, loadConfig, setLocalsFromConfig } from './lib/config.js';
-import * as load from './lib/load.js';
+import { pullAndUpdateCourse } from './lib/course.js';
 import * as externalGrader from './lib/externalGrader.js';
 import * as externalGraderResults from './lib/externalGraderResults.js';
 import * as externalGradingSocket from './lib/externalGradingSocket.js';
-import * as workspace from './lib/workspace.js';
-import * as sqldb from '@prairielearn/postgres';
-import * as migrations from '@prairielearn/migrations';
-import * as error from '@prairielearn/error';
-import * as sprocs from './sprocs/index.js';
-import * as news_items from './news_items/index.js';
-import * as cron from './cron/index.js';
-import * as socketServer from './lib/socket-server.js';
-import * as freeformServer from './question-servers/freeform.js';
-import { cache } from '@prairielearn/cache';
-import { LocalCache } from './lib/local-cache.js';
-import * as codeCaller from './lib/code-caller/index.js';
-import * as assets from './lib/assets.js';
-import * as namedLocks from '@prairielearn/named-locks';
-import { EncodedData } from '@prairielearn/browser-utils';
-import * as nodeMetrics from './lib/node-metrics.js';
-import { isEnterprise } from './lib/license.js';
-import * as lifecycleHooks from './lib/lifecycle-hooks.js';
-import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from './lib/paths.js';
-import staticNodeModules from './middlewares/staticNodeModules.js';
-import { flashMiddleware, flash } from '@prairielearn/flash';
 import { features } from './lib/features/index.js';
 import { featuresMiddleware } from './lib/features/middleware.js';
-import { markAllWorkspaceHostsUnhealthy } from './lib/workspaceHost.js';
-import { createSessionMiddleware } from '@prairielearn/session';
-import { PostgresSessionStore } from './lib/session-store.js';
-import { pullAndUpdateCourse } from './lib/course.js';
+import { isEnterprise } from './lib/license.js';
+import * as lifecycleHooks from './lib/lifecycle-hooks.js';
+import * as load from './lib/load.js';
+import { LocalCache } from './lib/local-cache.js';
+import * as nodeMetrics from './lib/node-metrics.js';
+import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from './lib/paths.js';
 import * as serverJobs from './lib/server-jobs.js';
+import { PostgresSessionStore } from './lib/session-store.js';
+import * as socketServer from './lib/socket-server.js';
 import { SocketActivityMetrics } from './lib/telemetry/socket-activity-metrics.js';
+import * as workspace from './lib/workspace.js';
+import { markAllWorkspaceHostsUnhealthy } from './lib/workspaceHost.js';
+import staticNodeModules from './middlewares/staticNodeModules.js';
+import * as news_items from './news_items/index.js';
+import * as freeformServer from './question-servers/freeform.js';
+import * as sprocs from './sprocs/index.js';
 
 process.on('warning', (e) => console.warn(e));
 

--- a/apps/prairielearn/src/sprocs/index.ts
+++ b/apps/prairielearn/src/sprocs/index.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+
 import { eachSeries } from 'async';
 
 import * as error from '@prairielearn/error';

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1,20 +1,22 @@
 import * as path from 'path';
-import _ from 'lodash';
-import fs from 'fs-extra';
-import * as async from 'async';
-import jju from 'jju';
+
 import { Ajv, type JSONSchemaType } from 'ajv';
+import * as async from 'async';
 import betterAjvErrors from 'better-ajv-errors';
 import { parseISO, isValid, isAfter, isFuture } from 'date-fns';
+import fs from 'fs-extra';
+import jju from 'jju';
+import _ from 'lodash';
 
 import { chalk } from '../lib/chalk.js';
 import { config } from '../lib/config.js';
-import * as schemas from '../schemas/index.js';
-import * as infofile from './infofile.js';
-import { validateJSON } from '../lib/json-load.js';
-import { makePerformance } from './performance.js';
-import { selectInstitutionForCourse } from '../models/institution.js';
 import { features } from '../lib/features/index.js';
+import { validateJSON } from '../lib/json-load.js';
+import { selectInstitutionForCourse } from '../models/institution.js';
+import * as schemas from '../schemas/index.js';
+
+import * as infofile from './infofile.js';
+import { makePerformance } from './performance.js';
 
 const perf = makePerformance('course-db');
 

--- a/apps/prairielearn/src/sync/fromDisk/assessmentModules.ts
+++ b/apps/prairielearn/src/sync/fromDisk/assessmentModules.ts
@@ -1,8 +1,8 @@
 import * as sqldb from '@prairielearn/postgres';
 
+import { CourseData } from '../course-db.js';
 import * as infofile from '../infofile.js';
 import { makePerformance } from '../performance.js';
-import { CourseData } from '../course-db.js';
 
 const perf = makePerformance('assessmentModules');
 

--- a/apps/prairielearn/src/sync/fromDisk/assessmentSets.ts
+++ b/apps/prairielearn/src/sync/fromDisk/assessmentSets.ts
@@ -1,8 +1,8 @@
 import * as sqldb from '@prairielearn/postgres';
 
+import { CourseData } from '../course-db.js';
 import * as infofile from '../infofile.js';
 import { makePerformance } from '../performance.js';
-import { CourseData } from '../course-db.js';
 
 const perf = makePerformance('assessmentSets');
 

--- a/apps/prairielearn/src/sync/fromDisk/assessments.ts
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.ts
@@ -1,14 +1,15 @@
 import { isFuture, isValid, parseISO } from 'date-fns';
 import _ from 'lodash';
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
-import * as infofile from '../infofile.js';
-import { features } from '../../lib/features/index.js';
-import { makePerformance } from '../performance.js';
-import { Assessment, CourseInstanceData } from '../course-db.js';
 import { IdSchema } from '../../lib/db-types.js';
+import { features } from '../../lib/features/index.js';
+import { Assessment, CourseInstanceData } from '../course-db.js';
+import * as infofile from '../infofile.js';
+import { makePerformance } from '../performance.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const perf = makePerformance('assessments');

--- a/apps/prairielearn/src/sync/fromDisk/courseInfo.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInfo.ts
@@ -1,7 +1,7 @@
 import * as sqldb from '@prairielearn/postgres';
 
-import * as infofile from '../infofile.js';
 import { CourseData } from '../course-db.js';
+import * as infofile from '../infofile.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
@@ -1,11 +1,12 @@
 import _ from 'lodash';
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
+import { IdSchema } from '../../lib/db-types.js';
+import { CourseData, CourseInstance } from '../course-db.js';
 import * as infofile from '../infofile.js';
 import { makePerformance } from '../performance.js';
-import { CourseData, CourseInstance } from '../course-db.js';
-import { IdSchema } from '../../lib/db-types.js';
 
 const perf = makePerformance('courseInstances');
 

--- a/apps/prairielearn/src/sync/fromDisk/questions.ts
+++ b/apps/prairielearn/src/sync/fromDisk/questions.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
+import { IdSchema } from '../../lib/db-types.js';
+import { CourseData, Question } from '../course-db.js';
 import * as infofile from '../infofile.js';
 import { makePerformance } from '../performance.js';
-import { CourseData, Question } from '../course-db.js';
-import { IdSchema } from '../../lib/db-types.js';
 
 const perf = makePerformance('questions');
 

--- a/apps/prairielearn/src/sync/fromDisk/tags.ts
+++ b/apps/prairielearn/src/sync/fromDisk/tags.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
+import { IdSchema } from '../../lib/db-types.js';
+import { CourseData } from '../course-db.js';
 import * as infofile from '../infofile.js';
 import { makePerformance } from '../performance.js';
-import { CourseData } from '../course-db.js';
-import { IdSchema } from '../../lib/db-types.js';
 
 const perf = makePerformance('tags');
 

--- a/apps/prairielearn/src/sync/fromDisk/topics.ts
+++ b/apps/prairielearn/src/sync/fromDisk/topics.ts
@@ -1,8 +1,8 @@
 import * as sqldb from '@prairielearn/postgres';
 
+import { CourseData } from '../course-db.js';
 import * as infofile from '../infofile.js';
 import { makePerformance } from '../performance.js';
-import { CourseData } from '../course-db.js';
 
 const perf = makePerformance('topics');
 

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -1,19 +1,20 @@
 import * as namedLocks from '@prairielearn/named-locks';
 
+import { chalk, chalkDim } from '../lib/chalk.js';
 import { config } from '../lib/config.js';
+import { getLockNameForCoursePath, selectOrInsertCourseByPath } from '../models/course.js';
+import { flushElementCache } from '../question-servers/freeform.js';
+
 import * as courseDB from './course-db.js';
+import * as syncAssessmentModules from './fromDisk/assessmentModules.js';
+import * as syncAssessmentSets from './fromDisk/assessmentSets.js';
+import * as syncAssessments from './fromDisk/assessments.js';
 import * as syncCourseInfo from './fromDisk/courseInfo.js';
 import * as syncCourseInstances from './fromDisk/courseInstances.js';
-import * as syncTopics from './fromDisk/topics.js';
 import * as syncQuestions from './fromDisk/questions.js';
 import * as syncTags from './fromDisk/tags.js';
-import * as syncAssessmentSets from './fromDisk/assessmentSets.js';
-import * as syncAssessmentModules from './fromDisk/assessmentModules.js';
-import * as syncAssessments from './fromDisk/assessments.js';
-import { flushElementCache } from '../question-servers/freeform.js';
+import * as syncTopics from './fromDisk/topics.js';
 import { makePerformance } from './performance.js';
-import { chalk, chalkDim } from '../lib/chalk.js';
-import { getLockNameForCoursePath, selectOrInsertCourseByPath } from '../models/course.js';
 
 const perf = makePerformance('sync');
 

--- a/apps/prairielearn/src/tests/access.test.ts
+++ b/apps/prairielearn/src/tests/access.test.ts
@@ -1,10 +1,12 @@
 import { assert } from 'chai';
-import request from 'request';
 import * as cheerio from 'cheerio';
+import request from 'request';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 import { ensureEnrollment } from '../models/enrollment.js';
+
 import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/accessAsStudent.test.ts
+++ b/apps/prairielearn/src/tests/accessAsStudent.test.ts
@@ -1,11 +1,13 @@
-import * as cheerio from 'cheerio';
 import { assert } from 'chai';
+import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 
+import * as sqldb from '@prairielearn/postgres';
+
 import { config, type Config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
-import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -1,22 +1,19 @@
-// The OpenTelemetry instrumentation for Express breaks our ability to inspect
-// the Express routes. We need to disable it before loading the server.
-import { disableInstrumentations } from '@prairielearn/opentelemetry';
-disableInstrumentations();
-
-import { test } from 'mocha';
-import axe from 'axe-core';
-import { JSDOM } from 'jsdom';
-import fetch from 'node-fetch';
 import { A11yError } from '@sa11y/format';
+import axe from 'axe-core';
 import expressListEndpoints from 'express-list-endpoints';
+import { JSDOM } from 'jsdom';
+import { test } from 'mocha';
+import fetch from 'node-fetch';
+
+import { disableInstrumentations } from '@prairielearn/opentelemetry';
 import * as sqldb from '@prairielearn/postgres';
 
-import * as server from '../../server.js';
-import * as news_items from '../../news_items/index.js';
 import { config } from '../../lib/config.js';
-import * as helperServer from '../helperServer.js';
 import { features } from '../../lib/features/index.js';
 import { EXAMPLE_COURSE_PATH } from '../../lib/paths.js';
+import * as news_items from '../../news_items/index.js';
+import * as server from '../../server.js';
+import * as helperServer from '../helperServer.js';
 
 const SITE_URL = 'http://localhost:' + config.serverPort;
 
@@ -246,6 +243,10 @@ describe('accessibility', () => {
   let endpoints: expressListEndpoints.Endpoint[] = [];
   let routeParams: Record<string, any> = {};
   before('set up testing server', async function () {
+    // The OpenTelemetry instrumentation for Express breaks our ability to inspect
+    // the Express routes. We need to disable it before loading the server.
+    disableInstrumentations();
+
     config.cronActive = false;
     await helperServer.before(EXAMPLE_COURSE_PATH).call(this);
     config.cronActive = true;

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.ts
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.ts
@@ -1,13 +1,14 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
-import * as helperClient from './helperClient.js';
-
-import { z } from 'zod';
 import { IdSchema, AssessmentInstanceSchema } from '../lib/db-types.js';
+
+import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/administrator.test.ts
+++ b/apps/prairielearn/src/tests/administrator.test.ts
@@ -1,8 +1,9 @@
 import { assert } from 'chai';
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/administratorQueries.test.ts
+++ b/apps/prairielearn/src/tests/administratorQueries.test.ts
@@ -3,8 +3,8 @@ import { step } from 'mocha-steps';
 
 import { config } from '../lib/config.js';
 
-import * as helperServer from './helperServer.js';
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 describe('AdministratorQuery page', function () {
   this.timeout(60000);

--- a/apps/prairielearn/src/tests/api.test.ts
+++ b/apps/prairielearn/src/tests/api.test.ts
@@ -1,11 +1,11 @@
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
-import fetch from 'node-fetch';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 
-import * as helperServer from './helperServer.js';
-import * as helperQuestion from './helperQuestion.js';
 import * as helperExam from './helperExam.js';
+import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const locals: Record<string, any> = {};
 

--- a/apps/prairielearn/src/tests/assets.test.ts
+++ b/apps/prairielearn/src/tests/assets.test.ts
@@ -1,10 +1,11 @@
-import { assert } from 'chai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+
+import { assert } from 'chai';
 import fetch from 'node-fetch';
 
-import { config } from '../lib/config.js';
 import * as assets from '../lib/assets.js';
+import { config } from '../lib/config.js';
 import { APP_ROOT_PATH } from '../lib/paths.js';
 
 import * as helperServer from './helperServer.js';

--- a/apps/prairielearn/src/tests/bonusPoints.test.ts
+++ b/apps/prairielearn/src/tests/bonusPoints.test.ts
@@ -1,10 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/chunkAssessment.test.ts
+++ b/apps/prairielearn/src/tests/chunkAssessment.test.ts
@@ -2,13 +2,14 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import * as tmp from 'tmp-promise';
 
-import { config } from '../lib/config.js';
-import * as chunks from '../lib/chunks.js';
 import * as sqldb from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
+import * as chunks from '../lib/chunks.js';
+import { config } from '../lib/config.js';
+
 import * as helperClient from './helperClient.js';
 import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/chunks.test.ts
+++ b/apps/prairielearn/src/tests/chunks.test.ts
@@ -1,18 +1,21 @@
-import { assert } from 'chai';
-import * as tmp from 'tmp-promise';
-import fs from 'fs-extra';
 import * as path from 'path';
+
+import { assert } from 'chai';
+import fs from 'fs-extra';
+import * as tmp from 'tmp-promise';
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
-import * as courseDB from '../sync/course-db.js';
 import * as chunksLib from '../lib/chunks.js';
 import { config } from '../lib/config.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
-import { makeMockLogger } from './mockLogger.js';
-import * as helperServer from './helperServer.js';
-import { syncDiskToSql } from '../sync/syncFromDisk.js';
+import * as courseDB from '../sync/course-db.js';
 import { makeInfoFile } from '../sync/infofile.js';
+import { syncDiskToSql } from '../sync/syncFromDisk.js';
+
+import * as helperServer from './helperServer.js';
+import { makeMockLogger } from './mockLogger.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
+
 import * as helperExam from './helperExam.js';
 import * as helperServer from './helperServer.js';
 

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -1,16 +1,19 @@
+import { exec } from 'child_process';
+import * as path from 'path';
+
+import * as async from 'async';
 import ERR from 'async-stacktrace';
 import { assert } from 'chai';
-import fs from 'fs-extra';
-import * as path from 'path';
-import * as async from 'async';
 import * as cheerio from 'cheerio';
-import { exec } from 'child_process';
-import fetch from 'node-fetch';
+import fs from 'fs-extra';
 import klaw from 'klaw';
+import fetch from 'node-fetch';
 import * as tmp from 'tmp';
 
-import { config } from '../lib/config.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/courseElementExtension.test.ts
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.ts
@@ -1,16 +1,19 @@
-import { assert } from 'chai';
-import { step } from 'mocha-steps';
-import fs from 'fs-extra';
-import { config } from '../lib/config.js';
-import * as sqldb from '@prairielearn/postgres';
-import _ from 'lodash';
 import * as path from 'path';
-import * as freeform from '../question-servers/freeform.js';
-import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths.js';
 import { promisify } from 'util';
 
-import * as helperServer from './helperServer.js';
+import { assert } from 'chai';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import { step } from 'mocha-steps';
+
+import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
+import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths.js';
+import * as freeform from '../question-servers/freeform.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/cron.test.ts
+++ b/apps/prairielearn/src/tests/cron.test.ts
@@ -1,9 +1,11 @@
-import _ from 'lodash';
-import * as cron from '../cron/index.js';
 import { assert } from 'chai';
+import _ from 'lodash';
+
 import * as sqldb from '@prairielearn/postgres';
 
+import * as cron from '../cron/index.js';
 import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/database.test.ts
+++ b/apps/prairielearn/src/tests/database.test.ts
@@ -1,8 +1,11 @@
-import _ from 'lodash';
 import * as path from 'node:path';
+
+import _ from 'lodash';
+
 import { describeDatabase, diffDirectoryAndDatabase } from '@prairielearn/postgres-tools';
 
 import { REPOSITORY_ROOT_PATH } from '../lib/paths.js';
+
 import * as helperDb from './helperDb.js';
 
 // Custom error type so we can display our own message and omit a stacktrace

--- a/apps/prairielearn/src/tests/editorUtil.test.ts
+++ b/apps/prairielearn/src/tests/editorUtil.test.ts
@@ -1,5 +1,6 @@
-import * as editor from '../lib/editorUtil.js';
 import { assert } from 'chai';
+
+import * as editor from '../lib/editorUtil.js';
 
 describe('editor library', () => {
   it('gets details for course info file', () => {

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -1,8 +1,10 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import { queryAsync } from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 import { enrollUser, unenrollUser } from './utils/enrollments.js';
 

--- a/apps/prairielearn/src/tests/exam.test.ts
+++ b/apps/prairielearn/src/tests/exam.test.ts
@@ -1,13 +1,13 @@
 import ERR from 'async-stacktrace';
-import _ from 'lodash';
 import { assert } from 'chai';
+import _ from 'lodash';
 
 import * as sqldb from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
-import * as helperQuestion from './helperQuestion.js';
-import * as helperExam from './helperExam.js';
 import * as helperAttachFiles from './helperAttachFiles.js';
+import * as helperExam from './helperExam.js';
+import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/exampleCourseQuestions.test.ts
+++ b/apps/prairielearn/src/tests/exampleCourseQuestions.test.ts
@@ -1,12 +1,13 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+
 import fg from 'fast-glob';
 
 import { config } from '../lib/config.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 
-import * as helperServer from './helperServer.js';
 import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const locals: Record<string, any> = {};
 

--- a/apps/prairielearn/src/tests/features.test.ts
+++ b/apps/prairielearn/src/tests/features.test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
+
 import { queryAsync } from '@prairielearn/postgres';
+
+import { FeatureManager } from '../lib/features/manager.js';
 
 import * as helperCourse from './helperCourse.js';
 import * as helperDb from './helperDb.js';
-import { FeatureManager } from '../lib/features/manager.js';
 
 describe('features', () => {
   before(async function () {

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -1,21 +1,24 @@
-import ERR from 'async-stacktrace';
-import request from 'request';
-import { assert } from 'chai';
-import { readFileSync } from 'node:fs';
-import fs from 'fs-extra';
-import * as path from 'path';
-import * as async from 'async';
-import * as cheerio from 'cheerio';
-import * as tmp from 'tmp';
-import fetch, { FormData } from 'node-fetch';
-
-import { config } from '../lib/config.js';
-import * as sqldb from '@prairielearn/postgres';
-import * as helperServer from './helperServer.js';
 import { exec } from 'child_process';
+import { readFileSync } from 'node:fs';
+import * as path from 'path';
+
+import * as async from 'async';
+import ERR from 'async-stacktrace';
+import { assert } from 'chai';
+import * as cheerio from 'cheerio';
+import fs from 'fs-extra';
+import fetch, { FormData } from 'node-fetch';
+import request from 'request';
+import * as tmp from 'tmp';
+
+import * as sqldb from '@prairielearn/postgres';
+
 import * as b64Util from '../lib/base64-util.js';
-import { encodePath } from '../lib/uri-util.js';
+import { config } from '../lib/config.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
+import { encodePath } from '../lib/uri-util.js';
+
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/getHomepage.test.ts
+++ b/apps/prairielearn/src/tests/getHomepage.test.ts
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
 const baseUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/gradeRate.test.ts
+++ b/apps/prairielearn/src/tests/gradeRate.test.ts
@@ -1,11 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 
-import * as helperServer from './helperServer.js';
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -1,12 +1,14 @@
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
+import fetch from 'node-fetch';
+import { io } from 'socket.io-client';
+
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import fetch from 'node-fetch';
-import * as helperServer from './helperServer.js';
-import * as sqldb from '@prairielearn/postgres';
-import { io } from 'socket.io-client';
+
 import { setUser, parseInstanceQuestionId, saveOrGrade, User } from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/groupExam.test.ts
+++ b/apps/prairielearn/src/tests/groupExam.test.ts
@@ -1,16 +1,18 @@
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
-import fetch from 'node-fetch';
 import fetchCookie from 'fetch-cookie';
-import { config } from '../lib/config.js';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 
 import { queryAsync, queryOneRowAsync, queryRows, loadSqlEquiv } from '@prairielearn/postgres';
-const sql = loadSqlEquiv(import.meta.url);
+
+import { config } from '../lib/config.js';
+import { UserSchema } from '../lib/db-types.js';
+import { TEST_COURSE_PATH } from '../lib/paths.js';
 
 import * as helperServer from './helperServer.js';
-import { TEST_COURSE_PATH } from '../lib/paths.js';
-import { UserSchema } from '../lib/db-types.js';
+
+const sql = loadSqlEquiv(import.meta.url);
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';

--- a/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
+++ b/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
-import { config } from '../lib/config.js';
 
 import {
   queryAsync,
@@ -12,9 +11,11 @@ import {
   queryOneRowAsync,
 } from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
-import { TEST_COURSE_PATH } from '../lib/paths.js';
+import { config } from '../lib/config.js';
 import { QuestionSchema, UserSchema, GroupRoleSchema } from '../lib/db-types.js';
+import { TEST_COURSE_PATH } from '../lib/paths.js';
+
+import * as helperServer from './helperServer.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.ts
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.ts
@@ -1,11 +1,13 @@
 import { assert } from 'chai';
-import * as sqldb from '@prairielearn/postgres';
 import { step } from 'mocha-steps';
 
-import * as helperServer from './helperServer.js';
-import { deleteAllGroups } from '../lib/groups.js';
+import * as sqldb from '@prairielearn/postgres';
+
 import * as groupUpdate from '../lib/group-update.js';
+import { deleteAllGroups } from '../lib/groups.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
+
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const locals: Record<string, any> = {};

--- a/apps/prairielearn/src/tests/groupRole.test.ts
+++ b/apps/prairielearn/src/tests/groupRole.test.ts
@@ -1,18 +1,20 @@
+import * as path from 'path';
+
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
-import fetch from 'node-fetch';
 import fs from 'fs-extra';
-import * as path from 'path';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 import * as tmp from 'tmp-promise';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import { syncCourseData, type GroupRole } from './sync/util.js';
-
-import * as helperServer from './helperServer.js';
 import { getGroupRoleReassignmentsAfterLeave } from '../lib/groups.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
+
+import * as helperServer from './helperServer.js';
+import { syncCourseData, type GroupRole } from './sync/util.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/groupRolePermissions.test.ts
+++ b/apps/prairielearn/src/tests/groupRolePermissions.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
-import { config } from '../lib/config.js';
 
 import {
   queryAsync,
@@ -11,9 +10,11 @@ import {
   queryRow,
 } from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
-import { TEST_COURSE_PATH } from '../lib/paths.js';
+import { config } from '../lib/config.js';
 import { UserSchema, GroupRoleSchema, IdSchema } from '../lib/db-types.js';
+import { TEST_COURSE_PATH } from '../lib/paths.js';
+
+import * as helperServer from './helperServer.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/groupScoreAndSync.test.ts
+++ b/apps/prairielearn/src/tests/groupScoreAndSync.test.ts
@@ -1,12 +1,14 @@
 import ERR from 'async-stacktrace';
-import _ from 'lodash';
 import { assert } from 'chai';
-import request from 'request';
 import * as cheerio from 'cheerio';
+import _ from 'lodash';
+import request from 'request';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
+
 import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/groupStudent.test.ts
+++ b/apps/prairielearn/src/tests/groupStudent.test.ts
@@ -1,16 +1,17 @@
 import ERR from 'async-stacktrace';
-import fetch from 'node-fetch';
+import { assert } from 'chai';
+import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
+import fetch from 'node-fetch';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import { assert } from 'chai';
-import * as cheerio from 'cheerio';
-
-import * as helperServer from './helperServer.js';
 import { idsEqual } from '../lib/id.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
+
 import { fetchCheerio } from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/helperAttachFiles.ts
+++ b/apps/prairielearn/src/tests/helperAttachFiles.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
-import fetch, { FormData } from 'node-fetch';
 import * as cheerio from 'cheerio';
+import fetch, { FormData } from 'node-fetch';
 
 import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/helperClient.ts
+++ b/apps/prairielearn/src/tests/helperClient.ts
@@ -1,6 +1,7 @@
-import fetch, { RequestInit, Response } from 'node-fetch';
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
+import fetch, { RequestInit, Response } from 'node-fetch';
+
 import { config } from '../lib/config.js';
 
 interface CheerioResponse extends Response {

--- a/apps/prairielearn/src/tests/helperCourse.ts
+++ b/apps/prairielearn/src/tests/helperCourse.ts
@@ -1,5 +1,6 @@
 import { TEST_COURSE_PATH } from '../lib/paths.js';
 import * as syncFromDisk from '../sync/syncFromDisk.js';
+
 import { makeMockLogger } from './mockLogger.js';
 
 export async function syncCourse(courseDir = TEST_COURSE_PATH) {

--- a/apps/prairielearn/src/tests/helperDb.ts
+++ b/apps/prairielearn/src/tests/helperDb.ts
@@ -1,16 +1,18 @@
-import pg from 'pg';
 import * as path from 'path';
 
-import * as sqldb from '@prairielearn/postgres';
+import { Context } from 'mocha';
+import pg from 'pg';
+
 import {
   init as initMigrations,
   initBatchedMigrations,
   SCHEMA_MIGRATIONS_PATH,
   stopBatchedMigrations,
 } from '@prairielearn/migrations';
-import * as sprocs from '../sprocs/index.js';
 import * as namedLocks from '@prairielearn/named-locks';
-import { Context } from 'mocha';
+import * as sqldb from '@prairielearn/postgres';
+
+import * as sprocs from '../sprocs/index.js';
 
 const POSTGRES_USER = 'postgres';
 const POSTGRES_HOST = 'localhost';

--- a/apps/prairielearn/src/tests/helperExam.ts
+++ b/apps/prairielearn/src/tests/helperExam.ts
@@ -1,10 +1,11 @@
-import _ from 'lodash';
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
+import _ from 'lodash';
 import fetch from 'node-fetch';
 
-import { config } from '../lib/config.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/helperQuestion.ts
+++ b/apps/prairielearn/src/tests/helperQuestion.ts
@@ -1,8 +1,9 @@
+import { setTimeout as sleep } from 'timers/promises';
+
 import { assert } from 'chai';
 import * as cheerio from 'cheerio';
-import fetch, { FormData } from 'node-fetch';
-import { setTimeout as sleep } from 'timers/promises';
 import _ from 'lodash';
+import fetch, { FormData } from 'node-fetch';
 
 import * as sqldb from '@prairielearn/postgres';
 

--- a/apps/prairielearn/src/tests/helperQuestionPreview.ts
+++ b/apps/prairielearn/src/tests/helperQuestionPreview.ts
@@ -1,7 +1,9 @@
 import { assert } from 'chai';
 import request from 'request';
-import * as helperQuestion from './helperQuestion.js';
+
 import * as sqldb from '@prairielearn/postgres';
+
+import * as helperQuestion from './helperQuestion.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/helperServer.ts
+++ b/apps/prairielearn/src/tests/helperServer.ts
@@ -1,32 +1,32 @@
-import * as tmp from 'tmp-promise';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { assert } from 'chai';
-import * as opentelemetry from '@prairielearn/opentelemetry';
-import debugfn from 'debug';
-import { cache } from '@prairielearn/cache';
 
-import * as assets from '../lib/assets.js';
-import { config } from '../lib/config.js';
-import * as load from '../lib/load.js';
+import { assert } from 'chai';
+import debugfn from 'debug';
+import * as tmp from 'tmp-promise';
+
+import { cache } from '@prairielearn/cache';
+import * as opentelemetry from '@prairielearn/opentelemetry';
+import * as sqldb from '@prairielearn/postgres';
+
 import * as cron from '../cron/index.js';
-import * as socketServer from '../lib/socket-server.js';
-import * as serverJobs from '../lib/server-jobs.js';
-import * as freeformServer from '../question-servers/freeform.js';
-import * as localCache from '../lib/local-cache.js';
+import * as assets from '../lib/assets.js';
 import * as codeCaller from '../lib/code-caller/index.js';
+import { config } from '../lib/config.js';
 import * as externalGrader from '../lib/externalGrader.js';
 import * as externalGradingSocket from '../lib/externalGradingSocket.js';
+import * as load from '../lib/load.js';
+import * as localCache from '../lib/local-cache.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
-
-import * as sqldb from '@prairielearn/postgres';
-const sql = sqldb.loadSqlEquiv(import.meta.url);
-
+import * as serverJobs from '../lib/server-jobs.js';
+import * as socketServer from '../lib/socket-server.js';
+import * as freeformServer from '../question-servers/freeform.js';
 import * as server from '../server.js';
 
-import * as helperDb from './helperDb.js';
 import * as helperCourse from './helperCourse.js';
+import * as helperDb from './helperDb.js';
 
 const debug = debugfn('prairielearn:helperServer');
+const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 config.startServer = false;
 // Pick a unique port based on the Mocha worker ID.

--- a/apps/prairielearn/src/tests/homework.test.ts
+++ b/apps/prairielearn/src/tests/homework.test.ts
@@ -1,14 +1,15 @@
-import _ from 'lodash';
 import { assert } from 'chai';
-import request from 'request';
 import * as cheerio from 'cheerio';
+import _ from 'lodash';
+import request from 'request';
 
-import { config } from '../lib/config.js';
 import * as sqldb from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
-import * as helperQuestion from './helperQuestion.js';
+import { config } from '../lib/config.js';
+
 import * as helperAttachFiles from './helperAttachFiles.js';
+import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/honorCode.test.ts
+++ b/apps/prairielearn/src/tests/honorCode.test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/instructorAssessment.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.ts
@@ -1,11 +1,11 @@
 import { assert } from 'chai';
-import request from 'request';
 import * as cheerio from 'cheerio';
 import _ from 'lodash';
+import request from 'request';
 
-import * as helperServer from './helperServer.js';
-import * as helperQuestion from './helperQuestion.js';
 import * as helperExam from './helperExam.js';
+import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const locals: Record<string, any> = {};
 

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -1,12 +1,12 @@
-import _ from 'lodash';
 import { assert } from 'chai';
-import request from 'request';
 import * as cheerio from 'cheerio';
 import { parse as csvParse } from 'csv-parse/sync';
+import _ from 'lodash';
+import request from 'request';
 
-import * as helperServer from './helperServer.js';
-import * as helperQuestion from './helperQuestion.js';
 import * as helperExam from './helperExam.js';
+import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const locals: Record<string, any> = {};
 

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -1,12 +1,14 @@
 import { assert } from 'chai';
-import { step } from 'mocha-steps';
 import fetchCookie from 'fetch-cookie';
+import { step } from 'mocha-steps';
+
 import { callRows, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
-import { extractAndSaveCSRFToken, fetchCheerio, getCSRFToken } from './helperClient.js';
-import { IdSchema, type User, UserSchema } from '../lib/db-types.js';
 import { config } from '../lib/config.js';
+import { IdSchema, type User, UserSchema } from '../lib/db-types.js';
+
+import { extractAndSaveCSRFToken, fetchCheerio, getCSRFToken } from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/instructorBreakVariants.test.ts
+++ b/apps/prairielearn/src/tests/instructorBreakVariants.test.ts
@@ -1,12 +1,14 @@
+import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
-import * as helperServer from './helperServer.js';
-import { IdSchema } from '../lib/db-types.js';
 import { config } from '../lib/config.js';
-import { AuthUser, withUser } from './utils/auth.js';
+import { IdSchema } from '../lib/db-types.js';
+
 import { fetchCheerio, getCSRFToken } from './helperClient.js';
-import { assert } from 'chai';
+import * as helperServer from './helperServer.js';
+import { AuthUser, withUser } from './utils/auth.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/instructorCourseAdminSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorCourseAdminSettings.test.ts
@@ -1,16 +1,19 @@
-import { config } from '../lib/config.js';
 import * as path from 'path';
+
+import { assert } from 'chai';
+import { execa } from 'execa';
 import fs from 'fs-extra';
-import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
 import { step } from 'mocha-steps';
 import * as tmp from 'tmp';
-import { execa } from 'execa';
 
-import * as helperServer from './helperServer.js';
-import { fetchCheerio } from './helperClient.js';
-import { assert } from 'chai';
-import { selectCourseById } from '../models/course.js';
+import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
 import { insertCoursePermissionsByUserUid } from '../models/course-permissions.js';
+import { selectCourseById } from '../models/course.js';
+
+import { fetchCheerio } from './helperClient.js';
+import * as helperServer from './helperServer.js';
 import { getOrCreateUser, withUser } from './utils/auth.js';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/instructorQuestions.test.ts
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.ts
@@ -1,13 +1,15 @@
-import _ from 'lodash';
 import { assert } from 'chai';
-import request from 'request';
 import * as cheerio from 'cheerio';
+import _ from 'lodash';
+import request from 'request';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
 import { idsEqual } from '../lib/id.js';
+
 import { testFileDownloads, testQuestionPreviews } from './helperQuestionPreview.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/issues.test.ts
+++ b/apps/prairielearn/src/tests/issues.test.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';

--- a/apps/prairielearn/src/tests/jsonLoad.test.ts
+++ b/apps/prairielearn/src/tests/jsonLoad.test.ts
@@ -1,5 +1,7 @@
-import { assert } from 'chai';
 import * as path from 'path';
+
+import { assert } from 'chai';
+
 import * as jsonLoad from '../lib/json-load.js';
 
 const testfile = (filename: string) => path.join(import.meta.dirname, 'testJsonLoad', filename);

--- a/apps/prairielearn/src/tests/lti.test.ts
+++ b/apps/prairielearn/src/tests/lti.test.ts
@@ -1,10 +1,12 @@
+import { assert } from 'chai';
 import fetch from 'node-fetch';
 import oauthSignature from 'oauth-signature';
-import { assert } from 'chai';
+
+import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
-import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/lti13.test.ts
+++ b/apps/prairielearn/src/tests/lti13.test.ts
@@ -1,17 +1,19 @@
-import { step } from 'mocha-steps';
 import { assert } from 'chai';
+import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
-import nodeJose from 'node-jose';
 import * as jose from 'jose';
-import express from 'express';
+import { step } from 'mocha-steps';
+import nodeJose from 'node-jose';
+
+import { queryAsync, queryOptionalRow } from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
-import { fetchCheerio } from './helperClient.js';
-import { queryAsync, queryOptionalRow } from '@prairielearn/postgres';
-import { selectUserByUid } from '../models/user.js';
 import { Lti13UserSchema } from '../lib/db-types.js';
+import { selectUserByUid } from '../models/user.js';
+
+import { fetchCheerio } from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const CLIENT_ID = 'prairielearn_test_lms';
 

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -4,14 +4,16 @@ import _ from 'lodash';
 import { step } from 'mocha-steps';
 import fetch from 'node-fetch';
 
-import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
-import { setUser, parseInstanceQuestionId, saveOrGrade, User } from './helperClient.js';
 import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
 import {
   insertCourseInstancePermissions,
   insertCoursePermissionsByUserUid,
 } from '../models/course-permissions.js';
+
+import { setUser, parseInstanceQuestionId, saveOrGrade, User } from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/markdown.test.ts
+++ b/apps/prairielearn/src/tests/markdown.test.ts
@@ -1,5 +1,6 @@
-import * as markdown from '../lib/markdown.js';
 import { assert } from 'chai';
+
+import * as markdown from '../lib/markdown.js';
 
 const testMarkdownQuestion = (question, expected) => {
   const actual = markdown.processQuestion(question);

--- a/apps/prairielearn/src/tests/mockLogger.ts
+++ b/apps/prairielearn/src/tests/mockLogger.ts
@@ -1,4 +1,5 @@
 import * as stream from 'stream';
+
 import winston from 'winston';
 
 interface MockLogger {

--- a/apps/prairielearn/src/tests/newsItems.test.ts
+++ b/apps/prairielearn/src/tests/newsItems.test.ts
@@ -1,10 +1,11 @@
 import { assert } from 'chai';
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import fetch from 'node-fetch';
+
 import * as sqldb from '@prairielearn/postgres';
 
-import * as news_items from '../news_items/index.js';
 import { config } from '../lib/config.js';
+import * as news_items from '../news_items/index.js';
 
 import * as helperServer from './helperServer.js';
 

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
@@ -1,11 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
-import * as helperServer from '../helperServer.js';
-import * as helperClient from '../helperClient.js';
 import { insertCoursePermissionsByUserUid } from '../../models/course-permissions.js';
+import * as helperClient from '../helperClient.js';
+import * as helperServer from '../helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.ts
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.ts
@@ -1,18 +1,19 @@
 // @ts-check
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
-import * as helperServer from '../helperServer.js';
-import * as helperClient from '../helperClient.js';
-import { ensureEnrollment } from '../../models/enrollment.js';
 import {
   insertCourseInstancePermissions,
   insertCoursePermissionsByUserUid,
   updateCourseInstancePermissionsRole,
   updateCoursePermissionsRole,
 } from '../../models/course-permissions.js';
+import { ensureEnrollment } from '../../models/enrollment.js';
+import * as helperClient from '../helperClient.js';
+import * as helperServer from '../helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/permissions/studentData.test.ts
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.ts
@@ -1,16 +1,17 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
-import * as helperServer from '../helperServer.js';
-import * as helperClient from '../helperClient.js';
-import { ensureEnrollment } from '../../models/enrollment.js';
 import {
   insertCourseInstancePermissions,
   insertCoursePermissionsByUserUid,
   updateCourseInstancePermissionsRole,
 } from '../../models/course-permissions.js';
+import { ensureEnrollment } from '../../models/enrollment.js';
+import * as helperClient from '../helperClient.js';
+import * as helperServer from '../helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/publicQuestionPreview.test.ts
+++ b/apps/prairielearn/src/tests/publicQuestionPreview.test.ts
@@ -1,8 +1,11 @@
-import { testQuestionPreviews, testFileDownloads } from './helperQuestionPreview.js';
-import { config } from '../lib/config.js';
 import { z } from 'zod';
-import { features } from '../lib/features/index.js';
+
 import * as sqldb from '@prairielearn/postgres';
+
+import { config } from '../lib/config.js';
+import { features } from '../lib/features/index.js';
+
+import { testQuestionPreviews, testFileDownloads } from './helperQuestionPreview.js';
 import * as helperServer from './helperServer.js';
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -1,8 +1,10 @@
-import { assert } from 'chai';
-import { step } from 'mocha-steps';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+
+import { assert } from 'chai';
+import { step } from 'mocha-steps';
 import fetch from 'node-fetch';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
@@ -10,6 +12,7 @@ import { Course } from '../lib/db-types.js';
 import { features } from '../lib/features/index.js';
 import { selectCourseById } from '../models/course.js';
 import * as syncFromDisk from '../sync/syncFromDisk.js';
+
 import { fetchCheerio } from './helperClient.js';
 import * as helperServer from './helperServer.js';
 import { makeMockLogger } from './mockLogger.js';

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.ts
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.ts
@@ -1,11 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 
-import * as helperServer from './helperServer.js';
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/redirects.test.ts
+++ b/apps/prairielearn/src/tests/redirects.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/rpy2.test.ts
+++ b/apps/prairielearn/src/tests/rpy2.test.ts
@@ -1,12 +1,14 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import { queryRow } from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 import { IdSchema } from '../lib/db-types.js';
 import { features } from '../lib/features/index.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
 

--- a/apps/prairielearn/src/tests/schemas.test.ts
+++ b/apps/prairielearn/src/tests/schemas.test.ts
@@ -1,5 +1,6 @@
 import { Ajv } from 'ajv';
 import { assert } from 'chai';
+
 import * as schemas from '../schemas/index.js';
 
 const isObject = (a) => !!a && a.constructor === Object;

--- a/apps/prairielearn/src/tests/serverJobs.test.ts
+++ b/apps/prairielearn/src/tests/serverJobs.test.ts
@@ -1,8 +1,10 @@
 import { assert } from 'chai';
 import stripAnsi from 'strip-ansi';
+
 import { logger } from '@prairielearn/logger';
 
 import { createServerJob, getJobSequence } from '../lib/server-jobs.js';
+
 import * as helperServer from './helperServer.js';
 
 function disableLoggingForTests() {

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.ts
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.ts
@@ -1,10 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.ts
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.ts
@@ -1,10 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.ts
@@ -2,8 +2,9 @@ import { assert } from 'chai';
 import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
-import * as helperDb from '../helperDb.js';
+
 import { type Mode } from '../../lib/db-types.js';
+import * as helperDb from '../helperDb.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/check_course_instance_access.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import * as helperDb from '../helperDb.js';

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import * as helperDb from '../helperDb.js';

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.ts
@@ -2,6 +2,7 @@ import { assert } from 'chai';
 import { step } from 'mocha-steps';
 
 import * as sqldb from '@prairielearn/postgres';
+
 import * as helperDb from '../helperDb.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentModulesSync.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 
 import * as helperDb from '../helperDb.js';
+
 import * as util from './util.js';
 
 /**

--- a/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.ts
@@ -1,6 +1,8 @@
 import { assert } from 'chai';
-import * as util from './util.js';
+
 import * as helperDb from '../helperDb.js';
+
+import * as util from './util.js';
 
 /**
  * Checks that the assessment set present in the database matches the data

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1,14 +1,17 @@
 // @ts-check
+import * as path from 'path';
+
 import { assert } from 'chai';
 import fs from 'fs-extra';
-import * as path from 'path';
+
+import * as sqldb from '@prairielearn/postgres';
+
 import { config } from '../../lib/config.js';
 import { features } from '../../lib/features/index.js';
-import * as sqldb from '@prairielearn/postgres';
 import { idsEqual } from '../../lib/id.js';
+import * as helperDb from '../helperDb.js';
 
 import * as util from './util.js';
-import * as helperDb from '../helperDb.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/sync/courseDb.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.ts
@@ -1,10 +1,12 @@
-import { assert } from 'chai';
-import * as tmp from 'tmp-promise';
-import fs from 'fs-extra';
 import * as path from 'path';
+
+import { assert } from 'chai';
+import fs from 'fs-extra';
+import * as tmp from 'tmp-promise';
 
 import * as courseDb from '../../sync/course-db.js';
 import * as infofile from '../../sync/infofile.js';
+
 import { Question } from './util.js';
 
 async function withTempDirectory(callback: (dir: string) => Promise<void>) {

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -1,9 +1,12 @@
+import * as path from 'path';
+
 import { assert } from 'chai';
 import fs from 'fs-extra';
-import * as path from 'path';
-import * as util from './util.js';
-import * as helperDb from '../helperDb.js';
+
 import { idsEqual } from '../../lib/id.js';
+import * as helperDb from '../helperDb.js';
+
+import * as util from './util.js';
 
 /**
  * Makes an empty course instance.

--- a/apps/prairielearn/src/tests/sync/courseSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseSync.test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
-import * as util from './util.js';
-import * as helperDb from '../helperDb.js';
+
 import { config } from '../../lib/config.js';
 import { features } from '../../lib/features/index.js';
 import { selectOrInsertCourseByPath } from '../../models/course.js';
+import * as helperDb from '../helperDb.js';
+
+import * as util from './util.js';
 
 const [sampleFeature1, sampleFeature2] = features.allFeatures();
 const invalidFeature = 'unknown-feature';

--- a/apps/prairielearn/src/tests/sync/initialSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/initialSync.test.ts
@@ -1,6 +1,8 @@
 import { assert } from 'chai';
-import * as util from './util.js';
+
 import * as helperDb from '../helperDb.js';
+
+import * as util from './util.js';
 
 describe('Initial Sync', () => {
   before('set up testing database', helperDb.before);

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.ts
@@ -1,10 +1,12 @@
-import { assert } from 'chai';
-import fs from 'fs-extra';
 import * as path from 'path';
 
-import * as util from './util.js';
-import * as helperDb from '../helperDb.js';
+import { assert } from 'chai';
+import fs from 'fs-extra';
+
 import { idsEqual } from '../../lib/id.js';
+import * as helperDb from '../helperDb.js';
+
+import * as util from './util.js';
 
 /**
  * Makes an empty question.

--- a/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/tagsTopicsSync.test.ts
@@ -1,6 +1,8 @@
 import { assert } from 'chai';
-import * as util from './util.js';
+
 import * as helperDb from '../helperDb.js';
+
+import * as util from './util.js';
 
 /**
  * Topics and tags are currently almost identical, so we test them together

--- a/apps/prairielearn/src/tests/sync/util.ts
+++ b/apps/prairielearn/src/tests/sync/util.ts
@@ -1,9 +1,11 @@
-import fs from 'fs-extra';
-import * as tmp from 'tmp-promise';
 import * as path from 'path';
-import * as sqldb from '@prairielearn/postgres';
-import stringify from 'json-stable-stringify';
+
 import { assert } from 'chai';
+import fs from 'fs-extra';
+import stringify from 'json-stable-stringify';
+import * as tmp from 'tmp-promise';
+
+import * as sqldb from '@prairielearn/postgres';
 
 import * as syncFromDisk from '../../sync/syncFromDisk.js';
 

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
@@ -1,12 +1,13 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
 import { v4 as uuid } from 'uuid';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 
-import * as helperServer from './helperServer.js';
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 import {
   getCourseData,
   COURSE_INSTANCE_ID,

--- a/apps/prairielearn/src/tests/testCourseQuestions.test.ts
+++ b/apps/prairielearn/src/tests/testCourseQuestions.test.ts
@@ -1,7 +1,7 @@
 import { config } from '../lib/config.js';
 
-import * as helperServer from './helperServer.js';
 import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const locals: Record<string, any> = {};
 

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.ts
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.ts
@@ -1,10 +1,12 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/utils/auth.ts
+++ b/apps/prairielearn/src/tests/utils/auth.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
+
 import { callRow, queryRow } from '@prairielearn/postgres';
+
 import { config } from '../../lib/config.js';
 import { IdSchema, User, UserSchema } from '../../lib/db-types.js';
 

--- a/apps/prairielearn/src/tests/utils/enrollments.ts
+++ b/apps/prairielearn/src/tests/utils/enrollments.ts
@@ -1,11 +1,13 @@
 import { assert } from 'chai';
 import fetch from 'node-fetch';
 import { z } from 'zod';
+
 import { queryRow } from '@prairielearn/postgres';
 
 // Must be imported so that `config.serverPort` is set.
 import '../helperServer';
 import { config } from '../../lib/config.js';
+
 import { AuthUser, withUser } from './auth.js';
 import { getCsrfToken } from './csrf.js';
 

--- a/apps/prairielearn/src/tests/workspaceAccess.test.ts
+++ b/apps/prairielearn/src/tests/workspaceAccess.test.ts
@@ -1,11 +1,13 @@
-import * as cheerio from 'cheerio';
 import { assert } from 'chai';
+import * as cheerio from 'cheerio';
 import fetch from 'node-fetch';
 
+import * as sqldb from '@prairielearn/postgres';
+
 import { config, type Config } from '../lib/config.js';
+
 import * as helperServer from './helperServer.js';
 
-import * as sqldb from '@prairielearn/postgres';
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const siteUrl = 'http://localhost:' + config.serverPort;

--- a/apps/prairielearn/src/tests/workspaceHost.test.ts
+++ b/apps/prairielearn/src/tests/workspaceHost.test.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import * as workspaceHostUtils from '../lib/workspaceHost.js';
+
 import * as helperDb from './helperDb.js';
 
 const WorkspaceHostSchema = z.object({

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.ts
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.ts
@@ -1,12 +1,14 @@
-import _ from 'lodash';
 import { assert } from 'chai';
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import _ from 'lodash';
+import fetch from 'node-fetch';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/tests/zoneGradingHomework.test.ts
+++ b/apps/prairielearn/src/tests/zoneGradingHomework.test.ts
@@ -1,12 +1,14 @@
-import _ from 'lodash';
 import { assert } from 'chai';
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
+import _ from 'lodash';
+import fetch from 'node-fetch';
+
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import * as helperServer from './helperServer.js';
+
 import * as helperQuestion from './helperQuestion.js';
+import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/webhooks/terminate.ts
+++ b/apps/prairielearn/src/webhooks/terminate.ts
@@ -1,6 +1,8 @@
+import * as crypto from 'crypto';
+
 import { Router } from 'express';
 import * as jose from 'jose';
-import * as crypto from 'crypto';
+
 import { logger } from '@prairielearn/logger';
 
 import { config } from '../lib/config.js';

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -1,38 +1,40 @@
 // @ts-check
-import ERR from 'async-stacktrace';
-import _ from 'lodash';
-import * as util from 'node:util';
-import express from 'express';
-import * as http from 'node:http';
-import fetch from 'node-fetch';
-import * as path from 'node:path';
-import { S3 } from '@aws-sdk/client-s3';
-import { ECRClient } from '@aws-sdk/client-ecr';
-import { Upload } from '@aws-sdk/lib-storage';
-import Docker from 'dockerode';
 import * as fs from 'node:fs';
-import * as async from 'async';
 import * as fsPromises from 'node:fs/promises';
+import * as http from 'node:http';
+import * as net from 'node:net';
+import * as path from 'node:path';
+import * as util from 'node:util';
+
+import { ECRClient } from '@aws-sdk/client-ecr';
+import { S3 } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
+import archiver from 'archiver';
+import * as async from 'async';
+import { Mutex } from 'async-mutex';
+import ERR from 'async-stacktrace';
+import bodyParser from 'body-parser';
+import debugfn from 'debug';
+import Docker from 'dockerode';
+import express from 'express';
+import asyncHandler from 'express-async-handler';
+import _ from 'lodash';
+import fetch from 'node-fetch';
 import { v4 as uuidv4 } from 'uuid';
 import yargsParser from 'yargs-parser';
-import debugfn from 'debug';
-import archiver from 'archiver';
-import * as net from 'node:net';
-import asyncHandler from 'express-async-handler';
-import bodyParser from 'body-parser';
-import { Mutex } from 'async-mutex';
+
+import { cache } from '@prairielearn/cache';
 import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 import * as workspaceUtils from '@prairielearn/workspace-utils';
-import { cache } from '@prairielearn/cache';
 
+import { makeS3ClientConfig, makeAwsClientConfig } from './lib/aws.js';
 import { config, loadConfig } from './lib/config.js';
 import { parseDockerLogs } from './lib/docker.js';
-import * as socketServer from './lib/socket-server.js';
-import { makeS3ClientConfig, makeAwsClientConfig } from './lib/aws.js';
 import { REPOSITORY_ROOT_PATH, APP_ROOT_PATH } from './lib/paths.js';
+import * as socketServer from './lib/socket-server.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:interface');

--- a/apps/workspace-host/src/lib/aws.ts
+++ b/apps/workspace-host/src/lib/aws.ts
@@ -1,4 +1,5 @@
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+
 import { makeAwsConfigProvider } from '@prairielearn/aws';
 
 import { config } from './config.js';

--- a/apps/workspace-host/src/lib/config.ts
+++ b/apps/workspace-host/src/lib/config.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import {
   ConfigLoader,
   makeFileConfigSource,

--- a/packages/browser-utils/src/encode-data.ts
+++ b/packages/browser-utils/src/encode-data.ts
@@ -1,4 +1,5 @@
 import { encode, decode } from 'js-base64';
+
 import { html, unsafeHtml, HtmlSafeString } from '@prairielearn/html';
 
 /**

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,8 +1,10 @@
+import assert from 'node:assert';
+
 import { Redis } from 'ioredis';
 import { LRUCache } from 'lru-cache';
+
 import { logger } from '@prairielearn/logger';
 import * as Sentry from '@prairielearn/sentry';
-import assert from 'node:assert';
 
 export class Cache {
   enabled = false;

--- a/packages/compiled-assets/src/cli.ts
+++ b/packages/compiled-assets/src/cli.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-import fs from 'fs-extra';
-import prettyBytes from 'pretty-bytes';
 import path from 'path';
 import { promisify } from 'util';
 import zlib from 'zlib';
+
 import { program } from 'commander';
+import fs from 'fs-extra';
+import prettyBytes from 'pretty-bytes';
 
 import { build } from './index.js';
 

--- a/packages/compiled-assets/src/index.test.ts
+++ b/packages/compiled-assets/src/index.test.ts
@@ -1,10 +1,11 @@
-import tmp from 'tmp-promise';
-import fs from 'fs-extra';
 import path from 'path';
-import getPort from 'get-port';
+
 import { assert } from 'chai';
 import express from 'express';
+import fs from 'fs-extra';
+import getPort from 'get-port';
 import fetch from 'node-fetch';
+import tmp from 'tmp-promise';
 
 import {
   init,

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -1,10 +1,12 @@
+import http from 'node:http';
+import path from 'path';
+
+import esbuild, { Metafile } from 'esbuild';
 import type { RequestHandler } from 'express';
 import expressStaticGzip from 'express-static-gzip';
-import esbuild, { Metafile } from 'esbuild';
-import path from 'path';
-import { globby } from 'globby';
 import fs from 'fs-extra';
-import http from 'node:http';
+import { globby } from 'globby';
+
 import { html, HtmlSafeString } from '@prairielearn/html';
 
 const DEFAULT_OPTIONS = {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,5 +1,6 @@
-import { assert } from 'chai';
 import { writeFile } from 'node:fs/promises';
+
+import { assert } from 'chai';
 import { withFile } from 'tmp-promise';
 import { z } from 'zod';
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,8 +1,9 @@
-import _ from 'lodash';
-import fs from 'fs-extra';
-import { z } from 'zod';
 import { EC2Client, DescribeTagsCommand } from '@aws-sdk/client-ec2';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import fs from 'fs-extra';
+import _ from 'lodash';
+import { z } from 'zod';
+
 import { fetchInstanceHostname, fetchInstanceIdentity } from '@prairielearn/aws-imds';
 
 const AbstractConfigSchema = z.record(z.string(), z.unknown());

--- a/packages/csv/src/index.test.ts
+++ b/packages/csv/src/index.test.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream';
+
 import { assert } from 'chai';
 
 import { stringifyStream } from './index.js';

--- a/packages/csv/src/index.ts
+++ b/packages/csv/src/index.ts
@@ -1,6 +1,6 @@
 import { stringify, Stringifier, Options as StringifierOptions } from 'csv-stringify';
-import { transform, Handler as TransformHandler } from 'stream-transform';
 import multipipe from 'multipipe';
+import { transform, Handler as TransformHandler } from 'stream-transform';
 
 export { stringify, Stringifier };
 

--- a/packages/docker-utils/src/index.ts
+++ b/packages/docker-utils/src/index.ts
@@ -4,6 +4,7 @@ import {
   GetAuthorizationTokenCommand,
 } from '@aws-sdk/client-ecr';
 import { subHours, isFuture } from 'date-fns';
+
 import { logger } from '@prairielearn/logger';
 
 export interface DockerAuth {

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+
 import { HtmlSafeString } from '@prairielearn/html';
 
 export { formatErrorStack, formatErrorStackSafe } from './format.js';

--- a/packages/express-test-utils/src/index.ts
+++ b/packages/express-test-utils/src/index.ts
@@ -1,5 +1,6 @@
-import * as express from 'express';
 import { Server } from 'node:http';
+
+import * as express from 'express';
 
 export interface WithServerContext {
   server: Server;

--- a/packages/flash/src/index.test.ts
+++ b/packages/flash/src/index.test.ts
@@ -1,7 +1,8 @@
 import { assert } from 'chai';
 
-import { flashMiddleware, flash } from './index.js';
 import { html } from '@prairielearn/html';
+
+import { flashMiddleware, flash } from './index.js';
 
 describe('flash', () => {
   it('throws an error if no session present', () => {

--- a/packages/flash/src/index.ts
+++ b/packages/flash/src/index.ts
@@ -1,5 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+
 import type { Request, Response, NextFunction } from 'express';
+
 import { HtmlSafeString, html } from '@prairielearn/html';
 
 const als = new AsyncLocalStorage<FlashStorage>();

--- a/packages/html-ejs/src/index.ts
+++ b/packages/html-ejs/src/index.ts
@@ -1,6 +1,7 @@
-import ejs from 'ejs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
+import ejs from 'ejs';
 
 import { unsafeHtml, type HtmlSafeString } from '@prairielearn/html';
 /**

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,5 +1,5 @@
-import { createLogger, transports } from 'winston';
 import { format } from 'logform';
+import { createLogger, transports } from 'winston';
 
 export const logger = createLogger({
   transports: [

--- a/packages/migrations/src/batched-migrations/batched-migration-job.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-job.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 const sql = loadSqlEquiv(import.meta.filename);

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
@@ -1,17 +1,19 @@
 import { assert } from 'chai';
-import { makePostgresTestUtils, queryAsync, queryRow, queryRows } from '@prairielearn/postgres';
-import * as namedLocks from '@prairielearn/named-locks';
-import * as error from '@prairielearn/error';
 
+import * as error from '@prairielearn/error';
+import * as namedLocks from '@prairielearn/named-locks';
+import { makePostgresTestUtils, queryAsync, queryRow, queryRows } from '@prairielearn/postgres';
+
+import { SCHEMA_MIGRATIONS_PATH, init } from '../index.js';
+
+import { BatchedMigrationJobRowSchema } from './batched-migration-job.js';
+import { BatchedMigrationRunner } from './batched-migration-runner.js';
 import {
   BatchedMigrationRowSchema,
   insertBatchedMigration,
   makeBatchedMigration,
   updateBatchedMigrationStatus,
 } from './batched-migration.js';
-import { BatchedMigrationJobRowSchema } from './batched-migration-job.js';
-import { BatchedMigrationRunner } from './batched-migration-runner.js';
-import { SCHEMA_MIGRATIONS_PATH, init } from '../index.js';
 
 const postgresTestUtils = makePostgresTestUtils({
   database: 'prairielearn_migrations',

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.ts
@@ -1,8 +1,14 @@
-import { loadSqlEquiv, queryAsync, queryRow, queryOptionalRow } from '@prairielearn/postgres';
-import { logger } from '@prairielearn/logger';
 import { serializeError } from 'serialize-error';
 import { z } from 'zod';
 
+import { logger } from '@prairielearn/logger';
+import { loadSqlEquiv, queryAsync, queryRow, queryOptionalRow } from '@prairielearn/postgres';
+
+import {
+  BatchedMigrationJobRowSchema,
+  BatchedMigrationJobStatus,
+  BatchedMigrationJobRow,
+} from './batched-migration-job.js';
 import {
   BatchedMigrationStatus,
   BatchedMigrationRow,
@@ -10,11 +16,6 @@ import {
   BatchedMigrationStatusSchema,
   BatchedMigrationImplementation,
 } from './batched-migration.js';
-import {
-  BatchedMigrationJobRowSchema,
-  BatchedMigrationJobStatus,
-  BatchedMigrationJobRow,
-} from './batched-migration-job.js';
 
 const sql = loadSqlEquiv(import.meta.filename);
 

--- a/packages/migrations/src/batched-migrations/batched-migration.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import {
   loadSqlEquiv,
   queryAsync,
@@ -5,7 +7,6 @@ import {
   queryRows,
   queryOptionalRow,
 } from '@prairielearn/postgres';
-import { z } from 'zod';
 
 const sql = loadSqlEquiv(import.meta.filename);
 

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.test.ts
@@ -1,12 +1,15 @@
+import path from 'node:path';
+
 import { use as chaiUse, assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import path from 'node:path';
-import { makePostgresTestUtils } from '@prairielearn/postgres';
+
 import * as namedLocks from '@prairielearn/named-locks';
+import { makePostgresTestUtils } from '@prairielearn/postgres';
 
 import { SCHEMA_MIGRATIONS_PATH, init } from '../index.js';
-import { BatchedMigrationsRunner } from './batched-migrations-runner.js';
+
 import { selectAllBatchedMigrations } from './batched-migration.js';
+import { BatchedMigrationsRunner } from './batched-migrations-runner.js';
 
 chaiUse(chaiAsPromised);
 

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
+
 import { doWithLock } from '@prairielearn/named-locks';
+import { loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres';
 
 import { MigrationFile, readAndValidateMigrationsFromDirectories } from '../load-migrations.js';
+
+import { BatchedMigrationRunner } from './batched-migration-runner.js';
 import {
   BatchedMigrationRowSchema,
   BatchedMigrationRow,
@@ -15,7 +18,6 @@ import {
   BatchedMigrationImplementation,
   validateBatchedMigrationImplementation,
 } from './batched-migration.js';
-import { BatchedMigrationRunner } from './batched-migration-runner.js';
 
 const sql = loadSqlEquiv(import.meta.filename);
 

--- a/packages/migrations/src/load-migrations.test.ts
+++ b/packages/migrations/src/load-migrations.test.ts
@@ -1,8 +1,9 @@
+import path from 'path';
+
 import { use as chaiUse, assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import path from 'path';
-import tmp from 'tmp-promise';
 import fs from 'fs-extra';
+import tmp from 'tmp-promise';
 
 import {
   parseAnnotations,

--- a/packages/migrations/src/migrations/migrations.test.ts
+++ b/packages/migrations/src/migrations/migrations.test.ts
@@ -1,5 +1,7 @@
-import { assert } from 'chai';
 import path from 'node:path';
+
+import { assert } from 'chai';
+
 import { makePostgresTestUtils, queryAsync } from '@prairielearn/postgres';
 
 import { getMigrationsToExecute, initWithLock } from './migrations.js';

--- a/packages/migrations/src/migrations/migrations.ts
+++ b/packages/migrations/src/migrations/migrations.ts
@@ -1,10 +1,11 @@
-import fs from 'fs-extra';
 import path from 'path';
 
-import * as namedLocks from '@prairielearn/named-locks';
-import { logger } from '@prairielearn/logger';
-import * as sqldb from '@prairielearn/postgres';
+import fs from 'fs-extra';
+
 import * as error from '@prairielearn/error';
+import { logger } from '@prairielearn/logger';
+import * as namedLocks from '@prairielearn/named-locks';
+import * as sqldb from '@prairielearn/postgres';
 
 import {
   MigrationFile,

--- a/packages/named-locks/src/index.ts
+++ b/packages/named-locks/src/index.ts
@@ -1,5 +1,6 @@
-import { PostgresPool, PoolClient } from '@prairielearn/postgres';
 import { PoolConfig } from 'pg';
+
+import { PostgresPool, PoolClient } from '@prairielearn/postgres';
 
 interface NamedLocksConfig {
   /**

--- a/packages/opentelemetry/src/init.ts
+++ b/packages/opentelemetry/src/init.ts
@@ -1,6 +1,24 @@
 import { Metadata, credentials } from '@grpc/grpc-js';
-
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { metrics } from '@opentelemetry/api';
+import { hrTimeToMilliseconds } from '@opentelemetry/core';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { OTLPTraceExporter as OTLPTraceExporterHttp } from '@opentelemetry/exporter-trace-otlp-http';
+import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk';
+import { ConnectInstrumentation } from '@opentelemetry/instrumentation-connect';
+import { DnsInstrumentation } from '@opentelemetry/instrumentation-dns';
+import { ExpressLayerType, ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
+import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
+import { awsEc2Detector } from '@opentelemetry/resource-detector-aws';
+import {
+  detectResourcesSync,
+  processDetector,
+  envDetector,
+  Resource,
+} from '@opentelemetry/resources';
 import {
   PeriodicExportingMetricReader,
   MeterProvider,
@@ -21,33 +39,8 @@ import {
   Sampler,
   ConsoleSpanExporter,
 } from '@opentelemetry/sdk-trace-base';
-import {
-  detectResourcesSync,
-  processDetector,
-  envDetector,
-  Resource,
-} from '@opentelemetry/resources';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { metrics } from '@opentelemetry/api';
-import { hrTimeToMilliseconds } from '@opentelemetry/core';
-
-// Exporters go here.
-import { OTLPTraceExporter as OTLPTraceExporterHttp } from '@opentelemetry/exporter-trace-otlp-http';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
-
-// Instrumentations go here.
-import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk';
-import { ConnectInstrumentation } from '@opentelemetry/instrumentation-connect';
-import { DnsInstrumentation } from '@opentelemetry/instrumentation-dns';
-import { ExpressLayerType, ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
-import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
-import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
-import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
-
-// Resource detectors go here.
-import { awsEc2Detector } from '@opentelemetry/resource-detector-aws';
 
 /**
  * Extends `BatchSpanProcessor` to give it the ability to filter out spans

--- a/packages/opentelemetry/src/metrics.test.ts
+++ b/packages/opentelemetry/src/metrics.test.ts
@@ -1,3 +1,4 @@
+import { Meter } from '@opentelemetry/api';
 import {
   InMemoryMetricExporter,
   AggregationTemporality,
@@ -5,7 +6,6 @@ import {
   PeriodicExportingMetricReader,
   Histogram,
 } from '@opentelemetry/sdk-metrics';
-import { Meter } from '@opentelemetry/api';
 import { use as chaiUse, assert } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/opentelemetry/src/tracing.test.ts
+++ b/packages/opentelemetry/src/tracing.test.ts
@@ -1,8 +1,8 @@
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { tracing } from '@opentelemetry/sdk-node';
 import { assert } from 'chai';
 
 import { context, init, instrumented, trace, SpanStatusCode } from './index.js';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
 describe('instrumented', () => {
   let contextManager: AsyncHooksContextManager;

--- a/packages/postgres-tools/src/bin/pg-describe.ts
+++ b/packages/postgres-tools/src/bin/pg-describe.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+import path from 'path';
+
 import async from 'async';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import _ from 'lodash';
-import path from 'path';
 import yargs from 'yargs';
 
 import { describeDatabase, formatDatabaseDescription, DatabaseDescription } from '../describe.js';

--- a/packages/postgres-tools/src/describe.ts
+++ b/packages/postgres-tools/src/describe.ts
@@ -1,6 +1,7 @@
 // @ts-check
 import chalk from 'chalk';
 import { parse as parsePostgresArray } from 'postgres-array';
+
 import { loadSqlEquiv, PostgresPool } from '@prairielearn/postgres';
 
 const sql = loadSqlEquiv(import.meta.url);

--- a/packages/postgres-tools/src/diff.ts
+++ b/packages/postgres-tools/src/diff.ts
@@ -1,9 +1,10 @@
 // @ts-check
-import fs from 'fs-extra';
 import path from 'node:path';
+
 import chalk from 'chalk';
-import _ from 'lodash';
 import { structuredPatch } from 'diff';
+import fs from 'fs-extra';
+import _ from 'lodash';
 
 import { describeDatabase, formatDatabaseDescription } from './describe.js';
 

--- a/packages/postgres/src/default-pool.test.ts
+++ b/packages/postgres/src/default-pool.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
-import { PostgresPool } from './pool.js';
+
 import * as pgPool from './default-pool.js';
+import { PostgresPool } from './pool.js';
 
 /**
  * Properties on {@link PostgresPool} that should not be available on the default

--- a/packages/postgres/src/pool.test.ts
+++ b/packages/postgres/src/pool.test.ts
@@ -1,7 +1,8 @@
-import { use as chaiUse, assert } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import { Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+
+import { use as chaiUse, assert } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { z, ZodError } from 'zod';
 
 import {

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -1,12 +1,13 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { Readable, Transform } from 'node:stream';
+import { callbackify } from 'node:util';
+
+import debugfn from 'debug';
 import _ from 'lodash';
+import multipipe from 'multipipe';
 import pg, { QueryResult } from 'pg';
 import Cursor from 'pg-cursor';
-import debugfn from 'debug';
-import { callbackify } from 'node:util';
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { z } from 'zod';
-import { Readable, Transform } from 'node:stream';
-import multipipe from 'multipipe';
 
 export type QueryParams = Record<string, any> | any[];
 

--- a/packages/session/src/before-end.test.ts
+++ b/packages/session/src/before-end.test.ts
@@ -1,6 +1,7 @@
+import { assert } from 'chai';
 import express, { type Request, type Response, type NextFunction } from 'express';
 import fetch from 'node-fetch';
-import { assert } from 'chai';
+
 import { withServer } from '@prairielearn/express-test-utils';
 
 import { beforeEnd } from './before-end.js';

--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -1,13 +1,15 @@
-import express from 'express';
 import { assert } from 'chai';
-import fetch from 'node-fetch';
-import fetchCookie from 'fetch-cookie';
-import setCookie from 'set-cookie-parser';
+import express from 'express';
 import asyncHandler from 'express-async-handler';
+import fetchCookie from 'fetch-cookie';
+import fetch from 'node-fetch';
+import setCookie from 'set-cookie-parser';
+
 import { withServer } from '@prairielearn/express-test-utils';
 
-import { createSessionMiddleware } from './index.js';
 import { MemoryStore } from './memory-store.js';
+
+import { createSessionMiddleware } from './index.js';
 
 const TEST_SECRET = 'test-secret';
 

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -1,10 +1,9 @@
-import type { Request, Response, NextFunction } from 'express';
-import onHeaders from 'on-headers';
-import signature from 'cookie-signature';
-import asyncHandler from 'express-async-handler';
 import cookie from 'cookie';
+import signature from 'cookie-signature';
+import type { Request, Response, NextFunction } from 'express';
+import asyncHandler from 'express-async-handler';
+import onHeaders from 'on-headers';
 
-import { type SessionStore } from './store.js';
 import { beforeEnd } from './before-end.js';
 import { type CookieSecure, shouldSecureCookie, getSessionIdFromCookie } from './cookie.js';
 import {
@@ -14,6 +13,7 @@ import {
   hashSession,
   truncateExpirationDate,
 } from './session.js';
+import { type SessionStore } from './store.js';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/session/src/session.ts
+++ b/packages/session/src/session.ts
@@ -1,6 +1,7 @@
+import crypto from 'node:crypto';
+
 import type { Request } from 'express';
 import uid from 'uid-safe';
-import crypto from 'node:crypto';
 
 import { SessionStore } from './store.js';
 

--- a/packages/session/src/test-utils.ts
+++ b/packages/session/src/test-utils.ts
@@ -1,5 +1,6 @@
-import express from 'express';
 import { Server } from 'node:http';
+
+import express from 'express';
 
 interface WithServerContext {
   server: Server;

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -1,7 +1,8 @@
+import crypto from 'node:crypto';
+
 import base64url from 'base64url';
 import debugfn from 'debug';
 import _ from 'lodash';
-import crypto from 'node:crypto';
 
 const debug = debugfn('prairielearn:csrf');
 const sep = '.';

--- a/packages/workspace-utils/src/index.ts
+++ b/packages/workspace-utils/src/index.ts
@@ -1,12 +1,14 @@
-import { loadSqlEquiv, queryAsync, queryOneRowAsync } from '@prairielearn/postgres';
-import { contains } from '@prairielearn/path-utils';
-import type { Server as SocketIOServer } from 'socket.io';
-import type { Emitter as SocketIOEmitter } from '@socket.io/redis-emitter';
-import fg, { Entry } from 'fast-glob';
-import { filesize } from 'filesize';
 import { type Dirent } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+
+import type { Emitter as SocketIOEmitter } from '@socket.io/redis-emitter';
+import fg, { Entry } from 'fast-glob';
+import { filesize } from 'filesize';
+import type { Server as SocketIOServer } from 'socket.io';
+
+import { contains } from '@prairielearn/path-utils';
+import { loadSqlEquiv, queryAsync, queryOneRowAsync } from '@prairielearn/postgres';
 
 const sql = loadSqlEquiv(import.meta.url);
 


### PR DESCRIPTION
This executes the changes from https://github.com/PrairieLearn/PrairieLearn/pull/9856. I intend to merge this independently so I can add the commit to `.git-blame-ignore-revs`.