### PR TITLE
Fix issue badge in assessment questions page

### DIFF
--- a/apps/prairielearn/src/pages/partials/issueBadge.ejs
+++ b/apps/prairielearn/src/pages/partials/issueBadge.ejs
@@ -2,7 +2,6 @@
     <% if (!(typeof suppressLink != 'undefined' && suppressLink)) { %>
         <% if (typeof issueQid != 'undefined') { %>
             <a class="badge badge-pill badge-danger" aria-label="<%= count %> open <%= count === 1 ? "issue" : "issues" %>" href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
-            " href="<%= urlPrefix %>/course_admin/issues?q=is%3Aopen+qid%3A<%= issueQid %>">
         <% } else { %>
             <a class="badge badge-pill badge-danger" aria-label="<%= count %> open <%= count === 1 ? "issue" : "issues" %>" href="<%= urlPrefix %>/course_admin/issues">
         <% } %>


### PR DESCRIPTION
Fixes an issue introduces in #10496. The link in the assessment questions page included some weird HTML in the text.