### PR TITLE
Downgrade novnc in prairielearn/workspace-desktop

### DIFF
--- a/workspaces/desktop/server/package.json
+++ b/workspaces/desktop/server/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@novnc/novnc": "^1.4.0",
+    "@novnc/novnc": "1.4.0",
     "command-line-args": "^6.0.0",
     "command-line-usage": "^7.0.2",
     "express": "^4.19.2",

--- a/workspaces/desktop/server/yarn.lock
+++ b/workspaces/desktop/server/yarn.lock
@@ -10,10 +10,10 @@
     lodash.assignwith "^4.2.0"
     typical "^7.1.1"
 
-"@novnc/novnc@^1.4.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.5.0.tgz#7df3e4aca48eaa7c0d6f690e7dee89480232e2f1"
-  integrity sha512-4yGHOtUCnEJUCsgEt/L78eeJu00kthurLBWXFiaXfonNx0pzbs6R/3gJb1byZe6iAE8V9MF0syQb0xIL8MSOtQ==
+"@novnc/novnc@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.4.0.tgz#68adae81a741624142b518323441e852c1f34281"
+  integrity sha512-kW6ALMc5BuH08e/ond/I1naYcfjc19JYMN1EdtmgjjjzPGCjW8fMtVM3MwM6q7YLRjPlQ3orEvoKMgSS7RkEVQ==
 
 accepts@~1.3.8:
   version "1.3.8"


### PR DESCRIPTION
`novnc` released a breaking change in a minor version, see https://github.com/novnc/noVNC/issues/1792. We can't consume any version newer than `1.4.0`.