### PR TITLE
Miscellaneous accessibility improvements

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -104,12 +104,7 @@ export function InstructorAssessments({
                         : ''}
                       <tr id="row-${row.id}">
                         <td class="align-middle" style="width: 1%">
-                          <a
-                            href="${urlPrefix}/assessment/${row.id}/"
-                            class="badge color-${row.color} color-hover"
-                          >
-                            ${row.label}
-                          </a>
+                          <span class="badge color-${row.color}">${row.label}</span>
                         </td>
                         <td class="align-middle">
                           ${row.sync_errors

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -98,7 +98,7 @@ export function InstructorAssessments({
                       ${row.start_new_assessment_group
                         ? html`
                             <tr>
-                              <th colspan="7">${row.assessment_group_heading}</th>
+                              <th colspan="7" scope="row">${row.assessment_group_heading}</th>
                             </tr>
                           `
                         : ''}

--- a/apps/prairielearn/src/pages/partials/navbar.ejs
+++ b/apps/prairielearn/src/pages/partials/navbar.ejs
@@ -20,9 +20,9 @@
 <% } %>
 
 <nav class="navbar navbar-dark bg-dark navbar-expand-md" aria-label="Global navigation">
-  <a class="navbar-brand" href="<%= homeUrl %>">
+  <a class="navbar-brand" href="<%= homeUrl %>" aria-label="Homepage">
     <span class="navbar-brand-label">PrairieLearn</span>
-    <span class="navbar-brand-hover-label text-secondary">Go home <i class="fa fa-angle-right" aria-hidden="true"></i></span>
+    <span class="navbar-brand-hover-label">Go home <i class="fa fa-angle-right" aria-hidden="true"></i></span>
   </a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
@@ -77,7 +77,7 @@ export function StudentAssessments({
                     ${row.start_new_assessment_group
                       ? html`
                           <tr>
-                            <th colspan="4" data-testid="assessment-group-heading">
+                            <th colspan="4" scope="row" data-testid="assessment-group-heading">
                               ${row.assessment_group_heading}
                             </th>
                           </tr>

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
@@ -85,25 +85,12 @@ export function StudentAssessments({
                       : ''}
                     <tr>
                       <td class="align-middle" style="width: 1%">
-                        ${row.multiple_instance_header ||
-                        (!row.active && row.assessment_instance_id === null)
-                          ? html`
-                              <span
-                                class="badge color-${row.assessment_set_color}"
-                                data-testid="assessment-set-badge"
-                              >
-                                ${row.label}
-                              </span>
-                            `
-                          : html`
-                              <a
-                                href="${urlPrefix}${row.link}"
-                                class="badge color-${row.assessment_set_color} color-hover"
-                                data-testid="assessment-set-badge"
-                              >
-                                ${row.label}
-                              </a>
-                            `}
+                        <span
+                          class="badge color-${row.assessment_set_color}"
+                          data-testid="assessment-set-badge"
+                        >
+                          ${row.label}
+                        </span>
                       </td>
                       <td class="align-middle">
                         ${row.multiple_instance_header ||


### PR DESCRIPTION
This PR makes two straightforward accessibility improvements:

- In the student/instructor assessment lists, the assessment badge (e.g. "HW1") no longer links to the assessment. This change was made for two reasons:
  - It prevents confusion from having two differently-named links that both go to the same place
  - The old link was an extraneous tab stop for someone tabbing through the page. Now, they can more quickly jump from assessment to assessment.
- The homepage link in the navbar now has an improved label ("Homepage") and the "Go home" text that appears on hover has sufficient contrast with the background.
- The assessment set/module header rows now use `scope="row"` to indicate the the heading applies to the row, not to the column as a whole.