### PR TITLE
Remove extra space from course sync message

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -206,8 +206,7 @@ function CourseDirectoryMissingAlert({
     return html`
       <div class="alert alert-danger">
         Course directory not found. You must
-        <a href="${resLocals.urlPrefix}/${resLocals.navPage}/syncs"> sync your course </a>
-        .
+        <a href="${resLocals.urlPrefix}/${resLocals.navPage}/syncs">sync your course</a>.
       </div>
     `;
   } else if (!courseInfoExists) {


### PR DESCRIPTION
Before:

<img width="254" alt="Screenshot 2024-08-07 at 15 22 00" src="https://github.com/user-attachments/assets/8f71c2c8-fd12-48c0-ba77-bcbc7467468c">

After:

<img width="223" alt="Screenshot 2024-08-07 at 15 22 12" src="https://github.com/user-attachments/assets/87d3463f-5c21-42e5-91e6-bb1eedb6677a">

