### PR TITLE
Fix production assets path

### DIFF
--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -171,7 +171,7 @@ function compiledPath(type: 'scripts' | 'stylesheets', sourceFile: string): stri
     throw new Error(`Unknown ${type} asset: ${sourceFile}`);
   }
 
-  return `${options.publicPath}/${assetPath}`;
+  return options.publicPath + assetPath;
 }
 
 export function compiledScriptPath(sourceFile: string): string {


### PR DESCRIPTION
When we initialize the middleware, we always ensure that `publicPath` ends with a slash, so adding another slash is redundant:

https://github.com/PrairieLearn/PrairieLearn/blob/9e9b7292f21485543466af4ccb3c4f41aecb168a/packages/compiled-assets/src/index.ts#L47-L49