### PR TITLE
Handle missing test cases in Python grader

### DIFF
--- a/graders/python/python_autograder/pl_main.py
+++ b/graders/python/python_autograder/pl_main.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
         # Compile total number of points
         max_points = test_case.get_total_points()
         earned_points = sum([test["points"] for test in results])
+        score = 0 if max_points == 0 else float(earned_points) / float(max_points)
 
         # load output files to results
         add_files(results)
@@ -106,7 +107,7 @@ if __name__ == "__main__":
         # Assemble final grading results
         grading_result = {}
         grading_result["tests"] = results
-        grading_result["score"] = float(earned_points) / float(max_points)
+        grading_result["score"] = score
         grading_result["succeeded"] = True
         grading_result["gradable"] = gradable
         grading_result["max_points"] = max_points
@@ -114,6 +115,13 @@ if __name__ == "__main__":
             grading_result["output"] = text_output
         if len(format_errors) > 0:
             grading_result["format_errors"] = format_errors
+
+        # Instructors may have named their tests incorrectly or somehow misconfigured things.
+        # Help point them in the right direction.
+        if len(results) == 0:
+            grading_result["message"] = (
+                "No tests were found. Please check your test cases."
+            )
 
         # Save images
         grading_result["images"] = []


### PR DESCRIPTION
If an instructor doesn't name their test case functions correctly (that is, they don't have a `test_` prefix), `unittest` won't be able to discover them. If there aren't any tests, there won't be any points, so we'll end up in a place where we try to compute `0 / 0`, which will of course fail. This PR special-cases that edge case so that we report a score of 0 if there weren't any tests.

I also added a user-facing message if no tests were found. Otherwise, `<pl-external-grader-results>` would just render "Score: 0%", which doesn't make it entirely clear that there weren't any tests to run.

Arguably we could consider it to be a "format error" if there aren't any tests and thus flag the submission as ungradable, but IMO that's overkill.