### PR TITLE
Refine Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,14 @@ updates:
       interval: monthly
     rebase-strategy: disabled
     groups:
+      # Many OpenTelemetry packages are still pre-v1, so updates frequently won't
+      # be considered patch/minor updates. We always want to bump these all
+      # together, so we'll include a special group for them. Dependabot evaluates
+      # groups in the order that they're listed, so this will take precedence over
+      # the catch-all patch/minor group below.
+      opentelemetry:
+        patterns:
+          - '@opentelemetry/*'
       all-patch-minor:
         update-types:
           - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
 
   - package-ecosystem: pip
     directories:
+      - '/docs'
       - '/graders/c'
       - '/graders/python'
       - '/images/plbase'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,158 +4,115 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
     groups:
-      ace:
-        patterns:
-          - 'ace-code'
-          - 'ace-builds'
-      aws:
-        patterns:
-          - '@aws-sdk/*'
-          - '@smithy/*'
-      opentelemetry:
-        patterns:
-          - '@opentelemetry/*'
-      pg:
-        patterns:
-          - 'pg'
-          - 'pg-*'
-      sentry:
-        patterns:
-          - '@sentry/*'
-      typescript-eslint:
-        patterns:
-          - '@typescript-eslint/*'
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: docker
     directory: '/'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
+
+  # Base image
+  - package-ecosystem: docker
+    directory: '/images/plbase'
+    schedule:
+      interval: monthly
+    rebase-strategy: disabled
+  - package-ecosystem: pip
+    directory: '/images/plbase'
+    schedule:
+      interval: monthly
+    rebase-strategy: disabled
+    groups:
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'
+
+  # Graders
   - package-ecosystem: pip
     directory: '/graders/python'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
+    groups:
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'
   - package-ecosystem: docker
     directory: '/graders/python'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: pip
     directory: '/graders/c'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
+    groups:
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'
   - package-ecosystem: docker
     directory: '/graders/c'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: docker
     directory: '/graders/java'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
-  - package-ecosystem: docker
-    directory: '/images/plbase'
-    schedule:
-      interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
-    rebase-strategy: disabled
-  - package-ecosystem: pip
-    directory: '/images/plbase'
-    schedule:
-      interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
-    rebase-strategy: disabled
-    groups:
-      pandas:
-        patterns:
-          - 'pandas'
-          - 'pandas-stubs'
-      lxml:
-        patterns:
-          - 'lxml'
-          - 'types-lxml'
+
+  # Workspaces
   - package-ecosystem: docker
     directory: '/workspaces/jupyterlab'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: pip
     directory: '/workspaces/jupyterlab-python'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
+    groups:
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'
   - package-ecosystem: docker
     directory: '/workspaces/xtermjs'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: npm
     directory: '/workspaces/xtermjs/src'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: docker
     directory: '/workspaces/desktop'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
   - package-ecosystem: npm
     directory: '/workspaces/desktop/server'
     schedule:
       interval: monthly
-      time: '06:00'
-      timezone: America/Chicago
-    open-pull-requests-limit: 99
     rebase-strategy: disabled
+    groups:
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,113 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: '/'
+  - package-ecosystem: docker
+    directories:
+      - '/'
+      - '/graders/*'
+      - '/images/*'
+      - '/workspaces/*'
     schedule:
       interval: monthly
     rebase-strategy: disabled
-    groups:
-      all-patch-minor:
-        update-types:
-          - 'patch'
-          - 'minor'
+
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: monthly
     rebase-strategy: disabled
-  - package-ecosystem: docker
-    directory: '/'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
 
-  # Base image
-  - package-ecosystem: docker
-    directory: '/images/plbase'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-  - package-ecosystem: pip
-    directory: '/images/plbase'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-    groups:
-      all-patch-minor:
-        update-types:
-          - 'patch'
-          - 'minor'
-
-  # Graders
-  - package-ecosystem: pip
-    directory: '/graders/python'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-    groups:
-      all-patch-minor:
-        update-types:
-          - 'patch'
-          - 'minor'
-  - package-ecosystem: docker
-    directory: '/graders/python'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-  - package-ecosystem: pip
-    directory: '/graders/c'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-    groups:
-      all-patch-minor:
-        update-types:
-          - 'patch'
-          - 'minor'
-  - package-ecosystem: docker
-    directory: '/graders/c'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-  - package-ecosystem: docker
-    directory: '/graders/java'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-
-  # Workspaces
-  - package-ecosystem: docker
-    directory: '/workspaces/jupyterlab'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-  - package-ecosystem: pip
-    directory: '/workspaces/jupyterlab-python'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-    groups:
-      all-patch-minor:
-        update-types:
-          - 'patch'
-          - 'minor'
-  - package-ecosystem: docker
-    directory: '/workspaces/xtermjs'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
   - package-ecosystem: npm
-    directory: '/workspaces/xtermjs/src'
+    directories:
+      - '/'
+      - '/workspaces/desktop/server'
+      - '/workspaces/xtermjs/src'
     schedule:
       interval: monthly
     rebase-strategy: disabled
-  - package-ecosystem: docker
-    directory: '/workspaces/desktop'
-    schedule:
-      interval: monthly
-    rebase-strategy: disabled
-  - package-ecosystem: npm
-    directory: '/workspaces/desktop/server'
+    groups:
+      all-patch-minor:
+        update-types:
+          - 'patch'
+          - 'minor'
+
+  - package-ecosystem: pip
+    directories:
+      - '/graders/c'
+      - '/graders/python'
+      - '/images/plbase'
+      - '/workspaces/jupyterlab-python'
     schedule:
       interval: monthly
     rebase-strategy: disabled


### PR DESCRIPTION
This PR makes a number of changes to our Dependabot config that should make its PRs more manageable and useful for us:

- We use the new `directories` key to a) ensure minimal PRs per ecosystem and b) reduce the duplication of config.
- Instead of using bespoke dependency groups, we now prefer to group all patch/minor updates together. The exception for this is `@opentelemetry/*` dependencies; see the inline note about this.