### PR TITLE
Fix sticky column issue in gradebook and students tab

### DIFF
--- a/apps/prairielearn/assets/stylesheets/instructorGradebook.css
+++ b/apps/prairielearn/assets/stylesheets/instructorGradebook.css
@@ -1,25 +1,3 @@
-.sticky-column {
-  position: sticky;
-  left: 0;
-  background: white;
-  background-clip: padding-box;
-  box-shadow: inset -1px 0 #dee2e6;
-}
-
-.table-hover tbody tr:hover td.sticky-column {
-  color: #212529;
-  background-color: #efefef;
-}
-
-.fixed-table-toolbar {
-  padding: 0 1em 0 1em;
-}
-
-.fixed-table-toolbar div.pagination,
-.fixed-table-toolbar div.pagination-detail {
-  margin: 0 1em 0 0 !important;
-}
-
 .gradebook-uin {
   max-width: 10em;
   overflow: hidden;

--- a/apps/prairielearn/assets/stylesheets/questionsTable.css
+++ b/apps/prairielearn/assets/stylesheets/questionsTable.css
@@ -1,26 +1,3 @@
 @import url('bootstrap-table/dist/bootstrap-table.min.css');
 @import url('bootstrap-table/dist/extensions/sticky-header/bootstrap-table-sticky-header.min.css');
 @import url('bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.css');
-
-.table > :not(caption) > * > .sticky-column {
-  position: sticky;
-  left: 0;
-  background-color: var(--bs-body-bg, white);
-  background-clip: padding-box;
-  box-shadow: inset -1px 0 #dee2e6;
-}
-
-.table.table-hover > tbody > tr:hover > td.sticky-column {
-  color: var(--bs-table-hover-color, #212529);
-  /* This cannot be transparent, to ensure the cell shows on top of others. TODO: handle a non-white background by combining --bs-body-bg with --bs-table-hover-bg. */
-  background-color: #efefef;
-}
-
-.fixed-table-toolbar {
-  padding: 0 1em 0 1em;
-}
-
-.fixed-table-toolbar div.pagination,
-.fixed-table-toolbar div.pagination-detail {
-  margin: 0 1em 0 0 !important;
-}

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -444,3 +444,29 @@ small .user-output-invalid {
   outline-width: 2px !important;
   outline-offset: -2px !important;
 }
+
+/* The sticky-column class is used to make the first column of a bootstrap-table sticky. */
+.table > :not(caption) > * > .sticky-column {
+  position: sticky;
+  left: 0;
+  background-color: var(--bs-body-bg, white);
+  background-clip: padding-box;
+  box-shadow: inset -1px 0 #dee2e6;
+}
+
+.table.table-hover > tbody > tr:hover > td.sticky-column {
+  color: var(--bs-table-hover-color, #212529);
+  /* This must be opaque, to ensure the cell shows on top of others.
+     TODO: compute this value by combining --bs-body-bg (opaque) with --bs-table-hover-bg (semi-transparent). */
+  background-color: #efefef;
+}
+
+/* This class is used in pages with bootstrap-table. Since these pages include the navigation in the toolbar, some padding is necessary. */
+.fixed-table-toolbar {
+  padding: 0 1em 0 1em;
+}
+
+.fixed-table-toolbar div.pagination,
+.fixed-table-toolbar div.pagination-detail {
+  margin: 0 1em 0 0 !important;
+}

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
@@ -35,26 +35,6 @@ export function InstructorAssessmentInstances({ resLocals }: { resLocals: Record
 
         ${compiledScriptTag('instructorAssessmentInstancesClient.ts')}
       </head>
-      <style>
-        .sticky-column {
-          position: sticky;
-          left: 0;
-          background: white;
-          background-clip: padding-box;
-          box-shadow: inset -1px 0 #dee2e6;
-        }
-        .table-hover tbody tr:hover td.sticky-column {
-          color: #212529;
-          background-color: #efefef;
-        }
-        .fixed-table-toolbar {
-          padding: 0 1em 0 1em;
-        }
-        .fixed-table-toolbar div.pagination,
-        .fixed-table-toolbar div.pagination-detail {
-          margin: 0 1em 0 0 !important;
-        }
-      </style>
       <body>
         ${renderEjs(import.meta.url, "<%- include('../partials/navbar'); %>", resLocals)}
         <main id="content" class="container-fluid">


### PR DESCRIPTION
Fixes #10525. This also centralizes the CSS styling of custom bootstrap-table handling sticky table and toolbar/pagination padding.