### PR TITLE
Improve markup/styling of user menu

### DIFF
--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -101,9 +101,9 @@
 
           <% if (locals.authn_is_administrator) { %>
 
-            <a class="dropdown-item" id="navbar-administrator-toggle">
+            <button type="button" class="dropdown-item" id="navbar-administrator-toggle">
               <% if (locals.access_as_administrator) { %>Turn off administrator access<% } else { %>Turn on administrator access<% } %>
-            </a>
+            </button>
 
             <div class="dropdown-divider"></div>
 
@@ -176,8 +176,8 @@
 
             <a class="dropdown-item" href="<%= instructorLink %>" id="navbar-user-view-authn-instructor">
               <div class="d-flex flex-row justify-content-left">
-                <div class="col-1 px-0"><% if (authnViewTypeMenuChecked == 'instructor') { %>&check;<% } %></div>
-                <div class="col pl-0">
+                <span class="<% if (authnViewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
+                <div class="pl-3">
                   <% if (locals.authz_data?.overrides && authnViewTypeMenuChecked == 'instructor') { %>Modified staff<% } else { %>Staff<% } %>
                   view <span class="badge badge-success">staff</span>
                 </div>
@@ -186,15 +186,15 @@
 
             <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-authn-student">
               <div class="d-flex flex-row justify-content-left">
-                <div class="col-1 px-0"><% if (authnViewTypeMenuChecked == 'student') { %>&check;<% } %></div>
-                <div class="col pl-0">Student view <span class="badge badge-warning">student</span></div>
+                <span class="<% if (authnViewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
+                <div class="pl-3">Student view <span class="badge badge-warning">student</span></div>
               </div>
             </a>
 
             <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-authn-student-no-rules">
               <div class="d-flex flex-row justify-content-left">
-                <div class="col-1 px-0"><% if (authnViewTypeMenuChecked == 'student-no-rules') { %>&check;<% } %></div>
-                <div class="col pl-0">Student view without access restrictions <span class="badge badge-warning">student</span></div>
+                <span class="<% if (authnViewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
+                <div class="pl-3">Student view without access restrictions <span class="badge badge-warning">student</span></div>
               </div>
             </a>
 

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -227,23 +227,23 @@
               <% if (authz_data.user_with_requested_uid_has_instructor_access_to_course_instance) { %>
                 <a class="dropdown-item" href="<%= instructorLink %>" id="navbar-user-view-instructor">
                   <div class="d-flex flex-row justify-content-left">
-                    <div class="col-1 px-0"><% if (viewTypeMenuChecked == 'instructor') { %>&check;<% } %></div>
-                    <div class="col pl-0">Staff view</div>
+                    <span class="<% if (viewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
+                    <div class="pl-3">Staff view</div>
                   </div>
                 </a>
               <% } %>
 
               <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-student">
                 <div class="d-flex flex-row justify-content-left">
-                  <div class="col-1 px-0"><% if (viewTypeMenuChecked == 'student') { %>&check;<% } %></div>
-                  <div class="col pl-0">Student view</div>
+                  <span class="<% if (viewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
+                  <div class="pl-3">Student view</div>
                 </div>
               </a>
 
               <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-student-no-rules">
                 <div class="d-flex flex-row justify-content-left">
-                  <div class="col-1 px-0"><% if (viewTypeMenuChecked == 'student-no-rules') { %>&check;<% } %></div>
-                  <div class="col pl-0">Student view without access restrictions</div>
+                  <span class="<% if (viewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
+                  <div class="pl-3">Student view without access restrictions</div>
                 </div>
               </a>
 


### PR DESCRIPTION
Changes in Bootstrap v5 result in the existing markup overflowing out of the dropdown container:

<img width="417" alt="Screenshot 2024-07-22 at 09 35 31" src="https://github.com/user-attachments/assets/2d88d4a8-bfb0-49ad-95d3-5521f6bc9799">

This updated markup improves things in a backwards-compatible way: rather than (mis-)using the `col*` classes to make space when an item is not checked, it now uses `visibility: hidden` to show/hide the checkbox as appropriate.