### PR TITLE
fix stale documentation for pl-excalidraw

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -260,7 +260,7 @@ Draw a vector diagram using [excalidraw](https://github.com/excalidraw/excalidra
   gradable="true"
   answers-name="vector"
   source-file-name="starter.excalidraw"
-  directory="client_files_question_path"
+  directory="clientFilesQuestion"
   width="100%"
   height="600px"
 ></pl-excalidraw>


### PR DESCRIPTION
Follow-up to #9900 

I forgot to update the documentation with the new case style. `exampleCourse/questions/element/excalidraw/question.html` already uses the correct style.

Thanks to @firasm for finding the bug!