### PR TITLE
Upgrade to typescript-eslint v8

### DIFF
--- a/apps/grader-host/src/lib/lifecycle.ts
+++ b/apps/grader-host/src/lib/lifecycle.ts
@@ -50,7 +50,7 @@ export async function inService() {
   try {
     await autoscaling.completeLifecycleAction(params);
     logger.info('lifecycle.inService(): completed action', params);
-  } catch (e) {
+  } catch {
     // don't return the error, because there is nothing to be done about it
     logger.error('lifecycle.inService(): error completing action', params);
   }
@@ -76,7 +76,7 @@ export async function abandonLaunch() {
     try {
       await autoscaling.completeLifecycleAction(params);
       logger.info('lifecycle.abandonLaunch(): completed action', params);
-    } catch (e) {
+    } catch {
       // don't return the error, because there is nothing to be done about it
       logger.error('lifecycle.abandonLaunch(): error completing action', params);
     }

--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -531,14 +531,13 @@ onDocumentReady(() => {
     rowA: AssessmentInstanceRow,
     rowB: AssessmentInstanceRow,
   ) {
-    let nameA: string | null, nameB: string | null, idA, idB;
-    if (assessmentGroupWork) {
-      (nameA = rowA.group_name), (nameB = rowB.group_name);
-      (idA = rowA.group_id ?? ''), (idB = rowB.group_id ?? '');
-    } else {
-      (nameA = rowA.uid), (nameB = rowB.uid);
-      (idA = rowA.user_id ?? ''), (idB = rowB.user_id ?? '');
-    }
+    const nameKey = assessmentGroupWork ? 'group_name' : 'uid';
+    const idKey = assessmentGroupWork ? 'group_id' : 'user_id';
+
+    const nameA = rowA[nameKey];
+    const nameB = rowB[nameKey];
+    const idA = rowA[idKey] ?? '';
+    const idB = rowB[idKey] ?? '';
 
     // Compare first by UID/group name, then user/group ID, then
     // instance number, then by instance ID.

--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -3261,9 +3261,9 @@ mechanicsObjects.byType['pl-distributed-load'] = class extends PLDrawingBaseElem
       var initObjTop = obj.top;
 
       var modify = function (subObj) {
-        (subObj.left = initSubObjLeft + obj.left - initObjLeft),
-          (subObj.top = initSubObjTop + obj.top - initObjTop),
-          (subObj.range = obj.range);
+        subObj.left = initSubObjLeft + obj.left - initObjLeft;
+        subObj.top = initSubObjTop + obj.top - initObjTop;
+        subObj.range = obj.range;
         subObj.angle = obj.angle;
         subObj.flipped = obj.flipped;
       };

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -296,7 +296,7 @@
               }
               $codePreview.removeClass('d-none');
             }
-          } catch (e) {
+          } catch {
             $imgPreview
               .on('load', () => {
                 $imgPreview.removeClass('d-none');

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateQuestion/instructorAiGenerateQuestion.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateQuestion/instructorAiGenerateQuestion.ts
@@ -48,7 +48,7 @@ export async function saveGeneratedQuestion(
 
   try {
     await editor.executeWithServerJob(serverJob);
-  } catch (err) {
+  } catch {
     throw new HttpRedirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
   }
 

--- a/apps/prairielearn/src/executor.js
+++ b/apps/prairielearn/src/executor.js
@@ -71,7 +71,7 @@ async function handleInput(line, codeCaller) {
       coursePath: '/course',
       forbiddenModules: request.forbidden_modules,
     });
-  } catch (err) {
+  } catch {
     // We should never actually hit this case - but if we do, handle it so
     // that all our bases are covered.
     return { needsFullRestart: true };

--- a/apps/prairielearn/src/lib/base64-util.js
+++ b/apps/prairielearn/src/lib/base64-util.js
@@ -14,7 +14,7 @@ export function b64EncodeUnicode(str) {
         return String.fromCharCode(parseInt('0x' + p1, 16));
       }),
     );
-  } catch (e) {
+  } catch {
     logger.error(`b64EncodeUnicode: returning empty string because failed to encode ${str}`);
     return '';
   }
@@ -31,7 +31,7 @@ export function b64DecodeUnicode(str) {
         })
         .join(''),
     );
-  } catch (e) {
+  } catch {
     logger.error(`b64DecodeUnicode: returning empty string because failed to decode ${str}`);
     return '';
   }

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.js
@@ -752,7 +752,7 @@ async function cleanupMountDirectories() {
         try {
           debug(`removing bind mount at ${absolutePath}`);
           await bindMount.umount(absolutePath);
-        } catch (e) {
+        } catch {
           // Ignore this, it was hopefully unmounted successfully before
         }
 

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.js
@@ -577,7 +577,7 @@ export class CodeCallerNative {
     try {
       const data = JSON.parse(this.outputRestart);
       return data.exited === true;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -241,7 +241,7 @@ export abstract class Editor {
               env: gitEnv,
             });
             job.data.saveSucceeded = true;
-          } catch (err) {
+          } catch {
             job.info('Failed to push changes to remote git repository');
             job.info('Pulling changes from remote git repository and trying again');
 

--- a/apps/prairielearn/src/lib/externalGraderCommon.ts
+++ b/apps/prairielearn/src/lib/externalGraderCommon.ts
@@ -124,7 +124,7 @@ export function makeGradingResult(jobId: string, rawData: Record<string, any> | 
   try {
     // replace NULL with unicode replacement character
     data = JSON.parse(dataStr.replace(/\0/g, '\ufffd'));
-  } catch (e) {
+  } catch {
     return makeGradingFailureWithMessage(jobId, dataStr, 'Could not parse the grading results.');
   }
 

--- a/apps/prairielearn/src/lib/externalGraderLocal.ts
+++ b/apps/prairielearn/src/lib/externalGraderLocal.ts
@@ -80,7 +80,7 @@ export class ExternalGraderLocal {
             '+x',
             path.join(dir, question.external_grading_entrypoint.slice(6)),
           ]);
-        } catch (e) {
+        } catch {
           logger.error('Could not make file executable; continuing execution anyways');
         }
       }
@@ -189,12 +189,12 @@ export class ExternalGraderLocal {
             try {
               results.results = JSON.parse(data.toString('utf8'));
               results.succeeded = true;
-            } catch (e) {
+            } catch {
               results.succeeded = false;
               results.message = 'Could not parse the grading results.';
             }
           }
-        } catch (err) {
+        } catch {
           logger.error('Could not read results.json');
           results.succeeded = false;
         }

--- a/apps/prairielearn/src/lib/externalGraderResults.js
+++ b/apps/prairielearn/src/lib/externalGraderResults.js
@@ -134,7 +134,7 @@ async function processMessage(data) {
   let jobId;
   try {
     jobId = IdSchema.parse(data.jobId);
-  } catch (err) {
+  } catch {
     throw new error.AugmentedError('Message does not contain a valid grading job id.', { data });
   }
 

--- a/apps/prairielearn/src/lib/instructorFiles.ts
+++ b/apps/prairielearn/src/lib/instructorFiles.ts
@@ -117,7 +117,7 @@ export function getPaths(
   if (requestedPath) {
     try {
       workingPath = path.join(coursePath, requestedPath);
-    } catch (err) {
+    } catch {
       throw new Error(`Invalid path: ${requestedPath}`);
     }
   }

--- a/apps/prairielearn/src/lib/question-submission.ts
+++ b/apps/prairielearn/src/lib/question-submission.ts
@@ -23,7 +23,7 @@ export async function processSubmission(
     let postData;
     try {
       postData = JSON.parse(req.body.postData);
-    } catch (e) {
+    } catch {
       throw new HttpStatusError(400, 'JSON parse failed on body.postData');
     }
     variant_id = postData.variant ? postData.variant.id : null;

--- a/apps/prairielearn/src/lib/uri-util.ts
+++ b/apps/prairielearn/src/lib/uri-util.ts
@@ -13,7 +13,7 @@ import { logger } from '@prairielearn/logger';
 export function encodePath(originalPath: string): string {
   try {
     return path.normalize(originalPath).split(path.sep).map(encodeURIComponent).join('/');
-  } catch (err) {
+  } catch {
     logger.error(`encodePath: returning empty string because failed to encode ${originalPath}`);
     return '';
   }

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -36,7 +36,7 @@ router.post(
       let course_ids: string[];
       try {
         course_ids = course_ids_string.split(',').map((x) => IdSchema.parse(x));
-      } catch (err) {
+      } catch {
         throw new error.HttpStatusError(
           400,
           `could not split course_ids into an array of integers: ${course_ids_string}`,

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -69,7 +69,7 @@ async function pipeCursorToArchive(res, cursor: sqldb.CursorIterator<any>) {
       let contents: string | Buffer;
       try {
         contents = Buffer.from(typeof row.contents === 'string' ? row.contents : '', 'base64');
-      } catch (err) {
+      } catch {
         // Ignore any errors in reading the contents and treat as a blank file.
         contents = '';
       }

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -66,7 +66,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
 
@@ -89,7 +89,7 @@ router.post(
       try {
         await editor.executeWithServerJob(serverJob);
         res.redirect(res.locals.urlPrefix + '/instance_admin/assessments');
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
     } else if (req.body.__action === 'change_id') {
@@ -105,7 +105,7 @@ router.post(
       let tid_new;
       try {
         tid_new = path.normalize(req.body.id);
-      } catch (err) {
+      } catch {
         throw new error.HttpStatusError(
           400,
           `Invalid TID (could not be normalized): ${req.body.id}`,
@@ -123,7 +123,7 @@ router.post(
         try {
           await editor.executeWithServerJob(serverJob);
           return res.redirect(req.originalUrl);
-        } catch (err) {
+        } catch {
           return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         }
       }

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
@@ -182,7 +182,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(`${res.locals.urlPrefix}/edit_error/${serverJob.jobSequenceId}`);
         return;
       }

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
@@ -63,7 +63,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         return;
       }

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -92,7 +92,7 @@ router.post(
         await editor.executeWithServerJob(serverJob);
         flash('success', 'Course configuration updated successfully');
         return res.redirect(req.originalUrl);
-      } catch (err) {
+      } catch {
         return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
     }
@@ -117,7 +117,7 @@ router.post(
       try {
         await editor.executeWithServerJob(serverJob);
         return res.redirect(req.originalUrl);
-      } catch (err) {
+      } catch {
         return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
     } else {

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
@@ -240,7 +240,7 @@ router.post(
       let deletePath: string;
       try {
         deletePath = path.join(res.locals.course.path, req.body.file_path);
-      } catch (err) {
+      } catch {
         throw new Error(`Invalid file path: ${req.body.file_path}`);
       }
       const editor = new FileDeleteEditor({
@@ -251,7 +251,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         return;
       }
@@ -260,7 +260,7 @@ router.post(
       let oldPath: string;
       try {
         oldPath = path.join(req.body.working_path, req.body.old_file_name);
-      } catch (err) {
+      } catch {
         throw new Error(
           `Invalid old file path: ${req.body.working_path} / ${req.body.old_file_name}`,
         );
@@ -280,7 +280,7 @@ router.post(
       let newPath: string;
       try {
         newPath = path.join(req.body.working_path, req.body.new_file_name);
-      } catch (err) {
+      } catch {
         throw new Error(
           `Invalid new file path: ${req.body.working_path} / ${req.body.new_file_name}`,
         );
@@ -301,7 +301,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(`${res.locals.urlPrefix}/edit_error/${serverJob.jobSequenceId}`);
         return;
       }
@@ -321,13 +321,13 @@ router.post(
       if (req.body.file_path) {
         try {
           filePath = path.join(res.locals.course.path, req.body.file_path);
-        } catch (err) {
+        } catch {
           throw new Error(`Invalid file path: ${req.body.file_path}`);
         }
       } else {
         try {
           filePath = path.join(req.body.working_path, req.file.originalname);
-        } catch (err) {
+        } catch {
           throw new Error(`Invalid file path: ${req.body.working_path} / ${req.file.originalname}`);
         }
       }
@@ -341,7 +341,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(`${res.locals.urlPrefix}/edit_error/${serverJob.jobSequenceId}`);
         return;
       }

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
@@ -60,7 +60,7 @@ router.get(
     const serverJob = await editor.prepareServerJob();
     try {
       await editor.executeWithServerJob(serverJob);
-    } catch (err) {
+    } catch {
       res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       return;
     }

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -66,7 +66,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         return;
       }
@@ -96,7 +96,7 @@ router.post(
       try {
         await editor.executeWithServerJob(serverJob);
         res.redirect(`${res.locals.plainUrlPrefix}/course/${res.locals.course.id}/course_admin`);
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
     } else if (req.body.__action === 'change_id') {
@@ -112,7 +112,7 @@ router.post(
       let ciid_new;
       try {
         ciid_new = path.normalize(req.body.id);
-      } catch (err) {
+      } catch {
         throw new error.HttpStatusError(
           400,
           `Invalid CIID (could not be normalized): ${req.body.id}`,
@@ -130,7 +130,7 @@ router.post(
         try {
           await editor.executeWithServerJob(serverJob);
           res.redirect(req.originalUrl);
-        } catch (err) {
+        } catch {
           res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         }
       }

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -103,7 +103,7 @@ router.post(
       let qid_new;
       try {
         qid_new = path.normalize(req.body.id);
-      } catch (err) {
+      } catch {
         throw new error.HttpStatusError(
           400,
           `Invalid QID (could not be normalized): ${req.body.id}`,
@@ -120,7 +120,7 @@ router.post(
         try {
           await editor.executeWithServerJob(serverJob);
           res.redirect(req.originalUrl);
-        } catch (err) {
+        } catch {
           res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         }
       }
@@ -133,7 +133,7 @@ router.post(
         const serverJob = await editor.prepareServerJob();
         try {
           await editor.executeWithServerJob(serverJob);
-        } catch (err) {
+        } catch {
           return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         }
         const questionId = await sqldb.queryRow(
@@ -161,7 +161,7 @@ router.post(
       try {
         await editor.executeWithServerJob(serverJob);
         res.redirect(res.locals.urlPrefix + '/course_admin/questions');
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
     } else if (req.body.__action === 'sharing_set_add') {

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -60,7 +60,7 @@ router.post(
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);
-      } catch (err) {
+      } catch {
         res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
         return;
       }

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
@@ -49,7 +49,7 @@ router.get(
             ltiClaim.get(['https://purl.imsglobal.org/spec/lti/claim/context', 'title']) ?? '',
           'cr-institution': res.locals.authn_institution.long_name ?? '',
         };
-      } catch (err) {
+      } catch {
         // If LTI information expired or otherwise errors, don't error here.
         // Continue on like there isn't LTI 1.3 information.
         lti13Info = null;

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -373,7 +373,7 @@ async function execPythonServer(codeCaller, phase, data, html, context) {
 
   try {
     await fs.access(fullFilename, fs.constants.R_OK);
-  } catch (err) {
+  } catch {
     // server.py does not exist
     return { result: defaultServerRet(phase, data, html, context), output: '' };
   }
@@ -787,7 +787,7 @@ async function legacyTraverseQuestionAndExecuteFunctions(phase, codeCaller, data
         }
       });
     });
-  } catch (err) {
+  } catch {
     // Black-hole any errors, they were (should have been) handled by course issues
   }
 
@@ -1871,7 +1871,7 @@ async function getCacheKey(course, data, context) {
     const commitHash = await getOrUpdateCourseCommitHash(course);
     const dataHash = objectHash({ data, context }, { algorithm: 'sha1', encoding: 'base64' });
     return `question:${commitHash}-${dataHash}`;
-  } catch (err) {
+  } catch {
     return null;
   }
 }

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -608,7 +608,7 @@ export async function loadInfoFile<T extends { uuid: string }>({
     } catch (err) {
       return infofile.makeError(err.message);
     }
-  } catch (err) {
+  } catch {
     // Invalid JSON; let's reparse with jju to get a better error message
     // for the user.
     let result: InfoFile<T> = { errors: [], warnings: [] };

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -53,7 +53,7 @@ app.get(
         instance_id: workspace_server_settings.instance_id,
       });
       db_status = 'ok';
-    } catch (_err) {
+    } catch {
       db_status = null;
     }
 
@@ -278,7 +278,7 @@ async function pruneStoppedContainers() {
     try {
       // Try to grab the container, but don't care if it doesn't exist
       container = await _getDockerContainerByLaunchUuid(ws.launch_uuid);
-    } catch (_err) {
+    } catch {
       // No container
       await sqldb.queryAsync(sql.clear_workspace_on_shutdown, {
         workspace_id: ws.id,
@@ -308,7 +308,7 @@ async function pruneRunawayContainers() {
   let running_workspaces;
   try {
     running_workspaces = await docker.listContainers({ all: true });
-  } catch (err) {
+  } catch {
     // Nothing to do
     return;
   }
@@ -1029,7 +1029,7 @@ async function sendGradedFilesArchive(workspace_id, res) {
       const filePath = path.join(workspaceDir, file.path);
       archive.file(filePath, { name: file.path });
       debug(`Sending ${file.path}`);
-    } catch (err) {
+    } catch {
       logger.warn(`Graded file ${file.path} does not exist.`);
       continue;
     }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.7",
     "@prairielearn/prettier-plugin-sql": "workspace:^",
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@typescript-eslint/parser": "^7.18.0",
+    "@typescript-eslint/eslint-plugin": "^8.4.0",
+    "@typescript-eslint/parser": "^8.4.0",
     "dependency-cruiser": "^16.4.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/packages/bind-mount/index.js
+++ b/packages/bind-mount/index.js
@@ -1,5 +1,5 @@
 try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const addon = require('bindings')('addon');
 
   module.exports.mount = (source, target) => {
@@ -25,7 +25,7 @@ try {
       });
     });
   };
-} catch (err) {
+} catch {
   module.exports.mount = () => {
     throw new Error('Failed to load native bindings');
   };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,8 +6,7 @@ import { z } from 'zod';
 
 import { fetchInstanceHostname, fetchInstanceIdentity } from '@prairielearn/aws-imds';
 
-const AbstractConfigSchema = z.record(z.string(), z.unknown());
-type AbstractConfig = z.infer<typeof AbstractConfigSchema>;
+type AbstractConfig = Record<string, unknown>;
 
 interface ConfigSource {
   load: (existingConfig: AbstractConfig) => Promise<AbstractConfig>;

--- a/packages/error/src/format.ts
+++ b/packages/error/src/format.ts
@@ -46,7 +46,7 @@ export function formatErrorStack(err: any, depth = 0, prefix = ''): string {
 export function formatErrorStackSafe(err: any): string {
   try {
     return formatErrorStack(err);
-  } catch (e) {
+  } catch {
     return err.stack;
   }
 }

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
@@ -195,7 +195,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
         // when we're shutting down.
         try {
           await sleep(sleepDurationMs, null, { ref: false, signal: this.abortController.signal });
-        } catch (err) {
+        } catch {
           // We don't care about errors here, they should only ever occur when
           // the AbortController is aborted. Continue to the next iteration of
           // the loop so we can shut down.

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -61,7 +61,7 @@ function debugParams(params: QueryParams): string {
   let s;
   try {
     s = JSON.stringify(params);
-  } catch (err) {
+  } catch {
     s = 'CANNOT JSON STRINGIFY';
   }
   return debugString(s);

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -12,7 +12,7 @@ export async function init(options: Sentry.NodeOptions) {
   if (!release) {
     try {
       release = (await execa('git', ['rev-parse', 'HEAD'])).stdout.trim();
-    } catch (e) {
+    } catch {
       // This most likely isn't running in an initialized git repository.
       // Default to not setting a release.
     }

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -72,7 +72,7 @@ export function getCheckedSignedTokenData(
     let tokenDate;
     try {
       tokenDate = new Date(parseInt(tokenDateString, 36));
-    } catch (e) {
+    } catch {
       debug(`getCheckedSignedTokenData(): FAIL - could not parse date: ${tokenDateString}`);
       return null;
     }
@@ -90,13 +90,13 @@ export function getCheckedSignedTokenData(
   let tokenDataJSON, tokenData;
   try {
     tokenDataJSON = base64url.default.decode(tokenDataString);
-  } catch (e) {
+  } catch {
     debug(`getCheckedSignedTokenData(): FAIL - could not base64 decode: ${tokenDateString}`);
     return null;
   }
   try {
     tokenData = JSON.parse(tokenDataJSON);
-  } catch (e) {
+  } catch {
     debug(`getCheckedSignedTokenData(): FAIL - could not parse JSON: ${tokenDataJSON}`);
     return null;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,44 +5735,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:7.18.0"
+"@typescript-eslint/eslint-plugin@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.4.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:7.18.0"
-    "@typescript-eslint/type-utils": "npm:7.18.0"
-    "@typescript-eslint/utils": "npm:7.18.0"
-    "@typescript-eslint/visitor-keys": "npm:7.18.0"
+    "@typescript-eslint/scope-manager": "npm:8.4.0"
+    "@typescript-eslint/type-utils": "npm:8.4.0"
+    "@typescript-eslint/utils": "npm:8.4.0"
+    "@typescript-eslint/visitor-keys": "npm:8.4.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^1.3.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^7.0.0
-    eslint: ^8.56.0
+    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
+    eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/2b37948fa1b0dab77138909dabef242a4d49ab93e4019d4ef930626f0a7d96b03e696cd027fa0087881c20e73be7be77c942606b4a76fa599e6b37f6985304c3
+  checksum: 10c0/c75e9bb176e9e0277c9f9c4c006bc2c31ac91984e555de1390a9bbe876e3b6787d59d96015b3f0cd083fd22c814aea4ed4858910d3afdd24d64ab79815da31e5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/parser@npm:7.18.0"
+"@typescript-eslint/parser@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/parser@npm:8.4.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:7.18.0"
-    "@typescript-eslint/types": "npm:7.18.0"
-    "@typescript-eslint/typescript-estree": "npm:7.18.0"
-    "@typescript-eslint/visitor-keys": "npm:7.18.0"
+    "@typescript-eslint/scope-manager": "npm:8.4.0"
+    "@typescript-eslint/types": "npm:8.4.0"
+    "@typescript-eslint/typescript-estree": "npm:8.4.0"
+    "@typescript-eslint/visitor-keys": "npm:8.4.0"
     debug: "npm:^4.3.4"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/370e73fca4278091bc1b657f85e7d74cd52b24257ea20c927a8e17546107ce04fbf313fec99aed0cc2a145ddbae1d3b12e9cc2c1320117636dc1281bcfd08059
+  checksum: 10c0/19f3358e5bc4bbad693183eefe1a90ea64be054a934bc2c8a972ff4738b94580b55ad4955af5797db42298628caa59b3ba3f9fd960582b5fc2c836da3a4578a5
   languageName: node
   linkType: hard
 
@@ -5786,20 +5786,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/type-utils@npm:7.18.0"
+"@typescript-eslint/scope-manager@npm:8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.4.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:7.18.0"
-    "@typescript-eslint/utils": "npm:7.18.0"
+    "@typescript-eslint/types": "npm:8.4.0"
+    "@typescript-eslint/visitor-keys": "npm:8.4.0"
+  checksum: 10c0/95188c663df7db106529c6b93c4c7c61647ed34ab6dd48114e41ddf49140ff606c5501ce2ae451a988ec49b5d3874ea96ff212fc102802327b10affd2ff80a37
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/type-utils@npm:8.4.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": "npm:8.4.0"
+    "@typescript-eslint/utils": "npm:8.4.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.3.0"
-  peerDependencies:
-    eslint: ^8.56.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/ad92a38007be620f3f7036f10e234abdc2fdc518787b5a7227e55fd12896dacf56e8b34578723fbf9bea8128df2510ba8eb6739439a3879eda9519476d5783fd
+  checksum: 10c0/ae51100594d9ca61c7577b5aed0bd10c1959725df5c38cd9653eed1fd3dbdfff9146b6e48f3409994b4c8d781b9d95025c36b30f73a5a1b3dbdee6d142cecc87
   languageName: node
   linkType: hard
 
@@ -5807,6 +5815,13 @@ __metadata:
   version: 7.18.0
   resolution: "@typescript-eslint/types@npm:7.18.0"
   checksum: 10c0/eb7371ac55ca77db8e59ba0310b41a74523f17e06f485a0ef819491bc3dd8909bb930120ff7d30aaf54e888167e0005aa1337011f3663dc90fb19203ce478054
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/types@npm:8.4.0"
+  checksum: 10c0/15e09ced84827c349553530a31822f06ae5bad456c03d561b7d0c64b6ad9b5d7ca795e030bd93e65d5a2cd41bfde36ed08dcd2ff9feaa8b60a67080827f47ecb
   languageName: node
   linkType: hard
 
@@ -5829,7 +5844,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:7.18.0, @typescript-eslint/utils@npm:^7.4.0":
+"@typescript-eslint/typescript-estree@npm:8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.4.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.4.0"
+    "@typescript-eslint/visitor-keys": "npm:8.4.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/170702b024121cff9268f53de8054796b0ce025f9a78d6f2bc850a360e5f3f7032ba3ee9d4b7392726308273a5f3ade5ab31b1788b504b514bc15afc07302b37
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/utils@npm:8.4.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.4.0"
+    "@typescript-eslint/types": "npm:8.4.0"
+    "@typescript-eslint/typescript-estree": "npm:8.4.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10c0/8c9c36b3aa23f9bcc28cc4b10f0fa2996f1bc6cdd75135f08c2ef734baa30dbd2a8b92f344b90518e1fd07a486936734789fc7e90b780221a7707dad8e9c9364
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^7.4.0":
   version: 7.18.0
   resolution: "@typescript-eslint/utils@npm:7.18.0"
   dependencies:
@@ -5850,6 +5898,16 @@ __metadata:
     "@typescript-eslint/types": "npm:7.18.0"
     eslint-visitor-keys: "npm:^3.4.3"
   checksum: 10c0/538b645f8ff1d9debf264865c69a317074eaff0255e63d7407046176b0f6a6beba34a6c51d511f12444bae12a98c69891eb6f403c9f54c6c2e2849d1c1cb73c0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.4.0":
+  version: 8.4.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.4.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.4.0"
+    eslint-visitor-keys: "npm:^3.4.3"
+  checksum: 10c0/339199b7fbb9ac83b530d03ab25f6bc5ceb688c9cd0ae460112cd14ee78ca7284a845aef5620cdf70170980123475ec875e85ebf595c60255ba3c0d6fe48c714
   languageName: node
   linkType: hard
 
@@ -12921,8 +12979,8 @@ __metadata:
   dependencies:
     "@changesets/cli": "npm:^2.27.7"
     "@prairielearn/prettier-plugin-sql": "workspace:^"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@typescript-eslint/eslint-plugin": "npm:^8.4.0"
+    "@typescript-eslint/parser": "npm:^8.4.0"
     dependency-cruiser: "npm:^16.4.0"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"


### PR DESCRIPTION
The main change was that `@typescript-eslint/no-unused-vars` no longer allows the caught value to go unused; that made up the bulk of the changes here.