### PR TITLE
Improve setup experience for SAML public certificates

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -146,8 +146,13 @@ export function AdministratorInstitutionSaml({
             <div class="form-group">
               <label for="certificate">Public Certificate</label>
               <textarea class="form-control" name="certificate" id="certificate" rows="20">
-${samlProvider?.certificate ?? ''}</textarea
+${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}</textarea
               >
+              <small id="certificateHelp" class="form-text text-muted">
+                The public certificate of the Identity Provider. This is used to verify the
+                signature of the SAML response. This <strong>must</strong> be a valid X.509
+                certificate in PEM format, including the header and footer.
+              </small>
             </div>
 
             <div class="form-group form-check">

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -145,7 +145,13 @@ export function AdministratorInstitutionSaml({
 
             <div class="form-group">
               <label for="certificate">Public Certificate</label>
-              <textarea class="form-control" name="certificate" id="certificate" rows="20">
+              <textarea
+                class="form-control"
+                name="certificate"
+                id="certificate"
+                rows="20"
+                aria-describedby="certificateHelp"
+              >
 ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}</textarea
               >
               <small id="certificateHelp" class="form-text text-muted">


### PR DESCRIPTION
This bit me during a recent setup process when I forgot to include the header/footer. Hopefully between a default that includes the header/footer and a documented requirement for them, I won't make that same mistake again.