### PR TITLE
Improve collapse behavior

### DIFF
--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
@@ -67,7 +67,7 @@
       {{/tests_missing_points}}
       {{#tests}}
         <div class="card mb-1 mt-1">
-          <div class="card-header d-flex collapsed" data-toggle="collapse" data-target="#card-{{uuid}}-{{index}}" style="cursor: pointer;">
+          <button class="card-header d-flex collapsed border-top-0 border-left-0 border-right-0" data-toggle="collapse" data-target="#card-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="card-{{uuid}}-{{index}}">
             <div class="mr-auto">
               <span class="card-title">
                 {{#show_points}}
@@ -80,7 +80,7 @@
             <div>
               <span class="fa fa-angle-down"></span>
             </div>
-          </div>
+          </button>
           <div id="card-{{uuid}}-{{index}}" class="collapse">
             <ul class="list-group list-group-flush">
               {{#has_description}}

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.css
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.css
@@ -1,7 +1,3 @@
-[id^='file-preview'] .file-status-container {
-  cursor: pointer;
-}
-
 [id^='file-preview'] .file-status {
   margin-bottom: 0px;
   font-size: 0.8em;

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.css
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.css
@@ -8,7 +8,7 @@
   transition: transform 400ms;
 }
 
-[id^='file-preview'] .file-status-container:not(.collapsed) .file-preview-icon {
+[id^='file-preview'] .file-status-container button:not(.collapsed) .file-preview-icon {
   transform: rotateX(180deg);
 }
 

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
@@ -53,10 +53,7 @@
         const pre = preview.querySelector('pre');
 
         const downloadButton = li.querySelector('.file-preview-download');
-        downloadButton.addEventListener('click', (event) => {
-          // Prevent this click from toggling the collapse state.
-          event.stopPropagation();
-
+        downloadButton.addEventListener('click', () => {
           downloadFile(path, file)
             .then(() => {
               hideErrorMessage();

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
@@ -18,7 +18,7 @@
             <button class="btn btn-outline-secondary btn-sm file-preview-download">
               Download
             </button>
-            <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="file-preview-contents-{{uuid}}-{{index}}">
+            <button type="button" class="btn btn-outline-secondary btn-sm collapsed" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="file-preview-contents-{{uuid}}-{{index}}">
               <span class="mr-2 js-toggle-show-preview-text">Show preview</span>
               <i class="file-preview-icon fa fa-angle-down"></i>
             </button>

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
@@ -8,7 +8,7 @@
     <ul class="list-group list-group-flush">
       {{#files}}
       <li class="list-group-item" data-file="{{name}}">
-        <div class="d-flex flex-row collapsed file-status-container" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}">
+        <div class="d-flex flex-row collapsed file-status-container">
           <div class="flex-grow-1 mr-2">
             <i class="fa fa-check-circle" style="color: {{check_icon_color}}" aria-hidden="true"></i>
             {{name}}
@@ -18,7 +18,7 @@
             <button class="btn btn-outline-secondary btn-sm file-preview-download">
               Download
             </button>
-            <button type="button" class="btn btn-outline-secondary btn-sm">
+            <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle="collapse" data-target="#file-preview-contents-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="file-preview-contents-{{uuid}}-{{index}}">
               <span class="mr-2 js-toggle-show-preview-text">Show preview</span>
               <i class="file-preview-icon fa fa-angle-down"></i>
             </button>

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.css
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.css
@@ -11,10 +11,6 @@
   border-style: solid;
 }
 
-[id^='file-upload'] .file-status-container.has-preview {
-  cursor: pointer;
-}
-
 [id^='file-upload'] .file-status-icon {
   margin-right: 10px;
   transition: all 400ms;
@@ -30,7 +26,7 @@
   content: 'Show preview';
 }
 
-[id^='file-upload'] .file-status-container:not(.collapsed) .file-preview-button::before {
+[id^='file-upload'] .file-preview-button:not(.collapsed)::before {
   content: 'Hide preview';
 }
 
@@ -39,7 +35,7 @@
   transition: transform 400ms;
 }
 
-[id^='file-upload'] .file-status-container:not(.collapsed) .file-preview-icon {
+[id^='file-upload'] .file-preview-button:not(.collapsed) .file-preview-icon {
   transform: rotateX(180deg);
 }
 

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -140,7 +140,7 @@
           // Show the preview for the newly-uploaded file
           const container = this.element.find(`li[data-file="${name}"]`);
           container.find('.file-preview').addClass('show');
-          container.find('.file-status-container').removeClass('collapsed');
+          container.find('.file-preview-button').removeClass('collapsed');
 
           // Ensure that students see a prompt if they try to navigate away
           // from the page without saving the form. This check is initially
@@ -207,16 +207,7 @@
         var fileData = this.getSubmittedFileContents(fileName);
 
         var $file = $('<li class="list-group-item" data-file="' + fileName + '"></li>');
-        var $fileStatusContainer = $(
-          '<div class="file-status-container collapsed d-flex flex-row" data-toggle="collapse" data-target="#file-preview-' +
-            uuid +
-            '-' +
-            index +
-            '"></div>',
-        );
-        if (isExpanded) {
-          $fileStatusContainer.removeClass('collapsed');
-        }
+        var $fileStatusContainer = $('<div class="file-status-container d-flex flex-row"></div>');
         if (fileData) {
           $fileStatusContainer.addClass('has-preview');
         }
@@ -258,7 +249,7 @@
           var download =
             '<a download="' +
             fileName +
-            '" class="btn btn-outline-secondary btn-sm mr-1" onclick="event.stopPropagation();" href="data:application/octet-stream;base64,' +
+            '" class="btn btn-outline-secondary btn-sm mr-1" href="data:application/octet-stream;base64,' +
             fileData +
             '">Download</a>';
 
@@ -308,7 +299,10 @@
           $fileStatusContainer.append(
             '<div class="align-self-center">' +
               download +
-              '<button type="button" class="btn btn-outline-secondary btn-sm file-preview-button"><span class="file-preview-icon fa fa-angle-down"></span></button></div>',
+              `<button type="button" class="btn btn-outline-secondary btn-sm file-preview-button ${!isExpanded ? 'collapsed' : ''}" data-toggle="collapse" data-target="#file-preview-${uuid}-${index}" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="file-preview-${uuid}-${index}">` +
+              '<span class="file-preview-icon fa fa-angle-down"></span>' +
+              '</button>' +
+              '</div>',
           );
         }
 

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -143,12 +143,7 @@ mjx-container {
   transform: rotateX(180deg);
 }
 
-/* Button in submission header context
-   prepends "hide" or "show" automatically */
-.submission-header {
-  cursor: pointer;
-}
-
+/* Button in submission header context prepends "hide" or "show" automatically */
 .submission-header .expand-icon {
   transition: transform 400ms;
 }
@@ -157,11 +152,11 @@ mjx-container {
   content: 'hide';
 }
 
-.submission-header.collapsed .expand-icon {
+.submission-header .expand-icon-container.collapsed .expand-icon {
   transform: rotateX(180deg);
 }
 
-.submission-header.collapsed .expand-icon-container::before {
+.submission-header .expand-icon-container.collapsed::before {
   content: 'show';
 }
 

--- a/apps/prairielearn/src/components/CourseRequestsTable.html.ts
+++ b/apps/prairielearn/src/components/CourseRequestsTable.html.ts
@@ -135,7 +135,7 @@ export function CourseRequestsTable({
                           >
                             <i class="fa fa-angle-up fa-fw expand-icon"></i>
                             Show Jobs
-                          </a>
+                          </button>
                         `
                       : ''}
                   </td>

--- a/apps/prairielearn/src/components/CourseRequestsTable.html.ts
+++ b/apps/prairielearn/src/components/CourseRequestsTable.html.ts
@@ -126,9 +126,8 @@ export function CourseRequestsTable({
                   <td class="align-middle">
                     ${row.jobs.length > 0
                       ? html`
-                          <a
-                            href="${urlPrefix}/administrator/jobSequence/${row.jobs[0].id}"
-                            class="show-hide-btn expand-icon-container btn btn-secondary btn-sm collapsed btn-xs text-nowrap"
+                          <button
+                            class="show-hide-btn btn btn-secondary btn-sm collapsed btn-xs text-nowrap"
                             data-toggle="collapse"
                             data-target="#course-requests-job-list-${row.id}"
                             aria-expanded="false"
@@ -144,7 +143,7 @@ export function CourseRequestsTable({
                 ${row.jobs.length > 0
                   ? html`
                       <tr>
-                        <td colspan="${showAll ? 10 : 9}" class="p-0">
+                        <td colspan="${showAll ? 11 : 10}" class="p-0">
                           <div id="course-requests-job-list-${row.id}" class="collapse">
                             <table class="table table-sm table-active mb-0">
                               <thead>

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -91,7 +91,7 @@ export function QuestionContainer({
               ? html`
                   <div class="mb-4 d-flex justify-content-center">
                     <button
-                      class="show-hide-btn expand-icon-container btn btn-outline-secondary btn-sm collapsed"
+                      class="show-hide-btn btn btn-outline-secondary btn-sm collapsed"
                       type="button"
                       data-toggle="collapse"
                       data-target="#more-submissions-collapser"

--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -93,8 +93,6 @@ export function SubmissionPanel({
                 class="card-header bg-info text-white d-flex align-items-center submission-header ${!expanded
                   ? ' collapsed'
                   : ''}"
-                data-toggle="collapse"
-                data-target="#submission-feedback-${submission.id}-body"
               >
                 <div class="mr-auto">
                   Feedback from the Course Staff
@@ -102,7 +100,16 @@ export function SubmissionPanel({
                     ? `(for submitted answer ${submission.submission_number})`
                     : ''}
                 </div>
-                <button type="button" class="expand-icon-container btn btn-outline-light btn-sm">
+                <button
+                  type="button"
+                  class="expand-icon-container btn btn-outline-light btn-sm ${!expanded
+                    ? 'collapsed'
+                    : ''}"
+                  data-toggle="collapse"
+                  data-target="#submission-feedback-${submission.id}-body"
+                  aria-expanded="${expanded ? 'true' : 'false'}"
+                  aria-controls="submission-feedback-${submission.id}-body"
+                >
                   <i class="fa fa-angle-up fa-fw ml-1 expand-icon"></i>
                 </button>
               </div>
@@ -193,13 +200,7 @@ export function SubmissionPanel({
         : ''}
 
       <div class="card mb-4" data-testid="submission-block">
-        <div
-          class="card-header bg-light text-dark d-flex align-items-center submission-header ${!expanded
-            ? ' collapsed'
-            : ''}"
-          data-toggle="collapse"
-          data-target="#submission-${submission.id}-body"
-        >
+        <div class="card-header bg-light text-dark d-flex align-items-center submission-header">
           <div class="mr-2">
             <div>
               <span class="mr-2">
@@ -223,12 +224,24 @@ export function SubmissionPanel({
           </div>
           <button
             type="button"
-            class="btn btn-outline-secondary btn-sm mr-2"
+            class="btn btn-outline-secondary btn-sm ml-2 mr-2"
             data-submission-id="${submission.id}"
+            data-toggle="modal"
+            data-target="#submissionInfoModal-${submission.id}"
+            aria-label="Submission info"
           >
             <i class="fa fa-info-circle fa-fw"></i>
           </button>
-          <button type="button" class="expand-icon-container btn btn-outline-secondary btn-sm">
+          <button
+            type="button"
+            class="expand-icon-container btn btn-outline-secondary btn-sm text-nowrap ${!expanded
+              ? 'collapsed'
+              : ''}"
+            data-toggle="collapse"
+            data-target="#submission-${submission.id}-body"
+            aria-expanded="${expanded ? 'true' : 'false'}"
+            aria-controls="submission-${submission.id}-body"
+          >
             <i class="fa fa-angle-up fa-fw ml-1 expand-icon"></i>
           </button>
         </div>
@@ -264,16 +277,6 @@ export function SubmissionPanel({
           course_instance_id,
         })}
       </div>
-
-      <script>
-        $(function () {
-          $('button[data-submission-id="${submission.id}"]').on('click', function (e) {
-            // Prevent this click from also expanding the submission
-            $('#submissionInfoModal-${submission.id}').modal('show');
-            e.stopPropagation();
-          });
-        });
-      </script>
     </div>
   `;
 }


### PR DESCRIPTION
This is being done ahead of Bootstrap 5. In v5, they changed how `data-toggle="collapse"` is handled. Now, they handle click events for that in the capturing phase instead of the bubbling phase (see https://github.com/twbs/bootstrap/issues/36063). This means that we no longer have the option of using `stopPropagation()` to ensure that clicks on nested buttons don't toggle the open/closed state. I opened https://github.com/twbs/bootstrap/pull/40574 to change Bootstrap to handle these events in the bubbling phase, but that's unlikely to be reviewed or released soon.

Now, collapse toggling is controlled only by an explicit button. The main user-facing change is that clicking on question submission/feedback panel headers will no longer toggle the open/closed state of the panel. IMO this is strictly (if indeed slightly) worse, but 🤷 

I made some accessibility improvements as I went:

- I added some missing `aria-expanded`/`aria-controls` attributes
- I changed `pl-external-grader-results` to use a `button` as a toggle instead of a `div`. This ensures that it can be navigated and operated with a keyboard.