### PR TITLE
Fix use of pattern in change id form

### DIFF
--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileRenameForm.ejs
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileRenameForm.ejs
@@ -11,7 +11,7 @@
   </div>
   <div class="form-group">
       <label for="renameFileInput">Path:</label>
-      <input type="text" class="form-control" id="renameFileInput" name="new_file_name" value="<%= file.name %>" size="<%= 1.5 * file.name.length %>" pattern="(?:[-A-Za-z0-9_]+|\.\.)(?:\/(?:[-A-Za-z0-9_]+|\.\.))*(?:\.[-A-Za-z0-9_]+)?" required>
+      <input type="text" class="form-control" id="renameFileInput" name="new_file_name" value="<%= file.name %>" size="<%= 1.5 * file.name.length %>" pattern="(?:[\-A-Za-z0-9_]+|\.\.)(?:\/(?:[\-A-Za-z0-9_]+|\.\.))*(?:\.[\-A-Za-z0-9_]+)?" required>
       <div class="invalid-feedback" id="invalidMessage-<%= file.id %>">
       </div>
   </div>

--- a/apps/prairielearn/src/pages/partials/changeIdForm.ejs
+++ b/apps/prairielearn/src/pages/partials/changeIdForm.ejs
@@ -6,7 +6,7 @@
     </div>
     <div class="form-group">
         <label for="changeIdInput"><%= id_label %>:</label>
-        <input type="text" class="form-control" id="changeIdInput" name="id" value="<%= id_old %>" pattern="[-A-Za-z0-9_/]+" required>
+        <input type="text" class="form-control" id="changeIdInput" name="id" value="<%= id_old %>" pattern="[\-A-Za-z0-9_\/]+" required>
         <div class="invalid-feedback" id="invalidIdMessage">
         </div>
     </div>


### PR DESCRIPTION
The form used to change QID, AID, CIID uses the `pattern` attribute to validate IDs. However, this attribute requires a pattern that uses the `v` flag, see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern#overview (emphasis mine):

> The pattern's regular expression is compiled with the ['v' flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_class#v-mode_character_class). This makes the regular expression [unicode-aware](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#unicode-aware_mode), and also changes how character classes are interpreted. This allows character class set intersection and subtraction operations, and in addition to ] and \, **the following characters must be escaped using a \ backslash if they represent literal characters: (, ), [, {, }, /, -, |.** Before mid-2023, the 'u' flag was specified instead; If you're updating older code, [this document outlines the differences](https://github.com/tc39/proposal-regexp-v-flag#how-is-the-v-flag-different-from-the-u-flag).