### PR TITLE
Reformat JSON to be compact

### DIFF
--- a/exampleCourse/courseInstances/SectionA/assessments/exam/groupExam/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/groupExam/infoAssessment.json
@@ -11,33 +11,13 @@
   "studentGroupJoin": true,
   "studentGroupLeave": true,
   "groupRoles": [
-    {
-      "name": "Manager",
-      "minimum": 1,
-      "maximum": 1,
-      "canAssignRoles": true
-    },
-    {
-      "name": "Recorder",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Reflector",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Contributor"
-    }
+    { "name": "Manager", "minimum": 1, "maximum": 1, "canAssignRoles": true },
+    { "name": "Recorder", "minimum": 1, "maximum": 1 },
+    { "name": "Reflector", "minimum": 1, "maximum": 1 },
+    { "name": "Contributor" }
   ],
   "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100,
-      "timeLimitMin": 50,
-      "showClosedAssessment": false
-    }
+    { "mode": "Public", "credit": 100, "timeLimitMin": 50, "showClosedAssessment": false }
   ],
   "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
   "canSubmit": ["Recorder"],

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json
@@ -17,15 +17,9 @@
     }
   ],
   "zones": [
-    {
-      "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }]
-    },
-    {
-      "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }]
-    },
-    {
-      "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }]
-    },
+    { "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }] },
+    { "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }] },
+    { "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }] },
     {
       "questions": [
         {

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedbackPrairieTest/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedbackPrairieTest/infoAssessment.json
@@ -5,27 +5,13 @@
   "set": "Exam",
   "number": "0",
   "allowAccess": [
-    {
-      "mode": "Exam",
-      "examUuid": "9c1b3e5c-9caa-4c82-9445-ac564d51c40d",
-      "credit": 100
-    },
-    {
-      "mode": "Exam",
-      "examUuid": "2b26b075-4c91-4fa0-8f1e-219326f4d046",
-      "credit": 100
-    }
+    { "mode": "Exam", "examUuid": "9c1b3e5c-9caa-4c82-9445-ac564d51c40d", "credit": 100 },
+    { "mode": "Exam", "examUuid": "2b26b075-4c91-4fa0-8f1e-219326f4d046", "credit": 100 }
   ],
   "zones": [
-    {
-      "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }]
-    },
-    {
-      "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }]
-    },
-    {
-      "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }]
-    },
+    { "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }] },
+    { "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }] },
+    { "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }] },
     {
       "questions": [
         {

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/practice/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/practice/infoAssessment.json
@@ -20,15 +20,9 @@
     }
   ],
   "zones": [
-    {
-      "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }]
-    },
-    {
-      "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }]
-    },
-    {
-      "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }]
-    },
+    { "questions": [{ "id": "template/number-input/random-prompt", "points": [3, 1] }] },
+    { "questions": [{ "id": "template/matrix-component-input/random-graph", "points": [3, 1] }] },
+    { "questions": [{ "id": "demo/annotated/engCircuit", "points": [5, 4, 3, 2, 1] }] },
     {
       "questions": [
         {

--- a/exampleCourse/courseInstances/SectionA/assessments/exam/realTimeGradingDisabled/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/exam/realTimeGradingDisabled/infoAssessment.json
@@ -6,12 +6,7 @@
   "number": "2",
   "allowRealTimeGrading": false,
   "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100,
-      "timeLimitMin": 3,
-      "showClosedAssessment": false
-    }
+    { "mode": "Public", "credit": 100, "timeLimitMin": 3, "showClosedAssessment": false }
   ],
   "zones": [
     {

--- a/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/infoAssessment.json
@@ -12,12 +12,7 @@
   "studentGroupCreate": true,
   "studentGroupJoin": true,
   "studentGroupLeave": true,
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "title": " How Markov chains work?",

--- a/exampleCourse/courseInstances/SectionA/assessments/groupWork/template/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/groupWork/template/infoAssessment.json
@@ -13,32 +13,12 @@
   "studentGroupJoin": true,
   "studentGroupLeave": true,
   "groupRoles": [
-    {
-      "name": "Manager",
-      "minimum": 1,
-      "maximum": 1,
-      "canAssignRoles": true
-    },
-    {
-      "name": "Recorder",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Reflector",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Contributor"
-    }
+    { "name": "Manager", "minimum": 1, "maximum": 1, "canAssignRoles": true },
+    { "name": "Recorder", "minimum": 1, "maximum": 1 },
+    { "name": "Reflector", "minimum": 1, "maximum": 1 },
+    { "name": "Contributor" }
   ],
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "title": "Fundamental questions",

--- a/exampleCourse/courseInstances/SectionA/assessments/worksheet/template/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/worksheet/template/infoAssessment.json
@@ -5,12 +5,7 @@
   "set": "Worksheet",
   "module": "AnotherModule",
   "number": "1",
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "questions": [

--- a/exampleCourse/elementExtensions/extendable-element/example-extension/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/example-extension/info.json
@@ -1,6 +1,4 @@
 {
   "controller": "example-extension.py",
-  "dependencies": {
-    "extensionStyles": ["example-extension.css"]
-  }
+  "dependencies": { "extensionStyles": ["example-extension.css"] }
 }

--- a/exampleCourse/elementExtensions/extendable-element/extension-clientfiles/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/extension-clientfiles/info.json
@@ -1,3 +1,1 @@
-{
-  "controller": "extension-clientfiles.py"
-}
+{ "controller": "extension-clientfiles.py" }

--- a/exampleCourse/elementExtensions/extendable-element/extension-cssjs/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/extension-cssjs/info.json
@@ -4,7 +4,5 @@
     "extensionStyles": ["extension-cssjs.css"],
     "extensionScripts": ["extension-cssjs.js"]
   },
-  "dynamicDependencies": {
-    "nodeModulesScripts": { "d3": "d3/dist/d3.min.js" }
-  }
+  "dynamicDependencies": { "nodeModulesScripts": { "d3": "d3/dist/d3.min.js" } }
 }

--- a/exampleCourse/elementExtensions/extendable-element/extension-fileio/info.json
+++ b/exampleCourse/elementExtensions/extendable-element/extension-fileio/info.json
@@ -1,3 +1,1 @@
-{
-  "controller": "extension-fileio.py"
-}
+{ "controller": "extension-fileio.py" }

--- a/exampleCourse/elementExtensions/pl-drawing/example-logo/info.json
+++ b/exampleCourse/elementExtensions/pl-drawing/example-logo/info.json
@@ -1,6 +1,1 @@
-{
-  "controller": "example-logo.py",
-  "dependencies": {
-    "extensionScripts": ["example-logo.js"]
-  }
-}
+{ "controller": "example-logo.py", "dependencies": { "extensionScripts": ["example-logo.js"] } }

--- a/exampleCourse/elementExtensions/pl-graph/edge-inc-matrix/info.json
+++ b/exampleCourse/elementExtensions/pl-graph/edge-inc-matrix/info.json
@@ -1,3 +1,1 @@
-{
-  "controller": "edge-inc-matrix.py"
-}
+{ "controller": "edge-inc-matrix.py" }

--- a/exampleCourse/elements/extendable-element/info.json
+++ b/exampleCourse/elements/extendable-element/info.json
@@ -1,3 +1,1 @@
-{
-  "controller": "extendable-element.py"
-}
+{ "controller": "extendable-element.py" }

--- a/exampleCourse/infoCourse.json
+++ b/exampleCourse/infoCourse.json
@@ -2,9 +2,7 @@
   "uuid": "fcc5282c-a752-4146-9bd6-ee19aac53fc5",
   "name": "XC 101",
   "title": "Example Course",
-  "options": {
-    "useNewQuestionRenderer": true
-  },
+  "options": { "useNewQuestionRenderer": true },
   "comment": "Add additional assessment sets here. Default ones are listed here: https://prairielearn.readthedocs.io/en/latest/course/#assessment-sets.",
   "assessmentSets": [
     {

--- a/exampleCourse/questions/demo/workspace/xtermjs/info.json
+++ b/exampleCourse/questions/demo/workspace/xtermjs/info.json
@@ -6,10 +6,7 @@
   "type": "v3",
   "singleVariant": true,
   "workspaceOptions": {
-    "comment": {
-      "why": "testing comments in workspace blocks",
-      "also": "testing object comments"
-    },
+    "comment": { "why": "testing comments in workspace blocks", "also": "testing object comments" },
     "image": "prairielearn/workspace-xtermjs",
     "port": 8080,
     "home": "/home/student",

--- a/testCourse/courseInstances/Sp15/assessments/exam10-gradeRate/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam10-gradeRate/infoAssessment.json
@@ -5,13 +5,7 @@
   "set": "Exam",
   "number": "10",
   "gradeRateMinutes": 10,
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100,
-      "timeLimitMin": 50
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100, "timeLimitMin": 50 }],
   "zones": [
     {
       "questions": [

--- a/testCourse/courseInstances/Sp15/assessments/exam12-sequentialQuestions/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam12-sequentialQuestions/infoAssessment.json
@@ -1,12 +1,10 @@
 {
   "uuid": "d7bcc376-4f23-41d6-9f71-87dd1d23991b",
   "allowAccess": [{ "mode": "Public", "credit": 100 }],
-
   "title": "Force student to complete questions in-order",
   "type": "Exam",
   "set": "Exam",
   "number": "12",
-
   "advanceScorePerc": 100,
   "zones": [
     {
@@ -23,19 +21,12 @@
       "advanceScorePerc": 25,
       "questions": [{ "id": "partialCredit3", "points": [1, 1, 1, 1], "advanceScorePerc": 60 }]
     },
-    {
-      "advanceScorePerc": 75,
-      "questions": [{ "id": "partialCredit2", "points": 1 }]
-    },
-    {
-      "questions": [{ "id": "partialCredit4_v2", "points": 1, "advanceScorePerc": 0 }]
-    },
+    { "advanceScorePerc": 75, "questions": [{ "id": "partialCredit2", "points": 1 }] },
+    { "questions": [{ "id": "partialCredit4_v2", "points": 1, "advanceScorePerc": 0 }] },
     {
       "advanceScorePerc": 35,
       "questions": [{ "id": "addVectors", "points": 1, "advanceScorePerc": 30 }]
     },
-    {
-      "questions": [{ "id": "addNumbers", "points": 1 }]
-    }
+    { "questions": [{ "id": "addNumbers", "points": 1 }] }
   ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam13-disableHonorCode/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam13-disableHonorCode/infoAssessment.json
@@ -13,10 +13,5 @@
       "endDate": "2300-07-10T23:59:59"
     }
   ],
-  "zones": [
-    {
-      "title": "Questions",
-      "questions": [{ "id": "addNumbers", "points": [5, 3, 1] }]
-    }
-  ]
+  "zones": [{ "title": "Questions", "questions": [{ "id": "addNumbers", "points": [5, 3, 1] }] }]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
@@ -10,12 +10,7 @@
   "studentGroupCreate": true,
   "studentGroupJoin": true,
   "studentGroupLeave": true,
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "title": "Hard questions",

--- a/testCourse/courseInstances/Sp15/assessments/exam15-breakVariants/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam15-breakVariants/infoAssessment.json
@@ -5,12 +5,7 @@
   "set": "Exam",
   "number": "15",
   "requireHonorCode": false,
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "title": "Questions",

--- a/testCourse/courseInstances/Sp15/assessments/exam16-groupWorkRoles/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam16-groupWorkRoles/infoAssessment.json
@@ -12,32 +12,12 @@
   "studentGroupLeave": true,
   "shuffleQuestions": false,
   "groupRoles": [
-    {
-      "name": "Manager",
-      "minimum": 1,
-      "maximum": 1,
-      "canAssignRoles": true
-    },
-    {
-      "name": "Recorder",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Reflector",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Contributor"
-    }
+    { "name": "Manager", "minimum": 1, "maximum": 1, "canAssignRoles": true },
+    { "name": "Recorder", "minimum": 1, "maximum": 1 },
+    { "name": "Reflector", "minimum": 1, "maximum": 1 },
+    { "name": "Contributor" }
   ],
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
   "zones": [
     {

--- a/testCourse/courseInstances/Sp15/assessments/exam5-perZoneGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam5-perZoneGrading/infoAssessment.json
@@ -17,30 +17,16 @@
     {
       "title": "Questions to test maxPoints",
       "maxPoints": 5,
-      "questions": [
-        {
-          "id": "partialCredit1",
-          "points": [10, 5, 1]
-        }
-      ]
+      "questions": [{ "id": "partialCredit1", "points": [10, 5, 1] }]
     },
     {
       "title": "Questions to test maxPoints and bestQuestions together",
       "bestQuestions": 2,
       "maxPoints": 15,
       "questions": [
-        {
-          "id": "partialCredit2",
-          "points": [10, 5, 1]
-        },
-        {
-          "id": "partialCredit3",
-          "points": [15, 10, 5, 1]
-        },
-        {
-          "id": "partialCredit4_v2",
-          "points": [20, 15, 10, 5, 1]
-        }
+        { "id": "partialCredit2", "points": [10, 5, 1] },
+        { "id": "partialCredit3", "points": [15, 10, 5, 1] },
+        { "id": "partialCredit4_v2", "points": [20, 15, 10, 5, 1] }
       ]
     }
   ]

--- a/testCourse/courseInstances/Sp15/assessments/exam7-modePublic/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam7-modePublic/infoAssessment.json
@@ -4,12 +4,7 @@
   "title": "Verify Exam Mode Lacks 'Waiting for a Proctor'",
   "set": "Exam",
   "number": "7",
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "title": "Hard questions",

--- a/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
@@ -6,12 +6,7 @@
   "number": "8",
   "allowRealTimeGrading": false,
   "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100,
-      "timeLimitMin": 50,
-      "showClosedAssessment": false
-    }
+    { "mode": "Public", "credit": 100, "timeLimitMin": 50, "showClosedAssessment": false }
   ],
   "zones": [
     {

--- a/testCourse/courseInstances/Sp15/assessments/hw1-automaticTestSuite/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw1-automaticTestSuite/infoAssessment.json
@@ -5,11 +5,7 @@
   "set": "Homework",
   "number": "1",
   "module": "Module1",
-  "allowAccess": [
-    {
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "credit": 100 }],
   "zones": [
     {
       "questions": [

--- a/testCourse/courseInstances/Sp15/assessments/hw4-perzonegrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw4-perzonegrading/infoAssessment.json
@@ -17,33 +17,15 @@
     {
       "title": "Questions to test maxPoints",
       "maxPoints": 7,
-      "questions": [
-        {
-          "id": "partialCredit4_v2",
-          "points": 4,
-          "maxPoints": 8
-        }
-      ]
+      "questions": [{ "id": "partialCredit4_v2", "points": 4, "maxPoints": 8 }]
     },
     {
       "title": "Questions to test bestQuestions",
       "bestQuestions": 1,
       "questions": [
-        {
-          "id": "partialCredit1",
-          "points": 5,
-          "maxPoints": 30
-        },
-        {
-          "id": "partialCredit2",
-          "points": 5,
-          "maxPoints": 40
-        },
-        {
-          "id": "partialCredit3",
-          "points": 5,
-          "maxPoints": 50
-        }
+        { "id": "partialCredit1", "points": 5, "maxPoints": 30 },
+        { "id": "partialCredit2", "points": 5, "maxPoints": 40 },
+        { "id": "partialCredit3", "points": 5, "maxPoints": 50 }
       ]
     }
   ]

--- a/testCourse/courseInstances/Sp15/assessments/hw5-templateGroupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw5-templateGroupWork/infoAssessment.json
@@ -12,25 +12,10 @@
   "studentGroupJoin": true,
   "studentGroupLeave": true,
   "groupRoles": [
-    {
-      "name": "Manager",
-      "minimum": 1,
-      "maximum": 1,
-      "canAssignRoles": true
-    },
-    {
-      "name": "Recorder",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Reflector",
-      "minimum": 1,
-      "maximum": 1
-    },
-    {
-      "name": "Contributor"
-    }
+    { "name": "Manager", "minimum": 1, "maximum": 1, "canAssignRoles": true },
+    { "name": "Recorder", "minimum": 1, "maximum": 1 },
+    { "name": "Reflector", "minimum": 1, "maximum": 1 },
+    { "name": "Contributor" }
   ],
   "allowAccess": [
     {
@@ -45,11 +30,7 @@
       "startDate": "2019-01-28T00:00:01",
       "endDate": "2019-01-30T23:59:59"
     },
-    {
-      "mode": "Public",
-      "credit": 0,
-      "startDate": "2019-01-30T00:00:01"
-    }
+    { "mode": "Public", "credit": 0, "startDate": "2019-01-30T00:00:01" }
   ],
   "canView": ["Manager", "Reflector", "Recorder", "Contributor"],
   "zones": [

--- a/testCourse/courseInstances/Sp15/assessments/hw6-templateGroupWork2/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw6-templateGroupWork2/infoAssessment.json
@@ -23,11 +23,7 @@
       "startDate": "2019-01-28T00:00:01",
       "endDate": "2019-01-30T23:59:59"
     },
-    {
-      "mode": "Public",
-      "credit": 0,
-      "startDate": "2019-01-30T00:00:01"
-    }
+    { "mode": "Public", "credit": 0, "startDate": "2019-01-30T00:00:01" }
   ],
   "zones": [
     {

--- a/testCourse/courseInstances/Sp15/assessments/hw7-bonusPoints/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw7-bonusPoints/infoAssessment.json
@@ -6,12 +6,7 @@
   "number": "7",
   "maxPoints": 10,
   "maxBonusPoints": 2,
-  "allowAccess": [
-    {
-      "mode": "Public",
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "mode": "Public", "credit": 100 }],
   "zones": [
     {
       "questions": [

--- a/testCourse/courseInstances/Sp15/assessments/hw8-activeAccessRestriction/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw8-activeAccessRestriction/infoAssessment.json
@@ -5,21 +5,9 @@
   "set": "Homework",
   "number": "8",
   "allowAccess": [
-    {
-      "startDate": "2020-01-01T00:00:01Z",
-      "endDate": "2020-12-31T23:59:59Z",
-      "credit": 100
-    },
-    {
-      "startDate": "2030-01-01T00:00:01Z",
-      "endDate": "2030-12-31T23:59:59Z",
-      "credit": 75
-    },
-    {
-      "startDate": "2000-01-01T00:00:01Z",
-      "endDate": "2024-12-31T23:59:59Z",
-      "active": false
-    },
+    { "startDate": "2020-01-01T00:00:01Z", "endDate": "2020-12-31T23:59:59Z", "credit": 100 },
+    { "startDate": "2030-01-01T00:00:01Z", "endDate": "2030-12-31T23:59:59Z", "credit": 75 },
+    { "startDate": "2000-01-01T00:00:01Z", "endDate": "2024-12-31T23:59:59Z", "active": false },
     {
       "startDate": "2025-01-01T00:00:01Z",
       "endDate": "2039-12-31T23:59:59Z",

--- a/testCourse/courseInstances/Sp15/assessments/hw9-internalExternalManual/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw9-internalExternalManual/infoAssessment.json
@@ -4,11 +4,7 @@
   "title": "Homework for Internal, External, Manual grading methods",
   "set": "Homework",
   "number": "9",
-  "allowAccess": [
-    {
-      "credit": 100
-    }
-  ],
+  "allowAccess": [{ "credit": 100 }],
   "zones": [
     {
       "comments": "Generic points, use default grading method",

--- a/testCourse/courseInstances/Sp15/infoCourseInstance.json
+++ b/testCourse/courseInstances/Sp15/infoCourseInstance.json
@@ -3,10 +3,6 @@
   "shortName": "Sp15",
   "longName": "Spring 2015",
   "allowAccess": [
-    {
-      "institution": "Any",
-      "startDate": "1800-01-19T00:00:01",
-      "endDate": "2400-05-13T23:59:59"
-    }
+    { "institution": "Any", "startDate": "1800-01-19T00:00:01", "endDate": "2400-05-13T23:59:59" }
   ]
 }

--- a/testCourse/infoCourse.json
+++ b/testCourse/infoCourse.json
@@ -2,9 +2,7 @@
   "uuid": "28760b11-beb1-4507-bb0a-a15bc8eaf091",
   "name": "QA 101",
   "title": "Test Course",
-  "options": {
-    "useNewQuestionRenderer": true
-  },
+  "options": { "useNewQuestionRenderer": true },
   "assessmentSets": [],
   "assessmentModules": [
     { "name": "Module1", "heading": "Module 1" },

--- a/testCourse/questions/workspace/info.json
+++ b/testCourse/questions/workspace/info.json
@@ -9,9 +9,6 @@
     "port": 8080,
     "home": "/home/prairie",
     "gradedFiles": ["starter_code.h", "starter_code.c"],
-    "environment": {
-      "FOO": "bar baz",
-      "ILL": "ini"
-    }
+    "environment": { "FOO": "bar baz", "ILL": "ini" }
   }
 }


### PR DESCRIPTION
This PR aims to pick a truly canonical formatting for our JSON files.

Background: https://prettier.io/docs/en/rationale#multi-line-objects is causing grief with JSON (auto-)formatting. Things are fine-ish when using the file-based JSON editor, all the usual "respect newlines when they already exist" things work correctly. However, things are not ok when programmatically editing JSON. we need to get from a JS object to JSON in order to have something for Prettier to format. There are two ways to do this:
- `JSON.stringify(obj)` produces compact JSON (no newlines). Prettier will then avoid introducing newlines unless absolutely needed. this results in really compact JSON in some cases like `"accessRules": [{ "credit": 100 }]`. IMO this isn't great.
- `JSON.stringify(obj, null, 2)` produces JSON that always has newlines. Prettier will then never collapse any objects to a single line, which blows up something like `{ "id": "addNumbers", "points": 1, "maxPoints": 5 }` into 5 lines, which IMO is more difficult to interpret at a glance, especially when there are lots of questions in play. Note that Prettier basically won't do anything useful for us in this case, as it really can't do anything that `JSON.stringify` wouldn't already have done

In the interest of picking one of these options, we're going for the former: first the JSON is printed as compactly as possible without whitespace, and then it's run through Prettier which will insert whitespace wherever necessary.

This PR was generated by running the following script in the root of the repo:

```js
// @ts-check
import fs from 'fs/promises';

import { globby } from 'globby';

for (const course of ['exampleCourse', 'testCourse']) {
  for (const file of await globby(`${course}/**/*.json`)) {
    const contents = await fs.readFile(file, 'utf8');
    await fs.writeFile(file, JSON.stringify(JSON.parse(contents)));
  }
}
```

I then ran `make format-js` to re-process everything with Prettier.