### PR TITLE
Fix sticky column styles in questions table for Bootstrap 5

### DIFF
--- a/apps/prairielearn/assets/stylesheets/questionsTable.css
+++ b/apps/prairielearn/assets/stylesheets/questionsTable.css
@@ -2,16 +2,17 @@
 @import url('bootstrap-table/dist/extensions/sticky-header/bootstrap-table-sticky-header.min.css');
 @import url('bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.css');
 
-.sticky-column {
+.table > :not(caption) > * > .sticky-column {
   position: sticky;
   left: 0;
-  background: white;
+  background-color: var(--bs-body-bg, white);
   background-clip: padding-box;
   box-shadow: inset -1px 0 #dee2e6;
 }
 
-.table-hover tbody tr:hover td.sticky-column {
-  color: #212529;
+.table.table-hover > tbody > tr:hover > td.sticky-column {
+  color: var(--bs-table-hover-color, #212529);
+  /* This cannot be transparent, to ensure the cell shows on top of others. TODO: handle a non-white background by combining --bs-body-bg with --bs-table-hover-bg. */
   background-color: #efefef;
 }
 


### PR DESCRIPTION
Fixes #10516. Bootstrap 5 introduces CSS styles that override our own custom styling for sticky columns. This PR changes the selectors to be more specific than the ones listed by Bootstrap. It also uses BS variables where appropriate, falling back to fixed colors to allow BS4 to continue working as before. This was tested in both BS4 and BS5.