### PR TITLE
Improve alignment in course staff feedback header

### DIFF
--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -90,7 +90,7 @@ export function SubmissionPanel({
         ? html`
             <div class="card mb-4 grading-block border-info">
               <div
-                class="card-header bg-info text-white d-flex submission-header ${!expanded
+                class="card-header bg-info text-white d-flex align-items-center submission-header ${!expanded
                   ? ' collapsed'
                   : ''}"
                 data-toggle="collapse"


### PR DESCRIPTION
Before:

![Screenshot 2024-08-06 at 15 15 42](https://github.com/user-attachments/assets/c2c41bff-c6ee-4ce3-b1ac-0eb566db5c19)

After:

![Screenshot 2024-08-06 at 15 15 50](https://github.com/user-attachments/assets/27b7e31f-5990-4ad5-82ee-80a8cf3e5d46)

This is consistent with all our other card headers.