### PR TITLE
Perform strict validation of course instance JSON

### DIFF
--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -3,6 +3,7 @@
   "title": "Course instance information",
   "description": "The specification file for a course instance.",
   "type": "object",
+  "additionalProperties": false,
   "required": ["uuid", "longName"],
   "properties": {
     "comment": {
@@ -16,6 +17,10 @@
     },
     "longName": {
       "description": "The long name of this course instance (e.g., 'Spring 2015').",
+      "type": "string"
+    },
+    "shortName": {
+      "description": "DEPRECATED -- do not use.",
       "type": "string"
     },
     "timezone": {
@@ -50,6 +55,7 @@
       "items": {
         "description": "An access rule that permits people to access this course instance. All restrictions present in the rule must be satisfied for the rule to allow access.",
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "comment": {
             "description": "Arbitrary comment for reference purposes.",

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -235,6 +235,8 @@ interface CourseInstanceAllowAccess {
 export interface CourseInstance {
   uuid: string;
   longName: string;
+  /** @deprecated */
+  shortName?: string | null;
   number: number;
   timezone: string;
   hideInEnrollPage: boolean;
@@ -1343,6 +1345,18 @@ async function validateCourseInstance(
       warnings.push(
         'The property "userRoles" should be deleted. Instead, course owners can now manage staff access on the "Staff" page.',
       );
+    }
+
+    // `shortName` has never been a meaningful property in course instance config.
+    // However, for many years our template course erroneously included it in the
+    // template course instance, so it's been copied around to basically every course.
+    // We didn't set `additionalProperties: false` in the schema, so we never caught
+    // this and for a long time it was silently ignored.
+    //
+    // To avoid breaking existing courses, we added it as a valid property to the schema,
+    // but we'll warn about it for any active or future course instances.
+    if (courseInstance.shortName) {
+      warnings.push('The property "shortName" is not used and should be deleted.');
     }
   }
 

--- a/apps/prairielearn/src/tests/testFileEditor/courseTemplate/courseInstances/Fa18/infoCourseInstance.json
+++ b/apps/prairielearn/src/tests/testFileEditor/courseTemplate/courseInstances/Fa18/infoCourseInstance.json
@@ -1,6 +1,5 @@
 {
     "uuid": "6d65eff5-b7c6-4b8f-bc18-ab5e7cbea2fa",
-    "shortName": "Fa18",
     "longName": "Fall 2018",
     "allowAccess": [
         {

--- a/apps/prairielearn/src/tests/testLoadCourse/brokenCourse/courseInstances/Fa18/infoCourseInstance.json
+++ b/apps/prairielearn/src/tests/testLoadCourse/brokenCourse/courseInstances/Fa18/infoCourseInstance.json
@@ -1,5 +1,4 @@
 {
     "uuid": "a9a5ebf0-010c-4b08-ae1b-ff3df687698c",
-    "shortName": "Fa18",
     "longName": "Fall 2018"
 }

--- a/docs/courseInstance.md
+++ b/docs/courseInstance.md
@@ -41,7 +41,6 @@ This file specifies basic information about the course instance:
 ```json
 {
   "uuid": "62fbe2a4-8c22-471a-98fe-19e5d5da1bbe",
-  "shortName": "Sp15",
   "longName": "Spring 2015",
   "allowAccess": [
     {

--- a/exampleCourse/courseInstances/SectionA/infoCourseInstance.json
+++ b/exampleCourse/courseInstances/SectionA/infoCourseInstance.json
@@ -1,6 +1,5 @@
 {
   "uuid": "a2c16a02-7f73-43d0-b5ec-5eb1efb8ae51",
-  "shortName": "Sp15",
   "longName": "Spring 2015",
   "comment": "to organize this course instance by module, use `groupAssessmentsBy:Module`",
   "allowAccess": [

--- a/testCourse/courseInstances/Sp15/infoCourseInstance.json
+++ b/testCourse/courseInstances/Sp15/infoCourseInstance.json
@@ -1,6 +1,5 @@
 {
   "uuid": "31a69dd9-81a1-4b17-b578-2098d20fb57a",
-  "shortName": "Sp15",
   "longName": "Spring 2015",
   "allowAccess": [
     { "institution": "Any", "startDate": "1800-01-19T00:00:01", "endDate": "2400-05-13T23:59:59" }


### PR DESCRIPTION
In the aftermath of some access confusion at Berkeley, we realized that we weren't rejecting extra properties if they were present in course instance JSON files. This made it too easy for an instructor to introduce config that didn't actually do anything.

The only complexity here is the fact that in our documentation, examples, and template course, we always included a `"shortName"` property that was never actually used. Rather than forcing every single course to delete it, we added it to the schema, marked it as deprecated, and added  a sync warning for any course instances that are accessible now or will be in the future.