### PR TITLE
Downgrade nltk in workspace-jupyterlab-python

### DIFF
--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -10,7 +10,7 @@ matplotlib==3.9.1
 nbconvert==7.16.4
 nbformat==5.10.4
 networkx==3.3
-nltk==3.8.2
+nltk==3.8.1
 numpy==1.26.4
 openpyxl==3.1.5
 pandas==2.2.2


### PR DESCRIPTION
The maintainer of `nltk` deleted this version for PyPi (https://github.com/nltk/nltk/issues/3301), which broke our builds. This PR downgrades it so the image will build again.