### PR TITLE
Fix display of QR code popover in Bootstrap 5

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/qrCodeButton.ts
+++ b/apps/prairielearn/assets/scripts/lib/qrCodeButton.ts
@@ -1,7 +1,7 @@
 import QR from 'qrcode-svg';
 import { observe } from 'selector-observer';
 
-import { parseHTMLElement } from '@prairielearn/browser-utils';
+import { onDocumentReady, parseHTMLElement } from '@prairielearn/browser-utils';
 
 observe('.js-qrcode-button', {
   add(el) {
@@ -11,13 +11,18 @@ observe('.js-qrcode-button', {
     if (content) {
       const qrCodeSvg = new QR({ content, width: 512, height: 512 }).svg();
 
-      // The `data-content` attribute appears to not support SVGs, so we need
-      // to manually initialize the popover with the SVG content.
-      $(el).popover({
-        content: parseHTMLElement(document, qrCodeSvg),
-        html: true,
-        trigger: 'click',
-        container: 'body',
+      // BS5 delays the initialization of popovers until the document load, so
+      // delay until that happens. Once we're no longer supporting BS4, this can
+      // be replaced with a proper BS5 API call.
+      onDocumentReady(() => {
+        // The `data-content` attribute appears to not support SVGs, so we need
+        // to manually initialize the popover with the SVG content.
+        $(el).popover({
+          content: parseHTMLElement(document, qrCodeSvg),
+          html: true,
+          trigger: 'click',
+          container: 'body',
+        });
       });
     }
   },


### PR DESCRIPTION
The QR code popover doesn't show when using Bootstrap 5. A console error indicates that `$().popover` isn't initialized when it is called to set up this popover. This PR ensures that the document has been initialized, which also means the JQuery API for Bootstrap 5 is initialized, before setting up the popover.