### PR TITLE
Fix flaky session tests

### DIFF
--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -311,11 +311,14 @@ describe('session middleware', () => {
       const fetchWithCookies = fetchCookie(fetch);
 
       // Generate a new session.
-      await fetchWithCookies(url);
+      const res = await fetchWithCookies(url);
+      assert.equal(res.status, 200);
+      await res.text();
 
       // Destroy the session.
       const destroyRes = await fetchWithCookies(`${url}/destroy`);
       assert.equal(destroyRes.status, 200);
+      await destroyRes.text();
 
       // Ensure the session cookie was cleared in the response.
       const header = destroyRes.headers.get('set-cookie');
@@ -349,7 +352,7 @@ describe('session middleware', () => {
       asyncHandler(async (req, res) => {
         await req.session.regenerate();
         req.session.regenerated = true;
-        res.sendStatus(200);
+        res.send('true');
       }),
     );
 
@@ -370,6 +373,7 @@ describe('session middleware', () => {
       // Regenerate the session.
       res = await fetchWithCookies(`${url}/regenerate`);
       assert.equal(res.status, 200);
+      assert.equal(await res.text(), 'true');
 
       // Ensure that the session cookie was changed.
       header = res.headers.get('set-cookie');
@@ -468,9 +472,9 @@ describe('session middleware', () => {
         },
       }),
     );
-    app.get('/', (_req, res) => res.sendStatus(200));
+    app.get('/', (req, res) => res.send(req.session.getExpirationDate().getTime()));
     app.get('/extend', (req, res) => {
-      req.session.setExpiration(Date.now() + 10000);
+      req.session.setExpiration(10000);
       res.sendStatus(200);
     });
 
@@ -480,6 +484,7 @@ describe('session middleware', () => {
       // Generate a new session.
       let res = await fetchWithCookies(url);
       assert.equal(res.status, 200);
+      await res.text();
 
       // Grab the original expiration date.
       let header = res.headers.get('set-cookie');
@@ -489,18 +494,17 @@ describe('session middleware', () => {
       const originalExpirationDate = cookies[0].expires;
       assert(originalExpirationDate);
 
-      // Also grab the expiration date from the store.
+      // Grab the session ID from the cookie.
       const sessionId = cookies[0].value.split('.')[0];
-      const session = await store.get(sessionId);
-      assert(session);
-      const originalStoreExpirationDate = session.expiresAt;
 
-      // Ensure that the expiration dates are consistent.
-      assert.equal(originalExpirationDate.getTime(), originalStoreExpirationDate.getTime());
+      // Ensure that the expiration dates are consistent between the cookie and the store.
+      const session = await store.get(sessionId);
+      assert.equal(originalExpirationDate.getTime(), session?.expiresAt.getTime());
 
       // Make another request with the same session.
       res = await fetchWithCookies(`${url}/extend`);
       assert.equal(res.status, 200);
+      await res.text();
 
       // Ensure that the cookie was set again.
       header = res.headers.get('set-cookie');
@@ -513,13 +517,9 @@ describe('session middleware', () => {
       // Ensure that the expiration date was extended.
       assert.notEqual(newExpirationDate.getTime(), originalExpirationDate.getTime());
 
-      // Also grab the new expiration date from the store.
+      // Ensure that the expiration dates are consistent between the cookie and the store.
       const newSession = await store.get(sessionId);
-      assert(newSession);
-      const newStoreExpirationDate = newSession.expiresAt;
-
-      // Ensure that the expiration dates are consistent.
-      assert.equal(newExpirationDate.getTime(), newStoreExpirationDate.getTime());
+      assert.equal(newExpirationDate.getTime(), newSession?.expiresAt.getTime());
     });
   });
 
@@ -547,6 +547,7 @@ describe('session middleware', () => {
       // Generate a new session.
       let res = await fetchWithCookies(url);
       assert.equal(res.status, 200);
+      await res.text();
 
       // Ensure the session was persisted.
       assert.equal(setCount, 1);
@@ -554,6 +555,7 @@ describe('session middleware', () => {
       // Make another request with the same session.
       res = await fetchWithCookies(url);
       assert.equal(res.status, 200);
+      await res.text();
 
       // Ensure the session was not persisted.
       assert.equal(setCount, 1);

--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -472,7 +472,7 @@ describe('session middleware', () => {
         },
       }),
     );
-    app.get('/', (req, res) => res.send(req.session.getExpirationDate().getTime()));
+    app.get('/', (_req, res) => res.sendStatus(200));
     app.get('/extend', (req, res) => {
       req.session.setExpiration(10000);
       res.sendStatus(200);


### PR DESCRIPTION
This PR aims to fix some flaky tests in the `@prairielearn/session` package. One test failure can be seen here: https://github.com/PrairieLearn/PrairieLearn/actions/runs/10169846939/job/28127680417

AFAICT, the test fails because the change isn't committed to the session store before we try to read it. We should be able to work around this by adding `await res.text()` in between making the request and reading from the session store, which will ensure that [all this garbage](https://github.com/PrairieLearn/PrairieLearn/blob/9683b6754ed6ce9cba52543b63450bed4f991807/packages/session/src/before-end.ts) works as expected.