### PR TITLE
Remove invalid justify-content-left class

### DIFF
--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -175,7 +175,7 @@
             <h6 class="dropdown-header"><%= headingAuthnViewTypeMenu %></h6>
 
             <a class="dropdown-item" href="<%= instructorLink %>" id="navbar-user-view-authn-instructor">
-              <div class="d-flex flex-row justify-content-left">
+              <div class="d-flex flex-row">
                 <span class="<% if (authnViewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
                 <div class="pl-3">
                   <% if (locals.authz_data?.overrides && authnViewTypeMenuChecked == 'instructor') { %>Modified staff<% } else { %>Staff<% } %>
@@ -185,14 +185,14 @@
             </a>
 
             <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-authn-student">
-              <div class="d-flex flex-row justify-content-left">
+              <div class="d-flex flex-row">
                 <span class="<% if (authnViewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
                 <div class="pl-3">Student view <span class="badge badge-warning">student</span></div>
               </div>
             </a>
 
             <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-authn-student-no-rules">
-              <div class="d-flex flex-row justify-content-left">
+              <div class="d-flex flex-row">
                 <span class="<% if (authnViewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
                 <div class="pl-3">Student view without access restrictions <span class="badge badge-warning">student</span></div>
               </div>
@@ -226,7 +226,7 @@
 
               <% if (authz_data.user_with_requested_uid_has_instructor_access_to_course_instance) { %>
                 <a class="dropdown-item" href="<%= instructorLink %>" id="navbar-user-view-instructor">
-                  <div class="d-flex flex-row justify-content-left">
+                  <div class="d-flex flex-row">
                     <span class="<% if (viewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
                     <div class="pl-3">Staff view</div>
                   </div>
@@ -234,14 +234,14 @@
               <% } %>
 
               <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-student">
-                <div class="d-flex flex-row justify-content-left">
+                <div class="d-flex flex-row">
                   <span class="<% if (viewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
                   <div class="pl-3">Student view</div>
                 </div>
               </a>
 
               <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-student-no-rules">
-                <div class="d-flex flex-row justify-content-left">
+                <div class="d-flex flex-row">
                   <span class="<% if (viewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
                   <div class="pl-3">Student view without access restrictions</div>
                 </div>

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -175,27 +175,21 @@
             <h6 class="dropdown-header"><%= headingAuthnViewTypeMenu %></h6>
 
             <a class="dropdown-item" href="<%= instructorLink %>" id="navbar-user-view-authn-instructor">
-              <div class="d-flex flex-row">
-                <span class="<% if (authnViewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
-                <div class="pl-3">
-                  <% if (locals.authz_data?.overrides && authnViewTypeMenuChecked == 'instructor') { %>Modified staff<% } else { %>Staff<% } %>
-                  view <span class="badge badge-success">staff</span>
-                </div>
-              </div>
+              <span class="<% if (authnViewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
+              <span class="pl-3">
+                <% if (locals.authz_data?.overrides && authnViewTypeMenuChecked == 'instructor') { %>Modified staff<% } else { %>Staff<% } %>
+                view <span class="badge badge-success">staff</span>
+              </span>
             </a>
 
             <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-authn-student">
-              <div class="d-flex flex-row">
-                <span class="<% if (authnViewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
-                <div class="pl-3">Student view <span class="badge badge-warning">student</span></div>
-              </div>
+              <span class="<% if (authnViewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
+              <span class="pl-3">Student view <span class="badge badge-warning">student</span></span>
             </a>
 
             <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-authn-student-no-rules">
-              <div class="d-flex flex-row">
-                <span class="<% if (authnViewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
-                <div class="pl-3">Student view without access restrictions <span class="badge badge-warning">student</span></div>
-              </div>
+              <span class="<% if (authnViewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
+              <span class="pl-3">Student view without access restrictions <span class="badge badge-warning">student</span></span>
             </a>
 
             <% if (authz_data.authn_user.uid != authz_data.user.uid) {
@@ -226,25 +220,19 @@
 
               <% if (authz_data.user_with_requested_uid_has_instructor_access_to_course_instance) { %>
                 <a class="dropdown-item" href="<%= instructorLink %>" id="navbar-user-view-instructor">
-                  <div class="d-flex flex-row">
-                    <span class="<% if (viewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
-                    <div class="pl-3">Staff view</div>
-                  </div>
+                  <span class="<% if (viewTypeMenuChecked != 'instructor') { %>invisible<% } %>">&check;</span>
+                  <span class="pl-3">Staff view</span>
                 </a>
               <% } %>
 
               <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-student">
-                <div class="d-flex flex-row">
-                  <span class="<% if (viewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
-                  <div class="pl-3">Student view</div>
-                </div>
+                <span class="<% if (viewTypeMenuChecked != 'student') { %>invisible<% } %>">&check;</span>
+                <span class="pl-3">Student view</span>
               </a>
 
               <a class="dropdown-item" href="<%= studentLink %>" id="navbar-user-view-student-no-rules">
-                <div class="d-flex flex-row">
-                  <span class="<% if (viewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
-                  <div class="pl-3">Student view without access restrictions</div>
-                </div>
+                <span class="<% if (viewTypeMenuChecked != 'student-no-rules') { %>invisible<% } %>">&check;</span>
+                <span class="pl-3">Student view without access restrictions</span>
               </a>
 
             <% } %>


### PR DESCRIPTION
`left` is not a valid `justify-content` value and thus the `justify-content-left` doesn't even exist. This could be replaced with `justify-content-start` but that doesn't seem to be necessary.