### PR TITLE
Drop Z from end of testCourse access rule dates

### DIFF
--- a/testCourse/courseInstances/Sp15/assessments/exam11-activeAccessRestriction/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam11-activeAccessRestriction/infoAssessment.json
@@ -8,29 +8,29 @@
     {
       "mode": "Public",
       "timeLimitMin": 50,
-      "startDate": "2010-01-01T00:00:01Z",
-      "endDate": "2010-01-01T23:59:59Z",
+      "startDate": "2010-01-01T00:00:01",
+      "endDate": "2010-01-01T23:59:59",
       "credit": 100
     },
     {
       "mode": "Public",
-      "startDate": "2020-01-01T00:00:01Z",
-      "endDate": "2021-01-01T00:00:01Z",
+      "startDate": "2020-01-01T00:00:01",
+      "endDate": "2021-01-01T00:00:01",
       "active": false,
       "showClosedAssessment": false
     },
     {
       "mode": "Public",
-      "startDate": "2030-01-01T00:00:01Z",
-      "endDate": "2031-01-01T00:00:01Z",
+      "startDate": "2030-01-01T00:00:01",
+      "endDate": "2031-01-01T00:00:01",
       "active": false,
       "showClosedAssessment": false,
       "showClosedAssessmentScore": false
     },
     {
       "mode": "Public",
-      "startDate": "1900-01-01T00:00:01Z",
-      "endDate": "2100-01-01T00:00:01Z",
+      "startDate": "1900-01-01T00:00:01",
+      "endDate": "2100-01-01T00:00:01",
       "active": false
     }
   ],

--- a/testCourse/courseInstances/Sp15/assessments/hw8-activeAccessRestriction/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw8-activeAccessRestriction/infoAssessment.json
@@ -5,12 +5,12 @@
   "set": "Homework",
   "number": "8",
   "allowAccess": [
-    { "startDate": "2020-01-01T00:00:01Z", "endDate": "2020-12-31T23:59:59Z", "credit": 100 },
-    { "startDate": "2030-01-01T00:00:01Z", "endDate": "2030-12-31T23:59:59Z", "credit": 75 },
-    { "startDate": "2000-01-01T00:00:01Z", "endDate": "2024-12-31T23:59:59Z", "active": false },
+    { "startDate": "2020-01-01T00:00:01", "endDate": "2020-12-31T23:59:59", "credit": 100 },
+    { "startDate": "2030-01-01T00:00:01", "endDate": "2030-12-31T23:59:59", "credit": 75 },
+    { "startDate": "2000-01-01T00:00:01", "endDate": "2024-12-31T23:59:59", "active": false },
     {
-      "startDate": "2025-01-01T00:00:01Z",
-      "endDate": "2039-12-31T23:59:59Z",
+      "startDate": "2025-01-01T00:00:01",
+      "endDate": "2039-12-31T23:59:59",
       "active": false,
       "showClosedAssessment": false
     }


### PR DESCRIPTION
I noticed this while testing the assessment access rules editor. Though the trailing Z passes our validation, it doesn't make a lot of sense since these dates are always treated as relative to the course instance timezone.