### PR TITLE
Docs: update highlight language in console output

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -64,7 +64,7 @@ When you are finished with PrairieLearn, type Control-C on the terminal where yo
 
 If you're using an Apple silicon Mac (M-series chips, etc.) or another ARM-based machine, you may see an error like the following when you try to run the PrairieLearn Docker image:
 
-```
+```console
 no matching manifest for linux/arm64/v8 in the manifest list entries
 ```
 

--- a/docs/installingLocal.md
+++ b/docs/installingLocal.md
@@ -119,7 +119,7 @@ The previous shells were launched in their own containers. If you want to open a
 
   which will output multiple columns of information about your running container(s). Look for the `prairielearn/prairielearn` image and copy its corresponding name. For example, the name of the PrairieLearn container in this `docker ps` output is `upbeat_roentgen`:
 
-  ```
+  ```console
   CONTAINER ID  IMAGE                      COMMAND              CREATED      STATUS      PORTS                   NAMES
   e0f522f41ea4  prairielearn/prairielearn  "/bin/sh -c /Prai…"  2 hours ago  Up 2 hours  0.0.0.0:3000->3000/tcp  upbeat_roentgen
   ```


### PR DESCRIPTION
It seems mkdocs is defaulting to bash for highlighting blocks:
![image](https://github.com/PrairieLearn/PrairieLearn/assets/1004907/18130836-8b72-429c-9c52-1cff753f7c1b)

This PR changes the language to "console" for text that is intended to demonstrate the output of commands. This disables any highlighting related to known keywords in the default language.