### PR TITLE
Bump express and dependencies

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -92,7 +92,7 @@
     "ejs": "^3.1.10",
     "es-main": "^1.3.0",
     "execa": "^9.3.1",
-    "express": "^4.19.2",
+    "express": "^4.20.0",
     "express-async-handler": "^1.2.0",
     "express-session": "^1.18.0",
     "fabric": "4.6.0-browser",

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -92,7 +92,7 @@
     "ejs": "^3.1.10",
     "es-main": "^1.3.0",
     "execa": "^9.3.1",
-    "express": "^4.20.0",
+    "express": "^4.21.0",
     "express-async-handler": "^1.2.0",
     "express-session": "^1.18.0",
     "fabric": "4.6.0-browser",

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.20.3",
     "debug": "^4.3.6",
     "dockerode": "^4.0.2",
-    "express": "^4.19.2",
+    "express": "^4.20.0",
     "express-async-handler": "^1.2.0",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.20.3",
     "debug": "^4.3.6",
     "dockerode": "^4.0.2",
-    "express": "^4.20.0",
+    "express": "^4.21.0",
     "express-async-handler": "^1.2.0",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",

--- a/packages/compiled-assets/package.json
+++ b/packages/compiled-assets/package.json
@@ -18,7 +18,7 @@
     "@prairielearn/html": "workspace:^",
     "commander": "^12.1.0",
     "esbuild": "^0.23.1",
-    "express": "^4.19.2",
+    "express": "^4.20.0",
     "express-static-gzip": "^2.1.7",
     "fs-extra": "^11.2.0",
     "globby": "^14.0.2",

--- a/packages/compiled-assets/package.json
+++ b/packages/compiled-assets/package.json
@@ -18,7 +18,7 @@
     "@prairielearn/html": "workspace:^",
     "commander": "^12.1.0",
     "esbuild": "^0.23.1",
-    "express": "^4.20.0",
+    "express": "^4.21.0",
     "express-static-gzip": "^2.1.7",
     "fs-extra": "^11.2.0",
     "globby": "^14.0.2",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -34,7 +34,7 @@
     "@types/uid-safe": "^2.1.5",
     "c8": "^10.1.2",
     "chai": "^5.1.1",
-    "express": "^4.20.0",
+    "express": "^4.21.0",
     "fetch-cookie": "^3.0.1",
     "mocha": "^10.7.3",
     "node-fetch": "^3.3.2",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -34,7 +34,7 @@
     "@types/uid-safe": "^2.1.5",
     "c8": "^10.1.2",
     "chai": "^5.1.1",
-    "express": "^4.19.2",
+    "express": "^4.20.0",
     "fetch-cookie": "^3.0.1",
     "mocha": "^10.7.3",
     "node-fetch": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14043,7 +14043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.16.0":
+"serve-static@npm:1.16.0, serve-static@npm:^1.14.1":
   version: 1.16.0
   resolution: "serve-static@npm:1.16.0"
   dependencies:
@@ -14052,18 +14052,6 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.18.0"
   checksum: 10c0/d7a5beca08cc55f92998d8b87c111dd842d642404231c90c11f504f9650935da4599c13256747b0a988442a59851343271fe8e1946e03e92cd79c447b5f3ae01
-  languageName: node
-  linkType: hard
-
-"serve-static@npm:^1.14.1":
-  version: 1.15.0
-  resolution: "serve-static@npm:1.15.0"
-  dependencies:
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    parseurl: "npm:~1.3.3"
-    send: "npm:0.18.0"
-  checksum: 10c0/fa9f0e21a540a28f301258dfe1e57bb4f81cd460d28f0e973860477dd4acef946a1f41748b5bd41c73b621bea2029569c935faa38578fd34cd42a9b4947088ba
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,7 +3034,7 @@ __metadata:
     chai: "npm:^5.1.1"
     commander: "npm:^12.1.0"
     esbuild: "npm:^0.23.1"
-    express: "npm:^4.19.2"
+    express: "npm:^4.20.0"
     express-static-gzip: "npm:^2.1.7"
     fs-extra: "npm:^11.2.0"
     get-port: "npm:^7.1.0"
@@ -3587,7 +3587,7 @@ __metadata:
     ejs: "npm:^3.1.10"
     es-main: "npm:^1.3.0"
     execa: "npm:^9.3.1"
-    express: "npm:^4.19.2"
+    express: "npm:^4.20.0"
     express-async-handler: "npm:^1.2.0"
     express-list-endpoints: "npm:^7.1.0"
     express-session: "npm:^1.18.0"
@@ -3764,7 +3764,7 @@ __metadata:
     chai: "npm:^5.1.1"
     cookie: "npm:^0.6.0"
     cookie-signature: "npm:^1.2.1"
-    express: "npm:^4.19.2"
+    express: "npm:^4.20.0"
     express-async-handler: "npm:^1.2.0"
     fetch-cookie: "npm:^3.0.1"
     mocha: "npm:^10.7.3"
@@ -3825,7 +3825,7 @@ __metadata:
     chai: "npm:^5.1.1"
     debug: "npm:^4.3.6"
     dockerode: "npm:^4.0.2"
-    express: "npm:^4.19.2"
+    express: "npm:^4.20.0"
     express-async-handler: "npm:^1.2.0"
     ioredis: "npm:^5.4.1"
     lodash: "npm:^4.17.21"
@@ -6537,27 +6537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.2":
-  version: 1.20.2
-  resolution: "body-parser@npm:1.20.2"
-  dependencies:
-    bytes: "npm:3.1.2"
-    content-type: "npm:~1.0.5"
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    http-errors: "npm:2.0.0"
-    iconv-lite: "npm:0.4.24"
-    on-finished: "npm:2.4.1"
-    qs: "npm:6.11.0"
-    raw-body: "npm:2.5.2"
-    type-is: "npm:~1.6.18"
-    unpipe: "npm:1.0.0"
-  checksum: 10c0/06f1438fff388a2e2354c96aa3ea8147b79bfcb1262dfcc2aae68ec13723d01d5781680657b74e9f83c808266d5baf52804032fbde2b7382b89bd8cdb273ace9
-  languageName: node
-  linkType: hard
-
-"body-parser@npm:^1.20.3":
+"body-parser@npm:1.20.3, body-parser@npm:^1.20.3":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
   dependencies:
@@ -8293,6 +8273,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
+  languageName: node
+  linkType: hard
+
 "encoding-sniffer@npm:^0.2.0":
   version: 0.2.0
   resolution: "encoding-sniffer@npm:0.2.0"
@@ -8909,42 +8896,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.19.2":
-  version: 4.19.2
-  resolution: "express@npm:4.19.2"
+"express@npm:^4.20.0":
+  version: 4.20.0
+  resolution: "express@npm:4.20.0"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:1.20.2"
+    body-parser: "npm:1.20.3"
     content-disposition: "npm:0.5.4"
     content-type: "npm:~1.0.4"
     cookie: "npm:0.6.0"
     cookie-signature: "npm:1.0.6"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
-    encodeurl: "npm:~1.0.2"
+    encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
     finalhandler: "npm:1.2.0"
     fresh: "npm:0.5.2"
     http-errors: "npm:2.0.0"
-    merge-descriptors: "npm:1.0.1"
+    merge-descriptors: "npm:1.0.3"
     methods: "npm:~1.1.2"
     on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
-    path-to-regexp: "npm:0.1.7"
+    path-to-regexp: "npm:0.1.10"
     proxy-addr: "npm:~2.0.7"
     qs: "npm:6.11.0"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
-    send: "npm:0.18.0"
-    serve-static: "npm:1.15.0"
+    send: "npm:0.19.0"
+    serve-static: "npm:1.16.0"
     setprototypeof: "npm:1.2.0"
     statuses: "npm:2.0.1"
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/e82e2662ea9971c1407aea9fc3c16d6b963e55e3830cd0ef5e00b533feda8b770af4e3be630488ef8a752d7c75c4fcefb15892868eeaafe7353cb9e3e269fdcb
+  checksum: 10c0/626e440e9feffa3f82ebce5e7dc0ad7a74fa96079994f30048cce450f4855a258abbcabf021f691aeb72154867f0d28440a8498c62888805faf667a829fb65aa
   languageName: node
   linkType: hard
 
@@ -11347,10 +11334,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-descriptors@npm:1.0.1":
-  version: 1.0.1
-  resolution: "merge-descriptors@npm:1.0.1"
-  checksum: 10c0/b67d07bd44cfc45cebdec349bb6e1f7b077ee2fd5beb15d1f7af073849208cb6f144fe403e29a36571baf3f4e86469ac39acf13c318381e958e186b2766f54ec
+"merge-descriptors@npm:1.0.3":
+  version: 1.0.3
+  resolution: "merge-descriptors@npm:1.0.3"
+  checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
   languageName: node
   linkType: hard
 
@@ -12791,10 +12778,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.7":
-  version: 0.1.7
-  resolution: "path-to-regexp@npm:0.1.7"
-  checksum: 10c0/50a1ddb1af41a9e68bd67ca8e331a705899d16fb720a1ea3a41e310480948387daf603abb14d7b0826c58f10146d49050a1291ba6a82b78a382d1c02c0b8f905
+"path-to-regexp@npm:0.1.10":
+  version: 0.1.10
+  resolution: "path-to-regexp@npm:0.1.10"
+  checksum: 10c0/34196775b9113ca6df88e94c8d83ba82c0e1a2063dd33bfe2803a980da8d49b91db8104f49d5191b44ea780d46b8670ce2b7f4a5e349b0c48c6779b653f1afe4
   languageName: node
   linkType: hard
 
@@ -14004,6 +13991,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:0.19.0":
+  version: 0.19.0
+  resolution: "send@npm:0.19.0"
+  dependencies:
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    mime: "npm:1.6.0"
+    ms: "npm:2.1.3"
+    on-finished: "npm:2.4.1"
+    range-parser: "npm:~1.2.1"
+    statuses: "npm:2.0.1"
+  checksum: 10c0/ea3f8a67a8f0be3d6bf9080f0baed6d2c51d11d4f7b4470de96a5029c598a7011c497511ccc28968b70ef05508675cebff27da9151dd2ceadd60be4e6cf845e3
+  languageName: node
+  linkType: hard
+
 "serialize-error@npm:^11.0.3":
   version: 11.0.3
   resolution: "serialize-error@npm:11.0.3"
@@ -14035,7 +14043,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.15.0, serve-static@npm:^1.14.1":
+"serve-static@npm:1.16.0":
+  version: 1.16.0
+  resolution: "serve-static@npm:1.16.0"
+  dependencies:
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    parseurl: "npm:~1.3.3"
+    send: "npm:0.18.0"
+  checksum: 10c0/d7a5beca08cc55f92998d8b87c111dd842d642404231c90c11f504f9650935da4599c13256747b0a988442a59851343271fe8e1946e03e92cd79c447b5f3ae01
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^1.14.1":
   version: 1.15.0
   resolution: "serve-static@npm:1.15.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,7 +3034,7 @@ __metadata:
     chai: "npm:^5.1.1"
     commander: "npm:^12.1.0"
     esbuild: "npm:^0.23.1"
-    express: "npm:^4.20.0"
+    express: "npm:^4.21.0"
     express-static-gzip: "npm:^2.1.7"
     fs-extra: "npm:^11.2.0"
     get-port: "npm:^7.1.0"
@@ -3587,7 +3587,7 @@ __metadata:
     ejs: "npm:^3.1.10"
     es-main: "npm:^1.3.0"
     execa: "npm:^9.3.1"
-    express: "npm:^4.20.0"
+    express: "npm:^4.21.0"
     express-async-handler: "npm:^1.2.0"
     express-list-endpoints: "npm:^7.1.0"
     express-session: "npm:^1.18.0"
@@ -3764,7 +3764,7 @@ __metadata:
     chai: "npm:^5.1.1"
     cookie: "npm:^0.6.0"
     cookie-signature: "npm:^1.2.1"
-    express: "npm:^4.20.0"
+    express: "npm:^4.21.0"
     express-async-handler: "npm:^1.2.0"
     fetch-cookie: "npm:^3.0.1"
     mocha: "npm:^10.7.3"
@@ -3825,7 +3825,7 @@ __metadata:
     chai: "npm:^5.1.1"
     debug: "npm:^4.3.6"
     dockerode: "npm:^4.0.2"
-    express: "npm:^4.20.0"
+    express: "npm:^4.21.0"
     express-async-handler: "npm:^1.2.0"
     ioredis: "npm:^5.4.1"
     lodash: "npm:^4.17.21"
@@ -8896,9 +8896,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.20.0":
-  version: 4.20.0
-  resolution: "express@npm:4.20.0"
+"express@npm:^4.21.0":
+  version: 4.21.0
+  resolution: "express@npm:4.21.0"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
@@ -8912,7 +8912,7 @@ __metadata:
     encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    finalhandler: "npm:1.2.0"
+    finalhandler: "npm:1.3.1"
     fresh: "npm:0.5.2"
     http-errors: "npm:2.0.0"
     merge-descriptors: "npm:1.0.3"
@@ -8921,17 +8921,17 @@ __metadata:
     parseurl: "npm:~1.3.3"
     path-to-regexp: "npm:0.1.10"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:6.11.0"
+    qs: "npm:6.13.0"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
     send: "npm:0.19.0"
-    serve-static: "npm:1.16.0"
+    serve-static: "npm:1.16.2"
     setprototypeof: "npm:1.2.0"
     statuses: "npm:2.0.1"
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/626e440e9feffa3f82ebce5e7dc0ad7a74fa96079994f30048cce450f4855a258abbcabf021f691aeb72154867f0d28440a8498c62888805faf667a829fb65aa
+  checksum: 10c0/4cf7ca328f3fdeb720f30ccb2ea7708bfa7d345f9cc460b64a82bf1b2c91e5b5852ba15a9a11b2a165d6089acf83457fc477dc904d59cd71ed34c7a91762c6cc
   languageName: node
   linkType: hard
 
@@ -9149,18 +9149,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.2.0":
-  version: 1.2.0
-  resolution: "finalhandler@npm:1.2.0"
+"finalhandler@npm:1.3.1":
+  version: 1.3.1
+  resolution: "finalhandler@npm:1.3.1"
   dependencies:
     debug: "npm:2.6.9"
-    encodeurl: "npm:~1.0.2"
+    encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
-  checksum: 10c0/64b7e5ff2ad1fcb14931cd012651631b721ce657da24aedb5650ddde9378bf8e95daa451da43398123f5de161a81e79ff5affe4f9f2a6d2df4a813d6d3e254b7
+  checksum: 10c0/d38035831865a49b5610206a3a9a9aae4e8523cbbcd01175d0480ffbf1278c47f11d89be3ca7f617ae6d94f29cf797546a4619cd84dd109009ef33f12f69019f
   languageName: node
   linkType: hard
 
@@ -13321,15 +13321,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.11.0":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
-  dependencies:
-    side-channel: "npm:^1.0.4"
-  checksum: 10c0/4e4875e4d7c7c31c233d07a448e7e4650f456178b9dd3766b7cfa13158fdb24ecb8c4f059fa91e820dc6ab9f2d243721d071c9c0378892dcdad86e9e9a27c68f
-  languageName: node
-  linkType: hard
-
 "qs@npm:6.13.0, qs@npm:^6.10.3, qs@npm:^6.11.0, qs@npm:^6.13.0":
   version: 6.13.0
   resolution: "qs@npm:6.13.0"
@@ -14043,7 +14034,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.16.0, serve-static@npm:^1.14.1":
+"serve-static@npm:1.16.2":
+  version: 1.16.2
+  resolution: "serve-static@npm:1.16.2"
+  dependencies:
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    parseurl: "npm:~1.3.3"
+    send: "npm:0.19.0"
+  checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^1.14.1":
   version: 1.16.0
   resolution: "serve-static@npm:1.16.0"
   dependencies:
@@ -14133,7 +14136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.0.4, side-channel@npm:^1.0.6":
+"side-channel@npm:^1.0.6":
   version: 1.0.6
   resolution: "side-channel@npm:1.0.6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -13961,27 +13961,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"send@npm:0.18.0":
-  version: 0.18.0
-  resolution: "send@npm:0.18.0"
-  dependencies:
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:1.2.0"
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    etag: "npm:~1.8.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:2.0.0"
-    mime: "npm:1.6.0"
-    ms: "npm:2.1.3"
-    on-finished: "npm:2.4.1"
-    range-parser: "npm:~1.2.1"
-    statuses: "npm:2.0.1"
-  checksum: 10c0/0eb134d6a51fc13bbcb976a1f4214ea1e33f242fae046efc311e80aff66c7a43603e26a79d9d06670283a13000e51be6e0a2cb80ff0942eaf9f1cd30b7ae736a
-  languageName: node
-  linkType: hard
-
 "send@npm:0.19.0":
   version: 0.19.0
   resolution: "send@npm:0.19.0"
@@ -14034,7 +14013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.16.2":
+"serve-static@npm:1.16.2, serve-static@npm:^1.14.1":
   version: 1.16.2
   resolution: "serve-static@npm:1.16.2"
   dependencies:
@@ -14043,18 +14022,6 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.19.0"
   checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
-  languageName: node
-  linkType: hard
-
-"serve-static@npm:^1.14.1":
-  version: 1.16.0
-  resolution: "serve-static@npm:1.16.0"
-  dependencies:
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    parseurl: "npm:~1.3.3"
-    send: "npm:0.18.0"
-  checksum: 10c0/d7a5beca08cc55f92998d8b87c111dd842d642404231c90c11f504f9650935da4599c13256747b0a988442a59851343271fe8e1946e03e92cd79c447b5f3ae01
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves some dependabot alerts. This still leaves open a couple of cases for path-to-regexp:

* sinon depends on it indirectly, but this is only used in tests, so it doesn't affect production.
* s3rver depends on it indirectly, but this is only used locally, not in production.

