### PR TITLE
Fix error page in production

### DIFF
--- a/apps/prairielearn/src/pages/error/error.js
+++ b/apps/prairielearn/src/pages/error/error.js
@@ -53,6 +53,7 @@ export default function (err, req, res, _next) {
 
   const templateData = {
     error: err,
+    errorStack: config.devMode && err.stack ? formatErrorStack(err) : null,
     error_data: jsonStringifySafe(
       _.omit(_.get(err, ['data'], {}), ['sql', 'sqlParams', 'sqlError']),
       null,
@@ -67,7 +68,6 @@ export default function (err, req, res, _next) {
   if (config.devMode) {
     // development error handler
     // will print stacktrace
-    templateData.errorStack = err.stack ? formatErrorStack(err) : null;
     res.render(path.join(import.meta.dirname, 'error'), templateData);
   } else {
     // production error handler


### PR DESCRIPTION
Before this change, the error page would error out with the following in production:

```
ReferenceError: /Users/nathan/git/PrairieLearn/apps/prairielearn/src/pages/error/error.ejs:48
    46|           <% } %>
    47| 
 >> 48|           <% if (errorStack) { %><p><strong>Stack trace:</strong></p><pre class="bg-dark text-white rounded p-2"><%= errorStack %></pre><% } %>
    49| 
    50|           <% if (error.data && error.data.sqlError) {%>
    51|           <p><strong>SQL error:</strong></p><pre class="bg-dark text-white rounded p-2">error: <%= error.data.sqlError.message %>

errorStack is not defined
```