### PR TITLE
Use Yarn --inline-builds flag in image builds and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,7 +323,7 @@ jobs:
           node-version: '20'
           cache: 'yarn'
       - name: Install Node dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --inline-builds
 
       - name: Set up Turborepo cache
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH="/PrairieLearn/node_modules/.bin:$PATH"
 COPY --parents .yarn/ yarn.lock .yarnrc.yml **/package.json packages/bind-mount/ /PrairieLearn/
 
 # Install Node dependencies.
-RUN cd /PrairieLearn && yarn install --immutable && yarn cache clean
+RUN cd /PrairieLearn && yarn install --immutable --inline-builds && yarn cache clean
 
 # NOTE: Modify .dockerignore to allowlist files/directories to copy.
 COPY . /PrairieLearn/


### PR DESCRIPTION
This will allow us to debug package build failures like the one in https://github.com/PrairieLearn/PrairieLearn/actions/runs/9356677931/job/25754696479.