### PR TITLE
Fix SAML still try to work when disable SAML but well configuration

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -1,6 +1,9 @@
 import { MultiSamlStrategy, type SamlConfig } from '@node-saml/passport-saml';
 
-import {getInstitutionAuthenticationProviders, getInstitutionSamlProvider} from '../../lib/institution.js';
+import {
+  getInstitutionAuthenticationProviders,
+  getInstitutionSamlProvider,
+} from '../../lib/institution.js';
 
 export async function getSamlOptions({
   institution_id,
@@ -13,7 +16,8 @@ export async function getSamlOptions({
 }): Promise<SamlConfig> {
   const samlProvider = await getInstitutionSamlProvider(institution_id);
   const InstitutionProvider = await getInstitutionAuthenticationProviders(institution_id);
-  if (!samlProvider || !InstitutionProvider.some((p)=> p.name === "SAML")) throw new Error('No SAML provider found for given institution');
+  if (!samlProvider || !InstitutionProvider.some((p) => p.name === 'SAML'))
+    throw new Error('No SAML provider found for given institution');
 
   // It's most convenient if folks can pass in `req.headers.host` directly,
   // but that's typed as `string | undefined`. So, we'll accept that type

--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -1,6 +1,6 @@
 import { MultiSamlStrategy, type SamlConfig } from '@node-saml/passport-saml';
 
-import { getInstitutionSamlProvider } from '../../lib/institution.js';
+import {getInstitutionAuthenticationProviders, getInstitutionSamlProvider} from '../../lib/institution.js';
 
 export async function getSamlOptions({
   institution_id,
@@ -12,7 +12,8 @@ export async function getSamlOptions({
   strictMode: boolean;
 }): Promise<SamlConfig> {
   const samlProvider = await getInstitutionSamlProvider(institution_id);
-  if (!samlProvider) throw new Error('No SAML provider found for given institution');
+  const InstitutionProvider = await getInstitutionAuthenticationProviders(institution_id);
+  if (!samlProvider || !InstitutionProvider.some((p)=> p.name === "SAML")) throw new Error('No SAML provider found for given institution');
 
   // It's most convenient if folks can pass in `req.headers.host` directly,
   // but that's typed as `string | undefined`. So, we'll accept that type

--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -15,9 +15,10 @@ export async function getSamlOptions({
   strictMode: boolean;
 }): Promise<SamlConfig> {
   const samlProvider = await getInstitutionSamlProvider(institution_id);
-  const InstitutionProvider = await getInstitutionAuthenticationProviders(institution_id);
-  if (!samlProvider || !InstitutionProvider.some((p) => p.name === 'SAML'))
+  const authenticationProviders = await getInstitutionAuthenticationProviders(institution_id);
+  if (!samlProvider || !authenticationProviders.some((p) => p.name === 'SAML')) {
     throw new Error('No SAML provider found for given institution');
+  }
 
   // It's most convenient if folks can pass in `req.headers.host` directly,
   // but that's typed as `string | undefined`. So, we'll accept that type


### PR DESCRIPTION
Fix SAML still works when disabled SAML but well configuration. 
<img width="623" src="https://github.com/PrairieLearn/PrairieLearn/assets/42112059/7d3b221a-4497-4eae-9020-5db32f598f80"> 
While SAML single sign-on providers are disable, even though the login entry is no longer displayed on the login page, it can still work on /pl/auth/institution/xxx/saml/login (However in the last judgment, user still unable to log in on users_select_or_insert.sql)
Code changed to add checking if saml is disable.