### PR TITLE
Prevent radio/checkbox inputs with long labels from shrinking

### DIFF
--- a/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
+++ b/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
@@ -4,7 +4,7 @@
 
 {{#answers}}
     <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1 gap-2">
-        <input class="form-check-input mt-0" type="checkbox"
+        <input class="form-check-input mt-0 flex-shrink-0" type="checkbox"
                name="{{name}}" value="{{key}}" {{^editable}}disabled{{/editable}}
                {{#checked}}checked{{/checked}} id="{{name}}-{{key}}">
 

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -7,7 +7,7 @@
     {{#answers}}
         <div class="form-check {{#inline}}form-check-inline d-inline-flex{{/inline}}{{^inline}}d-flex{{/inline}} align-items-center py-1 gap-2">
             <input
-                class="form-check-input mt-0"
+                class="form-check-input mt-0 flex-shrink-0"
                 type="radio"
                 name="{{name}}"
                 value="{{key}}"


### PR DESCRIPTION
Fixes https://github.com/PrairieLearn/PrairieLearn/issues/10534.

Before:

<img width="537" alt="Screenshot 2024-08-23 at 09 22 13" src="https://github.com/user-attachments/assets/b3bb88e2-d313-42de-aa73-38c2e0c1d607">
<img width="541" alt="Screenshot 2024-08-23 at 09 23 41" src="https://github.com/user-attachments/assets/57aff3d6-18c7-4ac6-8838-287723071edc">

After:

<img width="536" alt="Screenshot 2024-08-23 at 09 22 49" src="https://github.com/user-attachments/assets/5c7ce219-4023-47a6-a511-22c465ac0078">
<img width="537" alt="Screenshot 2024-08-23 at 09 24 20" src="https://github.com/user-attachments/assets/9b174a19-6218-4d22-9e98-5b773d3417d8">