### PR TITLE
Enable keyboard accessibility for pl-rich-text-editor

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -29,6 +29,22 @@
       ];
     }
 
+    options.modules.keyboard = {
+      bindings: {
+        tab: {
+          key: 9,
+          handler: () => {
+            // Overrides Quill tab behavior to insert a tab character. Retains
+            // other tab behaviours (e.g. indent list items or switch to
+            // different cell in a table), or to the browser default behavior
+            // (i.e., focus on the next focusable element)
+            // https://quilljs.com/docs/modules/keyboard#configuration
+            return true;
+          },
+        },
+      },
+    };
+
     let inputElement = $('#rte-input-' + uuid);
     let quill = new Quill('#rte-' + uuid, options);
     let renderer = null;

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -34,10 +34,11 @@
         tab: {
           key: 9,
           handler: () => {
-            // Overrides Quill tab behavior to insert a tab character. Retains
-            // other tab behaviours (e.g. indent list items or switch to
-            // different cell in a table), or to the browser default behavior
-            // (i.e., focus on the next focusable element)
+            // Overrides Quill tab behavior that inserts a tab character.
+            // Retains other Quill tab behaviours (indent list items or code
+            // blocks, switch cells in table), falling back to the browser's
+            // default behavior (focus on next focusable element) for
+            // accessibility.
             // https://quilljs.com/docs/modules/keyboard#configuration
             return true;
           },


### PR DESCRIPTION
Resolves #10013 (at least in part, until slab/quill#3952 is addressed). In essence, it overrides the case where a tab keypress inserts a tab character and causes it to focus on the next focusable element. It does not override other tab behaviours, like indenting lists, switching cells in a table, or indent inside a code block, so this would not work in those contexts, but it at least provides an option for a user to leave that context (if applicable) and exit the answer element.