### PR TITLE
Add forwards compat for bootstrap-table icons in Bootstrap 5

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -21,6 +21,15 @@ onDocumentReady(() => {
   const hasCourseInstancePermissionEdit = dataset.hasCourseInstancePermissionEdit === 'true';
 
   const bsTable = $('#usersTable').bootstrapTable({
+    // TODO: If we can pick up the following change, we can drop the `icons` config here:
+    // https://github.com/wenzhixin/bootstrap-table/pull/7190
+    iconsPrefix: 'fa',
+    icons: {
+      refresh: 'fa-sync',
+      autoRefresh: 'fa-clock',
+      columns: 'fa-table-list',
+    },
+
     buttons: {
       studentsOnly: {
         text: 'Students Only',

--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
@@ -30,6 +30,15 @@ onDocumentReady(() => {
 
   // @ts-expect-error The BootstrapTableOptions type does not handle extensions properly
   $('#grading-table').bootstrapTable({
+    // TODO: If we can pick up the following change, we can drop the `icons` config here:
+    // https://github.com/wenzhixin/bootstrap-table/pull/7190
+    iconsPrefix: 'fa',
+    icons: {
+      refresh: 'fa-sync',
+      autoRefresh: 'fa-clock',
+      columns: 'fa-table-list',
+    },
+
     classes: 'table table-sm table-bordered',
     url: instancesUrl,
     responseHandler: (res: { instance_questions: InstanceQuestionRow[] }) =>

--- a/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
@@ -14,6 +14,14 @@ onDocumentReady(() => {
 
   // @ts-expect-error The BootstrapTableOptions type does not handle extensions properly
   $('#gradebook-table').bootstrapTable({
+    // TODO: If we can pick up the following change, we can drop the `icons` config here:
+    // https://github.com/wenzhixin/bootstrap-table/pull/7190
+    iconsPrefix: 'fa',
+    icons: {
+      refresh: 'fa-sync',
+      columns: 'fa-table-list',
+    },
+
     url: `${urlPrefix}/instance_admin/gradebook/raw_data.json`,
     uniqueId: 'user_id',
     classes: 'table table-sm table-hover table-bordered',

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -168,9 +168,13 @@ onDocumentReady(() => {
   });
 
   const tableSettings = {
+    // TODO: If we can pick up the following change, we can drop the `icons` config here:
+    // https://github.com/wenzhixin/bootstrap-table/pull/7190
+    iconsPrefix: 'fa',
     icons: {
-      columns: 'fa-th-list',
+      columns: 'fa-table-list',
     },
+
     buttons: {
       clearFilters: {
         text: 'Clear filters',


### PR DESCRIPTION
`bootstrap-table` defaults to using `bootstrap-icons` when used with Bootstrap 5. However, we still want to use FontAwesome for the time being, so we need to set `iconsPrefix: 'fa'`. If we were able to pick up https://github.com/wenzhixin/bootstrap-table/pull/7190, we'd be able to just set that and have it automatically pick up the correct icons. However, we can't consume the latest version of `bootstrap-table` because of the breaking change introduced in https://github.com/wenzhixin/bootstrap-table/issues/6745, so we have to re-specify all the icons we use.

Part of #10095.