### PR TITLE
Disable machine-specific optimizations for pgvector

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -56,7 +56,7 @@ git clone --branch v0.7.0 https://github.com/pgvector/pgvector.git
 cd pgvector
 # This Docker image will be built in GitHub Actions but must run on a variety
 # of platforms, so we need to build it without machine-specific instructions.
-# https://github.com/pgvector/pgvector/issues/143
+# https://github.com/pgvector/pgvector/issues/130
 # https://github.com/pgvector/pgvector/issues/143
 make OPTFLAGS=""
 make install

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -54,7 +54,11 @@ dnf -y install postgresql15-server-devel
 cd /tmp
 git clone --branch v0.7.0 https://github.com/pgvector/pgvector.git
 cd pgvector
-make
+# This Docker image will be built in GitHub Actions but must run on a variety
+# of platforms, so we need to build it without machine-specific instructions.
+# https://github.com/pgvector/pgvector/issues/143
+# https://github.com/pgvector/pgvector/issues/143
+make OPTFLAGS=""
 make install
 rm -rf /tmp/pgvector
 dnf -y remove postgresql15-server-devel


### PR DESCRIPTION
This ensures that images built in GitHub Actions will run on other machines. Specifically, this fixes an issue where `CREATE EXTENSION vector;` would fail with "Illegal instruction" on my Apple Silicon Mac.