### PR TITLE
Fix type for assessment_access_rules.mode

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -969,7 +969,7 @@ export const AssessmentAccessRuleSchema = z.object({
   end_date: DateFromISOString.nullable(),
   exam_uuid: z.string().nullable(),
   id: IdSchema,
-  mode: ModeSchema,
+  mode: ModeSchema.nullable(),
   number: z.number(),
   password: z.string().nullable(),
   seb_config: z.any().nullable(),


### PR DESCRIPTION
This was introduced in #9961 with an incorrect type.