### PR TITLE
Add semantic headings

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -121,7 +121,7 @@ function InstanceUserInfo({
       <details>
         ${instance_group != null
           ? html`
-              <summary><h5 class="card-title">Group details</h5></summary>
+              <summary><h2 class="card-title h5">Group details</h2></summary>
               <div class="d-flex flex-wrap pb-2">
                 <div class="pr-1">${instance_group.name}</div>
                 <div class="pr-1">(${instance_group_uid_list?.join(', ')})</div>
@@ -129,7 +129,7 @@ function InstanceUserInfo({
             `
           : html`
               <summary>
-                <h5 class="card-title d-inline-block">Student details</h5>
+                <h2 class="card-title d-inline-block h5">Student details</h2>
               </summary>
               <div class="d-flex flex-wrap pb-2">
                 <div class="pr-1">${instance_user?.name}</div>
@@ -276,7 +276,7 @@ function AssessmentInstanceInfo({
 
   return html`
     <hr />
-    <h5 class="card-title">Assessment Instance:</h5>
+    <h2 class="card-title h5">Assessment Instance:</h2>
     <div class="d-flex flex-wrap">
       <div class="pr-1">AID:</div>
       <div>
@@ -326,7 +326,7 @@ function ManualGradingInfo({
 
   return html`
     <hr />
-    <h5 class="card-title">Manual Grading:</h5>
+    <h2 class="card-title h5">Manual Grading:</h2>
 
     <div class="d-flex flex-wrap">
       <div class="pr-1">Status:</div>

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -97,7 +97,7 @@ export function InstructorInfoPanel({
 
 function StaffUserInfo({ user }: { user: User }) {
   return html`
-    <h5 class="card-title">Staff user:</h5>
+    <h2 class="card-title h5">Staff user:</h2>
     <div class="d-flex flex-wrap pb-2">
       <div class="pr-1">${user.name}</div>
       <div class="pr-1">${user.uid}</div>
@@ -176,7 +176,7 @@ function QuestionInfo({
 
   return html`
     <hr />
-    <h5 class="card-title">Question:</h5>
+    <h2 class="card-title h5">Question:</h2>
 
     <div class="d-flex flex-wrap">
       <div class="pr-1">QID:</div>

--- a/apps/prairielearn/src/components/Modal.html.ts
+++ b/apps/prairielearn/src/components/Modal.html.ts
@@ -36,7 +36,7 @@ export function Modal({
             ${formAction ? html`action="${formAction}"` : ''}
           >
             <div class="modal-header">
-              <h4 class="modal-title" id=${titleId}>${title}</h4>
+              <h2 class="modal-title h4" id=${titleId}>${title}</h2>
             </div>
             ${body ? html`<div class="modal-body">${body}</div>` : ''} ${content ? content : ''}
             ${footer ? html`<div class="modal-footer">${footer}</div>` : ''}

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -617,11 +617,13 @@ function QuestionPanel({
   return html`
     <div class="card mb-4 question-block">
       <div class="card-header bg-primary text-white d-flex align-items-center">
-        ${QuestionTitle({
-          questionContext,
-          question,
-          questionNumber: instance_question_info?.question_number,
-        })}
+        <h1 class="h6 font-weight-normal mb-0">
+          ${QuestionTitle({
+            questionContext,
+            question,
+            questionNumber: instance_question_info?.question_number,
+          })}
+        </h1>
         ${showCopyQuestionButton
           ? html`
               <button

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -65,7 +65,7 @@ export function QuestionsTable({
       <div class="card-header bg-primary">
         <div class="row align-items-center justify-content-between">
           <div class="col-auto">
-            <span class="text-white">Questions</span>
+            <h1 class="text-white h6 font-weight-normal mb-0">Questions</h1>
           </div>
         </div>
       </div>

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.ts
@@ -31,7 +31,7 @@ export function AdministratorAdmins({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              Administrators
+              <h1 class="h6 font-weight-normal mb-0">Administrators</h1>
               <button
                 type="button"
                 class="btn btn-sm btn-light ml-auto"

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.ts
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.ts
@@ -31,7 +31,7 @@ export function AdministratorBatchedMigrations({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <span class="mr-auto">Batched migrations</span>
+              <h1 class="h6 font-weight-normal mb-0">Batched migrations</h1>
             </div>
             ${hasBatchedMigrations
               ? html`<div class="list-group list-group-flush">

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.html.ts
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.html.ts
@@ -35,6 +35,7 @@ export function AdministratorCourseRequests({
           navSubPage: 'courses',
         })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">All Course Requests</h1>
           ${CourseRequestsTable({
             rows,
             institutions,

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.ts
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.ts
@@ -45,6 +45,7 @@ export function AdministratorCourses({
           navSubPage: 'courses',
         })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">Courses</h1>
           ${CourseRequestsTable({
             rows: course_requests,
             institutions,

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -47,7 +47,9 @@ export function AdministratorFeatures({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Features</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Features</h1>
+            </div>
             ${features.length > 0
               ? html`<div class="list-group list-group-flush">
                   ${features.map((feature) => {

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -47,7 +47,7 @@ export function AdministratorFeatures({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Features</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Features</h1>
             ${features.length > 0
               ? html`<div class="list-group list-group-flush">
                   ${features.map((feature) => {

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
@@ -44,7 +44,7 @@ export function AdministratorInstitutions({
         <main id="content" class="container-fluid">
           <div id="institutions" class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              Institutions
+              <h1 class="h6 font-weight-normal mb-0">Institutions</h1>
               <button
                 type="button"
                 class="btn btn-sm btn-light ml-auto"

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
@@ -18,9 +18,9 @@ export function AdministratorNetworks({ resLocals }) {
         })}
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              Exam-mode networks
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Exam-mode networks</h1>
+            </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
@@ -18,7 +18,9 @@ export function AdministratorNetworks({ resLocals }) {
         })}
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Exam-mode networks</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
+              Exam-mode networks
+            </h1>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
@@ -47,7 +47,9 @@ export function AdministratorQueries({
         })}
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Queries</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Queries</h1>
+            </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <tbody>

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
@@ -47,7 +47,7 @@ export function AdministratorQueries({
         })}
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Queries</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Queries</h1>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <tbody>

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -177,7 +177,9 @@ export function AdministratorQuery({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-bold text-monospace mb-0">${sqlFilename}</h1>
+              <h1 class="h6 font-weight-normal mb-0">
+                Query: <span class="text-monospace">${sqlFilename}</span>
+              </h1>
               <button
                 class="btn btn-xs btn-light ml-2 my-n2"
                 type="button"

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -177,7 +177,7 @@ export function AdministratorQuery({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <span class="font-weight-bold text-monospace">${sqlFilename}</span>
+              <h1 class="h6 font-weight-bold text-monospace mb-0">${sqlFilename}</h1>
               <button
                 class="btn btn-xs btn-light ml-2 my-n2"
                 type="button"

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
@@ -24,6 +24,7 @@ export function AdministratorSettings({ resLocals }) {
           navSubPage: 'settings',
         })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">Administrator Settings</h1>
           <!-- Chunk generation -->
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
@@ -59,7 +59,7 @@ export function AdministratorWorkspaces({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <span class="mr-auto">Workspace hosts</span>
+              <h1 class="h6 font-weight-normal mb-0 mr-auto">Workspace hosts</h1>
               <button class="btn btn-light" id="toggle-all-workspaces" data-state="collapsed">
                 Expand all
               </button>

--- a/apps/prairielearn/src/pages/authPassword/authPassword.html.ts
+++ b/apps/prairielearn/src/pages/authPassword/authPassword.html.ts
@@ -22,6 +22,7 @@ export function AuthPassword({
           navPage: '',
         })}
         <main id="content" class="container">
+          <h1 class="sr-only">Assessment Password</h1>
           <div class="card mb-4">
             <div class="card-body">
               <p class="text-center">A password is required to access this assessment.</p>

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
@@ -57,6 +57,7 @@ export function CourseSyncs({
         </script>
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">Course Sync</h1>
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">Repository status</div>
             <div class="table-responsive">

--- a/apps/prairielearn/src/pages/enroll/enroll.html.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.html.ts
@@ -44,7 +44,7 @@ export function Enroll({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Courses</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Courses</h1>
             <table class="table table-sm table-hover table-striped">
               <tbody>
                 ${courseInstances.map((course_instance, idx) => {

--- a/apps/prairielearn/src/pages/enroll/enroll.html.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.html.ts
@@ -44,7 +44,9 @@ export function Enroll({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Courses</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Courses</h1>
+            </div>
             <table class="table table-sm table-hover table-striped">
               <tbody>
                 ${courseInstances.map((course_instance, idx) => {

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -55,9 +55,9 @@ export function ErrorPage({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-danger text-white h6 font-weight-normal">
-              Error processing request
-            </h1>
+            <div class="card-header bg-danger text-white">
+              <h1 class="h6 font-weight-normal mb-0">Error processing request</h1>
+            </div>
 
             <div class="card-body">
               <h2 class="mb-3 h4">${error.message}</h2>

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -55,7 +55,9 @@ export function ErrorPage({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-danger text-white">Error processing request</div>
+            <h1 class="card-header bg-danger text-white h6 font-weight-normal">
+              Error processing request
+            </h1>
 
             <div class="card-body">
               <h4 class="mb-3">${error.message}</h4>

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -60,7 +60,7 @@ export function ErrorPage({
             </h1>
 
             <div class="card-body">
-              <h4 class="mb-3">${error.message}</h4>
+              <h2 class="mb-3 h4">${error.message}</h2>
 
               ${unsafeHtml(errorInfo ?? '')}
 

--- a/apps/prairielearn/src/pages/home/home.html.ts
+++ b/apps/prairielearn/src/pages/home/home.html.ts
@@ -55,6 +55,7 @@ export function Home({
         </header>
 
         <main id="content" class="flex-grow-1">
+          <h1 class="sr-only">PrairieLearn Homepage</h1>
           ${ActionsHeader()}
 
           <div id="content" class="container py-5">

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -53,9 +53,11 @@ export function InstructorAssessmentAccess({
           })}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex align-items-center">
+            <h1
+              class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
+            >
               ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Access
-            </div>
+            </h1>
 
             <div class="table-responsive">
               <table class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -53,11 +53,11 @@ export function InstructorAssessmentAccess({
           })}
 
           <div class="card mb-4">
-            <h1
-              class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
-            >
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Access
-            </h1>
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Access
+              </h1>
+            </div>
 
             <div class="table-responsive">
               <table class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.html.ts
@@ -57,9 +57,11 @@ export function InstructorAssessmentDownloads({
           })}
 
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Downloads
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Downloads
+              </h1>
+            </div>
             ${resLocals.assessment.multiple_instance
               ? html`
                   <div class="card-body">

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.html.ts
@@ -57,9 +57,9 @@ export function InstructorAssessmentDownloads({
           })}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
               ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Downloads
-            </div>
+            </h1>
             ${resLocals.assessment.multiple_instance
               ? html`
                   <div class="card-body">

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -82,11 +82,11 @@ export function InstructorAssessmentGroups({
           ${!groupConfigInfo
             ? html`
                 <div class="card mb-4">
-                  <h1
-                    class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
-                  >
-                    ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
-                  </h1>
+                  <div class="card-header bg-primary text-white d-flex align-items-center">
+                    <h1 class="h6 font-weight-normal mb-0">
+                      ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
+                    </h1>
+                  </div>
                   <div class="card-body">
                     This is not a group assessment. To enable this functionality, please set
                     <code>"groupWork": true</code> in <code>infoAssessment.json</code>.

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -82,9 +82,11 @@ export function InstructorAssessmentGroups({
           ${!groupConfigInfo
             ? html`
                 <div class="card mb-4">
-                  <div class="card-header bg-primary text-white d-flex align-items-center">
+                  <h1
+                    class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
+                  >
                     ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
-                  </div>
+                  </h1>
                   <div class="card-body">
                     This is not a group assessment. To enable this functionality, please set
                     <code>"groupWork": true</code> in <code>infoAssessment.json</code>.
@@ -110,7 +112,9 @@ export function InstructorAssessmentGroups({
                   : ''}
                 <div class="card mb-4">
                   <div class="card-header bg-primary text-white d-flex align-items-center">
-                    ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
+                    <h1 class="h6 font-weight-normal mb-0">
+                      ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
+                    </h1>
                     ${resLocals.authz_data.has_course_instance_permission_edit
                       ? html`
                           <div class="ml-auto">

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -105,6 +105,9 @@ export function InstructorAssessmentInstance({
           navPage: '',
         })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">
+            ${resLocals.assessment_instance_label} instance for ${resLocals.instance_user.name}
+          </h1>
           ${ResetQuestionVariantsModal({
             csrfToken: resLocals.__csrf_token,
             groupWork: resLocals.assessment.group_work,

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
@@ -93,7 +93,9 @@ export function InstructorAssessmentInstances({ resLocals }: { resLocals: Record
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Students
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Students
+              </h1>
               ${resLocals.authz_data.has_course_instance_permission_edit
                 ? html`
                     <div class="ml-auto">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
@@ -60,9 +60,12 @@ export function ManualGradingAssessment({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Manual Grading Queue
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Manual Grading
+                Queue
+              </h1>
+            </div>
 
             <div class="table-responsive">
               <table id="instanceQuestionGradingTable" class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
@@ -60,9 +60,9 @@ export function ManualGradingAssessment({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
               ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Manual Grading Queue
-            </div>
+            </h1>
 
             <div class="table-responsive">
               <table id="instanceQuestionGradingTable" class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
@@ -105,9 +105,11 @@ export function AssessmentQuestion({
               `
             : ''}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              ${assessment.tid} / Question ${number_in_alternative_group}. ${question.title}
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${assessment.tid} / Question ${number_in_alternative_group}. ${question.title}
+              </h1>
+            </div>
             <form name="grading-form" method="POST">
               <input type="hidden" name="__action" value="batch_action" />
               <input type="hidden" name="__csrf_token" value="${__csrf_token}" />

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
@@ -105,9 +105,9 @@ export function AssessmentQuestion({
               `
             : ''}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
               ${assessment.tid} / Question ${number_in_alternative_group}. ${question.title}
-            </div>
+            </h1>
             <form name="grading-form" method="POST">
               <input type="hidden" name="__action" value="batch_action" />
               <input type="hidden" name="__csrf_token" value="${__csrf_token}" />

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -72,6 +72,7 @@ export function InstanceQuestion({
         </div>
         ${RubricSettingsModal({ resLocals })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">Instance Question Manual Grading</h1>
           ${resLocals.assessment_instance.open
             ? html`
                 <div class="alert alert-danger" role="alert">

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.html.ts
@@ -62,6 +62,9 @@ export function InstructorAssessmentQuestionStatistics({
       <body>
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">
+            ${resLocals.assessment_set.name} ${resLocals.assessment.number} Question Statistics
+          </h1>
           ${AssessmentSyncErrorsAndWarnings({
             authz_data: resLocals.authz_data,
             assessment: resLocals.assessment,

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -98,9 +98,11 @@ export function InstructorAssessmentQuestions({
           })}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex align-items-center">
+            <h1
+              class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
+            >
               ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Questions
-            </div>
+            </h1>
             ${AssessmentQuestionsTable({
               questions,
               assessmentType: resLocals.assessment.type,

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -98,11 +98,11 @@ export function InstructorAssessmentQuestions({
           })}
 
           <div class="card mb-4">
-            <h1
-              class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
-            >
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Questions
-            </h1>
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Questions
+              </h1>
+            </div>
             ${AssessmentQuestionsTable({
               questions,
               assessmentType: resLocals.assessment.type,

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
@@ -55,9 +55,11 @@ export function InstructorAssessmentRegrading({
             : ''}
 
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Regrading
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Regrading
+              </h1>
+            </div>
 
             ${resLocals.authz_data.has_course_instance_permission_edit
               ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
@@ -55,9 +55,9 @@ export function InstructorAssessmentRegrading({
             : ''}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
               ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Regrading
-            </div>
+            </h1>
 
             ${resLocals.authz_data.has_course_instance_permission_edit
               ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -41,9 +41,9 @@ export function InstructorAssessmentSettings({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex">
+            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
               ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Settings
-            </div>
+            </h1>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
                 <tr>

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -41,9 +41,11 @@ export function InstructorAssessmentSettings({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
-              ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Settings
-            </h1>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Settings
+              </h1>
+            </div>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
                 <tr>

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.html.ts
@@ -77,7 +77,7 @@ export function InstructorAssessmentStatistics({
             course: resLocals.course,
             urlPrefix: resLocals.urlPrefix,
           })}
-
+          <h1 class="sr-only">${resLocals.assessment_set.name} ${assessment.number} Statistics</h1>
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
               ${resLocals.assessment_set.name} ${assessment.number}: Score statistics

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.html.ts
@@ -73,9 +73,9 @@ function AssessmentUploadCard({
 }) {
   return html`
     <div class="card mb-4">
-      <div class="card-header bg-primary text-white">
+      <h1 class="card-header bg-primary text-white h6 font-weight-normal">
         ${assessmentSetName} ${assessmentNumber}: Uploads
-      </div>
+      </h1>
 
       ${authzHasPermissionEdit
         ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.html.ts
@@ -73,9 +73,11 @@ function AssessmentUploadCard({
 }) {
   return html`
     <div class="card mb-4">
-      <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-        ${assessmentSetName} ${assessmentNumber}: Uploads
-      </h1>
+      <div class="card-header bg-primary text-white">
+        <h1 class="h6 font-weight-normal mb-0">
+          ${assessmentSetName} ${assessmentNumber}: Uploads
+        </h1>
+      </div>
 
       ${authzHasPermissionEdit
         ? html`

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -67,7 +67,7 @@ export function InstructorAssessments({
             <div class="card-header bg-primary">
               <div class="row align-items-center justify-content-between">
                 <div class="col-auto">
-                  <span class="text-white">Assessments</span>
+                  <h1 class="text-white h6 font-weight-normal mb-0">Assessments</h1>
                 </div>
                 ${authz_data.has_course_permission_edit && !course.example_course
                   ? html`

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.html.ts
@@ -42,7 +42,7 @@ export function InstructorCourseAdminInstances({
             <div class="card-header bg-primary">
               <div class="row align-items-center justify-content-between">
                 <div class="col-auto">
-                  <span class="text-white">Course instances</span>
+                  <h1 class="text-white h6 font-weight-normal mb-0">Course instances</h1>
                 </div>
                 ${resLocals.authz_data.has_course_permission_edit &&
                 !resLocals.course.example_course &&

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.html.ts
@@ -27,7 +27,9 @@ export function InstructorCourseAdminSets({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Assessment sets</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Assessment sets</h1>
+            </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.html.ts
@@ -27,7 +27,7 @@ export function InstructorCourseAdminSets({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Assessment sets</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Assessment sets</h1>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -38,9 +38,9 @@ export function InstructorCourseAdminSettings({
           })}
 
           <div class="card  mb-4">
-            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
-              Course Settings
-            </h1>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1 class="h6 font-weight-normal mb-0">Course Settings</h1>
+            </div>
             <div class="card-body">
               ${!courseInfoExists || !coursePathExists
                 ? CourseDirectoryMissingAlert({

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -38,7 +38,9 @@ export function InstructorCourseAdminSettings({
           })}
 
           <div class="card  mb-4">
-            <div class="card-header bg-primary text-white d-flex">Course Settings</div>
+            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
+              Course Settings
+            </h1>
             <div class="card-body">
               ${!courseInfoExists || !coursePathExists
                 ? CourseDirectoryMissingAlert({

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -185,9 +185,9 @@ export function InstructorCourseAdminSharing({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
-              Course Sharing Info
-            </h1>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1 class="h6 font-weight-normal mb-0">Course Sharing Info</h1>
+            </div>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
                 <tr>

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -185,7 +185,9 @@ export function InstructorCourseAdminSharing({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex">Course Sharing Info</div>
+            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
+              Course Sharing Info
+            </h1>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
                 <tr>

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -86,7 +86,7 @@ export function InstructorCourseAdminStaff({
             <div class="card-header bg-primary">
               <div class="row align-items-center justify-content-between">
                 <div class="col-auto">
-                  <span class="text-white">Staff</span>
+                  <h1 class="text-white h6 font-weight-normal mb-0">Staff</h1>
                 </div>
                 <div class="col-auto">
                   <button

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
@@ -28,7 +28,9 @@ export function InstructorCourseAdminTags({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Tags</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Tags</h1>
+            </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
@@ -28,7 +28,7 @@ export function InstructorCourseAdminTags({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Tags</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Tags</h1>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.html.ts
@@ -28,7 +28,9 @@ export function InstructorCourseAdminTopics({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Topics</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Topics</h1>
+            </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.html.ts
@@ -28,7 +28,7 @@ export function InstructorCourseAdminTopics({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Topics</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Topics</h1>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">
                 <thead>

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.html.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.html.ts
@@ -63,6 +63,7 @@ export function InstructorEffectiveUser({
           navPage: 'effective',
         })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">Effective User</h1>
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">Authenticated user</div>
 

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
@@ -107,7 +107,7 @@ export function InstructorFileBrowserNoPermission({
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <div class="card-header bg-danger text-white">Files</div>
+            <h1 class="card-header bg-danger text-white h6 font-weight-normal">Files</h1>
             <div class="card-body">
               <h2>Insufficient permissions</h2>
               <p>You must have at least &quot;Viewer&quot; permissions for this course.</p>
@@ -196,6 +196,7 @@ export function InstructorFileBrowser({
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
           ${syncErrorsAndWarnings}
+          <h1 class="sr-only">File Browser</h1>
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
               <div class="row align-items-center justify-content-between">

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
@@ -106,9 +106,10 @@ export function InstructorFileBrowserNoPermission({
       <body>
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
-          <h1 class="sr-only">File Browser</h1>
           <div class="card mb-4">
-            <div class="card-header bg-danger text-white">File Browser</div>
+            <div class="card-header bg-danger text-white">
+              <h1 class="h6 font-weight-normal mb-0">Files</h1>
+            </div>
             <div class="card-body">
               <h2>Insufficient permissions</h2>
               <p>You must have at least &quot;Viewer&quot; permissions for this course.</p>
@@ -197,7 +198,7 @@ export function InstructorFileBrowser({
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
           ${syncErrorsAndWarnings}
-          <h1 class="sr-only">File Browser</h1>
+          <h1 class="sr-only">Files</h1>
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
               <div class="row align-items-center justify-content-between">

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
@@ -106,10 +106,9 @@ export function InstructorFileBrowserNoPermission({
       <body>
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">File Browser</h1>
           <div class="card mb-4">
-            <div class="card-header bg-danger text-white">
-              <h1 class="h6 font-weight-normal mb-0">Files</h1>
-            </div>
+            <div class="card-header bg-danger text-white">File Browser</div>
             <div class="card-body">
               <h2>Insufficient permissions</h2>
               <p>You must have at least &quot;Viewer&quot; permissions for this course.</p>

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
@@ -107,7 +107,9 @@ export function InstructorFileBrowserNoPermission({
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <h1 class="card-header bg-danger text-white h6 font-weight-normal">Files</h1>
+            <div class="card-header bg-danger text-white">
+              <h1 class="h6 font-weight-normal mb-0">Files</h1>
+            </div>
             <div class="card-body">
               <h2>Insufficient permissions</h2>
               <p>You must have at least &quot;Viewer&quot; permissions for this course.</p>

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
@@ -51,7 +51,7 @@ export function InstructorFileEditorNoPermission({
 
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <div class="card-header bg-danger text-white">File editor</div>
+            <h1 class="card-header bg-danger text-white h6 font-weight-normal">File editor</h1>
             <div class="card-body">
               <h2>Insufficient permissions</h2>
               ${resLocals.course.example_course
@@ -141,6 +141,7 @@ export function InstructorFileEditor({
                 </div>
               `
             : ''}
+          <h1 class="sr-only">File editor</h1>
 
           <form name="editor-form" method="POST">
             <input type="hidden" name="__csrf_token" value="${__csrf_token}" />

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
@@ -51,7 +51,9 @@ export function InstructorFileEditorNoPermission({
 
         <main id="content" class="container-fluid">
           <div class="card mb-4">
-            <h1 class="card-header bg-danger text-white h6 font-weight-normal">File editor</h1>
+            <div class="card-header bg-danger text-white">
+              <h1 class="h6 font-weight-normal mb-0">File editor</h1>
+            </div>
             <div class="card-body">
               <h2>Insufficient permissions</h2>
               ${resLocals.course.example_course

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
@@ -79,7 +79,9 @@ export function InstructorGradebook({
               })
             : html`
                 <div class="card mb-4">
-                  <h1 class="card-header bg-primary text-white h6 font-weight-normal">Gradebook</h1>
+                  <div class="card-header bg-primary text-white">
+                    <h1 class="h6 font-weight-normal mb-0">Gradebook</h1>
+                  </div>
                   <table id="gradebook-table"></table>
 
                   <div class="spinning-wheel card-body spinner-border">
@@ -105,7 +107,9 @@ function StudentDataViewMissing({
 }) {
   return html`
     <div class="card mb-4">
-      <h1 class="card-header bg-danger text-white h6 font-weight-normal">Gradebook</h1>
+      <div class="card-header bg-danger text-white h6 font-weight-normal">
+        <h1 class="h6 font-weight-normal mb-0">Gradebook</h1>
+      </div>
       <div class="card-body">
         <h2>Insufficient permissions</h2>
         <p>You must have permission to view student data in order to access the gradebook.</p>

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
@@ -79,7 +79,7 @@ export function InstructorGradebook({
               })
             : html`
                 <div class="card mb-4">
-                  <div class="card-header bg-primary text-white">Gradebook</div>
+                  <h1 class="card-header bg-primary text-white h6 font-weight-normal">Gradebook</h1>
                   <table id="gradebook-table"></table>
 
                   <div class="spinning-wheel card-body spinner-border">
@@ -105,7 +105,7 @@ function StudentDataViewMissing({
 }) {
   return html`
     <div class="card mb-4">
-      <div class="card-header bg-danger text-white">Gradebook</div>
+      <h1 class="card-header bg-danger text-white h6 font-weight-normal">Gradebook</h1>
       <div class="card-body">
         <h2>Insufficient permissions</h2>
         <p>You must have permission to view student data in order to access the gradebook.</p>

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -44,9 +44,9 @@ export function InstructorGradingJob({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
               Grading Job ${gradingJobRow.grading_job.id}
-            </div>
+            </h1>
 
             <table class="table table-sm table-hover two-column-description">
               <tbody>

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -44,9 +44,11 @@ export function InstructorGradingJob({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              Grading Job ${gradingJobRow.grading_job.id}
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">
+                Grading Job ${gradingJobRow.grading_job.id}
+              </h1>
+            </div>
 
             <table class="table table-sm table-hover two-column-description">
               <tbody>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -37,9 +37,11 @@ export function InstructorInstanceAdminAccess({
           })}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex align-items-center">
+            <h1
+              class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
+            >
               ${course_instance.long_name} course instance access rules
-            </div>
+            </h1>
 
             <div class="table-responsive">
               <table class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -37,11 +37,11 @@ export function InstructorInstanceAdminAccess({
           })}
 
           <div class="card mb-4">
-            <h1
-              class="card-header bg-primary text-white d-flex align-items-center h6 font-weight-normal"
-            >
-              ${course_instance.long_name} course instance access rules
-            </h1>
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+              <h1 class="h6 font-weight-normal mb-0">
+                ${course_instance.long_name} course instance access rules
+              </h1>
+            </div>
 
             <div class="table-responsive">
               <table class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
@@ -45,7 +45,9 @@ export function InstructorInstanceAdminLti({ resLocals }: { resLocals: Record<st
           ${!authz_data.has_course_permission_edit
             ? html`
                 <div class="card mb-4">
-                  <div class="card-header bg-danger text-white">LTI configuration</div>
+                  <h1 class="card-header bg-danger text-white h6 font-weight-normal">
+                    LTI configuration
+                  </h1>
                   <div class="card-body">
                     <h2>Insufficient permissions</h2>
                     <p>You must have at least &quot;Editor&quot; permissions for this course.</p>
@@ -66,7 +68,9 @@ export function InstructorInstanceAdminLti({ resLocals }: { resLocals: Record<st
               `
             : html`
                 <div class="card mb-4">
-                  <div class="card-header bg-primary text-white">LTI configuration</div>
+                  <h1 class="card-header bg-primary text-white h6 font-weight-normal">
+                    LTI configuration
+                  </h1>
                   <div class="card-body">
                     <p>
                       The LTI (Learning Tools Interoperability) standard allows other online

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
@@ -45,9 +45,9 @@ export function InstructorInstanceAdminLti({ resLocals }: { resLocals: Record<st
           ${!authz_data.has_course_permission_edit
             ? html`
                 <div class="card mb-4">
-                  <h1 class="card-header bg-danger text-white h6 font-weight-normal">
-                    LTI configuration
-                  </h1>
+                  <div class="card-header bg-danger text-white">
+                    <h1 class="h6 font-weight-normal mb-0">LTI configuration</h1>
+                  </div>
                   <div class="card-body">
                     <h2>Insufficient permissions</h2>
                     <p>You must have at least &quot;Editor&quot; permissions for this course.</p>
@@ -68,9 +68,9 @@ export function InstructorInstanceAdminLti({ resLocals }: { resLocals: Record<st
               `
             : html`
                 <div class="card mb-4">
-                  <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-                    LTI configuration
-                  </h1>
+                  <div class="card-header bg-primary text-white">
+                    <h1 class="h6 font-weight-normal mb-0">LTI configuration</h1>
+                  </div>
                   <div class="card-body">
                     <p>
                       The LTI (Learning Tools Interoperability) standard allows other online

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -40,9 +40,11 @@ export function InstructorInstanceAdminSettings({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
-              Course instance ${resLocals.course_instance.short_name}
-            </h1>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1 class="h6 font-weight-normal mb-0">
+                Course instance ${resLocals.course_instance.short_name}
+              </h1>
+            </div>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
                 <tr>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -40,9 +40,9 @@ export function InstructorInstanceAdminSettings({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex">
+            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
               Course instance ${resLocals.course_instance.short_name}
-            </div>
+            </h1>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
                 <tr>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -408,20 +408,20 @@ function FilterHelpModal() {
           </tr>
         </tbody>
       </table>
-      <h2 class="h4">Full-text search</h2>
+      <h3 class="h4">Full-text search</h3>
       <p>
         You can also search the issue message by simply entering text. For example,
         <code>no picture</code> would return any issues that contain text like "no picture".
       </p>
 
-      <h2 class="h4">Qualifier negation</h2>
+      <h3 class="h4">Qualifier negation</h3>
       <p>
         Any qualifier can be negated with the a hyphen (<code>-</code>). For example,
         <code>-is:manually-reported</code> would return all issues that were
         <strong>not</strong> manually reported.
       </p>
 
-      <h2 class="h4">Combining qualifiers</h2>
+      <h3 class="h4">Combining qualifiers</h3>
       <p>These can be combined to form complex searches. An example:</p>
       <code><pre>is:open qid:vector answer is wrong</pre></code>
       <p>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -408,20 +408,20 @@ function FilterHelpModal() {
           </tr>
         </tbody>
       </table>
-      <h4>Full-text search</h4>
+      <h2 class="h4">Full-text search</h2>
       <p>
         You can also search the issue message by simply entering text. For example,
         <code>no picture</code> would return any issues that contain text like "no picture".
       </p>
 
-      <h4>Qualifier negation</h4>
+      <h2 class="h4">Qualifier negation</h2>
       <p>
         Any qualifier can be negated with the a hyphen (<code>-</code>). For example,
         <code>-is:manually-reported</code> would return all issues that were
         <strong>not</strong> manually reported.
       </p>
 
-      <h4>Combining qualifiers</h4>
+      <h2 class="h4">Combining qualifiers</h2>
       <p>These can be combined to form complex searches. An example:</p>
       <code><pre>is:open qid:vector answer is wrong</pre></code>
       <p>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -100,7 +100,7 @@ export function InstructorIssues({
             <div class="card-header bg-primary text-white">
               <div class="d-flex flex-row align-items-center mb-2">
                 <div class="d-flex flex-column">
-                  Issues
+                  <h1 class="h6 font-weight-normal mb-0">Issues</h1>
                   <small>
                     <a href="${formattedCommonQueries.allOpenQuery}" class="mr-3 text-white">
                       <i class="fa fa-exclamation-circle"></i> ${openCount} open

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -91,9 +91,9 @@ export function InstructorQuestionSettings({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
-              Question Settings
-            </h1>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1 class="h6 font-weight-normal mb-0">Question Settings</h1>
+            </div>
             <div class="card-body">
               <form>
                 <div class="form-group">

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -91,7 +91,9 @@ export function InstructorQuestionSettings({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex">Question Settings</div>
+            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">
+              Question Settings
+            </h1>
             <div class="card-body">
               <form>
                 <div class="form-group">

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
@@ -60,9 +60,9 @@ export function InstructorQuestionStatistics({
           })}
 
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
               Detailed assessment statistics for question ${resLocals.question.qid}
-            </div>
+            </h1>
 
             <div class="table-responsive">
               <table class="table table-sm table-hover tablesorter table-bordered">

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
@@ -60,9 +60,11 @@ export function InstructorQuestionStatistics({
           })}
 
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">
-              Detailed assessment statistics for question ${resLocals.question.qid}
-            </h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">
+                Detailed assessment statistics for question ${resLocals.question.qid}
+              </h1>
+            </div>
 
             <div class="table-responsive">
               <table class="table table-sm table-hover tablesorter table-bordered">

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -53,6 +53,7 @@ export function RequestCourse({
           navPage: 'request_course',
         })}
         <main id="content" class="container">
+          <h1 class="sr-only">Request a Course</h1>
           ${CourseRequestsCard({ rows })}
           ${CourseNewRequestCard({ csrfToken: resLocals.__csrf_token })}
         </main>

--- a/apps/prairielearn/src/pages/jobSequence/jobSequence.html.ts
+++ b/apps/prairielearn/src/pages/jobSequence/jobSequence.html.ts
@@ -29,6 +29,7 @@ export function JobSequence({
           navPage: '',
         })}
         <main id="content" class="container-fluid">
+          <h1 class="sr-only">Job Sequence</h1>
           <div class="row">
             <div class="col-12">
               <a class="btn btn-primary mb-4" href="javascript:history.back();">

--- a/apps/prairielearn/src/pages/newsItems/newsItems.html.ts
+++ b/apps/prairielearn/src/pages/newsItems/newsItems.html.ts
@@ -45,7 +45,9 @@ export function NewsItems({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">News</h1>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1 class="h6 font-weight-normal mb-0">News</h1>
+            </div>
 
             ${newsItems.length === 0
               ? html`

--- a/apps/prairielearn/src/pages/newsItems/newsItems.html.ts
+++ b/apps/prairielearn/src/pages/newsItems/newsItems.html.ts
@@ -45,7 +45,7 @@ export function NewsItems({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex">News</div>
+            <h1 class="card-header bg-primary text-white d-flex h6 font-weight-normal">News</h1>
 
             ${newsItems.length === 0
               ? html`

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.html.ts
@@ -34,7 +34,9 @@ export function StudentAssessment({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              ${assessment_set.abbreviation}${assessment.number}: ${assessment.title}
+              <h1 class="h6 font-weight-normal mb-0">
+                ${assessment_set.abbreviation}${assessment.number}: ${assessment.title}
+              </h1>
               ${assessment.group_work ? html`<i class="fas fa-users"></i>` : ''}
             </div>
 

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -92,8 +92,10 @@ export function StudentAssessmentInstance({
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
               <span>
-                ${resLocals.assessment_set.abbreviation}${resLocals.assessment.number}:
-                ${resLocals.assessment.title}
+                <h1 class="h6 font-weight-normal mb-0">
+                  ${resLocals.assessment_set.abbreviation}${resLocals.assessment.number}:
+                  ${resLocals.assessment.title}
+                </h1>
                 ${resLocals.assessment.group_work ? html`<i class="fas fa-users"></i>` : ''}
               </span>
             </div>

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
@@ -63,7 +63,7 @@ export function StudentAssessments({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Assessments</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Assessments</h1>
 
             <table class="table table-sm table-hover">
               <thead>

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
@@ -63,7 +63,9 @@ export function StudentAssessments({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Assessments</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Assessments</h1>
+            </div>
 
             <table class="table table-sm table-hover">
               <thead>

--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
@@ -44,7 +44,7 @@ export function StudentGradebook({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white">Gradebook</div>
+            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Gradebook</h1>
 
             <table class="table table-sm table-hover">
               <thead>

--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
@@ -44,7 +44,9 @@ export function StudentGradebook({
         })}
         <main id="content" class="container">
           <div class="card mb-4">
-            <h1 class="card-header bg-primary text-white h6 font-weight-normal">Gradebook</h1>
+            <div class="card-header bg-primary text-white">
+              <h1 class="h6 font-weight-normal mb-0">Gradebook</h1>
+            </div>
 
             <table class="table table-sm table-hover">
               <thead>

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -50,7 +50,9 @@ export function Workspace({
         >
           <div class="d-flex flex-column mr-3 text-white">
             <span>
-              <a href="${navTitleHref}" target="_blank" class="text-white">${navTitle}</a>
+              <h1 class="h6 font-weight-normal mb-0">
+                <a href="${navTitleHref}" target="_blank" class="text-white">${navTitle}</a>
+              </h1>
             </span>
             <span class="small">
               <i class="fa fa-laptop-code" aria-hidden="true"></i>


### PR DESCRIPTION
Closes #10427. This PR adds `<h1>` headings to all pages that do not have one. This will help us meet accessibility requirements by having a heading that is readable by screen readers on all pages. For most pages here, I have updated the card header to be the `<h1>` title for the page. Pages that did not have a clear heading or title, I have added a heading with `.sr-only`. The goal here is to have very little impact on the visual presentation of the pages while adding these headings. 