### PR TITLE
Fix colspan for course commit hash

### DIFF
--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ejs
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ejs
@@ -22,7 +22,7 @@
             <tbody>
               <tr>
                 <th class="align-middle">Current commit hash</th>
-                <td><%= course.commit_hash %></td>
+                <td colspan="2"><%= course.commit_hash %></td>
               <tr>
                 <th class="align-middle">Path on disk</th>
                 <td class="align-middle"><%= course.path %></td>


### PR DESCRIPTION
This issue became apparent with Bootstrap 5's updated table border styles.