### PR TITLE
Convert missed EJS to TS

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -574,7 +574,7 @@ function StaffTable({
                                     <p class="small">
                                       Can see but not edit scores of individual students for the
                                       course instance
-                                      <code><%= cir.short_name %></code>.
+                                      <code>${cir.short_name}</code>.
                                     </p>
                                   </div>
                                 </button>
@@ -590,7 +590,7 @@ function StaffTable({
                                     <p class="small">
                                       Can see and edit scores of individual students for the course
                                       instance
-                                      <code><%= cir.short_name %></code>.
+                                      <code>${cir.short_name}</code>.
                                     </p>
                                   </div>
                                 </button>


### PR DESCRIPTION
There were two instances of missed EJS conversions in the `instructorCourseAdminStaff` page. This PR intends to convert those to TS. 

![Screenshot 2024-09-03 at 5 36 07 PM](https://github.com/user-attachments/assets/3dcb3cac-b984-40b8-9fc6-436f453bab1c)