### PR TITLE
Use official Bootstrap API to set sync popover max width

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentQuestionsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentQuestionsClient.ts
@@ -14,11 +14,7 @@ onDocumentReady(() => {
 
   $('[data-toggle="popover"]').popover({ sanitize: false });
 
-  $('.js-sync-popover[data-toggle="popover"]')
-    .popover({ sanitize: false })
-    .on('show.bs.popover', function () {
-      $($(this).data('bs.popover').getTipElement()).css('max-width', '80%');
-    });
+  $('.js-sync-popover[data-toggle="popover"]').popover({ sanitize: false });
 
   document.querySelectorAll<HTMLElement>('.js-histmini').forEach((element) => histmini(element));
 });

--- a/apps/prairielearn/assets/scripts/instructorAssessmentsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentsClient.ts
@@ -14,11 +14,7 @@ const statElements = [
 ];
 
 onDocumentReady(() => {
-  $('.js-sync-popover[data-toggle="popover"]')
-    .popover({ sanitize: false })
-    .on('show.bs.popover', function () {
-      $($(this).data('bs.popover').getTipElement()).css('max-width', '80%');
-    });
+  $('.js-sync-popover[data-toggle="popover"]').popover({ sanitize: false });
 
   updatePlots(document.body);
 

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -53,6 +53,7 @@ onDocumentReady(() => {
         data-html="true"
         data-title="Sync Errors"
         data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_errors_ansified}</pre>'
+        data-custom-class="sync-popover"
       >
         <i class="fa fa-times text-danger" aria-hidden="true"></i>
       </button>`;
@@ -65,6 +66,7 @@ onDocumentReady(() => {
         data-html="true"
         data-title="Sync Warnings"
         data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_warnings_ansified}</pre>'
+        data-custom-class="sync-popover"
       >
         <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
       </button>`;
@@ -181,13 +183,7 @@ onDocumentReady(() => {
     },
     onPreBody() {},
     onResetView() {
-      $('.js-sync-popover[data-toggle="popover"]')
-        .popover({
-          sanitize: false,
-        })
-        .on('show.bs.popover', function () {
-          $($(this).data('bs.popover').getTipElement()).css('max-width', '80%');
-        });
+      $('.js-sync-popover[data-toggle="popover"]').popover({ sanitize: false });
     },
   };
 

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -122,6 +122,10 @@ mjx-container {
   text-rendering: geometricPrecision;
 }
 
+.sync-popover {
+  max-width: 80%;
+}
+
 /**************
  * Submissions
  **************/

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -229,6 +229,7 @@ function AssessmentQuestionsTable({
                           data-html="true"
                           data-title="Sync Errors"
                           data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_errors_ansified}</pre>'
+                          data-custom-class="sync-popover"
                         >
                           <i class="fa fa-times text-danger" aria-hidden="true"></i>
                         </button>
@@ -243,6 +244,7 @@ function AssessmentQuestionsTable({
                             data-html="true"
                             data-title="Sync Warnings"
                             data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_warnings_ansified}</pre>'
+                            data-custom-class="sync-popover"
                           >
                             <i
                               class="fa fa-exclamation-triangle text-warning"

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -197,6 +197,7 @@ ${unsafeHtml(ansiUp.ansi_to_html(output))}</pre
       data-html="true"
       data-title="${title}"
       data-content="${escapeHtml(popoverContent)}"
+      data-custom-class="sync-popover"
     >
       <i class="fa ${classes}" aria-hidden="true"></i>
     </button>


### PR DESCRIPTION
`$(this).data('bs.popover').getTipElement()` is an undocumented, not-officially-supported API, and it won't work at all in Bootstrap 5. `data-custom-class`, on the other hand, is officially supported in both BS4 and BS5.

Fixes [an issue with the BS5 migration](https://github.com/PrairieLearn/PrairieLearn/pull/10095#issuecomment-2265321358) reported by @jonatanschroeder.