### PR TITLE
Fix escaping of multiple choice options with dropdown display

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -84,7 +84,7 @@
             <option
                 value="{{key}}"
                 style="white-space:normal;"
-                data-content="{{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{{html}}}"
+                data-content="{{^hide_letter_keys}}({{key}}){{/hide_letter_keys}} {{html}}"
                 {{#selected}}selected{{/selected}}
             ></option>
         {{/answers}}


### PR DESCRIPTION
Fixes #10396. The original code would cause problems for any option that included double quotes `"`, as it would close the `data-content` attribute.