### PR TITLE
Don't report missing user data after login as 500-level error

### DIFF
--- a/apps/prairielearn/src/ee/auth/azure/callback.ts
+++ b/apps/prairielearn/src/ee/auth/azure/callback.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import passport from 'passport';
 
+import { HttpStatusError } from '@prairielearn/error';
+
 import * as authnLib from '../../../lib/authn.js';
 
 const router = Router();
@@ -17,8 +19,6 @@ function authenticate(req, res): Promise<any> {
       (err, user) => {
         if (err) {
           reject(err);
-        } else if (!user) {
-          reject(new Error('Login failed'));
         } else {
           resolve(user);
         }
@@ -31,6 +31,13 @@ router.post(
   '/',
   asyncHandler(async (req, res) => {
     const user = await authenticate(req, res);
+
+    if (!user) {
+      // We shouldn't hit this case very often in practice, but if we do, we have
+      // no control over it, so we'll report the error as a 200 to avoid it
+      // contributing to error metrics.
+      throw new HttpStatusError(200, 'Login failed. Please try again.');
+    }
 
     const authnParams = {
       uid: user.upn,

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -4,7 +4,7 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import passport from 'passport';
 
-import * as error from '@prairielearn/error';
+import { HttpStatusError } from '@prairielearn/error';
 
 import * as authnLib from '../../../lib/authn.js';
 import { getInstitutionSamlProvider } from '../../lib/institution.js';
@@ -43,8 +43,6 @@ function authenticate(req, res): Promise<any> {
       (err, user) => {
         if (err) {
           reject(err);
-        } else if (!user) {
-          reject(new Error('Login failed'));
         } else {
           resolve(user);
         }
@@ -58,11 +56,18 @@ router.post(
   asyncHandler(async (req, res) => {
     const user = await authenticate(req, res);
 
+    if (!user) {
+      // We shouldn't hit this case very often in practice, but if we do, we have
+      // no control over it, so we'll report the error as a 200 to avoid it
+      // contributing to error metrics.
+      throw new HttpStatusError(200, 'Login failed. Please try again.');
+    }
+
     // Fetch this institution's attribute mappings.
     const institutionId = req.params.institution_id;
     const institutionSamlProvider = await getInstitutionSamlProvider(institutionId);
     if (!institutionSamlProvider) {
-      throw new error.HttpStatusError(404, 'Institution does not support SAML authentication');
+      throw new HttpStatusError(404, 'Institution does not support SAML authentication');
     }
 
     const uidAttribute = institutionSamlProvider.uid_attribute;

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -133,7 +133,7 @@ router.get(
   asyncHandler(async (req, res) => {
     const samlProvider = await getInstitutionSamlProvider(req.params.institution_id);
     if (!samlProvider) {
-      throw new error.HttpStatusError(404, 'Institution does not support SAML authentication');
+      throw new HttpStatusError(404, 'Institution does not support SAML authentication');
     }
 
     const metadata = await util.promisify(strategy.generateServiceProviderMetadata)(


### PR DESCRIPTION
A very small percentage of logins fail due to missing user data from Passport. From what I can tell, these errors are transient and we have no control over them. This PR changes those errors to return a 200 status code so that we don't get non-actionable alerts over 500 errors.

Note that other errors, e.g. SAML signature validation failures, will still be raised as 500s for now.