### PR TITLE
Add input validation to issue reporting

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -401,6 +401,7 @@ function IssueReportButton({
             rows="5"
             name="description"
             placeholder="Describe the issue"
+            required
           ></textarea>
         </div>
         <input type="hidden" name="__variant_id" value="${variant.id}" />

--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -196,6 +196,7 @@ function IssueReportingPanel({ variant, csrfToken }: { variant: Variant; csrfTok
             rows="5"
             name="description"
             placeholder="Describe the error in this question"
+            required
           ></textarea>
         </div>
         <input type="hidden" name="__variant_id" value="${variant.id}" />


### PR DESCRIPTION
Closes #10428. Currently, submitting an empty input field when reporting an issue in a question produces an error screen. This PR seeks to prevent submitting an empty form field by adding a `required` attribute to this input. 