### PR TITLE
Fix AI question generation bugs

### DIFF
--- a/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
+++ b/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
@@ -174,7 +174,7 @@ Keep in mind you are not just generating an example; you are generating an actua
  */
 export async function regenerateQuestion(
   client: OpenAI,
-  courseId: string | undefined,
+  courseId: string,
   authnUserId: string,
   originalPrompt: string,
   revisionPrompt: string,

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateQuestion/instructorAiGenerateQuestion.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateQuestion/instructorAiGenerateQuestion.ts
@@ -105,7 +105,7 @@ router.post(
     if (req.body.__action === 'generate_question') {
       const result = await generateQuestion(
         client,
-        res.locals.course ? res.locals.course.id : undefined,
+        res.locals.course.id,
         res.locals.authn_user.user_id,
         req.body.prompt,
       );
@@ -120,7 +120,13 @@ router.post(
           ),
         );
       } else {
-        throw new error.HttpStatusError(500, `Job sequence ${result.jobSequenceId} failed.`);
+        if (req.get('HX-Request')) {
+          res
+            .set('HX-Redirect', res.locals.urlPrefix + '/jobSequence/' + result.jobSequenceId)
+            .send();
+        } else {
+          res.redirect(res.locals.urlPrefix + '/jobSequence/' + result.jobSequenceId);
+        }
       }
     } else if (req.body.__action === 'regenerate_question') {
       const genJobs = await selectJobsByJobSequenceId(req.body.unsafe_sequence_job_id);
@@ -137,7 +143,7 @@ router.post(
 
       const result = await regenerateQuestion(
         client,
-        res.locals?.course?.course_id,
+        res.locals.course.id,
         res.locals.authn_user.user_id,
         genJobs[0]?.data?.prompt,
         req.body.prompt,
@@ -155,7 +161,13 @@ router.post(
           ),
         );
       } else {
-        res.redirect('/pl/jobSequence/' + result.jobSequenceId);
+        if (req.get('HX-Request')) {
+          res
+            .set('HX-Redirect', res.locals.urlPrefix + '/jobSequence/' + result.jobSequenceId)
+            .send();
+        } else {
+          res.redirect(res.locals.urlPrefix + '/jobSequence/' + result.jobSequenceId);
+        }
       }
     } else if (req.body.__action === 'save_question') {
       const genJobs = await selectJobsByJobSequenceId(req.body.unsafe_sequence_job_id);

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -56,7 +56,7 @@ router.post(
 
       const { syncContextDocuments } = await import('../../ee/lib/contextEmbeddings.js');
       const jobSequenceId = await syncContextDocuments(client, res.locals.authn_user.user_id);
-      res.redirect('/pl/jobSequence/' + jobSequenceId);
+      res.redirect('/pl/administrator/jobSequence/' + jobSequenceId);
     } else {
       throw new error.HttpStatusError(400, `unknown __action: ${req.body.__action}`);
     }

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -2308,6 +2308,16 @@ if (esMain(import.meta) && config.startServer) {
             dsn: config.sentryDsn,
             environment: config.sentryEnvironment,
 
+            // Sentry (specifically `import-in-the-middle`, which Sentry uses)
+            // is known to cause issues with loading `openai` as ESM. Their
+            // recommended workaround it to exclude the module from their hooks.
+            // See related issues:
+            // https://github.com/openai/openai-node/issues/903
+            // https://github.com/getsentry/sentry-javascript/issues/12414
+            registerEsmLoaderHooks: {
+              exclude: [/openai/],
+            },
+
             // We have our own OpenTelemetry setup, so ensure Sentry doesn't
             // try to set that up for itself.
             skipOpenTelemetrySetup: true,


### PR DESCRIPTION
This PR fixes several issues with AI question generation:

- Sentry's usage of `import-in-the-middle` breaks the `openai` library (see https://github.com/openai/openai-node/issues/903 and https://github.com/getsentry/sentry-javascript/issues/12414). I applied the recommended fix from Sentry.
- Server jobs weren't actually being associated with the course (the code was incorrectly reading `course.course_id` instead of `course.id`).
- Server job redirection was using routes that only exist in dev mode. I've updated them to use the correct routes.