### PR TITLE
Enable keyboard accessibility for Ace editor

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorFileEditorClient.js
+++ b/apps/prairielearn/assets/scripts/instructorFileEditorClient.js
@@ -20,6 +20,7 @@ window.InstructorFileEditor = function (options) {
     showPrintMargin: false,
     mode: options.aceMode,
     readOnly: options.readOnly,
+    enableKeyboardAccessibility: true,
   });
 
   if (options.altElementId) {

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -19,7 +19,9 @@ window.PLFileEditor = function (uuid, options) {
   this.restoreOriginalConfirmContainer = this.element.find('.restore-original-confirm-container');
   this.restoreOriginalConfirm = this.element.find('.restore-original-confirm');
   this.restoreOriginalCancel = this.element.find('.restore-original-cancel');
-  this.editor = ace.edit(this.editorElement.get(0));
+  this.editor = ace.edit(this.editorElement.get(0), {
+    enableKeyboardAccessibility: true,
+  });
   this.editor.setTheme('ace/theme/chrome');
   this.editor.getSession().setUseWrapMode(true);
   this.editor.setShowPrintMargin(false);

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -236,17 +236,20 @@ window.PLFileEditor.prototype.initRestoreOriginalButton = function () {
   this.restoreOriginalButton.click(() => {
     this.restoreOriginalButton.hide();
     this.restoreOriginalConfirmContainer.show();
+    this.restoreOriginalConfirm.focus();
   });
 
   this.restoreOriginalConfirm.click(() => {
     this.restoreOriginalConfirmContainer.hide();
     this.restoreOriginalButton.show();
+    this.restoreOriginalButton.focus();
     this.setEditorContents(this.b64DecodeUnicode(this.originalContents));
   });
 
   this.restoreOriginalCancel.click(() => {
     this.restoreOriginalConfirmContainer.hide();
     this.restoreOriginalButton.show();
+    this.restoreOriginalButton.focus();
   });
 };
 

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.mustache
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.mustache
@@ -67,10 +67,10 @@ $(function() {
         {{/preview}}
         <div class="card-footer d-flex">
             <div class="ml-auto">
-                <button type="button" class="btn btn-outline-secondary btn-sm restore-original" tabindex="-1" type="button">Restore original file</button>
+                <button type="button" class="btn btn-outline-secondary btn-sm restore-original">Restore original file</button>
                 <div class="restore-original-confirm-container" style="display: none;">
-                    <button type="button" class="btn btn-success btn-sm restore-original-confirm" tabindex="-1">Confirm restore original</button>
-                    <button type="button" class="btn btn-secondary btn-sm restore-original-cancel" tabindex="-1">Cancel</button>
+                    <button type="button" class="btn btn-success btn-sm restore-original-confirm">Confirm restore original</button>
+                    <button type="button" class="btn btn-secondary btn-sm restore-original-cancel">Cancel</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This was surfaced by a recent accessibility review. Now, to place the cursor into the editor, one must focus it and then press <kbd>Enter</kbd>. To be able to tab to other inputs, one can press <kbd>Esc</kbd> to exit the focus trap and one can then <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd> as normal.

I also took the opportunity to improve the keyboard accessibility of other parts of the `<pl-file-editor>` element.