### PR TITLE
Configure esbuild to target ES2017 in dev mode

### DIFF
--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -62,7 +62,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
 
     esbuildContext = await esbuild.context({
       entryPoints: sourcePaths,
-      target: 'es6',
+      target: 'es2017',
       format: 'iife',
       sourcemap: 'inline',
       bundle: true,


### PR DESCRIPTION
I missed this in #10306.