### PR TITLE
fix: centering of check and x-mark badges in pl-order-blocks

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
@@ -129,6 +129,9 @@ div.pl-order-blocks-header {
   margin: 4px;
   width: 19px;
   height: 19px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .pl-order-blocks-pairing-indicator {


### PR DESCRIPTION
I'm not sure when this broke or whether it was a bootstrap 5 issue or a font awesome issue. I just noticed today, here's the fix.

before: 
![image](https://github.com/user-attachments/assets/faec0136-fc2c-42cb-ab8b-1cd70dc9de74)


after: 
![image](https://github.com/user-attachments/assets/8302caf5-54c0-4e50-bc55-1029daf51984)

