### PR TITLE
Improve accessibility and responsiveness of grading conflict modal

### DIFF
--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -80,9 +80,7 @@ SELECT
     'assigned_grader_name',
     COALESCE(uag.name, uag.uid),
     'last_grader_name',
-    COALESCE(ulg.name, ulg.uid),
-    'modified_at_formatted',
-    format_date_short (iq.modified_at, ci.display_timezone)
+    COALESCE(ulg.name, ulg.uid)
   ) AS instance_question,
   jsonb_build_object(
     'id',

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -160,7 +160,7 @@ function ConflictGradingJobModal({
               applied. Please review the feedback below and select how you would like to proceed.
             </div>
             <div class="row mb-2">
-              <div class="col-lg-6 col-md-12">
+              <div class="col-lg-6 col-12">
                 <div><strong>Existing score and feedback</strong></div>
                 <div class="mb-2">
                   ${formatDateYMDHM(
@@ -180,7 +180,7 @@ function ConflictGradingJobModal({
                   })}
                 </div>
               </div>
-              <div class="col-lg-6 col-md-12">
+              <div class="col-lg-6 col-12">
                 <div><strong>Conflicting score and feedback</strong></div>
                 <div class="mb-2">
                   ${conflict_grading_job.date

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { formatDateYMDHM } from '@prairielearn/formatter';
 import { html, unsafeHtml } from '@prairielearn/html';
 import { renderEjs } from '@prairielearn/html-ejs';
 
@@ -9,7 +10,7 @@ import { PersonalNotesPanel } from '../../../components/PersonalNotesPanel.html.
 import { QuestionContainer } from '../../../components/QuestionContainer.html.js';
 import { QuestionSyncErrorsAndWarnings } from '../../../components/SyncErrorsAndWarnings.html.js';
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../../lib/assets.js';
-import { GradingJobSchema, User } from '../../../lib/db-types.js';
+import { DateFromISOString, GradingJobSchema, User } from '../../../lib/db-types.js';
 
 import { GradingPanel } from './gradingPanel.html.js';
 import { RubricSettingsModal } from './rubricSettingsModal.html.js';
@@ -17,7 +18,6 @@ import { RubricSettingsModal } from './rubricSettingsModal.html.js';
 export const GradingJobDataSchema = GradingJobSchema.extend({
   score_perc: z.number().nullable(),
   grader_name: z.string().nullable(),
-  grading_date_formatted: z.string().nullable(),
 });
 export type GradingJobData = z.infer<typeof GradingJobDataSchema>;
 
@@ -160,23 +160,16 @@ function ConflictGradingJobModal({
               applied. Please review the feedback below and select how you would like to proceed.
             </div>
             <div class="row mb-2">
-              <div class="col-6">
+              <div class="col-lg-6 col-md-12">
                 <div><strong>Existing score and feedback</strong></div>
-                <div>
-                  ${resLocals.instance_question.modified_at_formatted}, by
-                  ${resLocals.instance_question.last_grader_name}
+                <div class="mb-2">
+                  ${formatDateYMDHM(
+                    // The modified_at value may have come from a non-validated query
+                    DateFromISOString.parse(resLocals.instance_question.modified_at),
+                    resLocals.course_instance.display_timezone,
+                  )},
+                  by ${resLocals.instance_question.last_grader_name}
                 </div>
-              </div>
-              <div class="col-6">
-                <div><strong>Conflicting score and feedback</strong></div>
-                <div>
-                  ${conflict_grading_job.grading_date_formatted}, by
-                  ${conflict_grading_job.grader_name}
-                </div>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-6">
                 <div class="card">
                   ${GradingPanel({
                     resLocals,
@@ -187,7 +180,17 @@ function ConflictGradingJobModal({
                   })}
                 </div>
               </div>
-              <div class="col-6">
+              <div class="col-lg-6 col-md-12">
+                <div><strong>Conflicting score and feedback</strong></div>
+                <div class="mb-2">
+                  ${conflict_grading_job.date
+                    ? `${formatDateYMDHM(
+                        conflict_grading_job.date,
+                        resLocals.course_instance.display_timezone,
+                      )},`
+                    : ''}
+                  by ${conflict_grading_job.grader_name}
+                </div>
                 <div class="card">
                   ${GradingPanel({
                     resLocals,

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.sql
@@ -2,8 +2,7 @@
 SELECT
   gj.*,
   gj.score * 100 AS score_perc,
-  COALESCE(u.name, u.uid) AS grader_name,
-  format_date_short (gj.date, ci.display_timezone) AS grading_date_formatted
+  COALESCE(u.name, u.uid) AS grader_name
 FROM
   grading_jobs AS gj
   JOIN submissions AS s ON (s.id = gj.submission_id)


### PR DESCRIPTION
Closes #10503. Three changes in this modal:

* Moves the headings to be closer to their corresponding grading panels in the DOM.
* Makes the grading jobs more responsive by moving to a top-down layout in narrow viewports.
* Replaces the sproc-based formatted dates with library calls.

I did not add semantic headings, but I'm happy to add them if you believe they are relevant here, just let me know which heading level to use so it properly matches the conventions used in #10483 and #10440.