### PR TITLE
Add Bootstrap 4 feature flag

### DIFF
--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -3,13 +3,14 @@ import { FeatureManager } from './manager.js';
 const featureNames = [
   'course-instance-billing',
   'enforce-plan-grants-for-questions',
-  // Can only be applied to courses/institutions.
+  // Should only be applied to courses/institutions.
   'process-questions-in-worker',
   'question-sharing',
   'bot-grading',
   'disable-public-workspaces',
   'ai-question-generation',
-  // Can only be applied to institutions.
+  'bootstrap-4',
+  // Should only be applied to institutions.
   'lti13',
   'terms-clickthrough',
 ] as const;


### PR DESCRIPTION
This flag allows us to configure specific courses/institutions to render with Bootstrap 4 instead of Bootstrap 5.

I'm landing this in advance of https://github.com/PrairieLearn/PrairieLearn/pull/10095 so that I can disable this in advance of the Bootstrap 5 deploy.

