### PR TITLE
Improve points/percentage toggle markup

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -74,13 +74,7 @@ export function GradingPanel({
                     id="use-score-perc"
                     type="checkbox"
                   />
-                  <label
-                    class="custom-control-label"
-                    for="use-score-perc"
-                    arial-label="Grade by percentage"
-                  >
-                    Percentage
-                  </label>
+                  <label class="custom-control-label" for="use-score-perc">Percentage</label>
                 </div>
               </li>
             `

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -65,18 +65,21 @@ export function GradingPanel({
         ${resLocals.assessment_question.max_points
           ? // Percentage-based grading is only suitable if the question has points
             html`
-              <li class="list-group-item">
-                <div class="form-group row justify-content-center">
-                  <label class="custom-control-inline col-auto mx-0">
-                    <span class="">Points</span>
-                    <div class="custom-control custom-switch mx-2">
-                      <input
-                        class="custom-control-input js-manual-grading-pts-perc-select"
-                        name="use_score_perc"
-                        type="checkbox"
-                      />
-                      <span class="custom-control-label">Percentage</span>
-                    </div>
+              <li class="list-group-item d-flex justify-content-center">
+                <span>Points</span>
+                <div class="custom-control custom-switch mx-2">
+                  <input
+                    class="custom-control-input js-manual-grading-pts-perc-select"
+                    name="use_score_perc"
+                    id="use-score-perc"
+                    type="checkbox"
+                  />
+                  <label
+                    class="custom-control-label"
+                    for="use-score-perc"
+                    arial-label="Grade by percentage"
+                  >
+                    Percentage
                   </label>
                 </div>
               </li>


### PR DESCRIPTION
This is forwards-compatible with Bootstrap 5 and should be more accessible (see #10408). It associates the "percentage" label with the input, which reflects the fact that the "checked" state corresponds to "use percentage" and the unchecked state corresponds to "use points". The latter won't necessarily be 100% obvious to someone using a screenreader, but IMO this is still an improvement over the status quo where the input would have its label announced as "Points Percentage", which doesn't make any sense.

Minor UX change: it used to be that clicking on "Points" (which was part of the label) would toggle the input, but now that's only true for "Percentage".