### PR TITLE
Add copy button to repository field on course settings

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorCourseAdminSettingsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorCourseAdminSettingsClient.ts
@@ -1,6 +1,7 @@
 import { onDocumentReady } from '@prairielearn/browser-utils';
 
 import { saveButtonEnabling } from './lib/saveButtonEnabling.js';
+import './lib/clipboardPopover.js';
 
 onDocumentReady(() => {
   const courseSettingsForm = document.querySelector<HTMLFormElement>(

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -163,6 +163,7 @@ export function InstructorCourseAdminSettings({
                         class="btn btn-sm btn-outline-secondary btn-copy"
                         data-clipboard-text="${resLocals.course.repository}"
                         aria-label="Copy repository"
+                        ${resLocals.course.repository ? '' : 'disabled'}
                       >
                         <i class="far fa-clipboard"></i>
                       </button>

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -148,14 +148,26 @@ export function InstructorCourseAdminSettings({
                 </div>
                 <div class="form-group">
                   <label for="repository">Repository</label>
-                  <input
-                    type="text"
-                    class="form-control"
-                    id="repository"
-                    name="repository"
-                    value="${resLocals.course.repository}"
-                    disabled
-                  />
+                  <span class="input-group">
+                    <input
+                      type="text"
+                      class="form-control"
+                      id="repository"
+                      name="repository"
+                      value="${resLocals.course.repository}"
+                      disabled
+                    />
+                    <div class="input-group-append">
+                      <button
+                        type="button"
+                        class="btn btn-sm btn-outline-secondary btn-copy"
+                        data-clipboard-text="${resLocals.course.repository}"
+                        aria-label="Copy repository"
+                      >
+                        <i class="far fa-clipboard"></i>
+                      </button>
+                    </div>
+                  </span>
                   <small class="form-text text-muted">
                     The Github repository that can be used to sync course files.
                   </small>


### PR DESCRIPTION
Uses the same functionality as the one in the course instance/assessment pages for student links.