### PR TITLE
Cast to BIGINT in interval formatting sprocs

### DIFF
--- a/apps/prairielearn/src/sprocs/format_interval.sql
+++ b/apps/prairielearn/src/sprocs/format_interval.sql
@@ -1,10 +1,10 @@
 CREATE FUNCTION format_interval(d interval) RETURNS text AS $$
     WITH parts AS (
         SELECT
-            div(CAST(floor(DATE_PART('epoch', d)) AS integer), 60 * 60 * 24)     AS days,
-            mod(div(CAST(floor(DATE_PART('epoch', d)) AS integer), 60 * 60), 24) AS hours,
-            mod(div(CAST(floor(DATE_PART('epoch', d)) AS integer), 60), 60)      AS mins,
-            mod(CAST(floor(DATE_PART('epoch', d)) AS integer), 60)               AS secs
+            div(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60 * 60 * 24)     AS days,
+            mod(div(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60 * 60), 24) AS hours,
+            mod(div(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60), 60)      AS mins,
+            mod(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60)               AS secs
     )
     SELECT
         CASE

--- a/apps/prairielearn/src/sprocs/format_interval_short.sql
+++ b/apps/prairielearn/src/sprocs/format_interval_short.sql
@@ -6,10 +6,10 @@ DECLARE
     secs integer;
     s text;
 BEGIN
-    days := div(CAST(floor(DATE_PART('epoch', d)) AS integer), 60 * 60 * 24);
-    hours := mod(div(CAST(floor(DATE_PART('epoch', d)) AS integer), 60 * 60), 24);
-    mins := mod(div(CAST(floor(DATE_PART('epoch', d)) AS integer), 60), 60);
-    secs := mod(CAST(floor(DATE_PART('epoch', d)) AS integer), 60);
+    days := div(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60 * 60 * 24);
+    hours := mod(div(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60 * 60), 24);
+    mins := mod(div(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60), 60);
+    secs := mod(CAST(floor(DATE_PART('epoch', d)) AS bigint), 60);
     s := '';
     IF days > 0 THEN
         s := s || days::text || 'd';


### PR DESCRIPTION
We saw a case in practice where an instructor configured an assessment instance to close in the year 2214. That's a lot of milliseconds when computed as an interval relative to the present: 6.3 trillion milliseconds, give or take. This is quite a bit larger than the maximum of a 4-byte integer (2.1 billion).

With this change, we can now handle intervals of somewhere between 100 million and 200 million years.