### PR TITLE
fix: Filter null qids on instructor question settings page

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.sql
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.sql
@@ -5,7 +5,8 @@ FROM
   questions AS q
 WHERE
   q.course_id = $course_id
-  AND q.deleted_at IS NULL;
+  AND q.deleted_at IS NULL
+  AND q.qid IS NOT NULL;
 
 -- BLOCK select_question_id_from_uuid
 SELECT


### PR DESCRIPTION
If your course is consuming shared questions which are not present in local dev, the qid is null, causing an error on the instructorQuestionSettings page: 

```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      184
    ],
    "message": "Expected string, received null"
  }
]
    at get error [as error] (file:///PrairieLearn/node_modules/zod/lib/index.mjs:587:31)
    at ZodArray.parse (file:///PrairieLearn/node_modules/zod/lib/index.mjs:692:22)
    at PostgresPool.queryRows (/PrairieLearn/packages/postgres/src/pool.ts:902:29)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at <anonymous> (/PrairieLearn/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts:244:18)
```

This should only be a temporary fix, this won't be needed anymore once the column is properly marked `NOT NULL`, which is being worked on here: #9681 