### PR TITLE
Deduplicate exam numbers in test course

### DIFF
--- a/apps/prairielearn/src/tests/groupExam.test.ts
+++ b/apps/prairielearn/src/tests/groupExam.test.ts
@@ -22,7 +22,7 @@ const courseInstanceUrl = baseUrl + '/course_instance/1';
 const storedConfig: any = {};
 
 const GROUP_EXAM_1_TID = 'exam14-groupWork';
-const GROUP_EXAM_2_TID = 'exam15-groupWorkRoles';
+const GROUP_EXAM_2_TID = 'exam16-groupWorkRoles';
 const GROUP_NAME = 'groupBB';
 const GROUP_NAME_ALTERNATIVE = 'groupCC';
 

--- a/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
+++ b/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
@@ -26,7 +26,7 @@ const courseInstanceUrl = baseUrl + '/course_instance/1';
 
 const storedConfig: any = {};
 
-const GROUP_WORK_EXAM_TID = 'exam15-groupWorkRoles';
+const GROUP_WORK_EXAM_TID = 'exam16-groupWorkRoles';
 const QUESTION_ID_1 = 'demo/demoNewton-page1';
 const QUESTION_ID_2 = 'demo/demoNewton-page2';
 const QUESTION_ID_3 = 'addNumbers';

--- a/testCourse/courseInstances/Sp15/assessments/exam16-groupWorkRoles/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam16-groupWorkRoles/infoAssessment.json
@@ -3,7 +3,7 @@
   "type": "Exam",
   "title": "Group Activity Exam with Roles",
   "set": "Exam",
-  "number": "15",
+  "number": "16",
   "groupWork": true,
   "groupMaxSize": 4,
   "groupMinSize": 2,


### PR DESCRIPTION
There are currently two exams with number 15 in the test course. These were both created by long-standing PRs, so the number confusion was understandable. To avoid confusion this PR changes one to 16. 