### PR TITLE
Forbid postgres and config packages in client-side code

### DIFF
--- a/packages/compiled-assets/src/forbid-packages-plugin.ts
+++ b/packages/compiled-assets/src/forbid-packages-plugin.ts
@@ -1,0 +1,25 @@
+import { Plugin } from 'esbuild';
+
+/**
+ * ESBuild plugin that will forbid certain packages from being imported in a
+ * module graph. This is used to ensure that certain packages don't accidentally
+ * end up being used in client-side code.
+ */
+export function forbidPackages(packages: string[]): Plugin {
+  return {
+    name: 'forbid-packages',
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (packages.includes(args.path)) {
+          return {
+            errors: [
+              {
+                text: `Package "${args.path}" is forbidden in client-side code`,
+              },
+            ],
+          };
+        }
+      });
+    },
+  };
+}

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -9,12 +9,16 @@ import { globby } from 'globby';
 
 import { html, HtmlSafeString } from '@prairielearn/html';
 
+import { forbidPackages } from './forbid-packages-plugin.js';
+
 const DEFAULT_OPTIONS = {
   dev: process.env.NODE_ENV !== 'production',
   sourceDirectory: './assets',
   buildDirectory: './public/build',
   publicPath: '/build/',
 };
+
+const FORBIDDEN_PACKAGES = ['@prairielearn/postgres', '@prairielearn/config'];
 
 type AssetsManifest = Record<string, string>;
 
@@ -74,6 +78,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
       outbase: options.sourceDirectory,
       outdir: options.buildDirectory,
       entryNames: '[dir]/[name]',
+      plugins: [forbidPackages(FORBIDDEN_PACKAGES)],
     });
 
     esbuildServer = await esbuildContext.serve();
@@ -209,6 +214,7 @@ async function buildAssets(sourceDirectory: string, buildDirectory: string) {
     outbase: sourceDirectory,
     outdir: buildDirectory,
     metafile: true,
+    plugins: [forbidPackages(FORBIDDEN_PACKAGES)],
   });
 
   return buildResult.metafile;


### PR DESCRIPTION
Inspired by a comment by @jonatanschroeder here: https://github.com/PrairieLearn/PrairieLearn/pull/10230#discussion_r1678412882. This will ensure we get a nice error message if we accidentally introduce such a dependency.

Note that things would have already failed on things like imports of `fs`, `node:*`, and so on; this PR just makes sure we get a nice error message that's easier to debug.