### PR TITLE
Fix rendering of info HTML on error page

### DIFF
--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
@@ -221,13 +221,11 @@ export async function authzCourseOrInstance(req, res) {
           ${config.devMode && is_administrator
             ? html`
                 <div class="alert alert-warning" role="alert">
-                  <p>
-                    In Development Mode,
-                    <a href="/pl/administrator/query/select_or_insert_user"
-                      >go here to add the user</a
-                    >
-                    first and then try the emulation again.
-                  </p>
+                  In Development Mode,
+                  <a href="/pl/administrator/query/select_or_insert_user">
+                    go here to add the user
+                  </a>
+                  first and then try the emulation again.
                 </div>
                 ${isCourseInstance
                   ? html`

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -2,7 +2,7 @@ import jsonStringifySafe from 'json-stringify-safe';
 import _ from 'lodash';
 
 import { formatErrorStack } from '@prairielearn/error';
-import { HtmlSafeString, html } from '@prairielearn/html';
+import { HtmlSafeString, html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 import { formatQueryWithErrorPosition } from '@prairielearn/postgres';
 
@@ -23,7 +23,7 @@ export function ErrorPage({
     stack?: string;
     status?: number;
     data?: Record<string, any>;
-    info?: HtmlSafeString;
+    info?: string;
   };
   errorId: string;
   referrer: string | null;
@@ -61,7 +61,7 @@ export function ErrorPage({
             <div class="card-body">
               <h4 class="mb-3">${error.message}</h4>
 
-              ${error.info ?? ''}
+              ${unsafeHtml(error.info ?? '')}
 
               <p><strong>Error ID:</strong> <code>${errorId}</code></p>
 

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -2,7 +2,7 @@ import jsonStringifySafe from 'json-stringify-safe';
 import _ from 'lodash';
 
 import { formatErrorStack } from '@prairielearn/error';
-import { HtmlSafeString, html, unsafeHtml } from '@prairielearn/html';
+import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 import { formatQueryWithErrorPosition } from '@prairielearn/postgres';
 
@@ -14,6 +14,7 @@ function formatJson(value: any): string {
 
 export function ErrorPage({
   error,
+  errorInfo,
   errorId,
   referrer,
   resLocals,
@@ -23,8 +24,8 @@ export function ErrorPage({
     stack?: string;
     status?: number;
     data?: Record<string, any>;
-    info?: string;
   };
+  errorInfo?: string;
   errorId: string;
   referrer: string | null;
   resLocals: Record<string, any>;
@@ -61,7 +62,7 @@ export function ErrorPage({
             <div class="card-body">
               <h4 class="mb-3">${error.message}</h4>
 
-              ${unsafeHtml(error.info ?? '')}
+              ${unsafeHtml(errorInfo ?? '')}
 
               <p><strong>Error ID:</strong> <code>${errorId}</code></p>
 

--- a/apps/prairielearn/src/pages/error/error.js
+++ b/apps/prairielearn/src/pages/error/error.js
@@ -2,7 +2,7 @@
 
 import jsonStringifySafe from 'json-stringify-safe';
 
-import { formatErrorStackSafe } from '@prairielearn/error';
+import { AugmentedError, formatErrorStackSafe } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 
 import { config } from '../../lib/config.js';
@@ -40,7 +40,18 @@ export default function (err, req, res, _next) {
   res.send(
     ErrorPage({
       // Hide error details in production.
-      error: config.devMode ? err : { message: err.message, status: err.status },
+      error: config.devMode
+        ? err
+        : {
+            message: err.message,
+            status: err.status,
+          },
+      // Only include the info property if it's from an AugmentedError.
+      // We'll render this as unescaped HTML, so we need to be sure that
+      // it's safe to do so, and only AugmentedError guarantees that by
+      // forcing the `info` property to be constructed with an `html`
+      // template.
+      errorInfo: err instanceof AugmentedError ? err.info : undefined,
       errorId,
       referrer,
       resLocals: res.locals,

--- a/apps/prairielearn/src/pages/error/error.js
+++ b/apps/prairielearn/src/pages/error/error.js
@@ -40,12 +40,7 @@ export default function (err, req, res, _next) {
   res.send(
     ErrorPage({
       // Hide error details in production.
-      error: config.devMode
-        ? err
-        : {
-            message: err.message,
-            status: err.status,
-          },
+      error: config.devMode ? err : { message: err.message, status: err.status },
       // Only include the info property if it's from an AugmentedError.
       // We'll render this as unescaped HTML, so we need to be sure that
       // it's safe to do so, and only AugmentedError guarantees that by


### PR DESCRIPTION
This fixed two regressions introduced by #9935:

- `error.info` was previously rendered with `<%- ->` in EJS; we need to maintain that property now that we're no longer using EJS.
- `error.info` was previously shown even in production environments, but that was inadvertently broken.

I also added an additional check to make sure that we only render the `info` property of `AugmentedError` instances.