### PR TITLE
Fix unawaited promise on course instances page

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -1,6 +1,6 @@
 import { MultiSamlStrategy, type SamlConfig } from '@node-saml/passport-saml';
 
-import {getInstitutionAuthenticationProviders, getInstitutionSamlProvider} from '../../lib/institution.js';
+import { getInstitutionSamlProvider } from '../../lib/institution.js';
 
 export async function getSamlOptions({
   institution_id,
@@ -12,8 +12,7 @@ export async function getSamlOptions({
   strictMode: boolean;
 }): Promise<SamlConfig> {
   const samlProvider = await getInstitutionSamlProvider(institution_id);
-  const InstitutionProvider = await getInstitutionAuthenticationProviders(institution_id);
-  if (!samlProvider || !InstitutionProvider.some((p)=> p.name === "SAML")) throw new Error('No SAML provider found for given institution');
+  if (!samlProvider) throw new Error('No SAML provider found for given institution');
 
   // It's most convenient if folks can pass in `req.headers.host` directly,
   // but that's typed as `string | undefined`. So, we'll accept that type

--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -1,6 +1,6 @@
 import { MultiSamlStrategy, type SamlConfig } from '@node-saml/passport-saml';
 
-import { getInstitutionSamlProvider } from '../../lib/institution.js';
+import {getInstitutionAuthenticationProviders, getInstitutionSamlProvider} from '../../lib/institution.js';
 
 export async function getSamlOptions({
   institution_id,
@@ -12,7 +12,8 @@ export async function getSamlOptions({
   strictMode: boolean;
 }): Promise<SamlConfig> {
   const samlProvider = await getInstitutionSamlProvider(institution_id);
-  if (!samlProvider) throw new Error('No SAML provider found for given institution');
+  const InstitutionProvider = await getInstitutionAuthenticationProviders(institution_id);
+  if (!samlProvider || !InstitutionProvider.some((p)=> p.name === "SAML")) throw new Error('No SAML provider found for given institution');
 
   // It's most convenient if folks can pass in `req.headers.host` directly,
   // but that's typed as `string | undefined`. So, we'll accept that type

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
@@ -23,7 +23,7 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     try {
-      fs.access(res.locals.course.path);
+      await fs.access(res.locals.course.path);
     } catch (err) {
       if (err.code === 'ENOENT') {
         res.locals.needToSync = true;


### PR DESCRIPTION
When PrairieLearn cannot found course Path in /pl/course/:course_id(\d+)/course_admin/instances
PrairieLearn will crash.
<img width="579" src="https://github.com/PrairieLearn/PrairieLearn/assets/42112059/5d84c21b-9bd8-4e1b-ae3e-6101b155dc39">