### PR TITLE
Use disk contents to check for changes in file editor

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorFileEditorClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorFileEditorClient.ts
@@ -1,5 +1,4 @@
 import ace from 'ace-builds';
-import CryptoJS from 'crypto-js';
 import prettierBabelPlugin from 'prettier/plugins/babel';
 import prettierEstreePlugin from 'prettier/plugins/estree';
 import * as prettier from 'prettier/standalone';
@@ -36,7 +35,7 @@ function getCursorPositionFromCursorOffset(cursorOffset: number, lines: string[]
 
 class InstructorFileEditor {
   element: HTMLElement;
-  diskHash?: string;
+  diskContents?: string;
   saveElement?: HTMLButtonElement | null;
   inputContentsElement?: HTMLInputElement | null;
   editor: ace.Ace.Editor;
@@ -47,17 +46,16 @@ class InstructorFileEditor {
     aceMode,
     readOnly,
     contents,
+    diskContents,
   }: {
     element: HTMLElement;
     saveElement?: HTMLButtonElement | null;
     aceMode?: string;
     readOnly?: boolean;
     contents?: string;
+    diskContents?: string;
   }) {
     this.element = element;
-    this.diskHash = element.querySelector<HTMLInputElement>(
-      'input[name=file_edit_orig_hash]',
-    )?.value;
     const editorElement = element.querySelector<HTMLElement>('.editor');
     if (!editorElement) {
       throw new Error(`Could not find .editor element inside ${element.id}`);
@@ -78,6 +76,7 @@ class InstructorFileEditor {
     });
 
     this.setEditorContents(contents ? this.b64DecodeUnicode(contents) : '');
+    this.diskContents = diskContents ? this.b64DecodeUnicode(diskContents) : '';
 
     this.editor.commands.addCommand({
       name: 'saveAndSync',
@@ -140,14 +139,9 @@ class InstructorFileEditor {
     this.checkDiff();
   }
 
-  getHash(contents: string) {
-    return CryptoJS.SHA256(this.b64EncodeUnicode(contents)).toString();
-  }
-
   checkDiff() {
     if (this.saveElement) {
-      const curHash = this.getHash(this.editor.getValue());
-      this.saveElement.disabled = curHash === this.diskHash;
+      this.saveElement.disabled = this.editor.getValue() === this.diskContents;
     }
   }
 
@@ -197,17 +191,22 @@ onDocumentReady(() => {
   ace.config.set('themePath', aceBasePath);
 
   const draftEditorElement = document.querySelector<HTMLElement>('#file-editor-draft');
+  const diskEditorElement = document.querySelector<HTMLElement>('#file-editor-disk');
+
   const draftEditor = draftEditorElement
     ? new InstructorFileEditor({
         element: draftEditorElement,
         aceMode: draftEditorElement.dataset.aceMode,
         readOnly: draftEditorElement.dataset.readOnly === 'true',
         contents: draftEditorElement.dataset.contents,
+        // If the `#file-editor-disk` element exists, then the disk content is
+        // actually based on that element, and the draft element contains the
+        // last "unsuccessful" edit.
+        diskContents: diskEditorElement?.dataset.contents ?? draftEditorElement.dataset.contents,
         saveElement: document.querySelector<HTMLButtonElement>('#file-editor-save-button'),
       })
     : null;
 
-  const diskEditorElement = document.querySelector<HTMLElement>('#file-editor-disk');
   if (diskEditorElement) {
     new InstructorFileEditor({
       element: diskEditorElement,


### PR DESCRIPTION
Resolves #10247. Replaces the check for hash with a check for actual content in client side comparison of file editor content, which identifies if Save button should be enabled. While a hash clash is unlikely to cause a problem in these cases, this has the advantage of removing the dependency on cryptojs in the client side code.