### PR TITLE
Centralize styles for headings in card headers

### DIFF
--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -239,6 +239,14 @@ table td > .badge {
   padding-right: 1.25rem;
 }
 
+/** Ensure that headings in card headers are styled the same as standard card headers. */
+.card-header > :is(h1, h2, h3, h4, h5, h6) {
+  line-height: 1.5rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  font-weight: 400;
+}
+
 /* Custom button styles that look better in input groups */
 .btn.btn-med-light {
   color: #212529;

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -617,7 +617,7 @@ function QuestionPanel({
   return html`
     <div class="card mb-4 question-block">
       <div class="card-header bg-primary text-white d-flex align-items-center">
-        <h1 class="h6 font-weight-normal mb-0">
+        <h1>
           ${QuestionTitle({
             questionContext,
             question,

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -62,12 +62,8 @@ export function QuestionsTable({
     )}
 
     <div class="card mb-4">
-      <div class="card-header bg-primary">
-        <div class="row align-items-center justify-content-between">
-          <div class="col-auto">
-            <h1 class="text-white h6 font-weight-normal mb-0">Questions</h1>
-          </div>
-        </div>
+      <div class="card-header bg-primary text-white">
+        <h1>Questions</h1>
       </div>
 
       <form class="ml-1 btn-group" name="add-question-form" method="POST">

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -41,7 +41,9 @@ export function InstructorInstanceAdminLti13({
         })}
         <main id="content" class="container-fluid mb-4">
           <div class="card mb-4">
-            <div class="card-header bg-primary text-white d-flex">LTI 1.3 configuration</div>
+            <div class="card-header bg-primary text-white d-flex">
+              <h1>LTI 1.3 configuration</h1>
+            </div>
             <div class="card-body">
               <div class="row">
                 <div class="col-2">

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.html.ts
@@ -26,7 +26,7 @@ export function AdministratorAdmins({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">Administrators</h1>
+              <h1>Administrators</h1>
               <button
                 type="button"
                 class="btn btn-sm btn-light ml-auto"

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.ts
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.ts
@@ -31,7 +31,7 @@ export function AdministratorBatchedMigrations({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">Batched migrations</h1>
+              <h1>Batched migrations</h1>
             </div>
             ${hasBatchedMigrations
               ? html`<div class="list-group list-group-flush">

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -48,7 +48,7 @@ export function AdministratorFeatures({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Features</h1>
+              <h1>Features</h1>
             </div>
             ${features.length > 0
               ? html`<div class="list-group list-group-flush">

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.html.ts
@@ -39,7 +39,7 @@ export function AdministratorInstitutions({
         <main id="content" class="container-fluid">
           <div id="institutions" class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">Institutions</h1>
+              <h1>Institutions</h1>
               <button
                 type="button"
                 class="btn btn-sm btn-light ml-auto"

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
@@ -19,7 +19,7 @@ export function AdministratorNetworks({ resLocals }) {
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Exam-mode networks</h1>
+              <h1>Exam-mode networks</h1>
             </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
@@ -48,7 +48,7 @@ export function AdministratorQueries({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Queries</h1>
+              <h1>Queries</h1>
             </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -177,9 +177,7 @@ export function AdministratorQuery({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">
-                Query: <span class="text-monospace">${sqlFilename}</span>
-              </h1>
+              <h1>Query: <span class="text-monospace">${sqlFilename}</span></h1>
               <button
                 class="btn btn-xs btn-light ml-2 my-n2"
                 type="button"

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
@@ -58,8 +58,12 @@ export function AdministratorWorkspaces({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0 mr-auto">Workspace hosts</h1>
-              <button class="btn btn-light" id="toggle-all-workspaces" data-state="collapsed">
+              <h1>Workspace hosts</h1>
+              <button
+                class="btn btn-light ml-auto"
+                id="toggle-all-workspaces"
+                data-state="collapsed"
+              >
                 Expand all
               </button>
             </div>

--- a/apps/prairielearn/src/pages/editError/editError.html.ts
+++ b/apps/prairielearn/src/pages/editError/editError.html.ts
@@ -45,22 +45,18 @@ export function EditError({
           </script>
 
           <div class="card mb-4">
-            <h5 class="card-header bg-danger text-white">
-              <div class="row align-items-center justify-content-between">
-                <div class="col-auto">Edit Failure</div>
-                <div class="col-auto">
-                  <button
-                    type="button"
-                    class="btn btn-light btn-sm"
-                    data-toggle="collapse"
-                    data-target="#job-sequence-results"
-                    id="job-sequence-results-button"
-                  >
-                    Show detail
-                  </button>
-                </div>
-              </div>
-            </h5>
+            <div class="card-header bg-danger text-white d-flex align-items-center">
+              <h1>Edit Failure</h1>
+              <button
+                type="button"
+                class="btn btn-light btn-sm ml-auto"
+                data-toggle="collapse"
+                data-target="#job-sequence-results"
+                id="job-sequence-results-button"
+              >
+                Show detail
+              </button>
+            </div>
             <div class="card-body">
               <p>The file edit did not complete successfully.</p>
               ${failedSync

--- a/apps/prairielearn/src/pages/enroll/enroll.html.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.html.ts
@@ -40,7 +40,7 @@ export function Enroll({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Courses</h1>
+              <h1>Courses</h1>
             </div>
             <table class="table table-sm table-hover table-striped">
               <tbody>

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -56,7 +56,7 @@ export function ErrorPage({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-danger text-white">
-              <h1 class="h6 font-weight-normal mb-0">Error processing request</h1>
+              <h1>Error processing request</h1>
             </div>
 
             <div class="card-body">

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -49,9 +49,7 @@ export function InstructorAssessmentAccess({
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Access
-              </h1>
+              <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Access</h1>
             </div>
 
             <div class="table-responsive">

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.html.ts
@@ -58,9 +58,7 @@ export function InstructorAssessmentDownloads({
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Downloads
-              </h1>
+              <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Downloads</h1>
             </div>
             ${resLocals.assessment.multiple_instance
               ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -61,9 +61,7 @@ export function InstructorAssessmentGroups({
             ? html`
                 <div class="card mb-4">
                   <div class="card-header bg-primary text-white d-flex align-items-center">
-                    <h1 class="h6 font-weight-normal mb-0">
-                      ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
-                    </h1>
+                    <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups</h1>
                   </div>
                   <div class="card-body">
                     This is not a group assessment. To enable this functionality, please set
@@ -90,9 +88,7 @@ export function InstructorAssessmentGroups({
                   : ''}
                 <div class="card mb-4">
                   <div class="card-header bg-primary text-white d-flex align-items-center">
-                    <h1 class="h6 font-weight-normal mb-0">
-                      ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups
-                    </h1>
+                    <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups</h1>
                     ${resLocals.authz_data.has_course_instance_permission_edit
                       ? html`
                           <div class="ml-auto">

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
@@ -93,9 +93,7 @@ export function InstructorAssessmentInstances({ resLocals }: { resLocals: Record
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Students
-              </h1>
+              <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Students</h1>
               ${resLocals.authz_data.has_course_instance_permission_edit
                 ? html`
                     <div class="ml-auto">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
@@ -69,7 +69,7 @@ export function ManualGradingAssessment({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
+              <h1>
                 ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Manual Grading
                 Queue
               </h1>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.ts
@@ -108,7 +108,7 @@ export function AssessmentQuestion({
             : ''}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
+              <h1>
                 ${assessment.tid} / Question ${number_in_alternative_group}. ${question.title}
               </h1>
             </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.html.ts
@@ -99,9 +99,7 @@ export function InstructorAssessmentQuestions({
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Questions
-              </h1>
+              <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Questions</h1>
             </div>
             ${AssessmentQuestionsTable({
               questions,

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.html.ts
@@ -51,9 +51,7 @@ export function InstructorAssessmentRegrading({
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Regrading
-              </h1>
+              <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Regrading</h1>
             </div>
 
             ${resLocals.authz_data.has_course_instance_permission_edit

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -42,9 +42,7 @@ export function InstructorAssessmentSettings({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Settings
-              </h1>
+              <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Settings</h1>
             </div>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
@@ -152,57 +150,47 @@ export function InstructorAssessmentSettings({
             </table>
             ${resLocals.authz_data.has_course_permission_edit && !resLocals.course.example_course
               ? html`
-                  <div class="card-footer">
-                    <div class="row">
-                      <div class="col-auto">
-                        <form name="copy-assessment-form" class="form-inline" method="POST">
-                          <input
-                            type="hidden"
-                            name="__csrf_token"
-                            value="${resLocals.__csrf_token}"
-                          />
-                          <button
-                            name="__action"
-                            value="copy_assessment"
-                            class="btn btn-sm btn-primary"
-                          >
-                            <i class="fa fa-clone"></i> Make a copy of this assessment
-                          </button>
-                        </form>
-                      </div>
-                      <div class="col-auto">
-                        <button
-                          class="btn btn-sm btn-primary"
-                          href="#"
-                          data-toggle="modal"
-                          data-target="#deleteAssessmentModal"
-                        >
-                          <i class="fa fa-times" aria-hidden="true"></i> Delete this assessment
+                  <div class="card-footer d-flex flex-wrap align-items-center">
+                    <form name="copy-assessment-form" class="mr-2" method="POST">
+                      <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                      <button
+                        name="__action"
+                        value="copy_assessment"
+                        class="btn btn-sm btn-primary"
+                      >
+                        <i class="fa fa-clone"></i> Make a copy of this assessment
+                      </button>
+                    </form>
+                    <button
+                      class="btn btn-sm btn-primary"
+                      href="#"
+                      data-toggle="modal"
+                      data-target="#deleteAssessmentModal"
+                    >
+                      <i class="fa fa-times" aria-hidden="true"></i> Delete this assessment
+                    </button>
+                    ${Modal({
+                      id: 'deleteAssessmentModal',
+                      title: 'Delete assessment',
+                      body: html`
+                        <p>
+                          Are you sure you want to delete the assessment
+                          <strong>${resLocals.assessment.tid}</strong>?
+                        </p>
+                      `,
+                      footer: html`
+                        <input type="hidden" name="__action" value="delete_assessment" />
+                        <input
+                          type="hidden"
+                          name="__csrf_token"
+                          value="${resLocals.__csrf_token}"
+                        />
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+                          Cancel
                         </button>
-                      </div>
-                      ${Modal({
-                        id: 'deleteAssessmentModal',
-                        title: 'Delete assessment',
-                        body: html`
-                          <p>
-                            Are you sure you want to delete the assessment
-                            <strong>${resLocals.assessment.tid}</strong>?
-                          </p>
-                        `,
-                        footer: html`
-                          <input type="hidden" name="__action" value="delete_assessment" />
-                          <input
-                            type="hidden"
-                            name="__csrf_token"
-                            value="${resLocals.__csrf_token}"
-                          />
-                          <button type="button" class="btn btn-secondary" data-dismiss="modal">
-                            Cancel
-                          </button>
-                          <button type="submit" class="btn btn-danger">Delete</button>
-                        `,
-                      })}
-                    </div>
+                        <button type="submit" class="btn btn-danger">Delete</button>
+                      `,
+                    })}
                   </div>
                 `
               : ''}

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.html.ts
@@ -74,9 +74,7 @@ function AssessmentUploadCard({
   return html`
     <div class="card mb-4">
       <div class="card-header bg-primary text-white">
-        <h1 class="h6 font-weight-normal mb-0">
-          ${assessmentSetName} ${assessmentNumber}: Uploads
-        </h1>
+        <h1>${assessmentSetName} ${assessmentNumber}: Uploads</h1>
       </div>
 
       ${authzHasPermissionEdit

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -64,29 +64,19 @@ export function InstructorAssessments({
             urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary">
-              <div class="row align-items-center justify-content-between">
-                <div class="col-auto">
-                  <h1 class="text-white h6 font-weight-normal mb-0">Assessments</h1>
-                </div>
-                ${authz_data.has_course_permission_edit && !course.example_course
-                  ? html`
-                      <div class="col-auto">
-                        <form name="add-assessment-form" method="POST">
-                          <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                          <button
-                            name="__action"
-                            value="add_assessment"
-                            class="btn btn-sm btn-light"
-                          >
-                            <i class="fa fa-plus" aria-hidden="true"></i>
-                            <span class="d-none d-sm-inline">Add assessment</span>
-                          </button>
-                        </form>
-                      </div>
-                    `
-                  : ''}
-              </div>
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+              <h1>Assessments</h1>
+              ${authz_data.has_course_permission_edit && !course.example_course
+                ? html`
+                    <form class="ml-auto" name="add-assessment-form" method="POST">
+                      <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                      <button name="__action" value="add_assessment" class="btn btn-sm btn-light">
+                        <i class="fa fa-plus" aria-hidden="true"></i>
+                        <span class="d-none d-sm-inline">Add assessment</span>
+                      </button>
+                    </form>
+                  `
+                : ''}
             </div>
 
             <div class="table-responsive">

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.html.ts
@@ -29,35 +29,25 @@ export function InstructorCourseAdminInstances({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary">
-              <div class="row align-items-center justify-content-between">
-                <div class="col-auto">
-                  <h1 class="text-white h6 font-weight-normal mb-0">Course instances</h1>
-                </div>
-                ${resLocals.authz_data.has_course_permission_edit &&
-                !resLocals.course.example_course &&
-                !resLocals.needToSync
-                  ? html`
-                      <div class="col-auto">
-                        <form name="add-course-instance-form" method="POST">
-                          <input
-                            type="hidden"
-                            name="__csrf_token"
-                            value="${resLocals.__csrf_token}"
-                          />
-                          <button
-                            name="__action"
-                            value="add_course_instance"
-                            class="btn btn-sm btn-light"
-                          >
-                            <i class="fa fa-plus" aria-hidden="true"></i>
-                            <span class="d-none d-sm-inline">Add course instance</span>
-                          </button>
-                        </form>
-                      </div>
-                    `
-                  : ''}
-              </div>
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+              <h1>Course instances</h1>
+              ${resLocals.authz_data.has_course_permission_edit &&
+              !resLocals.course.example_course &&
+              !resLocals.needToSync
+                ? html`
+                    <form class="ml-auto" name="add-course-instance-form" method="POST">
+                      <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                      <button
+                        name="__action"
+                        value="add_course_instance"
+                        class="btn btn-sm btn-light"
+                      >
+                        <i class="fa fa-plus" aria-hidden="true"></i>
+                        <span class="d-none d-sm-inline">Add course instance</span>
+                      </button>
+                    </form>
+                  `
+                : ''}
             </div>
 
             <div class="table-responsive">

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.html.ts
@@ -28,7 +28,7 @@ export function InstructorCourseAdminSets({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Assessment sets</h1>
+              <h1>Assessment sets</h1>
             </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -39,7 +39,7 @@ export function InstructorCourseAdminSettings({
 
           <div class="card  mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1 class="h6 font-weight-normal mb-0">Course Settings</h1>
+              <h1>Course Settings</h1>
             </div>
             <div class="card-body">
               ${!courseInfoExists || !coursePathExists

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.html.ts
@@ -171,7 +171,7 @@ export function InstructorCourseAdminSharing({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1 class="h6 font-weight-normal mb-0">Course Sharing Info</h1>
+              <h1>Course Sharing Info</h1>
             </div>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
@@ -239,33 +239,29 @@ export function InstructorCourseAdminSharing({
           </div>
 
           <div class="card mb-4">
-            <div class="card-header bg-primary">
-              <div class="row align-items-center justify-content-between">
-                <div class="col-auto">
-                  <span class="text-white">Sharing Sets</span>
-                </div>
-                ${isCourseOwner
-                  ? html`<div class="col-auto">
-                      <button
-                        type="button"
-                        class="btn btn-light btn-sm ml-auto"
-                        data-toggle="popover"
-                        data-container="body"
-                        data-html="true"
-                        data-placement="auto"
-                        title="Create Sharing Set"
-                        data-content="${escapeHtml(
-                          AddSharingSetPopover({
-                            csrfToken: resLocals.__csrf_token,
-                          }),
-                        )}"
-                      >
-                        <i class="fas fa-plus" aria-hidden="true"></i>
-                        <span class="d-none d-sm-inline">Create Sharing Set</span>
-                      </button>
-                    </div>`
-                  : ''}
-              </div>
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+              <span>Sharing Sets</span>
+              ${isCourseOwner
+                ? html`
+                    <button
+                      type="button"
+                      class="btn btn-light btn-sm ml-auto"
+                      data-toggle="popover"
+                      data-container="body"
+                      data-html="true"
+                      data-placement="auto"
+                      title="Create Sharing Set"
+                      data-content="${escapeHtml(
+                        AddSharingSetPopover({
+                          csrfToken: resLocals.__csrf_token,
+                        }),
+                      )}"
+                    >
+                      <i class="fas fa-plus" aria-hidden="true"></i>
+                      <span class="d-none d-sm-inline">Create Sharing Set</span>
+                    </button>
+                  `
+                : ''}
             </div>
             <table class="table table-sm table-hover table-striped">
               <thead>

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -76,87 +76,83 @@ export function InstructorCourseAdminStaff({
             urlPrefix: resLocals.urlPrefix,
           })}
           <div class="card mb-4">
-            <div class="card-header bg-primary">
-              <div class="row align-items-center justify-content-between">
-                <div class="col-auto">
-                  <h1 class="text-white h6 font-weight-normal mb-0">Staff</h1>
-                </div>
-                <div class="col-auto">
-                  <button
-                    type="button"
-                    class="btn btn-light btn-sm ml-auto"
-                    data-toggle="popover"
-                    data-container="body"
-                    data-html="true"
-                    data-placement="auto"
-                    title="Remove all student data access"
-                    data-content="${escapeHtml(
-                      CoursePermissionsRemoveStudentDataAccessForm({
-                        csrfToken: resLocals.__csrf_token,
-                      }),
-                    )}"
-                    data-testid="remove-all-student-data-access-button"
-                  >
-                    <i class="fas fa-eye-slash" aria-hidden="true"></i>
-                    <span class="d-none d-sm-inline">Remove all student data access</span>
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-light btn-sm ml-auto"
-                    data-toggle="popover"
-                    data-container="body"
-                    data-html="true"
-                    data-placement="auto"
-                    title="Delete users with no access"
-                    data-content="${escapeHtml(
-                      CoursePermissionsDeleteNoAccessForm({
-                        csrfToken: resLocals.__csrf_token,
-                      }),
-                    )}"
-                    data-testid="delete-users-with-no-access-button"
-                  >
-                    <i class="fas fa-recycle" aria-hidden="true"></i>
-                    <span class="d-none d-sm-inline">Delete users with no access</span>
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-light btn-sm ml-auto"
-                    data-toggle="popover"
-                    data-container="body"
-                    data-html="true"
-                    data-placement="auto"
-                    title="Delete non-owners"
-                    data-content="${escapeHtml(
-                      CoursePermissionsDeleteNonOwnersForm({
-                        csrfToken: resLocals.__csrf_token,
-                      }),
-                    )}"
-                    data-testid="delete-non-owners-button"
-                  >
-                    <i class="fas fa-users-slash" aria-hidden="true"></i>
-                    <span class="d-none d-sm-inline">Delete non-owners</span>
-                  </button>
-                  <button
-                    type="button"
-                    class="btn btn-light btn-sm ml-auto"
-                    data-toggle="popover"
-                    data-container="body"
-                    data-html="true"
-                    data-placement="auto"
-                    title="Add users"
-                    data-content="${escapeHtml(
-                      CoursePermissionsInsertForm({
-                        csrfToken: resLocals.__csrf_token,
-                        uidsLimit,
-                        courseInstances,
-                      }),
-                    )}"
-                    data-testid="add-users-button"
-                  >
-                    <i class="fas fa-users" aria-hidden="true"></i>
-                    <span class="d-none d-sm-inline">Add users</span>
-                  </button>
-                </div>
+            <div class="card-header bg-primary text-white d-flex flex-wrap align-items-center">
+              <h1 class="mr-2">Staff</h1>
+              <div class="ml-auto">
+                <button
+                  type="button"
+                  class="btn btn-light btn-sm ml-auto"
+                  data-toggle="popover"
+                  data-container="body"
+                  data-html="true"
+                  data-placement="auto"
+                  title="Remove all student data access"
+                  data-content="${escapeHtml(
+                    CoursePermissionsRemoveStudentDataAccessForm({
+                      csrfToken: resLocals.__csrf_token,
+                    }),
+                  )}"
+                  data-testid="remove-all-student-data-access-button"
+                >
+                  <i class="fas fa-eye-slash" aria-hidden="true"></i>
+                  <span class="d-none d-sm-inline">Remove all student data access</span>
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-light btn-sm ml-auto"
+                  data-toggle="popover"
+                  data-container="body"
+                  data-html="true"
+                  data-placement="auto"
+                  title="Delete users with no access"
+                  data-content="${escapeHtml(
+                    CoursePermissionsDeleteNoAccessForm({
+                      csrfToken: resLocals.__csrf_token,
+                    }),
+                  )}"
+                  data-testid="delete-users-with-no-access-button"
+                >
+                  <i class="fas fa-recycle" aria-hidden="true"></i>
+                  <span class="d-none d-sm-inline">Delete users with no access</span>
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-light btn-sm ml-auto"
+                  data-toggle="popover"
+                  data-container="body"
+                  data-html="true"
+                  data-placement="auto"
+                  title="Delete non-owners"
+                  data-content="${escapeHtml(
+                    CoursePermissionsDeleteNonOwnersForm({
+                      csrfToken: resLocals.__csrf_token,
+                    }),
+                  )}"
+                  data-testid="delete-non-owners-button"
+                >
+                  <i class="fas fa-users-slash" aria-hidden="true"></i>
+                  <span class="d-none d-sm-inline">Delete non-owners</span>
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-light btn-sm ml-auto"
+                  data-toggle="popover"
+                  data-container="body"
+                  data-html="true"
+                  data-placement="auto"
+                  title="Add users"
+                  data-content="${escapeHtml(
+                    CoursePermissionsInsertForm({
+                      csrfToken: resLocals.__csrf_token,
+                      uidsLimit,
+                      courseInstances,
+                    }),
+                  )}"
+                  data-testid="add-users-button"
+                >
+                  <i class="fas fa-users" aria-hidden="true"></i>
+                  <span class="d-none d-sm-inline">Add users</span>
+                </button>
               </div>
             </div>
             ${StaffTable({

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.html.ts
@@ -29,7 +29,7 @@ export function InstructorCourseAdminTags({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Tags</h1>
+              <h1>Tags</h1>
             </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.html.ts
@@ -29,7 +29,7 @@ export function InstructorCourseAdminTopics({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Topics</h1>
+              <h1>Topics</h1>
             </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover table-striped">

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
@@ -108,7 +108,7 @@ export function InstructorFileBrowserNoPermission({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-danger text-white">
-              <h1 class="h6 font-weight-normal mb-0">Files</h1>
+              <h1>Files</h1>
             </div>
             <div class="card-body">
               <h2>Insufficient permissions</h2>

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
@@ -52,7 +52,7 @@ export function InstructorFileEditorNoPermission({
         <main id="content" class="container-fluid">
           <div class="card mb-4">
             <div class="card-header bg-danger text-white">
-              <h1 class="h6 font-weight-normal mb-0">File editor</h1>
+              <h1>File editor</h1>
             </div>
             <div class="card-body">
               <h2>Insufficient permissions</h2>

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
@@ -80,7 +80,7 @@ export function InstructorGradebook({
             : html`
                 <div class="card mb-4">
                   <div class="card-header bg-primary text-white">
-                    <h1 class="h6 font-weight-normal mb-0">Gradebook</h1>
+                    <h1>Gradebook</h1>
                   </div>
                   <table id="gradebook-table"></table>
 
@@ -108,7 +108,7 @@ function StudentDataViewMissing({
   return html`
     <div class="card mb-4">
       <div class="card-header bg-danger text-white h6 font-weight-normal">
-        <h1 class="h6 font-weight-normal mb-0">Gradebook</h1>
+        <h1>Gradebook</h1>
       </div>
       <div class="card-body">
         <h2>Insufficient permissions</h2>

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -45,9 +45,7 @@ export function InstructorGradingJob({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
-                Grading Job ${gradingJobRow.grading_job.id}
-              </h1>
+              <h1>Grading Job ${gradingJobRow.grading_job.id}</h1>
             </div>
 
             <table class="table table-sm table-hover two-column-description">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -33,9 +33,7 @@ export function InstructorInstanceAdminAccess({
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${course_instance.long_name} course instance access rules
-              </h1>
+              <h1>${course_instance.long_name} course instance access rules</h1>
             </div>
 
             <div class="table-responsive">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
@@ -43,7 +43,7 @@ export function InstructorInstanceAdminLti({ resLocals }: { resLocals: Record<st
             ? html`
                 <div class="card mb-4">
                   <div class="card-header bg-danger text-white">
-                    <h1 class="h6 font-weight-normal mb-0">LTI configuration</h1>
+                    <h1>LTI configuration</h1>
                   </div>
                   <div class="card-body">
                     <h2>Insufficient permissions</h2>
@@ -66,7 +66,7 @@ export function InstructorInstanceAdminLti({ resLocals }: { resLocals: Record<st
             : html`
                 <div class="card mb-4">
                   <div class="card-header bg-primary text-white">
-                    <h1 class="h6 font-weight-normal mb-0">LTI configuration</h1>
+                    <h1>LTI configuration</h1>
                   </div>
                   <div class="card-body">
                     <p>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -41,9 +41,7 @@ export function InstructorInstanceAdminSettings({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1 class="h6 font-weight-normal mb-0">
-                Course instance ${resLocals.course_instance.short_name}
-              </h1>
+              <h1>Course instance ${resLocals.course_instance.short_name}</h1>
             </div>
             <table class="table table-sm table-hover two-column-description">
               <tbody>
@@ -112,16 +110,10 @@ export function InstructorInstanceAdminSettings({
               </tbody>
             </table>
             ${resLocals.authz_data.has_course_permission_edit && !resLocals.course.example_course
-              ? html`
-                  <div class="card-footer">
-                    <div class="row">
-                      ${CopyCourseInstanceForm({
-                        csrfToken: resLocals.__csrf_token,
-                        shortName: resLocals.course_instance.short_name,
-                      })}
-                    </div>
-                  </div>
-                `
+              ? CopyCourseInstanceForm({
+                  csrfToken: resLocals.__csrf_token,
+                  shortName: resLocals.course_instance.short_name,
+                })
               : ''}
           </div>
         </main>
@@ -180,15 +172,13 @@ function CopyCourseInstanceForm({
   shortName: string;
 }) {
   return html`
-    <div class="col-auto">
-      <form name="copy-course-instance-form" class="form-inline" method="POST">
+    <div class="card-footer d-flex flex-wrap align-items-center">
+      <form name="copy-course-instance-form" class="form-inline mr-2" method="POST">
         <input type="hidden" name="__csrf_token" value="${csrfToken}" />
         <button name="__action" value="copy_course_instance" class="btn btn-sm btn-primary">
           <i class="fa fa-clone"></i> Make a copy of this course instance
         </button>
       </form>
-    </div>
-    <div class="col-auto">
       <button
         class="btn btn-sm btn-primary"
         href="#"
@@ -197,19 +187,19 @@ function CopyCourseInstanceForm({
       >
         <i class="fa fa-times" aria-hidden="true"></i> Delete this course instance
       </button>
+      ${Modal({
+        id: 'deleteCourseInstanceModal',
+        title: 'Delete course instance',
+        body: html`
+          <p>Are you sure you want to delete the course instance <strong>${shortName}</strong>?</p>
+        `,
+        footer: html`
+          <input type="hidden" name="__action" value="delete_course_instance" />
+          <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-danger">Delete</button>
+        `,
+      })}
     </div>
-    ${Modal({
-      id: 'deleteCourseInstanceModal',
-      title: 'Delete course instance',
-      body: html`
-        <p>Are you sure you want to delete the course instance <strong>${shortName}</strong>?</p>
-      `,
-      footer: html`
-        <input type="hidden" name="__action" value="delete_course_instance" />
-        <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-danger">Delete</button>
-      `,
-    })}
   `;
 }

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -100,7 +100,7 @@ export function InstructorIssues({
             <div class="card-header bg-primary text-white">
               <div class="d-flex flex-row align-items-center mb-2">
                 <div class="d-flex flex-column">
-                  <h1>Issues</h1>
+                  <h1 class="h6 font-weight-normal mb-0">Issues</h1>
                   <small>
                     <a href="${formattedCommonQueries.allOpenQuery}" class="mr-3 text-white">
                       <i class="fa fa-exclamation-circle"></i> ${openCount} open

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -100,7 +100,7 @@ export function InstructorIssues({
             <div class="card-header bg-primary text-white">
               <div class="d-flex flex-row align-items-center mb-2">
                 <div class="d-flex flex-column">
-                  <h1 class="h6 font-weight-normal mb-0">Issues</h1>
+                  <h1>Issues</h1>
                   <small>
                     <a href="${formattedCommonQueries.allOpenQuery}" class="mr-3 text-white">
                       <i class="fa fa-exclamation-circle"></i> ${openCount} open

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -92,7 +92,7 @@ export function InstructorQuestionSettings({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1 class="h6 font-weight-normal mb-0">Question Settings</h1>
+              <h1>Question Settings</h1>
             </div>
             <div class="card-body">
               <form>

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.ts
@@ -61,9 +61,7 @@ export function InstructorQuestionStatistics({
 
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
-                Detailed assessment statistics for question ${resLocals.question.qid}
-              </h1>
+              <h1>Detailed assessment statistics for question ${resLocals.question.qid}</h1>
             </div>
 
             <div class="table-responsive">

--- a/apps/prairielearn/src/pages/newsItems/newsItems.html.ts
+++ b/apps/prairielearn/src/pages/newsItems/newsItems.html.ts
@@ -46,7 +46,7 @@ export function NewsItems({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1 class="h6 font-weight-normal mb-0">News</h1>
+              <h1>News</h1>
             </div>
 
             ${newsItems.length === 0

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.html.ts
@@ -34,9 +34,7 @@ export function StudentAssessment({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">
-                ${assessment_set.abbreviation}${assessment.number}: ${assessment.title}
-              </h1>
+              <h1>${assessment_set.abbreviation}${assessment.number}: ${assessment.title}</h1>
               ${assessment.group_work ? html`<i class="fas fa-users"></i>` : ''}
             </div>
 

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -91,7 +91,7 @@ export function StudentAssessmentInstance({
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex align-items-center">
               <span>
-                <h1 class="h6 font-weight-normal mb-0">
+                <h1>
                   ${resLocals.assessment_set.abbreviation}${resLocals.assessment.number}:
                   ${resLocals.assessment.title}
                 </h1>

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
@@ -59,7 +59,7 @@ export function StudentAssessments({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Assessments</h1>
+              <h1>Assessments</h1>
             </div>
 
             <table class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
@@ -45,7 +45,7 @@ export function StudentGradebook({
         <main id="content" class="container">
           <div class="card mb-4">
             <div class="card-header bg-primary text-white">
-              <h1 class="h6 font-weight-normal mb-0">Gradebook</h1>
+              <h1>Gradebook</h1>
             </div>
 
             <table class="table table-sm table-hover">

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -50,7 +50,7 @@ export function Workspace({
         >
           <div class="d-flex flex-column mr-3 text-white">
             <span>
-              <h1 class="h6 font-weight-normal mb-0">
+              <h1>
                 <a href="${navTitleHref}" target="_blank" class="text-white">${navTitle}</a>
               </h1>
             </span>

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -50,7 +50,7 @@ export function Workspace({
         >
           <div class="d-flex flex-column mr-3 text-white">
             <span>
-              <h1>
+              <h1 class="h6 font-weight-normal mb-0">
                 <a href="${navTitleHref}" target="_blank" class="text-white">${navTitle}</a>
               </h1>
             </span>


### PR DESCRIPTION
This PR adds a rule to `apps/prairielearn/public/stylesheets/local.css` that will apply consistent formatting to any heading element that's the immediate child of a `card-header`. This removes the need to use `h6 font-weight-normal mb-0` classes every time we want to put a header in a card (which is now basically always).