### PR TITLE
Fix search in gradebook with missing assessments

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
@@ -117,6 +117,7 @@ onDocumentReady(() => {
           </a>
         `.toString(),
         class: 'text-nowrap',
+        searchable: false,
         sortable: true,
         sortOrder: 'desc',
         formatter: (score: number | null, row: GradebookRow) => {


### PR DESCRIPTION
#10175 updated the gradebook page, but introduced a bug in search. In particular, the new page uses fields that use sub-properties ([supported by bootstrap-table](https://github.com/wenzhixin/bootstrap-table/blob/eab8d6f1bad7b2371c3560fd696592e7429a513f/src/utils/index.js#L490-L494)), but it seems search does not properly support this kind of field identification (to the best of my knowledge, this is because the check in search [uses `!== null`](https://github.com/wenzhixin/bootstrap-table/blob/eab8d6f1bad7b2371c3560fd696592e7429a513f/src/bootstrap-table.js#L1083), which does not account for undefined).

The solution here is to disable search on score columns.