### PR TITLE
Improve popover accessibility

### DIFF
--- a/.changeset/young-beans-wink.md
+++ b/.changeset/young-beans-wink.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/browser-utils': minor
+---
+
+Add `trapFocus` and `focusFirstFocusbaleChild` functions

--- a/apps/prairielearn/assets/scripts/behaviors/popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/popover.ts
@@ -1,11 +1,16 @@
 import { on } from 'delegated-events';
 import { observe } from 'selector-observer';
 
-import { onDocumentReady } from '@prairielearn/browser-utils';
+import { focusFirstFocusableChild, onDocumentReady, trapFocus } from '@prairielearn/browser-utils';
 
 import { getPopoverContainerForTrigger, getPopoverTriggerForContainer } from '../lib/popover.js';
 
 const openPopoverTriggers = new Set<HTMLElement>();
+
+function closeOpenPopovers() {
+  openPopoverTriggers.forEach((popover) => $(popover).popover('hide'));
+  openPopoverTriggers.clear();
+}
 
 // We need to wrap this in `onDocumentReady` because Bootstrap doesn't
 // add its jQuery API to the jQuery object until after this event.
@@ -48,10 +53,32 @@ onDocumentReady(() => {
     $(trigger).popover('hide');
   });
 
+  // Close open popovers if the user hits the escape key.
+  //
+  // Note that this does not gracefully handle popovers inside of modals, as
+  // Bootstrap has its own escape key handling for modals.
+  on('keydown', 'body', (event) => {
+    if (event.key === 'Escape') {
+      closeOpenPopovers();
+    }
+  });
+
+  on('click', 'body', (e) => {
+    if (openPopoverTriggers.size === 0) return;
+
+    // If this click occurred inside a popover, do nothing.
+    const closestPopover = (e.target as HTMLElement).closest('.popover');
+    if (closestPopover) return;
+
+    // Close all open popovers.
+    closeOpenPopovers();
+  });
+
   // We continue to use the jQuery API for event handling to ensure compatibility with Bootstrap 4.
+
+  // Hide other open popovers when a new popover is opened.
   $(document.body).on('show.bs.popover', () => {
-    openPopoverTriggers.forEach((popover) => $(popover).popover('hide'));
-    openPopoverTriggers.clear();
+    closeOpenPopovers();
   });
 
   $(document.body).on('inserted.bs.popover', (event) => {
@@ -65,6 +92,29 @@ onDocumentReady(() => {
   });
 
   $(document.body).on('shown.bs.popover', (event) => {
+    const target = event.target as HTMLElement;
+
     openPopoverTriggers.add(event.target);
+
+    const container = getPopoverContainerForTrigger(event.target);
+    if (container) {
+      // Trap focus inside this new popover.
+      const trap = trapFocus(container);
+
+      // Remove focus trap when this popover is ultimately hidden.
+      const removeFocusTrap = () => {
+        trap.deactivate();
+        $(target).off('hide.bs.popover', removeFocusTrap);
+      };
+      $(target).on('hide.bs.popover', removeFocusTrap);
+
+      // Attempt to place focus on the correct item inside the popover.
+      const popoverBody = container.querySelector('.popover-body') as HTMLElement;
+      focusFirstFocusableChild(popoverBody);
+    }
+  });
+
+  $(document.body).on('hide.bs.popover', (event) => {
+    openPopoverTriggers.delete(event.target);
   });
 });

--- a/packages/browser-utils/README.md
+++ b/packages/browser-utils/README.md
@@ -90,3 +90,28 @@ document.querySelectorAll('.js-delete-course').forEach((el) => {
   });
 });
 ```
+
+### `trapFocus`
+
+This function can be used to trap focus within an element, such as a popover or modal. It will ensure that the user cannot tab out of the element.
+
+```ts
+import { trapFocus } from '@prairielearn/browser-utils';
+
+const popover = document.querySelector('.popover');
+const trap = trapFocus(popover);
+
+// When the container is being closed or removed, deactivate the trap.
+trap.deactivate();
+```
+
+### `focusFirstFocusableChild`
+
+This function will focus the first focusable child of an element. This is useful when opening a modal or popover.
+
+```ts
+import { focusFirstFocusableChild } from '@prairielearn/browser-utils';
+
+const modal = document.querySelector('.modal');
+focusFirstFocusableChild(modal);
+```

--- a/packages/browser-utils/src/focus.ts
+++ b/packages/browser-utils/src/focus.ts
@@ -1,0 +1,127 @@
+// Borrowed from Bootstrap:
+// https://github.com/twbs/bootstrap/blob/5f75413735d8779aeefe0097af9dc5a416208ae5/js/src/dom/selector-engine.js#L67
+const FOCUSABLE_SELECTOR = [
+  'a',
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'details',
+  '[tabindex]',
+  '[contenteditable="true"]',
+]
+  .map((selector) => `${selector}:not([tabindex^="-"]):not(.btn-close)`)
+  .join(',');
+
+function isElement(object: Element) {
+  return typeof object?.nodeType !== 'undefined';
+}
+
+function isVisible(element: Element) {
+  if (!isElement(element) || element.getClientRects().length === 0) {
+    return false;
+  }
+
+  const elementIsVisible = getComputedStyle(element).getPropertyValue('visibility') === 'visible';
+  // Handle `details` element as its content may falsly appear visible when it is closed
+  const closedDetails = element.closest('details:not([open])');
+
+  if (!closedDetails) {
+    return elementIsVisible;
+  }
+
+  if (closedDetails !== element) {
+    const summary = element.closest('summary');
+    if (summary && summary.parentNode !== closedDetails) {
+      return false;
+    }
+
+    if (summary === null) {
+      return false;
+    }
+  }
+
+  return elementIsVisible;
+}
+
+function isDisabled(element: Element) {
+  if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+    return true;
+  }
+
+  if (typeof (element as any).disabled !== 'undefined') {
+    return (element as any).disabled;
+  }
+
+  return element.hasAttribute('disabled') && element.getAttribute('disabled') !== 'false';
+}
+
+function focusableChildren(element: Element): HTMLElement[] {
+  const focusableChildren = element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+  return Array.from(focusableChildren).filter((child) => !isDisabled(child) && isVisible(child));
+}
+
+export interface FocusTrap {
+  deactivate(): void;
+}
+
+export function trapFocus(element: Element): FocusTrap {
+  // Store the previous active element so we can restore it later.
+  const previousActiveElement = document.activeElement ?? document.body;
+
+  function keyDown(e: KeyboardEvent) {
+    console.log('handling keydown', e.key);
+    if (e.key !== 'Tab') return;
+
+    const focusable = focusableChildren(element);
+    const firstFocusable = focusable[0];
+    const lastFocusable = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      // Tabbing backwards
+      if (document.activeElement === firstFocusable) {
+        (focusable[focusable.length - 1] as HTMLElement).focus();
+        e.preventDefault();
+      }
+    } else {
+      // Tabbing forwards
+      if (document.activeElement === lastFocusable) {
+        (focusable[0] as HTMLElement).focus();
+        e.preventDefault();
+      }
+    }
+  }
+
+  document.addEventListener('keydown', keyDown);
+
+  return {
+    deactivate() {
+      document.removeEventListener('keydown', keyDown);
+      (previousActiveElement as HTMLElement)?.focus();
+    },
+  };
+}
+
+export function focusFirstFocusableChild(el: HTMLElement) {
+  // In case the user (or more frequently, Cypress) is too fast and focuses a
+  // specific element inside the container before this script runs, don't transfer
+  // focus to a different element.
+  if (el.contains(document.activeElement)) return;
+
+  // Escape hatch: if the first element isn't the one that should be focused,
+  // add the `autofocus` attribute to the element that should be.
+  const autofocusElement = el.querySelector<HTMLElement>('[autofocus]');
+  if (autofocusElement) {
+    autofocusElement.focus();
+    return;
+  }
+
+  const focusablePopoverChildren = focusableChildren(el);
+  if (focusablePopoverChildren.length > 0) {
+    focusablePopoverChildren[0].focus();
+    return;
+  }
+
+  // If we still couldn't find a child element, focus the container itself.
+  el.focus();
+}

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -2,3 +2,4 @@ export { onDocumentReady } from './on-document-ready.js';
 export { parseHTML, parseHTMLElement } from './parse-html.js';
 export { EncodedData, decodeData } from './encode-data.js';
 export { templateFromAttributes } from './template-from-attributes.js';
+export { trapFocus, focusFirstFocusableChild } from './focus.js';


### PR DESCRIPTION
Closes #10488.

I tested this on the assessment "Settings" tab with the "Change AID" button, though these changes should apply to all popovers. To test:

- Click to open a popover.
- Hit <kbd>Esc</kbd>; the popover should close.
- Open the popover again.
- Check that the focus moves to the first focusable child.
- Click inside the popover; the popover should not close.
- Click on the input inside the popover; the popover should not close.
- Click outside the popover; the popover should close.
- Hit <kbd>Tab</kbd> or <kbd>Shift+Tab</kbd> repeatedly; focus should not leave the popover.