### PR TITLE
Add NOT NULL constraints to assessment_sets table

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -868,14 +868,14 @@ export const IssueSchema = z.object({
 export type Issue = z.infer<typeof IssueSchema>;
 
 export const AssessmentSetSchema = z.object({
-  abbreviation: z.string().nullable(),
-  color: z.string().nullable(),
+  abbreviation: z.string(),
+  color: z.string(),
   course_id: IdSchema,
-  heading: z.string().nullable(),
+  heading: z.string(),
   id: IdSchema,
   implicit: z.boolean(),
-  name: z.string().nullable(),
-  number: z.number().nullable(),
+  name: z.string(),
+  number: z.number(),
 });
 export type AssessmentSet = z.infer<typeof AssessmentSetSchema>;
 

--- a/apps/prairielearn/src/migrations/20240605165348_assessment_sets__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20240605165348_assessment_sets__not_null_constraints__add.sql
@@ -1,0 +1,19 @@
+ALTER TABLE assessment_sets
+ALTER COLUMN abbreviation
+SET NOT NULL;
+
+ALTER TABLE assessment_sets
+ALTER COLUMN color
+SET NOT NULL;
+
+ALTER TABLE assessment_sets
+ALTER COLUMN heading
+SET NOT NULL;
+
+ALTER TABLE assessment_sets
+ALTER COLUMN name
+SET NOT NULL;
+
+ALTER TABLE assessment_sets
+ALTER COLUMN number
+SET NOT NULL;

--- a/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.sql
+++ b/apps/prairielearn/src/tests/sprocs/check_assessment_access.test.sql
@@ -54,9 +54,17 @@ WITH
   ),
   setup_assessment_sets AS (
     INSERT INTO
-      assessment_sets (id, course_id)
+      assessment_sets (
+        id,
+        course_id,
+        abbreviation,
+        color,
+        heading,
+        name,
+        number
+      )
     VALUES
-      (1, 1)
+      (1, 1, 'HW', 'green1', 'Homeworks', 'Homework', 1)
   ),
   setup_assessments AS (
     INSERT INTO

--- a/database/tables/assessment_sets.pg
+++ b/database/tables/assessment_sets.pg
@@ -1,12 +1,12 @@
 columns
-    abbreviation: text
-    color: text
+    abbreviation: text not null
+    color: text not null
     course_id: bigint not null
-    heading: text
+    heading: text not null
     id: bigint not null default nextval('assessment_sets_id_seq'::regclass)
     implicit: boolean not null default false
-    name: text
-    number: integer
+    name: text not null
+    number: integer not null
 
 indexes
     assessment_sets_pkey: PRIMARY KEY (id) USING btree (id)


### PR DESCRIPTION
I checked in our production databases and this table already satisfies these new constraints. Having this be safely reflected in our types will help out with refactoring some other pages.

I deliberately decided not to use the more complicated multi-step migration like the one in [`apps/prairielearn/src/migrations/20240111010531_groups__group_config_id__not_null.sql`](https://github.com/PrairieLearn/PrairieLearn/blob/bf96affaace6514e83c62cd828ad2083749fea06/apps/prairielearn/src/migrations/20240111010531_groups__group_config_id__not_null.sql). `assessment_sets` has less than 10k rows in all production environments so even if we hold a table lock, it'll be for a very short amount of time.