### PR TITLE
Fix double decoding of instructor files

### DIFF
--- a/apps/prairielearn/src/lib/instructorFiles.js
+++ b/apps/prairielearn/src/lib/instructorFiles.js
@@ -5,7 +5,7 @@ import * as error from '@prairielearn/error';
 import { html } from '@prairielearn/html';
 import { contains } from '@prairielearn/path-utils';
 
-import { encodePath, decodePath } from './uri-util.js';
+import { encodePath } from './uri-util.js';
 
 /**
  * For the file path of the current page, this function returns rich
@@ -69,7 +69,7 @@ export function getPaths(req, res) {
 
   if (req.params[0]) {
     try {
-      paths.workingPath = path.join(res.locals.course.path, decodePath(req.params[0]));
+      paths.workingPath = path.join(res.locals.course.path, req.params[0]);
     } catch (err) {
       throw new Error(`Invalid path: ${req.params[0]}`);
     }

--- a/apps/prairielearn/src/lib/uri-util.js
+++ b/apps/prairielearn/src/lib/uri-util.js
@@ -3,31 +3,16 @@ import * as path from 'path';
 
 import { logger } from '@prairielearn/logger';
 
+/**
+ *
+ * @param {string} originalPath
+ * @returns {string}
+ */
 export function encodePath(originalPath) {
   try {
-    let encodedPath = [];
-    path
-      .normalize(originalPath)
-      .split(path.sep)
-      .forEach((dir) => {
-        encodedPath.push(encodeURIComponent(dir));
-      });
-    return encodedPath.join('/');
+    return path.normalize(originalPath).split(path.sep).map(encodeURIComponent).join('/');
   } catch (err) {
     logger.error(`encodePath: returning empty string because failed to encode ${originalPath}`);
-    return '';
-  }
-}
-
-export function decodePath(originalPath) {
-  try {
-    let decodedPath = [];
-    originalPath.split(path.sep).forEach((dir) => {
-      decodedPath.push(decodeURIComponent(dir));
-    });
-    return decodedPath.join('/');
-  } catch (err) {
-    logger.error(`decodePath: returning empty string because failed to decode ${originalPath}`);
     return '';
   }
 }

--- a/apps/prairielearn/src/lib/uri-util.js
+++ b/apps/prairielearn/src/lib/uri-util.js
@@ -4,9 +4,12 @@ import * as path from 'path';
 import { logger } from '@prairielearn/logger';
 
 /**
+ * Encodes a path for use in a URL. This is a middle-ground between `encodeURI`
+ * and `encodeURIComponent`, in that all characters encoded by
+ * `encodeURIComponent` are encoded, but slashes are not encoded.
  *
- * @param {string} originalPath
- * @returns {string}
+ * @param {string} originalPath path of the file that is the basis for the encoding
+ * @returns {string} Encoded path
  */
 export function encodePath(originalPath) {
   try {

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.js
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.js
@@ -4,8 +4,6 @@ import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
 
-import { decodePath } from '../../lib/uri-util.js';
-
 const router = express.Router();
 
 router.get(
@@ -16,7 +14,7 @@ router.get(
     }
     if (req.query.type) res.type(req.query.type.toString());
     if (req.query.attachment) res.attachment(req.query.attachment.toString());
-    res.sendFile(decodePath(req.params[0]), { root: res.locals.course.path });
+    res.sendFile(req.params[0], { root: res.locals.course.path });
   }),
 );
 

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -227,7 +227,6 @@ const verifyFileData = [
     clientFilesDir: 'clientFilesQuestion',
     serverFilesDir: 'serverFilesQuestion',
     testFilesDir: 'tests',
-    index: 3,
   },
   {
     title: 'assessment',
@@ -235,7 +234,6 @@ const verifyFileData = [
     path: assessmentPath,
     clientFilesDir: 'clientFilesAssessment',
     serverFilesDir: 'serverFilesAssessment',
-    index: 1,
   },
   {
     title: 'course instance',
@@ -243,7 +241,6 @@ const verifyFileData = [
     path: courseInstancePath,
     clientFilesDir: 'clientFilesCourseInstance',
     serverFilesDir: 'serverFilesCourseInstance',
-    index: 2,
   },
   {
     title: 'course (through course instance)',
@@ -251,7 +248,6 @@ const verifyFileData = [
     path: '',
     clientFilesDir: 'clientFilesCourse',
     serverFilesDir: 'serverFilesCourse',
-    index: 5,
   },
   {
     title: 'course',
@@ -259,7 +255,6 @@ const verifyFileData = [
     path: '',
     clientFilesDir: 'clientFilesCourse',
     serverFilesDir: 'serverFilesCourse',
-    index: 5,
   },
 ];
 
@@ -943,14 +938,21 @@ function waitForJobSequence(locals, expectedResult) {
   });
 }
 
-function doFiles(data) {
+function doFiles(data: {
+  title: string;
+  url: string;
+  path: string;
+  clientFilesDir: string;
+  serverFilesDir: string;
+  testFilesDir?: string;
+}) {
   describe(`test file handlers for ${data.title}`, function () {
     describe('Files', function () {
       testUploadFile({
         adminUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'testfile.txt'),
-        id: 'New',
+        newButtonId: 'New',
         contents: 'This is a line of text.',
         filename: 'testfile.txt',
       });
@@ -959,7 +961,6 @@ function doFiles(data) {
         adminUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'testfile.txt'),
-        id: data.index,
         contents: 'This is a different line of text.',
         filename: 'anotherfile.txt',
       });
@@ -981,7 +982,7 @@ function doFiles(data) {
         adminUrl: data.url,
         url: data.url,
         path: path.join(data.path, data.clientFilesDir, 'testfile.txt'),
-        id: 'NewClient',
+        newButtonId: 'NewClient',
         contents: 'This is a line of text.',
         filename: 'testfile.txt',
       });
@@ -990,7 +991,6 @@ function doFiles(data) {
         adminUrl: data.url,
         url: data.url + '/' + encodePath(path.join(data.path, data.clientFilesDir)),
         path: path.join(data.path, data.clientFilesDir, 'testfile.txt'),
-        id: 0,
         contents: 'This is a different line of text.',
         filename: 'anotherfile.txt',
       });
@@ -1012,7 +1012,7 @@ function doFiles(data) {
         adminUrl: data.url,
         url: data.url,
         path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
-        id: 'NewServer',
+        newButtonId: 'NewServer',
         contents: 'This is a line of text.',
         filename: 'testfile.txt',
       });
@@ -1021,7 +1021,6 @@ function doFiles(data) {
         adminUrl: data.url,
         url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
         path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
-        id: 0,
         contents: 'This is a different line of text.',
         filename: 'anotherfile.txt',
       });
@@ -1040,35 +1039,36 @@ function doFiles(data) {
     });
     if (data.testFilesDir) {
       describe('Test Files', function () {
-        testUploadFile({
-          adminUrl: data.url,
-          url: data.url,
-          path: path.join(data.path, data.testFilesDir, 'testfile.txt'),
-          id: 'NewTest',
-          contents: 'This is a line of text.',
-          filename: 'testfile.txt',
-        });
+        if (data.testFilesDir) {
+          testUploadFile({
+            adminUrl: data.url,
+            url: data.url,
+            path: path.join(data.path, data.testFilesDir, 'testfile.txt'),
+            newButtonId: 'NewTest',
+            contents: 'This is a line of text.',
+            filename: 'testfile.txt',
+          });
 
-        testUploadFile({
-          adminUrl: data.url,
-          url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir)),
-          path: path.join(data.path, data.testFilesDir, 'testfile.txt'),
-          id: 0,
-          contents: 'This is a different line of text.',
-          filename: 'anotherfile.txt',
-        });
+          testUploadFile({
+            adminUrl: data.url,
+            url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir)),
+            path: path.join(data.path, data.testFilesDir, 'testfile.txt'),
+            contents: 'This is a different line of text.',
+            filename: 'anotherfile.txt',
+          });
 
-        testRenameFile({
-          url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir)),
-          path: path.join(data.path, data.testFilesDir, 'subdir', 'testfile.txt'),
-          contents: 'This is a different line of text.',
-          new_file_name: path.join('subdir', 'testfile.txt'),
-        });
+          testRenameFile({
+            url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir)),
+            path: path.join(data.path, data.testFilesDir, 'subdir', 'testfile.txt'),
+            contents: 'This is a different line of text.',
+            new_file_name: path.join('subdir', 'testfile.txt'),
+          });
 
-        testDeleteFile({
-          url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir, 'subdir')),
-          path: path.join(data.path, data.testFilesDir, 'subdir', 'testfile.txt'),
-        });
+          testDeleteFile({
+            url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir, 'subdir')),
+            path: path.join(data.path, data.testFilesDir, 'subdir', 'testfile.txt'),
+          });
+        }
       });
     }
     describe('Files with % in name', function () {
@@ -1076,8 +1076,16 @@ function doFiles(data) {
         adminUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'test%file.txt'),
-        id: 'New',
+        newButtonId: 'New',
         contents: 'This is a line of text in a file with percent.',
+        filename: 'test%file.txt',
+      });
+
+      testUploadFile({
+        adminUrl: data.url,
+        url: data.url,
+        path: path.join(data.path, 'test%file.txt'),
+        contents: 'This is a different line of text in a file with percent.',
         filename: 'test%file.txt',
       });
 
@@ -1087,7 +1095,6 @@ function doFiles(data) {
 
       // testRenameFile({
       //   url: data.url,
-      //   id: data.index,
       //   path: path.join(data.path, 'sub%dir', 'test%file.txt'),
       //   contents: 'This is a line of text in a file with percent.',
       //   new_file_name: path.join('sub%dir', 'test%file.txt'),
@@ -1105,7 +1112,7 @@ function testUploadFile(params: {
   adminUrl: string;
   url: string;
   path: string;
-  id: string | number;
+  newButtonId?: string;
   contents: string;
   filename: string;
 }) {
@@ -1116,28 +1123,29 @@ function testUploadFile(params: {
       locals.$ = cheerio.load(await res.text());
     });
     it('should have a CSRF token and either a file_path or a working_path', () => {
-      elemList = locals.$(`button[id="instructorFileUploadForm-${params.id}"]`);
+      if (params.newButtonId) {
+        elemList = locals.$(`button[id="instructorFileUploadForm-${params.newButtonId}"]`);
+      } else {
+        const row = locals.$(`tr:has(a:contains("${params.path.split('/').pop()}"))`);
+        elemList = row.find(`button[id^="instructorFileUploadForm-"]`);
+      }
       assert.lengthOf(elemList, 1);
       const $ = cheerio.load(elemList[0].attribs['data-content']);
       // __csrf_token
-      elemList = $(
-        `form[name="instructor-file-upload-form-${params.id}"] input[name="__csrf_token"]`,
-      );
+      elemList = $(`input[name="__csrf_token"]`);
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
       locals.__csrf_token = elemList[0].attribs.value;
       assert.isString(locals.__csrf_token);
       // file_path or working_path
-      elemList = $(`form[name="instructor-file-upload-form-${params.id}"] input[name="file_path"]`);
-      if (elemList.length > 0) {
+      if (!params.newButtonId) {
+        elemList = $(`input[name="file_path"]`);
         assert.lengthOf(elemList, 1);
         assert.nestedProperty(elemList[0], 'attribs.value');
         locals.file_path = elemList[0].attribs.value;
         locals.working_path = undefined;
       } else {
-        elemList = $(
-          `form[name="instructor-file-upload-form-${params.id}"] input[name="working_path"]`,
-        );
+        elemList = $(`input[name="working_path"]`);
         assert.lengthOf(elemList, 1);
         assert.nestedProperty(elemList[0], 'attribs.value');
         locals.working_path = elemList[0].attribs.value;

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -949,7 +949,7 @@ function doFiles(data: {
   describe(`test file handlers for ${data.title}`, function () {
     describe('Files', function () {
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'testfile.txt'),
         newButtonId: 'New',
@@ -958,7 +958,7 @@ function doFiles(data: {
       });
 
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'testfile.txt'),
         contents: 'This is a different line of text.',
@@ -979,7 +979,7 @@ function doFiles(data: {
     });
     describe('Client Files', function () {
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url,
         path: path.join(data.path, data.clientFilesDir, 'testfile.txt'),
         newButtonId: 'NewClient',
@@ -988,7 +988,7 @@ function doFiles(data: {
       });
 
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url + '/' + encodePath(path.join(data.path, data.clientFilesDir)),
         path: path.join(data.path, data.clientFilesDir, 'testfile.txt'),
         contents: 'This is a different line of text.',
@@ -1009,7 +1009,7 @@ function doFiles(data: {
     });
     describe('Server Files', function () {
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url,
         path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
         newButtonId: 'NewServer',
@@ -1018,7 +1018,7 @@ function doFiles(data: {
       });
 
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
         path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
         contents: 'This is a different line of text.',
@@ -1041,7 +1041,7 @@ function doFiles(data: {
       describe('Test Files', function () {
         if (data.testFilesDir) {
           testUploadFile({
-            adminUrl: data.url,
+            fileViewBaseUrl: data.url,
             url: data.url,
             path: path.join(data.path, data.testFilesDir, 'testfile.txt'),
             newButtonId: 'NewTest',
@@ -1050,7 +1050,7 @@ function doFiles(data: {
           });
 
           testUploadFile({
-            adminUrl: data.url,
+            fileViewBaseUrl: data.url,
             url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir)),
             path: path.join(data.path, data.testFilesDir, 'testfile.txt'),
             contents: 'This is a different line of text.',
@@ -1073,7 +1073,7 @@ function doFiles(data: {
     }
     describe('Files with % in name', function () {
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'test%file.txt'),
         newButtonId: 'New',
@@ -1082,7 +1082,7 @@ function doFiles(data: {
       });
 
       testUploadFile({
-        adminUrl: data.url,
+        fileViewBaseUrl: data.url,
         url: data.url,
         path: path.join(data.path, 'test%file.txt'),
         contents: 'This is a different line of text in a file with percent.',
@@ -1109,7 +1109,7 @@ function doFiles(data: {
 }
 
 function testUploadFile(params: {
-  adminUrl: string;
+  fileViewBaseUrl: string;
   url: string;
   path: string;
   newButtonId?: string;
@@ -1177,7 +1177,7 @@ function testUploadFile(params: {
 
   describe(`Uploaded file is available`, function () {
     it('file view should match contents', async () => {
-      const res = await fetch(`${params.adminUrl}/${encodePath(params.path)}`);
+      const res = await fetch(`${params.fileViewBaseUrl}/${encodePath(params.path)}`);
       assert.isOk(res.ok);
       locals.$ = cheerio.load(await res.text());
       const pre = locals.$('.card-body pre');

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -966,7 +966,6 @@ function doFiles(data) {
 
       testRenameFile({
         url: data.url,
-        id: data.index,
         path: path.join(data.path, 'subdir', 'testfile.txt'),
         contents: 'This is a different line of text.',
         new_file_name: path.join('subdir', 'testfile.txt'),
@@ -998,7 +997,6 @@ function doFiles(data) {
 
       testRenameFile({
         url: data.url + '/' + encodePath(path.join(data.path, data.clientFilesDir)),
-        id: 0,
         path: path.join(data.path, data.clientFilesDir, 'subdir', 'testfile.txt'),
         contents: 'This is a different line of text.',
         new_file_name: path.join('subdir', 'testfile.txt'),
@@ -1030,7 +1028,6 @@ function doFiles(data) {
 
       testRenameFile({
         url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
-        id: 0,
         path: path.join(data.path, data.serverFilesDir, 'subdir', 'testfile.txt'),
         contents: 'This is a different line of text.',
         new_file_name: path.join('subdir', 'testfile.txt'),
@@ -1063,7 +1060,6 @@ function doFiles(data) {
 
         testRenameFile({
           url: data.url + '/' + encodePath(path.join(data.path, data.testFilesDir)),
-          id: 0,
           path: path.join(data.path, data.testFilesDir, 'subdir', 'testfile.txt'),
           contents: 'This is a different line of text.',
           new_file_name: path.join('subdir', 'testfile.txt'),
@@ -1194,7 +1190,6 @@ function testUploadFile(params: {
 
 function testRenameFile(params: {
   url: string;
-  id: string | number;
   path: string;
   contents: string;
   new_file_name: string;
@@ -1206,28 +1201,24 @@ function testRenameFile(params: {
       locals.$ = cheerio.load(await res.text());
     });
     it('should have a CSRF token, old_file_name, working_path', () => {
-      elemList = locals.$(`button[id="instructorFileRenameForm-${params.id}"]`);
+      const row = locals.$(`tr:has(a:contains("${params.path.split('/').pop()}"))`);
+      elemList = row.find(`button[id^="instructorFileRenameForm-"]`);
       assert.lengthOf(elemList, 1);
       const $ = cheerio.load(elemList[0].attribs['data-content']);
       // __csrf_token
-      elemList = $(
-        `form[name="instructor-file-rename-form-${params.id}"] input[name="__csrf_token"]`,
-      );
+      elemList = $(`input[name="__csrf_token"]`);
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
       locals.__csrf_token = elemList[0].attribs.value;
       assert.isString(locals.__csrf_token);
       // old_file_name
-      elemList = $(
-        `form[name="instructor-file-rename-form-${params.id}"] input[name="old_file_name"]`,
-      );
+      elemList = $(`input[name="old_file_name"]`);
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
       locals.old_file_name = elemList[0].attribs.value;
+      assert.equal(locals.old_file_name, params.path.split('/').pop());
       // working_path
-      elemList = $(
-        `form[name="instructor-file-rename-form-${params.id}"] input[name="working_path"]`,
-      );
+      elemList = $(`input[name="working_path"]`);
       assert.lengthOf(elemList, 1);
       assert.nestedProperty(elemList[0], 'attribs.value');
       locals.working_path = elemList[0].attribs.value;


### PR DESCRIPTION
Fixes #9906. Processing of file paths was decoding the URI components, but Express [already takes care of that](https://expressjs.com/en/api.html#req.params). This would cause issues in paths that included `%` symbols in its decoded form.

Also simplifies and adds types to `encodePath`, and removes the (now unnecessary) `decodePath` function.

Pending: add a CI test to ensure this is handled as expected.