### PR TITLE
Update submission params and true_answer after grading

### DIFF
--- a/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql
+++ b/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql
@@ -114,6 +114,8 @@ BEGIN
         graded_at = now(),
         gradable = new_gradable,
         broken = new_broken,
+        params = COALESCE(new_params, params),
+        true_answer = COALESCE(new_true_answer, true_answer),
         format_errors = new_format_errors,
         partial_scores = new_partial_scores,
         score = new_score,


### PR DESCRIPTION
This fixes an issue reported on Slack: https://prairielearn.slack.com/archives/C266KEH9A/p1724793294305189

For posterity, this can be reproduced with the following question:

```html
<pl-question-panel>
  This is a test
</pl-question-panel>
  
<pl-answer-panel>
  {{{params.answer-feedback}}}
</pl-answer-panel>
  
<pl-submission-panel>
  {{{params.submission-feedback}}}
</pl-submission-panel>
```

```py
def grade(data):
    data["params"]["submission-feedback"] = "HELLO"
    data["params"]["answer-feedback"] = "TEST"
    data["score"] = 1
```

The expected behavior is that after one submission, `HELLO` would be shown in the submission panel and `TEST` would be shown in the answer panel. However, this didn't occur; it was only shown after the _second_ submission.

I broke this (or rather, uncovered this bug) in #10495 by changing the rendering logic to pull `params` and `true_answer` from the submission if one was present. However, we weren't actually updating those values on the `submissions` row, just on the variant.