### PR TITLE
Improve spacing in manual grading sidebar

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -102,7 +102,7 @@ export function GradingPanel({
               </li>
             `
           : ''}
-        <li class="form-group list-group-item">
+        <li class="list-group-item">
           <label>
             Feedback:
             <textarea
@@ -122,7 +122,7 @@ ${submission.feedback?.manual}</textarea
         </li>
         ${open_issues.length > 0 && context !== 'existing'
           ? html`
-              <li class="form-group list-group-item">
+              <li class="list-group-item">
                 <div class="form-check">
                   ${open_issues.map(
                     (issue) => html`


### PR DESCRIPTION
I noticed this while going through things with a fine-toothed comb while testing the Bootstrap 5 migration.

Before:

<img width="467" alt="Screenshot 2024-08-07 at 11 26 02" src="https://github.com/user-attachments/assets/3bc9a10b-caa1-4d04-ab10-41af363805e5">

After:

<img width="468" alt="Screenshot 2024-08-07 at 11 25 38" src="https://github.com/user-attachments/assets/a5d5e20c-e338-4f82-95aa-554563829f63">

