### PR TITLE
Update example element/dataframe/question.html - typo with show-dtype

### DIFF
--- a/exampleCourse/questions/element/dataframe/question.html
+++ b/exampleCourse/questions/element/dataframe/question.html
@@ -19,9 +19,9 @@
   By default, a Pandas DataFrame will display its index column and header row, as well as a postscript label with
   the table dimensions. You can toggle these with attributes on the <code>pl-dataframe</code> tag.
   Here, we've set the following:
-  <code>show-header="false" show-index="false" show-dimensions="false" show-dtype="none" digits="4" display-variable-name="data_frame" width="10_000"</code>:
+  <code>show-header="false" show-index="false" show-dimensions="false" show-dtype="false" digits="4" display-variable-name="data_frame" width="10_000"</code>:
 </p>
-<pl-dataframe params-name="df" show-index="false" show-dimensions="false" digits="4" display-variable-name="data_frame"
+<pl-dataframe params-name="df" show-index="false" show-dimensions="false" show-dtype="false" digits="4" display-variable-name="data_frame"
   width="10_000"></pl-dataframe>
 <p>
   Here's another Pandas DataFrame. This DataFrame has timestamps and uses the new encoding rule in

--- a/exampleCourse/questions/element/dataframe/question.html
+++ b/exampleCourse/questions/element/dataframe/question.html
@@ -21,7 +21,7 @@
   Here, we've set the following:
   <code>show-header="false" show-index="false" show-dimensions="false" show-dtype="false" digits="4" display-variable-name="data_frame" width="10_000"</code>:
 </p>
-<pl-dataframe params-name="df" show-index="false" show-dimensions="false" show-dtype="false" digits="4" display-variable-name="data_frame"
+<pl-dataframe params-name="df" show-header="false" show-index="false" show-dimensions="false" show-dtype="false" digits="4" display-variable-name="data_frame"
   width="10_000"></pl-dataframe>
 <p>
   Here's another Pandas DataFrame. This DataFrame has timestamps and uses the new encoding rule in

--- a/exampleCourse/questions/element/dataframe/question.html
+++ b/exampleCourse/questions/element/dataframe/question.html
@@ -32,8 +32,8 @@
   show-python="false"></pl-dataframe>
 
 <p>
-  Here's a Pandas DataFrame with equivalent R types at the bottom, done by setting <code>show-dtype="r"</code>.
-  This DataFrame uses the default indexing, and thus the display is changed to being 1-indexed to comply
+  Here's a Pandas DataFrame with equivalent R types at the bottom, done by setting <code>show-dtype="true" display-language="r"</code>.
+  This DataFrame uses the default indexing, and thus these settings will also change the display to being 1-indexed to comply
   with the convention in R.
 </p>
 <pl-dataframe params-name="dft" show-dimensions="true" show-dtype="true" display-language="r" digits="2"


### PR DESCRIPTION
The documentation in the question mentions `show-dtype="none"`, but this should be `show-dtype="false"`. Also, the attribute was missing from the actual code in the example, although the default value is false anyway.