### PR TITLE
Configure esbuild to target ES2017

### DIFF
--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -196,7 +196,7 @@ async function buildAssets(sourceDirectory: string, buildDirectory: string) {
   const files = await globby(path.join(sourceDirectory, '*/*.{js,jsx,ts,tsx,css}'));
   const buildResult = await esbuild.build({
     entryPoints: files,
-    target: 'es6',
+    target: 'es2017',
     format: 'iife',
     sourcemap: 'linked',
     bundle: true,


### PR DESCRIPTION
This fixes a bug with the instructor assessments page. That page has a script that lazy-loads assessment stats; it uses `async.eachLimit` to do so in parallel:

https://github.com/PrairieLearn/PrairieLearn/blob/a7af6ed27d636da3611c5fcde03da4790eac5092/apps/prairielearn/assets/scripts/instructorAssessmentsClient.ts#L28

However, the `async` library requires that async functions actually _be_ async with the `async` keyboard. When `esbuild` targets `es6`, it transforms async functions into generator functions, so the `async` library doesn't know to await them. This means that only three assessments worth of stats will be loaded per page load, since the `async` library thinks the first three never finishes.

This change should be very safe, as async functions as ES2017 in general have been widely available in browsers since 2017.