### PR TITLE
User-friendly message on Docker if workspaces are unavailable

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -8,7 +8,7 @@ cd /PrairieLearn
 make -s start-support
 
 if [ -S /var/run/docker.sock ] ; then 
-    PREFIX="-all"
+    SUFFIX="-all"
 else
     echo "Running PrairieLearn without support for external graders and workspaces." 1>&2
     echo "To enable external graders and workspaces, follow the instructions here:" 1>&2
@@ -17,8 +17,8 @@ fi
 
 if [[ $NODEMON == "true" || $DEV == "true" ]]; then
     make migrate-dev > /dev/null
-    make dev$PREFIX
+    make dev$SUFFIX
 else
     make migrate > /dev/null
-    make start$PREFIX
+    make start$SUFFIX
 fi

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -7,10 +7,18 @@ echo 'Starting PrairieLearn...'
 cd /PrairieLearn
 make -s start-support
 
-if [[ $NODEMON == "true" || DEV == "true" ]]; then
+if [ -S /var/run/docker.sock ] ; then 
+    PREFIX="-all"
+else
+    echo "Running PrairieLearn without support for external graders and workspaces." 1>&2
+    echo "To enable external graders and workspaces, follow the instructions here:" 1>&2
+    echo "https://prairielearn.readthedocs.io/en/latest/installing/#support-for-external-graders-and-workspaces" 1>&2
+fi
+
+if [[ $NODEMON == "true" || $DEV == "true" ]]; then
     make migrate-dev > /dev/null
-    make dev-all
+    make dev$PREFIX
 else
     make migrate > /dev/null
-    make start-all
+    make start$PREFIX
 fi


### PR DESCRIPTION
Users that run PrairieLearn locally have commented on Slack about errors when running without workspaces enabled. This is caused by the fact that the workspace host assumes that Docker is available, but this is not the case in this context.

This PR checks if the Docker socket is available locally. If it's not, it runs only the main PrairieLearn code (not the workspace host), and prints a message on the terminal pointing instructors that wish to use external graders and workspaces to the appropriate link.

The text I propose is a suggestion, I'm open to changing it to make it clearer or (if expected) less intrusive.