### PR TITLE
Format example/test course JSON with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -53,6 +53,10 @@ docs/code-docs/
 # prettier-plugin-sql does not properly support sprocs, so ignoring those
 apps/prairielearn/src/sprocs/*.sql
 
+# exampleCourse and testCourse contain info.json files with different formatting on purpose, ignore
+exampleCourse/**/*.json
+testCourse/**/*.json
+
 # exampleCourse and testCourse contain question.html files that are actually Mustache files, ignore
 exampleCourse/**/*.html
 testCourse/**/*.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -53,10 +53,6 @@ docs/code-docs/
 # prettier-plugin-sql does not properly support sprocs, so ignoring those
 apps/prairielearn/src/sprocs/*.sql
 
-# exampleCourse and testCourse contain info.json files with different formatting on purpose, ignore
-exampleCourse/**/*.json
-testCourse/**/*.json
-
 # exampleCourse and testCourse contain question.html files that are actually Mustache files, ignore
 exampleCourse/**/*.html
 testCourse/**/*.html

--- a/exampleCourse/courseInstances/SectionA/assessments/demo/externalGrading/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/demo/externalGrading/infoAssessment.json
@@ -1,51 +1,48 @@
 {
-    "uuid": "854E9FAF-7282-4501-99D8-B8C309AD7C9E",
-    "type": "Homework",
-    "title": "Questions using external auto-graders",
-    "set": "Collection",
-    "number": "2",
-    "zones": [
-        {
-            "title": "Questions using Python External Grader",
-            "questions": [
-                {"id": "demo/autograder/codeEditor",            "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/codeUpload",            "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/square",         "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/numpy",          "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/leadingTrailing","points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/pandas",         "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/plots",          "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/random",         "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/earlyExit",      "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/python/randomFunctionName",      "points": 1, "maxPoints": 5},
-                {"id": "demo/autograder/ansiOutput",            "points": 2, "maxPoints": 4},
-                {"id": "demo/autograder/python/orderBlocksRandomParams",     "points": 1, "maxPoints": 2},
-                {"id": "demo/autograder/python/orderBlocksAddNumpy",         "points": 1, "maxPoints": 2}
-            ]
-        },
-        {
-            "title": "Questions using C External Grader",
-            "questions": [
-                {"id": "demo/autograder/c/drawTriangle",     "points": 1},
-                {"id": "demo/autograder/c/square",           "points": 1},
-                {"id": "demo/autograder/c/salesTax",         "points": 1},
-                {"id": "demo/autograder/c/squareCheck",      "points": 1},
-                {"id": "demo/autograder/c/linkedListDelete", "points": 1}
-            ]
-        },
-        {
-            "title": "Questions using Java External Grader",
-            "questions": [
-                {"id": "demo/autograder/java/square", "points": 1},
-                {"id": "demo/autograder/java/helloWorld", "points": 1}
-
-            ]
-        },
-        {
-            "title": "Questions using R External Grader",
-            "questions": [
-                {"id": "demo/autograder/r/createRObject", "points": 1}
-            ]
-        }
-    ]
+  "uuid": "854E9FAF-7282-4501-99D8-B8C309AD7C9E",
+  "type": "Homework",
+  "title": "Questions using external auto-graders",
+  "set": "Collection",
+  "number": "2",
+  "zones": [
+    {
+      "title": "Questions using Python External Grader",
+      "questions": [
+        { "id": "demo/autograder/codeEditor", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/codeUpload", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/square", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/numpy", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/leadingTrailing", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/pandas", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/plots", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/random", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/earlyExit", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/python/randomFunctionName", "points": 1, "maxPoints": 5 },
+        { "id": "demo/autograder/ansiOutput", "points": 2, "maxPoints": 4 },
+        { "id": "demo/autograder/python/orderBlocksRandomParams", "points": 1, "maxPoints": 2 },
+        { "id": "demo/autograder/python/orderBlocksAddNumpy", "points": 1, "maxPoints": 2 }
+      ]
+    },
+    {
+      "title": "Questions using C External Grader",
+      "questions": [
+        { "id": "demo/autograder/c/drawTriangle", "points": 1 },
+        { "id": "demo/autograder/c/square", "points": 1 },
+        { "id": "demo/autograder/c/salesTax", "points": 1 },
+        { "id": "demo/autograder/c/squareCheck", "points": 1 },
+        { "id": "demo/autograder/c/linkedListDelete", "points": 1 }
+      ]
+    },
+    {
+      "title": "Questions using Java External Grader",
+      "questions": [
+        { "id": "demo/autograder/java/square", "points": 1 },
+        { "id": "demo/autograder/java/helloWorld", "points": 1 }
+      ]
+    },
+    {
+      "title": "Questions using R External Grader",
+      "questions": [{ "id": "demo/autograder/r/createRObject", "points": 1 }]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/demo/workspaces/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/demo/workspaces/infoAssessment.json
@@ -1,19 +1,19 @@
 {
-    "uuid": "ca79f95c-a788-45dc-b888-cbdd8ff72aa4",
-    "type": "Homework",
-    "title": "Questions using workspaces",
-    "set": "Collection",
-    "number": "3",
-    "zones": [
-        {
-            "questions": [
-              {"id": "demo/workspace/vscode",       "points": 1, "maxPoints": 5},
-              {"id": "demo/workspace/jupyterlab",   "points": 1, "maxPoints": 5},
-              {"id": "demo/workspace/xtermjs",      "points": 1, "maxPoints": 5},
-              {"id": "demo/workspace/desktop",      "points": 1, "maxPoints": 5},
-              {"id": "demo/workspace/rstudio",      "points": 1, "maxPoints": 5},
-              {"id": "demo/workspace/dynamicFiles", "points": 1, "maxPoints": 5}
-            ]
-        }
-    ]
+  "uuid": "ca79f95c-a788-45dc-b888-cbdd8ff72aa4",
+  "type": "Homework",
+  "title": "Questions using workspaces",
+  "set": "Collection",
+  "number": "3",
+  "zones": [
+    {
+      "questions": [
+        { "id": "demo/workspace/vscode", "points": 1, "maxPoints": 5 },
+        { "id": "demo/workspace/jupyterlab", "points": 1, "maxPoints": 5 },
+        { "id": "demo/workspace/xtermjs", "points": 1, "maxPoints": 5 },
+        { "id": "demo/workspace/desktop", "points": 1, "maxPoints": 5 },
+        { "id": "demo/workspace/rstudio", "points": 1, "maxPoints": 5 },
+        { "id": "demo/workspace/dynamicFiles", "points": 1, "maxPoints": 5 }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/activeAccessRestriction/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/activeAccessRestriction/infoAssessment.json
@@ -1,39 +1,39 @@
 {
-    "uuid": "75be4222-e9d1-11eb-9a03-0242ac130003",
-    "type": "Exam",
-    "title": "Exam with active access restriction",
-    "set": "Exam",
-    "number": "3",
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "endDate": "2030-01-01T00:00:00",
-            "active": false,
-            "comment": "This access rule allows students to see the exam on the Assessments page before it starts. Students cannot begin the exam at this time."
-        },
-        {
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 50,
-            "startDate": "2030-01-01T00:00:01",
-            "endDate": "2030-01-01T23:59:59",
-            "showClosedAssessment": false
-        },
-        {
-            "mode": "Public",
-            "active": false,
-            "startDate": "2030-01-04T00:00:01",
-            "comment": "This access rule allows students to view their exams two days after all exams finish. Note that students who did not write the exam cannot view it."
-        }
-    ],
-    "zones": [
-        {
-            "title": "Math Questions",
-            "questions": [
-                {"id": "demo/calculation",              "points": [10, 9, 8, 7, 6]},
-                {"id": "demo/randomMultipleChoice",     "points": [25, 24, 23, 22, 21]},
-                {"id": "demo/randomCheckbox",           "points": [25, 24, 23, 22, 21]}
-            ]
-        }
-    ]
+  "uuid": "75be4222-e9d1-11eb-9a03-0242ac130003",
+  "type": "Exam",
+  "title": "Exam with active access restriction",
+  "set": "Exam",
+  "number": "3",
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "endDate": "2030-01-01T00:00:00",
+      "active": false,
+      "comment": "This access rule allows students to see the exam on the Assessments page before it starts. Students cannot begin the exam at this time."
+    },
+    {
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 50,
+      "startDate": "2030-01-01T00:00:01",
+      "endDate": "2030-01-01T23:59:59",
+      "showClosedAssessment": false
+    },
+    {
+      "mode": "Public",
+      "active": false,
+      "startDate": "2030-01-04T00:00:01",
+      "comment": "This access rule allows students to view their exams two days after all exams finish. Note that students who did not write the exam cannot view it."
+    }
+  ],
+  "zones": [
+    {
+      "title": "Math Questions",
+      "questions": [
+        { "id": "demo/calculation", "points": [10, 9, 8, 7, 6] },
+        { "id": "demo/randomMultipleChoice", "points": [25, 24, 23, 22, 21] },
+        { "id": "demo/randomCheckbox", "points": [25, 24, 23, 22, 21] }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/groupExam/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/groupExam/infoAssessment.json
@@ -1,111 +1,97 @@
 {
-    "uuid": "431ab712-5973-48b5-a864-c9a61d6ed70d",
-    "type": "Exam",
-    "title": "Group Work Exam Example",
-    "set": "Exam",
-    "number": "5",
-    "groupMaxSize": 5,
-    "groupMinSize": 1,
-    "groupWork": true,
-    "studentGroupCreate": true,
-    "studentGroupJoin": true,
-    "studentGroupLeave": true,
-    "groupRoles": [
+  "uuid": "431ab712-5973-48b5-a864-c9a61d6ed70d",
+  "type": "Exam",
+  "title": "Group Work Exam Example",
+  "set": "Exam",
+  "number": "5",
+  "groupMaxSize": 5,
+  "groupMinSize": 1,
+  "groupWork": true,
+  "studentGroupCreate": true,
+  "studentGroupJoin": true,
+  "studentGroupLeave": true,
+  "groupRoles": [
+    {
+      "name": "Manager",
+      "minimum": 1,
+      "maximum": 1,
+      "canAssignRoles": true
+    },
+    {
+      "name": "Recorder",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Reflector",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Contributor"
+    }
+  ],
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 50,
+      "showClosedAssessment": false
+    }
+  ],
+  "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
+  "canSubmit": ["Recorder"],
+  "zones": [
+    {
+      "title": "Fundamental questions",
+      "questions": [
         {
-            "name": "Manager",
-            "minimum": 1,
-            "maximum": 1,
-            "canAssignRoles": true
+          "numberChoose": 1,
+          "points": [25, 24, 23, 22, 21, 20],
+          "alternatives": [{ "id": "demo/calculation" }, { "id": "demo/matrixAlgebra" }]
         },
         {
-            "name": "Recorder",
-            "minimum": 1,
-            "maximum": 1
-        },
-        {
-            "name": "Reflector",
-            "minimum": 1,
-            "maximum": 1
-        },
-        {
-            "name": "Contributor"
+          "numberChoose": 1,
+          "points": [25, 24, 23, 22, 21, 20],
+          "alternatives": [{ "id": "demo/fixedCheckbox" }, { "id": "demo/randomPlot" }]
         }
-    ],
-    "allowAccess": [
+      ]
+    },
+    {
+      "title": "Intermediate questions",
+      "questions": [
         {
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 50,
-            "showClosedAssessment": false
-       }
-    ],
-    "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
-    "canSubmit": ["Recorder"],
-    "zones": [
-        {
-            "title": "Fundamental questions",
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": [25, 24, 23, 22, 21, 20],
-                    "alternatives": [
-                        {"id": "demo/calculation"},
-                        {"id": "demo/matrixAlgebra"}
-                    ]
-                },
-                {
-                    "numberChoose": 1,
-                    "points": [25, 24, 23, 22, 21, 20],
-                    "alternatives": [
-                        {"id": "demo/fixedCheckbox"},
-                        {"id": "demo/randomPlot"}
-                    ]
-                }
-            ]
+          "numberChoose": 1,
+          "points": [10, 9, 8, 7, 6],
+          "alternatives": [{ "id": "demo/matrixComplexAlgebra" }, { "id": "demo/randomCheckbox" }]
         },
         {
-            "title": "Intermediate questions",
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": [10, 9, 8, 7, 6],
-                    "alternatives": [
-                        {"id": "demo/matrixComplexAlgebra"},
-                        {"id": "demo/randomCheckbox"}
-                    ]
-                },
-                {
-                    "numberChoose": 1,
-                    "points": [10, 9, 8, 7, 6],
-                    "alternatives": [
-                        {"id": "demo/randomMultipleChoice"}
-                    ]
-                }
-           ]
-        },
-        {
-            "title": "Advanced questions",
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": [5, 4, 3, 2, 1],
-                    "alternatives": [
-                        {"id": "demo/randomDataFrame"},
-                        {"id": "template/symbolic-input/random"}
-                    ]
-                },
-                {
-                    "numberChoose": 1,
-                    "points": [5, 4, 3, 2, 1],
-                    "canView": ["Reflector"],
-                    "canSubmit": ["Reflector"],
-                    "alternatives": [
-                        {"id": "demo/custom/element"},
-                        {"id": "demo/custom/gradeFunction"}
-                    ]
-                }
-            ]
+          "numberChoose": 1,
+          "points": [10, 9, 8, 7, 6],
+          "alternatives": [{ "id": "demo/randomMultipleChoice" }]
         }
-    ],
-    "text": "For this quiz you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
+      ]
+    },
+    {
+      "title": "Advanced questions",
+      "questions": [
+        {
+          "numberChoose": 1,
+          "points": [5, 4, 3, 2, 1],
+          "alternatives": [
+            { "id": "demo/randomDataFrame" },
+            { "id": "template/symbolic-input/random" }
+          ]
+        },
+        {
+          "numberChoose": 1,
+          "points": [5, 4, 3, 2, 1],
+          "canView": ["Reflector"],
+          "canSubmit": ["Reflector"],
+          "alternatives": [{ "id": "demo/custom/element" }, { "id": "demo/custom/gradeFunction" }]
+        }
+      ]
+    }
+  ],
+  "text": "For this quiz you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
@@ -1,51 +1,45 @@
 {
-    "uuid": "12D012E5-9C66-4092-BA1A-0445919CB0C3",
-    "type": "Exam",
-    "title": "Exam with real-time autograding",
-    "set": "Exam",
-    "module": "FinalModule",
-    "number": "1",
-    "allowAccess": [
+  "uuid": "12D012E5-9C66-4092-BA1A-0445919CB0C3",
+  "type": "Exam",
+  "title": "Exam with real-time autograding",
+  "set": "Exam",
+  "module": "FinalModule",
+  "number": "1",
+  "allowAccess": [
+    {
+      "comment": "Set the start/end dates for the quiz period. By using the showClosedAssessment: false, students do not have access to the quiz questions after the time limit is reached",
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2025-12-31T23:59:59",
+      "timeLimitMin": 50,
+      "showClosedAssessment": false
+    }
+  ],
+  "zones": [
+    {
+      "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }]
+    },
+    {
+      "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }]
+    },
+    {
+      "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }]
+    },
+    {
+      "questions": [
         {
-            "comment": "Set the start/end dates for the quiz period. By using the showClosedAssessment: false, students do not have access to the quiz questions after the time limit is reached",
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2025-12-31T23:59:59",
-            "timeLimitMin": 50,
-            "showClosedAssessment": false
+          "comment": "Similar questions",
+          "numberChoose": 1,
+          "points": [4, 2, 1],
+          "alternatives": [
+            { "id": "demo/annotated/mathOuterProduct" },
+            { "id": "demo/annotated/mathMatrixMult" },
+            { "id": "demo/annotated/mathMatrixMultT" }
+          ]
         }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "template/number-input/random-prompt","points": [3,1]}
-            ]
-        },
-        {
-            "questions": [
-              {"id": "template/matrix-component-input/random-graph","points": [3,1]}
-            ]
-        },
-        {
-            "questions": [
-              {"id": "demo/annotated/engCircuit", "points": [5,4,3,2,1]}
-            ]
-        },
-        {
-            "questions": [
-              {
-                  "comment": "Similar questions",
-                  "numberChoose": 1,
-                  "points": [4,2,1],
-                  "alternatives": [
-                      {"id": "demo/annotated/mathOuterProduct"},
-                      {"id": "demo/annotated/mathMatrixMult"},
-                      {"id": "demo/annotated/mathMatrixMultT"}
-                  ]
-              }
-            ]
-        }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is an example of an auto-graded exam with instant feedback, where students will receive a single (fixed) variant for each question, and can have a pre-defined number of retry attempts, depending on the difficulty level and question type. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md target=_blank>here</a>.</p><p> You can enter any general instructions for your exam here. For example, you can provide access to <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>.</p>"
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is an example of an auto-graded exam with instant feedback, where students will receive a single (fixed) variant for each question, and can have a pre-defined number of retry attempts, depending on the difficulty level and question type. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md target=_blank>here</a>.</p><p> You can enter any general instructions for your exam here. For example, you can provide access to <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>.</p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedbackPrairieTest/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedbackPrairieTest/infoAssessment.json
@@ -1,51 +1,45 @@
 {
-    "uuid": "13D012E5-9C66-5092-BA1A-0445919CB0C3",
-    "type": "Exam",
-    "title": "Exam with real-time autograding linked to PrairieTest",
-    "set": "Exam",
-    "number": "0",
-    "allowAccess": [
-      {
-          "mode": "Exam",
-          "examUuid": "9c1b3e5c-9caa-4c82-9445-ac564d51c40d",
-          "credit": 100
-      },
-      {
-        "mode": "Exam",
-        "examUuid": "2b26b075-4c91-4fa0-8f1e-219326f4d046",
-        "credit": 100
-      }
-    ],
-    "zones": [
+  "uuid": "13D012E5-9C66-5092-BA1A-0445919CB0C3",
+  "type": "Exam",
+  "title": "Exam with real-time autograding linked to PrairieTest",
+  "set": "Exam",
+  "number": "0",
+  "allowAccess": [
+    {
+      "mode": "Exam",
+      "examUuid": "9c1b3e5c-9caa-4c82-9445-ac564d51c40d",
+      "credit": 100
+    },
+    {
+      "mode": "Exam",
+      "examUuid": "2b26b075-4c91-4fa0-8f1e-219326f4d046",
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }]
+    },
+    {
+      "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }]
+    },
+    {
+      "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }]
+    },
+    {
+      "questions": [
         {
-            "questions": [
-                {"id": "template/number-input/random-prompt","points": [3,1]}
-            ]
-        },
-        {
-            "questions": [
-              {"id": "template/matrix-component-input/random-graph","points": [3,1]}
-            ]
-        },
-        {
-            "questions": [
-              {"id": "demo/annotated/engCircuit", "points": [5,4,3,2,1]}
-            ]
-        },
-        {
-            "questions": [
-              {
-                  "comment": "Similar questions",
-                  "numberChoose": 1,
-                  "points": [4,2,1],
-                  "alternatives": [
-                      {"id": "demo/annotated/mathOuterProduct"},
-                      {"id": "demo/annotated/mathMatrixMult"},
-                      {"id": "demo/annotated/mathMatrixMultT"}
-                  ]
-              }
-            ]
+          "comment": "Similar questions",
+          "numberChoose": 1,
+          "points": [4, 2, 1],
+          "alternatives": [
+            { "id": "demo/annotated/mathOuterProduct" },
+            { "id": "demo/annotated/mathMatrixMult" },
+            { "id": "demo/annotated/mathMatrixMultT" }
+          ]
         }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is an example of an auto-graded exam with instant feedback, where students will receive a single (fixed) variant for each question, and can have a pre-defined number of retry attempts, depending on the difficulty level and question type. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md target=_blank>here</a>.</p><p>This exam is linked to <a href=https://us.prairietest.com/pt target=_blank>PrairieTest</a>, a scheduling and proctoring tool that will control student's access to the exam. </p><p> You can enter any general instructions for your exam here. For example, you can provide access to <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>.</p>"
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is an example of an auto-graded exam with instant feedback, where students will receive a single (fixed) variant for each question, and can have a pre-defined number of retry attempts, depending on the difficulty level and question type. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md target=_blank>here</a>.</p><p>This exam is linked to <a href=https://us.prairietest.com/pt target=_blank>PrairieTest</a>, a scheduling and proctoring tool that will control student's access to the exam. </p><p> You can enter any general instructions for your exam here. For example, you can provide access to <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>.</p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/manualGrading/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/manualGrading/infoAssessment.json
@@ -1,75 +1,75 @@
 {
-    "uuid": "854E9FAF-7283-4501-99D8-B8C309AD7C9E",
-    "type": "Exam",
-    "title": "Exam including autograded and manually graded questions",
-    "set": "Exam",
-    "number": "4",
-    "allowAccess": [
+  "uuid": "854E9FAF-7283-4501-99D8-B8C309AD7C9E",
+  "type": "Exam",
+  "title": "Exam including autograded and manually graded questions",
+  "set": "Exam",
+  "number": "4",
+  "allowAccess": [
+    {
+      "comment": "students will have access to this timed exam, but will not be able to see their scores or questions once the exam is completed",
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 3,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2323-11-07T23:59:59",
+      "showClosedAssessment": false,
+      "showClosedAssessmentScore": false
+    },
+    {
+      "comment": "students will have access to their final total score at a later time, after all the questions are manually graded and scores are uploaded",
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2323-11-08T00:00:00",
+      "endDate": "2323-11-15T23:59:59",
+      "showClosedAssessment": false
+    }
+  ],
+  "zones": [
+    {
+      "title": "Auto-graded questions",
+      "questions": [
         {
-            "comment": "students will have access to this timed exam, but will not be able to see their scores or questions once the exam is completed",
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 3,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2323-11-07T23:59:59",
-            "showClosedAssessment": false,
-            "showClosedAssessmentScore": false
-       },
-       {
-           "comment": "students will have access to their final total score at a later time, after all the questions are manually graded and scores are uploaded",
-           "mode": "Public",
-           "credit": 0,
-           "startDate": "2323-11-08T00:00:00",
-           "endDate": "2323-11-15T23:59:59",
-           "showClosedAssessment": false
-      }
-    ],
-    "zones": [
-      {
-          "title": "Auto-graded questions",
-          "questions": [
-              {
-                  "numberChoose": 1,
-                  "points": 5,
-                  "alternatives": [
-                      {"id": "template/checkbox/random-prompt"},
-                      {"id": "template/multiple-choice/random"}
-                  ]
-              },
-              {
-                  "numberChoose": 1,
-                  "points": [5,1],
-                  "alternatives": [
-                      {"id": "template/multiple-choice/images"},
-                      {"id": "demo/multipleChoiceSingleCorrect"}
-                  ]
-              },
-              {
-                  "numberChoose": 1,
-                  "points": 5,
-                  "alternatives": [
-                      {"id": "template/multiple-choice/random-prompt-true-false"},
-                      {"id": "template/multiple-choice/random-prompt"}
-                  ]
-              },
-              {
-                  "numberChoose": 1,
-                  "points": [5,2],
-                  "alternatives": [
-                      {"id": "demo/fixedCheckbox"},
-                      {"id": "template/symbolic-input/random"}
-                  ]
-              }
+          "numberChoose": 1,
+          "points": 5,
+          "alternatives": [
+            { "id": "template/checkbox/random-prompt" },
+            { "id": "template/multiple-choice/random" }
           ]
-      },
-      {
-          "title": "Manually graded questions",
-          "questions": [
-              {"id": "demo/manualGrade/codeUpload",          "autoPoints": [10, 7, 4], "manualPoints": 5},
-              {"id": "demo/fileDownloadUpload",              "points": [10]},
-              {"id": "demo/markdownEditorLivePreview",       "points": [5]}
+        },
+        {
+          "numberChoose": 1,
+          "points": [5, 1],
+          "alternatives": [
+            { "id": "template/multiple-choice/images" },
+            { "id": "demo/multipleChoiceSingleCorrect" }
           ]
-      }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> The auto-graded questions are graded as students complete the assessment, allowing them to see their scores immediately and retry some of the questions when points are still available.</p> <p> Students can save the manually graded question as they complete the assessment. Instructors will later download the submission files, assign grades, and upload back the scores and feedback. </p><p> The assessment will be closed when the time limit expires (here set to 3 minutes), or once students click the 'Finish assessment' button. Students will not be able to see their total score after the assessment is closed. An additional access rule can be used to allow students to see their total score once all the questions are graded.</p>"
+        },
+        {
+          "numberChoose": 1,
+          "points": 5,
+          "alternatives": [
+            { "id": "template/multiple-choice/random-prompt-true-false" },
+            { "id": "template/multiple-choice/random-prompt" }
+          ]
+        },
+        {
+          "numberChoose": 1,
+          "points": [5, 2],
+          "alternatives": [
+            { "id": "demo/fixedCheckbox" },
+            { "id": "template/symbolic-input/random" }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Manually graded questions",
+      "questions": [
+        { "id": "demo/manualGrade/codeUpload", "autoPoints": [10, 7, 4], "manualPoints": 5 },
+        { "id": "demo/fileDownloadUpload", "points": [10] },
+        { "id": "demo/markdownEditorLivePreview", "points": [5] }
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> The auto-graded questions are graded as students complete the assessment, allowing them to see their scores immediately and retry some of the questions when points are still available.</p> <p> Students can save the manually graded question as they complete the assessment. Instructors will later download the submission files, assign grades, and upload back the scores and feedback. </p><p> The assessment will be closed when the time limit expires (here set to 3 minutes), or once students click the 'Finish assessment' button. Students will not be able to see their total score after the assessment is closed. An additional access rule can be used to allow students to see their total score once all the questions are graded.</p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/practice/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/practice/infoAssessment.json
@@ -1,54 +1,48 @@
 {
-    "uuid": "12D012E4-9C66-4092-BA1A-0445919CB0C3",
-    "type": "Exam",
-    "title": "Auto-graded randomized practice exams",
-    "set": "Practice Exam",
-    "module": "FinalModule",
-    "number": "1",
-    "comment": "students can open several instances of this quiz for practice. Here we disable the honor code message, since in the practice environment students may be allowed to communicate with each other.",
-    "multipleInstance": true,
-    "requireHonorCode": false,
-    "allowAccess": [
+  "uuid": "12D012E4-9C66-4092-BA1A-0445919CB0C3",
+  "type": "Exam",
+  "title": "Auto-graded randomized practice exams",
+  "set": "Practice Exam",
+  "module": "FinalModule",
+  "number": "1",
+  "comment": "students can open several instances of this quiz for practice. Here we disable the honor code message, since in the practice environment students may be allowed to communicate with each other.",
+  "multipleInstance": true,
+  "requireHonorCode": false,
+  "allowAccess": [
+    {
+      "comment": "Set the start/end dates for the quiz period. By using the showClosedAssessment: false, students do not have access to the quiz questions after the time limit is reached",
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2025-12-31T23:59:59",
+      "timeLimitMin": 50,
+      "showClosedAssessment": false
+    }
+  ],
+  "zones": [
+    {
+      "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }]
+    },
+    {
+      "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }]
+    },
+    {
+      "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }]
+    },
+    {
+      "questions": [
         {
-            "comment": "Set the start/end dates for the quiz period. By using the showClosedAssessment: false, students do not have access to the quiz questions after the time limit is reached",
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2025-12-31T23:59:59",
-            "timeLimitMin": 50,
-            "showClosedAssessment": false
+          "comment": "Similar questions",
+          "numberChoose": 1,
+          "points": [4, 2, 1],
+          "alternatives": [
+            { "id": "demo/annotated/mathOuterProduct" },
+            { "id": "demo/annotated/mathMatrixMult" },
+            { "id": "demo/annotated/mathMatrixMultT" }
+          ]
         }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "template/number-input/random-prompt","points": [3,1]}
-            ]
-        },
-        {
-            "questions": [
-              {"id": "template/matrix-component-input/random-graph","points": [3,1]}
-            ]
-        },
-        {
-            "questions": [
-              {"id": "demo/annotated/engCircuit", "points": [5,4,3,2,1]}
-            ]
-        },
-        {
-            "questions": [
-              {
-                  "comment": "Similar questions",
-                  "numberChoose": 1,
-                  "points": [4,2,1],
-                  "alternatives": [
-                      {"id": "demo/annotated/mathOuterProduct"},
-                      {"id": "demo/annotated/mathMatrixMult"},
-                      {"id": "demo/annotated/mathMatrixMultT"}
-                  ]
-              }
-            ]
-        }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is an example of a practice exam, where students can generate many different instances of the same assessment for additional practice. </p> <p> You can read more about a general exam setup <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md target=_blank>here</a>.</p>"
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is an example of a practice exam, where students can generate many different instances of the same assessment for additional practice. </p> <p> You can read more about a general exam setup <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md target=_blank>here</a>.</p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/realTimeGradingDisabled/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/realTimeGradingDisabled/infoAssessment.json
@@ -1,67 +1,67 @@
 {
-    "uuid": "1f73588f-129e-4c88-a859-b0fff8ef1b27",
-    "type": "Exam",
-    "title": "Exam with real-time grading disabled",
-    "set": "Exam",
-    "number": "2",
-    "allowRealTimeGrading": false,
-    "allowAccess": [
+  "uuid": "1f73588f-129e-4c88-a859-b0fff8ef1b27",
+  "type": "Exam",
+  "title": "Exam with real-time grading disabled",
+  "set": "Exam",
+  "number": "2",
+  "allowRealTimeGrading": false,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 3,
+      "showClosedAssessment": false
+    }
+  ],
+  "zones": [
+    {
+      "title": "Warm-up",
+      "questions": [
         {
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 3,
-            "showClosedAssessment": false
-       }
-    ],
-    "zones": [
-        {
-            "title": "Warm-up",
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": 25,
-                    "alternatives": [
-                        {"id": "template/checkbox/random-prompt"},
-                        {"id": "template/multiple-choice/random"}
-                    ]
-                }
-            ]
-        },
-        {
-            "title": "Choice question type",
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": 10,
-                    "alternatives": [
-                        {"id": "template/multiple-choice/images"},
-                        {"id": "demo/multipleChoiceSingleCorrect"}
-                    ]
-                },
-                {
-                    "numberChoose": 1,
-                    "points": 10,
-                    "alternatives": [
-                        {"id": "template/multiple-choice/random-prompt-true-false"},
-                        {"id": "template/multiple-choice/random-prompt"}
-                    ]
-                }
-           ]
-        },
-        {
-            "title": "Math",
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": 5,
-                    "alternatives": [
-                        {"id": "demo/fixedCheckbox"},
-                        {"id": "template/symbolic-input/random"}
-                    ]
-                },
-                {"id": "demo/randomMultipleChoice", "points": 5}
-            ]
+          "numberChoose": 1,
+          "points": 25,
+          "alternatives": [
+            { "id": "template/checkbox/random-prompt" },
+            { "id": "template/multiple-choice/random" }
+          ]
         }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> This assessment will only be graded after it is completed. Students will not be able to auto-grade their questions during the assessment, instead they will only be able to save their answers. The assessment will be graded once the time limit expires (here set to 3 minutes), or once students click the 'Finish assessment' button. Once the assessment is closed, the questions will be auto-graded, and students will be able to immediately see their total score. To prevent students from seeing their total score as soon as the assessment is over, instructors can set 'showClosedAssessmentScore' to false. </p> <p> In this assessment configuration, students will never see their grading result for each specific question, because it uses 'showClosedAssessment: false'. If this attribute is removed, students are be able to go back to each question from a closed assessment, and review how the questions were graded. </p>"
+      ]
+    },
+    {
+      "title": "Choice question type",
+      "questions": [
+        {
+          "numberChoose": 1,
+          "points": 10,
+          "alternatives": [
+            { "id": "template/multiple-choice/images" },
+            { "id": "demo/multipleChoiceSingleCorrect" }
+          ]
+        },
+        {
+          "numberChoose": 1,
+          "points": 10,
+          "alternatives": [
+            { "id": "template/multiple-choice/random-prompt-true-false" },
+            { "id": "template/multiple-choice/random-prompt" }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Math",
+      "questions": [
+        {
+          "numberChoose": 1,
+          "points": 5,
+          "alternatives": [
+            { "id": "demo/fixedCheckbox" },
+            { "id": "template/symbolic-input/random" }
+          ]
+        },
+        { "id": "demo/randomMultipleChoice", "points": 5 }
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> This assessment will only be graded after it is completed. Students will not be able to auto-grade their questions during the assessment, instead they will only be able to save their answers. The assessment will be graded once the time limit expires (here set to 3 minutes), or once students click the 'Finish assessment' button. Once the assessment is closed, the questions will be auto-graded, and students will be able to immediately see their total score. To prevent students from seeing their total score as soon as the assessment is over, instructors can set 'showClosedAssessmentScore' to false. </p> <p> In this assessment configuration, students will never see their grading result for each specific question, because it uses 'showClosedAssessment: false'. If this attribute is removed, students are be able to go back to each question from a closed assessment, and review how the questions were graded. </p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/gallery/drawingElements/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/gallery/drawingElements/infoAssessment.json
@@ -1,29 +1,29 @@
 {
-    "uuid": "6338DE4E-7E66-4B58-8CB4-1E126FB9AF9C",
-    "type": "Homework",
-    "title": "Question gallery for PL drawing elements",
-    "set": "Collection",
-    "number": "5",
-    "zones": [
-        {
-            "questions": [
-                {"id": "demo/drawing/simpleTutorial",             "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/gradeVector",                "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/liftingMechanism",           "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/frame-exploded",             "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/centroid",                   "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/collarRod",                  "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/pulley",                     "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/graphs",                     "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/inclinedPlane",              "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/inclinedPlane-reaction",     "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/vmDiagrams",                 "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/buttons",                    "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/customizedButtons",          "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/extensions",                 "points": 2, "maxPoints": 6},
-                {"id": "demo/drawing/resistorCapacitorCircuit",   "points": 2, "maxPoints": 6},
-                {"id": "element/drawingGallery",                  "points": 2, "maxPoints": 6}
-            ]
-        }
-    ]
+  "uuid": "6338DE4E-7E66-4B58-8CB4-1E126FB9AF9C",
+  "type": "Homework",
+  "title": "Question gallery for PL drawing elements",
+  "set": "Collection",
+  "number": "5",
+  "zones": [
+    {
+      "questions": [
+        { "id": "demo/drawing/simpleTutorial", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/gradeVector", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/liftingMechanism", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/frame-exploded", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/centroid", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/collarRod", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/pulley", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/graphs", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/inclinedPlane", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/inclinedPlane-reaction", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/vmDiagrams", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/buttons", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/customizedButtons", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/extensions", "points": 2, "maxPoints": 6 },
+        { "id": "demo/drawing/resistorCapacitorCircuit", "points": 2, "maxPoints": 6 },
+        { "id": "element/drawingGallery", "points": 2, "maxPoints": 6 }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/gallery/elements/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/gallery/elements/infoAssessment.json
@@ -1,54 +1,52 @@
 {
-    "uuid": "69aa799b-9492-4db2-9102-7753263f4863",
-    "type": "Homework",
-    "title": "Question gallery for PL elements",
-    "set": "Collection",
-    "number": "4",
-    "zones": [
-        {
-            "title": "Submission Elements",
-            "questions": [
-                {"id": "element/multipleChoice",           "points": 2, "maxPoints": 10},
-                {"id": "element/checkbox",                 "points": 2, "maxPoints": 10},
-                {"id": "element/numberInput",              "points": 2, "maxPoints": 10},
-                {"id": "element/dropdown",                 "points": 2, "maxPoints": 10},
-                {"id": "element/orderBlocks",              "points": 2, "maxPoints": 10},
-                {"id": "element/integerInput",             "points": 2, "maxPoints": 10},
-                {"id": "element/symbolicInput",            "points": 2, "maxPoints": 10},
-                {"id": "element/bigOInput",                "points": 2, "maxPoints": 10},
-                {"id": "element/unitsInput",               "points": 2, "maxPoints": 10},
-                {"id": "element/stringInput",              "points": 2, "maxPoints": 10},
-                {"id": "element/matching",                 "points": 2, "maxPoints": 10},
-                {"id": "element/matrixComponentInput",     "points": 2, "maxPoints": 10},
-                {"id": "demo/matrixComplexAlgebra",        "points": 2, "maxPoints": 10},
-                {"id": "element/richTextEditor",           "points": 2},
-                {"id": "element/fileEditor",               "points": 2, "maxPoints": 10},
-                {"id": "element/fileUpload",               "points": 2},
-                {"id": "element/codeDocumentation",        "points": 2, "maxPoints": 10}
-            ]
-        },
-        {
-            "title": "Decorative Elements",
-            "questions": [
-                {"id": "element/code",                     "points": 2, "maxPoints": 10},
-                {"id": "element/hiddenHints",              "points": 2, "maxPoints": 10},
-                {"id": "element/pythonVariable",           "points": 2, "maxPoints": 10},
-                {"id": "element/dataframe",                "points": 2, "maxPoints": 10},
-                {"id": "element/figure",                   "points": 2, "maxPoints": 10},
-                {"id": "element/fileDownload",             "points": 2, "maxPoints": 10},
-                {"id": "element/variableOutput",           "points": 2, "maxPoints": 10},
-                {"id": "element/matrixLatex",              "points": 2, "maxPoints": 10},
-                {"id": "element/graph",                    "points": 2, "maxPoints": 10},
-                {"id": "element/overlay",                  "points": 2, "maxPoints": 10},
-                {"id": "element/xssSafe",                  "points": 2},
-                {"id": "element/card",                     "points": 2, "maxPoints": 10}
-            ]
-        },
-        {
-            "title": "Conditional Elements",
-            "questions": [
-                {"id": "element/panels",                   "points": 2, "maxPoints": 10}
-            ]
-        }
-    ]
+  "uuid": "69aa799b-9492-4db2-9102-7753263f4863",
+  "type": "Homework",
+  "title": "Question gallery for PL elements",
+  "set": "Collection",
+  "number": "4",
+  "zones": [
+    {
+      "title": "Submission Elements",
+      "questions": [
+        { "id": "element/multipleChoice", "points": 2, "maxPoints": 10 },
+        { "id": "element/checkbox", "points": 2, "maxPoints": 10 },
+        { "id": "element/numberInput", "points": 2, "maxPoints": 10 },
+        { "id": "element/dropdown", "points": 2, "maxPoints": 10 },
+        { "id": "element/orderBlocks", "points": 2, "maxPoints": 10 },
+        { "id": "element/integerInput", "points": 2, "maxPoints": 10 },
+        { "id": "element/symbolicInput", "points": 2, "maxPoints": 10 },
+        { "id": "element/bigOInput", "points": 2, "maxPoints": 10 },
+        { "id": "element/unitsInput", "points": 2, "maxPoints": 10 },
+        { "id": "element/stringInput", "points": 2, "maxPoints": 10 },
+        { "id": "element/matching", "points": 2, "maxPoints": 10 },
+        { "id": "element/matrixComponentInput", "points": 2, "maxPoints": 10 },
+        { "id": "demo/matrixComplexAlgebra", "points": 2, "maxPoints": 10 },
+        { "id": "element/richTextEditor", "points": 2 },
+        { "id": "element/fileEditor", "points": 2, "maxPoints": 10 },
+        { "id": "element/fileUpload", "points": 2 },
+        { "id": "element/codeDocumentation", "points": 2, "maxPoints": 10 }
+      ]
+    },
+    {
+      "title": "Decorative Elements",
+      "questions": [
+        { "id": "element/code", "points": 2, "maxPoints": 10 },
+        { "id": "element/hiddenHints", "points": 2, "maxPoints": 10 },
+        { "id": "element/pythonVariable", "points": 2, "maxPoints": 10 },
+        { "id": "element/dataframe", "points": 2, "maxPoints": 10 },
+        { "id": "element/figure", "points": 2, "maxPoints": 10 },
+        { "id": "element/fileDownload", "points": 2, "maxPoints": 10 },
+        { "id": "element/variableOutput", "points": 2, "maxPoints": 10 },
+        { "id": "element/matrixLatex", "points": 2, "maxPoints": 10 },
+        { "id": "element/graph", "points": 2, "maxPoints": 10 },
+        { "id": "element/overlay", "points": 2, "maxPoints": 10 },
+        { "id": "element/xssSafe", "points": 2 },
+        { "id": "element/card", "points": 2, "maxPoints": 10 }
+      ]
+    },
+    {
+      "title": "Conditional Elements",
+      "questions": [{ "id": "element/panels", "points": 2, "maxPoints": 10 }]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/gallery/questions/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/gallery/questions/infoAssessment.json
@@ -1,32 +1,32 @@
 {
-    "uuid": "13D012E5-9C66-4092-BA1A-0445919CB0C3",
-    "type": "Homework",
-    "title": "Questions from the gallery at https://www.prairielearn.com",
-    "set": "Collection",
-    "number": "1",
-    "zones": [
-        {
-            "title": "Checkbox Input",
-            "questions": [
-                {"id": "gallery/checkbox/simple","points": 1},
-                {"id": "gallery/checkbox/complex","points": 1}
-            ]
-        },
-        {
-            "title": "Include Figure",
-            "questions": [
-                {"id": "gallery/includeFigure/simple","points": 1},
-                {"id": "gallery/includeFigure/complex","points": 1}
-            ]
-        },
-        {
-            "title": "Multiple-choice Input",
-            "questions": [
-                {"id": "gallery/multipleChoice/simple","points": 1},
-                {"id": "gallery/multipleChoice/complex","points": 1},
-                {"id": "gallery/multipleChoice/advanced","points": 1}
-            ]
-        }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> This assessment includes examples from the question gallery at <a href=\"https://www.prairielearn.com/catalog/questions\" target=\"_blank\">https://www.prairielearn.com/catalog/questions</a>.</p>"
+  "uuid": "13D012E5-9C66-4092-BA1A-0445919CB0C3",
+  "type": "Homework",
+  "title": "Questions from the gallery at https://www.prairielearn.com",
+  "set": "Collection",
+  "number": "1",
+  "zones": [
+    {
+      "title": "Checkbox Input",
+      "questions": [
+        { "id": "gallery/checkbox/simple", "points": 1 },
+        { "id": "gallery/checkbox/complex", "points": 1 }
+      ]
+    },
+    {
+      "title": "Include Figure",
+      "questions": [
+        { "id": "gallery/includeFigure/simple", "points": 1 },
+        { "id": "gallery/includeFigure/complex", "points": 1 }
+      ]
+    },
+    {
+      "title": "Multiple-choice Input",
+      "questions": [
+        { "id": "gallery/multipleChoice/simple", "points": 1 },
+        { "id": "gallery/multipleChoice/complex", "points": 1 },
+        { "id": "gallery/multipleChoice/advanced", "points": 1 }
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> This assessment includes examples from the question gallery at <a href=\"https://www.prairielearn.com/catalog/questions\" target=\"_blank\">https://www.prairielearn.com/catalog/questions</a>.</p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/infoAssessment.json
@@ -1,32 +1,32 @@
 {
-    "uuid": "7AD9015B-1609-4CD6-BB6E-9FEB28B7D0CA",
-    "type": "Homework",
-    "title": "Group activity template using Jupyter notebooks",
-    "set": "GroupActivity",
-    "module": "AnotherModule",
-    "number": "2",
-    "comment": "this is a group activity, with minimum size of 1 and maximum size of 5, where students can self-assign to groups.",
-    "groupWork": true,
-    "groupMinSize": 1,
-    "groupMaxSize": 5,
-    "studentGroupCreate": true,
-    "studentGroupJoin": true,
-    "studentGroupLeave": true,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100
-        }
-    ],
-    "zones": [
-      {
-        "title": " How Markov chains work?",
-        "questions": [
-            {"id": "demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro","points": 1},
-            {"id": "demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler","points": 1},
-            {"id": "demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank","points": 1}
-        ]
-      }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is a group assignment where students will share the same questions and grades. In this configuration, students can create their own groups, with minimum size of 1 and maximum size of 5 (we set minimum of 1 so that anyone can try this assessment on their own, since the assessment can be not started unless the minimum size is reached). PrairieLearn also provides an option were instructors pre-assign students to teams. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md>here</a>. "
+  "uuid": "7AD9015B-1609-4CD6-BB6E-9FEB28B7D0CA",
+  "type": "Homework",
+  "title": "Group activity template using Jupyter notebooks",
+  "set": "GroupActivity",
+  "module": "AnotherModule",
+  "number": "2",
+  "comment": "this is a group activity, with minimum size of 1 and maximum size of 5, where students can self-assign to groups.",
+  "groupWork": true,
+  "groupMinSize": 1,
+  "groupMaxSize": 5,
+  "studentGroupCreate": true,
+  "studentGroupJoin": true,
+  "studentGroupLeave": true,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "title": " How Markov chains work?",
+      "questions": [
+        { "id": "demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro", "points": 1 },
+        { "id": "demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler", "points": 1 },
+        { "id": "demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank", "points": 1 }
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> This is a group assignment where students will share the same questions and grades. In this configuration, students can create their own groups, with minimum size of 1 and maximum size of 5 (we set minimum of 1 so that anyone can try this assessment on their own, since the assessment can be not started unless the minimum size is reached). PrairieLearn also provides an option were instructors pre-assign students to teams. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md>here</a>. "
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/groupWork/template/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/groupWork/template/infoAssessment.json
@@ -1,65 +1,65 @@
 {
-    "uuid": "1646F291-3E3C-4992-892B-5B62FE52884E",
-    "type": "Homework",
-    "title": "Group activity template",
-    "set": "GroupActivity",
-    "module": "IntroModule",
-    "number": "1",
-    "comment": "this is a group activity, with minimum size of 1 and maximum size of 5, where students can self-assign to groups.",
-    "groupWork": true,
-    "groupMinSize": 1,
-    "groupMaxSize": 5,
-    "studentGroupCreate": true,
-    "studentGroupJoin": true,
-    "studentGroupLeave": true,
-    "groupRoles": [
+  "uuid": "1646F291-3E3C-4992-892B-5B62FE52884E",
+  "type": "Homework",
+  "title": "Group activity template",
+  "set": "GroupActivity",
+  "module": "IntroModule",
+  "number": "1",
+  "comment": "this is a group activity, with minimum size of 1 and maximum size of 5, where students can self-assign to groups.",
+  "groupWork": true,
+  "groupMinSize": 1,
+  "groupMaxSize": 5,
+  "studentGroupCreate": true,
+  "studentGroupJoin": true,
+  "studentGroupLeave": true,
+  "groupRoles": [
+    {
+      "name": "Manager",
+      "minimum": 1,
+      "maximum": 1,
+      "canAssignRoles": true
+    },
+    {
+      "name": "Recorder",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Reflector",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Contributor"
+    }
+  ],
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "title": "Fundamental questions",
+      "bestQuestions": 3,
+      "questions": [
         {
-            "name": "Manager",
-            "minimum": 1,
-            "maximum": 1,
-            "canAssignRoles": true
+          "id": "demo/demoNewton-page1",
+          "points": 1,
+          "maxPoints": 5,
+          "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
+          "canSubmit": ["Recorder"]
         },
         {
-            "name": "Recorder",
-            "minimum": 1,
-            "maximum": 1
-        },
-        {
-            "name": "Reflector",
-            "minimum": 1,
-            "maximum": 1
-        },
-        {
-            "name": "Contributor"
+          "id": "demo/demoNewton-page2",
+          "points": 1,
+          "maxPoints": 5,
+          "canView": ["Reflector"],
+          "canSubmit": ["Reflector"]
         }
-    ],
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100
-        }
-    ],
-    "zones": [
-        {
-            "title": "Fundamental questions",
-            "bestQuestions": 3,
-            "questions": [
-                {
-                    "id": "demo/demoNewton-page1",
-                    "points": 1, 
-                    "maxPoints": 5, 
-                    "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
-                    "canSubmit": ["Recorder"]
-                },
-                {
-                    "id": "demo/demoNewton-page2", 
-                    "points": 1, 
-                    "maxPoints": 5,
-                    "canView": ["Reflector"],
-                    "canSubmit": ["Reflector"]
-                }
-            ]
-        }
-    ],
-    "text": "For this homework you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
+      ]
+    }
+  ],
+  "text": "For this homework you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/homework/extraCredit/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/homework/extraCredit/infoAssessment.json
@@ -1,65 +1,65 @@
 {
-    "uuid": "754dac56-fc1f-4888-a74a-1b365fd48379",
-    "type": "Homework",
-    "title": "Homework template including extra credit",
-    "set": "Homework",
-    "module": "AnotherModule",
-    "number": "2",
-    "allowAccess": [
-      {
-          "comment": "Set end date for 100% credit",
-          "mode": "Public",
-          "credit": 100,
-          "startDate": "2021-01-01T00:00:01",
-          "endDate": "2023-11-15T23:59:59"
-      },
-      {
-          "comment": "Set later end date for reduced credit",
-          "mode": "Public",
-          "credit": 50,
-          "startDate": "2021-01-01T00:00:01",
-          "endDate": "2023-11-30T23:59:59"
-      },
-      {
-          "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
-          "mode": "Public",
-          "credit": 0,
-          "startDate": "2021-01-01T00:00:01",
-          "endDate": "2023-12-31T23:59:59"
-      }
-    ],
-    "maxPoints": 24,
-    "maxBonusPoints": 3,
-    "zones": [
-        {
-            "title": "Zone 1: Fundamental questions",
-            "bestQuestions": 2,
-            "questions": [
-                {"id": "demo/calculation",          "points": 1, "maxPoints": 3},
-                {"id": "demo/randomCheckbox",       "points": 1, "maxPoints": 3},
-                {"id": "demo/randomPlot",           "points": 1, "maxPoints": 3},
-                {"id": "demo/randomFakeData",       "points": 1, "maxPoints": 3},
-                {"id": "demo/randomZippedFile",     "points": 1, "maxPoints": 3}
-            ]
-        },
-        {
-            "title": "Zone 2: Intermediate questions",
-            "maxPoints": 6,
-            "questions": [
-                {"id": "demo/annotated/engCentroid", "points": 1, "maxPoints": 3},
-                {"id": "demo/annotated/engLogic",    "points": 1, "maxPoints": 3},
-                {"id": "workshop/PeriodicTable1",    "points": 1, "maxPoints": 3}
-           ]
-        },
-        {
-            "title": "Zone 3: Advanced questions",
-            "questions": [
-                {"id": "demo/annotated/mathProof",             "points": 3, "maxPoints": 3},
-                {"id": "demo/computeNumber-fromDataFrame",     "points": 1, "maxPoints": 6},
-                {"id": "demo/computeNumber-fromArray",         "points": 1, "maxPoints": 6},
-                {"id": "demo/computeRotationMatrix",           "points": 1, "maxPoints": 6}
-            ]
-        }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong></p> <p>This assessment organizes questions into zones with varying degrees of difficulty. Instructors may find it helpful to use zones to organize questions by topic, difficulty or other categories. However, zones are not required. </p> <p>Here is the breakdown of points for this assessment:</p><p><ul><li>In zone 1, only the two questions with the highest scores will count towards the total points. Since each question in this zone has maximum points equal to 2, the maximum points for this zone is equal to 6.</li><li>Zone 2 has 9 points available, but the maximum points is set to 6.</li><li>Zone 3 has 21 points available.</li></ul></p><p> Note that the overall assignment has maximum of 24 points, hence students will only need to get 12 out of the 21 points in zone 3 to achieve 100% credit.</p><p>In addition, this assessment allows students to get 3 bonus points. If they get 15 points for zone 3, they will have a total of 27/24 points, giving them 112% credit.</p> <p> All questions included in this assessment are designed as <i>drilling for mastery</i>. Read more <a href='https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md' target='_blank'>here</a>.</small> </p>"
+  "uuid": "754dac56-fc1f-4888-a74a-1b365fd48379",
+  "type": "Homework",
+  "title": "Homework template including extra credit",
+  "set": "Homework",
+  "module": "AnotherModule",
+  "number": "2",
+  "allowAccess": [
+    {
+      "comment": "Set end date for 100% credit",
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-11-15T23:59:59"
+    },
+    {
+      "comment": "Set later end date for reduced credit",
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-11-30T23:59:59"
+    },
+    {
+      "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-12-31T23:59:59"
+    }
+  ],
+  "maxPoints": 24,
+  "maxBonusPoints": 3,
+  "zones": [
+    {
+      "title": "Zone 1: Fundamental questions",
+      "bestQuestions": 2,
+      "questions": [
+        { "id": "demo/calculation", "points": 1, "maxPoints": 3 },
+        { "id": "demo/randomCheckbox", "points": 1, "maxPoints": 3 },
+        { "id": "demo/randomPlot", "points": 1, "maxPoints": 3 },
+        { "id": "demo/randomFakeData", "points": 1, "maxPoints": 3 },
+        { "id": "demo/randomZippedFile", "points": 1, "maxPoints": 3 }
+      ]
+    },
+    {
+      "title": "Zone 2: Intermediate questions",
+      "maxPoints": 6,
+      "questions": [
+        { "id": "demo/annotated/engCentroid", "points": 1, "maxPoints": 3 },
+        { "id": "demo/annotated/engLogic", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/PeriodicTable1", "points": 1, "maxPoints": 3 }
+      ]
+    },
+    {
+      "title": "Zone 3: Advanced questions",
+      "questions": [
+        { "id": "demo/annotated/mathProof", "points": 3, "maxPoints": 3 },
+        { "id": "demo/computeNumber-fromDataFrame", "points": 1, "maxPoints": 6 },
+        { "id": "demo/computeNumber-fromArray", "points": 1, "maxPoints": 6 },
+        { "id": "demo/computeRotationMatrix", "points": 1, "maxPoints": 6 }
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong></p> <p>This assessment organizes questions into zones with varying degrees of difficulty. Instructors may find it helpful to use zones to organize questions by topic, difficulty or other categories. However, zones are not required. </p> <p>Here is the breakdown of points for this assessment:</p><p><ul><li>In zone 1, only the two questions with the highest scores will count towards the total points. Since each question in this zone has maximum points equal to 2, the maximum points for this zone is equal to 6.</li><li>Zone 2 has 9 points available, but the maximum points is set to 6.</li><li>Zone 3 has 21 points available.</li></ul></p><p> Note that the overall assignment has maximum of 24 points, hence students will only need to get 12 out of the 21 points in zone 3 to achieve 100% credit.</p><p>In addition, this assessment allows students to get 3 bonus points. If they get 15 points for zone 3, they will have a total of 27/24 points, giving them 112% credit.</p> <p> All questions included in this assessment are designed as <i>drilling for mastery</i>. Read more <a href='https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md' target='_blank'>here</a>.</small> </p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/homework/manualGrading/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/homework/manualGrading/infoAssessment.json
@@ -1,62 +1,65 @@
 {
-    "uuid": "4975d809-5a1d-460d-9e9a-313a6c657f92",
-    "type": "Homework",
-    "title": "Homework with autograded and manually graded questions",
-    "set": "Homework",
-    "module": "IntroModule",
-    "number": "3",
-    "allowAccess": [
+  "uuid": "4975d809-5a1d-460d-9e9a-313a6c657f92",
+  "type": "Homework",
+  "title": "Homework with autograded and manually graded questions",
+  "set": "Homework",
+  "module": "IntroModule",
+  "number": "3",
+  "allowAccess": [
+    {
+      "comment": "Set end date for 100% credit",
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-11-15T23:59:59"
+    },
+    {
+      "comment": "Set later end date for reduced credit",
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-11-30T23:59:59"
+    },
+    {
+      "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-12-31T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Zone 1: Unlimited question variants with one single attempt",
+      "questions": [
+        { "id": "template/checkbox/random-prompt", "points": 1, "maxPoints": 6 },
+        { "id": "template/string-input/random", "points": 1, "maxPoints": 3 },
+        { "id": "template/symbolic-input/random", "points": 1, "maxPoints": 6 }
+      ]
+    },
+    {
+      "title": "Zone 2: Unlimited question variants with prescribed number of attempts",
+      "questions": [
         {
-            "comment": "Set end date for 100% credit",
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2023-11-15T23:59:59"
+          "id": "demo/annotated/engVectorDrawing",
+          "points": 2,
+          "maxPoints": 6,
+          "triesPerVariant": 2
         },
-        {
-            "comment": "Set later end date for reduced credit",
-            "mode": "Public",
-            "credit": 50,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2023-11-30T23:59:59"
-        },
-        {
-            "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
-            "mode": "Public",
-            "credit": 0,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2023-12-31T23:59:59"
-        }
-    ],
-    "zones": [
-        {
-            "title": "Zone 1: Unlimited question variants with one single attempt",
-            "questions": [
-                {"id": "template/checkbox/random-prompt", "points": 1,"maxPoints": 6},
-                {"id": "template/string-input/random", "points": 1, "maxPoints": 3},
-                {"id": "template/symbolic-input/random", "points": 1,"maxPoints": 6}
-            ]
-        },
-        {
-            "title": "Zone 2: Unlimited question variants with prescribed number of attempts",
-            "questions": [
-                {"id": "demo/annotated/engVectorDrawing", "points": 2, "maxPoints": 6, "triesPerVariant": 2},
-                {"id": "demo/annotated/engBeamStress", "points": 2, "maxPoints": 6, "triesPerVariant": 3}
-            ]
-        },
-        {
-            "title": "Zone 3: Single question variant with unlimited number of attempts",
-            "questions": [
-                {"id": "demo/annotated/engMarkovBrewing", "points": 8}
-            ]
-        },
-        {
-            "title": "Zone 4: Manually graded questions",
-            "questions": [
-                {"id": "demo/autograder/codeUpload",           "autoPoints": 10, "manualPoints": 5},
-                {"id": "demo/fileDownloadUpload",              "points": 10},
-                {"id": "demo/markdownEditorLivePreview",       "points": 5}
-            ]
-        }
-    ]
+        { "id": "demo/annotated/engBeamStress", "points": 2, "maxPoints": 6, "triesPerVariant": 3 }
+      ]
+    },
+    {
+      "title": "Zone 3: Single question variant with unlimited number of attempts",
+      "questions": [{ "id": "demo/annotated/engMarkovBrewing", "points": 8 }]
+    },
+    {
+      "title": "Zone 4: Manually graded questions",
+      "questions": [
+        { "id": "demo/autograder/codeUpload", "autoPoints": 10, "manualPoints": 5 },
+        { "id": "demo/fileDownloadUpload", "points": 10 },
+        { "id": "demo/markdownEditorLivePreview", "points": 5 }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/homework/template/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/homework/template/infoAssessment.json
@@ -1,55 +1,58 @@
 {
-    "uuid": "13D012E4-9C66-4092-BA1A-1445919DB0C3",
-    "type": "Homework",
-    "title": "Homework template",
-    "set": "Homework",
-    "module": "IntroModule",
-    "number": "1",
-    "allowAccess": [
+  "uuid": "13D012E4-9C66-4092-BA1A-1445919DB0C3",
+  "type": "Homework",
+  "title": "Homework template",
+  "set": "Homework",
+  "module": "IntroModule",
+  "number": "1",
+  "allowAccess": [
+    {
+      "comment": "Set end date for 100% credit",
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-11-15T23:59:59"
+    },
+    {
+      "comment": "Set later end date for reduced credit",
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-11-30T23:59:59"
+    },
+    {
+      "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2023-12-31T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Zone 1: Unlimited question variants with one single attempt",
+      "questions": [
+        { "id": "template/checkbox/random-prompt", "points": 1, "maxPoints": 6 },
+        { "id": "template/string-input/random", "points": 1, "maxPoints": 3 },
+        { "id": "template/symbolic-input/random", "points": 1, "maxPoints": 6 }
+      ]
+    },
+    {
+      "title": "Zone 2: Unlimited question variants with prescribed number of attempts",
+      "questions": [
         {
-            "comment": "Set end date for 100% credit",
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2023-11-15T23:59:59"
+          "id": "demo/annotated/engVectorDrawing",
+          "points": 2,
+          "maxPoints": 6,
+          "triesPerVariant": 2
         },
-        {
-            "comment": "Set later end date for reduced credit",
-            "mode": "Public",
-            "credit": 50,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2023-11-30T23:59:59"
-        },
-        {
-            "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
-            "mode": "Public",
-            "credit": 0,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2023-12-31T23:59:59"
-        }
-    ],
-    "zones": [
-        {
-            "title": "Zone 1: Unlimited question variants with one single attempt",
-            "questions": [
-                {"id": "template/checkbox/random-prompt", "points": 1,"maxPoints": 6},
-                {"id": "template/string-input/random", "points": 1, "maxPoints": 3},
-                {"id": "template/symbolic-input/random", "points": 1,"maxPoints": 6}
-            ]
-        },
-        {
-            "title": "Zone 2: Unlimited question variants with prescribed number of attempts",
-            "questions": [
-                {"id": "demo/annotated/engVectorDrawing", "points": 2, "maxPoints": 6, "triesPerVariant": 2},
-                {"id": "demo/annotated/engBeamStress", "points": 2, "maxPoints": 6, "triesPerVariant": 3}
-            ]
-        },
-        {
-            "title": "Zone 3: Single question variant with unlimited number of attempts",
-            "questions": [
-                {"id": "demo/annotated/engMarkovBrewing", "points": 8}
-            ]
-        }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong></p> </p><p><strong>Zone 1</strong> includes examples of lower level questions that involve nearly automatic responses. As such, we use the drilling for mastery configuration (PrairieLearn default for homework), where students can create unlimited question variants, each one with a single attempt. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md/#Drilling-basic-skills-using-unlimited-variants-with single-attempt target=_blank>here</a>.</p> <p><strong>Zone 2</strong> includes examples of more sophisticated questions that often involve more than one step to achieve the solution. These questions allow students to retry the same question variant more than once, before creating a new variant. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md/#Limiting-the-number-of-attempts-per-variant target=_blank>here</a>.</p><p><strong>Zone 3</strong> includes a coding question that involve multiple skills levels (lower to high) and several steps to obtain the solution. Students receive only one variant of the question and have unlimited attempts to complete it successfuly. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md/#Unlimited-retry-attempts-for-the-same-question-variant target=_blank>here</a>.</p>"
+        { "id": "demo/annotated/engBeamStress", "points": 2, "maxPoints": 6, "triesPerVariant": 3 }
+      ]
+    },
+    {
+      "title": "Zone 3: Single question variant with unlimited number of attempts",
+      "questions": [{ "id": "demo/annotated/engMarkovBrewing", "points": 8 }]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong></p> </p><p><strong>Zone 1</strong> includes examples of lower level questions that involve nearly automatic responses. As such, we use the drilling for mastery configuration (PrairieLearn default for homework), where students can create unlimited question variants, each one with a single attempt. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md/#Drilling-basic-skills-using-unlimited-variants-with single-attempt target=_blank>here</a>.</p> <p><strong>Zone 2</strong> includes examples of more sophisticated questions that often involve more than one step to achieve the solution. These questions allow students to retry the same question variant more than once, before creating a new variant. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md/#Limiting-the-number-of-attempts-per-variant target=_blank>here</a>.</p><p><strong>Zone 3</strong> includes a coding question that involve multiple skills levels (lower to high) and several steps to obtain the solution. Students receive only one variant of the question and have unlimited attempts to complete it successfuly. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md/#Unlimited-retry-attempts-for-the-same-question-variant target=_blank>here</a>.</p>"
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/infoAssessment.json
@@ -1,41 +1,49 @@
 {
-    "uuid": "13D012E4-9C66-4092-BA1A-0445919DB0C3",
-    "type": "Homework",
-    "title": "Learning new concepts asynchronously",
-    "set": "Lecture",
-    "module": "IntroModule",
-    "number": "1",
-    "allowAccess": [
+  "uuid": "13D012E4-9C66-4092-BA1A-0445919DB0C3",
+  "type": "Homework",
+  "title": "Learning new concepts asynchronously",
+  "set": "Lecture",
+  "module": "IntroModule",
+  "number": "1",
+  "allowAccess": [
+    {
+      "comment": "Set end date for 100% credit",
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2025-12-01T23:59:59"
+    },
+    {
+      "comment": "Set later end date for reduced credit",
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2025-12-08T23:59:59"
+    },
+    {
+      "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2021-01-01T00:00:01",
+      "endDate": "2025-12-31T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
         {
-            "comment": "Set end date for 100% credit",
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2021-01-01T00:00:01",
-            "endDate": "2025-12-01T23:59:59"
-       },
-       {
-           "comment": "Set later end date for reduced credit",
-           "mode": "Public",
-           "credit": 50,
-           "startDate": "2021-01-01T00:00:01",
-           "endDate": "2025-12-08T23:59:59"
-      },
-      {
-          "comment": "Set another end date, potentially end of the term, for zero credit (can practice, but no longer earn points for the assessment)",
-          "mode": "Public",
-          "credit": 0,
-          "startDate": "2021-01-01T00:00:01",
-          "endDate": "2025-12-31T23:59:59"
-     }
-    ],
-    "zones": [
+          "id": "demo/annotated/LectureVelocity/1-Introduction",
+          "points": 1,
+          "triesPerVariant": 2
+        },
+        { "id": "demo/annotated/LectureVelocity/2-Derivative", "points": 1 },
         {
-            "questions": [
-                { "id": "demo/annotated/LectureVelocity/1-Introduction", "points": 1, "triesPerVariant": 2},
-                { "id": "demo/annotated/LectureVelocity/2-Derivative", "points": 1},
-                { "id": "demo/annotated/LectureVelocity/4-KnowledgeTest", "points": 2, "triesPerVariant": 2}
-            ]
+          "id": "demo/annotated/LectureVelocity/4-KnowledgeTest",
+          "points": 2,
+          "triesPerVariant": 2
         }
-    ],
-    "text": "<p><strong>Comments about this assessment:</strong> </p><p> Just like there are different teaching methods, people also learn in different ways. Mixing how content is presented to students can improve the learner engagement. In this assessment, we combine a mixture of text, equations, plots, videos, interactive JupyterLabs, and short quiz questions to introduce new course content to students. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md target=_blank>here</a>.</p> "
+      ]
+    }
+  ],
+  "text": "<p><strong>Comments about this assessment:</strong> </p><p> Just like there are different teaching methods, people also learn in different ways. Mixing how content is presented to students can improve the learner engagement. In this assessment, we combine a mixture of text, equations, plots, videos, interactive JupyterLabs, and short quiz questions to introduce new course content to students. Read more <a href=https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md target=_blank>here</a>.</p> "
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/questionTemplates/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/questionTemplates/infoAssessment.json
@@ -1,53 +1,53 @@
 {
-    "uuid": "69DE0FEC-92AB-4361-B654-5C56F795D1FD",
-    "type": "Homework",
-    "title": "Question templates",
-    "set": "Collection",
-    "number": "6",
-    "zones": [
-      {
-          "title": "Template: copy, paste and edit to start creating questions",
-          "questions": [
-              {"id": "demo/multipleChoiceSingleCorrect", "points": 1},
-              {"id": "template/multiple-choice/random", "points": 1, "maxPoints": 2},
-              {"id": "template/multiple-choice/random-prompt", "points": 1, "maxPoints": 4},
-              {"id": "template/multiple-choice/numeric", "points": 1, "maxPoints": 4},
-              {"id": "template/multiple-choice/random-prompt-true-false", "points": 1, "maxPoints": 2},
-              {"id": "template/multiple-choice/images", "points": 1, "maxPoints": 4},
-              {"id": "demo/multiAnswerMC",                     "points": 2, "maxPoints": 10},
-              {"id": "template/integer-input/random", "points": 1, "maxPoints": 2},
-              {"id": "template/number-input/random", "points": 1, "maxPoints": 2},
-              {"id": "demo/matrixAlgebra",                   "points": 2, "maxPoints": 10},
-              {"id": "template/symbolic-input/random",                  "points": 2, "maxPoints": 10},
-              {"id": "template/figure/dynamic", "points": 1, "maxPoints": 4}
-          ]
-      },
-      {
-          "title": "More question examples and tips",
-          "questions": [
-              {"id": "demo/numberInputGradingMethod", "points": 1, "maxPoints": 2},
-              {"id": "demo/numberInputTips", "points": 1, "maxPoints": 2},
-              {"id": "demo/randomDataFrame",                 "points": 2, "maxPoints": 6},
-              {"id": "demo/overlayTriangle",                 "points": 2, "maxPoints": 4},
-              {"id": "demo/overlayDropdown",                 "points": 1, "maxPoints": 5},
-              {"id": "demo/proofBlocks",                     "points": 1, "maxPoints": 5},
-              {"id": "demo/markdownEditorLivePreview",       "points": 2},
-              {"id": "demo/graphvizEditorPreview",           "points": 2},
-              {"id": "demo/addHTMLtable",                    "points": 2, "maxPoints": 4},
-              {"id": "demo/insertEmbeddedVideo",             "points": 2, "maxPoints": 4},
-              {"id": "element/markdown",                 "points": 2, "maxPoints": 10},
-              {"id": "demo/survey",                  "points": 1, "maxPoints": 1}
-          ]
-      },
-        {
-            "title": "Questions using additional customization (elements or grading function)",
-            "questions": [
-                {"id": "demo/custom/element",                  "points": 1, "maxPoints": 1},
-                {"id": "demo/custom/gradeFunction",            "points": 1, "maxPoints": 1},
-                {"id": "demo/custom/extension",                "points": 1, "maxPoints": 1},
-                {"id": "demo/custom/elementHiddenTag",         "points": 1, "maxPoints": 1},
-                {"id": "demo/custom/stylingScripts",           "points": 1, "maxPoints": 1}
-            ]
-        }
-    ]
+  "uuid": "69DE0FEC-92AB-4361-B654-5C56F795D1FD",
+  "type": "Homework",
+  "title": "Question templates",
+  "set": "Collection",
+  "number": "6",
+  "zones": [
+    {
+      "title": "Template: copy, paste and edit to start creating questions",
+      "questions": [
+        { "id": "demo/multipleChoiceSingleCorrect", "points": 1 },
+        { "id": "template/multiple-choice/random", "points": 1, "maxPoints": 2 },
+        { "id": "template/multiple-choice/random-prompt", "points": 1, "maxPoints": 4 },
+        { "id": "template/multiple-choice/numeric", "points": 1, "maxPoints": 4 },
+        { "id": "template/multiple-choice/random-prompt-true-false", "points": 1, "maxPoints": 2 },
+        { "id": "template/multiple-choice/images", "points": 1, "maxPoints": 4 },
+        { "id": "demo/multiAnswerMC", "points": 2, "maxPoints": 10 },
+        { "id": "template/integer-input/random", "points": 1, "maxPoints": 2 },
+        { "id": "template/number-input/random", "points": 1, "maxPoints": 2 },
+        { "id": "demo/matrixAlgebra", "points": 2, "maxPoints": 10 },
+        { "id": "template/symbolic-input/random", "points": 2, "maxPoints": 10 },
+        { "id": "template/figure/dynamic", "points": 1, "maxPoints": 4 }
+      ]
+    },
+    {
+      "title": "More question examples and tips",
+      "questions": [
+        { "id": "demo/numberInputGradingMethod", "points": 1, "maxPoints": 2 },
+        { "id": "demo/numberInputTips", "points": 1, "maxPoints": 2 },
+        { "id": "demo/randomDataFrame", "points": 2, "maxPoints": 6 },
+        { "id": "demo/overlayTriangle", "points": 2, "maxPoints": 4 },
+        { "id": "demo/overlayDropdown", "points": 1, "maxPoints": 5 },
+        { "id": "demo/proofBlocks", "points": 1, "maxPoints": 5 },
+        { "id": "demo/markdownEditorLivePreview", "points": 2 },
+        { "id": "demo/graphvizEditorPreview", "points": 2 },
+        { "id": "demo/addHTMLtable", "points": 2, "maxPoints": 4 },
+        { "id": "demo/insertEmbeddedVideo", "points": 2, "maxPoints": 4 },
+        { "id": "element/markdown", "points": 2, "maxPoints": 10 },
+        { "id": "demo/survey", "points": 1, "maxPoints": 1 }
+      ]
+    },
+    {
+      "title": "Questions using additional customization (elements or grading function)",
+      "questions": [
+        { "id": "demo/custom/element", "points": 1, "maxPoints": 1 },
+        { "id": "demo/custom/gradeFunction", "points": 1, "maxPoints": 1 },
+        { "id": "demo/custom/extension", "points": 1, "maxPoints": 1 },
+        { "id": "demo/custom/elementHiddenTag", "points": 1, "maxPoints": 1 },
+        { "id": "demo/custom/stylingScripts", "points": 1, "maxPoints": 1 }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/worksheet/template/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/worksheet/template/infoAssessment.json
@@ -1,22 +1,22 @@
 {
-    "uuid": "E236920C-020C-448A-8E93-53CB6849BBDD",
-    "type": "Homework",
-    "title": "Worksheet template: Newton's law",
-    "set": "Worksheet",
-    "module": "AnotherModule",
-    "number": "1",
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100
-       }
-    ],
-    "zones": [
-        {
-            "questions": [
-                { "id": "demo/demoNewton-page1", "points": 5, "advanceScorePerc": 50 },
-                { "id": "demo/demoNewton-page2", "points": 5 }
-            ]
-        }
-    ]
+  "uuid": "E236920C-020C-448A-8E93-53CB6849BBDD",
+  "type": "Homework",
+  "title": "Worksheet template: Newton's law",
+  "set": "Worksheet",
+  "module": "AnotherModule",
+  "number": "1",
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
+        { "id": "demo/demoNewton-page1", "points": 5, "advanceScorePerc": 50 },
+        { "id": "demo/demoNewton-page2", "points": 5 }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/assessments/workshop/summer2020/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/workshop/summer2020/infoAssessment.json
@@ -1,58 +1,58 @@
 {
-    "uuid": "C19C0B7C-8728-49FE-8682-4E48E9694E3A",
-    "type": "Homework",
-    "title": "Workshop from Summer 2020",
-    "set": "Workshop",
-    "number": "1",
-    "comment": "This assessment was created for the workshop offered in Summer 2020",
-    "zones": [
-        {
-            "title": "Lesson 1",
-            "comment": "Workshop Day 1: https://prairielearn.readthedocs.io/en/latest/workshop/lesson1/",
-            "questions": [
-                {"id": "workshop/PeriodicTable1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson1_example1_v1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson1_example1_v2", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson1_example2", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson1_example3_v1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson1_example3_v2", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson1_example3_v3", "points": 1, "maxPoints": 3}
-            ]
-        },
-        {
-            "title": "Lesson 3",
-            "comment": "Workshop Day 3: https://prairielearn.readthedocs.io/en/latest/workshop/lesson3/",
-            "questions": [
-                {"id": "workshop/Lesson3_example1_v1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example1_v2", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example1_v3", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example2_v1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example2_v2", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example2_v3", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example3", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example4_v1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson3_example4_v2", "points": 1, "maxPoints": 3}
-            ]
-        },
-        {
-            "title": "Lesson 4",
-            "comment": "Workshop Day 4: https://prairielearn.readthedocs.io/en/latest/workshop/lesson4/",
-            "questions": [
-                {"id": "workshop/Lesson4_example1", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson4_example2", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson4_example3", "points": 1, "maxPoints": 3},
-                {"id": "workshop/Lesson4_example4", "points": 1, "maxPoints": 3}
-            ]
-        },
-        {
-            "title": "Lesson 5",
-            "comment": "Workshop Day 5: https://prairielearn.readthedocs.io/en/latest/workshop/lesson5/",
-            "questions": [
-              {"id": "workshop/Lesson5_example1", "points": 1, "maxPoints": 3},
-              {"id": "workshop/Lesson5_example2", "points": 1, "maxPoints": 3},
-              {"id": "workshop/Lesson5_example3", "points": 1, "maxPoints": 3},
-              {"id": "demo/drawing/centroid", "points": 1, "maxPoints": 3}
-            ]
-        }
-    ]
+  "uuid": "C19C0B7C-8728-49FE-8682-4E48E9694E3A",
+  "type": "Homework",
+  "title": "Workshop from Summer 2020",
+  "set": "Workshop",
+  "number": "1",
+  "comment": "This assessment was created for the workshop offered in Summer 2020",
+  "zones": [
+    {
+      "title": "Lesson 1",
+      "comment": "Workshop Day 1: https://prairielearn.readthedocs.io/en/latest/workshop/lesson1/",
+      "questions": [
+        { "id": "workshop/PeriodicTable1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson1_example1_v1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson1_example1_v2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson1_example2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson1_example3_v1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson1_example3_v2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson1_example3_v3", "points": 1, "maxPoints": 3 }
+      ]
+    },
+    {
+      "title": "Lesson 3",
+      "comment": "Workshop Day 3: https://prairielearn.readthedocs.io/en/latest/workshop/lesson3/",
+      "questions": [
+        { "id": "workshop/Lesson3_example1_v1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example1_v2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example1_v3", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example2_v1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example2_v2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example2_v3", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example3", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example4_v1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson3_example4_v2", "points": 1, "maxPoints": 3 }
+      ]
+    },
+    {
+      "title": "Lesson 4",
+      "comment": "Workshop Day 4: https://prairielearn.readthedocs.io/en/latest/workshop/lesson4/",
+      "questions": [
+        { "id": "workshop/Lesson4_example1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson4_example2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson4_example3", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson4_example4", "points": 1, "maxPoints": 3 }
+      ]
+    },
+    {
+      "title": "Lesson 5",
+      "comment": "Workshop Day 5: https://prairielearn.readthedocs.io/en/latest/workshop/lesson5/",
+      "questions": [
+        { "id": "workshop/Lesson5_example1", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson5_example2", "points": 1, "maxPoints": 3 },
+        { "id": "workshop/Lesson5_example3", "points": 1, "maxPoints": 3 },
+        { "id": "demo/drawing/centroid", "points": 1, "maxPoints": 3 }
+      ]
+    }
+  ]
 }

--- a/exampleCourse/courseInstances/SectionA/infoCourseInstance.json
+++ b/exampleCourse/courseInstances/SectionA/infoCourseInstance.json
@@ -1,14 +1,14 @@
 {
-    "uuid": "a2c16a02-7f73-43d0-b5ec-5eb1efb8ae51",
-    "shortName": "Sp15",
-    "longName": "Spring 2015",
-    "comment": "to organize this course instance by module, use `groupAssessmentsBy:Module`",
-    "allowAccess": [
-        {
-            "comment": "you probably want to set access to just your institution and semester start/end dates",
-            "institution": "Any",
-            "startDate": "1800-01-19T00:00:01",
-            "endDate": "2400-05-13T23:59:59"
-        }
-    ]
+  "uuid": "a2c16a02-7f73-43d0-b5ec-5eb1efb8ae51",
+  "shortName": "Sp15",
+  "longName": "Spring 2015",
+  "comment": "to organize this course instance by module, use `groupAssessmentsBy:Module`",
+  "allowAccess": [
+    {
+      "comment": "you probably want to set access to just your institution and semester start/end dates",
+      "institution": "Any",
+      "startDate": "1800-01-19T00:00:01",
+      "endDate": "2400-05-13T23:59:59"
+    }
+  ]
 }

--- a/exampleCourse/elementExtensions/extendable-element/example-extension/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/example-extension/info.json
@@ -1,6 +1,6 @@
 {
-    "controller": "example-extension.py",
-    "dependencies": {
-        "extensionStyles": [ "example-extension.css" ]
-    }
+  "controller": "example-extension.py",
+  "dependencies": {
+    "extensionStyles": ["example-extension.css"]
+  }
 }

--- a/exampleCourse/elementExtensions/extendable-element/extension-clientfiles/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/extension-clientfiles/info.json
@@ -1,3 +1,3 @@
 {
-    "controller": "extension-clientfiles.py"
+  "controller": "extension-clientfiles.py"
 }

--- a/exampleCourse/elementExtensions/extendable-element/extension-cssjs/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/extension-cssjs/info.json
@@ -1,10 +1,10 @@
 {
-    "controller": "extension-cssjs.py",
-    "dependencies": {
-        "extensionStyles": ["extension-cssjs.css"],
-        "extensionScripts": ["extension-cssjs.js"]
-    },
-    "dynamicDependencies": {
-        "nodeModulesScripts": {"d3": "d3/dist/d3.min.js"}
-    }
+  "controller": "extension-cssjs.py",
+  "dependencies": {
+    "extensionStyles": ["extension-cssjs.css"],
+    "extensionScripts": ["extension-cssjs.js"]
+  },
+  "dynamicDependencies": {
+    "nodeModulesScripts": { "d3": "d3/dist/d3.min.js" }
+  }
 }

--- a/exampleCourse/elementExtensions/extendable-element/extension-fileio/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/extension-fileio/info.json
@@ -1,3 +1,3 @@
 {
-    "controller": "extension-fileio.py"
+  "controller": "extension-fileio.py"
 }

--- a/exampleCourse/elementExtensions/pl-drawing/example-logo/info.json
+++ b/exampleCourse/elementExtensions/pl-drawing/example-logo/info.json
@@ -1,6 +1,6 @@
 {
-    "controller": "example-logo.py",
-    "dependencies": {
-        "extensionScripts": ["example-logo.js"]
-    }
+  "controller": "example-logo.py",
+  "dependencies": {
+    "extensionScripts": ["example-logo.js"]
+  }
 }

--- a/exampleCourse/elementExtensions/pl-graph/edge-inc-matrix/info.json
+++ b/exampleCourse/elementExtensions/pl-graph/edge-inc-matrix/info.json
@@ -1,3 +1,3 @@
 {
-    "controller": "edge-inc-matrix.py"
+  "controller": "edge-inc-matrix.py"
 }

--- a/exampleCourse/elements/clickable-image/info.json
+++ b/exampleCourse/elements/clickable-image/info.json
@@ -1,16 +1,10 @@
 {
-    "controller": "clickable-image.py",
-    "comment": "use comments to discuss top-level details", 
-    "dependencies": {
-        "comment": "or to explain dependencies",
-        "elementStyles": [
-            "clickable-image.css"
-        ],
-        "clientFilesCourseScripts": [
-            "sharedElementCode.js"
-        ],
-        "clientFilesCourseStyles": [
-            "sharedElementStyles.css"
-        ]
-    }
+  "controller": "clickable-image.py",
+  "comment": "use comments to discuss top-level details",
+  "dependencies": {
+    "comment": "or to explain dependencies",
+    "elementStyles": ["clickable-image.css"],
+    "clientFilesCourseScripts": ["sharedElementCode.js"],
+    "clientFilesCourseStyles": ["sharedElementStyles.css"]
+  }
 }

--- a/exampleCourse/elements/course-element/info.json
+++ b/exampleCourse/elements/course-element/info.json
@@ -1,17 +1,9 @@
 {
-    "controller": "course-element.py",
-    "dependencies": {
-        "elementScripts": [
-            "course-element.js"
-        ],
-        "elementStyles": [
-            "course-element.css"
-        ],
-        "clientFilesCourseScripts": [
-            "sharedElementCode.js"
-        ],
-        "clientFilesCourseStyles": [
-            "sharedElementStyles.css"
-        ]
-    }
+  "controller": "course-element.py",
+  "dependencies": {
+    "elementScripts": ["course-element.js"],
+    "elementStyles": ["course-element.css"],
+    "clientFilesCourseScripts": ["sharedElementCode.js"],
+    "clientFilesCourseStyles": ["sharedElementStyles.css"]
+  }
 }

--- a/exampleCourse/elements/extendable-element/info.json
+++ b/exampleCourse/elements/extendable-element/info.json
@@ -1,3 +1,3 @@
 {
-    "controller": "extendable-element.py"
+  "controller": "extendable-element.py"
 }

--- a/exampleCourse/infoCourse.json
+++ b/exampleCourse/infoCourse.json
@@ -1,55 +1,149 @@
 {
-    "uuid": "fcc5282c-a752-4146-9bd6-ee19aac53fc5",
-    "name": "XC 101",
-    "title": "Example Course",
-    "options": {
-        "useNewQuestionRenderer": true
+  "uuid": "fcc5282c-a752-4146-9bd6-ee19aac53fc5",
+  "name": "XC 101",
+  "title": "Example Course",
+  "options": {
+    "useNewQuestionRenderer": true
+  },
+  "comment": "Add additional assessment sets here. Default ones are listed here: https://prairielearn.readthedocs.io/en/latest/course/#assessment-sets.",
+  "assessmentSets": [
+    {
+      "abbreviation": "W",
+      "name": "Workshop",
+      "heading": "Workshops and Tutorials",
+      "color": "gray1"
     },
-    "comment": "Add additional assessment sets here. Default ones are listed here: https://prairielearn.readthedocs.io/en/latest/course/#assessment-sets.",
-    "assessmentSets": [
-      {"abbreviation": "W", "name": "Workshop", "heading": "Workshops and Tutorials", "color": "gray1"},
-      {"abbreviation": "C", "name": "Collection", "heading": "Collection of example questions", "color": "purple1"},
-      {"abbreviation": "L", "name": "Lecture", "heading": "Pre-Lecture Activities", "color": "blue1"},
-      {"abbreviation": "G", "name": "GroupActivity", "heading": "Group Activities", "color": "pink1"}
-
-    ],
-    "assessmentModules": [
-        {"name": "IntroModule", "heading": "Introductory Module"},
-        {"name": "AnotherModule", "heading": "Another Module"},
-        {"name": "FinalModule", "heading": "Final Module"}
-    ],
-    "topics": [
-        {"name": "Template", "color": "orange1", "description": "Templates to copy as the start for a new question."},
-        {"name": "Autograder", "color": "orange2", "description": "Questions using the external code grading feature."},
-        {"name": "Element", "color": "orange3", "description": "Overviews for each feature available within an element."},
-        {"name": "Demo", "color": "purple1", "description": "Demonstration questions showcasing PrairieLearn Features."},
-        {"name": "Workshop Demo", "color": "pink2", "description": "Demonstration questions from the PrairieLearn workshop."},
-        {"name": "Gallery", "color": "purple1", "description": "Example questions highlighted in www.prairielearn.com"},
-        {"name": "Drawing", "color": "purple2", "description": "Create interactive drawings."},
-        {"name": "Custom", "color": "gray1", "description": "Generate custom elements or styles within PrairieLearn."},
-        {"name": "Manual", "color": "gray2", "description": "Submission that must be graded manually."},
-        {"name": "Algebra", "color": "red3", "description": "Basic algebra."},
-        {"name": "Calculus", "color": "yellow3", "description": "Single and multiple variable calculus."},
-        {"name": "Vectors", "color": "blue3", "description": "Vector algebra in 3D."},
-        {"name": "Functions", "color": "pink3", "description": "Writing and calling functions in code."},
-        {"name": "Energy", "color": "purple3", "description": "Mechanical energy; kinetic and potential."},
-        {"name": "Particle kinetics", "color": "red3", "description": "Newton's equation for point masses."},
-        {"name": "Coding", "color": "turquoise3", "description": "Writing computer code."},
-        {"name": "Center of mass", "color": "green3", "description": "Calculating the center of mass for irregular bodies and systems."},
-        {"name": "Linear algebra", "color": "brown3", "description": "Matrix math."},
-        {"name": "Math", "color": "orange1", "description": "Mathematics topics"},
-        {"name": "Engineering", "color": "orange1", "description": "Engineering topics"}
-
-    ],
-    "tags": [
-        {"name": "mwest", "color": "gray1", "description": "Question originally written by mwest"},
-        {"name": "tbretl", "color": "blue1", "description": "Question originally written by tbretl"},
-        {"name": "mfsilva", "color": "blue1", "description": "Question originally written by mfsilva"},
-        {"name": "balamut2", "color": "orange1", "description": "Question originally written by balamut2"},
-        {"name": "ressick2", "color": "gray1", "description": "Question originally written by ressick2"},
-        {"name": "eliving2", "color": "gray1", "description": "Question originally written by eliving2"},
-        {"name": "nnytko2", "color": "turquoise1", "description": "Question originally written by nnytko2"},
-        {"name": "astec", "color": "orange2", "description": "Question originally written by andrewstec"},
-        {"name": "pearl", "color": "yellow3", "description": "Question originally written by pearl"}
-    ]
+    {
+      "abbreviation": "C",
+      "name": "Collection",
+      "heading": "Collection of example questions",
+      "color": "purple1"
+    },
+    {
+      "abbreviation": "L",
+      "name": "Lecture",
+      "heading": "Pre-Lecture Activities",
+      "color": "blue1"
+    },
+    {
+      "abbreviation": "G",
+      "name": "GroupActivity",
+      "heading": "Group Activities",
+      "color": "pink1"
+    }
+  ],
+  "assessmentModules": [
+    { "name": "IntroModule", "heading": "Introductory Module" },
+    { "name": "AnotherModule", "heading": "Another Module" },
+    { "name": "FinalModule", "heading": "Final Module" }
+  ],
+  "topics": [
+    {
+      "name": "Template",
+      "color": "orange1",
+      "description": "Templates to copy as the start for a new question."
+    },
+    {
+      "name": "Autograder",
+      "color": "orange2",
+      "description": "Questions using the external code grading feature."
+    },
+    {
+      "name": "Element",
+      "color": "orange3",
+      "description": "Overviews for each feature available within an element."
+    },
+    {
+      "name": "Demo",
+      "color": "purple1",
+      "description": "Demonstration questions showcasing PrairieLearn Features."
+    },
+    {
+      "name": "Workshop Demo",
+      "color": "pink2",
+      "description": "Demonstration questions from the PrairieLearn workshop."
+    },
+    {
+      "name": "Gallery",
+      "color": "purple1",
+      "description": "Example questions highlighted in www.prairielearn.com"
+    },
+    { "name": "Drawing", "color": "purple2", "description": "Create interactive drawings." },
+    {
+      "name": "Custom",
+      "color": "gray1",
+      "description": "Generate custom elements or styles within PrairieLearn."
+    },
+    {
+      "name": "Manual",
+      "color": "gray2",
+      "description": "Submission that must be graded manually."
+    },
+    { "name": "Algebra", "color": "red3", "description": "Basic algebra." },
+    {
+      "name": "Calculus",
+      "color": "yellow3",
+      "description": "Single and multiple variable calculus."
+    },
+    { "name": "Vectors", "color": "blue3", "description": "Vector algebra in 3D." },
+    {
+      "name": "Functions",
+      "color": "pink3",
+      "description": "Writing and calling functions in code."
+    },
+    {
+      "name": "Energy",
+      "color": "purple3",
+      "description": "Mechanical energy; kinetic and potential."
+    },
+    {
+      "name": "Particle kinetics",
+      "color": "red3",
+      "description": "Newton's equation for point masses."
+    },
+    { "name": "Coding", "color": "turquoise3", "description": "Writing computer code." },
+    {
+      "name": "Center of mass",
+      "color": "green3",
+      "description": "Calculating the center of mass for irregular bodies and systems."
+    },
+    { "name": "Linear algebra", "color": "brown3", "description": "Matrix math." },
+    { "name": "Math", "color": "orange1", "description": "Mathematics topics" },
+    { "name": "Engineering", "color": "orange1", "description": "Engineering topics" }
+  ],
+  "tags": [
+    { "name": "mwest", "color": "gray1", "description": "Question originally written by mwest" },
+    { "name": "tbretl", "color": "blue1", "description": "Question originally written by tbretl" },
+    {
+      "name": "mfsilva",
+      "color": "blue1",
+      "description": "Question originally written by mfsilva"
+    },
+    {
+      "name": "balamut2",
+      "color": "orange1",
+      "description": "Question originally written by balamut2"
+    },
+    {
+      "name": "ressick2",
+      "color": "gray1",
+      "description": "Question originally written by ressick2"
+    },
+    {
+      "name": "eliving2",
+      "color": "gray1",
+      "description": "Question originally written by eliving2"
+    },
+    {
+      "name": "nnytko2",
+      "color": "turquoise1",
+      "description": "Question originally written by nnytko2"
+    },
+    {
+      "name": "astec",
+      "color": "orange2",
+      "description": "Question originally written by andrewstec"
+    },
+    { "name": "pearl", "color": "yellow3", "description": "Question originally written by pearl" }
+  ]
 }

--- a/exampleCourse/questions/demo/addHTMLtable/info.json
+++ b/exampleCourse/questions/demo/addHTMLtable/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "2866E321-E59E-439A-9195-CFE98B73D0F5",
-    "title": "Demo: display HTML table",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Su20"],
-    "type": "v3"
+  "uuid": "2866E321-E59E-439A-9195-CFE98B73D0F5",
+  "title": "Demo: display HTML table",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/info.json
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "8FC9FB0E-0C9F-42F8-BDDA-A966C566302A",
-    "title": "Introduction",
-    "topic": "Math",
-    "tags": ["mfsilva", "Sp21"],
-    "type": "v3"
+  "uuid": "8FC9FB0E-0C9F-42F8-BDDA-A966C566302A",
+  "title": "Introduction",
+  "topic": "Math",
+  "tags": ["mfsilva", "Sp21"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/info.json
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/info.json
@@ -1,14 +1,14 @@
 {
-    "uuid": "9FC9FB0E-0C9F-42F8-BDDA-A966C566302A",
-    "title": "Derivative definition",
-    "topic": "Math",
-    "type": "v3",
-    "tags": ["mfsilva", "Sp21"],
-    "singleVariant": true,
-    "workspaceOptions": {
-      "image": "prairielearn/workspace-jupyterlab-python",
-      "port": 8080,
-      "home": "/home/jovyan",
-      "rewriteUrl": false
-    }
+  "uuid": "9FC9FB0E-0C9F-42F8-BDDA-A966C566302A",
+  "title": "Derivative definition",
+  "topic": "Math",
+  "type": "v3",
+  "tags": ["mfsilva", "Sp21"],
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-jupyterlab-python",
+    "port": 8080,
+    "home": "/home/jovyan",
+    "rewriteUrl": false
+  }
 }

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/info.json
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "F4701174-2276-4473-BFD6-0EC1B09A2011",
-    "title": "Check what you learned",
-    "topic": "Math",
-    "tags": ["mfsilva", "Sp21"],
-    "type": "v3"
+  "uuid": "F4701174-2276-4473-BFD6-0EC1B09A2011",
+  "title": "Check what you learned",
+  "topic": "Math",
+  "tags": ["mfsilva", "Sp21"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/info.json
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/info.json
@@ -1,26 +1,22 @@
 {
-    "uuid": "689A41B2-4144-43C7-A54E-403A47398423",
-    "title": "Gambler Example",
-    "topic": "Coding",
-    "tags": [
-        "workspace", "mfsilva", "Sp21"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    },
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-jupyterlab",
-        "port": 8080,
-        "home": "/home/jovyan",
-        "rewriteUrl": false,
-        "gradedFiles": [
-            "Markov-Chains-2.ipynb"
-        ]
-    }
+  "uuid": "689A41B2-4144-43C7-A54E-403A47398423",
+  "title": "Gambler Example",
+  "topic": "Coding",
+  "tags": ["workspace", "mfsilva", "Sp21"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  },
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-jupyterlab",
+    "port": 8080,
+    "home": "/home/jovyan",
+    "rewriteUrl": false,
+    "gradedFiles": ["Markov-Chains-2.ipynb"]
+  }
 }

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/info.json
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/info.json
@@ -1,26 +1,22 @@
 {
-    "uuid": "2dc15fd2-5b09-4050-8721-069ab8db9517",
-    "title": "Introduction",
-    "topic": "Coding",
-    "tags": [
-        "workspace", "mfsilva", "Sp21"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    },
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-jupyterlab-python",
-        "port": 8080,
-        "home": "/home/jovyan",
-        "rewriteUrl": false,
-        "gradedFiles": [
-            "Markov-Chains-1.ipynb"
-        ]
-    }
+  "uuid": "2dc15fd2-5b09-4050-8721-069ab8db9517",
+  "title": "Introduction",
+  "topic": "Coding",
+  "tags": ["workspace", "mfsilva", "Sp21"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  },
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-jupyterlab-python",
+    "port": 8080,
+    "home": "/home/jovyan",
+    "rewriteUrl": false,
+    "gradedFiles": ["Markov-Chains-1.ipynb"]
+  }
 }

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/info.json
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/info.json
@@ -1,26 +1,22 @@
 {
-    "uuid": "2ec15fd2-5b09-4050-8721-069ab7db9517",
-    "title": "PageRank",
-    "topic": "Coding",
-    "tags": [
-        "workspace", "mfsilva", "Sp21"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    },
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-jupyterlab-python",
-        "port": 8080,
-        "home": "/home/jovyan",
-        "rewriteUrl": false,
-        "gradedFiles": [
-            "Markov-Chains-3.ipynb"
-        ]
-    }
+  "uuid": "2ec15fd2-5b09-4050-8721-069ab7db9517",
+  "title": "PageRank",
+  "topic": "Coding",
+  "tags": ["workspace", "mfsilva", "Sp21"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  },
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-jupyterlab-python",
+    "port": 8080,
+    "home": "/home/jovyan",
+    "rewriteUrl": false,
+    "gradedFiles": ["Markov-Chains-3.ipynb"]
+  }
 }

--- a/exampleCourse/questions/demo/annotated/engBeamStress/info.json
+++ b/exampleCourse/questions/demo/annotated/engBeamStress/info.json
@@ -1,8 +1,8 @@
 {
-    "uuid": "8EC0F089-FD8D-447B-BE27-B9A92650E8E4",
-    "title": "Compute the normal stress",
-    "topic": "Engineering",
-    "singleVariant": true,
-    "tags": ["mfsilva","Su20"],
-    "type": "v3"
+  "uuid": "8EC0F089-FD8D-447B-BE27-B9A92650E8E4",
+  "title": "Compute the normal stress",
+  "topic": "Engineering",
+  "singleVariant": true,
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/engCentroid/info.json
+++ b/exampleCourse/questions/demo/annotated/engCentroid/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "DA2E555F-3F7B-4F3F-9857-E72DA8630919",
-    "title": "Find the centroid",
-    "topic": "Math",
-    "type": "v3",
-    "tags": ["mfsilva"]
+  "uuid": "DA2E555F-3F7B-4F3F-9857-E72DA8630919",
+  "title": "Find the centroid",
+  "topic": "Math",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/annotated/engCircuit/info.json
+++ b/exampleCourse/questions/demo/annotated/engCircuit/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "F1B6713D-1B27-4BA4-987E-6E2230A3CFBC",
-    "title": "Understanding a simple circuit",
-    "topic": "Engineering",
-    "tags": ["mfsilva","Su20"],
-    "type": "v3"
+  "uuid": "F1B6713D-1B27-4BA4-987E-6E2230A3CFBC",
+  "title": "Understanding a simple circuit",
+  "topic": "Engineering",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/engLogic/info.json
+++ b/exampleCourse/questions/demo/annotated/engLogic/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "78D80628-968F-40AE-9480-2C0369E46A1D",
-    "title": "Understanding logic circuit",
-    "topic": "Engineering",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "78D80628-968F-40AE-9480-2C0369E46A1D",
+  "title": "Understanding logic circuit",
+  "topic": "Engineering",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/engMarkovBrewing/info.json
+++ b/exampleCourse/questions/demo/annotated/engMarkovBrewing/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "b8ebc3fb-9662-496c-b7c3-31a29102b21c",
-    "title": "Construct the recipe for a new probiotic",
-    "topic": "Engineering",
-    "tags": ["Sp21","nnytko2"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 15
-    }
+  "uuid": "b8ebc3fb-9662-496c-b7c3-31a29102b21c",
+  "title": "Construct the recipe for a new probiotic",
+  "topic": "Engineering",
+  "tags": ["Sp21", "nnytko2"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 15
+  }
 }

--- a/exampleCourse/questions/demo/annotated/engVectorDrawing/info.json
+++ b/exampleCourse/questions/demo/annotated/engVectorDrawing/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "a216df15-f8b3-4d69-a1b7-6001daa5846a",
-    "title": "Illustrate a vector",
-    "topic": "Math",
-    "type": "v3",
-    "tags": ["mfsilva", "Su20"]
+  "uuid": "a216df15-f8b3-4d69-a1b7-6001daa5846a",
+  "title": "Illustrate a vector",
+  "topic": "Math",
+  "type": "v3",
+  "tags": ["mfsilva", "Su20"]
 }

--- a/exampleCourse/questions/demo/annotated/mathMatrixMult/info.json
+++ b/exampleCourse/questions/demo/annotated/mathMatrixMult/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "af335c37-1126-43b0-aba5-627eeb2e10a7",
-    "title": "Muliply two matrices",
-    "topic": "Math",
-    "tags": ["tbretl"],
-    "type": "v3"
+  "uuid": "af335c37-1126-43b0-aba5-627eeb2e10a7",
+  "title": "Muliply two matrices",
+  "topic": "Math",
+  "tags": ["tbretl"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/mathMatrixMultT/info.json
+++ b/exampleCourse/questions/demo/annotated/mathMatrixMultT/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "af435c36-1126-43b0-aba5-627eeb2e10a8",
-    "title": "Multiply two matrices",
-    "topic": "Math",
-    "tags": ["mwest", "mfsilva"],
-    "type": "v3"
+  "uuid": "af435c36-1126-43b0-aba5-627eeb2e10a8",
+  "title": "Multiply two matrices",
+  "topic": "Math",
+  "tags": ["mwest", "mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-even/info.json
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-even/info.json
@@ -1,8 +1,7 @@
 {
-    "uuid": "f555b053-6d49-4719-a850-7e4b2a3d2016",
-    "title": "Select the appropriate numbers",
-    "topic": "Math",
-    "tags": ["mfsilva", "Sp21"],
-    "type": "v3"
-
+  "uuid": "f555b053-6d49-4719-a850-7e4b2a3d2016",
+  "title": "Select the appropriate numbers",
+  "topic": "Math",
+  "tags": ["mfsilva", "Sp21"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-odd/info.json
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-odd/info.json
@@ -1,8 +1,7 @@
 {
-    "uuid": "111D35D3-0003-4212-8FB1-131F2543A056",
-    "title": "Select the appropriate numbers",
-    "topic": "Math",
-    "tags": ["mfsilva", "Sp21"],
-    "type": "v3"
-
+  "uuid": "111D35D3-0003-4212-8FB1-131F2543A056",
+  "title": "Select the appropriate numbers",
+  "topic": "Math",
+  "tags": ["mfsilva", "Sp21"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-prime/info.json
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-prime/info.json
@@ -1,8 +1,7 @@
 {
-    "uuid": "D5556274-BFAD-4ABA-BBE2-6D1E5FB05DEE",
-    "title": "Select the appropriate numbers",
-    "topic": "Math",
-    "tags": ["mfsilva", "Sp21"],
-    "type": "v3"
-
+  "uuid": "D5556274-BFAD-4ABA-BBE2-6D1E5FB05DEE",
+  "title": "Select the appropriate numbers",
+  "topic": "Math",
+  "tags": ["mfsilva", "Sp21"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/annotated/mathOuterProduct/info.json
+++ b/exampleCourse/questions/demo/annotated/mathOuterProduct/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "cc29f57c-1a13-4161-b052-1cd795011d98",
-    "title": "Compute the outer product",
-    "topic": "Math",
-    "tags": ["mfsilva","Sp21"],
-    "type": "v3"
+  "uuid": "cc29f57c-1a13-4161-b052-1cd795011d98",
+  "title": "Compute the outer product",
+  "topic": "Math",
+  "tags": ["mfsilva", "Sp21"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/autograder/ansiOutput/info.json
+++ b/exampleCourse/questions/demo/autograder/ansiOutput/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "9978df8a-449d-4a39-8d93-df18dbce7e05",
-    "title": "Demo: ANSI colors in code autograder output",
-    "topic": "Autograder",
-    "type": "v3",
-    "tags": ["Fa19"]
+  "uuid": "9978df8a-449d-4a39-8d93-df18dbce7e05",
+  "title": "Demo: ANSI colors in code autograder output",
+  "topic": "Autograder",
+  "type": "v3",
+  "tags": ["Fa19"]
 }

--- a/exampleCourse/questions/demo/autograder/c/drawTriangle/info.json
+++ b/exampleCourse/questions/demo/autograder/c/drawTriangle/info.json
@@ -1,17 +1,15 @@
 {
-    "uuid": "6e2f0457-5809-4f44-bc25-243f742e09c9",
-    "title": "Autograder demo: Draw a triangle in C",
-    "topic": "Autograder",
-    "tags": [
-        "code", "jonatan", "muchen", "c"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-c",
-        "timeout": 100,
-        "entrypoint": "python3 /grade/tests/test.py"
-    }
+  "uuid": "6e2f0457-5809-4f44-bc25-243f742e09c9",
+  "title": "Autograder demo: Draw a triangle in C",
+  "topic": "Autograder",
+  "tags": ["code", "jonatan", "muchen", "c"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-c",
+    "timeout": 100,
+    "entrypoint": "python3 /grade/tests/test.py"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/c/linkedListDelete/info.json
+++ b/exampleCourse/questions/demo/autograder/c/linkedListDelete/info.json
@@ -1,17 +1,15 @@
 {
-    "uuid": "e873fd4b-870f-4267-b2dc-0d6c96ab235d",
-    "title": "Autograder demo: Remove linked list element in C (Check Framework)",
-    "topic": "Autograder",
-    "tags": [
-      "jonatan", "demo", "autograder", "c", "check", "asan"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-c",
-        "timeout": 100,
-        "entrypoint": "python3 /grade/tests/test.py"
-    }
+  "uuid": "e873fd4b-870f-4267-b2dc-0d6c96ab235d",
+  "title": "Autograder demo: Remove linked list element in C (Check Framework)",
+  "topic": "Autograder",
+  "tags": ["jonatan", "demo", "autograder", "c", "check", "asan"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-c",
+    "timeout": 100,
+    "entrypoint": "python3 /grade/tests/test.py"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/c/salesTax/info.json
+++ b/exampleCourse/questions/demo/autograder/c/salesTax/info.json
@@ -1,17 +1,15 @@
 {
-    "uuid": "b0eba3d7-e1f0-4f47-8af6-f16f251ba92F",
-    "title": "Autograder Demo: Sales Tax in C++",
-    "topic": "Autograder",
-    "tags": [
-        "jonatan", "code",  "c++"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-c",
-        "timeout": 10,
-        "entrypoint": "python3 /grade/tests/test.py"
-    }
+  "uuid": "b0eba3d7-e1f0-4f47-8af6-f16f251ba92F",
+  "title": "Autograder Demo: Sales Tax in C++",
+  "topic": "Autograder",
+  "tags": ["jonatan", "code", "c++"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-c",
+    "timeout": 10,
+    "entrypoint": "python3 /grade/tests/test.py"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/c/square/info.json
+++ b/exampleCourse/questions/demo/autograder/c/square/info.json
@@ -1,17 +1,15 @@
 {
-    "uuid": "1e1a7e46-1511-49b8-8869-744276a309a0",
-    "title": "Autograder demo: Square function in C (Standard Output Override)",
-    "topic": "Autograder",
-    "tags": [
-        "jonatan","code", "c"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-c",
-        "timeout": 100,
-        "entrypoint": "python3 /grade/tests/test.py"
-    }
+  "uuid": "1e1a7e46-1511-49b8-8869-744276a309a0",
+  "title": "Autograder demo: Square function in C (Standard Output Override)",
+  "topic": "Autograder",
+  "tags": ["jonatan", "code", "c"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-c",
+    "timeout": 100,
+    "entrypoint": "python3 /grade/tests/test.py"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/c/squareCheck/info.json
+++ b/exampleCourse/questions/demo/autograder/c/squareCheck/info.json
@@ -1,17 +1,15 @@
 {
-    "uuid": "b0793f85-be3b-45ad-b210-7c1c20fba420",
-    "title": "Autograder demo: Square function in C (Check Framework)",
-    "topic": "Autograder",
-    "tags": [
-      "jonatan", "demo", "autograder", "c", "check"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-c",
-        "timeout": 100,
-        "entrypoint": "python3 /grade/tests/test.py"
-    }
+  "uuid": "b0793f85-be3b-45ad-b210-7c1c20fba420",
+  "title": "Autograder demo: Square function in C (Check Framework)",
+  "topic": "Autograder",
+  "tags": ["jonatan", "demo", "autograder", "c", "check"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-c",
+    "timeout": 100,
+    "entrypoint": "python3 /grade/tests/test.py"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/codeEditor/info.json
+++ b/exampleCourse/questions/demo/autograder/codeEditor/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "3551731f-b6b4-4afc-b1f8-a8a4f7f73bcc",
-    "title": "Demo: Fibonacci function, in-browser editor, external grading",
-    "topic": "Autograder",
-    "tags": ["code"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "3551731f-b6b4-4afc-b1f8-a8a4f7f73bcc",
+  "title": "Demo: Fibonacci function, in-browser editor, external grading",
+  "topic": "Autograder",
+  "tags": ["code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/autograder/codeUpload/info.json
+++ b/exampleCourse/questions/demo/autograder/codeUpload/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "b0444a41-1472-4aa5-a024-ee1091bdab8e",
-    "title": "Demo: Fibonacci function, file upload, external grading",
-    "topic": "Autograder",
-    "tags": ["code"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "b0444a41-1472-4aa5-a024-ee1091bdab8e",
+  "title": "Demo: Fibonacci function, file upload, external grading",
+  "topic": "Autograder",
+  "tags": ["code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/autograder/java/helloWorld/info.json
+++ b/exampleCourse/questions/demo/autograder/java/helloWorld/info.json
@@ -1,17 +1,15 @@
 {
-    "uuid": "ad089d0e-44b8-4ae7-add4-26bcd1474015",
-    "type": "v3",
-    "title": "Autograder demo: Hello World in Java",
-    "topic": "Autograder",
-    "tags": [
-        "burcu", "code"
-    ],
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-java",
-        "timeout": 100,
-        "entrypoint": "autograder.sh"
-    }
+  "uuid": "ad089d0e-44b8-4ae7-add4-26bcd1474015",
+  "type": "v3",
+  "title": "Autograder demo: Hello World in Java",
+  "topic": "Autograder",
+  "tags": ["burcu", "code"],
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-java",
+    "timeout": 100,
+    "entrypoint": "autograder.sh"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/java/square/info.json
+++ b/exampleCourse/questions/demo/autograder/java/square/info.json
@@ -1,18 +1,15 @@
 {
-    "uuid": "e2bdacbe-a8ba-41c1-86aa-607aa84ab2d2",
-    "title": "Autograder demo: Square method in Java",
-    "topic": "Autograder",
-    "tags": [
-        "jonatan",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-java",
-        "timeout": 20,
-        "entrypoint": "autograder.sh"
-    }
+  "uuid": "e2bdacbe-a8ba-41c1-86aa-607aa84ab2d2",
+  "title": "Autograder demo: Square method in Java",
+  "topic": "Autograder",
+  "tags": ["jonatan", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-java",
+    "timeout": 20,
+    "entrypoint": "autograder.sh"
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/earlyExit/info.json
+++ b/exampleCourse/questions/demo/autograder/python/earlyExit/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "c7e4d4ab-2c0c-4fcb-9c33-1fb19e025b4c",
-    "title": "Autograder demo: Quitting grading early",
-    "topic": "Autograder",
-    "tags": [
-        "fa22",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "c7e4d4ab-2c0c-4fcb-9c33-1fb19e025b4c",
+  "title": "Autograder demo: Quitting grading early",
+  "topic": "Autograder",
+  "tags": ["fa22", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/info.json
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "12ead399-f913-4a0c-9922-f46a2fccb4ad",
-    "title": "Autograder demo: Adding leading/trailing code",
-    "topic": "Autograder",
-    "tags": [
-        "Fa20",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "12ead399-f913-4a0c-9922-f46a2fccb4ad",
+  "title": "Autograder demo: Adding leading/trailing code",
+  "topic": "Autograder",
+  "tags": ["Fa20", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/numpy/info.json
+++ b/exampleCourse/questions/demo/autograder/python/numpy/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "DF0FF186-DECC-448C-B23C-78D86A966E4C",
-    "title": "Autograder demo: Using NumPy arrays",
-    "topic": "Autograder",
-    "tags": [
-        "sp20",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "DF0FF186-DECC-448C-B23C-78D86A966E4C",
+  "title": "Autograder demo: Using NumPy arrays",
+  "topic": "Autograder",
+  "tags": ["sp20", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/orderBlocksAddNumpy/info.json
+++ b/exampleCourse/questions/demo/autograder/python/orderBlocksAddNumpy/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "356308B1-25E3-44EB-B455-83A4F21371BE",
-    "title": "Element pl-order-blocks: Externally graded python code using numpy",
-    "topic": "Autograder",
-    "tags": ["code"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "356308B1-25E3-44EB-B455-83A4F21371BE",
+  "title": "Element pl-order-blocks: Externally graded python code using numpy",
+  "topic": "Autograder",
+  "tags": ["code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/orderBlocksRandomParams/info.json
+++ b/exampleCourse/questions/demo/autograder/python/orderBlocksRandomParams/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "3551731f-b6b4-4afc-b1f8-a8a4f7f73bcd",
-    "title": "Element pl-order-blocks: Externally graded python code with randomized parameters",
-    "topic": "Autograder",
-    "tags": ["code"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "3551731f-b6b4-4afc-b1f8-a8a4f7f73bcd",
+  "title": "Element pl-order-blocks: Externally graded python code with randomized parameters",
+  "topic": "Autograder",
+  "tags": ["code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/pandas/info.json
+++ b/exampleCourse/questions/demo/autograder/python/pandas/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "F22EC735-A1EB-4816-AB4C-3DF908A62719",
-    "title": "Autograder demo: Grading Pandas DataFrames",
-    "topic": "Autograder",
-    "tags": [
-        "sp20",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "F22EC735-A1EB-4816-AB4C-3DF908A62719",
+  "title": "Autograder demo: Grading Pandas DataFrames",
+  "topic": "Autograder",
+  "tags": ["sp20", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/plots/info.json
+++ b/exampleCourse/questions/demo/autograder/python/plots/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "D833155A-CEE4-48E2-A573-977722718D1C",
-    "title": "Autograder demo: Checking Matplotlib plots",
-    "topic": "Autograder",
-    "tags": [
-        "sp20",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "D833155A-CEE4-48E2-A573-977722718D1C",
+  "title": "Autograder demo: Checking Matplotlib plots",
+  "topic": "Autograder",
+  "tags": ["sp20", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/random/info.json
+++ b/exampleCourse/questions/demo/autograder/python/random/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "3d375a95-7497-4d80-b211-729ef61ecd81",
-    "title": "Autograder demo: Code with randomization",
-    "topic": "Autograder",
-    "tags": [
-        "sp20",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "3d375a95-7497-4d80-b211-729ef61ecd81",
+  "title": "Autograder demo: Code with randomization",
+  "topic": "Autograder",
+  "tags": ["sp20", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/randomFunctionName/info.json
+++ b/exampleCourse/questions/demo/autograder/python/randomFunctionName/info.json
@@ -1,19 +1,15 @@
 {
-    "uuid": "6151dec6-f12d-4d05-969a-dd8be64d4664",
-    "title": "Autograder demo: Randomized function name",
-    "topic": "Autograder",
-    "tags": [
-        "erobson2",
-        "steven.wolfman",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "6151dec6-f12d-4d05-969a-dd8be64d4664",
+  "title": "Autograder demo: Randomized function name",
+  "topic": "Autograder",
+  "tags": ["erobson2", "steven.wolfman", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/python/square/info.json
+++ b/exampleCourse/questions/demo/autograder/python/square/info.json
@@ -1,21 +1,16 @@
 {
-    "uuid": "994D6DDE-B41F-4EC5-90CC-9CE18EF5558B",
-    "title": "Autograder demo: Square a number",
-    "topic": "Autograder",
-    "tags": [
-        "sp20",
-        "mfsilva",
-        "nnytko2",
-        "code"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "comment": "testing comments in external grading blocks",
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "994D6DDE-B41F-4EC5-90CC-9CE18EF5558B",
+  "title": "Autograder demo: Square a number",
+  "topic": "Autograder",
+  "tags": ["sp20", "mfsilva", "nnytko2", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "comment": "testing comments in external grading blocks",
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/demo/autograder/r/createRObject/info.json
+++ b/exampleCourse/questions/demo/autograder/r/createRObject/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "eaf28719-7c5f-43b3-93da-33e14998f2a1",
-    "title": "Autograder demo: Create an Object in R",
-    "topic": "Autograder",
-    "tags": ["v3", "demo", "autograder"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-r",
-        "entrypoint": "/r_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "eaf28719-7c5f-43b3-93da-33e14998f2a1",
+  "title": "Autograder demo: Create an Object in R",
+  "topic": "Autograder",
+  "tags": ["v3", "demo", "autograder"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-r",
+    "entrypoint": "/r_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/calculation/info.json
+++ b/exampleCourse/questions/demo/calculation/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "8b4891d6-64d1-4e89-b72d-ad2133f25b2f",
-    "title": "Simple calculation to add numbers",
-    "topic": "Demo",
-    "tags": ["mwest", "fa17"],
-    "type": "v3"
+  "uuid": "8b4891d6-64d1-4e89-b72d-ad2133f25b2f",
+  "title": "Simple calculation to add numbers",
+  "topic": "Demo",
+  "tags": ["mwest", "fa17"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/computeNumber-fromArray/info.json
+++ b/exampleCourse/questions/demo/computeNumber-fromArray/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "67D4A2DC-2D89-453A-ADA6-A469B519F7FF",
-    "title": "Compute the standard deviation of given dataset",
-    "topic": "Demo",
-    "tags": ["mfsilva"],
-    "type": "v3"
+  "uuid": "67D4A2DC-2D89-453A-ADA6-A469B519F7FF",
+  "title": "Compute the standard deviation of given dataset",
+  "topic": "Demo",
+  "tags": ["mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/computeNumber-fromDataFrame/info.json
+++ b/exampleCourse/questions/demo/computeNumber-fromDataFrame/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "120E7069-EB22-41C4-8B29-6264D72B979A",
-    "title": "Compute the average of given dataset",
-    "topic": "Demo",
-    "tags": ["mfsilva"],
-    "type": "v3"
+  "uuid": "120E7069-EB22-41C4-8B29-6264D72B979A",
+  "title": "Compute the average of given dataset",
+  "topic": "Demo",
+  "tags": ["mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/computeRotationMatrix/info.json
+++ b/exampleCourse/questions/demo/computeRotationMatrix/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "d4910fe7-e9b2-439b-8bce-5af9bd2bc331",
-    "title": "Determine the rotation matrix",
-    "topic": "Demo",
-    "type": "v3",
-    "tags": ["mfsilva"]
+  "uuid": "d4910fe7-e9b2-439b-8bce-5af9bd2bc331",
+  "title": "Determine the rotation matrix",
+  "topic": "Demo",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/custom/element/info.json
+++ b/exampleCourse/questions/demo/custom/element/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "15d19db0-7277-46f6-abc6-74a006b039d6",
-    "title": "Demo: Custom element",
-    "topic": "Custom",
-    "type": "v3"
+  "uuid": "15d19db0-7277-46f6-abc6-74a006b039d6",
+  "title": "Demo: Custom element",
+  "topic": "Custom",
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/custom/elementHiddenTag/info.json
+++ b/exampleCourse/questions/demo/custom/elementHiddenTag/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "a0848579-00ae-45f0-bfdf-33c0e68e4f57",
-    "title": "Demo: Custom element with a clickable image",
-    "topic": "Custom",
-    "type": "v3"
+  "uuid": "a0848579-00ae-45f0-bfdf-33c0e68e4f57",
+  "title": "Demo: Custom element with a clickable image",
+  "topic": "Custom",
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/custom/extension/info.json
+++ b/exampleCourse/questions/demo/custom/extension/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "dbdc1c97-b7d1-4a51-8855-e6c0e40b64ea",
-    "title": "Demo: Custom element extensions",
-    "topic": "Custom",
-    "tags": ["nnytko2"],
-    "type": "v3"
+  "uuid": "dbdc1c97-b7d1-4a51-8855-e6c0e40b64ea",
+  "title": "Demo: Custom element extensions",
+  "topic": "Custom",
+  "tags": ["nnytko2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/custom/gradeFunction/info.json
+++ b/exampleCourse/questions/demo/custom/gradeFunction/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "de771443-9058-4a46-9915-f50bdfc5755f",
-    "title": "Demo: Custom grading function without using PrairieLearn element",
-    "topic": "Custom",
-    "tags": ["mwest", "fa17"],
-    "type": "v3"
+  "uuid": "de771443-9058-4a46-9915-f50bdfc5755f",
+  "title": "Demo: Custom grading function without using PrairieLearn element",
+  "topic": "Custom",
+  "tags": ["mwest", "fa17"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/custom/stylingScripts/info.json
+++ b/exampleCourse/questions/demo/custom/stylingScripts/info.json
@@ -1,11 +1,11 @@
 {
-    "uuid": "41027D6D-016A-4202-9F09-3F7997391E8E",
-    "title": "Demo: Custom question styles and scripts",
-    "topic": "Custom",
-    "type": "v3",
-    "tags": ["Sp20", "nnytko2"],
-    "dependencies": {
-        "clientFilesQuestionStyles": [ "style.css" ],
-        "clientFilesQuestionScripts": [ "script.js" ]
-    }
+  "uuid": "41027D6D-016A-4202-9F09-3F7997391E8E",
+  "title": "Demo: Custom question styles and scripts",
+  "topic": "Custom",
+  "type": "v3",
+  "tags": ["Sp20", "nnytko2"],
+  "dependencies": {
+    "clientFilesQuestionStyles": ["style.css"],
+    "clientFilesQuestionScripts": ["script.js"]
+  }
 }

--- a/exampleCourse/questions/demo/demoNewton-page1/info.json
+++ b/exampleCourse/questions/demo/demoNewton-page1/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "098AEE53-F369-4A1B-AB24-F4DE4E389E74",
-    "title": "Newton's law of motion - Intro",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Fa20"],
-    "type": "v3"
+  "uuid": "098AEE53-F369-4A1B-AB24-F4DE4E389E74",
+  "title": "Newton's law of motion - Intro",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Fa20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/demoNewton-page2/info.json
+++ b/exampleCourse/questions/demo/demoNewton-page2/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "3C16A975-2EFD-4AD4-9398-16D97170A648",
-    "title": "Second law",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Fa20"],
-    "type": "v3"
+  "uuid": "3C16A975-2EFD-4AD4-9398-16D97170A648",
+  "title": "Second law",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Fa20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/drawing/buttons/info.json
+++ b/exampleCourse/questions/demo/drawing/buttons/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "415f128d-7ad2-4fe2-b5eb-bf1a466b01b6",
-    "title": "Demo: All placeable drawing objects",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	"nnytko2"
-    ]
+  "uuid": "415f128d-7ad2-4fe2-b5eb-bf1a466b01b6",
+  "title": "Demo: All placeable drawing objects",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["nnytko2"]
 }

--- a/exampleCourse/questions/demo/drawing/centroid/info.json
+++ b/exampleCourse/questions/demo/drawing/centroid/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "DA1E555F-3F7B-4F3F-9857-E72DA8630919",
-    "title": "Demo: Drawing a centroid",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "DA1E555F-3F7B-4F3F-9857-E72DA8630919",
+  "title": "Demo: Drawing a centroid",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/collarRod/info.json
+++ b/exampleCourse/questions/demo/drawing/collarRod/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "D41A5E6C-FADA-4C87-B2F4-27E277C3A152",
-    "title": "Demo: Drawing collar boundary conditions",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "D41A5E6C-FADA-4C87-B2F4-27E277C3A152",
+  "title": "Demo: Drawing collar boundary conditions",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/customizedButtons/info.json
+++ b/exampleCourse/questions/demo/drawing/customizedButtons/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "e09a1d39-d4d9-47fe-80e5-fcd48733e3b5",
-    "title": "Demo: Drawing with custom button parameters",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	"nnytko2"
-    ]
+  "uuid": "e09a1d39-d4d9-47fe-80e5-fcd48733e3b5",
+  "title": "Demo: Drawing with custom button parameters",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["nnytko2"]
 }

--- a/exampleCourse/questions/demo/drawing/extensions/info.json
+++ b/exampleCourse/questions/demo/drawing/extensions/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "490f9f7b-8fa6-4820-a379-b4bea4213f66",
-    "title": "Demo: Adding custom features with extensions",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	"nnytko2"
-    ]
+  "uuid": "490f9f7b-8fa6-4820-a379-b4bea4213f66",
+  "title": "Demo: Adding custom features with extensions",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["nnytko2"]
 }

--- a/exampleCourse/questions/demo/drawing/frame-exploded/info.json
+++ b/exampleCourse/questions/demo/drawing/frame-exploded/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "F52891FE-AFFC-440B-BE91-C437B277625C",
-    "title": "Demo: Drawing Exploded FBDs",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-        "sb866"
-    ]
+  "uuid": "F52891FE-AFFC-440B-BE91-C437B277625C",
+  "title": "Demo: Drawing Exploded FBDs",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["sb866"]
 }

--- a/exampleCourse/questions/demo/drawing/gradeVector/info.json
+++ b/exampleCourse/questions/demo/drawing/gradeVector/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "EE600B7E-A076-414F-95B2-4A29C383CFF5",
-    "title": "Demo: Drawing with debugging of pl-vector grading",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "EE600B7E-A076-414F-95B2-4A29C383CFF5",
+  "title": "Demo: Drawing with debugging of pl-vector grading",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/graphs/info.json
+++ b/exampleCourse/questions/demo/drawing/graphs/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "D40AA821-4961-4E0C-A2D1-62D33EB1FF41",
-    "title": "Demo: Drawing sketch",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "D40AA821-4961-4E0C-A2D1-62D33EB1FF41",
+  "title": "Demo: Drawing sketch",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/inclinedPlane-reaction/info.json
+++ b/exampleCourse/questions/demo/drawing/inclinedPlane-reaction/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "F52711FE-AFFC-440B-BE91-C437B277625C",
-    "title": "Demo: Drawing of FBD and obtaining reactions (with force pair)",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-        "mfsilva",
-        "sb866"
-    ]
+  "uuid": "F52711FE-AFFC-440B-BE91-C437B277625C",
+  "title": "Demo: Drawing of FBD and obtaining reactions (with force pair)",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva", "sb866"]
 }

--- a/exampleCourse/questions/demo/drawing/inclinedPlane/info.json
+++ b/exampleCourse/questions/demo/drawing/inclinedPlane/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "F52711FE-AFFC-440A-BE91-C437B277625C",
-    "title": "Demo: Drawing of FBD and obtaining reactions",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "F52711FE-AFFC-440A-BE91-C437B277625C",
+  "title": "Demo: Drawing of FBD and obtaining reactions",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/liftingMechanism/info.json
+++ b/exampleCourse/questions/demo/drawing/liftingMechanism/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "999AD327-3915-4B0F-B826-87EEE3F842C5",
-    "title": "Demo: Drawing a lifting mechanism",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "999AD327-3915-4B0F-B826-87EEE3F842C5",
+  "title": "Demo: Drawing a lifting mechanism",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/pulley/info.json
+++ b/exampleCourse/questions/demo/drawing/pulley/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "C88F9893-F238-44BE-AF2D-5D5639ACCB40",
-    "title": "Demo: Drawing a pulley",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "C88F9893-F238-44BE-AF2D-5D5639ACCB40",
+  "title": "Demo: Drawing a pulley",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/info.json
+++ b/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "aeaabc56-3d1d-66c2-bb3b-a332f9aa7a49",
-    "title": "Demo: Resistor-Capacitor Circuit",
-    "topic": "Circuits",
-    "type": "v3",
-    "tags": [
-        "mariana@prairielearn.com", "calculation", "sp23"
-    ]
+  "uuid": "aeaabc56-3d1d-66c2-bb3b-a332f9aa7a49",
+  "title": "Demo: Resistor-Capacitor Circuit",
+  "topic": "Circuits",
+  "type": "v3",
+  "tags": ["mariana@prairielearn.com", "calculation", "sp23"]
 }

--- a/exampleCourse/questions/demo/drawing/simpleTutorial/info.json
+++ b/exampleCourse/questions/demo/drawing/simpleTutorial/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "B68C0746-15E0-45E4-9FB4-4CA839DE9900",
-    "title": "Demo: Drawing with objects for grading",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "B68C0746-15E0-45E4-9FB4-4CA839DE9900",
+  "title": "Demo: Drawing with objects for grading",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/drawing/vmDiagrams/info.json
+++ b/exampleCourse/questions/demo/drawing/vmDiagrams/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "056BE837-BCFE-4375-8AAB-36840B600D2C",
-    "title": "Demo: Drawing a VM diagram",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "056BE837-BCFE-4375-8AAB-36840B600D2C",
+  "title": "Demo: Drawing a VM diagram",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/demo/fileDownloadUpload/info.json
+++ b/exampleCourse/questions/demo/fileDownloadUpload/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "c0444a42-1472-4aa5-a024-ee1091bdab8e",
-    "title": "Demo: File upload for manual grading",
-    "topic": "Demo",
-    "tags": ["mfsilva"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "Manual"
+  "uuid": "c0444a42-1472-4aa5-a024-ee1091bdab8e",
+  "title": "Demo: File upload for manual grading",
+  "topic": "Demo",
+  "tags": ["mfsilva"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "Manual"
 }

--- a/exampleCourse/questions/demo/fixedCheckbox/info.json
+++ b/exampleCourse/questions/demo/fixedCheckbox/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "7c4ccac6-1031-43ed-a673-feb64c2f8bbf",
-    "title": "Motion of an object",
-    "topic": "Demo",
-    "type": "v3"
+  "uuid": "7c4ccac6-1031-43ed-a673-feb64c2f8bbf",
+  "title": "Motion of an object",
+  "topic": "Demo",
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/graphvizEditorPreview/info.json
+++ b/exampleCourse/questions/demo/graphvizEditorPreview/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "0b638a5e-897a-46c6-869c-68da31fe646e",
-    "title": "Demo: Graphviz editing with live preview",
-    "topic": "Demo",
-    "tags": ["code",  "jonatan"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "Manual"
+  "uuid": "0b638a5e-897a-46c6-869c-68da31fe646e",
+  "title": "Demo: Graphviz editing with live preview",
+  "topic": "Demo",
+  "tags": ["code", "jonatan"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "Manual"
 }

--- a/exampleCourse/questions/demo/insertEmbeddedVideo/info.json
+++ b/exampleCourse/questions/demo/insertEmbeddedVideo/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "944A6726-E4C2-417F-9BE5-A9C38D522C96",
-    "title": "Demo: Show embedded video and survey question",
-    "topic": "Demo",
-    "tags": ["mfsilva"],
-    "type": "v3"
+  "uuid": "944A6726-E4C2-417F-9BE5-A9C38D522C96",
+  "title": "Demo: Show embedded video and survey question",
+  "topic": "Demo",
+  "tags": ["mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/manualGrade/codeUpload/info.json
+++ b/exampleCourse/questions/demo/manualGrade/codeUpload/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "a218ee9c-fabb-4b23-bdbe-2705952aaf3c",
-    "title": "Demo: Fibonacci function, file upload, manual grading",
-    "topic": "Demo",
-    "tags": ["code"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "Manual"
+  "uuid": "a218ee9c-fabb-4b23-bdbe-2705952aaf3c",
+  "title": "Demo: Fibonacci function, file upload, manual grading",
+  "topic": "Demo",
+  "tags": ["code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "Manual"
 }

--- a/exampleCourse/questions/demo/markdownEditorLivePreview/info.json
+++ b/exampleCourse/questions/demo/markdownEditorLivePreview/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "b30f913b-8077-4b4a-9046-115e23486806",
-    "title": "Demo: Markdown editing with live preview",
-    "topic": "Demo",
-    "tags": ["code", "nnytko2", "jonatan"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "Manual"
+  "uuid": "b30f913b-8077-4b4a-9046-115e23486806",
+  "title": "Demo: Markdown editing with live preview",
+  "topic": "Demo",
+  "tags": ["code", "nnytko2", "jonatan"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "Manual"
 }

--- a/exampleCourse/questions/demo/matrixAlgebra/info.json
+++ b/exampleCourse/questions/demo/matrixAlgebra/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "af335c36-1126-43b0-aba5-627eeb2e10a7",
-    "title": "Template pl-matrix-input: Matrix algebra",
-    "topic": "Demo",
-    "tags": ["tbretl"],
-    "type": "v3"
+  "uuid": "af335c36-1126-43b0-aba5-627eeb2e10a7",
+  "title": "Template pl-matrix-input: Matrix algebra",
+  "topic": "Demo",
+  "tags": ["tbretl"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/matrixComplexAlgebra/info.json
+++ b/exampleCourse/questions/demo/matrixComplexAlgebra/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "63234b1e-f7e5-4a47-bf9a-9f02cc604c29",
-    "title": "Element pl-matrix-input: Matrix algebra with complex values",
-    "topic": "Element",
-    "tags": ["tbretl",  "sp18"],
-    "type": "v3"
+  "uuid": "63234b1e-f7e5-4a47-bf9a-9f02cc604c29",
+  "title": "Element pl-matrix-input: Matrix algebra with complex values",
+  "topic": "Element",
+  "tags": ["tbretl", "sp18"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/multiAnswerMC/info.json
+++ b/exampleCourse/questions/demo/multiAnswerMC/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "3f030556-e75b-11eb-ba80-0242ac130004",
-    "title": "Template pl-checkbox: Multi-answer MC with coverage grading scheme",
-    "topic": "Demo",
-    "type": "v3"
+  "uuid": "3f030556-e75b-11eb-ba80-0242ac130004",
+  "title": "Template pl-checkbox: Multi-answer MC with coverage grading scheme",
+  "topic": "Demo",
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/multipleChoiceSingleCorrect/info.json
+++ b/exampleCourse/questions/demo/multipleChoiceSingleCorrect/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "2dafe1f8-7b11-4efd-8d24-77b6b457b2e9",
-    "title": "Template pl-multiple-choice: Fixed correct answer, randomly chosen distractors",
-    "topic": "Demo",
-    "tags": ["balamut2", "Sp20"],
-    "type": "v3"
+  "uuid": "2dafe1f8-7b11-4efd-8d24-77b6b457b2e9",
+  "title": "Template pl-multiple-choice: Fixed correct answer, randomly chosen distractors",
+  "topic": "Demo",
+  "tags": ["balamut2", "Sp20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/numberInputGradingMethod/info.json
+++ b/exampleCourse/questions/demo/numberInputGradingMethod/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "CDAE32C9-EAB2-4CA9-B3E6-770F0DEDFF26",
-    "title": "Demo: different comparison methods in pl-number-input",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Sp20"],
-    "type": "v3"
+  "uuid": "CDAE32C9-EAB2-4CA9-B3E6-770F0DEDFF26",
+  "title": "Demo: different comparison methods in pl-number-input",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Sp20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/numberInputTips/info.json
+++ b/exampleCourse/questions/demo/numberInputTips/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "7A839DA8-5FC0-452B-9DBB-AD34B8CAF553",
-    "title": "Demo: guidelines for rounding with pl-number-input",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Sp20"],
-    "type": "v3"
+  "uuid": "7A839DA8-5FC0-452B-9DBB-AD34B8CAF553",
+  "title": "Demo: guidelines for rounding with pl-number-input",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Sp20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/overlayDropdown/info.json
+++ b/exampleCourse/questions/demo/overlayDropdown/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "a3af2408-9d4d-4e38-a9f3-3ad7d23ec692",
-    "title": "Demo: Overlay image with dropdown selections on top",
-    "topic": "Demo",
-    "tags": ["astec", "fa17"],
-    "type": "v3"
+  "uuid": "a3af2408-9d4d-4e38-a9f3-3ad7d23ec692",
+  "title": "Demo: Overlay image with dropdown selections on top",
+  "topic": "Demo",
+  "tags": ["astec", "fa17"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/overlayTriangle/info.json
+++ b/exampleCourse/questions/demo/overlayTriangle/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "e93af989-ba82-4859-9b86-f850152341ce",
-    "title": "Demo: Randomize a drawing with overlaid inputs",
-    "topic": "Demo",
-    "tags": [
-        "nnytko2"
-    ],
-    "type": "v3"
+  "uuid": "e93af989-ba82-4859-9b86-f850152341ce",
+  "title": "Demo: Randomize a drawing with overlaid inputs",
+  "topic": "Demo",
+  "tags": ["nnytko2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/randomDataFrame/info.json
+++ b/exampleCourse/questions/demo/randomDataFrame/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "30751afa-5d76-4492-95df-5bf0bd3458aa",
-    "title": "Demo: Randomized Python DataFrame",
-    "topic": "Demo",
-    "tags": ["balamut2", "fa19"],
-    "type": "v3"
+  "uuid": "30751afa-5d76-4492-95df-5bf0bd3458aa",
+  "title": "Demo: Randomized Python DataFrame",
+  "topic": "Demo",
+  "tags": ["balamut2", "fa19"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/randomMultipleChoice/info.json
+++ b/exampleCourse/questions/demo/randomMultipleChoice/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "4e4e3bff-cb60-4a7e-9575-49137774f3b2",
-    "title": "Demo: Randomized multiple choice options",
-    "topic": "Demo",
-    "type": "v3"
+  "uuid": "4e4e3bff-cb60-4a7e-9575-49137774f3b2",
+  "title": "Demo: Randomized multiple choice options",
+  "topic": "Demo",
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/randomPlot/info.json
+++ b/exampleCourse/questions/demo/randomPlot/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "34d1ad5a-bb2a-4f00-8cf7-2f8b356905df",
-    "title": "Determine a quantity from a plot",
-    "topic": "Demo",
-    "tags": ["tbretl"],
-    "type": "v3"
+  "uuid": "34d1ad5a-bb2a-4f00-8cf7-2f8b356905df",
+  "title": "Determine a quantity from a plot",
+  "topic": "Demo",
+  "tags": ["tbretl"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/demo/randomZippedFile/info.json
+++ b/exampleCourse/questions/demo/randomZippedFile/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "d752946b-8c87-4b3b-a22f-a133117d6d38",
-    "title": "Randomized zipped file generation",
-    "topic": "Demo",
-    "tags": ["erobson"],
-    "type": "v3",
-    "showCorrectAnswer": false,
-    "singleVariant": false
+  "uuid": "d752946b-8c87-4b3b-a22f-a133117d6d38",
+  "title": "Randomized zipped file generation",
+  "topic": "Demo",
+  "tags": ["erobson"],
+  "type": "v3",
+  "showCorrectAnswer": false,
+  "singleVariant": false
 }

--- a/exampleCourse/questions/demo/survey/info.json
+++ b/exampleCourse/questions/demo/survey/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "f532aa25-511e-42a9-be4c-0daec9ef45e1",
-    "title": "Demo: Obtaining feedback from students",
-    "topic": "Demo",
-    "tags": ["Fa18", "v3", "glherman", "balamut2"],
-    "type": "v3",
-    "singleVariant": true,
-    "showCorrectAnswer": false
+  "uuid": "f532aa25-511e-42a9-be4c-0daec9ef45e1",
+  "title": "Demo: Obtaining feedback from students",
+  "topic": "Demo",
+  "tags": ["Fa18", "v3", "glherman", "balamut2"],
+  "type": "v3",
+  "singleVariant": true,
+  "showCorrectAnswer": false
 }

--- a/exampleCourse/questions/demo/workspace/desktop/info.json
+++ b/exampleCourse/questions/demo/workspace/desktop/info.json
@@ -1,20 +1,14 @@
 {
-    "uuid": "4c12d197-9068-4dcb-8359-8048d61bdc28",
-    "title": "Workspace demo: GUI Desktop",
-    "topic": "Workspace",
-    "tags": [
-        "fa21",
-        "nnytko2"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-desktop",
-        "port": 8080,
-        "home": "/home/prairielearner",
-        "gradedFiles": [
-            "starter_code.h",
-            "starter_code.c"
-        ]
-    }
+  "uuid": "4c12d197-9068-4dcb-8359-8048d61bdc28",
+  "title": "Workspace demo: GUI Desktop",
+  "topic": "Workspace",
+  "tags": ["fa21", "nnytko2"],
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-desktop",
+    "port": 8080,
+    "home": "/home/prairielearner",
+    "gradedFiles": ["starter_code.h", "starter_code.c"]
+  }
 }

--- a/exampleCourse/questions/demo/workspace/dynamicFiles/info.json
+++ b/exampleCourse/questions/demo/workspace/dynamicFiles/info.json
@@ -1,19 +1,14 @@
 {
-    "uuid": "3e5005c1-6a5e-4959-9fc4-13f6e6f83961",
-    "title": "Workspace demo: using dynamic files",
-    "topic": "Workspace",
-    "tags": [
-        "sp23",
-        "jonatan"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-xtermjs",
-        "port": 8080,
-        "home": "/home/student",
-        "gradedFiles": [
-            "dynamic.txt"
-        ]
-    }
+  "uuid": "3e5005c1-6a5e-4959-9fc4-13f6e6f83961",
+  "title": "Workspace demo: using dynamic files",
+  "topic": "Workspace",
+  "tags": ["sp23", "jonatan"],
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-xtermjs",
+    "port": 8080,
+    "home": "/home/student",
+    "gradedFiles": ["dynamic.txt"]
+  }
 }

--- a/exampleCourse/questions/demo/workspace/jupyterlab/info.json
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/info.json
@@ -1,27 +1,22 @@
 {
-    "uuid": "F158CCF4-48F8-42F9-BBE6-C761210EA540",
-    "title": "Workspace demo: JupyterLab",
-    "topic": "Workspace",
-    "tags": [
-        "su20",
-        "tyang15", "mfsilva", "nnytko2"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "workspaceOptions": {
-      "image": "prairielearn/workspace-jupyterlab-python",
-      "port": 8080,
-      "home": "/home/jovyan",
-      "rewriteUrl": false,
-      "gradedFiles": [
-          "Workbook.ipynb"
-      ]
-    },
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "F158CCF4-48F8-42F9-BBE6-C761210EA540",
+  "title": "Workspace demo: JupyterLab",
+  "topic": "Workspace",
+  "tags": ["su20", "tyang15", "mfsilva", "nnytko2"],
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-jupyterlab-python",
+    "port": 8080,
+    "home": "/home/jovyan",
+    "rewriteUrl": false,
+    "gradedFiles": ["Workbook.ipynb"]
+  },
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/workspace/rstudio/info.json
+++ b/exampleCourse/questions/demo/workspace/rstudio/info.json
@@ -1,34 +1,23 @@
 {
-    "uuid": "92344697-f0ba-4dc2-af2b-e112a48d04f0",
-    "title": "Workspace demo with Create An R Object question",
-    "topic": "Workspace",
-    "tags": [
-        "sp23",
-        "echuber2",
-        "balamut2",
-        "eddelbuettel",
-        "v3",
-        "demo",
-        "r-autograder",
-        "rstudio"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-rstudio",
-        "port": 3939,
-        "args": "",
-        "rewriteUrl": false,
-        "home": "/home/rstudio/workspace",
-        "gradedFiles": [
-          "student.R"
-        ]
-    },
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-r",
-        "entrypoint": "/r_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "92344697-f0ba-4dc2-af2b-e112a48d04f0",
+  "title": "Workspace demo with Create An R Object question",
+  "topic": "Workspace",
+  "tags": ["sp23", "echuber2", "balamut2", "eddelbuettel", "v3", "demo", "r-autograder", "rstudio"],
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-rstudio",
+    "port": 3939,
+    "args": "",
+    "rewriteUrl": false,
+    "home": "/home/rstudio/workspace",
+    "gradedFiles": ["student.R"]
+  },
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-r",
+    "entrypoint": "/r_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/workspace/vscode/info.json
+++ b/exampleCourse/questions/demo/workspace/vscode/info.json
@@ -1,27 +1,22 @@
 {
-    "uuid": "499d4c47-74a6-4e3e-ad65-1d38d9d97e8e",
-    "title": "Workspace demo: VS Code",
-    "topic": "Workspace",
-    "tags": [
-        "su20",
-        "tyang15"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "workspaceOptions": {
-        "image": "codercom/code-server:3.4.1",
-        "port": 8080,
-        "args": "--auth none",
-        "home": "/home/coder",
-        "gradedFiles": [
-            "fibonacci.py"
-        ]
-    },
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 20
-    }
+  "uuid": "499d4c47-74a6-4e3e-ad65-1d38d9d97e8e",
+  "title": "Workspace demo: VS Code",
+  "topic": "Workspace",
+  "tags": ["su20", "tyang15"],
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "codercom/code-server:3.4.1",
+    "port": 8080,
+    "args": "--auth none",
+    "home": "/home/coder",
+    "gradedFiles": ["fibonacci.py"]
+  },
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 20
+  }
 }

--- a/exampleCourse/questions/demo/workspace/xtermjs/info.json
+++ b/exampleCourse/questions/demo/workspace/xtermjs/info.json
@@ -1,25 +1,18 @@
 {
-    "uuid": "8a75c8cf-ed51-4141-9910-2da2f74cc8af",
-    "title": "Workspace demo: Xterm.js",
-    "topic": "Workspace",
-    "tags": [
-        "su20",
-        "nnytko2",
-        "tyang15"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "workspaceOptions": {
-        "comment": {
-            "why": "testing comments in workspace blocks",
-            "also": "testing object comments"
-        },
-        "image": "prairielearn/workspace-xtermjs",
-        "port": 8080,
-        "home": "/home/student",
-        "gradedFiles": [
-            "**/*.h",
-            "**/*.c"
-        ]
-    }
+  "uuid": "8a75c8cf-ed51-4141-9910-2da2f74cc8af",
+  "title": "Workspace demo: Xterm.js",
+  "topic": "Workspace",
+  "tags": ["su20", "nnytko2", "tyang15"],
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "comment": {
+      "why": "testing comments in workspace blocks",
+      "also": "testing object comments"
+    },
+    "image": "prairielearn/workspace-xtermjs",
+    "port": 8080,
+    "home": "/home/student",
+    "gradedFiles": ["**/*.h", "**/*.c"]
+  }
 }

--- a/exampleCourse/questions/element/bigOInput/info.json
+++ b/exampleCourse/questions/element/bigOInput/info.json
@@ -1,11 +1,7 @@
 {
-    "uuid": "68f966f0-7da9-4ce9-a3c9-f1ca50cdd8fe",
-    "title": "Element pl-big-o-input: Input of asymptotic expressions",
-    "topic": "Element",
-    "tags": [
-        "samuelr6",
-        "tuedo2",
-        "erobson2"
-    ],
-    "type": "v3"
+  "uuid": "68f966f0-7da9-4ce9-a3c9-f1ca50cdd8fe",
+  "title": "Element pl-big-o-input: Input of asymptotic expressions",
+  "topic": "Element",
+  "tags": ["samuelr6", "tuedo2", "erobson2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/card/info.json
+++ b/exampleCourse/questions/element/card/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "9a20c3a0-2f08-4efc-a4f5-4e1cdc2026b4",
-    "title": "Element pl-card: Display content within a card-styled component",
-    "topic": "Element",
-    "tags": [
-        "tyang15",
-        "balamut2"
-    ],
-    "type": "v3"
+  "uuid": "9a20c3a0-2f08-4efc-a4f5-4e1cdc2026b4",
+  "title": "Element pl-card: Display content within a card-styled component",
+  "topic": "Element",
+  "tags": ["tyang15", "balamut2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/checkbox/info.json
+++ b/exampleCourse/questions/element/checkbox/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "78f68188-12ea-4775-9c6c-5a4263a6c0d8",
-    "title": "Element pl-checkbox: Input multiple selection options",
-    "topic": "Element",
-    "tags": ["balamut2", "mfsilva"],
-    "type": "v3"
+  "uuid": "78f68188-12ea-4775-9c6c-5a4263a6c0d8",
+  "title": "Element pl-checkbox: Input multiple selection options",
+  "topic": "Element",
+  "tags": ["balamut2", "mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/code/info.json
+++ b/exampleCourse/questions/element/code/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "21314721-8b4e-4b8b-90bc-e93ce8b2e7c6",
-    "title": "Element pl-code: Display code with syntax highlighting",
-    "topic": "Element",
-    "type": "v3"
+  "uuid": "21314721-8b4e-4b8b-90bc-e93ce8b2e7c6",
+  "title": "Element pl-code: Display code with syntax highlighting",
+  "topic": "Element",
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/codeDocumentation/info.json
+++ b/exampleCourse/questions/element/codeDocumentation/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "711c33ff-6077-46a1-9fb7-cbed954bb9f2",
-    "title": "Examples from element documentation",
-    "topic": "Element",
-    "tags": ["balamut2", "Sp19"],
-    "type": "v3"
+  "uuid": "711c33ff-6077-46a1-9fb7-cbed954bb9f2",
+  "title": "Examples from element documentation",
+  "topic": "Element",
+  "tags": ["balamut2", "Sp19"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/dataframe/info.json
+++ b/exampleCourse/questions/element/dataframe/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "53af648a-68a3-49c8-b062-b329a2ca7842",
-    "title": "Element pl-dataframe: Display of Pandas DataFrames",
-    "topic": "Element",
-    "type": "v3",
-    "tags": [ "erobson2" ]
+  "uuid": "53af648a-68a3-49c8-b062-b329a2ca7842",
+  "title": "Element pl-dataframe: Display of Pandas DataFrames",
+  "topic": "Element",
+  "type": "v3",
+  "tags": ["erobson2"]
 }

--- a/exampleCourse/questions/element/drawingGallery/info.json
+++ b/exampleCourse/questions/element/drawingGallery/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "51F69D57-0CF7-4DBB-952D-1BFD16F3823C",
-    "title": "Gallery of drawings from documentation",
-    "topic": "Drawing",
-    "type": "v3",
-    "tags": [
-	       "mfsilva"
-    ]
+  "uuid": "51F69D57-0CF7-4DBB-952D-1BFD16F3823C",
+  "title": "Gallery of drawings from documentation",
+  "topic": "Drawing",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/element/dropdown/info.json
+++ b/exampleCourse/questions/element/dropdown/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "8b4891d6-64d1-4e89-b72d-ad2133f25b3e",
-    "title": "Element pl-dropdown: Fill in the blanks",
-    "topic": "Element",
-    "tags": ["steca"],
-    "type": "v3"
+  "uuid": "8b4891d6-64d1-4e89-b72d-ad2133f25b3e",
+  "title": "Element pl-dropdown: Fill in the blanks",
+  "topic": "Element",
+  "tags": ["steca"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/figure/info.json
+++ b/exampleCourse/questions/element/figure/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "73f032f9-19de-41a6-ae9d-148d1c5264a3",
-    "title": "Element pl-figure: Display a statically or dynamically generated image",
-    "topic": "Element",
-    "tags": ["bojinyao"],
-    "type": "v3"
+  "uuid": "73f032f9-19de-41a6-ae9d-148d1c5264a3",
+  "title": "Element pl-figure: Display a statically or dynamically generated image",
+  "topic": "Element",
+  "tags": ["bojinyao"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/fileDownload/info.json
+++ b/exampleCourse/questions/element/fileDownload/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "0941aa93-15fe-4ce7-ac93-2b41a2a8cf3e",
-    "title": "Element pl-file-download: Download files and generated data",
-    "topic": "Element",
-    "tags": ["tbretl"],
-    "type": "v3"
+  "uuid": "0941aa93-15fe-4ce7-ac93-2b41a2a8cf3e",
+  "title": "Element pl-file-download: Download files and generated data",
+  "topic": "Element",
+  "tags": ["tbretl"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/fileEditor/info.json
+++ b/exampleCourse/questions/element/fileEditor/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "a5563b66-dfa1-4f69-a9d8-18a6ae1f6d7e",
-    "title": "Element pl-file-editor: In-browser file editor",
-    "topic": "Element",
-    "tags": ["balamut2", "code"],
-    "type": "v3"
+  "uuid": "a5563b66-dfa1-4f69-a9d8-18a6ae1f6d7e",
+  "title": "Element pl-file-editor: In-browser file editor",
+  "topic": "Element",
+  "tags": ["balamut2", "code"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/fileUpload/info.json
+++ b/exampleCourse/questions/element/fileUpload/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "c0444a41-1472-4aa5-a024-ee1091bdab8e",
-    "title": "Element pl-upload: upload a file",
-    "topic": "Element",
-    "tags": ["mfsilva"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "Manual"
+  "uuid": "c0444a41-1472-4aa5-a024-ee1091bdab8e",
+  "title": "Element pl-upload: upload a file",
+  "topic": "Element",
+  "tags": ["mfsilva"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "Manual"
 }

--- a/exampleCourse/questions/element/graph/info.json
+++ b/exampleCourse/questions/element/graph/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "3c4fc412-7bf2-45e2-bae4-f8e7a5faede5",
-    "title": "Element pl-graph: Displaying graphs from data",
-    "topic": "Element",
-    "tags": ["nnytko2"],
-    "type": "v3"
+  "uuid": "3c4fc412-7bf2-45e2-bae4-f8e7a5faede5",
+  "title": "Element pl-graph: Displaying graphs from data",
+  "topic": "Element",
+  "tags": ["nnytko2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/hiddenHints/info.json
+++ b/exampleCourse/questions/element/hiddenHints/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "28b2c61f-7808-4c22-a186-faec11920bb0",
-    "title": "Element pl-hidden-hints: Display progressive hints",
-    "topic": "Element",
-    "tags": ["erobson2", "Fa22"],
-    "type": "v3"
+  "uuid": "28b2c61f-7808-4c22-a186-faec11920bb0",
+  "title": "Element pl-hidden-hints: Display progressive hints",
+  "topic": "Element",
+  "tags": ["erobson2", "Fa22"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/integerInput/info.json
+++ b/exampleCourse/questions/element/integerInput/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "84c56612-1cbe-4cb8-9722-047fc37512f5",
-    "title": "Element pl-integer-input: Input of integers",
-    "topic": "Element",
-    "tags": ["balamut2", "Sp19"],
-    "type": "v3"
+  "uuid": "84c56612-1cbe-4cb8-9722-047fc37512f5",
+  "title": "Element pl-integer-input: Input of integers",
+  "topic": "Element",
+  "tags": ["balamut2", "Sp19"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/markdown/info.json
+++ b/exampleCourse/questions/element/markdown/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "ba98f00f-065a-4e26-9a07-c189bad154cc",
-    "title": "Demo: Display of Markdown content in HTML",
-    "topic": "Demo",
-    "type": "v3"
+  "uuid": "ba98f00f-065a-4e26-9a07-c189bad154cc",
+  "title": "Demo: Display of Markdown content in HTML",
+  "topic": "Demo",
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/matching/info.json
+++ b/exampleCourse/questions/element/matching/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "14ae5b99-0d06-414d-9c82-fd0f24023bcd",
-    "title": "Element pl-matching: Match statements with options.",
-    "topic": "Element",
-    "tags": ["nealterrell"],
-    "type": "v3"
+  "uuid": "14ae5b99-0d06-414d-9c82-fd0f24023bcd",
+  "title": "Element pl-matching: Match statements with options.",
+  "topic": "Element",
+  "tags": ["nealterrell"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/matrixComponentInput/info.json
+++ b/exampleCourse/questions/element/matrixComponentInput/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "1cf1b5f1-5da3-4bcd-8050-7ab0fdf6628e",
-    "title": "Element pl-matrix-component-input: Input of matrices in grid format",
-    "topic": "Element",
-    "type": "v3",
-    "tags": [
-		    "mfsilva"
-    ]
+  "uuid": "1cf1b5f1-5da3-4bcd-8050-7ab0fdf6628e",
+  "title": "Element pl-matrix-component-input: Input of matrices in grid format",
+  "topic": "Element",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/element/matrixLatex/info.json
+++ b/exampleCourse/questions/element/matrixLatex/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "4d2cf71b-869f-40d3-905a-a67cc855e4be",
-    "title": "Element pl-matrix-latex: Display of 2D numpy arrays in latex format",
-    "topic": "Element",
-    "type": "v3",
-    "tags": ["mfsilva"]
+  "uuid": "4d2cf71b-869f-40d3-905a-a67cc855e4be",
+  "title": "Element pl-matrix-latex: Display of 2D numpy arrays in latex format",
+  "topic": "Element",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/element/multipleChoice/info.json
+++ b/exampleCourse/questions/element/multipleChoice/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "d57c08e9-f1a6-4b65-a698-f29bc8ce047a",
-    "title": "Element pl-multiple-choice: Input of multiple choice answers",
-    "topic": "Element",
-    "tags": ["balamut2", "Sp19"],
-    "type": "v3"
+  "uuid": "d57c08e9-f1a6-4b65-a698-f29bc8ce047a",
+  "title": "Element pl-multiple-choice: Input of multiple choice answers",
+  "topic": "Element",
+  "tags": ["balamut2", "Sp19"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/numberInput/info.json
+++ b/exampleCourse/questions/element/numberInput/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "933849d9-d7ee-4462-b743-b50e43b03b9e",
-    "title": "Element pl-number-input: Input of real and complex numbers",
-    "topic": "Element",
-    "tags": ["balamut2", "Sp18"],
-    "type": "v3"
+  "uuid": "933849d9-d7ee-4462-b743-b50e43b03b9e",
+  "title": "Element pl-number-input: Input of real and complex numbers",
+  "topic": "Element",
+  "tags": ["balamut2", "Sp18"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/overlay/info.json
+++ b/exampleCourse/questions/element/overlay/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "F539AB6B-4281-49E5-882D-8FC20C4EBE13",
-    "title": "Element pl-overlay: Positioning elements on top of other elements",
-    "topic": "Element",
-    "tags": [
-        "mfsilva"
-    ],
-    "type": "v3"
+  "uuid": "F539AB6B-4281-49E5-882D-8FC20C4EBE13",
+  "title": "Element pl-overlay: Positioning elements on top of other elements",
+  "topic": "Element",
+  "tags": ["mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/panels/info.json
+++ b/exampleCourse/questions/element/panels/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "81a3e61d-9ecc-457c-9dac-db5b6b451d3c",
-    "title": "Elements to show or hide text in specific panels",
-    "topic": "Element",
-    "tags": [ "mwest"],
-    "type": "v3"
+  "uuid": "81a3e61d-9ecc-457c-9dac-db5b6b451d3c",
+  "title": "Elements to show or hide text in specific panels",
+  "topic": "Element",
+  "tags": ["mwest"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/pythonVariable/info.json
+++ b/exampleCourse/questions/element/pythonVariable/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "815ff014-338c-4f0c-8672-56dcd0675969",
-    "title": "Element pl-python-variable: Display of Python variables",
-    "topic": "Element",
-    "type": "v3",
-    "tags": [ "nnytko2" ]
+  "uuid": "815ff014-338c-4f0c-8672-56dcd0675969",
+  "title": "Element pl-python-variable: Display of Python variables",
+  "topic": "Element",
+  "type": "v3",
+  "tags": ["nnytko2"]
 }

--- a/exampleCourse/questions/element/richTextEditor/info.json
+++ b/exampleCourse/questions/element/richTextEditor/info.json
@@ -1,8 +1,8 @@
 {
-    "uuid": "dde741c2-b10e-4caf-b491-23a4565ceb98",
-    "title": "Element pl-rich-text-editor: In-browser rich text editor",
-    "topic": "Element",
-    "gradingMethod": "Manual",
-    "tags": ["jonatan"],
-    "type": "v3"
+  "uuid": "dde741c2-b10e-4caf-b491-23a4565ceb98",
+  "title": "Element pl-rich-text-editor: In-browser rich text editor",
+  "topic": "Element",
+  "gradingMethod": "Manual",
+  "tags": ["jonatan"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/stringInput/info.json
+++ b/exampleCourse/questions/element/stringInput/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "c07e099f-0149-471e-9c44-ab55622bedec",
-    "title": "Element pl-string-input: Input of short strings",
-    "topic": "Element",
-    "tags": [ "mfsilva", "balamut2"],
-    "type": "v3"
+  "uuid": "c07e099f-0149-471e-9c44-ab55622bedec",
+  "title": "Element pl-string-input: Input of short strings",
+  "topic": "Element",
+  "tags": ["mfsilva", "balamut2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/symbolicInput/info.json
+++ b/exampleCourse/questions/element/symbolicInput/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "cffe78ed-a500-4b0a-a3fe-5b4e9d63c810",
-    "title": "Element pl-symbolic-input: Input of symbolic answers",
-    "topic": "Element",
-    "tags": [ "tbretl"],
-    "type": "v3"
+  "uuid": "cffe78ed-a500-4b0a-a3fe-5b4e9d63c810",
+  "title": "Element pl-symbolic-input: Input of symbolic answers",
+  "topic": "Element",
+  "tags": ["tbretl"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/template/info.json
+++ b/exampleCourse/questions/element/template/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "a271f065-aa2c-4a9d-a74d-504f9e30bb85",
-    "title": "Element pl-template: Template element for display",
-    "topic": "Element",
-    "tags": ["erobson2"],
-    "type": "v3"
+  "uuid": "a271f065-aa2c-4a9d-a74d-504f9e30bb85",
+  "title": "Element pl-template: Template element for display",
+  "topic": "Element",
+  "tags": ["erobson2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/unitsInput/info.json
+++ b/exampleCourse/questions/element/unitsInput/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "c0e2d0aa-d3c1-48db-ab49-4765c5816997",
-    "title": "Element pl-units-input: Input of answers with units",
-    "topic": "Element",
-    "tags": [
-        "units",
-        "erobson2"
-    ],
-    "type": "v3"
+  "uuid": "c0e2d0aa-d3c1-48db-ab49-4765c5816997",
+  "title": "Element pl-units-input: Input of answers with units",
+  "topic": "Element",
+  "tags": ["units", "erobson2"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/variableOutput/info.json
+++ b/exampleCourse/questions/element/variableOutput/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "cc99f57c-1a13-4161-b052-1cd795011d98",
-    "title": "Element pl-variable-output: Display matrix and scalar data",
-    "topic": "Element",
-    "tags": ["eliving2", "Sp19"],
-    "type": "v3"
+  "uuid": "cc99f57c-1a13-4161-b052-1cd795011d98",
+  "title": "Element pl-variable-output: Display matrix and scalar data",
+  "topic": "Element",
+  "tags": ["eliving2", "Sp19"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/element/xssSafe/info.json
+++ b/exampleCourse/questions/element/xssSafe/info.json
@@ -1,8 +1,8 @@
 {
-    "uuid": "07d724c3-ae9d-425f-86fc-6154cc87abaa",
-    "title": "Element pl-xss-safe: present potentially malicious student code",
-    "topic": "Element",
-    "gradingMethod": "Manual",
-    "tags": ["jonatan", "manual"],
-    "type": "v3"
+  "uuid": "07d724c3-ae9d-425f-86fc-6154cc87abaa",
+  "title": "Element pl-xss-safe: present potentially malicious student code",
+  "topic": "Element",
+  "gradingMethod": "Manual",
+  "tags": ["jonatan", "manual"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/gallery/checkbox/complex/info.json
+++ b/exampleCourse/questions/gallery/checkbox/complex/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A36B4F",
-    "title": "Select the correct answers (with randomized parameters)",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A36B4F",
+  "title": "Select the correct answers (with randomized parameters)",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/gallery/checkbox/simple/info.json
+++ b/exampleCourse/questions/gallery/checkbox/simple/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A37B4F",
-    "title": "Select the correct answers",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A37B4F",
+  "title": "Select the correct answers",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/gallery/includeFigure/complex/info.json
+++ b/exampleCourse/questions/gallery/includeFigure/complex/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A36B3D",
-    "title": "Select the appropriate points (with dynamic figure)",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A36B3D",
+  "title": "Select the appropriate points (with dynamic figure)",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/gallery/includeFigure/simple/info.json
+++ b/exampleCourse/questions/gallery/includeFigure/simple/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A36B3E",
-    "title": "Select the appropriate points",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "4C16523E-AC7B-41B7-9D38-41DC66A36B3E",
+  "title": "Select the appropriate points",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/gallery/multipleChoice/advanced/info.json
+++ b/exampleCourse/questions/gallery/multipleChoice/advanced/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "4C16523E-ACCC-41B7-9D38-41DC66A36B4F",
-    "title": "Randomized multiple-choice question  with dynamic drawing",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "4C16523E-ACCC-41B7-9D38-41DC66A36B4F",
+  "title": "Randomized multiple-choice question  with dynamic drawing",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/gallery/multipleChoice/complex/info.json
+++ b/exampleCourse/questions/gallery/multipleChoice/complex/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "5C16523E-ACCC-41B7-9D38-41DC66A36B4F",
-    "title": "Randomized multiple-choice question",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "5C16523E-ACCC-41B7-9D38-41DC66A36B4F",
+  "title": "Randomized multiple-choice question",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/gallery/multipleChoice/simple/info.json
+++ b/exampleCourse/questions/gallery/multipleChoice/simple/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "4C16533E-AC7B-41B7-9D38-41DC66A37B4F",
-    "title": "Simple multiple-choice question",
-    "topic": "Gallery",
-    "type": "v3",
-    "tags": [
-		    "Sp21", "mfsilva"
-    ]
+  "uuid": "4C16533E-AC7B-41B7-9D38-41DC66A37B4F",
+  "title": "Simple multiple-choice question",
+  "topic": "Gallery",
+  "type": "v3",
+  "tags": ["Sp21", "mfsilva"]
 }

--- a/exampleCourse/questions/template/figure/dynamic/info.json
+++ b/exampleCourse/questions/template/figure/dynamic/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "8FC8FB0E-0C9F-42F8-BDDA-A966C566302A",
-    "title": "Figure: dynamic image",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "8FC8FB0E-0C9F-42F8-BDDA-A966C566302A",
+  "title": "Figure: dynamic image",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/integer-input/random/info.json
+++ b/exampleCourse/questions/template/integer-input/random/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "5E64666F-1588-4EBB-8E8D-C1FA4141F20D",
-    "title": "Integer input: random parameters and correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "5E64666F-1588-4EBB-8E8D-C1FA4141F20D",
+  "title": "Integer input: random parameters and correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/matrix-component-input/random-graph/info.json
+++ b/exampleCourse/questions/template/matrix-component-input/random-graph/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "3c5fc412-8bf2-45e2-bae4-f8e7a5faede5",
-    "title": "Matrix component input: random graph",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "3c5fc412-8bf2-45e2-bae4-f8e7a5faede5",
+  "title": "Matrix component input: random graph",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/matrix-input/random/info.json
+++ b/exampleCourse/questions/template/matrix-input/random/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "af445c37-1126-43b0-aba5-627eeb2e10a7",
-    "title": "Matrix input: random parameters and correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "af445c37-1126-43b0-aba5-627eeb2e10a7",
+  "title": "Matrix input: random parameters and correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/multiple-choice/images/info.json
+++ b/exampleCourse/questions/template/multiple-choice/images/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "44ABEAD3-3AFE-4097-B877-91319B35C22E",
-    "title": "Multiple choice: images as choices",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "44ABEAD3-3AFE-4097-B877-91319B35C22E",
+  "title": "Multiple choice: images as choices",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/multiple-choice/numeric/info.json
+++ b/exampleCourse/questions/template/multiple-choice/numeric/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "d776ae4b-8b8b-4e40-9054-926e3464bb79",
-    "title": "Multiple choice: random numeric answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "d776ae4b-8b8b-4e40-9054-926e3464bb79",
+  "title": "Multiple choice: random numeric answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/info.json
+++ b/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "65581157-89fc-4dcc-9544-368166d6759e",
-    "title": "Multiple choice: random true/false question from list",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "65581157-89fc-4dcc-9544-368166d6759e",
+  "title": "Multiple choice: random true/false question from list",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/multiple-choice/random-prompt/info.json
+++ b/exampleCourse/questions/template/multiple-choice/random-prompt/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "fd9d93ad-0658-4586-9c24-83480e4c8bb7",
-    "title": "Multiple choice: random question from list",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "fd9d93ad-0658-4586-9c24-83480e4c8bb7",
+  "title": "Multiple choice: random question from list",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/multiple-choice/random/info.json
+++ b/exampleCourse/questions/template/multiple-choice/random/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "f24e0597-bb8c-42aa-abef-6a96b6afcca8",
-    "title": "Multiple choice: random correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "f24e0597-bb8c-42aa-abef-6a96b6afcca8",
+  "title": "Multiple choice: random correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/number-input/random-prompt/info.json
+++ b/exampleCourse/questions/template/number-input/random-prompt/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "9b90ecf4-4580-54be-9a51-bafd47d7d1e6",
-    "title": "Number input: random parameters and correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "9b90ecf4-4580-54be-9a51-bafd47d7d1e6",
+  "title": "Number input: random parameters and correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/number-input/random/info.json
+++ b/exampleCourse/questions/template/number-input/random/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "9b90ecf4-4580-44be-9a51-bafd47d7d1e6",
-    "title": "Number input: random parameters and correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "9b90ecf4-4580-44be-9a51-bafd47d7d1e6",
+  "title": "Number input: random parameters and correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/string-input/random/info.json
+++ b/exampleCourse/questions/template/string-input/random/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "C88B8131-1FB4-4234-A94F-0B49B3AA09CF",
-    "title": "String input: random parameters and correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "C88B8131-1FB4-4234-A94F-0B49B3AA09CF",
+  "title": "String input: random parameters and correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/template/symbolic-input/random/info.json
+++ b/exampleCourse/questions/template/symbolic-input/random/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "16620404-1340-42ef-9897-20687adebaf8",
-    "title": "Symbolic input: random parameters and correct answer",
-    "topic": "Template",
-    "type": "v3"
+  "uuid": "16620404-1340-42ef-9897-20687adebaf8",
+  "title": "Symbolic input: random parameters and correct answer",
+  "topic": "Template",
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson1_example1_v1/info.json
+++ b/exampleCourse/questions/workshop/Lesson1_example1_v1/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "C143AF0A-8DFA-4647-8375-828BEAB5A1B6",
-    "title": "Workshop: Lesson 1, example 1, version 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "C143AF0A-8DFA-4647-8375-828BEAB5A1B6",
+  "title": "Workshop: Lesson 1, example 1, version 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson1_example1_v2/info.json
+++ b/exampleCourse/questions/workshop/Lesson1_example1_v2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "BA8C539D-AB79-456F-9002-261FDFCB55AA",
-    "title": "Find the area under the curve",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "BA8C539D-AB79-456F-9002-261FDFCB55AA",
+  "title": "Find the area under the curve",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson1_example2/info.json
+++ b/exampleCourse/questions/workshop/Lesson1_example2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "BBE492C5-5710-4CEE-B84F-F9210154FE4B",
-    "title": "Workshop: Lesson 1, example 2",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "BBE492C5-5710-4CEE-B84F-F9210154FE4B",
+  "title": "Workshop: Lesson 1, example 2",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson1_example3_v1/info.json
+++ b/exampleCourse/questions/workshop/Lesson1_example3_v1/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "0716F0A1-EAEC-4CD0-ADB2-FBD9813DE74D",
-    "title": "Workshop: Lesson 1, example 3, version 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "0716F0A1-EAEC-4CD0-ADB2-FBD9813DE74D",
+  "title": "Workshop: Lesson 1, example 3, version 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson1_example3_v2/info.json
+++ b/exampleCourse/questions/workshop/Lesson1_example3_v2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "F1B6703D-1B27-4BA4-987E-6E2230A3CFBC",
-    "title": "Workshop: Lesson 1, example 3, version 2",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "F1B6703D-1B27-4BA4-987E-6E2230A3CFBC",
+  "title": "Workshop: Lesson 1, example 3, version 2",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson1_example3_v3/info.json
+++ b/exampleCourse/questions/workshop/Lesson1_example3_v3/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "3287551E-F7BD-4E6C-9F3D-92D5D885B5B5",
-    "title": "Workshop: Lesson 1, example 3, version 3",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "3287551E-F7BD-4E6C-9F3D-92D5D885B5B5",
+  "title": "Workshop: Lesson 1, example 3, version 3",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example1_v1/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example1_v1/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "C4A50D26-A768-4F9C-9FB5-92C932D93D51",
-    "title": "Compute the Matrix-Vector Multiplication",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "C4A50D26-A768-4F9C-9FB5-92C932D93D51",
+  "title": "Compute the Matrix-Vector Multiplication",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example1_v2/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example1_v2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "5CD1C0CD-4FC2-4BD6-AC94-CB5F72F29BBE",
-    "title": "Workshop: Lesson 3, example 1, version 2",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "5CD1C0CD-4FC2-4BD6-AC94-CB5F72F29BBE",
+  "title": "Workshop: Lesson 3, example 1, version 2",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example1_v3/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example1_v3/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "E5B5B025-0005-4EA4-946F-251A64974D2E",
-    "title": "Workshop: Lesson 3, example 1, version 3",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "E5B5B025-0005-4EA4-946F-251A64974D2E",
+  "title": "Workshop: Lesson 3, example 1, version 3",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example2_v1/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example2_v1/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "6FD12673-1BB1-4819-B031-CCC39C3CCBD6",
-    "title": "Workshop: Lesson 3, example 2, version 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "6FD12673-1BB1-4819-B031-CCC39C3CCBD6",
+  "title": "Workshop: Lesson 3, example 2, version 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example2_v2/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example2_v2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "37004CC5-4F17-4D43-9662-E46C01C00930",
-    "title": "Workshop: Lesson 3, example 2, version 2",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "37004CC5-4F17-4D43-9662-E46C01C00930",
+  "title": "Workshop: Lesson 3, example 2, version 2",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example2_v3/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example2_v3/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "8EC0F087-FD8D-447B-BE27-B9A92650E8E4",
-    "title": "Workshop: Lesson 3, example 2, version 3",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "8EC0F087-FD8D-447B-BE27-B9A92650E8E4",
+  "title": "Workshop: Lesson 3, example 2, version 3",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example3/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example3/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "C78B8131-1FB4-4234-A94F-0B49B3AA09CF",
-    "title": "Workshop: Lesson 3, example 3",
-    "topic": "Workshop Demo",
-    "type": "v3",
-    "tags": [
-        "Su20",
-        "mfsilva"
-    ]
+  "uuid": "C78B8131-1FB4-4234-A94F-0B49B3AA09CF",
+  "title": "Workshop: Lesson 3, example 3",
+  "topic": "Workshop Demo",
+  "type": "v3",
+  "tags": ["Su20", "mfsilva"]
 }

--- a/exampleCourse/questions/workshop/Lesson3_example4_v1/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example4_v1/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "3020BAD8-5924-43F9-AA8C-93687AC051DB",
-    "title": "Workshop: Lesson 3, example 4, version 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "3020BAD8-5924-43F9-AA8C-93687AC051DB",
+  "title": "Workshop: Lesson 3, example 4, version 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson3_example4_v2/info.json
+++ b/exampleCourse/questions/workshop/Lesson3_example4_v2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "68D80628-968F-40AE-9480-2C0369E46A1D",
-    "title": "Understanding logic circuit",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "68D80628-968F-40AE-9480-2C0369E46A1D",
+  "title": "Understanding logic circuit",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson4_example1/info.json
+++ b/exampleCourse/questions/workshop/Lesson4_example1/info.json
@@ -1,11 +1,7 @@
 {
-    "uuid": "e3ff255b-4fe9-4214-a2d1-3ea1b01951d8",
-    "title": "Give a matrix that satisfy given property",
-    "topic": "Workshop Demo",
-    "type": "v3",
-    "tags": [
-        "Sp20",
-        "phierony",
-        "mfsilva"
-    ]
+  "uuid": "e3ff255b-4fe9-4214-a2d1-3ea1b01951d8",
+  "title": "Give a matrix that satisfy given property",
+  "topic": "Workshop Demo",
+  "type": "v3",
+  "tags": ["Sp20", "phierony", "mfsilva"]
 }

--- a/exampleCourse/questions/workshop/Lesson4_example2/info.json
+++ b/exampleCourse/questions/workshop/Lesson4_example2/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "68B7A478-C6AF-49F2-8AB6-63A872EB947F",
-    "title": "Workshop: Lesson 4, example 2, version 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "68B7A478-C6AF-49F2-8AB6-63A872EB947F",
+  "title": "Workshop: Lesson 4, example 2, version 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson4_example3/info.json
+++ b/exampleCourse/questions/workshop/Lesson4_example3/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "A3F9BCE8-B9E7-4A8F-937B-F2948DD68CF1",
-    "title": "Workshop: Lesson 4, example 3, version 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "A3F9BCE8-B9E7-4A8F-937B-F2948DD68CF1",
+  "title": "Workshop: Lesson 4, example 3, version 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson4_example4/info.json
+++ b/exampleCourse/questions/workshop/Lesson4_example4/info.json
@@ -1,18 +1,15 @@
 {
-    "uuid": "BD8D4209-5A16-4FED-AEBB-9E32643C1FF7",
-    "title": "Write a simple code using numpy",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "nnytko2"
-    ],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "prairielearn/grader-python",
-        "entrypoint": "/python_autograder/run.sh",
-        "timeout": 60
-    }
+  "uuid": "BD8D4209-5A16-4FED-AEBB-9E32643C1FF7",
+  "title": "Write a simple code using numpy",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "nnytko2"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "entrypoint": "/python_autograder/run.sh",
+    "timeout": 60
+  }
 }

--- a/exampleCourse/questions/workshop/Lesson5_example1/info.json
+++ b/exampleCourse/questions/workshop/Lesson5_example1/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "f592735d-f703-4daf-b316-88e8362f6487",
-    "title": "Workshop: Lesson 5, example 1",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva"
-    ],
-    "type": "v3"
+  "uuid": "f592735d-f703-4daf-b316-88e8362f6487",
+  "title": "Workshop: Lesson 5, example 1",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson5_example2/info.json
+++ b/exampleCourse/questions/workshop/Lesson5_example2/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "96f4e7a9-fac6-4b82-bdd1-138fa65520f0",
-    "title": "Workshop: Lesson 5, example 2",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva"
-    ],
-    "type": "v3"
+  "uuid": "96f4e7a9-fac6-4b82-bdd1-138fa65520f0",
+  "title": "Workshop: Lesson 5, example 2",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva"],
+  "type": "v3"
 }

--- a/exampleCourse/questions/workshop/Lesson5_example3/info.json
+++ b/exampleCourse/questions/workshop/Lesson5_example3/info.json
@@ -1,9 +1,7 @@
 {
-    "uuid": "a116df15-f8b3-4d69-a1b7-6001daa5846a",
-    "title": "Workshop: Lesson 5, example 3",
-    "topic": "Workshop Demo",
-    "type": "v3",
-    "tags": [
-        "mfsilva"
-    ]
+  "uuid": "a116df15-f8b3-4d69-a1b7-6001daa5846a",
+  "title": "Workshop: Lesson 5, example 3",
+  "topic": "Workshop Demo",
+  "type": "v3",
+  "tags": ["mfsilva"]
 }

--- a/exampleCourse/questions/workshop/PeriodicTable1/info.json
+++ b/exampleCourse/questions/workshop/PeriodicTable1/info.json
@@ -1,10 +1,7 @@
 {
-    "uuid": "8522fe6c-1987-4381-9d9b-db81504a4916",
-    "title": "Periodic Table",
-    "topic": "Workshop Demo",
-    "tags": [
-        "mfsilva",
-        "Su20"
-    ],
-    "type": "v3"
+  "uuid": "8522fe6c-1987-4381-9d9b-db81504a4916",
+  "title": "Periodic Table",
+  "topic": "Workshop Demo",
+  "tags": ["mfsilva", "Su20"],
+  "type": "v3"
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam1-automaticTestSuite/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam1-automaticTestSuite/infoAssessment.json
@@ -1,32 +1,32 @@
 {
-    "uuid": "82981f95-3cab-49b1-976d-aa8187ab47ae",
-    "type": "Exam",
-    "title": "Exam for automatic test suite",
-    "set": "Exam",
-    "number": "1",
-    "module": "Module1",
-    "allowAccess": [
-        {
-            "mode": "Exam",
-            "credit": 100,
-            "timeLimitMin": 50,
-            "startDate": "1900-07-07T23:59:59",
-            "endDate": "2300-07-10T23:59:59"
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addNumbers",              "points": [5, 3, 1]},
-                {"id": "addVectors",              "autoPoints": [11, 9], "manualPoints": 10},
-                {"id": "fossilFuelsRadio",        "points": [17, 13, 7, 2]},
-                {"id": "partialCredit1",          "points": [19]},
-                {"id": "partialCredit2",          "points": [9, 7, 5, 3]},
-                {"id": "partialCredit3",          "points": [13, 13, 8, 0.5, 0.1]},
-                {"id": "brokenGeneration",        "points": [10]}
-              ]
-        }
-    ],
-    "text": "The following formula sheets are available to you on this exam:<ul><li><a href=\"<%= clientFilesAssessment %>/formulas.pdf\">PDF version</a></li>"
+  "uuid": "82981f95-3cab-49b1-976d-aa8187ab47ae",
+  "type": "Exam",
+  "title": "Exam for automatic test suite",
+  "set": "Exam",
+  "number": "1",
+  "module": "Module1",
+  "allowAccess": [
+    {
+      "mode": "Exam",
+      "credit": 100,
+      "timeLimitMin": 50,
+      "startDate": "1900-07-07T23:59:59",
+      "endDate": "2300-07-10T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addNumbers", "points": [5, 3, 1] },
+        { "id": "addVectors", "autoPoints": [11, 9], "manualPoints": 10 },
+        { "id": "fossilFuelsRadio", "points": [17, 13, 7, 2] },
+        { "id": "partialCredit1", "points": [19] },
+        { "id": "partialCredit2", "points": [9, 7, 5, 3] },
+        { "id": "partialCredit3", "points": [13, 13, 8, 0.5, 0.1] },
+        { "id": "brokenGeneration", "points": [10] }
+      ]
+    }
+  ],
+  "text": "The following formula sheets are available to you on this exam:<ul><li><a href=\"<%= clientFilesAssessment %>/formulas.pdf\">PDF version</a></li>"
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam10-gradeRate/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam10-gradeRate/infoAssessment.json
@@ -1,24 +1,24 @@
 {
-    "uuid": "c39b94e8-2f26-4c38-a7b4-d0fb3a26396a",
-    "type": "Exam",
-    "title": "Test limiting grade rate",
-    "set": "Exam",
-    "number": "10",
-    "gradeRateMinutes": 10,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 50
-        }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "partialCredit1", "points": [19, 19, 19]},
-                {"id": "partialCredit2", "points": [9, 9, 9]},
-                {"id": "partialCredit3", "points": [13, 13, 13]}
-              ]
-        }
-    ]
+  "uuid": "c39b94e8-2f26-4c38-a7b4-d0fb3a26396a",
+  "type": "Exam",
+  "title": "Test limiting grade rate",
+  "set": "Exam",
+  "number": "10",
+  "gradeRateMinutes": 10,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 50
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
+        { "id": "partialCredit1", "points": [19, 19, 19] },
+        { "id": "partialCredit2", "points": [9, 9, 9] },
+        { "id": "partialCredit3", "points": [13, 13, 13] }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam11-activeAccessRestriction/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam11-activeAccessRestriction/infoAssessment.json
@@ -1,50 +1,50 @@
 {
-    "uuid": "db241fb7-8ca4-4316-a92d-85c7753c6d9c",
-    "type": "Exam",
-    "title": "Test Active Access Rule",
-    "set": "Exam",
-    "number": "11",
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "timeLimitMin": 50,
-            "startDate": "2010-01-01T00:00:01Z",
-            "endDate": "2010-01-01T23:59:59Z",
-            "credit": 100
-        },
-        {
-            "mode": "Public",
-            "startDate": "2020-01-01T00:00:01Z",
-            "endDate": "2021-01-01T00:00:01Z",
-            "active": false,
-            "showClosedAssessment": false
-        },
-        {
-            "mode": "Public",
-            "startDate": "2030-01-01T00:00:01Z",
-            "endDate": "2031-01-01T00:00:01Z",
-            "active": false,
-            "showClosedAssessment": false,
-            "showClosedAssessmentScore": false
-        },
-        {
-            "mode": "Public",
-            "startDate": "1900-01-01T00:00:01Z",
-            "endDate": "2100-01-01T00:00:01Z",
-            "active": false
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addNumbers",              "points": [5, 3, 1]},
-                {"id": "addVectors",              "points": [11, 9]},
-                {"id": "fossilFuelsRadio",        "points": [17, 13, 7, 2]},
-                {"id": "partialCredit1",          "points": [19]},
-                {"id": "partialCredit2",          "points": [9, 7, 5, 3]},
-                {"id": "partialCredit3",          "points": [13, 13, 8, 0.5, 0.1]}
-            ]
-        }
-    ]
+  "uuid": "db241fb7-8ca4-4316-a92d-85c7753c6d9c",
+  "type": "Exam",
+  "title": "Test Active Access Rule",
+  "set": "Exam",
+  "number": "11",
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "timeLimitMin": 50,
+      "startDate": "2010-01-01T00:00:01Z",
+      "endDate": "2010-01-01T23:59:59Z",
+      "credit": 100
+    },
+    {
+      "mode": "Public",
+      "startDate": "2020-01-01T00:00:01Z",
+      "endDate": "2021-01-01T00:00:01Z",
+      "active": false,
+      "showClosedAssessment": false
+    },
+    {
+      "mode": "Public",
+      "startDate": "2030-01-01T00:00:01Z",
+      "endDate": "2031-01-01T00:00:01Z",
+      "active": false,
+      "showClosedAssessment": false,
+      "showClosedAssessmentScore": false
+    },
+    {
+      "mode": "Public",
+      "startDate": "1900-01-01T00:00:01Z",
+      "endDate": "2100-01-01T00:00:01Z",
+      "active": false
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addNumbers", "points": [5, 3, 1] },
+        { "id": "addVectors", "points": [11, 9] },
+        { "id": "fossilFuelsRadio", "points": [17, 13, 7, 2] },
+        { "id": "partialCredit1", "points": [19] },
+        { "id": "partialCredit2", "points": [9, 7, 5, 3] },
+        { "id": "partialCredit3", "points": [13, 13, 8, 0.5, 0.1] }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam12-sequentialQuestions/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam12-sequentialQuestions/infoAssessment.json
@@ -1,53 +1,41 @@
 {
-    "uuid": "d7bcc376-4f23-41d6-9f71-87dd1d23991b",
-    "allowAccess": [{"mode": "Public", "credit": 100}],
+  "uuid": "d7bcc376-4f23-41d6-9f71-87dd1d23991b",
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
 
-    "title": "Force student to complete questions in-order",
-    "type": "Exam",
-    "set": "Exam",
-    "number": "12",
+  "title": "Force student to complete questions in-order",
+  "type": "Exam",
+  "set": "Exam",
+  "number": "12",
 
-    "advanceScorePerc": 100,
-    "zones": [
+  "advanceScorePerc": 100,
+  "zones": [
+    {
+      "questions": [
         {
-            "questions": [
-                {
-                    "numberChoose": 1,
-                    "points": 1,
-                    "advanceScorePerc": 1,
-                    "alternatives": [
-                        {"id": "partialCredit1", "advanceScorePerc": 0}
-                    ]
-                }
-            ]
-        },
-        {
-            "advanceScorePerc": 25,
-            "questions": [
-                {"id": "partialCredit3", "points": [1,1,1,1], "advanceScorePerc": 60}
-            ]
-        },
-        {
-          "advanceScorePerc": 75,
-          "questions": [
-            {"id": "partialCredit2", "points": 1}
-          ]
-        },
-        {
-            "questions": [
-                {"id": "partialCredit4_v2", "points": 1, "advanceScorePerc": 0}
-            ]
-        },
-        {
-            "advanceScorePerc": 35,
-            "questions": [
-                {"id": "addVectors", "points": 1, "advanceScorePerc": 30}
-            ]
-        },
-        {
-            "questions": [
-                {"id": "addNumbers", "points": 1}
-            ]
+          "numberChoose": 1,
+          "points": 1,
+          "advanceScorePerc": 1,
+          "alternatives": [{ "id": "partialCredit1", "advanceScorePerc": 0 }]
         }
-    ]
+      ]
+    },
+    {
+      "advanceScorePerc": 25,
+      "questions": [{ "id": "partialCredit3", "points": [1, 1, 1, 1], "advanceScorePerc": 60 }]
+    },
+    {
+      "advanceScorePerc": 75,
+      "questions": [{ "id": "partialCredit2", "points": 1 }]
+    },
+    {
+      "questions": [{ "id": "partialCredit4_v2", "points": 1, "advanceScorePerc": 0 }]
+    },
+    {
+      "advanceScorePerc": 35,
+      "questions": [{ "id": "addVectors", "points": 1, "advanceScorePerc": 30 }]
+    },
+    {
+      "questions": [{ "id": "addNumbers", "points": 1 }]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam13-disableHonorCode/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam13-disableHonorCode/infoAssessment.json
@@ -1,24 +1,22 @@
 {
-    "uuid": "8374f97a-64a7-4419-9235-759f7728b1f8",
-    "type": "Exam",
-    "title": "Exam with honor code disabled",
-    "set": "Exam",
-    "number": "13",
-    "requireHonorCode": false,
-    "allowAccess": [
-    	{
-            "mode": "Exam",
-            "credit": 100,
-            "startDate": "1900-07-07T23:59:59",
-            "endDate": "2300-07-10T23:59:59"
-        }
-    ],
-    "zones": [
-        {
-            "title": "Questions",
-            "questions": [
-                {"id": "addNumbers",       "points": [5, 3, 1]}
-            ]
-        }
-    ]
+  "uuid": "8374f97a-64a7-4419-9235-759f7728b1f8",
+  "type": "Exam",
+  "title": "Exam with honor code disabled",
+  "set": "Exam",
+  "number": "13",
+  "requireHonorCode": false,
+  "allowAccess": [
+    {
+      "mode": "Exam",
+      "credit": 100,
+      "startDate": "1900-07-07T23:59:59",
+      "endDate": "2300-07-10T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Questions",
+      "questions": [{ "id": "addNumbers", "points": [5, 3, 1] }]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam15-breakVariants/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam15-breakVariants/infoAssessment.json
@@ -15,8 +15,8 @@
     {
       "title": "Questions",
       "questions": [
-        {"id": "partialCredit1", "points": [5, 4, 3, 2, 1]},
-        {"id": "partialCredit2", "points": [5, 4, 3, 2, 1]}
+        { "id": "partialCredit1", "points": [5, 4, 3, 2, 1] },
+        { "id": "partialCredit2", "points": [5, 4, 3, 2, 1] }
       ]
     }
   ]

--- a/testCourse/courseInstances/Sp15/assessments/exam16-groupWorkRoles/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam16-groupWorkRoles/infoAssessment.json
@@ -12,25 +12,25 @@
   "studentGroupLeave": true,
   "shuffleQuestions": false,
   "groupRoles": [
-      {
-          "name": "Manager",
-          "minimum": 1,
-          "maximum": 1,
-          "canAssignRoles": true
-      },
-      {
-          "name": "Recorder",
-          "minimum": 1,
-          "maximum": 1
-      },
-      {
-          "name": "Reflector",
-          "minimum": 1,
-          "maximum": 1
-      },
-      {
-          "name": "Contributor"
-      }
+    {
+      "name": "Manager",
+      "minimum": 1,
+      "maximum": 1,
+      "canAssignRoles": true
+    },
+    {
+      "name": "Recorder",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Reflector",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Contributor"
+    }
   ],
   "allowAccess": [
     {
@@ -44,9 +44,9 @@
       "canSubmit": ["Recorder"],
       "title": "Hard questions",
       "questions": [
-          {"id": "demo/demoNewton-page1",          "points": 1},
-          {"id": "demo/demoNewton-page2",        "points": 1, "canView": ["Recorder"]},
-          {"id": "addNumbers",        "points": 1, "canView": ["Reflector"], "canSubmit": ["Reflector"]}
+        { "id": "demo/demoNewton-page1", "points": 1 },
+        { "id": "demo/demoNewton-page2", "points": 1, "canView": ["Recorder"] },
+        { "id": "addNumbers", "points": 1, "canView": ["Reflector"], "canSubmit": ["Reflector"] }
       ]
     }
   ]

--- a/testCourse/courseInstances/Sp15/assessments/exam2-miscProblems/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam2-miscProblems/infoAssessment.json
@@ -1,26 +1,26 @@
 {
-    "uuid": "4491f76f-f637-43be-8e2d-a60b292e3673",
-    "type": "Exam",
-    "title": "Miscellaneous exam",
-    "set": "Exam",
-    "number": "2",
-    "module": "Module2",
-    "allowAccess": [
-        {
-            "mode": "Exam",
-            "credit": 100,
-            "startDate": "1900-07-07T23:59:59",
-            "endDate": "2300-07-10T23:59:59",
-            "timeLimitMin": 50
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addVectors",                 "points": [10, 5, 1]},
-                {"id": "positionTimeGraph",          "points": [10]}
-            ]
-        }
-    ]
+  "uuid": "4491f76f-f637-43be-8e2d-a60b292e3673",
+  "type": "Exam",
+  "title": "Miscellaneous exam",
+  "set": "Exam",
+  "number": "2",
+  "module": "Module2",
+  "allowAccess": [
+    {
+      "mode": "Exam",
+      "credit": 100,
+      "startDate": "1900-07-07T23:59:59",
+      "endDate": "2300-07-10T23:59:59",
+      "timeLimitMin": 50
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addVectors", "points": [10, 5, 1] },
+        { "id": "positionTimeGraph", "points": [10] }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam5-perZoneGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam5-perZoneGrading/infoAssessment.json
@@ -1,44 +1,47 @@
 {
-    "uuid": "d5f8c334-983a-4225-a7a0-4f951b88ce78",
-    "type": "Exam",
-    "title": "Exam to test per-zone grading",
-    "set": "Exam",
-    "number": "5",
-    "allowAccess": [
+  "uuid": "d5f8c334-983a-4225-a7a0-4f951b88ce78",
+  "type": "Exam",
+  "title": "Exam to test per-zone grading",
+  "set": "Exam",
+  "number": "5",
+  "allowAccess": [
+    {
+      "mode": "Exam",
+      "credit": 100,
+      "startDate": "1900-07-07T23:59:59",
+      "endDate": "2300-07-10T23:59:59",
+      "timeLimitMin": 50
+    }
+  ],
+  "zones": [
+    {
+      "title": "Questions to test maxPoints",
+      "maxPoints": 5,
+      "questions": [
         {
-            "mode": "Exam",
-            "credit": 100,
-            "startDate": "1900-07-07T23:59:59",
-            "endDate": "2300-07-10T23:59:59",
-            "timeLimitMin": 50
+          "id": "partialCredit1",
+          "points": [10, 5, 1]
         }
-    ],
-    "zones": [{
-            "title": "Questions to test maxPoints",
-            "maxPoints": 5,
-            "questions": [{
-                    "id": "partialCredit1",
-                    "points": [10, 5, 1]
-                }
-            ]
+      ]
+    },
+    {
+      "title": "Questions to test maxPoints and bestQuestions together",
+      "bestQuestions": 2,
+      "maxPoints": 15,
+      "questions": [
+        {
+          "id": "partialCredit2",
+          "points": [10, 5, 1]
         },
         {
-            "title": "Questions to test maxPoints and bestQuestions together",
-            "bestQuestions": 2,
-            "maxPoints": 15,
-            "questions": [{
-                    "id": "partialCredit2",
-                    "points": [10, 5, 1]
-                },
-                {
-                    "id": "partialCredit3",
-                    "points": [15, 10, 5, 1]
-                },
-                {
-                    "id": "partialCredit4_v2",
-                    "points": [20, 15, 10, 5, 1]
-                }
-            ]
+          "id": "partialCredit3",
+          "points": [15, 10, 5, 1]
+        },
+        {
+          "id": "partialCredit4_v2",
+          "points": [20, 15, 10, 5, 1]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam6-password/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam6-password/infoAssessment.json
@@ -1,26 +1,26 @@
 {
-    "uuid": "7806904c-78b9-4bc9-b8b4-8b6ae32dabb8",
-    "type": "Exam",
-    "title": "Exam with password diamond",
-    "set": "Exam",
-    "number": "6",
-    "allowAccess": [
-        {
-            "mode": "Exam",
-            "credit": 100,
-            "startDate": "1900-07-07T23:59:59",
-            "endDate": "2300-07-10T23:59:59",
-            "timeLimitMin": 50,
-            "password": "diamond"
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addVectors",                 "points": [10, 5, 1]},
-                {"id": "positionTimeGraph",          "points": [10]}
-            ]
-        }
-    ]
+  "uuid": "7806904c-78b9-4bc9-b8b4-8b6ae32dabb8",
+  "type": "Exam",
+  "title": "Exam with password diamond",
+  "set": "Exam",
+  "number": "6",
+  "allowAccess": [
+    {
+      "mode": "Exam",
+      "credit": 100,
+      "startDate": "1900-07-07T23:59:59",
+      "endDate": "2300-07-10T23:59:59",
+      "timeLimitMin": 50,
+      "password": "diamond"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addVectors", "points": [10, 5, 1] },
+        { "id": "positionTimeGraph", "points": [10] }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam7-modePublic/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam7-modePublic/infoAssessment.json
@@ -1,28 +1,28 @@
 {
-    "uuid": "ccdcc95b-76b5-4d08-b1d9-f87948f916ba",
-    "type": "Exam",
-    "title": "Verify Exam Mode Lacks 'Waiting for a Proctor'",
-    "set": "Exam",
-    "number": "7",
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addNumbers",              "points": [5, 3, 1]},
-                {"id": "addVectors",              "points": [11, 9]},
-                {"id": "fossilFuelsRadio",        "points": [17, 13, 7, 2]},
-                {"id": "partialCredit1",          "points": [19]},
-                {"id": "partialCredit2",          "points": [9, 7, 5, 3]},
-                {"id": "partialCredit3",          "points": [13, 13, 8, 0.5, 0.1]},
-                {"id": "brokenGeneration",        "points": [10]}
-              ]
-        }
-    ],
-    "text": "This exam should not display the 'Waiting for a Proctor' message if accessed through a public mode."
+  "uuid": "ccdcc95b-76b5-4d08-b1d9-f87948f916ba",
+  "type": "Exam",
+  "title": "Verify Exam Mode Lacks 'Waiting for a Proctor'",
+  "set": "Exam",
+  "number": "7",
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addNumbers", "points": [5, 3, 1] },
+        { "id": "addVectors", "points": [11, 9] },
+        { "id": "fossilFuelsRadio", "points": [17, 13, 7, 2] },
+        { "id": "partialCredit1", "points": [19] },
+        { "id": "partialCredit2", "points": [9, 7, 5, 3] },
+        { "id": "partialCredit3", "points": [13, 13, 8, 0.5, 0.1] },
+        { "id": "brokenGeneration", "points": [10] }
+      ]
+    }
+  ],
+  "text": "This exam should not display the 'Waiting for a Proctor' message if accessed through a public mode."
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
@@ -1,30 +1,30 @@
 {
-    "uuid": "3f4e1c41-486b-40e5-a748-1cca9e7fe74e",
-    "type": "Exam",
-    "title": "Test disabling real-time grading",
-    "set": "Exam",
-    "number": "8",
-    "allowRealTimeGrading": false,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 50,
-            "showClosedAssessment": false
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addNumbers",              "points": 5},
-                {"id": "addVectors",              "points": 11},
-                {"id": "fossilFuelsRadio",        "points": 17},
-                {"id": "partialCredit1",          "points": 19},
-                {"id": "partialCredit2",          "points": 9},
-                {"id": "partialCredit3",          "points": 13},
-                {"id": "brokenGeneration",        "points": 10}
-              ]
-        }
-    ]
+  "uuid": "3f4e1c41-486b-40e5-a748-1cca9e7fe74e",
+  "type": "Exam",
+  "title": "Test disabling real-time grading",
+  "set": "Exam",
+  "number": "8",
+  "allowRealTimeGrading": false,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 50,
+      "showClosedAssessment": false
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addNumbers", "points": 5 },
+        { "id": "addVectors", "points": 11 },
+        { "id": "fossilFuelsRadio", "points": 17 },
+        { "id": "partialCredit1", "points": 19 },
+        { "id": "partialCredit2", "points": 9 },
+        { "id": "partialCredit3", "points": 13 },
+        { "id": "brokenGeneration", "points": 10 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam9-disableRealTimeGradingWithholdGrades/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam9-disableRealTimeGradingWithholdGrades/infoAssessment.json
@@ -1,31 +1,31 @@
 {
-    "uuid": "ac1973c7-e3d0-4df4-93f6-e40808c06713",
-    "type": "Exam",
-    "title": "Test disabling real-time grading and withholding grades",
-    "set": "Exam",
-    "number": "9",
-    "allowRealTimeGrading": false,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100,
-            "timeLimitMin": 50,
-            "showClosedAssessment": false,
-            "showClosedAssessmentScore": false
-        }
-    ],
-    "zones": [
-        {
-            "title": "Hard questions",
-            "questions": [
-                {"id": "addNumbers",              "points": 5},
-                {"id": "addVectors",              "points": 11},
-                {"id": "fossilFuelsRadio",        "points": 17},
-                {"id": "partialCredit1",          "points": 19},
-                {"id": "partialCredit2",          "points": 9},
-                {"id": "partialCredit3",          "points": 13},
-                {"id": "brokenGeneration",        "points": 10}
-              ]
-        }
-    ]
+  "uuid": "ac1973c7-e3d0-4df4-93f6-e40808c06713",
+  "type": "Exam",
+  "title": "Test disabling real-time grading and withholding grades",
+  "set": "Exam",
+  "number": "9",
+  "allowRealTimeGrading": false,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "timeLimitMin": 50,
+      "showClosedAssessment": false,
+      "showClosedAssessmentScore": false
+    }
+  ],
+  "zones": [
+    {
+      "title": "Hard questions",
+      "questions": [
+        { "id": "addNumbers", "points": 5 },
+        { "id": "addVectors", "points": 11 },
+        { "id": "fossilFuelsRadio", "points": 17 },
+        { "id": "partialCredit1", "points": 19 },
+        { "id": "partialCredit2", "points": 9 },
+        { "id": "partialCredit3", "points": 13 },
+        { "id": "brokenGeneration", "points": 10 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw1-automaticTestSuite/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw1-automaticTestSuite/infoAssessment.json
@@ -1,30 +1,30 @@
 {
-    "uuid": "294e5841-b705-4720-b5d4-266b82e9c6c8",
-    "type": "Homework",
-    "title": "Homework for automatic test suite",
-    "set": "Homework",
-    "number": "1",
-    "module": "Module1",
-    "allowAccess": [
-        {
-            "credit": 100
-        }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "addNumbers",                "points": 1, "maxPoints": 5},
-                {"id": "addVectors",                "points": 2, "maxPoints": 11},
-                {"id": "fossilFuelsRadio",          "points": 3, "maxPoints": 14},
-                {"id": "downloadFile",              "points": 5, "maxPoints": 17},
-                {"id": "partialCredit1",            "points": 1, "maxPoints": 6},
-                {"id": "partialCredit2",            "points": 2, "maxPoints": 7, "triesPerVariant": 3},
-                {"id": "partialCredit3",            "points": 3, "maxPoints": 11, "triesPerVariant": 5},
-                {"id": "partialCredit4_v2",         "points": 4, "maxPoints": 13},
-                {"id": "partialCredit5_v2_partial", "points": 5, "maxPoints": 12},
-                {"id": "partialCredit6_no_partial", "points": 3, "maxPoints": 8},
-                {"id": "brokenGrading",             "points": 2, "maxPoints": 4}
-            ]
-        }
-    ]
+  "uuid": "294e5841-b705-4720-b5d4-266b82e9c6c8",
+  "type": "Homework",
+  "title": "Homework for automatic test suite",
+  "set": "Homework",
+  "number": "1",
+  "module": "Module1",
+  "allowAccess": [
+    {
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
+        { "id": "addNumbers", "points": 1, "maxPoints": 5 },
+        { "id": "addVectors", "points": 2, "maxPoints": 11 },
+        { "id": "fossilFuelsRadio", "points": 3, "maxPoints": 14 },
+        { "id": "downloadFile", "points": 5, "maxPoints": 17 },
+        { "id": "partialCredit1", "points": 1, "maxPoints": 6 },
+        { "id": "partialCredit2", "points": 2, "maxPoints": 7, "triesPerVariant": 3 },
+        { "id": "partialCredit3", "points": 3, "maxPoints": 11, "triesPerVariant": 5 },
+        { "id": "partialCredit4_v2", "points": 4, "maxPoints": 13 },
+        { "id": "partialCredit5_v2_partial", "points": 5, "maxPoints": 12 },
+        { "id": "partialCredit6_no_partial", "points": 3, "maxPoints": 8 },
+        { "id": "brokenGrading", "points": 2, "maxPoints": 4 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw2-miscProblems/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw2-miscProblems/infoAssessment.json
@@ -1,47 +1,47 @@
 {
-    "uuid": "b6468c04-f28c-465a-9108-077ed53e2148",
-    "type": "Homework",
-    "title": "Miscellaneous homework",
-    "set": "Homework",
-    "number": "2",
-    "module": "Module1",
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 120,
-            "startDate": "2014-04-07T00:00:01",
-            "endDate": "2014-07-10T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2014-07-07T00:00:01",
-            "endDate": "2024-07-10T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 80,
-            "startDate": "2014-07-07T00:00:01",
-            "endDate": "2024-08-10T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 50,
-            "startDate": "2014-07-07T00:00:01",
-            "endDate": "2024-09-10T23:59:59"
-        }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "addVectors",                 "points": 1, "maxPoints": 5},
-                {"id": "fossilFuelsRadio",           "points": 2, "maxPoints": 10},
-                {"id": "positionTimeGraph",          "points": 2, "maxPoints": 10},
-                {"id": "downloadFile",               "points": 2, "maxPoints": 10},
-                {"id": "differentiatePolynomial",    "points": 2, "maxPoints": 10},
-                {"id": "subfolder/nestedQuestion",   "points": 2, "maxPoints": 10},
-                {"id": "workspace",                  "points": 2, "maxPoints": 10}
-            ]
-        }
-    ]
+  "uuid": "b6468c04-f28c-465a-9108-077ed53e2148",
+  "type": "Homework",
+  "title": "Miscellaneous homework",
+  "set": "Homework",
+  "number": "2",
+  "module": "Module1",
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 120,
+      "startDate": "2014-04-07T00:00:01",
+      "endDate": "2014-07-10T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2014-07-07T00:00:01",
+      "endDate": "2024-07-10T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 80,
+      "startDate": "2014-07-07T00:00:01",
+      "endDate": "2024-08-10T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2014-07-07T00:00:01",
+      "endDate": "2024-09-10T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
+        { "id": "addVectors", "points": 1, "maxPoints": 5 },
+        { "id": "fossilFuelsRadio", "points": 2, "maxPoints": 10 },
+        { "id": "positionTimeGraph", "points": 2, "maxPoints": 10 },
+        { "id": "downloadFile", "points": 2, "maxPoints": 10 },
+        { "id": "differentiatePolynomial", "points": 2, "maxPoints": 10 },
+        { "id": "subfolder/nestedQuestion", "points": 2, "maxPoints": 10 },
+        { "id": "workspace", "points": 2, "maxPoints": 10 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw3-partialCredit/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw3-partialCredit/infoAssessment.json
@@ -1,46 +1,46 @@
 {
-    "uuid": "ffc6cb45-5d86-4b97-ab73-b828050deec9",
-    "type": "Homework",
-    "title": "Homework to test partial credit",
-    "set": "Homework",
-    "number": "3",
-    "module": "Module2",
-    "constantQuestionValue": true,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 120,
-            "startDate": "2014-04-07T00:00:01",
-            "endDate": "2014-07-10T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2014-07-07T00:00:01",
-            "endDate": "2024-07-10T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 80,
-            "startDate": "2014-07-07T00:00:01",
-            "endDate": "2024-08-10T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 50,
-            "startDate": "2014-07-07T00:00:01",
-            "endDate": "2024-09-10T23:59:59"
-        }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "partialCredit1",            "points": 1, "maxPoints": 5},
-                {"id": "partialCredit2",            "points": 2, "maxPoints": 10},
-                {"id": "partialCredit3",            "points": 2, "maxPoints": 10, "triesPerVariant": 3},
-                {"id": "partialCredit4_v2",         "points": 2, "maxPoints": 10},
-                {"id": "partialCredit6_no_partial", "points": 3, "maxPoints": 11}
-            ]
-        }
-    ]
+  "uuid": "ffc6cb45-5d86-4b97-ab73-b828050deec9",
+  "type": "Homework",
+  "title": "Homework to test partial credit",
+  "set": "Homework",
+  "number": "3",
+  "module": "Module2",
+  "constantQuestionValue": true,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 120,
+      "startDate": "2014-04-07T00:00:01",
+      "endDate": "2014-07-10T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2014-07-07T00:00:01",
+      "endDate": "2024-07-10T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 80,
+      "startDate": "2014-07-07T00:00:01",
+      "endDate": "2024-08-10T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2014-07-07T00:00:01",
+      "endDate": "2024-09-10T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
+        { "id": "partialCredit1", "points": 1, "maxPoints": 5 },
+        { "id": "partialCredit2", "points": 2, "maxPoints": 10 },
+        { "id": "partialCredit3", "points": 2, "maxPoints": 10, "triesPerVariant": 3 },
+        { "id": "partialCredit4_v2", "points": 2, "maxPoints": 10 },
+        { "id": "partialCredit6_no_partial", "points": 3, "maxPoints": 11 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw4-perzonegrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw4-perzonegrading/infoAssessment.json
@@ -1,47 +1,50 @@
 {
-    "uuid": "2c5be1cc-8a8b-4fca-9bc6-c909a1f1b860",
-    "type": "Homework",
-    "title": "Homework to test per-zone grading",
-    "set": "Homework",
-    "number": "4",
-    "module": "Module2",
-    "allowAccess": [
+  "uuid": "2c5be1cc-8a8b-4fca-9bc6-c909a1f1b860",
+  "type": "Homework",
+  "title": "Homework to test per-zone grading",
+  "set": "Homework",
+  "number": "4",
+  "module": "Module2",
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "1900-07-07T23:59:59",
+      "endDate": "2300-07-10T23:59:59"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Questions to test maxPoints",
+      "maxPoints": 7,
+      "questions": [
         {
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "1900-07-07T23:59:59",
-            "endDate": "2300-07-10T23:59:59"
+          "id": "partialCredit4_v2",
+          "points": 4,
+          "maxPoints": 8
         }
-    ],
-    "zones": [{
-            "title": "Questions to test maxPoints",
-            "maxPoints": 7,
-            "questions": [{
-                    "id": "partialCredit4_v2",
-                    "points": 4,
-                    "maxPoints": 8
-                }
-            ]
+      ]
+    },
+    {
+      "title": "Questions to test bestQuestions",
+      "bestQuestions": 1,
+      "questions": [
+        {
+          "id": "partialCredit1",
+          "points": 5,
+          "maxPoints": 30
         },
         {
-            "title": "Questions to test bestQuestions",
-            "bestQuestions": 1,
-            "questions": [{
-                    "id": "partialCredit1",
-                    "points": 5,
-                    "maxPoints": 30
-                },
-                {
-                    "id": "partialCredit2",
-                    "points": 5,
-                    "maxPoints": 40
-                },
-                {
-                    "id": "partialCredit3",
-                    "points": 5,
-                    "maxPoints": 50
-                }
-            ]
+          "id": "partialCredit2",
+          "points": 5,
+          "maxPoints": 40
+        },
+        {
+          "id": "partialCredit3",
+          "points": 5,
+          "maxPoints": 50
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw5-templateGroupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw5-templateGroupWork/infoAssessment.json
@@ -1,68 +1,74 @@
 {
-    "uuid": "d1959584-48c6-477a-8a4a-d50e1a4a95c7",
-    "type": "Homework",
-    "title": "Group Activity Template",
-    "set": "Homework",
-    "number": "5",
-    "module": "Module3",
-    "groupWork": true,
-    "groupMaxSize": 5,
-    "groupMinSize": 2,
-    "studentGroupCreate": true,
-    "studentGroupJoin": true,
-    "studentGroupLeave": true,
-    "groupRoles": [
+  "uuid": "d1959584-48c6-477a-8a4a-d50e1a4a95c7",
+  "type": "Homework",
+  "title": "Group Activity Template",
+  "set": "Homework",
+  "number": "5",
+  "module": "Module3",
+  "groupWork": true,
+  "groupMaxSize": 5,
+  "groupMinSize": 2,
+  "studentGroupCreate": true,
+  "studentGroupJoin": true,
+  "studentGroupLeave": true,
+  "groupRoles": [
+    {
+      "name": "Manager",
+      "minimum": 1,
+      "maximum": 1,
+      "canAssignRoles": true
+    },
+    {
+      "name": "Recorder",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Reflector",
+      "minimum": 1,
+      "maximum": 1
+    },
+    {
+      "name": "Contributor"
+    }
+  ],
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2019-01-18T00:00:01",
+      "endDate": "2019-01-28T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2019-01-28T00:00:01",
+      "endDate": "2019-01-30T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2019-01-30T00:00:01"
+    }
+  ],
+  "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
+  "zones": [
+    {
+      "canSubmit": ["Recorder"],
+      "title": "Fundamental questions",
+      "bestQuestions": 3,
+      "questions": [
+        { "id": "demo/demoNewton-page1", "points": 1, "maxPoints": 5 },
+        { "id": "demo/demoNewton-page2", "points": 1, "maxPoints": 5, "canView": ["Recorder"] },
         {
-            "name": "Manager",
-            "minimum": 1,
-            "maximum": 1,
-            "canAssignRoles": true
-        },
-        {
-            "name": "Recorder",
-            "minimum": 1,
-            "maximum": 1
-        },
-        {
-            "name": "Reflector",
-            "minimum": 1,
-            "maximum": 1
-        },
-        {
-            "name": "Contributor"
+          "id": "addNumbers",
+          "points": 1,
+          "maxPoints": 5,
+          "canView": ["Reflector"],
+          "canSubmit": ["Reflector"]
         }
-    ],
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2019-01-18T00:00:01",
-            "endDate": "2019-01-28T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 50,
-            "startDate": "2019-01-28T00:00:01",
-            "endDate": "2019-01-30T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 0,
-            "startDate": "2019-01-30T00:00:01"
-        }
-    ],
-    "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
-    "zones": [
-        {
-            "canSubmit": ["Recorder"],
-            "title": "Fundamental questions",
-            "bestQuestions": 3,
-            "questions": [
-                {"id": "demo/demoNewton-page1",          "points": 1, "maxPoints": 5},
-                {"id": "demo/demoNewton-page2",        "points": 1, "maxPoints": 5, "canView": ["Recorder"]},
-                {"id": "addNumbers",        "points": 1, "maxPoints": 5, "canView": ["Reflector"], "canSubmit": ["Reflector"]}
-            ]
-        }
-    ],
-    "text": "For this homework you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
+      ]
+    }
+  ],
+  "text": "For this homework you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw6-templateGroupWork2/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw6-templateGroupWork2/infoAssessment.json
@@ -1,43 +1,43 @@
 {
-    "uuid": "958b387e-f1b7-463f-96e2-0bdfd4663bca",
-    "type": "Homework",
-    "title": "Group Activity Template 2",
-    "set": "Homework",
-    "number": "6",
-    "groupWork": true,
-    "groupMaxSize": 3,
-    "groupMinSize": 3,
-    "studentGroupCreate": true,
-    "studentGroupJoin": true,
-    "studentGroupLeave": true,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100,
-            "startDate": "2019-01-18T00:00:01",
-            "endDate": "2019-01-28T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 50,
-            "startDate": "2019-01-28T00:00:01",
-            "endDate": "2019-01-30T23:59:59"
-        },
-        {
-            "mode": "Public",
-            "credit": 0,
-            "startDate": "2019-01-30T00:00:01"
-        }
-    ],
-    "zones": [
-        {
-            "title": "Fundamental questions",
-            "bestQuestions": 3,
-            "questions": [
-                {"id": "demo/demoNewton-page1",          "points": 1, "maxPoints": 5},
-                {"id": "demo/demoNewton-page2",        "points": 1, "maxPoints": 5}
-            ]
-        }
-    ],
-    "text": "For this homework you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
+  "uuid": "958b387e-f1b7-463f-96e2-0bdfd4663bca",
+  "type": "Homework",
+  "title": "Group Activity Template 2",
+  "set": "Homework",
+  "number": "6",
+  "groupWork": true,
+  "groupMaxSize": 3,
+  "groupMinSize": 3,
+  "studentGroupCreate": true,
+  "studentGroupJoin": true,
+  "studentGroupLeave": true,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100,
+      "startDate": "2019-01-18T00:00:01",
+      "endDate": "2019-01-28T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 50,
+      "startDate": "2019-01-28T00:00:01",
+      "endDate": "2019-01-30T23:59:59"
+    },
+    {
+      "mode": "Public",
+      "credit": 0,
+      "startDate": "2019-01-30T00:00:01"
+    }
+  ],
+  "zones": [
+    {
+      "title": "Fundamental questions",
+      "bestQuestions": 3,
+      "questions": [
+        { "id": "demo/demoNewton-page1", "points": 1, "maxPoints": 5 },
+        { "id": "demo/demoNewton-page2", "points": 1, "maxPoints": 5 }
+      ]
+    }
+  ],
+  "text": "For this homework you can use the <a target=\"_blank\" href=\"<%= clientFilesCourse %>/formulas.pdf\">formula sheet</a>."
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw7-bonusPoints/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw7-bonusPoints/infoAssessment.json
@@ -1,23 +1,23 @@
 {
-    "uuid": "97ba7431-ebb2-463c-990c-94e1fdabdd75",
-    "type": "Homework",
-    "title": "Bonus points",
-    "set": "Homework",
-    "number": "7",
-    "maxPoints": 10,
-    "maxBonusPoints": 2,
-    "allowAccess": [
-        {
-            "mode": "Public",
-            "credit": 100
-        }
-    ],
-    "zones": [
-        {
-            "questions": [
-                {"id": "partialCredit1", "points": 8},
-                {"id": "partialCredit2", "points": 8}
-            ]
-        }
-    ]
+  "uuid": "97ba7431-ebb2-463c-990c-94e1fdabdd75",
+  "type": "Homework",
+  "title": "Bonus points",
+  "set": "Homework",
+  "number": "7",
+  "maxPoints": 10,
+  "maxBonusPoints": 2,
+  "allowAccess": [
+    {
+      "mode": "Public",
+      "credit": 100
+    }
+  ],
+  "zones": [
+    {
+      "questions": [
+        { "id": "partialCredit1", "points": 8 },
+        { "id": "partialCredit2", "points": 8 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw8-activeAccessRestriction/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw8-activeAccessRestriction/infoAssessment.json
@@ -1,40 +1,40 @@
 {
-    "uuid": "1f7b004e-1431-48ba-8bac-ca5c14a80cfb",
-    "type": "Homework",
-    "title": "Homework to test Active Rule",
-    "set": "Homework",
-    "number": "8",
-    "allowAccess": [
-        {
-            "startDate": "2020-01-01T00:00:01Z",
-            "endDate": "2020-12-31T23:59:59Z",
-            "credit": 100
-        },
-        {
-            "startDate": "2030-01-01T00:00:01Z",
-            "endDate": "2030-12-31T23:59:59Z",
-            "credit": 75
-        },
-        {
-            "startDate": "2000-01-01T00:00:01Z",
-            "endDate": "2024-12-31T23:59:59Z",
-            "active": false
-        },
-        {
-            "startDate": "2025-01-01T00:00:01Z",
-            "endDate": "2039-12-31T23:59:59Z",
-            "active": false,
-            "showClosedAssessment": false
-        }
-    ],
-    "zones": [
-        {
-            "title": "Zone 1",
-            "questions": [
-                {"id": "partialCredit1",    "points": 10},
-                {"id": "fossilFuelsRadio",  "points": 2, "maxPoints": 10},
-                {"id": "positionTimeGraph", "points": 2, "maxPoints": 10}
-            ]
-        }
-    ]
+  "uuid": "1f7b004e-1431-48ba-8bac-ca5c14a80cfb",
+  "type": "Homework",
+  "title": "Homework to test Active Rule",
+  "set": "Homework",
+  "number": "8",
+  "allowAccess": [
+    {
+      "startDate": "2020-01-01T00:00:01Z",
+      "endDate": "2020-12-31T23:59:59Z",
+      "credit": 100
+    },
+    {
+      "startDate": "2030-01-01T00:00:01Z",
+      "endDate": "2030-12-31T23:59:59Z",
+      "credit": 75
+    },
+    {
+      "startDate": "2000-01-01T00:00:01Z",
+      "endDate": "2024-12-31T23:59:59Z",
+      "active": false
+    },
+    {
+      "startDate": "2025-01-01T00:00:01Z",
+      "endDate": "2039-12-31T23:59:59Z",
+      "active": false,
+      "showClosedAssessment": false
+    }
+  ],
+  "zones": [
+    {
+      "title": "Zone 1",
+      "questions": [
+        { "id": "partialCredit1", "points": 10 },
+        { "id": "fossilFuelsRadio", "points": 2, "maxPoints": 10 },
+        { "id": "positionTimeGraph", "points": 2, "maxPoints": 10 }
+      ]
+    }
+  ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/hw9-internalExternalManual/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw9-internalExternalManual/infoAssessment.json
@@ -13,19 +13,18 @@
     {
       "comments": "Generic points, use default grading method",
       "questions": [
-        {"id": "internalGrade/addingNumbers", "points": 2, "maxPoints": 6},
-        {"id": "manualGrade/codeUpload",      "points": 2, "maxPoints": 6},
-        {"id": "externalGrade/alpine",        "points": 2, "maxPoints": 6}
+        { "id": "internalGrade/addingNumbers", "points": 2, "maxPoints": 6 },
+        { "id": "manualGrade/codeUpload", "points": 2, "maxPoints": 6 },
+        { "id": "externalGrade/alpine", "points": 2, "maxPoints": 6 }
       ]
     },
     {
       "comments": "Behavior based on separate points for manual and auto",
       "questions": [
-        {"id": "internalGrade/addingNumbers2", "manualPoints": 2},
-        {"id": "manualGrade/addingNumbers2", "autoPoints": 2, "maxAutoPoints": 6},
-        {"id": "addNumbers", "autoPoints": 0, "maxAutoPoints": 0, "manualPoints": 0}
+        { "id": "internalGrade/addingNumbers2", "manualPoints": 2 },
+        { "id": "manualGrade/addingNumbers2", "autoPoints": 2, "maxAutoPoints": 6 },
+        { "id": "addNumbers", "autoPoints": 0, "maxAutoPoints": 0, "manualPoints": 0 }
       ]
     }
   ]
 }
-

--- a/testCourse/courseInstances/Sp15/infoCourseInstance.json
+++ b/testCourse/courseInstances/Sp15/infoCourseInstance.json
@@ -1,12 +1,12 @@
 {
-    "uuid": "31a69dd9-81a1-4b17-b578-2098d20fb57a",
-    "shortName": "Sp15",
-    "longName": "Spring 2015",
-    "allowAccess": [
-        {
-            "institution": "Any",
-            "startDate": "1800-01-19T00:00:01",
-            "endDate": "2400-05-13T23:59:59"
-        }
-    ]
+  "uuid": "31a69dd9-81a1-4b17-b578-2098d20fb57a",
+  "shortName": "Sp15",
+  "longName": "Spring 2015",
+  "allowAccess": [
+    {
+      "institution": "Any",
+      "startDate": "1800-01-19T00:00:01",
+      "endDate": "2400-05-13T23:59:59"
+    }
+  ]
 }

--- a/testCourse/elements/course-element/info.json
+++ b/testCourse/elements/course-element/info.json
@@ -1,17 +1,9 @@
 {
-    "controller": "course-element.py",
-    "dependencies": {
-        "elementScripts": [
-            "course-element.js"
-        ],
-        "elementStyles": [
-            "course-element.css"
-        ],
-        "clientFilesCourseScripts": [
-            "sharedElementCode.js"
-        ],
-        "clientFilesCourseStyles": [
-            "sharedElementStyles.css"
-        ]
-    }
+  "controller": "course-element.py",
+  "dependencies": {
+    "elementScripts": ["course-element.js"],
+    "elementStyles": ["course-element.css"],
+    "clientFilesCourseScripts": ["sharedElementCode.js"],
+    "clientFilesCourseStyles": ["sharedElementStyles.css"]
+  }
 }

--- a/testCourse/infoCourse.json
+++ b/testCourse/infoCourse.json
@@ -1,50 +1,90 @@
 {
-    "uuid": "28760b11-beb1-4507-bb0a-a15bc8eaf091",
-    "name": "QA 101",
-    "title": "Test Course",
-    "options": {
-        "useNewQuestionRenderer": true
+  "uuid": "28760b11-beb1-4507-bb0a-a15bc8eaf091",
+  "name": "QA 101",
+  "title": "Test Course",
+  "options": {
+    "useNewQuestionRenderer": true
+  },
+  "assessmentSets": [],
+  "assessmentModules": [
+    { "name": "Module1", "heading": "Module 1" },
+    { "name": "Module2", "heading": "Module 2" },
+    { "name": "Module3", "heading": "Module 3" },
+    { "name": "Module4", "heading": "Module 4" },
+    { "name": "Module5", "heading": "Module 5" }
+  ],
+  "topics": [
+    { "name": "Algebra", "color": "red3", "description": "Basic algebra." },
+    {
+      "name": "Calculus",
+      "color": "yellow3",
+      "description": "Single and multiple variable calculus."
     },
-    "assessmentSets": [],
-    "assessmentModules": [
-        {"name": "Module1", "heading": "Module 1"},
-        {"name": "Module2", "heading": "Module 2"},
-        {"name": "Module3", "heading": "Module 3"},
-        {"name": "Module4", "heading": "Module 4"},
-        {"name": "Module5", "heading": "Module 5"}
-    ],
-    "topics": [
-        {"name": "Algebra", "color": "red3", "description": "Basic algebra."},
-        {"name": "Calculus", "color": "yellow3", "description": "Single and multiple variable calculus."},
-        {"name": "Vectors", "color": "blue3", "description": "Vector algebra in 3D."},
-        {"name": "Functions", "color": "pink3", "description": "Writing and calling functions in code."},
-        {"name": "Energy", "color": "purple3", "description": "Mechanical energy; kinetic and potential."},
-        {"name": "Particle kinetics", "color": "red3", "description": "Newton's equation for point masses."},
-        {"name": "Coding", "color": "turquoise3", "description": "Writing computer code."},
-        {"name": "Center of mass", "color": "green3", "description": "Calculating the center of mass for irregular bodies and systems."},
-        {"name": "Linear algebra", "color": "brown3", "description": "Matrix math."},
-        {"name": "Test", "color": "gray3", "description": "Feature examples."},
-        {"name": "Names", "color": "red2", "description": "Questions to help you learn names."},
-        {"name": "Statistics", "color": "blue2", "description": "Probability distributions."}
-    ],
-    "tags": [
-        {"name": "mwest", "color": "gray1", "description": "Question originally written by mwest"},
-        {"name": "tbretl", "color": "blue1", "description": "Question originally written by tbretl"},
-        {"name": "mfsilva", "color": "blue1", "description": "Question originally written by mfsilva"},
-        {"name": "balamut2", "color": "orange1", "description": "Question originally written by balamut2"},
-        {"name": "ressick2", "color": "gray1", "description": "Question originally written by ressick2"},
-        {"name": "eliving2", "color": "gray1", "description": "Question originally written by eliving2"},
-        {"name": "tpl101", "color": "gray1", "description": "Question originally written for the XC 101 example course"},
-        {"name": "fa17", "color": "gray1", "description": "Question written in Fall 2017"},
-        {"name": "sp18", "color": "gray1", "description": "Question written in Spring 2018"},
-        {"name": "su18", "color": "gray1", "description": "Question written in Summer 2018"},
-        {"name": "fa18", "color": "gray1", "description": "Question written in Fall 2018"},
-        {"name": "v2", "color": "red1", "description": "v2 generation question"},
-        {"name": "v3", "color": "green1", "description": "v3 generation question (freeform)"},
-        {"name": "pearl", "color": "yellow3", "description": "Question originally written by pearl"}
-    ],
-    "sharingSets": [
-        {"name": "python-exercises", "description": "Python exercises for shraing"},
-        {"name": "final-exam", "description": "Questions that can be used on a final exam"}
-    ]
+    { "name": "Vectors", "color": "blue3", "description": "Vector algebra in 3D." },
+    {
+      "name": "Functions",
+      "color": "pink3",
+      "description": "Writing and calling functions in code."
+    },
+    {
+      "name": "Energy",
+      "color": "purple3",
+      "description": "Mechanical energy; kinetic and potential."
+    },
+    {
+      "name": "Particle kinetics",
+      "color": "red3",
+      "description": "Newton's equation for point masses."
+    },
+    { "name": "Coding", "color": "turquoise3", "description": "Writing computer code." },
+    {
+      "name": "Center of mass",
+      "color": "green3",
+      "description": "Calculating the center of mass for irregular bodies and systems."
+    },
+    { "name": "Linear algebra", "color": "brown3", "description": "Matrix math." },
+    { "name": "Test", "color": "gray3", "description": "Feature examples." },
+    { "name": "Names", "color": "red2", "description": "Questions to help you learn names." },
+    { "name": "Statistics", "color": "blue2", "description": "Probability distributions." }
+  ],
+  "tags": [
+    { "name": "mwest", "color": "gray1", "description": "Question originally written by mwest" },
+    { "name": "tbretl", "color": "blue1", "description": "Question originally written by tbretl" },
+    {
+      "name": "mfsilva",
+      "color": "blue1",
+      "description": "Question originally written by mfsilva"
+    },
+    {
+      "name": "balamut2",
+      "color": "orange1",
+      "description": "Question originally written by balamut2"
+    },
+    {
+      "name": "ressick2",
+      "color": "gray1",
+      "description": "Question originally written by ressick2"
+    },
+    {
+      "name": "eliving2",
+      "color": "gray1",
+      "description": "Question originally written by eliving2"
+    },
+    {
+      "name": "tpl101",
+      "color": "gray1",
+      "description": "Question originally written for the XC 101 example course"
+    },
+    { "name": "fa17", "color": "gray1", "description": "Question written in Fall 2017" },
+    { "name": "sp18", "color": "gray1", "description": "Question written in Spring 2018" },
+    { "name": "su18", "color": "gray1", "description": "Question written in Summer 2018" },
+    { "name": "fa18", "color": "gray1", "description": "Question written in Fall 2018" },
+    { "name": "v2", "color": "red1", "description": "v2 generation question" },
+    { "name": "v3", "color": "green1", "description": "v3 generation question (freeform)" },
+    { "name": "pearl", "color": "yellow3", "description": "Question originally written by pearl" }
+  ],
+  "sharingSets": [
+    { "name": "python-exercises", "description": "Python exercises for shraing" },
+    { "name": "final-exam", "description": "Questions that can be used on a final exam" }
+  ]
 }

--- a/testCourse/questions/addNumbers/info.json
+++ b/testCourse/questions/addNumbers/info.json
@@ -1,10 +1,8 @@
 {
-    "uuid": "8b4891d6-64d1-4e89-b72d-ad2133f25b2f",
-    "title": "Add two numbers",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3",
-    "sharingSets": [
-        "final-exam"
-    ]
+  "uuid": "8b4891d6-64d1-4e89-b72d-ad2133f25b2f",
+  "title": "Add two numbers",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3",
+  "sharingSets": ["final-exam"]
 }

--- a/testCourse/questions/addVectors/info.json
+++ b/testCourse/questions/addVectors/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "e11b3c85-e011-4931-96e9-be5879f15be4",
-    "title": "Addition of vectors in Cartesian coordinates",
-    "topic": "Vectors",
-    "tags": ["numeric", "v2"],
-    "clientFiles": ["client.js", "question.html", "answer.html", "submission.html", "fig1.png"],
-    "type": "Calculation",
-    "sharedPublicly": true
+  "uuid": "e11b3c85-e011-4931-96e9-be5879f15be4",
+  "title": "Addition of vectors in Cartesian coordinates",
+  "topic": "Vectors",
+  "tags": ["numeric", "v2"],
+  "clientFiles": ["client.js", "question.html", "answer.html", "submission.html", "fig1.png"],
+  "type": "Calculation",
+  "sharedPublicly": true
 }

--- a/testCourse/questions/brokenGeneration/info.json
+++ b/testCourse/questions/brokenGeneration/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "a2f12dbe-e030-4782-87aa-713d61728539",
-    "title": "Broken generation function",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa18", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "a2f12dbe-e030-4782-87aa-713d61728539",
+  "title": "Broken generation function",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa18", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/brokenGrading/info.json
+++ b/testCourse/questions/brokenGrading/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "02db4828-5462-43fa-93bd-6e9d4ff7ac5d",
-    "title": "Broken grading function",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "02db4828-5462-43fa-93bd-6e9d4ff7ac5d",
+  "title": "Broken grading function",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/brokenSubmission/info.json
+++ b/testCourse/questions/brokenSubmission/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "d34b6bcd-3f62-4066-8dbf-5abc1d5f022c",
-    "title": "Broken (missing) Submissions",
-    "topic": "Algebra",
-    "tags": ["nnytko2", "sp20", "v3"],
-    "type": "v3"
+  "uuid": "d34b6bcd-3f62-4066-8dbf-5abc1d5f022c",
+  "title": "Broken (missing) Submissions",
+  "topic": "Algebra",
+  "tags": ["nnytko2", "sp20", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/customElement/info.json
+++ b/testCourse/questions/customElement/info.json
@@ -1,6 +1,6 @@
 {
-    "uuid": "15d19db0-7277-46f6-abc6-74a006b039d6",
-    "title": "Demo: Custom element",
-    "topic": "Custom",
-    "type": "v3"
+  "uuid": "15d19db0-7277-46f6-abc6-74a006b039d6",
+  "title": "Demo: Custom element",
+  "topic": "Custom",
+  "type": "v3"
 }

--- a/testCourse/questions/demo/demoNewton-page1/info.json
+++ b/testCourse/questions/demo/demoNewton-page1/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "590dc9ff-fb0b-4346-8650-23c5793fd382",
-    "title": "Newton's law of motion - Intro",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Fa20"],
-    "type": "v3"
+  "uuid": "590dc9ff-fb0b-4346-8650-23c5793fd382",
+  "title": "Newton's law of motion - Intro",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Fa20"],
+  "type": "v3"
 }

--- a/testCourse/questions/demo/demoNewton-page2/info.json
+++ b/testCourse/questions/demo/demoNewton-page2/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "bb95699b-738e-43a1-8171-a29f73d0d264",
-    "title": "Second law",
-    "topic": "Demo",
-    "tags": ["mfsilva", "Fa20"],
-    "type": "v3"
+  "uuid": "bb95699b-738e-43a1-8171-a29f73d0d264",
+  "title": "Second law",
+  "topic": "Demo",
+  "tags": ["mfsilva", "Fa20"],
+  "type": "v3"
 }

--- a/testCourse/questions/differentiatePolynomial/info.json
+++ b/testCourse/questions/differentiatePolynomial/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "16620404-1340-41ef-9897-20687adebaf8",
-    "title": "Differentiate a polynomial function of one variable",
-    "topic": "Calculus",
-    "tags": ["tbretl", "v3"],
-    "type": "v3"
+  "uuid": "16620404-1340-41ef-9897-20687adebaf8",
+  "title": "Differentiate a polynomial function of one variable",
+  "topic": "Calculus",
+  "tags": ["tbretl", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/downloadFile/info.json
+++ b/testCourse/questions/downloadFile/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "0941aa93-15fe-4ce7-ac93-2b41a2a8cf3e",
-    "title": "File download example question",
-    "topic": "Test",
-    "tags": ["tbretl", "v3"],
-    "type": "v3"
+  "uuid": "0941aa93-15fe-4ce7-ac93-2b41a2a8cf3e",
+  "title": "File download example question",
+  "topic": "Test",
+  "tags": ["tbretl", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/externalGrade/alpine/info.json
+++ b/testCourse/questions/externalGrade/alpine/info.json
@@ -1,15 +1,15 @@
 {
-    "uuid": "3f3946e4-ebbd-452f-b1f3-756cb4f3a2f2",
-    "title": "External Grading: Alpine Linux smoke test",
-    "topic": "Autograder",
-    "tags": ["code", "v3"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "External",
-    "externalGradingOptions": {
-        "enabled": true,
-        "image": "alpine:latest",
-        "entrypoint": "/grade/tests/grade.sh",
-        "timeout": 10
-    }
+  "uuid": "3f3946e4-ebbd-452f-b1f3-756cb4f3a2f2",
+  "title": "External Grading: Alpine Linux smoke test",
+  "topic": "Autograder",
+  "tags": ["code", "v3"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "alpine:latest",
+    "entrypoint": "/grade/tests/grade.sh",
+    "timeout": 10
+  }
 }

--- a/testCourse/questions/fossilFuelsRadio/info.json
+++ b/testCourse/questions/fossilFuelsRadio/info.json
@@ -1,26 +1,22 @@
 {
-    "uuid": "58f1d810-b3e6-4683-b47d-d1a47032929b",
-    "title": "Advantages of fossil fuels (radio)",
-    "topic": "Energy",
-    "tags": ["MC", "v2"],
-    "clientFiles": ["client.js", "power-station.jpg"],
-    "type": "MultipleChoice",
-    "options": {
-        "text": "Which of the following is an advantage of fossil fuels relative to renewable energy sources?<img src=\"<% print(questionFile(\"power-station.jpg\")) %>\" width=\"400px\" class=\"img-responsive center-block\" />",
-        "correctAnswers": [
-            "Cheap",
-            "High energy density",
-            "Provide energy on demand"
-        ],
-        "incorrectAnswers": [
-            "Non-polluting",
-            "Low energy density",
-            "Low production of carbon dioxide",
-            "High production of carbon dioxide",
-            "Secure",
-            "Sustainable",
-            "Low energy return"
-        ],
-        "numberAnswers": 5
-    }
+  "uuid": "58f1d810-b3e6-4683-b47d-d1a47032929b",
+  "title": "Advantages of fossil fuels (radio)",
+  "topic": "Energy",
+  "tags": ["MC", "v2"],
+  "clientFiles": ["client.js", "power-station.jpg"],
+  "type": "MultipleChoice",
+  "options": {
+    "text": "Which of the following is an advantage of fossil fuels relative to renewable energy sources?<img src=\"<% print(questionFile(\"power-station.jpg\")) %>\" width=\"400px\" class=\"img-responsive center-block\" />",
+    "correctAnswers": ["Cheap", "High energy density", "Provide energy on demand"],
+    "incorrectAnswers": [
+      "Non-polluting",
+      "Low energy density",
+      "Low production of carbon dioxide",
+      "High production of carbon dioxide",
+      "Secure",
+      "Sustainable",
+      "Low energy return"
+    ],
+    "numberAnswers": 5
+  }
 }

--- a/testCourse/questions/internalGrade/addingNumbers/info.json
+++ b/testCourse/questions/internalGrade/addingNumbers/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "8c4891a6-64d1-4e89-b72d-ad2133f25b2f",
-    "title": "Internal Grading: Adding two numbers",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "8c4891a6-64d1-4e89-b72d-ad2133f25b2f",
+  "title": "Internal Grading: Adding two numbers",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/internalGrade/addingNumbers2/info.json
+++ b/testCourse/questions/internalGrade/addingNumbers2/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "fa1a5009-c878-43c2-9746-8cdeab2e4bb2",
-    "title": "Internal Grading: Adding two numbers (with manual points)",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "fa1a5009-c878-43c2-9746-8cdeab2e4bb2",
+  "title": "Internal Grading: Adding two numbers (with manual points)",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/manualGrade/addingNumbers2/info.json
+++ b/testCourse/questions/manualGrade/addingNumbers2/info.json
@@ -1,8 +1,8 @@
 {
-    "uuid": "6c232924-a6e1-473b-9ae4-1df3d5493afc",
-    "title": "Manual Grading: Adding two numbers (with auto points)",
-    "topic": "Algebra",
-    "gradingMethod": "Manual",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "6c232924-a6e1-473b-9ae4-1df3d5493afc",
+  "title": "Manual Grading: Adding two numbers (with auto points)",
+  "topic": "Algebra",
+  "gradingMethod": "Manual",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/manualGrade/codeUpload/info.json
+++ b/testCourse/questions/manualGrade/codeUpload/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "a218ee9c-fabb-4b23-cdbe-2705952aaf3a",
-    "title": "Manual Grading: Fibonacci function, file upload",
-    "topic": "Manual",
-    "tags": ["code", "v3"],
-    "type": "v3",
-    "singleVariant": true,
-    "gradingMethod": "Manual"
+  "uuid": "a218ee9c-fabb-4b23-cdbe-2705952aaf3a",
+  "title": "Manual Grading: Fibonacci function, file upload",
+  "topic": "Manual",
+  "tags": ["code", "v3"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "Manual"
 }

--- a/testCourse/questions/partialCredit1/info.json
+++ b/testCourse/questions/partialCredit1/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "a3af2408-9d4d-4e38-a9f3-3ad7d23ec601",
-    "title": "Partial credit 1",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "a3af2408-9d4d-4e38-a9f3-3ad7d23ec601",
+  "title": "Partial credit 1",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/partialCredit2/info.json
+++ b/testCourse/questions/partialCredit2/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "af771a22-ce28-4bdf-9fcf-2eb10c7cc18f",
-    "title": "Partial credit 2",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "af771a22-ce28-4bdf-9fcf-2eb10c7cc18f",
+  "title": "Partial credit 2",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/partialCredit3/info.json
+++ b/testCourse/questions/partialCredit3/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "b0e54645-d51e-4581-afe4-9ec4ff1ce9d3",
-    "title": "Partial credit 3",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3"
+  "uuid": "b0e54645-d51e-4581-afe4-9ec4ff1ce9d3",
+  "title": "Partial credit 3",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/partialCredit4_v2/info.json
+++ b/testCourse/questions/partialCredit4_v2/info.json
@@ -1,8 +1,8 @@
 {
-    "uuid": "7c0a303d-9b87-48a8-a968-b062210bae1a",
-    "title": "Partial credit 4 (v2 without partial credit)",
-    "topic": "Algebra",
-    "tags": ["tbretl", "fa17", "tpl101", "v2"],
-    "clientFiles": ["client.js", "question.html", "answer.html", "submission.html"],
-    "type": "Calculation"
+  "uuid": "7c0a303d-9b87-48a8-a968-b062210bae1a",
+  "title": "Partial credit 4 (v2 without partial credit)",
+  "topic": "Algebra",
+  "tags": ["tbretl", "fa17", "tpl101", "v2"],
+  "clientFiles": ["client.js", "question.html", "answer.html", "submission.html"],
+  "type": "Calculation"
 }

--- a/testCourse/questions/partialCredit5_v2_partial/info.json
+++ b/testCourse/questions/partialCredit5_v2_partial/info.json
@@ -1,9 +1,9 @@
 {
-    "uuid": "d3d60b64-491b-4599-80ad-c68fecdb29ec",
-    "title": "Partial credit 5 (v2 with partial credit)",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v2"],
-    "clientFiles": ["client.js", "question.html", "answer.html", "submission.html"],
-    "type": "Calculation",
-    "partialCredit": true
+  "uuid": "d3d60b64-491b-4599-80ad-c68fecdb29ec",
+  "title": "Partial credit 5 (v2 with partial credit)",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v2"],
+  "clientFiles": ["client.js", "question.html", "answer.html", "submission.html"],
+  "type": "Calculation",
+  "partialCredit": true
 }

--- a/testCourse/questions/partialCredit6_no_partial/info.json
+++ b/testCourse/questions/partialCredit6_no_partial/info.json
@@ -1,8 +1,8 @@
 {
-    "uuid": "c74c1b16-73a5-4a36-b3e0-1cf71b28e39c",
-    "title": "Partial credit 6 (v3 question with partial credit disabled)",
-    "topic": "Algebra",
-    "tags": ["mwest", "fa17", "tpl101", "v3"],
-    "type": "v3",
-    "partialCredit": false
+  "uuid": "c74c1b16-73a5-4a36-b3e0-1cf71b28e39c",
+  "title": "Partial credit 6 (v3 question with partial credit disabled)",
+  "topic": "Algebra",
+  "tags": ["mwest", "fa17", "tpl101", "v3"],
+  "type": "v3",
+  "partialCredit": false
 }

--- a/testCourse/questions/positionTimeGraph/info.json
+++ b/testCourse/questions/positionTimeGraph/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "7c4ccac6-1031-43ed-a673-feb64c2f8bbf",
-    "title": "Understanding motion from a position-time graph",
-    "topic": "Vectors",
-    "tags": ["MC", "v3"],
-    "type": "v3"
+  "uuid": "7c4ccac6-1031-43ed-a673-feb64c2f8bbf",
+  "title": "Understanding motion from a position-time graph",
+  "topic": "Vectors",
+  "tags": ["MC", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/prairieDrawFigure/info.json
+++ b/testCourse/questions/prairieDrawFigure/info.json
@@ -1,11 +1,7 @@
 {
-    "uuid": "6a636a73-2ace-4666-9f75-5ba015844638",
-    "title": "Element pl-prairiedraw-figure: Display of dynamic figures",
-    "topic": "Element",
-    "type": "v3",
-    "tags": [
-        "v3",
-		"ressick2",
-        "Su18"
-    ]
+  "uuid": "6a636a73-2ace-4666-9f75-5ba015844638",
+  "title": "Element pl-prairiedraw-figure: Display of dynamic figures",
+  "topic": "Element",
+  "type": "v3",
+  "tags": ["v3", "ressick2", "Su18"]
 }

--- a/testCourse/questions/subfolder/nestedQuestion/info.json
+++ b/testCourse/questions/subfolder/nestedQuestion/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "5fa17ff4-20a9-4e93-af03-f4e52b4cc485",
-    "title": "Nested question",
-    "topic": "Algebra",
-    "tags": ["nnytko2", "sp20", "v3"],
-    "type": "v3"
+  "uuid": "5fa17ff4-20a9-4e93-af03-f4e52b4cc485",
+  "title": "Nested question",
+  "topic": "Algebra",
+  "tags": ["nnytko2", "sp20", "v3"],
+  "type": "v3"
 }

--- a/testCourse/questions/threeJS/info.json
+++ b/testCourse/questions/threeJS/info.json
@@ -1,7 +1,7 @@
 {
-    "uuid": "e64f7842-6fee-48dd-93f3-5bd60f286723",
-    "title": "Element pl-threejs: Display 3D objects and input transformations",
-    "topic": "Element",
-    "tags": ["tbretl"],
-    "type": "v3"
+  "uuid": "e64f7842-6fee-48dd-93f3-5bd60f286723",
+  "title": "Element pl-threejs: Display 3D objects and input transformations",
+  "topic": "Element",
+  "tags": ["tbretl"],
+  "type": "v3"
 }

--- a/testCourse/questions/v2checkbox/info.json
+++ b/testCourse/questions/v2checkbox/info.json
@@ -1,24 +1,14 @@
 {
-    "uuid": "b1533f99-f8e3-4495-b31c-d479096d40ae",
-    "title": "Checkbox question (v2)",
-    "topic": "Test",
-    "type": "Checkbox",
-    "options": {
-      "text": "Check the TRUE statements.",
-      "correctAnswers": [
-        "True",
-        "Correct",
-        "Yes",
-        "$1$"
-      ],
-      "incorrectAnswers": [
-        "False",
-        "Incorrect",
-        "No",
-        "$0$"
-      ],
-      "numberAnswers": 8,
-      "minCorrectAnswers": 4,
-      "maxCorrectAnswers": 4
-    }
+  "uuid": "b1533f99-f8e3-4495-b31c-d479096d40ae",
+  "title": "Checkbox question (v2)",
+  "topic": "Test",
+  "type": "Checkbox",
+  "options": {
+    "text": "Check the TRUE statements.",
+    "correctAnswers": ["True", "Correct", "Yes", "$1$"],
+    "incorrectAnswers": ["False", "Incorrect", "No", "$0$"],
+    "numberAnswers": 8,
+    "minCorrectAnswers": 4,
+    "maxCorrectAnswers": 4
+  }
 }

--- a/testCourse/questions/workspace/info.json
+++ b/testCourse/questions/workspace/info.json
@@ -1,24 +1,17 @@
 {
-    "uuid": "1f0966f5-f417-4df6-a104-a19e5494ee64",
-    "title": "Workspace test",
-    "topic": "Workspace",
-    "tags": [
-        "su20",
-        "nnytko2",
-        "tyang15"
-    ],
-    "type": "v3",
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-xtermjs",
-        "port": 8080,
-        "home": "/home/prairie",
-        "gradedFiles": [
-            "starter_code.h",
-            "starter_code.c"
-        ],
-        "environment": {
-            "FOO": "bar baz",
-            "ILL": "ini"
-        }
+  "uuid": "1f0966f5-f417-4df6-a104-a19e5494ee64",
+  "title": "Workspace test",
+  "topic": "Workspace",
+  "tags": ["su20", "nnytko2", "tyang15"],
+  "type": "v3",
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-xtermjs",
+    "port": 8080,
+    "home": "/home/prairie",
+    "gradedFiles": ["starter_code.h", "starter_code.c"],
+    "environment": {
+      "FOO": "bar baz",
+      "ILL": "ini"
     }
+  }
 }

--- a/testCourse/questions/workspaceInvalidDynamicFiles/info.json
+++ b/testCourse/questions/workspaceInvalidDynamicFiles/info.json
@@ -1,13 +1,13 @@
 {
-    "uuid": "d7e80f01-e4ea-406e-9d64-f5fffcf7cb49",
-    "title": "Workspace test with invalid files",
-    "topic": "Workspace",
-    "tags": [ "jonatan", "workspace" ],
-    "type": "v3",
-    "workspaceOptions": {
-        "image": "prairielearn/workspace-xtermjs",
-        "port": 8080,
-        "home": "/home/prairie",
-        "gradedFiles": []
-    }
+  "uuid": "d7e80f01-e4ea-406e-9d64-f5fffcf7cb49",
+  "title": "Workspace test with invalid files",
+  "topic": "Workspace",
+  "tags": ["jonatan", "workspace"],
+  "type": "v3",
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-xtermjs",
+    "port": 8080,
+    "home": "/home/prairie",
+    "gradedFiles": []
+  }
 }


### PR DESCRIPTION
Careful hand formatting of JSON will become less relevant as we move towards UI editors for JSON config files. This moves us in that direction by auto-formatting all JSON files in `testCourse` and `exampleCourse`.

I'm specifically requesting review from a lot of the core team to get a variety of viewpoints on this.

Note that this isn't perfect: currently, JSON files are generally formatted with `JSON.stringify(..., null, 2)` when PL writes them to disk. This means that editing one of these files with a PL GUI editor will result in formatting differences. IMO we should unconditionally use Prettier as a library to format JSON files when they're edited "automatically" by PL (as opposed to in the Ace file editor).

Once this lands, I'll open a followup with a PR that adds this commit to `.git-blame-ignore-revs` and updates `.prettierignore` to no longer forbid formatting of these files.