### PR TITLE
Fix typos in docs and code

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -338,7 +338,7 @@ onDocumentReady(() => {
               class="btn btn-xs"
               ,
               type="button"
-              title="Show figerprint changes help"
+              title="Show fingerprint changes help"
               data-toggle="modal"
               data-target="#fingerprint-changes-help"
             >

--- a/apps/prairielearn/src/lib/instructorFiles.js
+++ b/apps/prairielearn/src/lib/instructorFiles.js
@@ -88,7 +88,7 @@ export function getPaths(req, res) {
         path: paths.clientDir,
         info: `This file will be placed in the subdirectory <code>${path.basename(
           paths.clientDir,
-        )}</code> and will be accessible from the student's webbrowser.`,
+        )}</code> and will be accessible from the student's web browser.`,
       });
     }
     if (paths.serverDir) {
@@ -97,7 +97,7 @@ export function getPaths(req, res) {
         path: paths.serverDir,
         info: `This file will be placed in the subdirectory <code>${path.basename(
           paths.serverDir,
-        )}</code> and will be accessible only from the server. It will not be accessible from the student's webbrowser.`,
+        )}</code> and will be accessible only from the server. It will not be accessible from the student's web browser.`,
       });
     }
     if (paths.testsDir) {
@@ -106,7 +106,7 @@ export function getPaths(req, res) {
         path: paths.testsDir,
         info: `This file will be placed in the subdirectory <code>${path.basename(
           paths.testsDir,
-        )}</code> and will be accessible only from the server. It will not be accessible from the student's webbrowser. This is appropriate for code to support <a href='https://prairielearn.readthedocs.io/en/latest/externalGrading/'>externally graded questions</a>.`,
+        )}</code> and will be accessible only from the server. It will not be accessible from the student's web browser. This is appropriate for code to support <a href='https://prairielearn.readthedocs.io/en/latest/externalGrading/'>externally graded questions</a>.`,
       });
     }
   }

--- a/docs/PrairieDraw.md
+++ b/docs/PrairieDraw.md
@@ -141,7 +141,7 @@ Draw an arrow out of the screen (circle with center dot) at `vector`.
 Draw an arrow into the screen (circle with center x) at `vector`.
 
 `circleArrow(center, radius, startAngle, endAngle [, type, fixedRad, idealSegmentSize])`
-Draw an arrow arc centerd at `center`, with radius `radius`, from `startAngle` to `endAngle` (in radians). The `fixedRad` option (default false) specifies if a constant radius should be used (as opposed to curling in the beginning/end).
+Draw an arrow arc centered at `center`, with radius `radius`, from `startAngle` to `endAngle` (in radians). The `fixedRad` option (default false) specifies if a constant radius should be used (as opposed to curling in the beginning/end).
 
 `circleArrowCentered(center, radius, centerAngle, extentAngle [, type, fixedRad])`
 Draw an arrow arc centered at `center`, with radius `radius`, centerd at `centerAngle` and spanning `extentAngle` (in radians).

--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -328,11 +328,11 @@ If an instructor does not assign a student to a group, the student will need to 
 
 When calculating a student's grade for a group assessment, PrairieLearn will always use the score of their group's assessment instance.
 
-> Note: Students cannot see eachother's edits in real-time, although this is planned for a future version of PrairieLearn.
+> Note: Students cannot see each other's edits in real-time, although this is planned for a future version of PrairieLearn.
 
 ![Student view of assessment with groupwork enabled](groupwork_student_perspective_assessment.png)
 
-Students are able to see their groupmates' UIDs, which can become a point of contact to communicate with eachother outside of PrairieLearn. They are also able to leave their group to join a different one.
+Students are able to see their groupmates' UIDs, which can become a point of contact to communicate with each other outside of PrairieLearn. They are also able to leave their group to join a different one.
 
 ### Enabling custom group roles
 

--- a/docs/clientServerFiles.md
+++ b/docs/clientServerFiles.md
@@ -2,9 +2,9 @@
 
 There are multiple locations within each course where files can be stored for access from the client or server. These can be used for code libraries used in questions, images embedded within questions, formula sheets available during exams, or online textbooks for reference during exams.
 
-`ClientFiles` directories contain files that are accessible from the client webbrowser. This is appropriate for code libraries used on the client, or for files that a student should have access to, such as an image, reference webpages, or formula sheets.
+`ClientFiles` directories contain files that are accessible from the client web browser. This is appropriate for code libraries used on the client, or for files that a student should have access to, such as an image, reference webpages, or formula sheets.
 
-`ServerFiles` directories are only accessible from code running on the server, so are useful for libraries that can solve questions or generate random question instances. Files in a `serverFiles` directory cannot be directly accessed by the student's webbrowser.
+`ServerFiles` directories are only accessible from code running on the server, so are useful for libraries that can solve questions or generate random question instances. Files in a `serverFiles` directory cannot be directly accessed by the student's web browser.
 
 ## Directory layout
 

--- a/docs/codeExecution.md
+++ b/docs/codeExecution.md
@@ -36,7 +36,7 @@ This is still how PrairieLearn functions by default for local development. The `
 
 Under this mode, PrairieLearn uses Docker to provide a degree of isolation from both PrairieLearn and other courses.
 
-Instead of using a pool of zygotes as described above, it actually maintains a pool of Docker containers, each of which runs a simple Node script (the _executor_), which in turn runs a Python zygote. The Node script listens for requests from PrairieLearn and essentially just forwards them to the Python process. You may ask, "Why not just run the zygote as the primary process in the container?" Well, starting up a Docker container is significantly more expensive than starting up a Python interpreter. Given that we ocasionally want to completely restart the Python worker, such as when it encounters an error, having an additional level of indirection allows us to gracefully restart the Python process inside the Docker container without having to restart the entire Docker container.
+Instead of using a pool of zygotes as described above, it actually maintains a pool of Docker containers, each of which runs a simple Node script (the _executor_), which in turn runs a Python zygote. The Node script listens for requests from PrairieLearn and essentially just forwards them to the Python process. You may ask, "Why not just run the zygote as the primary process in the container?" Well, starting up a Docker container is significantly more expensive than starting up a Python interpreter. Given that we occasionally want to completely restart the Python worker, such as when it encounters an error, having an additional level of indirection allows us to gracefully restart the Python process inside the Docker container without having to restart the entire Docker container.
 
 This mode also allows us to isolate one course from another so that course A cannot see content from course B, and vice versa. To achieve this, we take advantage of bind mounts. When creating a container, PrairieLearn also creates a special directory on the host, and then mounts that directory to `/course` in the container. To execute content for course A, PrairieLearn first bind mounts that course's directory to the container's host directory. This is transitive to the container, which will now see that course's content at `/course`. In the future, when a different course's code needs to be executed in that container, PrairieLearn will simply update the bind mount to point to the other course.
 
@@ -61,7 +61,7 @@ The primary external interface of these callers is the `call()` function, which 
   - For core elements, this is an item in PrairieLearn's `elements` directory.
 - `file`: the name of the file whose code will be executed (e.g. `server.py`)
 - `fcn`: the name of the function in `file` that will be executed (e.g. `grade` or `render`).
-- `args`: an array of JSON-encodeable arguments to the function being called.
+- `args`: an array of JSON-encodable arguments to the function being called.
 
 The piece of code to execute is specified by (`type`, `directory`, `file`) instead of an absolute path because the location of each file on disk may change between each type of code caller; allowing the code caller to construct the path from that information keeps the code that uses a caller agnostic to the underlying caller being used.
 

--- a/docs/course.md
+++ b/docs/course.md
@@ -128,7 +128,7 @@ The following list of standardized assessments sets is automatically included in
 | abbreviation | name            | purpose                                                 |
 | ------------ | --------------- | ------------------------------------------------------- |
 | `HW`         | Homework        | Weekly homeworks done at home.                          |
-| `MP`         | Machine Problem | Weekly coding assisgnments done outside of class.       |
+| `MP`         | Machine Problem | Weekly coding assignments done outside of class.        |
 | `Q`          | Quiz            | Short frequent quizzes.                                 |
 | `PQ`         | Practice Quiz   | Practice quizzes.                                       |
 | `E`          | Exam            | Long-form midterm or final exams.                       |
@@ -260,9 +260,9 @@ Each question in the course has a topic from the list specified in the `infoCour
 
 | Property      | Description                                                                                       |
 | ------------- | ------------------------------------------------------------------------------------------------- |
-| `name`        | Brief name for the topic. Shorter is better. Should be in sentence case (leading captial letter). |
+| `name`        | Brief name for the topic. Shorter is better. Should be in sentence case (leading capital letter). |
 | `color`       | The color scheme for this topic (see below for choices).                                          |
-| `description` | An explanation of what the topic includes, for human referance.                                   |
+| `description` | An explanation of what the topic includes, for human reference.                                   |
 
 For example, topics could be listed like:
 
@@ -291,7 +291,7 @@ Each question can have zero, one, or many tags associated with it. The propertie
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`        | Brief name for the tag. Tags should have very short names (preferably just a single word) because there might be many of them on one question. Should typically be in lower case (e.g., `drawing`) or an uppercase abbreviation (e.g., `MC`). |
 | `color`       | The color scheme for this tag (see below for choices).                                                                                                                                                                                        |
-| `description` | An explanation of what the tag means, for human referance.                                                                                                                                                                                    |
+| `description` | An explanation of what the tag means, for human reference.                                                                                                                                                                                    |
 
 ### Standardized tag names
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -58,7 +58,7 @@ images, files, and code display. The following **decorative** elements are avail
 - [`pl-file-download`](#pl-file-download-element): Enable file downloads for
   data-centric questions.
 - [`pl-file-preview`](#pl-file-preview-element): Displays a preview of submitted files.
-- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a networkx graph.
+- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a network graph.
 - [`pl-matrix-latex`](#pl-matrix-latex-element): Displays matrices using
   appropriate LaTeX commands for use in a mathematical expression.
 - [`pl-overlay`](#pl-overlay-element): Allows layering existing elements on top of one another in specified positions.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -58,7 +58,7 @@ images, files, and code display. The following **decorative** elements are avail
 - [`pl-file-download`](#pl-file-download-element): Enable file downloads for
   data-centric questions.
 - [`pl-file-preview`](#pl-file-preview-element): Displays a preview of submitted files.
-- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a [`networkx`](https://networkx.org/) graph.
+- [`pl-graph`](#pl-graph-element): Displays graphs, using [GraphViz DOT notation](https://graphviz.org/doc/info/lang.html), an adjacency matrix, or a [`networkx`](https://networkx.org/) graph.
 - [`pl-matrix-latex`](#pl-matrix-latex-element): Displays matrices using
   appropriate LaTeX commands for use in a mathematical expression.
 - [`pl-overlay`](#pl-overlay-element): Allows layering existing elements on top of one another in specified positions.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -58,7 +58,7 @@ images, files, and code display. The following **decorative** elements are avail
 - [`pl-file-download`](#pl-file-download-element): Enable file downloads for
   data-centric questions.
 - [`pl-file-preview`](#pl-file-preview-element): Displays a preview of submitted files.
-- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a networkx graph.
+- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a [`networkx`](https://networkx.org/) graph.
 - [`pl-matrix-latex`](#pl-matrix-latex-element): Displays matrices using
   appropriate LaTeX commands for use in a mathematical expression.
 - [`pl-overlay`](#pl-overlay-element): Allows layering existing elements on top of one another in specified positions.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -58,7 +58,7 @@ images, files, and code display. The following **decorative** elements are avail
 - [`pl-file-download`](#pl-file-download-element): Enable file downloads for
   data-centric questions.
 - [`pl-file-preview`](#pl-file-preview-element): Displays a preview of submitted files.
-- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a network graph.
+- [`pl-graph`](#pl-graph-element): Displays graphs, using GraphViz DOT notation, an adjacency matrix, or a networkx graph.
 - [`pl-matrix-latex`](#pl-matrix-latex-element): Displays matrices using
   appropriate LaTeX commands for use in a mathematical expression.
 - [`pl-overlay`](#pl-overlay-element): Allows layering existing elements on top of one another in specified positions.

--- a/docs/questionSharing.md
+++ b/docs/questionSharing.md
@@ -43,7 +43,7 @@ To refer to a question from another course, use the question id (qid) prefixed b
 
 Questions that make use of `clientFilesQuestion`, `serverFilesQuestion`, and `serverFilesCourse` will work as expected. Using `clientFilesCourse` in a question is not supported at this time.
 
-If a sharing course attempts to share a question which accesses client or server files associated with a course instance or an assessment, the question will not work as expected because the consuming course can not use it within the context of the sharing course's course intance or assessment.
+If a sharing course attempts to share a question which accesses client or server files associated with a course instance or an assessment, the question will not work as expected because the consuming course can not use it within the context of the sharing course's course instance or assessment.
 
 See the [the client and server files documentation](clientServerFiles.md) for general information about client and server files.
 

--- a/docs/regrading.md
+++ b/docs/regrading.md
@@ -49,11 +49,11 @@ To award some or all students maximum points for a question during a regrade, ed
 ],
 ```
 
-In the example above the questions `anEasyQ` and `SecondAltQ` will award maximum points to any student who has these questions and is regraded.
+In the example above, the questions `anEasyQ` and `SecondAltQ` will award maximum points to any student who has these questions and is regraded.
 
 ## Handling questions with alternatives
 
-For questions that all students get on their assessment the above system is straightforward. For questions with alternatives it is less clear. For example, consider the case when `SecondAltQ` is broken in the assessment above. In the above example we only awarded maxinum points to those students who received `SecondAltQ`, while students with `FirstAltQ` did not receive automatic maximum points. However, it is probably a better idea to give maximum points to all students irrespective of which alternative they received, as follows:
+For questions that all students get on their assessment the above system is straightforward. For questions with alternatives it is less clear. For example, consider the case when `SecondAltQ` is broken in the assessment above. In the above example, we only awarded maximum points to those students who received `SecondAltQ`, while students with `FirstAltQ` did not receive automatic maximum points. However, it is probably a better idea to give maximum points to all students irrespective of which alternative they received, as follows:
 
 ```json
 {


### PR DESCRIPTION
I was reading through some documentation and stumbled upon some minor typos. Two were found in the code but they're very small.