### PR TITLE
Remove unnecessary margins from instructor assessments footer

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ejs
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ejs
@@ -144,10 +144,8 @@
         </div>
 
         <div class="card-footer">
-          <p>
-            Download <a href="<%= urlPrefix %>/instance_admin/assessments/file/<%= csvFilename %>"><%= csvFilename %></a>
-            (includes more statistics columns than displayed above)
-          </p>
+          Download <a href="<%= urlPrefix %>/instance_admin/assessments/file/<%= csvFilename %>"><%= csvFilename %></a>
+          (includes more statistics columns than displayed above)
         </div>
 
       </div>


### PR DESCRIPTION
I noticed this while going through our UI with a fine-tooth comb while evaluating Bootstrap 5.

Before:

<img width="518" alt="Screenshot 2024-06-21 at 13 18 32" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/634746eb-4f2c-41c4-b27c-f8d97155f5de">

After:

<img width="579" alt="Screenshot 2024-06-21 at 13 18 16" src="https://github.com/PrairieLearn/PrairieLearn/assets/1476544/c3cecfb9-cf54-4cb7-959f-be9272afabc0">
