### PR TITLE
Typo in instructorQuestionSettings.html.ts: "course" -> "question"

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -214,7 +214,7 @@ export function InstructorQuestionSettings({
                         href="${resLocals.urlPrefix}/question/${resLocals.question
                           .id}/file_view/${infoPath}"
                       >
-                        View course configuration
+                        View question configuration
                       </a>
                       in <code>info.json</code>
                     `


### PR DESCRIPTION
When the example question cannot be edited, it should say "View question configuration" to parallel "Edit question configuration." However it currently says "View course configuration" by mistake.