### PR TITLE
Add support for arguments in xtermjs workspace

### DIFF
--- a/workspaces/xtermjs/Dockerfile
+++ b/workspaces/xtermjs/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /xterm
 RUN yarn install --frozen-lockfile
 
 RUN useradd -m student
-ENTRYPOINT node server.js -w /home/student
+ENTRYPOINT ["node", "server.js", "-w", "/home/student"]


### PR DESCRIPTION
The xtermjs workspace includes, in its entrypoint script, support for command line arguments, in particular the terminal command (shell). This can be useful if a different program is to be used instead of bash (e.g., python). However, the Dockerfile configuration does not currently allow run args to be passed to the entrypoint. This PR changes the entrypoint configuration so that, if the question sets the value of `args` (e.g., `"args": "-c /usr/bin/python"`), these arguments are sent to the workspace script.