### PR TITLE
Make shouldEdit() part of the Editor API

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -76,7 +76,7 @@ interface BaseEditorOptions {
   locals: Record<string, any>;
 }
 
-export class Editor {
+export abstract class Editor {
   protected authz_data: Record<string, any>;
   protected course: Course;
   protected user: User;
@@ -92,8 +92,18 @@ export class Editor {
     this.commitMessage = null;
   }
 
-  async write() {
-    throw new Error('write must be defined in a subclass');
+  /**
+   * Write changes to disk. Should set `this.pathsToAdd` and `this.commitMessage`.
+   */
+  abstract write(): Promise<void>;
+
+  /**
+   * Determines whether or not the edit should be executed. For instance, this
+   * can check if the edit would actually modify a file and skip the write/commit/push
+   * steps if it would not.
+   */
+  protected async shouldEdit() {
+    return true;
   }
 
   assertCanEdit() {
@@ -190,46 +200,48 @@ export class Editor {
         await cleanAndResetRepository(this.course, gitEnv, job);
 
         try {
-          job.data.saveAttempted = true;
-          job.info('Write changes to disk');
-          await this.write();
+          if (await this.shouldEdit()) {
+            job.data.saveAttempted = true;
+            job.info('Write changes to disk');
+            await this.write();
 
-          if (this.pathsToAdd == null) {
-            throw new Error('pathsToAdd must be set in write()');
-          }
+            if (this.pathsToAdd == null) {
+              throw new Error('pathsToAdd must be set in write()');
+            }
 
-          if (this.commitMessage == null) {
-            throw new Error('commitMessage must be set in write()');
-          }
+            if (this.commitMessage == null) {
+              throw new Error('commitMessage must be set in write()');
+            }
 
-          job.info('Commit changes');
-          await job.exec('git', ['add', ...this.pathsToAdd], {
-            cwd: this.course.path,
-            env: gitEnv,
-          });
-          await job.exec(
-            'git',
-            [
-              '-c',
-              `user.name="${this.user.name}"`,
-              '-c',
-              `user.email="${this.user.email || this.user.uid}"`,
-              'commit',
-              '-m',
-              this.commitMessage,
-            ],
-            {
+            job.info('Commit changes');
+            await job.exec('git', ['add', ...this.pathsToAdd], {
               cwd: this.course.path,
               env: gitEnv,
-            },
-          );
+            });
+            await job.exec(
+              'git',
+              [
+                '-c',
+                `user.name="${this.user.name}"`,
+                '-c',
+                `user.email="${this.user.email || this.user.uid}"`,
+                'commit',
+                '-m',
+                this.commitMessage,
+              ],
+              {
+                cwd: this.course.path,
+                env: gitEnv,
+              },
+            );
 
-          job.info('Push changes to remote git repository');
-          await job.exec('git', ['push'], {
-            cwd: this.course.path,
-            env: gitEnv,
-          });
-          job.data.saveSucceeded = true;
+            job.info('Push changes to remote git repository');
+            await job.exec('git', ['push'], {
+              cwd: this.course.path,
+              env: gitEnv,
+            });
+            job.data.saveSucceeded = true;
+          }
         } finally {
           // Whether or not we error, we'll do a clean and reset.
           //

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -95,7 +95,7 @@ export abstract class Editor {
   /**
    * Write changes to disk. Should set `this.pathsToAdd` and `this.commitMessage`.
    */
-  abstract write(): Promise<void>;
+  protected abstract write(): Promise<void>;
 
   /**
    * Determines whether or not the edit should be executed. For instance, this
@@ -106,7 +106,7 @@ export abstract class Editor {
     return true;
   }
 
-  assertCanEdit() {
+  protected assertCanEdit() {
     // Do not allow users to edit without permission
     if (!this.authz_data.has_course_permission_edit) {
       throw new HttpStatusError(403, 'Access denied (must be course editor)');
@@ -1400,7 +1400,7 @@ export class FileModifyEditor extends Editor {
     return sha256(contents).toString();
   }
 
-  shouldEdit() {
+  async shouldEdit() {
     debug('get hash of edit contents');
     const editHash = this.getHash(this.editContents);
     debug('editHash: ' + editHash);

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -87,11 +87,6 @@ router.post(
         origHash,
       });
 
-      if (!editor.shouldEdit()) {
-        res.redirect(req.originalUrl);
-        return;
-      }
-
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.js
@@ -335,11 +335,6 @@ router.post(
         fileContents: req.file.buffer,
       });
 
-      if (!(await editor.shouldEdit())) {
-        res.redirect(req.originalUrl);
-        return;
-      }
-
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -215,11 +215,6 @@ router.post(
         origHash: req.body.file_edit_orig_hash,
       });
 
-      if (!editor.shouldEdit()) {
-        res.redirect(req.originalUrl);
-        return;
-      }
-
       editor.assertCanEdit();
 
       debug('Write draft file edit to db and to file store');

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.js
@@ -207,16 +207,6 @@ router.post(
     if (req.body.__action === 'save_and_sync') {
       debug('Save and sync');
 
-      const editor = new FileModifyEditor({
-        locals: res.locals,
-        container,
-        filePath: paths.workingPath,
-        editContents: req.body.file_edit_contents,
-        origHash: req.body.file_edit_orig_hash,
-      });
-
-      editor.assertCanEdit();
-
       debug('Write draft file edit to db and to file store');
       const editID = await writeDraftEdit({
         userID: res.locals.user.user_id,
@@ -229,6 +219,14 @@ router.post(
         uid: res.locals.user.uid,
         user_name: res.locals.user.name,
         editContents: req.body.file_edit_contents,
+      });
+
+      const editor = new FileModifyEditor({
+        locals: res.locals,
+        container,
+        filePath: paths.workingPath,
+        editContents: req.body.file_edit_contents,
+        origHash: req.body.file_edit_orig_hash,
       });
 
       const serverJob = await editor.prepareServerJob();


### PR DESCRIPTION
This is a prerequisite for #9894. See discussion here: https://github.com/PrairieLearn/PrairieLearn/pull/9894/files#r1613905518

In short, to avoid a TOCTOU bug, we need the `shouldEdit()` check to run with the course lock held, and for it to run after we've pulled in new changes from the remote. This PR achieves that by making the `Editor` class has a `shouldEdit()` function that it will call on itself when it wants to check if a write is safe.