### PR TITLE
Make compiled-assets throw errors in dev mode for missing files

### DIFF
--- a/packages/compiled-assets/src/index.test.ts
+++ b/packages/compiled-assets/src/index.test.ts
@@ -65,6 +65,15 @@ async function testProject(options: CompiledAssetsOptions) {
         const cssText = await cssRes.text();
         assert.match(cssText, /body\s*\{/);
         assert.match(cssText, /color:\s*red/);
+
+        assert.throws(
+          () => compiledScriptPath('nonexistent.js'),
+          'Unknown scripts asset: nonexistent.js',
+        );
+        assert.throws(
+          () => compiledStylesheetPath('nonexistent.css'),
+          'Unknown stylesheets asset: nonexistent.css',
+        );
       } finally {
         server.close();
       }

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -36,6 +36,7 @@ export interface CompiledAssetsOptions {
 let options: Required<CompiledAssetsOptions> = { ...DEFAULT_OPTIONS };
 let esbuildContext: esbuild.BuildContext | null = null;
 let esbuildServer: esbuild.ServeResult | null = null;
+let relativeSourcePaths: string[] | null = null;
 
 export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<void> {
   options = {
@@ -54,6 +55,11 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
     // new entrypoints that are added while the server is running.
     const sourceGlob = path.join(options.sourceDirectory, '*', '*.{js,ts,css}');
     const sourcePaths = await globby(sourceGlob);
+
+    // Save the result of globbing for the source paths so that we can later
+    // check if a given filename exists.
+    relativeSourcePaths = sourcePaths.map((p) => path.relative(options.sourceDirectory, p));
+
     esbuildContext = await esbuild.context({
       entryPoints: sourcePaths,
       target: 'es6',
@@ -148,6 +154,14 @@ function compiledPath(type: 'scripts' | 'stylesheets', sourceFile: string): stri
   const sourceFilePath = `${type}/${sourceFile}`;
 
   if (options.dev) {
+    // To ensure that errors that would be raised in production are also raised
+    // in development, we'll check for the existence of the asset file on disk.
+    // This mirrors the production check of the file in the manifest: if a file
+    // exists on disk, it should be in the manifest.
+    if (!relativeSourcePaths?.find((p) => p === sourceFilePath)) {
+      throw new Error(`Unknown ${type} asset: ${sourceFile}`);
+    }
+
     return options.publicPath + sourceFilePath.replace(/\.(js|ts)x?$/, '.js');
   }
 


### PR DESCRIPTION
If an error would be thrown in production because of a missing script/stylesheet, it will now be thrown in development/testing environments. This should make errors like #10036 much easier to catch before we hit production.