### PR TITLE
Add lint rule to block unnecessary backticks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -105,6 +105,10 @@ module.exports = {
     // This was enabled when we upgraded to `@typescript-eslint/*` v6.
     // TODO: fix the violations so we can enable this rule.
     '@typescript-eslint/no-dynamic-delete': 'off',
+
+    // Blocks double-quote strings (unless a single quote is present in the
+    // string) and backticks (unless there is a tag or substitution in place).
+    quotes: ['error', 'single', { avoidEscape: true }],
   },
   overrides: [
     {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -105,10 +105,6 @@ module.exports = {
     // This was enabled when we upgraded to `@typescript-eslint/*` v6.
     // TODO: fix the violations so we can enable this rule.
     '@typescript-eslint/no-dynamic-delete': 'off',
-
-    // Blocks double-quote strings (unless a single quote is present in the
-    // string) and backticks (unless there is a tag or substitution in place).
-    quotes: ['error', 'single', { avoidEscape: true }],
   },
   overrides: [
     {

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -19,3 +19,6 @@ b5ee36cebacd8c3192dd0e2457ab472cc185a055
 
 # Order all imports with the `import/order` ESLint rule
 1b3268b50c71ac447d4f7885259c2a9164cef461
+
+# Force single quotes when possible
+623f369b794110a40acf00334b7eb2b70cc86fb4


### PR DESCRIPTION
Depends on #10076. Once that is merged, will add the commit hash to .git-blame-ignore-revs.