### PR TITLE
Replace terms feature flag with config boolean

### DIFF
--- a/apps/prairielearn/src/ee/lib/terms.ts
+++ b/apps/prairielearn/src/ee/lib/terms.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 
 import { callRow } from '@prairielearn/postgres';
 
+import { config } from '../../lib/config.js';
 import { setCookie } from '../../lib/cookie.js';
 import { EnumModeSchema, type User } from '../../lib/db-types.js';
-import { features } from '../../lib/features/index.js';
 import { HttpRedirect } from '../../lib/redirect.js';
 
 function hasUserAcceptedTerms(user: User): boolean {
@@ -29,13 +29,7 @@ function hasUserAcceptedTerms(user: User): boolean {
  * @returns Whether the user should be redirected to the terms acceptance page
  */
 export async function shouldRedirectToTermsPage(user: User, ip: string) {
-  if (hasUserAcceptedTerms(user)) return false;
-
-  const featureEnabled = await features.enabled('terms-clickthrough', {
-    institution_id: user.institution_id,
-    user_id: user.user_id,
-  });
-  if (!featureEnabled) return false;
+  if (!config.requireTermsAcceptance || hasUserAcceptedTerms(user)) return false;
 
   const { mode } = await callRow(
     'ip_to_mode',

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -540,6 +540,7 @@ const ConfigSchema = z.object({
   stripeProductIds: z.record(z.string(), z.string()).default({}),
   openAiApiKey: z.string().nullable().default(null),
   openAiOrganization: z.string().nullable().default(null),
+  requireTermsAcceptance: z.boolean().default(false),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -12,7 +12,6 @@ const featureNames = [
   'bootstrap-4',
   // Should only be applied to institutions.
   'lti13',
-  'terms-clickthrough',
 ] as const;
 
 const features = new FeatureManager(featureNames);


### PR DESCRIPTION
I'm trying to practice good feature-flag hygiene. Now that this is proven out, we can safely replace the feature flag with a server-wide config option.