### PR TITLE
Improve Codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+# This config file can be validated with the following command:
+# curl --data-binary @.codecov.yml https://codecov.io/validate
+
+comment:
+  # Only post a comment if code/coverage changed.
+  require_changes: true
+  # Only post a comment if a base and head commit are both present.
+  require_base: true
+  require_head: true
+coverage:
+  status:
+    project:
+      # Don't fail the status check if coverage decreases.
+      informational: true
+    patch:
+      # Don't fail the status check if coverage decreases.
+      informational: true


### PR DESCRIPTION
This should make Codecov less chatty and prevent it from adding failing status checks to PRs. I don't think we're ready to commit to a certain coverage percentage; we really just want to make it easy to see/track how many lines are covered.