### PR TITLE
Fix Sentry memory leak when OTel is disabled

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -2330,8 +2330,10 @@ if (esMain(import.meta) && config.startServer) {
             },
 
             // We have our own OpenTelemetry setup, so ensure Sentry doesn't
-            // try to set that up for itself.
-            skipOpenTelemetrySetup: true,
+            // try to set that up for itself, but only if OpenTelemetry is
+            // enabled. Otherwise, allow Sentry to install its own stuff so
+            // that request isolation works correctly.
+            skipOpenTelemetrySetup: config.openTelemetryEnabled,
 
             beforeSend: (event) => {
               // This will be necessary until we can consume the following change:


### PR DESCRIPTION
Certain environments run Sentry without also enabling OpenTelemetry. Before this change, Sentry wouldn't have the required OTel pieces in place for request isolation to work (see https://docs.sentry.io/platforms/javascript/guides/node/opentelemetry/custom-setup/). Now, if our own OTel setup isn't enabled via our config, we'll allow Sentry to set OpenTelemetry up for itself.