### PR TITLE
Remove red portion of scorebar

### DIFF
--- a/apps/prairielearn/src/components/Scorebar.html.ts
+++ b/apps/prairielearn/src/components/Scorebar.html.ts
@@ -10,7 +10,10 @@ export function Scorebar(
       <div class="progress-bar bg-success" style="width: ${Math.floor(Math.min(100, score))}%">
         ${score >= 50 ? `${Math.floor(score)}%` : ''}
       </div>
-      <div class="progress-bar bg-danger" style="width: ${100 - Math.floor(Math.min(100, score))}%">
+      <div
+        class="d-flex flex-column justify-content-center text-center"
+        style="width: ${100 - Math.floor(Math.min(100, score))}%"
+      >
         ${score >= 50 ? '' : `${Math.floor(score)}%`}
       </div>
     </div>


### PR DESCRIPTION
This is being done in response to feedback that our frequent use of red in the UI can be anxiety-inducing. While we believe many usages of red are justified (e.g., alerting a student to an incorrect answer or unanswered question), there's no need to highlight the incorrect/unanswered portion of the score in red.

Before:

<img width="1626" alt="Screenshot 2024-09-11 at 11 40 16" src="https://github.com/user-attachments/assets/089525b8-1f8c-428d-9ef9-457b282ddc68">

After:

<img width="1626" alt="Screenshot 2024-09-11 at 11 40 42" src="https://github.com/user-attachments/assets/28e74974-159c-46e9-9d03-c7ce146feb52">

This change has a positive impact on accessibility as well: it's better for users with red/green colorblindness. Strictly speaking, the previous design was accessible since it didn't exclusively use color to communicate information. Even then, it can be convenient to visually scan a list for outliers instead of reading a bunch of percentages, which is now much easier withour red and green being adjacent to each other.