### PR TITLE
Use yellow color for unanswered status badge

### DIFF
--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -252,7 +252,7 @@ export function ExamQuestionStatus({
   };
 }) {
   const badge_color = {
-    unanswered: 'danger',
+    unanswered: 'warning',
     invalid: 'danger',
     grading: 'default',
     saved: 'info',


### PR DESCRIPTION
Before this change, students were immediately presented with a wall of red upon starting an exam:

<img width="531" alt="Screenshot 2024-09-13 at 14 17 25" src="https://github.com/user-attachments/assets/d1f61dbd-de29-4686-817f-d869447fc682">

Now, they'll see yellow instead:

<img width="536" alt="Screenshot 2024-09-13 at 14 18 26" src="https://github.com/user-attachments/assets/c9079567-d244-4ef7-aeee-953a4b9b077f">

We're using yellow instead of a more neutral color because we _really_ want students to be aware of any questions they haven't answered.

Red is reserved for invalid or incorrect answers:

<img width="508" alt="Screenshot 2024-09-13 at 14 15 28" src="https://github.com/user-attachments/assets/aa46ecf4-e0b9-485f-8bc8-8024e15baa1f">


