### PR TITLE
Fix PDF previewer in Safari

### DIFF
--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
@@ -104,7 +104,7 @@
 
           const code = preview.querySelector('code');
           const img = preview.querySelector('img');
-          const object = preview.querySelector('object');
+          const iframe = preview.querySelector('iframe');
 
           fetch(path, { method: 'GET' })
             .then((result) => {
@@ -170,11 +170,11 @@
                 hideErrorMessage();
               } else if (type === 'application/pdf') {
                 const url = URL.createObjectURL(blob);
-                object.data = url;
-                object.onload = () => {
+                iframe.src = url;
+                iframe.onload = () => {
                   URL.revokeObjectURL(url);
                 };
-                object.closest('.embed-responsive').classList.remove('d-none');
+                iframe.closest('.embed-responsive').classList.remove('d-none');
                 hideErrorMessage();
               } else {
                 // We can't preview this file.

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
@@ -28,9 +28,9 @@
         <div class="file-preview collapse" id="file-preview-contents-{{uuid}}-{{index}}">
           <img class="d-none mw-100 mt-2">
           <div class="d-none embed-responsive embed-responsive-4by3 mt-2"> 
-            <object type="application/pdf" class="embed-responsive-item">
+            <iframe class="embed-responsive-item">
               This PDF cannot be displayed. 
-            </object>
+            </iframe>
           </div> 
           <div class="file-preview-container mt-2">
             <pre class="d-none bg-dark text-white rounded p-3 mb-0"><code></code></pre>

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -280,11 +280,10 @@
             if (this.isPdf(fileData)) {
               const $objectPreview = $(
                 `<div class="mt-2 embed-responsive embed-responsive-4by3">
-                   <object type="application/pdf" 
-                           class="embed-responsive-item" 
-                           data="data:application/pdf;base64,${fileData}">
+                   <iframe class="embed-responsive-item" 
+                           src="data:application/pdf;base64,${fileData}">
                      PDF file cannot be displayed.
-                   </object>
+                   </iframe>
                  </div>`,
               );
               $preview.append($objectPreview);

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.html.ts
@@ -396,13 +396,12 @@ function FileContentPreview({
   if (fileInfo.isPDF) {
     return html`
       <div class="embed-responsive embed-responsive-4by3">
-        <object
-          data="${paths.urlPrefix}/file_download/${paths.workingPathRelativeToCourse}?type=application/pdf#view=FitH"
-          type="application/pdf"
+        <iframe
+          src="${paths.urlPrefix}/file_download/${paths.workingPathRelativeToCourse}?type=application/pdf#view=FitH"
           class="embed-responsive-item"
         >
           This PDF cannot be displayed.
-        </object>
+        </iframe>
       </div>
     `;
   }


### PR DESCRIPTION
As discussed on Slack. The use of `object type="application/pdf"` seems to cause Safari to crash. Using `iframe` produces a similar interface in Edge/Chrome/Firefox on Windows, and now works on Safari on Mac.