### PR TITLE
Introduce applyKeyOrder function

### DIFF
--- a/apps/prairielearn/src/lib/json.test.ts
+++ b/apps/prairielearn/src/lib/json.test.ts
@@ -1,0 +1,71 @@
+import { assert } from 'chai';
+
+import { applyKeyOrder } from './json.js';
+
+describe('applyKeyOrder', () => {
+  it('works with a string', () => {
+    assert(applyKeyOrder('a', 'b') === 'b');
+  });
+
+  it('works with a number', () => {
+    assert(applyKeyOrder(1, 2) === 2);
+  });
+
+  it('works with a boolean', () => {
+    assert(applyKeyOrder(true, false) === false);
+  });
+
+  it('works with a simple object', () => {
+    assert.deepEqual(applyKeyOrder({ a: 1 }, { a: 2 }), { a: 2 });
+  });
+
+  it('works with an object with multiple keys', () => {
+    const original = { a: 1, b: 2 };
+    const modified = { b: 3, a: 4 };
+    const result = applyKeyOrder(original, modified);
+    assert.deepEqual(result, { a: 4, b: 3 });
+    assert.deepEqual(Object.keys(result), ['a', 'b']);
+  });
+
+  it('works with an object with added keys', () => {
+    const original = { a: 1 };
+    const modified = { b: 3, a: 1 };
+    const result = applyKeyOrder(original, modified);
+    assert.deepEqual(result, { a: 1, b: 3 });
+    assert.deepEqual(Object.keys(result), ['a', 'b']);
+  });
+
+  it('works with an object with removed keys', () => {
+    const original = { a: 1, b: 2 };
+    const modified = { a: 1 };
+    const result = applyKeyOrder(original, modified);
+    assert.deepEqual(result, { a: 1 });
+    assert.deepEqual(Object.keys(result), ['a']);
+  });
+
+  it('works with nested objects', () => {
+    const original = { a: { b: 1, c: 2 } };
+    const modified = { a: { c: 3, b: 4 } };
+    const result = applyKeyOrder(original, modified);
+    assert.deepEqual(result, { a: { b: 4, c: 3 } });
+    assert.deepEqual(Object.keys(result.a), ['b', 'c']);
+  });
+
+  it('works with arrays', () => {
+    const original = { a: [{ b: 1, c: 2 }] };
+    const modified = { a: [{ c: 3, b: 4 }] };
+    const result = applyKeyOrder(original, modified);
+    assert.deepEqual(result, { a: [{ b: 4, c: 3 }] });
+    assert.deepEqual(Object.keys(result.a[0]), ['b', 'c']);
+  });
+
+  it('handles null', () => {
+    assert(applyKeyOrder(null, 'a') === 'a');
+    assert(applyKeyOrder('a', null) === null);
+  });
+
+  it('handles undefined', () => {
+    assert(applyKeyOrder(undefined, 'a') === 'a');
+    assert(applyKeyOrder('a', undefined) === undefined);
+  });
+});

--- a/apps/prairielearn/src/lib/json.ts
+++ b/apps/prairielearn/src/lib/json.ts
@@ -1,0 +1,46 @@
+/**
+ * Given an original object and a modified object, returns a new object
+ * that contains all the data from the modified object, but with the keys
+ * matching the order that they appear in the original object. Keys that are
+ * not present in the original object are added at the end.
+ *
+ *
+ * This function is meant to be used when programmatically editing JSON data.
+ * It's designed to minimize the changes in the JSON data such that a `git diff`
+ * doesn't show spurious changes unrelated to the actual data changes.
+ */
+export function applyKeyOrder(original: any, modified: any): any {
+  if (typeof original !== 'object' || original === null) {
+    return modified;
+  }
+
+  if (typeof modified !== 'object' || modified === null) {
+    return modified;
+  }
+
+  if (Array.isArray(original) && Array.isArray(modified)) {
+    return modified.map((value, index) => applyKeyOrder(original[index], value));
+  }
+
+  if (typeof original === 'object' && typeof modified === 'object') {
+    const result: any = {};
+
+    // Add keys from original in the order they appear.
+    for (const key of Object.keys(original)) {
+      if (key in modified) {
+        result[key] = applyKeyOrder(original[key], modified[key]);
+      }
+    }
+
+    // Add keys from modified that are not in original.
+    for (const key of Object.keys(modified)) {
+      if (!(key in result)) {
+        result[key] = modified[key];
+      }
+    }
+
+    return result;
+  }
+
+  return modified;
+}


### PR DESCRIPTION
This is a utility that will be useful in upcoming work to programmatically modify JSON. It tries to maintain the existing order of keys so that a `git diff` is as clean as possible. This may not matter much for the average user who isn't ever looking at Git history, but it'll be very valuable to me and other testers who are trying to validate that the editor is idempotent for unchanged data.

I'm opening a PR for this in isolation since this is trivially reviewable/testable on its own.