### PR TITLE
Use GPT4 with Structured Outputs for AI grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
 import { OpenAI } from 'openai';
+import { zodResponseFormat } from 'openai/helpers/zod';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
@@ -125,7 +126,7 @@ export async function aiGrade({
       $('script').remove();
       const student_answer = $.html();
 
-      const completion = await openai.chat.completions.create({
+      const completion = await openai.beta.chat.completions.parse({
         messages: [
           {
             role: 'system',
@@ -137,32 +138,35 @@ export async function aiGrade({
             content: `Question: \n${question_prompt} \nAnswer: \n${student_answer} \nHow would you grade this? Please return the json object.`,
           },
         ],
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o-2024-08-06',
         user: `course_${course.id}`,
+        response_format: zodResponseFormat(GPTGradeSchema, 'grades'),
       });
 
       let msg = `\nInstance question ${instance_question.id}\n`;
       try {
         msg += `Number of tokens used: ${completion.usage ? completion.usage.total_tokens : 0}\n`;
-        msg += `Raw ChatGPT response:\n${completion.choices[0].message.content}`;
-        if (completion.choices[0].message.content === null) {
+        const grade_response = completion.choices[0].message;
+        msg += `Raw ChatGPT response:\n${grade_response.content}`;
+        if (grade_response.parsed) {
+          await manualGrading.updateInstanceQuestionScore(
+            assessment_question.assessment_id,
+            instance_question.id,
+            submission.id,
+            null, // modified_at
+            {
+              score_perc: grade_response.parsed.grade,
+              feedback: { manual: grade_response.parsed.feedback },
+              // NEXT STEPS: rubrics
+            },
+            '1',
+          );
+          msg += `\nAI grades: ${grade_response.parsed.grade}`;
+        } else if (grade_response.refusal) {
+          job.error(`ERROR AI grading for ${instance_question.id}`);
+          job.error(grade_response.refusal);
           error_count++;
-          continue;
         }
-        const gpt_answer = GPTGradeSchema.parse(JSON.parse(completion.choices[0].message.content));
-        await manualGrading.updateInstanceQuestionScore(
-          assessment_question.assessment_id,
-          instance_question.id,
-          submission.id,
-          null, // modified_at
-          {
-            score_perc: gpt_answer.grade,
-            feedback: { manual: gpt_answer.feedback },
-            // NEXT STEPS: rubrics
-          },
-          '1',
-        );
-        msg += `\nAI grades: ${gpt_answer.grade}`;
       } catch (err) {
         job.error(`ERROR AI grading for ${instance_question.id}`);
         job.error(err);


### PR DESCRIPTION
GPT4 has been tested to be better than GPT3.5 when dealing with longer contexts. Future developments of AI grading will involve providing graded examples to the LLM, and local tests have shown GPT4 with RAG to decrease the error from 15% to 7%. GPT4 also supports more stable parsing of json outputs than GPT3.5. Thus, we are bumping the GPT version used in AI grading to GPT4. 
My next PR will work on implementing RAG in the grade to achieve a better performance. 
![image](https://github.com/user-attachments/assets/15ee3c14-22ec-4fe1-961b-b1d34ba4334b)
