### PR TITLE
docs: Add more LTI 1.3 institution admin processes

### DIFF
--- a/docs/lti13.md
+++ b/docs/lti13.md
@@ -1,6 +1,6 @@
 # LTI 1.3 configuration
 
-LTI 1.3 is available in early beta. Reach out to support@prairielearn.com to get it set up.
+LTI 1.3 is available in beta. Reach out to support@prairielearn.com to get it set up.
 
 Learning Tools Interoperability (LTI) provides app integration between Learning Management Systems (LMSes) like Canvas, Moodle, etc. and PrairieLearn. It includes single sign on from the LMS with additional features like course context information and roles. Version 1.3 enhances LTI to include an API for asynchronous two-way updates for assessments, scores, and rosters.
 


### PR DESCRIPTION
More strongly describe the workflow for getting institutions set up with LTI 1.3. A cleaned up, generic version of https://github.com/PrairieLearn/canvas/blob/main/sis_import/hogwarts/hogwarts_lti_setup.md

Notes from the UMich integration:

LMS: Ask the LMS what they use for SSO values
- Are we using custom values for UIN? Or something else?
PL: Setup the LTI instance in PL (or go with defaults)
LMS: 
- Setup developer key, get client ID
- Add ?test to the end of the auth URL for testing
- Give Client ID to PL
PL: 
- PL configure the ClientID
- Maybe adjust the custom claims, if needed
- Enable SSO for LTI 1.3
LMS:
- Add the integration to a course (or account)
- Settings / Navigation / Drag PrairieLearn up to the top menu
LMS/PL: 
- Follow the PrairieLearn link in the left menu
- Confirm the ?test auth repeats the information and claims we are looking for
LMS:
- Remove the ?test from the auth URL
