### PR TITLE
C Grader: fix mode change for parent directory

### DIFF
--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -361,8 +361,9 @@ class CGrader:
         file = os.path.abspath(file)
         self.run_command(["chmod", mode, file], sandboxed=False)
         parent = os.path.dirname(file)
+        # Ensure that all users can resolve the path name
         if change_parent and parent and not os.path.samefile(file, parent):
-            self.change_mode(parent, "711")
+            self.change_mode(parent, "a+x")
 
     def test_send_in_check_out(self, *args, **kwargs):
         """Old deprecated function name,


### PR DESCRIPTION
Based on an issue raised on Slack. The `change_mode` method changes the mode (permissions)  of a file, and also ensures that the entire path is accessible to all users. This used to be done by setting the parent permissions recursively to 711, ensuring all users have the x (1) permission. The problem with this approach is that, if the parent directory had already been given other permissions (e.g., through a previous call to `change_mode`), this change would remove those permissions. The change here ensures that permissions are only added to the parents, never removed.