### PR TITLE
Reorder buttons in modals for consistency

### DIFF
--- a/apps/prairielearn/src/components/AssessmentRegenerate.html.ts
+++ b/apps/prairielearn/src/components/AssessmentRegenerate.html.ts
@@ -16,9 +16,9 @@ export function RegenerateInstanceModal({ csrfToken }: { csrfToken: string }) {
     `,
     footer: html`
       <form method="POST">
-        <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
         <input type="hidden" name="__csrf_token" value="${csrfToken}" />
         <input type="hidden" name="__action" value="regenerate_instance" />
+        <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
         <button type="submit" class="btn btn-danger">Regenerate assessment instance</button>
       </form>
     `,

--- a/apps/prairielearn/src/components/AssessmentRegenerate.html.ts
+++ b/apps/prairielearn/src/components/AssessmentRegenerate.html.ts
@@ -16,10 +16,10 @@ export function RegenerateInstanceModal({ csrfToken }: { csrfToken: string }) {
     `,
     footer: html`
       <form method="POST">
+        <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
         <input type="hidden" name="__csrf_token" value="${csrfToken}" />
         <input type="hidden" name="__action" value="regenerate_instance" />
         <button type="submit" class="btn btn-danger">Regenerate assessment instance</button>
-        <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
       </form>
     `,
   });

--- a/apps/prairielearn/src/components/GroupWorkInfoContainer.html.ts
+++ b/apps/prairielearn/src/components/GroupWorkInfoContainer.html.ts
@@ -100,9 +100,9 @@ function LeaveGroupModal({ csrfToken }: { csrfToken: string }) {
       </p>
     `,
     footer: html`
-      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
       <input type="hidden" name="__action" value="leave_group" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
       <button id="leave-group" type="submit" class="btn btn-danger">Leave group</button>
     `,
   });

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -406,13 +406,11 @@ function DeleteSamlConfigurationModal({ csrfToken }: { csrfToken: string }) {
       </p>
     `,
     footer: html`
+      <input type="hidden" name="__csrf_token" value="${csrfToken}" />
       <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-      <form method="POST">
-        <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-        <button class="btn btn-danger" type="submit" name="__action" value="delete">
-          Delete SAML configuration
-        </button>
-      </form>
+      <button class="btn btn-danger" type="submit" name="__action" value="delete">
+        Delete SAML configuration
+      </button>
     `,
   });
 }

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
@@ -123,14 +123,7 @@ export function AdministratorInstitutions({
                 </div>
               `,
               footer: html`
-                <button
-                  type="button"
-                  class="btn btn-secondary"
-                  data-dismiss="modal"
-                  onclick="$('#add-institution-modal').modal('hide')"
-                >
-                  Cancel
-                </button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                 <button type="submit" class="btn btn-primary">Add institution</button>
               `,
             })}

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
@@ -305,32 +305,30 @@ function TimeRemainingHelpModal() {
     id: 'time-remaining-help',
     title: 'Time Remaining',
     body: html`
-      <div class="modal-body">
-        <p>
-          For open assessments with a time limit, this column will indicate the number of minutes
-          (rounded down) the student has left to complete the assessment. If the value is
-          <strong>&lt; 1 min</strong>, the student has less than one minute to complete it. This
-          column may also contain one of the following special values.
-        </p>
-        <ul>
-          <li>
-            <strong>Expired</strong> indicates the assessment time limit has expired, and will be
-            automatically closed as soon as possible. If an assessment is Expired for a prolonged
-            period of time, this typically means the student has closed their browser or lost
-            connectivity, and the assessment will be closed as soon as the student opens the
-            assessment. No further submissions are accepted at this point.
-          </li>
-          <li>
-            <strong>Closed</strong> indicates the assessment has been closed, and no further
-            submissions are accepted.
-          </li>
-          <li>
-            <strong>Open (no time limit)</strong> indicates that the assessment is still open and
-            accepting submissions, and there is no time limit to submit the assessment (other than
-            those indicated by access rules).
-          </li>
-        </ul>
-      </div>
+      <p>
+        For open assessments with a time limit, this column will indicate the number of minutes
+        (rounded down) the student has left to complete the assessment. If the value is
+        <strong>&lt; 1 min</strong>, the student has less than one minute to complete it. This
+        column may also contain one of the following special values.
+      </p>
+      <ul>
+        <li>
+          <strong>Expired</strong> indicates the assessment time limit has expired, and will be
+          automatically closed as soon as possible. If an assessment is Expired for a prolonged
+          period of time, this typically means the student has closed their browser or lost
+          connectivity, and the assessment will be closed as soon as the student opens the
+          assessment. No further submissions are accepted at this point.
+        </li>
+        <li>
+          <strong>Closed</strong> indicates the assessment has been closed, and no further
+          submissions are accepted.
+        </li>
+        <li>
+          <strong>Open (no time limit)</strong> indicates that the assessment is still open and
+          accepting submissions, and there is no time limit to submit the assessment (other than
+          those indicated by access rules).
+        </li>
+      </ul>
     `,
     footer: html`
       <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
@@ -126,8 +126,8 @@ function GradingConflictModal() {
     title: 'Grading conflict detected',
     body: html`<p>Another grader has already graded this submission.</p>`,
     footer: html`
-      <a class="btn btn-primary conflict-details-link" href="/">See details</a>
       <button type="button" class="btn btn-secondary" data-dismiss="modal">Dismiss</button>
+      <a class="btn btn-primary conflict-details-link" href="/">See details</a>
     `,
   });
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.html.ts
@@ -243,8 +243,8 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
             <div class="js-settings-error-alert-placeholder"></div>
             <div class="modal-footer">
               ${resLocals.authz_data.has_course_instance_permission_edit
-                ? [
-                    rubric_data
+                ? html`
+                    ${rubric_data
                       ? html`
                           <button
                             type="button"
@@ -253,11 +253,17 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                             Disable rubric
                           </button>
                         `
-                      : '',
-                    html`<button type="submit" class="btn btn-primary">Save rubric</button>`,
-                  ]
-                : ''}
-              <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                      : ''}
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                      Cancel
+                    </button>
+                    <button type="submit" class="btn btn-primary">Save rubric</button>
+                  `
+                : html`
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                      Close
+                    </button>
+                  `}
             </div>
           </div>
         </form>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -340,17 +340,15 @@ function CloseMatchingIssuesModal({
       </p>
     `,
     footer: html`
-      <div class="modal-footer">
-        <input type="hidden" name="__action" value="close_matching" />
-        <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-        <input
-          type="hidden"
-          name="unsafe_issue_ids"
-          value="${issues.map((issue) => issue.id).join(',')}"
-        />
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-danger">Close issues</button>
-      </div>
+      <input type="hidden" name="__action" value="close_matching" />
+      <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+      <input
+        type="hidden"
+        name="unsafe_issue_ids"
+        value="${issues.map((issue) => issue.id).join(',')}"
+      />
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+      <button type="submit" class="btn btn-danger">Close issues</button>
     `,
   });
 }

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -797,10 +797,10 @@ function ConfirmFinishModal({
       <p>Are you sure you want to finish, complete, and close out the assessment?</p>
     `,
     footer: html`
+      <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
       <input type="hidden" name="__action" value="finish" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
       <button type="submit" class="btn btn-danger">Finish assessment</button>
-      <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
     `,
   });
 }

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -797,9 +797,9 @@ function ConfirmFinishModal({
       <p>Are you sure you want to finish, complete, and close out the assessment?</p>
     `,
     footer: html`
-      <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
       <input type="hidden" name="__action" value="finish" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+      <button type="button" data-dismiss="modal" class="btn btn-secondary">Cancel</button>
       <button type="submit" class="btn btn-danger">Finish assessment</button>
     `,
   });

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -182,8 +182,8 @@ function ResetModal({ __csrf_token }: { __csrf_token: string }) {
       </ul>
     `,
     footer: html`
-      <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
       <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
       <button name="__action" value="reset" class="btn btn-danger">
         <i class="fas fa-trash text-white" aria-hidden="true"></i>
         Reset
@@ -210,8 +210,8 @@ function RebootModal({ __csrf_token }: { __csrf_token: string }) {
       </ul>
     `,
     footer: html`
-      <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
       <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+      <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
       <button name="__action" value="reboot" class="btn btn-info">
         <i class="fas fa-sync text-white" aria-hidden="true"></i>
         Reboot


### PR DESCRIPTION
Resolves #10414. Modals that have two or more buttons in the footer should always have the main "action" button on the bottom-right corner, with the cancel/close/dismiss button to the left of that action button.

Review ignoring whitespace.