### PR TITLE
Remove disableInstrumentations call from accessibility tests

### DIFF
--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -1,8 +1,3 @@
-// The OpenTelemetry instrumentation for Express breaks our ability to inspect
-// the Express routes. We need to disable it before loading the server.
-import { disableInstrumentations } from '@prairielearn/opentelemetry';
-disableInstrumentations();
-
 import { test } from 'mocha';
 import axe from 'axe-core';
 import { JSDOM } from 'jsdom';


### PR DESCRIPTION
I originally set out to reorder `disableInstrumentations()` until after all imports, which reflects what happens at runtime thanks to import hosting. However, I also tried just removing it, and everything still works as expected, so I opted to go that simpler route instead!