### PR TITLE
Force rebuild of plbase image

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -ex
 
+# If you need to rebuild this image without actually changing anything,
+# add a dot to the following line:
+# .
+
 dnf update -y
 
 # Notes:


### PR DESCRIPTION
I'm doing this ahead of #9903. There's a new version of Node (20.14.0) that's being pulled in and I'd like to better understand how much of the image size increase from that other PR can be attributed to new Node (or other changes) vs. `pgvector` itself.