### PR TITLE
Fix capitalization of section in assessment docs

### DIFF
--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -650,7 +650,7 @@ Some instructors may wish to publish links that point students directly to their
 
 The appropriate link to provide to students can be found by opening the "Settings" tab of the Assessment. This page includes, among other useful information, a Student Link that can be provided to students. This link points students directly to the specific assessment, enrolling them automatically in the course if they are not yet enrolled.
 
-## Client Fingerprint Tracking and Changes
+## Client fingerprint tracking and changes
 
 While a student is working on an assessment, PrairieLearn tracks the user's IP address, session ID, and user agent (this includes the operating system, browser application, and version). These attributes together make up a client fingerprint. The fingerprints are then recorded during events while accessing the assessment instance. For example, when a student views a question, a record of the client fingerprint is saved along with the view event.
 


### PR DESCRIPTION
This makes the header capitalization in the docs consistent with the other headers in the same file.