### PR TITLE
fix: institution save flash response

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
@@ -75,7 +75,7 @@ router.post(
           row_id: req.params.institution_id,
         });
       });
-      flash('success', 'Successfully updated general information and enrollment limits.');
+      flash('success', 'Successfully updated institution settings.');
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'update_plans') {
       const desiredPlans = parseDesiredPlanGrants({

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
@@ -75,7 +75,7 @@ router.post(
           row_id: req.params.institution_id,
         });
       });
-      flash('success', 'Successfully updated enrollment limits.');
+      flash('success', 'Successfully updated general information and enrollment limits.');
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'update_plans') {
       const desiredPlans = parseDesiredPlanGrants({


### PR DESCRIPTION
Updates the flash response on an institution save to imply it's updating not only enrollment limits.