### PR TITLE
Don't immediately close focus-triggered popover with focusable child

### DIFF
--- a/apps/prairielearn/assets/scripts/behaviors/popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/popover.ts
@@ -129,7 +129,7 @@ onDocumentReady(() => {
     const container = getPopoverContainerForTrigger(event.target);
 
     // If the popover is focus-triggered, we'll skip the focus trap and
-    // autofocus logic. If the move the focus off the trigger, the popover
+    // autofocus logic. If we move the focus off the trigger, the popover
     // will immediately close, which we don't want.
     if (container && !isFocusTrigger(target)) {
       // Trap focus inside this new popover.

--- a/apps/prairielearn/assets/scripts/behaviors/popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/popover.ts
@@ -12,6 +12,36 @@ function closeOpenPopovers() {
   openPopoverTriggers.clear();
 }
 
+/**
+ * Returns the trigger modes for a popover trigger as configured by `data-bs-trigger`,
+ * `data-trigger`, or `trigger: ...` in the popover's options.
+ *
+ * If the trigger mode cannot be determined, an empty array is returned.
+ */
+function getPopoverTriggerModes(trigger: HTMLElement): string[] {
+  // Bootstrap 4 uses jQuery data to store popover configuration.
+  const config = $(trigger).data('bs.popover');
+  if (config) {
+    return config.config?.trigger?.split?.(' ') ?? [];
+  }
+
+  // Bootstrap 5 allows us to access the popover instance more directly.
+  const instance = window.bootstrap?.Popover?.getInstance?.(trigger);
+  if (instance) {
+    return (instance as any)._config?.trigger?.split?.(' ') ?? [];
+  }
+
+  return [];
+}
+
+/**
+ * Returns whether a popover trigger is focus-triggered.
+ */
+function isFocusTrigger(trigger: HTMLElement) {
+  const triggerModes = getPopoverTriggerModes(trigger);
+  return triggerModes.includes('focus');
+}
+
 // We need to wrap this in `onDocumentReady` because Bootstrap doesn't
 // add its jQuery API to the jQuery object until after this event.
 // `selector-observer` will start running its callbacks immediately, so they'd
@@ -97,7 +127,11 @@ onDocumentReady(() => {
     openPopoverTriggers.add(event.target);
 
     const container = getPopoverContainerForTrigger(event.target);
-    if (container) {
+
+    // If the popover is focus-triggered, we'll skip the focus trap and
+    // autofocus logic. If the move the focus off the trigger, the popover
+    // will immediately close, which we don't want.
+    if (container && !isFocusTrigger(target)) {
       // Trap focus inside this new popover.
       const trap = trapFocus(container);
 


### PR DESCRIPTION
As reported by @eliotwrobson, if a popover with `data-trigger="focus"` contains a focusable child, focus would be immediately moved to that child, which would close the popover:

https://github.com/user-attachments/assets/bf2f9480-1f18-44a3-832f-049faafcdb74

Now, we detect when a popover is focus-triggered and skip the autofocus/focus-trap logic, which ensures that the popover stays open:

https://github.com/user-attachments/assets/93845bad-c3ed-491e-b1e5-cf44ba6d9ed4

To test this, you can add a focusable child to a popover's contents. I tested this with both Bootstrap 4 and 5, and it worked correctly in each.

I think we should abandon `data-trigger="focus"` in favor of the default `"click"` trigger. Now that we have <kbd>Esc</kbd> and close-on-click-outside implemented universally, that should really be the best option for all popovers.