### PR TITLE
Add ignores to Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
       # Recent versions of `bootstrap-table` broke behavior we rely on:
       # https://github.com/wenzhixin/bootstrap-table/issues/6745
       - dependency-name: 'bootstrap-table'
+      # We're putting off this upgrade for now:
+      # https://github.com/PrairieLearn/PrairieLearn/pull/6835
+      - dependency-name: 'fabric'
       # Recent versions of `threejs` don't include the pre-bundled file we rely on.
       - dependency-name: 'threejs'
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,12 @@ updates:
     schedule:
       interval: monthly
     rebase-strategy: disabled
+    ignore:
+      # Recent versions of `bootstrap-table` broke behavior we rely on:
+      # https://github.com/wenzhixin/bootstrap-table/issues/6745
+      - dependency-name: 'bootstrap-table'
+      # Recent versions of `threejs` don't include the pre-bundled file we rely on.
+      - dependency-name: 'threejs'
     groups:
       # Many OpenTelemetry packages are still pre-v1, so updates frequently won't
       # be considered patch/minor updates. We always want to bump these all
@@ -48,6 +54,10 @@ updates:
     schedule:
       interval: monthly
     rebase-strategy: disabled
+    ignore:
+      # We're not ready to jump to the latest version of `numpy` yet.
+      - dependency-name: 'numpy'
+        versions: ['>=2']
     groups:
       all-patch-minor:
         update-types:


### PR DESCRIPTION
This will keep Dependabot from trying to update things we don't want it to.