### PR TITLE
Fix session extension

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -174,7 +174,7 @@ export async function initExpress() {
       sessionTtl <
       (config.sessionStoreExpireSeconds - config.sessionStoreAutoExtendThrottleSeconds) * 1000
     ) {
-      req.session.setExpiration(config.sessionStoreExpireSeconds);
+      req.session.setExpiration(config.sessionStoreExpireSeconds * 1000);
     }
 
     next();


### PR DESCRIPTION
`setExpiration` expects either a `Date` or a milliseconds value.