### PR TITLE
Fix string formatting issues in pl-order-blocks

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -285,7 +285,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
             )
 
         if format is FormatType.CODE:
-            inner_html = f'<pl-code language="{code_language or ""}">{inner_html}</pl-code>'
+            inner_html = f'<pl-code {f'language="{code_language}"' if code_language else ""}>{inner_html}</pl-code>'
 
         answer_data_dict: OrderBlocksAnswerData = {
             "inner_html": inner_html,

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -193,7 +193,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
         and feedback_type is not FeedbackType.NONE
     ):
         raise Exception(
-            "feedback type {feedback_type.value} is not available with the {grading_method.value} grading-method."
+            f"feedback type {feedback_type.value} is not available with the {grading_method.value} grading-method."
         )
 
     format = pl.get_enum_attrib(element, "format", FormatType, FormatType.DEFAULT)
@@ -285,13 +285,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
             )
 
         if format is FormatType.CODE:
-            inner_html = (
-                "<pl-code"
-                + (' language="' + code_language + '"' if code_language else "")
-                + ">"
-                + inner_html
-                + "</pl-code>"
-            )
+            inner_html = f'<pl-code language="{code_language if code_language else ""}">{inner_html}</pl-code>'
 
         answer_data_dict: OrderBlocksAnswerData = {
             "inner_html": inner_html,

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -285,7 +285,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
             )
 
         if format is FormatType.CODE:
-            inner_html = f'<pl-code language="{code_language if code_language else ""}">{inner_html}</pl-code>'
+            inner_html = f'<pl-code language="{code_language or ""}">{inner_html}</pl-code>'
 
         answer_data_dict: OrderBlocksAnswerData = {
             "inner_html": inner_html,


### PR DESCRIPTION
Changes to string formatting in pl-order-blocks file.

One is actually a bug fix where an error message was not displaying correctly.

The other change doesn't change behavior just makes the code nicer.