### PR TITLE
Fix broken form for choosing sharing name

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -78,34 +78,34 @@ const chooseSharingNameModal = (canChooseSharingName, resLocals) => {
           </div>
           ${canChooseSharingName
             ? html`
-                <div class="modal-body">
-                  <p class="form-text">Enter the sharing name you would like for your course.</p>
-                  <div>
-                    <label for="course_sharing_name">Enter Sharing Name</label>
-                    <input class="form-control" type="text" name="course_sharing_name" required />
+                <form name="choose-sharing-name" method="POST">
+                  <input type="hidden" name="__action" value="choose_sharing_name" />
+                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                  <div class="modal-body">
+                    <p class="form-text">Enter the sharing name you would like for your course.</p>
+                    <div>
+                      <label for="course_sharing_name">Enter Sharing Name</label>
+                      <input class="form-control" type="text" name="course_sharing_name" required />
+                    </div>
+                    <p>
+                      <strong
+                        >Once you have shared a question either publicly or with another course, you
+                        will no longer be able to change your sharing name.</strong
+                      >
+                      Doing so would break the assessments of other courses that have imported your
+                      questions. It is recommended that you choose something short but descriptive.
+                      For example, if you're teaching a calculus course at a university that goes by
+                      the abbreviation 'XYZ', then you could choose the sharing name 'xyz-calculus'.
+                      Then other courses will import questions from your course with the syntax
+                      '@xyz-calculus/qid'.
+                    </p>
                   </div>
-                  <p>
-                    <strong
-                      >Once you have shared a question either publicly or with another course, you
-                      will no longer be able to change your sharing name.</strong
-                    >
-                    Doing so would break the assessments of other courses that have imported your
-                    questions. It is recommended that you choose something short but descriptive.
-                    For example, if you're teaching a calculus course at a university that goes by
-                    the abbreviation 'XYZ', then you could choose the sharing name 'xyz-calculus'.
-                    Then other courses will import questions from your course with the syntax
-                    '@xyz-calculus/qid'.
-                  </p>
-                </div>
-                <div class="modal-footer">
-                  <form name="choose-sharing-name" method="POST">
-                    <input type="hidden" name="__action" value="choose_sharing_name" />
-                    <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                  <div class="modal-footer">
                     <div class="text-right mt-4">
                       <button type="submit" class="btn btn-primary">Choose Sharing Name</button>
                     </div>
-                  </form>
-                </div>
+                  </div>
+                </form>
               `
             : html`
                 <div class="modal-body">


### PR DESCRIPTION
Fixes error introduced in final commit of #9860, where the input box was accidentally moved outside of the form tag.

The error wasn't caught by tests because it doesn't affect calling the endpoint from code,
only submitting the form in the webpage itself.


@Michael-Holmes-SDE feel free to leave a review on this as well.