### PR TITLE
Fix width of pl-dropdown when used in pl-overlay

### DIFF
--- a/apps/prairielearn/elements/pl-dropdown/pl-dropdown.mustache
+++ b/apps/prairielearn/elements/pl-dropdown/pl-dropdown.mustache
@@ -1,7 +1,7 @@
 
 {{#question}}
     <span class="d-inline-block form-group form-inline">
-        <select name="{{answers-name}}" class="custom-select" {{^editable}}disabled{{/editable}}>
+        <select name="{{answers-name}}" class="custom-select w-auto" {{^editable}}disabled{{/editable}}>
             {{#options}}
                 <option value="{{value}}" {{#selected}}selected{{/selected}}>{{{value}}}</option>
             {{/options}}


### PR DESCRIPTION
This is a forwards-compatibility fix for Bootstrap 5. The updated `<select>` styles caused a problem when a `<pl-dropdown>` element was positioned towards the right of a `<pl-overlay>`:

<img width="478" alt="Screenshot 2024-08-16 at 12 01 20" src="https://github.com/user-attachments/assets/63fc3b84-988d-4525-ab26-6550e9ffc237">

Using `width: auto` ensures that the select uses its natural width so that the options are visible:

<img width="485" alt="Screenshot 2024-08-16 at 12 01 30" src="https://github.com/user-attachments/assets/4f07076f-1097-4105-812c-25e1ee11d597">

