### PR TITLE
Correctly revert to Public mode after access end

### DIFF
--- a/apps/prairielearn/src/sprocs/ip_to_mode.sql
+++ b/apps/prairielearn/src/sprocs/ip_to_mode.sql
@@ -22,12 +22,28 @@ BEGIN
 
     -- Consider each PT reservation which is either active or corresponds to
     -- a session that will start soon or started recently.
+    --
+    -- We consider a session to be "active" is either of the following is true:
+    --
+    -- - The reservation is checked in but hasn't had their access start yet.
+    --   We'll consider the reservation active for the first hour after check-in.
+    -- - The reservation has had their access start at some point, and the current
+    --   time is within the access window.
     FOR reservation IN
         SELECT
             r.session_id,
             (
-                (r.checked_in IS NOT NULL AND ip_to_mode.date BETWEEN r.checked_in AND r.checked_in + '1 hour'::interval)
-                OR ip_to_mode.date BETWEEN r.access_start AND r.access_end
+                (
+                    r.checked_in IS NOT NULL
+                    AND r.access_start IS NULL
+                    AND r.access_end IS NULL
+                    AND ip_to_mode.date BETWEEN r.checked_in AND r.checked_in + '1 hour'::interval
+                )
+                OR (
+                    r.access_start IS NOT NULL
+                    AND r.access_end IS NOT NULL
+                    AND ip_to_mode.date BETWEEN r.access_start AND r.access_end
+                )
             ) AS reservation_active,
             l.id AS location_id,
             l.filter_networks AS location_filter_networks

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.sql
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.sql
@@ -161,4 +161,4 @@ UPDATE pt_reservations
 SET
   -- Start 5 minutes in the past to avoid races between PT and JS time.
   access_start = NOW() - interval '5 minutes',
-  access_end = NOW() + interval '1 hour';
+  access_end = NOW() + interval '20 minutes';

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
@@ -192,8 +192,8 @@ describe('sproc ip_to_mode tests', function () {
 
           const result = await sqldb.callAsync('ip_to_mode', [
             '10.0.0.1',
-            // 100 minutes from now (40 minutes after access end)
-            new Date(Date.now() + 1000 * 60 * 100),
+            // 60 minutes from now (40 minutes after access end)
+            new Date(Date.now() + 1000 * 60 * 60),
             user_id,
           ]);
           assert.equal(result.rows[0].mode, 'Public');

--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
@@ -177,8 +177,8 @@ describe('sproc ip_to_mode tests', function () {
 
           const result = await sqldb.callAsync('ip_to_mode', [
             '10.0.0.1',
-            // 65 minutes from now (5 minutes after access end)
-            new Date(Date.now() + 1000 * 60 * 65),
+            // 25 minutes from now (5 minutes after access end)
+            new Date(Date.now() + 1000 * 60 * 25),
             user_id,
           ]);
           assert.equal(result.rows[0].mode, 'Exam');
@@ -293,6 +293,26 @@ describe('sproc ip_to_mode tests', function () {
             '192.168.0.01',
             // 90 minutes from now.
             new Date(Date.now() + 1000 * 60 * 90),
+            user_id,
+          ]);
+          assert.equal(result.rows[0].mode, 'Public');
+        });
+      });
+
+      it('should return "Public" for any IP address, outside the access date range but within an hour of check-in', async () => {
+        await helperDb.runInTransactionAndRollback(async () => {
+          await createCenterExamReservation();
+
+          // Remove IP restriction.
+          await sqldb.queryAsync('UPDATE pt_locations SET filter_networks = FALSE;', {});
+
+          await sqldb.queryAsync(sql.check_in_reservations, {});
+          await sqldb.queryAsync(sql.start_reservations, {});
+
+          const result = await sqldb.callAsync('ip_to_mode', [
+            '192.168.0.01',
+            // 50 minutes from now.
+            new Date(Date.now() + 1000 * 60 * 50),
             user_id,
           ]);
           assert.equal(result.rows[0].mode, 'Public');


### PR DESCRIPTION
This fixes a bug with PrairieTest access control. When network filtering isn't active, we use simple heuristics to check if a reservation is considered "active". One of them is to check if it's been less than an hour since checkin. This is to ensure that the student is put into exam mode immediately after checking in, even before they've started their exam. However, for very short exams, it's possible that `access_start` and `access_end` will occur very quickly. In that case, we were still considering the reservation to be "active" even after `access_end`, thus keeping the user in Exam mode. There was no way for an instructor to recover and take the student out of Exam mode, as there's no way to check out a student once they've started their exam.

The fix is to only look at `checked_in` if the student hasn't started their exam. Once they have, we'll only look at `access_start` and `access_end`.

Implemented while pairing with @mwest1066.