### PR TITLE
Add backwards-compatible fix for checkbox/radio spacing

### DIFF
--- a/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
+++ b/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
@@ -3,7 +3,7 @@
 {{^inline}}<div class="d-block">{{/inline}}
 
 {{#answers}}
-    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1">
+    <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1 gap-2">
         <input class="form-check-input mt-0" type="checkbox"
                name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -5,7 +5,7 @@
 <span>
 {{/inline}}
     {{#answers}}
-        <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1">
+        <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1 gap-2">
             <input
                 class="form-check-input mt-0"
                 type="radio"


### PR DESCRIPTION
Bootstrap 5 changed how radios/checkboxes are styled. It now uses floating, which isn't compatible with `display: flex`.

<img width="137" alt="Screenshot 2024-08-15 at 13 54 39" src="https://github.com/user-attachments/assets/c689ae11-501e-4bf1-b660-2bd0fc60ef8a">

To fix this, I used Bootstrap 5's new "gap" utilities to add that spacing back. These classes don't exist in Bootstrap 4, so they won't have any effect there.

<img width="217" alt="Screenshot 2024-08-15 at 13 58 52" src="https://github.com/user-attachments/assets/6c71684f-e4b5-4c5f-ba07-f32bd7cabc89">
