### PR TITLE
Fix SAML metadata endpoint

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -136,7 +136,7 @@ router.get(
       throw new HttpStatusError(404, 'Institution does not support SAML authentication');
     }
 
-    const metadata = await util.promisify(strategy.generateServiceProviderMetadata)(
+    const metadata = await util.promisify(strategy.generateServiceProviderMetadata.bind(strategy))(
       req,
       samlProvider.public_key,
       samlProvider.public_key,


### PR DESCRIPTION
Without this, we get a fun error:

```
TypeError: Cannot read properties of undefined (reading '_options')
    at generateServiceProviderMetadata (/Users/nathan/git/PrairieLearn/node_modules/@node-saml/passport-saml/src/multiSamlStrategy.ts:82:17)
    at node:internal/util:430:7
    at new Promise (<anonymous>)
    at generateServiceProviderMetadata (node:internal/util:416:12)
    at <anonymous> (/Users/nathan/git/PrairieLearn/apps/prairielearn/src/ee/auth/saml/router.ts:139:83)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

I tested this change locally and confirmed that it fixed the error.