### PR TITLE
Set default S3 bucket for workspace logs in dev mode

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -322,7 +322,10 @@ const ConfigSchema = z.object({
    * https://expressjs.com/en/4x/api.html#trust.proxy.options.table
    */
   trustProxy: z.union([z.boolean(), z.number(), z.string()]).default(false),
-  workspaceLogsS3Bucket: z.string().nullable().default(null),
+  workspaceLogsS3Bucket: z
+    .string()
+    .nullable()
+    .default(process.env.NODE_ENV !== 'production' ? 'workspace-logs' : null),
   workspaceLogsFlushIntervalSec: z.number().default(60),
   /**
    * The number of days after which a workspace version's logs should no longer

--- a/apps/workspace-host/src/lib/config.ts
+++ b/apps/workspace-host/src/lib/config.ts
@@ -58,7 +58,10 @@ const ConfigSchema = z.object({
   workspaceMaxGradedFilesCount: z.number().default(100),
   /** Controls the maximum size of all graded files in bytes. */
   workspaceMaxGradedFilesSize: z.number().default(100 * 1024 * 1024),
-  workspaceLogsS3Bucket: z.string().nullable().default(null),
+  workspaceLogsS3Bucket: z
+    .string()
+    .nullable()
+    .default(process.env.NODE_ENV !== 'production' ? 'workspace-logs' : null),
   /**
    * How long to wait for a workspace container to start. If the container
    * doesn't complete a health check within this period, it is marked as


### PR DESCRIPTION
This allows local debugging of workspaces to match the workflow in production. We already configure this bucket via `s3rver`: https://github.com/PrairieLearn/PrairieLearn/blob/57bffa851437c4b4b0f9a89ec59855c2e40bb227/docker/start_s3rver.sh#L27