### PR TITLE
Unify wide popovers

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -93,9 +93,9 @@ onDocumentReady(() => {
           html: true,
           trigger: 'click',
           content: timeLimitEditPopoverContent,
+          customClass: 'popover-wide',
         })
         .on('show.bs.popover', function () {
-          $($(this).data('bs.popover').getTipElement()).css('max-width', '350px');
           $(this).find('.select-time-limit').change();
         });
     },

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -53,7 +53,7 @@ onDocumentReady(() => {
         data-html="true"
         data-title="Sync Errors"
         data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_errors_ansified}</pre>'
-        data-custom-class="sync-popover"
+        data-custom-class="popover-wide"
       >
         <i class="fa fa-times text-danger" aria-hidden="true"></i>
       </button>`;
@@ -66,7 +66,7 @@ onDocumentReady(() => {
         data-html="true"
         data-title="Sync Warnings"
         data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_warnings_ansified}</pre>'
-        data-custom-class="sync-popover"
+        data-custom-class="popover-wide"
       >
         <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
       </button>`;

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -122,8 +122,8 @@ mjx-container {
   text-rendering: geometricPrecision;
 }
 
-.sync-popover {
-  max-width: 80%;
+.popover-wide {
+  max-width: min(800px, 90vw);
 }
 
 /**************

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -229,7 +229,7 @@ function AssessmentQuestionsTable({
                           data-html="true"
                           data-title="Sync Errors"
                           data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_errors_ansified}</pre>'
-                          data-custom-class="sync-popover"
+                          data-custom-class="popover-wide"
                         >
                           <i class="fa fa-times text-danger" aria-hidden="true"></i>
                         </button>
@@ -244,7 +244,7 @@ function AssessmentQuestionsTable({
                             data-html="true"
                             data-title="Sync Warnings"
                             data-content='<pre style="background-color: black" class="text-white rounded p-3 mb-0">${question.sync_warnings_ansified}</pre>'
-                            data-custom-class="sync-popover"
+                            data-custom-class="popover-wide"
                           >
                             <i
                               class="fa fa-exclamation-triangle text-warning"

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -197,7 +197,7 @@ ${unsafeHtml(ansiUp.ansi_to_html(output))}</pre
       data-html="true"
       data-title="${title}"
       data-content="${escapeHtml(popoverContent)}"
-      data-custom-class="sync-popover"
+      data-custom-class="popover-wide"
     >
       <i class="fa ${classes}" aria-hidden="true"></i>
     </button>


### PR DESCRIPTION
Takes the place of #10405 and builds on #10401 to use a single `popover-wide` class for all "wide" popovers that should be wider than Bootstrap's default.