### PR TITLE
Drop custom max-width from time limit popover

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -95,7 +95,6 @@ onDocumentReady(() => {
           content: timeLimitEditPopoverContent,
         })
         .on('show.bs.popover', function () {
-          $($(this).data('bs.popover').getTipElement()).css('max-width', '350px');
           $(this).find('.select-time-limit').change();
         });
     },


### PR DESCRIPTION
`getTipElement` isn't supported in Bootstrap 5, and at any rate, setting this custom `max-width` appears to be unnecessary here, so we can drop this without any issue.