### PR TITLE
Force s3rver to listen on 127.0.0.1

### DIFF
--- a/apps/prairielearn/src/lib/aws.js
+++ b/apps/prairielearn/src/lib/aws.js
@@ -31,7 +31,7 @@ const awsConfigProvider = makeAwsConfigProvider({
           accessKeyId: 'S3RVER',
           secretAccessKey: 'S3RVER',
         },
-        endpoint: 'http://localhost:5000',
+        endpoint: 'http://127.0.0.1:5000',
       };
     }
 

--- a/apps/workspace-host/src/lib/aws.ts
+++ b/apps/workspace-host/src/lib/aws.ts
@@ -19,7 +19,7 @@ const awsConfigProvider = makeAwsConfigProvider({
           accessKeyId: 'S3RVER',
           secretAccessKey: 'S3RVER',
         },
-        endpoint: 'http://localhost:5000',
+        endpoint: 'http://127.0.0.1:5000',
       };
     }
 

--- a/docker/start_s3rver.sh
+++ b/docker/start_s3rver.sh
@@ -24,7 +24,7 @@ if [ -n "$PID" ]; then
 fi
 
 mkdir -p ./s3rver
-node_modules/.bin/s3rver --directory ./s3rver --port 5000 --configure-bucket workspaces --configure-bucket chunks --configure-bucket file-store --configure-bucket workspace-logs > /dev/null &
+node_modules/.bin/s3rver --address 127.0.0.1 --port 5000 --directory ./s3rver --configure-bucket workspaces --configure-bucket chunks --configure-bucket file-store --configure-bucket workspace-logs > /dev/null &
 
 # wait for s3rver to start
 until lsof -i :5000 > /dev/null ; do sleep 1 ; done

--- a/packages/aws/README.md
+++ b/packages/aws/README.md
@@ -67,7 +67,7 @@ const awsConfigProvider = makeAwsConfigProvider({
           accessKeyId: 'S3RVER',
           secretAccessKey: 'S3RVER',
         },
-        endpoint: 'http://localhost:5000',
+        endpoint: 'http://127.0.0.1:5000',
       };
     }
 


### PR DESCRIPTION
This should fix the CI failures like the one here: https://github.com/PrairieLearn/PrairieLearn/actions/runs/9485947777/job/26139121551?pr=10003

I'm not entirely sure what the actual root cause is, but here's what I observed:

- A lot of tests were failing with `ECONNREFUSED 127.0.0.1:5000`
- When running the original `node_modules/.bin/s3rver ...` command manually, it logs `S3rver listening on ::1:5000` (an IPv6 address)
- When I run `curl  http://localhost:5000`, I get a response from s3rver
- When I run `node -e "fetch('http://localhost:5000')"`, I get the same `ECONNREFUSED` we see in the test failures
- When I run `node -e ...` on my _local_ machine (macOS) outside the container, everything works as expected, even though s3rver is listening on an IPv6 address
- `node -e "dns.lookup('localhost', console.log)"` reports `null ::1 6` both in the container and on my machine; it's not clear to me why `fetch` (and indeed `node:http`) resolve `localhost` to an IPv4 address