### PR TITLE
Make navbar compatible with Bootstrap 5

### DIFF
--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -179,11 +179,6 @@ a.badge {
   text-decoration: none;
 }
 
-.navbar,
-#course-nav {
-  align-items: baseline;
-}
-
 .no-select {
   user-select: none;
 }

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -42,6 +42,10 @@
       <% } %>
     </ul>
 
+    <% if (devMode) { %>
+       <a id="navbar-load-from-disk" class="btn btn-success btn-sm" href="<%= urlPrefix %>/loadFromDisk">Load from disk</a>
+    <% } %>
+
     <%# User and logout %>
     <%
     let displayedName;
@@ -75,9 +79,6 @@
       data-authn-course-instance-role="<%= locals.authz_data?.authn_course_instance_role %>"
       data-has-instructor-access="<%= locals.authz_data?.user_with_requested_uid_has_instructor_access_to_course_instance?.toString() %>"
     >
-      <% if (devMode) { %>
-          <li class="mb-2 mb-md-0 mr-2 "><a id="navbar-load-from-disk" class="btn btn-success" href="<%= urlPrefix %>/loadFromDisk">Load from disk</a></li>
-      <% } %>
 
 
       <li class="nav-item dropdown mb-2 mb-md-0 mr-2 <% if (navPage == "effective") { %>active<% } %>">

--- a/apps/prairielearn/src/pages/partials/navbarStudent.ejs
+++ b/apps/prairielearn/src/pages/partials/navbarStudent.ejs
@@ -1,11 +1,11 @@
       <%# Course title %> 
       <%# course and course_instance are undefined if we do not have access to the current page %>
-      <li class="nav-item mr-4"><span class="navbar-text"><%= (typeof course !== 'undefined') ? course.short_name : '' %>, <%= (typeof course !== 'undefined' ) ? course_instance.short_name : '' %></span></li>
+      <li class="nav-item navbar-text mr-4"><%= (typeof course !== 'undefined') ? course.short_name : '' %>, <%= (typeof course !== 'undefined' ) ? course_instance.short_name : '' %></li>
 
       <%# Main pages %> 
-      <li class="nav item <% if (navPage == "assessments") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/assessments">Assessments</a></li>
-      <li class="nav item <% if (navPage == "gradebook") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/gradebook">Gradebook</a></li>
+      <li class="nav-item <% if (navPage == "assessments") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/assessments">Assessments</a></li>
+      <li class="nav-item <% if (navPage == "gradebook") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/gradebook">Gradebook</a></li>
 
       <% if (typeof assessment_instance_label != 'undefined' && typeof assessment_instance != 'undefined') { %>
-      <li class="nav item <% if (navPage == "assessment_instance") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>"><%= assessment_instance_label %></a></li>
+      <li class="nav-item <% if (navPage == "assessment_instance") { %>active<% } %>"><a class="nav-link" href="<%= urlPrefix %>/assessment_instance/<%= assessment_instance.id %>"><%= assessment_instance_label %></a></li>
       <% } %>


### PR DESCRIPTION
These changes ensure that the navbar renders correctly with both Bootstrap 4 and Bootstrap 5 styles. Things should render basically the same with Bootstrap 4, with the exception that the dev mode "Load from disk" button is now a) smaller and b) located outside of an `<li>`, which is necessary for proper alignment in Bootstrap 5.