### PR TITLE
Fix prompt in example chemistry question

### DIFF
--- a/exampleCourse/questions/workshop/PeriodicTable1/question.html
+++ b/exampleCourse/questions/workshop/PeriodicTable1/question.html
@@ -1,6 +1,6 @@
 <pl-question-panel>
   <p> {{params.name}} has density $\rho = {{params.rho}} \rm g/cm^3$ and a molar mass $M = {{params.M}} \rm g/mol $</p>
-  <p> Determine the number of atoms in 1 cm<sup>3</sup>.</p>
+  <p> Determine the number of atoms in $1 \rm cm^3$ of this element.</p>
 </pl-question-panel>
 
 <pl-number-input answers-name="N" comparison="sigfig" digits="1" label="$N=$"></pl-number-input>

--- a/exampleCourse/questions/workshop/PeriodicTable1/question.html
+++ b/exampleCourse/questions/workshop/PeriodicTable1/question.html
@@ -1,6 +1,6 @@
 <pl-question-panel>
-  <p> {{params.name}} has density $\rho = {{params.rho}} \rm g/cm^3$ and atomic weight $M = {{params.M}} \rm g/mol $</p>
-  <p> Determine the atomic number $N$.</p>
+  <p> {{params.name}} has density $\rho = {{params.rho}} \rm g/cm^3$ and a molar mass $M = {{params.M}} \rm g/mol $</p>
+  <p> Determine the number of atoms in 1 cm<sup>3</sup>.</p>
 </pl-question-panel>
 
 <pl-number-input answers-name="N" comparison="sigfig" digits="1" label="$N=$"></pl-number-input>


### PR DESCRIPTION
The changes proposed are to eliminate the confusion that may arise when a student is faced with having to provide an answer for "atomic number" when in reality, the question expects the student to provide an answer about the "number of atoms".