### PR TITLE
Only enable OTel AWS resource detector in production-like environments

### DIFF
--- a/.changeset/large-bees-lay.md
+++ b/.changeset/large-bees-lay.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/opentelemetry': minor
+---
+
+Only enable AWS resource detector in production-like environments


### PR DESCRIPTION
Fixes #10241. @trombonekenny could you try this out and report if this fixes the issue you were seeing?