### PR TITLE
Add accessibility labels to buttons

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -494,6 +494,8 @@ onDocumentReady(() => {
         <button
           class="btn btn-secondary btn-xs ml-1 time-limit-edit-button"
           id="row${row.assessment_instance_id}PopoverTimeLimit"
+          title="Change time limit"
+          aria-label="Change time limit"
           data-row="${JSON.stringify(row)}"
           data-placement="bottom"
           data-boundary="window"

--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -494,7 +494,6 @@ onDocumentReady(() => {
         <button
           class="btn btn-secondary btn-xs ml-1 time-limit-edit-button"
           id="row${row.assessment_instance_id}PopoverTimeLimit"
-          title="Change time limit"
           aria-label="Change time limit"
           data-row="${JSON.stringify(row)}"
           data-placement="bottom"

--- a/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
@@ -132,6 +132,7 @@ onDocumentReady(() => {
                 <button
                   type="button"
                   class="btn btn-xs btn-secondary edit-score ml-1"
+                  aria-label="Edit score"
                   data-assessment-instance-id="${assessment_instance_id}"
                   data-score="${score}"
                   data-other-users="${JSON.stringify(uid_other_users_group ?? [])}"

--- a/apps/prairielearn/src/components/EditQuestionPointsScore.html.ts
+++ b/apps/prairielearn/src/components/EditQuestionPointsScore.html.ts
@@ -37,6 +37,7 @@ export function EditQuestionPointsScoreButton({
     data-html="true"
     data-placement="auto"
     title="Change question ${label}"
+    aria-label="Edit question ${label}"
     data-content="${escapeHtml(editForm)}"
     data-testid="edit-question-points-score-button-${field}"
   >

--- a/apps/prairielearn/src/components/EditQuestionPointsScore.html.ts
+++ b/apps/prairielearn/src/components/EditQuestionPointsScore.html.ts
@@ -37,7 +37,7 @@ export function EditQuestionPointsScoreButton({
     data-html="true"
     data-placement="auto"
     title="Change question ${label}"
-    aria-label="Edit question ${label}"
+    aria-label="Change question ${label}"
     data-content="${escapeHtml(editForm)}"
     data-testid="edit-question-points-score-button-${field}"
   >

--- a/apps/prairielearn/src/components/PersonalNotesPanel.html.ts
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.html.ts
@@ -233,6 +233,7 @@ function DeletePersonalNoteButton({
       data-html="true"
       data-placement="auto"
       title="Confirm delete"
+      aria-label="Delete personal note"
       data-content="${escapeHtml(popoverContent)}"
       data-testid="delete-personal-note-button"
     >

--- a/apps/prairielearn/src/components/StudentAccessRulesPopover.html.ts
+++ b/apps/prairielearn/src/components/StudentAccessRulesPopover.html.ts
@@ -32,8 +32,9 @@ export function StudentAccessRulesPopover({
       data-trigger="focus"
       data-container="body"
       data-html="true"
-      title="${assessmentSetName} ${assessmentNumber}"
+      title="Access details"
       data-content="${escapeHtml(StudentAccessRulesPopoverContent({ accessRules }))}"
+      aria-label="Access details"
     >
       <i class="fa fa-question-circle"></i>
     </a>

--- a/apps/prairielearn/src/components/StudentAccessRulesPopover.html.ts
+++ b/apps/prairielearn/src/components/StudentAccessRulesPopover.html.ts
@@ -14,15 +14,7 @@ export const AuthzAccessRuleSchema = z.object({
 });
 export type AuthzAccessRule = z.infer<typeof AuthzAccessRuleSchema>;
 
-export function StudentAccessRulesPopover({
-  assessmentSetName,
-  assessmentNumber,
-  accessRules,
-}: {
-  assessmentSetName: string;
-  assessmentNumber: string;
-  accessRules: AuthzAccessRule[];
-}) {
+export function StudentAccessRulesPopover({ accessRules }: { accessRules: AuthzAccessRule[] }) {
   return html`
     <a
       tabindex="0"

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -178,6 +178,7 @@ export function InstructorAssessmentInstance({
                             data-container="body"
                             data-html="false"
                             title="Client Fingerprint Changes"
+                            aria-label="Client Fingerprint Changes"
                             data-content="Client fingerprints are a record of a user's IP address, user agent and sesssion. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
                             ><i class="fa fa-question-circle"></i
                           ></a>
@@ -208,6 +209,7 @@ export function InstructorAssessmentInstance({
                             data-html="true"
                             data-placement="auto"
                             title="Change total points"
+                            aria-label="Change total points"
                             data-content="${escapeHtml(
                               EditTotalPointsForm({
                                 resLocals,
@@ -237,6 +239,7 @@ export function InstructorAssessmentInstance({
                             data-html="true"
                             data-placement="auto"
                             title="Change total percentage score"
+                            aria-label="Change total percentage score"
                             data-content="${escapeHtml(
                               EditTotalScorePercForm({
                                 resLocals,

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -596,7 +596,12 @@ function StaffTable({
                                 </button>
                               </div>
                             </div>
-                            <button type="submit" class="btn btn-sm btn-outline-primary">
+                            <button
+                              type="submit"
+                              title="Remove access"
+                              class="btn btn-sm btn-outline-primary"
+                              aria-label="Remove access"
+                            >
                               <i class="fa fa-times"></i>
                             </button>
                           </div>

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -598,7 +598,6 @@ function StaffTable({
                             </div>
                             <button
                               type="submit"
-                              title="Remove access"
                               class="btn btn-sm btn-outline-primary"
                               aria-label="Remove access"
                             >

--- a/apps/prairielearn/src/pages/partials/issueBadge.ejs
+++ b/apps/prairielearn/src/pages/partials/issueBadge.ejs
@@ -1,9 +1,9 @@
 <% if (count > 0) { %>
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
-            <a class="badge badge-pill badge-danger" aria-label="Assessment Issues" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
+            <a class="badge badge-pill badge-danger" aria-label="Open Issues" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
-            <a class="badge badge-pill badge-danger" aria-label="Assessment Issues" href="<%= urlPrefix %>/course_admin/issues">
+            <a class="badge badge-pill badge-danger" aria-label="Open Issues" href="<%= urlPrefix %>/course_admin/issues">
         <% } %>
         <%= count %></a>
     <% } else { %>

--- a/apps/prairielearn/src/pages/partials/issueBadge.ejs
+++ b/apps/prairielearn/src/pages/partials/issueBadge.ejs
@@ -1,9 +1,9 @@
 <% if (count > 0) { %>
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
-            <a class="badge badge-pill badge-danger" aria-label="Open Issues" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
+            <a class="badge badge-pill badge-danger" aria-label="<%= count %> Open Issues" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
-            <a class="badge badge-pill badge-danger" aria-label="Open Issues" href="<%= urlPrefix %>/course_admin/issues">
+            <a class="badge badge-pill badge-danger" aria-label="<%= count %> Open Issues" href="<%= urlPrefix %>/course_admin/issues">
         <% } %>
         <%= count %></a>
     <% } else { %>

--- a/apps/prairielearn/src/pages/partials/issueBadge.ejs
+++ b/apps/prairielearn/src/pages/partials/issueBadge.ejs
@@ -1,9 +1,21 @@
 <% if (count > 0) { %>
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
-            <a class="badge badge-pill badge-danger" aria-label="<%= count %> Open Issues" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
+            <a class="badge badge-pill badge-danger" aria-label="<%= count %> 
+                <% if (count === 1) { %>
+                    open issue
+                    <% } else { %> 
+                    open issues
+                <% } %>
+            " href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
-            <a class="badge badge-pill badge-danger" aria-label="<%= count %> Open Issues" href="<%= urlPrefix %>/course_admin/issues">
+            <a class="badge badge-pill badge-danger" aria-label="<%= count %>
+                <% if (count === 1) { %>
+                    open issue
+                <% } else { %> 
+                    open issues
+            <% } %>
+            " href="<%= urlPrefix %>/course_admin/issues">
         <% } %>
         <%= count %></a>
     <% } else { %>

--- a/apps/prairielearn/src/pages/partials/issueBadge.ejs
+++ b/apps/prairielearn/src/pages/partials/issueBadge.ejs
@@ -1,9 +1,9 @@
 <% if (count > 0) { %>
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
-            <a class="badge badge-pill badge-danger" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
+            <a class="badge badge-pill badge-danger" aria-label="Assessment Issues" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
-            <a class="badge badge-pill badge-danger" href="<%= urlPrefix %>/course_admin/issues">
+            <a class="badge badge-pill badge-danger" aria-label="Assessment Issues" href="<%= urlPrefix %>/course_admin/issues">
         <% } %>
         <%= count %></a>
     <% } else { %>

--- a/apps/prairielearn/src/pages/partials/issueBadge.ejs
+++ b/apps/prairielearn/src/pages/partials/issueBadge.ejs
@@ -1,21 +1,10 @@
 <% if (count > 0) { %>
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
-            <a class="badge badge-pill badge-danger" aria-label="<%= count %> 
-                <% if (count === 1) { %>
-                    open issue
-                    <% } else { %> 
-                    open issues
-                <% } %>
+            <a class="badge badge-pill badge-danger" aria-label="<%= count %> open <%= count === 1 ? "issue" : "issues" %>" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
             " href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
-            <a class="badge badge-pill badge-danger" aria-label="<%= count %>
-                <% if (count === 1) { %>
-                    open issue
-                <% } else { %> 
-                    open issues
-            <% } %>
-            " href="<%= urlPrefix %>/course_admin/issues">
+            <a class="badge badge-pill badge-danger" aria-label="<%= count %> open <%= count === 1 ? "issue" : "issues" %>" href="<%= urlPrefix %>/course_admin/issues">
         <% } %>
         <%= count %></a>
     <% } else { %>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -22,13 +22,7 @@ import { Scorebar } from '../../components/Scorebar.html.js';
 import { StudentAccessRulesPopover } from '../../components/StudentAccessRulesPopover.html.js';
 import { TimeLimitExpiredModal } from '../../components/TimeLimitExpiredModal.html.js';
 import { compiledScriptTag } from '../../lib/assets.js';
-import {
-  Assessment,
-  AssessmentInstance,
-  AssessmentSet,
-  GroupConfig,
-  InstanceQuestion,
-} from '../../lib/db-types.js';
+import { AssessmentInstance, GroupConfig, InstanceQuestion } from '../../lib/db-types.js';
 import { formatPoints } from '../../lib/format.js';
 import { GroupInfo } from '../../lib/groups.js';
 
@@ -127,8 +121,6 @@ export function StudentAssessmentInstance({
                       </div>
                       <div class="col-md-9 col-sm-12">
                         ${AssessmentStatus({
-                          assessment: resLocals.assessment,
-                          assessment_set: resLocals.assessment_set,
                           assessment_instance: resLocals.assessment_instance,
                           authz_result: resLocals.authz_result,
                         })}
@@ -156,8 +148,6 @@ export function StudentAssessmentInstance({
                       </div>
                       <div class="col-md-6 col-sm-12">
                         ${AssessmentStatus({
-                          assessment: resLocals.assessment,
-                          assessment_set: resLocals.assessment_set,
                           assessment_instance: resLocals.assessment_instance,
                           authz_result: resLocals.authz_result,
                         })}
@@ -532,13 +522,9 @@ export function StudentAssessmentInstance({
 }
 
 function AssessmentStatus({
-  assessment,
-  assessment_set,
   assessment_instance,
   authz_result,
 }: {
-  assessment: Assessment;
-  assessment_set: AssessmentSet;
   assessment_instance: AssessmentInstance;
   authz_result: any;
 }) {
@@ -549,8 +535,6 @@ function AssessmentStatus({
       Available credit: ${authz_result.credit_date_string}
       ${StudentAccessRulesPopover({
         accessRules: authz_result.access_rules,
-        assessmentSetName: assessment_set.name,
-        assessmentNumber: assessment.number,
       })}
     `;
   }

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.ts
@@ -111,8 +111,6 @@ export function StudentAssessments({
                           : 'Assessment closed.'}
                         ${StudentAccessRulesPopover({
                           accessRules: row.access_rules,
-                          assessmentSetName: row.assessment_set_name,
-                          assessmentNumber: row.assessment_number,
                         })}
                       </td>
                       <td class="text-center align-middle">


### PR DESCRIPTION
Closes #10486. This PR intends to add accessibility labels to buttons that may be missing them. This will improve readability for screen readers when focusing on a button. I have tested most pages with a screen reader and I think I caught most of the buttons that did not have labels. If you are able to find anymore, please let me know. 