### PR TITLE
Improve button focus styles

### DIFF
--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -310,3 +310,132 @@ small .user-output-invalid {
   margin-left: 5px;
   background: #fff;
 }
+
+/***********************************
+ * Button focus accessibility styles
+ ***********************************/
+
+/**
+ * TODO: After we're running with only Bootstrap 5, these can be collapsed into
+ * a single rule with all the different selectors, since they can all share the
+ * same var(--bs-btn-hover-color) value.
+ */
+
+.btn.btn-primary:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffffff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-secondary:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffffff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-success:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffffff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-danger:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffffff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-warning:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #000000) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-info:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffffff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-light:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #000000) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-dark:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffffff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-link:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #007bff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-primary:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #007bff) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-secondary:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #6c757d) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-success:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #28a745) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-danger:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #dc3545) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-warning:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #ffc107) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-info:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #17a2b8) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-light:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #f8f9fa) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}
+
+.btn.btn-outline-dark:focus:focus-visible {
+  outline-style: solid !important;
+  outline-color: var(--bs-btn-hover-color, #343a40) !important;
+  outline-width: 2px !important;
+  outline-offset: -2px !important;
+}

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
@@ -88,6 +88,7 @@ export function AdministratorSettings({ resLocals }) {
               </script>
             </div>
           </div>
+
           ${isEnterprise() && config.openAiApiKey && config.openAiOrganization
             ? html`
                 <div class="card mb-4">
@@ -102,6 +103,41 @@ export function AdministratorSettings({ resLocals }) {
                 </div>
               `
             : ''}
+
+          <div class="card mb-4">
+            <div class="card-header bg-primary text-white">
+              <h2>Bootstrap playground</h2>
+            </div>
+            <div class="card-body">
+              <p>
+                This serves as a testing ground for custom focus styles that are meant to comply
+                with stricter accessibility requirements.
+              </p>
+              <div class="mb-4" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                <button type="button" class="btn btn-primary">Primary</button>
+                <button type="button" class="btn btn-secondary">Secondary</button>
+                <button type="button" class="btn btn-success">Success</button>
+                <button type="button" class="btn btn-danger">Danger</button>
+                <button type="button" class="btn btn-warning">Warning</button>
+                <button type="button" class="btn btn-info">Info</button>
+                <button type="button" class="btn btn-light">Light</button>
+                <button type="button" class="btn btn-dark">Dark</button>
+                <button type="button" class="btn btn-link">Link</button>
+              </div>
+              <div class="mb-4" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+                <button type="button" class="btn btn-outline-primary">Primary</button>
+                <button type="button" class="btn btn-outline-secondary">Secondary</button>
+                <button type="button" class="btn btn-outline-success">Success</button>
+                <button type="button" class="btn btn-outline-danger">Danger</button>
+                <button type="button" class="btn btn-outline-warning">Warning</button>
+                <button type="button" class="btn btn-outline-info">Info</button>
+                <button type="button" class="btn btn-outline-dark">Dark</button>
+              </div>
+              <div class="p-4 bg-dark">
+                <button type="button" class="btn btn-outline-light">Light</button>
+              </div>
+            </div>
+          </div>
         </main>
       </body>
     </html>


### PR DESCRIPTION
This PR aims to improve our button focus styles to meet certain accessibility requirements from the University of Illinois. They claim that the default Bootstrap focus indicators lack sufficient contrast with the background. The solution I went for here is to introduce another focus outline that matches the color of the text, which should hopefully offer sufficient contrast (given that the button text itself has sufficient contrast with button background colors).

<img width="1016" alt="Screenshot 2024-08-16 at 09 26 18" src="https://github.com/user-attachments/assets/3fb981d4-3e3a-4169-a7f9-3feb2a8b1209">

These styles are applied only when the [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) pseudo-class applies, so they'll only be visible to folks who are navigating PrairieLearn via keyboard.