### PR TITLE
Fix filter by assessment in questions page

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -129,7 +129,9 @@ onDocumentReady(() => {
     var values = $('<div>')
       .html(value)
       .find('.badge')
-      .filter((i, elem) => $(elem).text().toUpperCase() === search.toUpperCase()).length;
+      .filter(
+        (i, elem) => $(elem).text().trim().toUpperCase() === search.trim().toUpperCase(),
+      ).length;
     return !!values;
   };
 


### PR DESCRIPTION
Fixes #10387. Issue was related to a change in the assessment badge. The filter assumed no spaces before/after the assessment label, which used to be the case but is no longer the case.