### PR TITLE
Remove user-facing mode overrides

### DIFF
--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -71,7 +71,6 @@ onDocumentReady(() => {
     removeCookie(['pl_requested_uid', 'pl2_requested_uid']);
     removeCookie(['pl_requested_course_role', 'pl2_requested_course_role']);
     removeCookie(['pl_requested_course_instance_role', 'pl2_requested_course_instance_role']);
-    removeCookie(['pl_requested_mode', 'pl2_requested_mode']);
     removeCookie(['pl_requested_date', 'pl2_requested_date']);
     setCookie(['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
   });
@@ -91,7 +90,6 @@ onDocumentReady(() => {
     removeCookie(['pl_requested_uid', 'pl2_requested_uid']);
     removeCookie(['pl_requested_course_role', 'pl2_requested_course_role']);
     removeCookie(['pl_requested_course_instance_role', 'pl2_requested_course_instance_role']);
-    removeCookie(['pl_requested_mode', 'pl2_requested_mode']);
     removeCookie(['pl_requested_date', 'pl2_requested_date']);
     setCookie(['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
 

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.js
@@ -143,13 +143,6 @@ export async function authzCourseOrInstance(req, res) {
       cookie: 'pl2_requested_course_instance_role',
     });
   }
-  if (req.cookies.pl2_requested_mode) {
-    overrides.push({
-      name: 'Mode',
-      value: req.cookies.pl2_requested_mode,
-      cookie: 'pl2_requested_mode',
-    });
-  }
   if (req.cookies.pl2_requested_date) {
     overrides.push({
       name: 'Date',
@@ -302,7 +295,7 @@ export async function authzCourseOrInstance(req, res) {
     allow_example_course_override: false,
     ip: req.ip,
     req_date,
-    req_mode: req.cookies.pl2_requested_mode || res.locals.authz_data.mode,
+    req_mode: res.locals.authz_data.mode,
     req_course_role: req.cookies.pl2_requested_course_role || null,
     req_course_instance_role: req.cookies.pl2_requested_course_instance_role || null,
   };

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.html.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.html.ts
@@ -264,44 +264,6 @@ export function InstructorEffectiveUser({
             : ''}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Effective mode</div>
-
-            <div class="card-body">
-              <p><strong>Effective mode:</strong> ${authz_data.mode}</p>
-
-              <div class="alert alert-secondary mb-0">
-                <form class="form-inline" id="changeModeForm" method="POST">
-                  <div class="form-group">
-                    <label class="mr-2" for="changeMode">Change effective mode to:</label>
-                    <select class="custom-select mr-2" id="changeMode" name="pl_requested_mode">
-                      ${authz_data.mode === 'Public'
-                        ? html`<option value="Public" selected>Public (current)</option>`
-                        : html`<option value="Public">Public</option>`}
-                      ${authz_data.mode === 'Exam'
-                        ? html`<option value="Exam" selected>Exam (current)</option>`
-                        : html`<option value="Exam">Exam</option>`}
-                    </select>
-                  </div>
-                  <input type="hidden" name="__action" value="changeMode" />
-                  <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                  <button type="submit" class="btn btn-primary">Change mode</button>
-                </form>
-              </div>
-            </div>
-
-            <div class="card-footer">
-              <small>
-                The <em>mode</em> of the server determines which assessments are available. The
-                <em>Public</em> mode is used when PrairieLearn is accessed from the general internet
-                (on campus, at home, etc). The <em>Exam</em> mode is used when the user is
-                physically sitting at a computer in the CBTF (Computer-Based Testing Facility). The
-                options above allow you to test out the different modes to see which assessments
-                will be seen in either Public or Exam mode.
-              </small>
-            </div>
-          </div>
-
-          <div class="card mb-4">
             <div class="card-header bg-primary text-white">Effective date</div>
 
             <div class="card-body">

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -67,7 +67,6 @@ router.post(
       clearCookie(res, ['pl_requested_uid', 'pl2_requested_uid']);
       clearCookie(res, ['pl_requested_course_role', 'pl2_requested_course_role']);
       clearCookie(res, ['pl_requested_course_instance_role', 'pl2_requested_course_instance_role']);
-      clearCookie(res, ['pl_requested_mode', 'pl2_requested_mode']);
       clearCookie(res, ['pl_requested_date', 'pl2_requested_date']);
       setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
       res.redirect(req.originalUrl);
@@ -93,12 +92,6 @@ router.post(
         req.body.pl_requested_course_instance_role,
         { maxAge: 60 * 60 * 1000 },
       );
-      setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'changeMode') {
-      setCookie(res, ['pl_requested_mode', 'pl2_requested_mode'], req.body.pl_requested_mode, {
-        maxAge: 60 * 60 * 1000,
-      });
       setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'changeDate') {

--- a/apps/prairielearn/src/tests/permissions/studentData.test.ts
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.ts
@@ -477,7 +477,7 @@ describe('student data access', function () {
     async () => {
       const headers = {
         cookie:
-          'pl_test_user=test_instructor; pl2_requested_uid=student@example.com; pl2_requested_mode=Exam',
+          'pl_test_user=test_instructor; pl2_requested_uid=student@example.com; pl_test_mode=Exam',
       };
       let response = await helperClient.fetchCheerio(context.examAssessmentInstanceUrl, {
         headers,
@@ -504,7 +504,7 @@ describe('student data access', function () {
     async () => {
       const headers = {
         cookie:
-          'pl_test_user=test_instructor; pl2_requested_uid=student@example.com; pl2_requested_mode=Exam',
+          'pl_test_user=test_instructor; pl2_requested_uid=student@example.com; pl_test_mode=Exam',
       };
       let response = await helperClient.fetchCheerio(context.examQuestionInstanceUrl, { headers });
       assert.isTrue(response.ok);


### PR DESCRIPTION
This came out of discussion here: https://github.com/PrairieLearn/PrairieLearn/pull/9743#discussion_r1683578490

Users already have two good options for testing assessments that only have PrairieTest access rules:

- Use "Student view without access restrictions" (easy)
- Run a 1-person course session in PrairieTest (high fidelity with the PrairieTest experience)

With upcoming changes to make exam mode more secure, the mode override/emulation already wouldn't work without additional, complex configuration for users. So, we're opting to remove it entirely.