### PR TITLE
Run node-gyp install before installing dependencies with Yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,21 @@ ENV PATH="/PrairieLearn/node_modules/.bin:$PATH"
 COPY --parents .yarn/ yarn.lock .yarnrc.yml **/package.json packages/bind-mount/ /PrairieLearn/
 
 # Install Node dependencies.
-RUN cd /PrairieLearn && yarn install --immutable --inline-builds && yarn cache clean
+#
+# The `node-gyp` stuff is a workaround to a bug where multiple instances of `node-gyp`
+# end up running at the same time and corrupt the Node headers that are being written
+# to disk. This is somewhat of a known issue with Yarn and `node-gyp` specifically:
+#
+# https://github.com/nodejs/node-gyp/issues/1054
+# https://github.com/yarnpkg/yarn/issues/1874
+#
+# By running `node-gyp install` at the beginning, we ensure that the later invocations
+# of `node-gyp` will find the headers already installed and not try to install them
+# again, thus avoiding the corruption issue.
+#
+# If the following issue is ever addressed, we can use that instead:
+# https://github.com/yarnpkg/berry/issues/6339
+RUN cd /PrairieLearn && yarn install -g node-gyp && yarn node-gyp install && yarn install --immutable --inline-builds && yarn cache clean
 
 # NOTE: Modify .dockerignore to allowlist files/directories to copy.
 COPY . /PrairieLearn/


### PR DESCRIPTION
This takes another approach to fixing the issue described in #9999. See that PR for more context.