### PR TITLE
Fix "Tag for grading" button type

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
@@ -280,6 +280,7 @@ function gradingTagDropdown(courseStaff: User[]) {
   return html`
     <div class="dropdown btn-group">
       <button
+        type="button"
         class="btn btn-secondary dropdown-toggle grading-tag-button"
         data-toggle="dropdown"
         name="status"


### PR DESCRIPTION
This button did not have an explicit type, which caused it to default to submit (since it's inside a form). This is not causing a problem currently, but seems to be a problem in Bootstrap 5, where clicking the button causes a submit event to be triggered.