### PR TITLE
Preinstall node-gyp headers in GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,6 +322,8 @@ jobs:
         with:
           node-version: '20'
           cache: 'yarn'
+      - name: Preinstall node-gyp headers
+        run: yarn dlx node-gyp install
       - name: Install Node dependencies
         run: yarn install --immutable --inline-builds
 
@@ -377,6 +379,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Preinstall node-gyp headers
+        run: yarn dlx node-gyp install
 
       - name: Install Node dependencies
         run: yarn workspaces focus @prairielearn/actions-report-image-sizes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           node-version: 20.x
           cache: 'yarn'
 
+      - name: Preinstall node-gyp headers
+        run: yarn dlx node-gyp install
+
       - name: Install Dependencies
         run: yarn --immutable
 


### PR DESCRIPTION
Applies the change from #10015 to the GitHub Actions workflows to avoid CI failures.