### PR TITLE
Ensure MathJax.typesetPromise is available during initialization

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -65,15 +65,13 @@ const mathjaxPromise = new Promise<void>((resolve) => {
     },
   };
 
+  // The MathJax initialization script will wipe our `typesetPromise` function
+  // until it has loaded itself, so we'll do this hacky little thing to ensure
+  // that `typesetPromise` is always available, even while MathJax is loading.
   let mj = window.MathJax;
-
   Object.defineProperty(window, 'MathJax', {
     set: (value) => {
       mj = value;
-
-      // The MathJax initialization script will wipe our `typesetPromise` function
-      // until it has loaded itself, so we'll do this hacky little thing to ensure
-      // that `typesetPromise` is always available, even while MathJax is loading.
       mj.typesetPromise = mathjaxTypeset;
     },
     get() {

--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -64,6 +64,24 @@ const mathjaxPromise = new Promise<void>((resolve) => {
       },
     },
   };
+
+  let mj = window.MathJax;
+
+  Object.defineProperty(window, 'MathJax', {
+    set: (value) => {
+      mj = value;
+
+      // The MathJax initialization script will wipe our `typesetPromise` function
+      // until it has loaded itself, so we'll do this hacky little thing to ensure
+      // that `typesetPromise` is always available, even while MathJax is loading.
+      mj.typesetPromise = mathjaxTypeset;
+    },
+    get() {
+      return mj;
+    },
+    configurable: true,
+    enumerable: true,
+  });
 });
 
 export async function mathjaxTypeset() {


### PR DESCRIPTION
Without this change, there's a period of time during the MathJax initialization process where `window.MathJax.typesetPromise` isn't defined. That means that code [like this](https://github.com/PrairieLearn/PrairieLearn/blob/d078da2229918014143a1eff31c64595792928d9/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache#L70) will produce errors during page initialization:

<img width="471" alt="Screenshot 2024-08-05 at 16 12 32" src="https://github.com/user-attachments/assets/22fc528c-d0b6-4b55-84a0-36245a245f6e">

By using an accessor property descriptor, we git ourselves a way to hook into the assignment that MathJax does and add our `typesetPromise` function back to `window.MathJax`.