### PR TITLE
Add colored border to scorebar

### DIFF
--- a/apps/prairielearn/src/components/Scorebar.html.ts
+++ b/apps/prairielearn/src/components/Scorebar.html.ts
@@ -6,7 +6,10 @@ export function Scorebar(
 ) {
   if (score == null) return '';
   return html`
-    <div class="progress bg" style="min-width: ${minWidth}; max-width: ${maxWidth};">
+    <div
+      class="progress border border-success"
+      style="min-width: ${minWidth}; max-width: ${maxWidth};"
+    >
       <div class="progress-bar bg-success" style="width: ${Math.floor(Math.min(100, score))}%">
         ${score >= 50 ? `${Math.floor(score)}%` : ''}
       </div>


### PR DESCRIPTION
This makes the scorebar more visible, especially at a 0% score or when the containing table row is hovered.

<img width="160" alt="Screenshot 2024-09-12 at 09 41 13" src="https://github.com/user-attachments/assets/6b9fe5fe-a872-4126-b2ee-eb31c1d72067">
