### PR TITLE
Add link to GitHub access settings from course staff page

### DIFF
--- a/apps/prairielearn/src/lib/github.js
+++ b/apps/prairielearn/src/lib/github.js
@@ -354,3 +354,22 @@ export async function createCourseRepoJob(options, authn_user) {
 export function reponameFromShortname(short_name) {
   return 'pl-' + short_name.replace(' ', '').toLowerCase();
 }
+
+/**
+ * Returns the HTTPS URL for the course page on GitHub, based on the course's
+ * repository. Assumes that the repository is set using the SSH URL for GitHub.
+ * Returns null if the URL cannot be retrieved from the repository.
+ *
+ * @param {string | null} repository The repository associated to the course
+ * @returns {string | null} The HTTP prefix to access course information on
+ * GitHub
+ */
+export function httpPrefixForCourseRepo(repository) {
+  if (repository) {
+    const githubRepoMatch = repository.match(/^git@github.com:\/?(.+?)(\.git)?\/?$/);
+    if (githubRepoMatch) {
+      return `https://github.com/${githubRepoMatch[1]}`;
+    }
+  }
+  return null;
+}

--- a/apps/prairielearn/src/lib/github.test.ts
+++ b/apps/prairielearn/src/lib/github.test.ts
@@ -1,0 +1,37 @@
+import { assert } from 'chai';
+
+import { httpPrefixForCourseRepo } from './github.js';
+
+describe('Github library', () => {
+  describe('httpPrefixforCourseRepo', () => {
+    it('Converts to HTTPS prefix when repo has proper format', async () => {
+      assert.equal(
+        httpPrefixForCourseRepo('git@github.com:username/repo.git'),
+        'https://github.com/username/repo',
+      );
+      assert.equal(
+        httpPrefixForCourseRepo('git@github.com:username2/repo-other.git'),
+        'https://github.com/username2/repo-other',
+      );
+      assert.equal(
+        httpPrefixForCourseRepo('git@github.com:username3/repo-yet-another'),
+        'https://github.com/username3/repo-yet-another',
+      );
+      assert.equal(
+        httpPrefixForCourseRepo('git@github.com:onemore/repository.git/'),
+        'https://github.com/onemore/repository',
+      );
+    });
+
+    it('Returns null if repo uses a different format', async () => {
+      assert.isNull(httpPrefixForCourseRepo('https://github.com/username/repo.git'));
+      assert.isNull(httpPrefixForCourseRepo('https://www.github.com/username/repo.git'));
+      assert.isNull(httpPrefixForCourseRepo('git@gitlab.com:username/repo.git'));
+    });
+
+    it('Returns null if repo is not provided', async () => {
+      assert.isNull(httpPrefixForCourseRepo(''));
+      assert.isNull(httpPrefixForCourseRepo(null));
+    });
+  });
+});

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -199,12 +199,13 @@ export function InstructorCourseAdminStaff({
                 ${AccessLevelsTable()}
               </details>
               ${githubAccessLink
-                ? html`<div class="alert alert-info">
-                    The settings above do not affect access to the course's repository. To change
-                    repository permissions, go to the
-                    <a href="${githubAccessLink}" target="_blank">access settings page</a> on
-                    GitHub.
-                  </div>`
+                ? html`
+                    <div class="alert alert-info mt-3">
+                      The settings above do not affect access to the course's Git repository. To
+                      change repository permissions, go to the
+                      <a href="${githubAccessLink}" target="_blank">GitHub access settings page</a>.
+                    </div>
+                  `
                 : ''}
             </small>
           </div>

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -49,11 +49,13 @@ export function InstructorCourseAdminStaff({
   courseInstances,
   courseUsers,
   uidsLimit,
+  githubAccessLink,
 }: {
   resLocals: Record<string, any>;
   courseInstances: CourseInstance[];
   courseUsers: CourseUsersRow[];
   uidsLimit: number;
+  githubAccessLink: string | null;
 }) {
   return html`
     <!doctype html>
@@ -196,6 +198,14 @@ export function InstructorCourseAdminStaff({
                 <summary>Recommended access levels</summary>
                 ${AccessLevelsTable()}
               </details>
+              ${githubAccessLink
+                ? html`<div class="alert alert-info">
+                    The settings above do not affect access to the course's repository. To change
+                    repository permissions, go to the
+                    <a href="${githubAccessLink}" target="_blank">access settings page</a> on
+                    GitHub.
+                  </div>`
+                : ''}
             </small>
           </div>
         </main>

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
@@ -9,6 +9,7 @@ import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 
 import { User } from '../../lib/db-types.js';
+import { httpPrefixForCourseRepo } from '../../lib/github.js';
 import { idsEqual } from '../../lib/id.js';
 import { parseUidsString } from '../../lib/user.js';
 import {
@@ -65,12 +66,21 @@ router.get(
       CourseUsersRowSchema,
     );
 
+    let githubAccessLink: string | null = null;
+    if (!res.locals.course.example_course) {
+      const githubPrefix = httpPrefixForCourseRepo(res.locals.course.repository);
+      if (githubPrefix) {
+        githubAccessLink = `${githubPrefix}/settings/access`;
+      }
+    }
+
     res.send(
       InstructorCourseAdminStaff({
         resLocals: res.locals,
         courseInstances,
         courseUsers,
         uidsLimit: MAX_UIDS,
+        githubAccessLink,
       }),
     );
   }),

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -18,6 +18,7 @@ import {
   QuestionCopyEditor,
 } from '../../lib/editors.js';
 import { features } from '../../lib/features/index.js';
+import { httpPrefixForCourseRepo } from '../../lib/github.js';
 import { idsEqual } from '../../lib/id.js';
 import { startTestQuestion } from '../../lib/question-testing.js';
 import { encodePath } from '../../lib/uri-util.js';
@@ -230,15 +231,9 @@ router.get(
       // The example course is not found at the root of its repository, so its path is hardcoded
       questionGHLink = `https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/${res.locals.question.qid}`;
     } else if (res.locals.course.repository) {
-      const githubRepoMatch = res.locals.course.repository.match(
-        /^git@github.com:\/?(.+?)(\.git)?\/?$/,
-      );
-      if (githubRepoMatch) {
-        questionGHLink =
-          'https://github.com/' +
-          githubRepoMatch[1] +
-          `/tree/${res.locals.course.branch}/questions/` +
-          res.locals.question.qid;
+      const githubPrefix = httpPrefixForCourseRepo(res.locals.course.repository);
+      if (githubPrefix) {
+        questionGHLink = `${githubPrefix}/tree/${res.locals.course.branch}/questions/${res.locals.question.qid}`;
       }
     }
 


### PR DESCRIPTION
Resolves #10271. This should reduce the confusion that often comes up in questions about giving staff access to the course repository. This code uses the same pattern used in the "Show on GitHub" link in the question settings page.