### PR TITLE
Attempt to fix node-gyp building of native dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "migrate-dev": "yarn workspace @prairielearn/prairielearn dev:no-watch --migrate-and-exit",
     "migrate": "yarn workspace @prairielearn/prairielearn start --migrate-and-exit",
     "refresh-workspace-hosts-dev": "yarn workspace @prairielearn/prairielearn dev:no-watch --refresh-workspace-hosts-and-exit",
-    "refresh-workspace-hosts": "yarn workspace @prairielearn/prairielearn start --refresh-workspace-hosts-and-exit"
+    "refresh-workspace-hosts": "yarn workspace @prairielearn/prairielearn start --refresh-workspace-hosts-and-exit",
+    "preinstall": "node-gyp install"
   },
   "dependencies": {
     "node-gyp": "^10.1.0"


### PR DESCRIPTION
I'm 95% sure the intermittent CI failures we're facing are a result of the issue described in these places:

- https://github.com/nodejs/node-gyp/issues/1054
- https://github.com/yarnpkg/yarn/issues/1874

Specifically, this is exactly what we're facing:

> What was super weird is that the C compiler complained about files that were apparently truncated. Those files were node.js header files, downloaded by node-gyp before the compilation process. Since gyp verifies the integrity of these files, they can't be corrupted at the source. The corruptions occurred in different files and on different lines every time.

The recommended fix that's floating around is to run `node-gyp install` in a `preinstall` hook. This should ensure that the necessary headers are downloaded and unpacked before the builds start. That said, I'm not 100% sure that this will fix things. When testing `rm -rf node_modules && yarn --inline-builds`, it looks like this `preinstall` script is run concurrently with all the _other_ package builds 😕 

This is apparently a Yarn-specific issue, and not the first one we've found IIRC. `pnpm` seems to be the best Node package manager at the moment. Maybe we should switch?