### PR TITLE
Switch from bootstrap-select to tom-select

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/info.json
+++ b/apps/prairielearn/elements/pl-multiple-choice/info.json
@@ -2,6 +2,7 @@
   "controller": "pl-multiple-choice.py",
   "dependencies": {
     "elementStyles": ["pl-multiple-choice.css"],
+    "elementScripts": ["pl-multiple-choice.js"],
     "nodeModulesStyles": ["tom-select/dist/css/tom-select.bootstrap4.min.css"],
     "nodeModulesScripts": ["tom-select/dist/js/tom-select.popular.min.js"]
   }

--- a/apps/prairielearn/elements/pl-multiple-choice/info.json
+++ b/apps/prairielearn/elements/pl-multiple-choice/info.json
@@ -2,7 +2,7 @@
   "controller": "pl-multiple-choice.py",
   "dependencies": {
     "elementStyles": ["pl-multiple-choice.css"],
-    "nodeModulesStyles": ["bootstrap-select/dist/css/bootstrap-select.min.css"],
-    "nodeModulesScripts": ["bootstrap-select/dist/js/bootstrap-select.min.js"]
+    "nodeModulesStyles": ["tom-select/dist/css/tom-select.bootstrap4.min.css"],
+    "nodeModulesScripts": ["tom-select/dist/js/tom-select.base.min.js"]
   }
 }

--- a/apps/prairielearn/elements/pl-multiple-choice/info.json
+++ b/apps/prairielearn/elements/pl-multiple-choice/info.json
@@ -3,6 +3,6 @@
   "dependencies": {
     "elementStyles": ["pl-multiple-choice.css"],
     "nodeModulesStyles": ["tom-select/dist/css/tom-select.bootstrap4.min.css"],
-    "nodeModulesScripts": ["tom-select/dist/js/tom-select.base.min.js"]
+    "nodeModulesScripts": ["tom-select/dist/js/tom-select.popular.min.js"]
   }
 }

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.css
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.css
@@ -17,12 +17,11 @@
   border-radius: 0.2rem;
 }
 
-.pl-multiple-choice-dropdown .ts-wrapper {
-  width: var(--pl-multiple-choice-dropdown-width, auto);
+.pl-multiple-choice-dropdown .ts-wrapper .ts-control .item {
+  min-width: var(--pl-multiple-choice-dropdown-width, 220px);
 }
 
 .pl-multiple-choice-dropdown .ts-control {
-  /** Always show the cursor as a pointer. */
   cursor: pointer !important;
 
   /** https://github.com/orchidjs/tom-select/issues/757 */

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.css
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.css
@@ -16,3 +16,15 @@
   margin-right: 0.5rem;
   border-radius: 0.2rem;
 }
+
+.pl-multiple-choice-dropdown .ts-wrapper {
+  width: var(--pl-multiple-choice-dropdown-width, auto);
+}
+
+.pl-multiple-choice-dropdown .ts-control {
+  /** Always show the cursor as a pointer. */
+  cursor: pointer !important;
+
+  /** https://github.com/orchidjs/tom-select/issues/757 */
+  padding-right: 2.5rem !important;
+}

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.js
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.js
@@ -1,0 +1,67 @@
+/* eslint-env browser */
+/* global TomSelect, MathJax */
+
+window.PLMultipleChoice = function (uuid) {
+  const selectElement = document.getElementById('pl-multiple-choice-select-' + uuid);
+  const container = selectElement.closest('.pl-multiple-choice-dropdown');
+
+  const select = new TomSelect(selectElement, {
+    plugins: ['no_backspace_delete', 'dropdown_input'],
+    allowEmptyOption: true,
+
+    // Search based on the `content` field, which comes from the `data-content`
+    // attribute on each option.
+    searchField: ['content'],
+
+    // Ensure searches happen immediately.
+    refreshThrottle: 0,
+
+    // Mirror default `<select>` behavior, only open on Down/Enter/Space.
+    openOnFocus: false,
+
+    // Render items based on the `data-content` attribute.
+    render: {
+      option: (data) => {
+        return `<div>${data.content}</div>`;
+      },
+      item: (data) => {
+        return `<div class="${data.disabled ? 'text-muted' : ''}">${data.content}</div>`;
+      },
+    },
+  });
+
+  // In case the dropdown items contain math, render it when the
+  // dropdown is opened or closed.
+  select.on('dropdown_open', () => {
+    // The first time the dropdown is opened, this even is fired before the
+    // options are actually present in the DOM. We'll wait for the next tick
+    // to ensure that the options are present.
+    setTimeout(() => MathJax.typesetPromise([container]), 0);
+  });
+  select.on('dropdown_close', () => MathJax.typesetPromise([container]));
+
+  // By default, `tom-select` will set the placeholder as the "active" option,
+  // but this means that the active option can't be changed with the up/down keys
+  // immediately after opening the dropdown. We'll override this function to
+  // ensure that a non-disabled option is always set as the active one.
+  const originalSetActiveOption = select.setActiveOption.bind(select);
+  select.setActiveOption = (option, scroll = true) => {
+    if (option?.getAttribute('aria-disabled') === 'true') {
+      option = select.wrapper.querySelector('[data-selectable]');
+    }
+
+    originalSetActiveOption(option, scroll);
+  };
+
+  // Mirror native `<select>` behavior, open the dropdown on Space or Enter.
+  select.control.addEventListener('keydown', (event) => {
+    if (event.key === ' ' || event.key === 'Enter') {
+      select.open();
+      event.preventDefault();
+    }
+  });
+
+  // Because we set `openOnFocus: false`, we need to manually open the dropdown
+  // when the control is clicked.
+  select.control.addEventListener('click', () => select.open());
+};

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -67,7 +67,16 @@
         $(() => {
             const select = new TomSelect('#pl-multiple-choice-select-{{uuid}}', {
                 plugins: ['no_backspace_delete', 'dropdown_input'],
+                allowEmptyOption: true,
+
+                // Search based on the `content` field, which comes from the `data-content`
+                // attribute on each option.
                 searchField: ['content'],
+
+                // Ensure searches happen immediately.
+                refreshThrottle: 0,
+
+                // Render items based on the `data-content` attribute.
                 render: {
                     option: (data, escape) => {
                         return`<div>${data.content}</div>`
@@ -90,7 +99,7 @@
         class="d-inline-flex"
         {{^editable}}disabled{{/editable}}
     >
-        <option value="" disabled selected>Select an option</option>
+        <option value="" disabled selected data-content="Select an option"></option>
         {{#answers}}
             <option
                 value="{{key}}"

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -82,7 +82,7 @@
                         return`<div>${data.content}</div>`
                     },
                     item: (data, escape) => {
-                        return `<div>${data.content}</div>`
+                        return `<div class="${data.disabled ? 'text-muted' : ''}">${data.content}</div>`
                     }
                 }
             });

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -76,6 +76,9 @@
                 // Ensure searches happen immediately.
                 refreshThrottle: 0,
 
+                // Mirror default `<select>` behavior, only open on Down/Enter/Space.
+                openOnFocus: false,
+
                 // Render items based on the `data-content` attribute.
                 render: {
                     option: (data, escape) => {
@@ -87,10 +90,40 @@
                 }
             });
 
+
             // In case the dropdown items contain math, render it when the
             // dropdown is opened or closed.
             select.on('dropdown_open', () => MathJax.typesetPromise());
-            select.on('dropdown_close', () => MathJax.typesetPromise())
+            select.on('dropdown_close', () => MathJax.typesetPromise());
+
+
+            // By default, `tom-select` will set the placeholder as the "active" option,
+            // but this means that the active option can't be changed with the up/down keys
+            // immediately after opening the dropdown. We'll override this function to
+            // ensure that a non-disabled option is always set as the active one.
+            const originalSetActiveOption = select.setActiveOption.bind(select);
+            select.setActiveOption = (option, scroll = true) => {
+                if (option?.getAttribute('aria-disabled') === 'true') {
+                    option = select.wrapper.querySelector('[data-selectable]');
+                }
+
+                originalSetActiveOption(option, scroll);
+            };
+
+            // Mirror native `<select>` behavior, open the dropdown on Space or Enter.
+            select.control.addEventListener('keydown', (event) => {
+                if (event.key === ' ' || event.key === 'Enter') {
+                    select.open();
+                    event.preventDefault();
+                }
+            });
+
+            // Because we set `openOnFocus: false`, we need to manually open the dropdown
+            // when the control is clicked.
+            select.control.addEventListener('click', (event) => {
+                select.open();
+            });
+
         });
     </script>
     <select

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -64,67 +64,7 @@
     {{#size}}style="--pl-multiple-choice-dropdown-width: {{size}}px"{{/size}}
 >
     <script>
-        $(() => {
-            const select = new TomSelect('#pl-multiple-choice-select-{{uuid}}', {
-                plugins: ['no_backspace_delete', 'dropdown_input'],
-                allowEmptyOption: true,
-
-                // Search based on the `content` field, which comes from the `data-content`
-                // attribute on each option.
-                searchField: ['content'],
-
-                // Ensure searches happen immediately.
-                refreshThrottle: 0,
-
-                // Mirror default `<select>` behavior, only open on Down/Enter/Space.
-                openOnFocus: false,
-
-                // Render items based on the `data-content` attribute.
-                render: {
-                    option: (data, escape) => {
-                        return`<div>${data.content}</div>`
-                    },
-                    item: (data, escape) => {
-                        return `<div class="${data.disabled ? 'text-muted' : ''}">${data.content}</div>`
-                    }
-                }
-            });
-
-
-            // In case the dropdown items contain math, render it when the
-            // dropdown is opened or closed.
-            select.on('dropdown_open', () => MathJax.typesetPromise());
-            select.on('dropdown_close', () => MathJax.typesetPromise());
-
-
-            // By default, `tom-select` will set the placeholder as the "active" option,
-            // but this means that the active option can't be changed with the up/down keys
-            // immediately after opening the dropdown. We'll override this function to
-            // ensure that a non-disabled option is always set as the active one.
-            const originalSetActiveOption = select.setActiveOption.bind(select);
-            select.setActiveOption = (option, scroll = true) => {
-                if (option?.getAttribute('aria-disabled') === 'true') {
-                    option = select.wrapper.querySelector('[data-selectable]');
-                }
-
-                originalSetActiveOption(option, scroll);
-            };
-
-            // Mirror native `<select>` behavior, open the dropdown on Space or Enter.
-            select.control.addEventListener('keydown', (event) => {
-                if (event.key === ' ' || event.key === 'Enter') {
-                    select.open();
-                    event.preventDefault();
-                }
-            });
-
-            // Because we set `openOnFocus: false`, we need to manually open the dropdown
-            // when the control is clicked.
-            select.control.addEventListener('click', (event) => {
-                select.open();
-            });
-
-        });
+        $(() => new window.PLMultipleChoice("{{uuid}}"));
     </script>
     <select
         name="{{name}}"

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -62,13 +62,27 @@
 <span class="py-1 d-inline align-items-center">
     <script>
         $(() => {
-            $('#pl-multiple-choice-select-{{uuid}}').selectpicker({})
-                .on('rendered.bs.select loaded.bs.select shown.bs.select', (e) => {
-                    // If any of the options has math, render the math as needed
-                    // Events: loaded (when the page opens), rendered (when the value changes),
-                    // shown (when the dropdown extends)
-                    MathJax.typesetPromise();
-                });
+            const select = new TomSelect('#pl-multiple-choice-select-{{uuid}}', {
+                render: {
+                    option: (data, escape) => {
+                        console.log('rendering option', data)
+                        return`<div>${data.content}</div>`
+                    },
+                    item: (data, escape) => {
+                        console.log('rendering item', data);
+                        return `<div>${data.content}</div>`
+                    }
+                }
+            });
+            select.on('dropdown_open', () => {
+                // If any of the options has math, render the math as needed
+                // Events: loaded (when the page opens), rendered (when the value changes),
+                // shown (when the dropdown extends)
+                MathJax.typesetPromise();
+            })
+            select.on('dropdown_close', () => {
+                MathJax.typesetPromise();
+            })
         });
     </script>
     <select

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -59,41 +59,38 @@
 {{/radio}}
 {{^radio}}
 <!-- Weirdly enough putting this in a div causes it to display without the inline -->
-<span class="py-1 d-inline align-items-center">
+<span
+    class="py-1 d-inline align-items-center pl-multiple-choice-dropdown"
+    {{#size}}style="--pl-multiple-choice-dropdown-width: {{size}}px"{{/size}}
+>
     <script>
         $(() => {
             const select = new TomSelect('#pl-multiple-choice-select-{{uuid}}', {
+                plugins: ['no_backspace_delete', 'dropdown_input'],
+                searchField: ['content'],
                 render: {
                     option: (data, escape) => {
-                        console.log('rendering option', data)
                         return`<div>${data.content}</div>`
                     },
                     item: (data, escape) => {
-                        console.log('rendering item', data);
                         return `<div>${data.content}</div>`
                     }
                 }
             });
-            select.on('dropdown_open', () => {
-                // If any of the options has math, render the math as needed
-                // Events: loaded (when the page opens), rendered (when the value changes),
-                // shown (when the dropdown extends)
-                MathJax.typesetPromise();
-            })
-            select.on('dropdown_close', () => {
-                MathJax.typesetPromise();
-            })
+
+            // In case the dropdown items contain math, render it when the
+            // dropdown is opened or closed.
+            select.on('dropdown_open', () => MathJax.typesetPromise());
+            select.on('dropdown_close', () => MathJax.typesetPromise())
         });
     </script>
     <select
         name="{{name}}"
-        data-style="btn-light border border-secondary"
         id="pl-multiple-choice-select-{{uuid}}"
-        title="Nothing selected"
         class="d-inline-flex"
-        {{#size}}data-width="{{size}}px"{{/size}}
         {{^editable}}disabled{{/editable}}
     >
+        <option value="" disabled selected>Select an option</option>
         {{#answers}}
             <option
                 value="{{key}}"

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -169,6 +169,7 @@
     "three": "0.160.1",
     "tmp": "^0.2.3",
     "tmp-promise": "^3.0.3",
+    "tom-select": "^2.3.1",
     "tzientist": "^3.2.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -68,7 +68,6 @@
     "body-parser": "^1.20.2",
     "bootstrap": "^4.6.2",
     "bootstrap-icons": "^1.11.3",
-    "bootstrap-select": "^1.13.18",
     "bootstrap-table": "1.21.2",
     "bowser": "^2.11.0",
     "byline": "^5.0.0",

--- a/exampleCourse/questions/element/multipleChoice/question.html
+++ b/exampleCourse/questions/element/multipleChoice/question.html
@@ -246,7 +246,7 @@
 
     <p>
       The sky is
-      <pl-multiple-choice answers-name="sky-color10" display="dropdown" allow-blank="true" order="random" size="25">
+      <pl-multiple-choice answers-name="sky-color10" display="dropdown" allow-blank="true" order="random" size="30">
         <pl-answer correct="true" feedback="Correct! The sky is indeed blue.">Blue ($470nm$)</pl-answer>
         <pl-answer score="0.5">Purple ($400nm$)</pl-answer>
         <pl-answer feedback="Hint: The correct answer is a complementary color to this one." score="0.1">

--- a/exampleCourse/questions/element/multipleChoice/question.html
+++ b/exampleCourse/questions/element/multipleChoice/question.html
@@ -246,7 +246,7 @@
 
     <p>
       The sky is
-      <pl-multiple-choice answers-name="sky-color10" display="dropdown" allow-blank="true" order="random" size="30">
+      <pl-multiple-choice answers-name="sky-color10" display="dropdown" allow-blank="true" order="random" size="25">
         <pl-answer correct="true" feedback="Correct! The sky is indeed blue.">Blue ($470nm$)</pl-answer>
         <pl-answer score="0.5">Purple ($400nm$)</pl-answer>
         <pl-answer feedback="Hint: The correct answer is a complementary color to this one." score="0.1">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,6 +2786,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@orchidjs/sifter@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@orchidjs/sifter@npm:1.0.3"
+  dependencies:
+    "@orchidjs/unicode-variants": "npm:^1.0.4"
+  checksum: 10c0/a0c4659ae7a8729ba7adef1b531e6dea394e9bba0309e3e803d66f6efa3d5d74c6d959540ccd8ae056b7283e1713f937cf81efede2b4ce6dddfa198a3a3f0a35
+  languageName: node
+  linkType: hard
+
+"@orchidjs/unicode-variants@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@orchidjs/unicode-variants@npm:1.0.4"
+  checksum: 10c0/b5e8362b6e98127db4ec9a1e02432f01ac2e679feb9d7cf47d7a77f65161c31cc2635bd511cc04ec7e3bb907fcdb1449ce3867245278c714e4d64ea989c49b9f
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -3505,6 +3521,7 @@ __metadata:
     three: "npm:0.160.1"
     tmp: "npm:^0.2.3"
     tmp-promise: "npm:^3.0.3"
+    tom-select: "npm:^2.3.1"
     tsx: "npm:^4.16.5"
     typescript: "npm:^5.5.4"
     typescript-cp: "npm:^0.1.9"
@@ -14471,6 +14488,16 @@ __metadata:
     "@tokenizer/token": "npm:^0.3.0"
     ieee754: "npm:^1.2.1"
   checksum: 10c0/5bf5eba51d63f71f301659ff70ce10ca43e7038364883437d8b4541cc98377e3e56109b11720e25fe51047014efaccdff90eaf6de9a78270483578814b838ab9
+  languageName: node
+  linkType: hard
+
+"tom-select@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "tom-select@npm:2.3.1"
+  dependencies:
+    "@orchidjs/sifter": "npm:^1.0.3"
+    "@orchidjs/unicode-variants": "npm:^1.0.4"
+  checksum: 10c0/82267fbb10e3573e750aba8da12fe0bdcd71d155b2eb9e86c148bfa9a50a638ff911feaa23f9c8d09b069b47f3a52a766f291d4cf8f399e16be4082e119c1c75
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,7 +3411,6 @@ __metadata:
     body-parser: "npm:^1.20.2"
     bootstrap: "npm:^4.6.2"
     bootstrap-icons: "npm:^1.11.3"
-    bootstrap-select: "npm:^1.13.18"
     bootstrap-table: "npm:1.21.2"
     bowser: "npm:^2.11.0"
     byline: "npm:^5.0.0"
@@ -6362,16 +6361,6 @@ __metadata:
   version: 1.11.3
   resolution: "bootstrap-icons@npm:1.11.3"
   checksum: 10c0/37eefd418c6bbbb304bdff0f2ed527f82c3c6f331d3e3a7c4aa8bbdbaf7118bb86725b024f85e7d738c613d48c7353cd81c09e58e9d8d34c5633960fdec8410b
-  languageName: node
-  linkType: hard
-
-"bootstrap-select@npm:^1.13.18":
-  version: 1.13.18
-  resolution: "bootstrap-select@npm:1.13.18"
-  peerDependencies:
-    bootstrap: ">=3.0.0"
-    jquery: 1.9.1 - 3
-  checksum: 10c0/84a569bc6a66dbffb80003f66b9525a84f20207cc00dc6f8a6f791a46ee8ae055011a5168d0f203f3f19b7c08e42ca7d60dd302b28b9a3ba4896dcce6a9821d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`bootstrap-select` doesn't fully support Bootstrap 5, which is a problem given we want to upgrade to Bootstrap 5 (#10095).

This PR switches us to use [`tom-select`](https://github.com/orchidjs/tom-select) instead, which better supports Bootstrap 5. 