### PR TITLE
Fix preview for upload of PDF files over 2MB

### DIFF
--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -278,7 +278,7 @@
 
           try {
             if (this.isPdf(fileData)) {
-              const url = this.b64ToBlobUrl(fileData);
+              const url = this.b64ToBlobUrl(fileData, { type: 'application/pdf' });
               const $objectPreview = $(
                 `<div class="mt-2 embed-responsive embed-responsive-4by3">
                    <iframe class="embed-responsive-item" src="${url}">
@@ -386,7 +386,7 @@
       );
     }
 
-    b64ToBlobUrl(str) {
+    b64ToBlobUrl(str, options = undefined) {
       const blob = new Blob(
         [
           new Uint8Array(
@@ -395,7 +395,7 @@
               .map((c) => c.charCodeAt(0)),
           ),
         ],
-        { type: 'application/pdf' },
+        options,
       );
       return URL.createObjectURL(blob);
     }

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -278,14 +278,17 @@
 
           try {
             if (this.isPdf(fileData)) {
+              const url = this.b64ToBlobUrl(fileData);
               const $objectPreview = $(
                 `<div class="mt-2 embed-responsive embed-responsive-4by3">
-                   <iframe class="embed-responsive-item" 
-                           src="data:application/pdf;base64,${fileData}">
+                   <iframe class="embed-responsive-item" src="${url}">
                      PDF file cannot be displayed.
                    </iframe>
                  </div>`,
               );
+              $objectPreview.find('iframe').on('load', () => {
+                URL.revokeObjectURL(url);
+              });
               $preview.append($objectPreview);
             } else {
               var fileContents = this.b64DecodeUnicode(fileData);
@@ -297,16 +300,19 @@
               $codePreview.removeClass('d-none');
             }
           } catch {
+            const url = this.b64ToBlobUrl(fileData);
             $imgPreview
               .on('load', () => {
                 $imgPreview.removeClass('d-none');
+                URL.revokeObjectURL(url);
               })
               .on('error', () => {
                 $error
                   .text('Content preview is not available for this type of file.')
                   .removeClass('d-none');
+                URL.revokeObjectURL(url);
               })
-              .attr('src', 'data:application/octet-stream;base64,' + fileData);
+              .attr('src', url);
           }
           $file.append($preview);
           $fileStatusContainer.append(
@@ -378,6 +384,20 @@
           })
           .join(''),
       );
+    }
+
+    b64ToBlobUrl(str) {
+      const blob = new Blob(
+        [
+          new Uint8Array(
+            atob(str)
+              .split('')
+              .map((c) => c.charCodeAt(0)),
+          ),
+        ],
+        { type: 'application/pdf' },
+      );
+      return URL.createObjectURL(blob);
     }
   }
 


### PR DESCRIPTION
As reported on Slack. The preview feature of pl-file-upload fails on Chrome/Edge for PDF files that are larger than 1536KB (i.e., whose base64 representation is larger than 2MB), likely due to the length of the data URL. This PR fixes this by converting the base64 content to a blob URL. This was tested locally with a 46MB file (far larger than what the upload will require) and it works very well.

For completeness I also did the same change in image uploads, although I didn't have the same issue in those cases.