### PR TITLE
Avoid infinite recursion in Sentry event processor

### DIFF
--- a/.changeset/giant-shirts-complain.md
+++ b/.changeset/giant-shirts-complain.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/sentry': patch
+---
+
+Handle errors inside request event processor

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -63,8 +63,16 @@ export function requestHandler() {
   return (req: any, _res: any, next: any) => {
     Sentry.withIsolationScope((scope) => {
       scope.addEventProcessor((event) => {
-        event.transaction = extractTransaction(req);
-        return Sentry.addRequestDataToEvent(event, req);
+        // If an event processor throws an error, Sentry will catch it and
+        // retrigger the event processor, which infinitely recurses. We'll
+        // treat our event processor as a best-effort operation and silently
+        // swallow any errors.
+        try {
+          event.transaction = extractTransaction(req);
+          return Sentry.addRequestDataToEvent(event, req);
+        } catch {
+          return event;
+        }
       });
 
       next();


### PR DESCRIPTION
This fixes an issue that reared its head in production.