### PR TITLE
Improve behavior of instance time limit adjust popover

### DIFF
--- a/apps/prairielearn/assets/scripts/behaviors/dropdown.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/dropdown.ts
@@ -17,6 +17,14 @@ onDocumentReady(() => {
             return;
           }
 
+          // Sometimes we have dropdown buttons that manually trigger popovers. Since
+          // we can't rely on `data-toggle="popover"` to detect these, we also support
+          // a `data-bs-toggles-popover` attribute.
+          if (clickEvent?.target.closest('[data-bs-toggle-popover]')) {
+            event.preventDefault();
+            return;
+          }
+
           // If the click occurred inside a popover, prevent the dropdown from hiding.
           if (clickEvent?.target.closest('.popover')) {
             event.preventDefault();

--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -73,7 +73,6 @@ onDocumentReady(() => {
       $('.time-limit-edit-button')
         .popover({
           sanitize: false,
-          placement: 'right',
           title() {
             const row = $(this).data('row');
             return row.action === 'set_time_limit_all'
@@ -492,6 +491,7 @@ onDocumentReady(() => {
           class="btn btn-secondary btn-xs ml-1 time-limit-edit-button"
           id="row${row.assessment_instance_id}PopoverTimeLimit"
           data-row="${JSON.stringify(row)}"
+          data-placement="right"
         >
           <i class="bi-pencil-square" aria-hidden="true"></i>
         </a>

--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -491,7 +491,8 @@ onDocumentReady(() => {
           class="btn btn-secondary btn-xs ml-1 time-limit-edit-button"
           id="row${row.assessment_instance_id}PopoverTimeLimit"
           data-row="${JSON.stringify(row)}"
-          data-placement="right"
+          data-placement="bottom"
+          data-boundary="window"
         >
           <i class="bi-pencil-square" aria-hidden="true"></i>
         </a>

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
@@ -124,6 +124,8 @@ export function InstructorAssessmentInstances({ resLocals }: { resLocals: Record
                                 </button>
                                 <button
                                   class="dropdown-item time-limit-edit-button time-limit-edit-all-button"
+                                  data-placement="left"
+                                  data-bs-toggle-popover
                                 >
                                   <i class="far fa-clock" aria-hidden="true"></i> Change time limit
                                   for all instances


### PR DESCRIPTION
Doing this ahead of Bootstrap 5. This change ensures that the dropdown remains open when the popover is triggered, which ensures that Bootstrap can place the popover correctly relative to the triggering element.