### PR TITLE
Fix typo in external grading documentation

### DIFF
--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -88,7 +88,7 @@ This config file specifies the following things:
 
 - External grading is enabled
 - The `prairielearn/grader-python` image will be used
-- The files/directories under `serverFilesCourse/python_autograder` will copied into your image while grading
+- The files/directories under `serverFilesCourse/python_autograder` will be copied into your image while grading
 - The script `/grade/serverFilesCourse/python_autograder/run.sh` will be executed when your container starts up
 - If grading takes longer that 5 seconds, the container will be killed
 

--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -87,7 +87,7 @@ Here's an example of a complete `externalGradingOptions` portion of a question's
 This config file specifies the following things:
 
 - External grading is enabled
-- The `prairielearn/centos7-python` image will be used
+- The `prairielearn/grader-python` image will be used
 - The files/directories under `serverFilesCourse/python_autograder` will copied into your image while grading
 - The script `/grade/serverFilesCourse/python_autograder/run.sh` will be executed when your container starts up
 - If grading takes longer that 5 seconds, the container will be killed


### PR DESCRIPTION
Two small tweaks to the documentation on external grading as mentioned over on Slack. Starting with something simple to make sure I have the workflow correct.

I did not see a Compare and Review button as mentioned [here](https://prairielearn.readthedocs.io/en/latest/contributing/#contributing-to-prairielearn) so not sure if this is the correct order of operations or the instructions are out of date

![image](https://github.com/user-attachments/assets/bdbf2b0e-dba6-4c3b-ad25-a390f88418f0)
