### PR TITLE
Fix check for blank answer in pl-rich-text-editor

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -48,6 +48,25 @@
     quill.setContents(quill.clipboard.convert({ html: contents }));
 
     quill.on('text-change', function () {
+      // If a user types something and erases it, the editor will be blank, but
+      // the content will be something like `<p></p>`. In order to make sure
+      // this is treated as blank by the element's parse code and tagged as
+      // invalid if allow-blank is not true, we explicitly set the value to an
+      // empty string if the editor is blank. This is done using the `isBlank`
+      // method, used by Quill to determine if the placeholder should be shown.
+      // This is not a perfect solution, since it will not catch cases like
+      // content with only a space or a bulleted list without text, but we're ok
+      // with this caveat.
+      //
+      // An alternative solution would be to use the `getText` method, but this
+      // would cause a false positive for elements that are part of the answer
+      // but don't have a text (e.g., images).
+      //
+      // Because `isBlank` is undocumented, this solution may break in the
+      // future (see https://github.com/slab/quill/issues/4254). To ensure that
+      // the element continues to work if this method is removed, we use
+      // optional chaining in the call. This would cause the empty check to
+      // fail but not crash, so the element can continue working.
       let contents = quill.editor?.isBlank?.()
         ? ''
         : rtePurify.sanitize(quill.getSemanticHTML(), rtePurifyConfig);

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -48,7 +48,7 @@
     quill.setContents(quill.clipboard.convert({ html: contents }));
 
     quill.on('text-change', function () {
-      let contents = quill.editor.isBlank()
+      let contents = quill.editor?.isBlank?.()
         ? ''
         : rtePurify.sanitize(quill.getSemanticHTML(), rtePurifyConfig);
       if (contents && renderer) contents = renderer.makeMarkdown(contents);

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -48,7 +48,9 @@
     quill.setContents(quill.clipboard.convert({ html: contents }));
 
     quill.on('text-change', function () {
-      let contents = rtePurify.sanitize(quill.getSemanticHTML(), rtePurifyConfig);
+      let contents = quill.editor.isBlank()
+        ? ''
+        : rtePurify.sanitize(quill.getSemanticHTML(), rtePurifyConfig);
       if (contents && renderer) contents = renderer.makeMarkdown(contents);
       inputElement.val(
         btoa(


### PR DESCRIPTION
Resolves #10011. In essence ensures that if the content is blank, then a blank answer is sent to the input, so that the appropriate check can be done for missing answer. This was not the case if you type something then delete it.

This uses `quill.editor.isBlank()` as a means to identify if the answer is empty or not. This is an undocumented API, so the code is written to have a bit of control so that, if the function ceases to exist in the future, the code doesn't break.

The code will be considered blank in the same scenarios where Quill shows the placeholder, so things like adding a space or an empty list item will not be considered blank.