### PR TITLE
Introduce formatter package with formatDate function

### DIFF
--- a/packages/formatter/.mocharc.cjs
+++ b/packages/formatter/.mocharc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  require: ['tsx'],
+};

--- a/packages/formatter/package.json
+++ b/packages/formatter/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@prairielearn/formatter",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PrairieLearn/PrairieLearn.git",
+    "directory": "packages/formatter"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
+    "test": "c8 mocha src/**/*.test.ts"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "workspace:^",
+    "@types/node": "^20.12.11",
+    "c8": "^9.1.0",
+    "chai": "^5.1.1",
+    "mocha": "^10.4.0",
+    "tsx": "^4.10.4",
+    "typescript": "^5.4.5"
+  },
+  "c8": {
+    "reporter": [
+      "html",
+      "text-summary",
+      "cobertura"
+    ],
+    "all": true,
+    "include": [
+      "src/**"
+    ]
+  }
+}

--- a/packages/formatter/src/date.test.ts
+++ b/packages/formatter/src/date.test.ts
@@ -1,0 +1,35 @@
+import { assert } from 'chai';
+
+import { formatDate } from './date.js';
+
+describe('date formatting', () => {
+  describe('formatDate', () => {
+    it('formats a UTC date', () => {
+      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      assert.equal(formatDate(date, 'UTC'), '2018-01-01 12:00:00 (UTC)');
+    });
+    it('formats a CST date', () => {
+      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      assert.equal(formatDate(date, 'America/Chicago'), '2018-01-01 06:00:00 (CST)');
+    });
+    it('formats a CDT date', () => {
+      const date = new Date(Date.UTC(2018, 6, 1, 12, 0, 0));
+      assert.equal(formatDate(date, 'America/Chicago'), '2018-07-01 07:00:00 (CDT)');
+    });
+    it('formats dates with zero hours', () => {
+      const date = new Date(Date.UTC(2018, 0, 1, 0, 1, 0));
+      assert.equal(formatDate(date, 'UTC'), '2018-01-01 00:01:00 (UTC)');
+    });
+    it('formats dates without the timezone', () => {
+      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      assert.equal(formatDate(date, 'UTC', { includeTz: false }), '2018-01-01 12:00:00');
+    });
+    it('formats dates with the long timezone name', () => {
+      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      assert.equal(
+        formatDate(date, 'America/Chicago', { longTz: true }),
+        '2018-01-01 06:00:00 (Central Standard Time)',
+      );
+    });
+  });
+});

--- a/packages/formatter/src/date.ts
+++ b/packages/formatter/src/date.ts
@@ -1,0 +1,34 @@
+import keyBy from 'lodash/keyBy.js';
+
+/**
+ * Format a date to a human-readable string like '2020-03-27T12:34:56 (CDT)'.
+ *
+ * @param date The date to format.
+ * @param timeZone The time zone to use for formatting.
+ * @param param2.includeTz Whether to include the time zone in the output (default true).
+ * @param param2.longTz Whether to use the long time zone name (default false).
+ * @returns Human-readable string representing the date.
+ */
+export function formatDate(
+  date: Date,
+  timeZone: string,
+  { includeTz = true, longTz = false }: { includeTz?: boolean; longTz?: boolean } = {},
+): string {
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: longTz ? 'long' : 'short',
+  };
+  const parts = keyBy(new Intl.DateTimeFormat('en-US', options).formatToParts(date), (x) => x.type);
+  let dateFormatted = `${parts.year.value}-${parts.month.value}-${parts.day.value} ${parts.hour.value}:${parts.minute.value}:${parts.second.value}`;
+  if (includeTz) {
+    dateFormatted = `${dateFormatted} (${parts.timeZoneName.value})`;
+  }
+  return dateFormatted;
+}

--- a/packages/formatter/src/index.ts
+++ b/packages/formatter/src/index.ts
@@ -1,0 +1,1 @@
+export { formatDate } from './date.js';

--- a/packages/formatter/tsconfig.json
+++ b/packages/formatter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@prairielearn/tsconfig/tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["mocha", "node", "express-session"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,6 +2974,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@prairielearn/formatter@workspace:packages/formatter":
+  version: 0.0.0-use.local
+  resolution: "@prairielearn/formatter@workspace:packages/formatter"
+  dependencies:
+    "@prairielearn/tsconfig": "workspace:^"
+    "@types/node": ^20.12.11
+    c8: ^9.1.0
+    chai: ^5.1.1
+    lodash: ^4.17.21
+    mocha: ^10.4.0
+    tsx: ^4.10.4
+    typescript: ^5.4.5
+  languageName: unknown
+  linkType: soft
+
 "@prairielearn/grader-host@workspace:apps/grader-host":
   version: 0.0.0-use.local
   resolution: "@prairielearn/grader-host@workspace:apps/grader-host"


### PR DESCRIPTION
This function has existed for some time in PrairieTest, but now we need it in PrairieLearn for #9103! Moving it to a package that can be used in both places ensure that we won't have duplicate implementations in the long run.

cc @mylesw27 since we talked about you doing this in an upcoming PR, let's land this one first so that other changes aren't blocked on your own larger PR!