### PR TITLE
Fix OpenTelemetry CJS preloads

### DIFF
--- a/.changeset/nine-apes-taste.md
+++ b/.changeset/nine-apes-taste.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/opentelemetry': patch
+---
+
+Fix CommonJS preloads of packages

--- a/packages/opentelemetry/src/commonjs-preloads.ts
+++ b/packages/opentelemetry/src/commonjs-preloads.ts
@@ -1,10 +1,13 @@
+import { createRequire } from 'module';
+
 // The packages below were determined by inspecting the implementation of each
 // instrumentation package and finding which packages/files they're patching.
 const PRELOAD_PACKAGES = [
-  // @opentelemetry/instrumentation-aws
+  // @opentelemetry/instrumentation-aws-sdk
   '@aws-sdk/middleware-stack/dist/cjs/MiddlewareStack.js',
   '@aws-sdk/middleware-stack/dist-cjs/MiddlewareStack.js',
   '@aws-sdk/middleware-stack',
+  '@smithy/middleware-stack',
   '@aws-sdk/smithy-client',
   'aws-sdk/lib/core.js',
   'aws-sdk',
@@ -27,11 +30,14 @@ const PRELOAD_PACKAGES = [
   'redis',
 ];
 
+const require = createRequire(import.meta.url);
 for (const pkg of PRELOAD_PACKAGES) {
   try {
-    // TODO: switch to using `createRequire` once this is native ESM.
     require(pkg);
-  } catch (e) {
+  } catch (e: any) {
     // Ignore; package is likely not installed.
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      throw e;
+    }
   }
 }

--- a/packages/opentelemetry/src/commonjs-preloads.ts
+++ b/packages/opentelemetry/src/commonjs-preloads.ts
@@ -35,9 +35,8 @@ for (const pkg of PRELOAD_PACKAGES) {
   try {
     require(pkg);
   } catch (e: any) {
-    // Ignore; package is likely not installed.
-    if (e.code !== 'MODULE_NOT_FOUND') {
-      throw e;
-    }
+    // If the package is not found, it's fine, it just means that it wasn't
+    // installed. We'll throw any other errors.
+    if (e.code !== 'MODULE_NOT_FOUND') throw e;
   }
 }


### PR DESCRIPTION
I neglected to do this during the ESM transition, which means that we currently have incomplete instrumentation for monkey-patched modules. This was failing to work because `require()` isn't defined in ESM modules. I made the error handling more precise to ensure that any similar errors will fail loudly in the future.