### PR TITLE
Add course instructor page for modules

### DIFF
--- a/apps/prairielearn/src/components/NavbarContext.html.ts
+++ b/apps/prairielearn/src/components/NavbarContext.html.ts
@@ -140,6 +140,12 @@ const navPagesTabs: Partial<Record<Exclude<NavPage, undefined>, TabInfo[]>> = {
       iconClasses: 'fas fa-quote-right',
       tabLabel: 'Topics',
     },
+    {
+      activeSubPage: 'modules',
+      urlSuffix: '/course_admin/modules',
+      iconClasses: 'fa fa-layer-group',
+      tabLabel: 'Modules',
+    },
   ],
   assessment: [
     {

--- a/apps/prairielearn/src/components/NavbarContext.html.ts
+++ b/apps/prairielearn/src/components/NavbarContext.html.ts
@@ -95,6 +95,12 @@ const navPagesTabs: Partial<Record<Exclude<NavPage, undefined>, TabInfo[]>> = {
       tabLabel: 'Issues',
     },
     {
+      activeSubPage: 'modules',
+      urlSuffix: '/course_admin/modules',
+      iconClasses: 'fa fa-layer-group',
+      tabLabel: 'Modules',
+    },
+    {
       activeSubPage: 'questions',
       urlSuffix: '/course_admin/questions',
       iconClasses: 'fa fa-question',
@@ -139,12 +145,6 @@ const navPagesTabs: Partial<Record<Exclude<NavPage, undefined>, TabInfo[]>> = {
       urlSuffix: '/course_admin/topics',
       iconClasses: 'fas fa-quote-right',
       tabLabel: 'Topics',
-    },
-    {
-      activeSubPage: 'modules',
-      urlSuffix: '/course_admin/modules',
-      iconClasses: 'fa fa-layer-group',
-      tabLabel: 'Modules',
     },
   ],
   assessment: [

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -235,6 +235,16 @@ export const AssessmentInstanceSchema = z.object({
 });
 export type AssessmentInstance = z.infer<typeof AssessmentInstanceSchema>;
 
+export const AssessmentModuleSchema = z.object({
+  id: IdSchema,
+  course_id: IdSchema,
+  name: z.string(),
+  heading: z.string().nullable(),
+  number: z.number().nullable(),
+  implicit: z.boolean(),
+});
+export type AssessmentModule = z.infer<typeof AssessmentModuleSchema>;
+
 export const AssessmentQuestionSchema = z.object({
   advance_score_perc: z.number().nullable(),
   alternative_group_id: IdSchema.nullable(),

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
@@ -54,8 +54,7 @@ export function InstructorCourseAdminModules({
             </div>
             <div class="card-footer">
               <small>
-                Modules can represent course topics, chapters, or any assessments of related
-                content. More information on modules can be found in the
+                Modules can be used to group assessments by topic, chapter, section, or other category. More information on modules can be found in the
                 <a href="https://prairielearn.readthedocs.io/en/latest/course/#assessment-modules">
                   PrairieLearn documentation</a
                 >.

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
@@ -1,0 +1,60 @@
+import { html } from '@prairielearn/html';
+
+import { HeadContents } from '../../components/HeadContents.html.js';
+import { Navbar } from '../../components/Navbar.html.js';
+import { CourseSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
+import { AssessmentModule } from '../../lib/db-types.js';
+
+export function InstructorCourseAdminModules({
+  resLocals,
+  modules,
+}: {
+  resLocals: Record<string, any>;
+  modules: AssessmentModule[];
+}) {
+  return html`
+    <!doctype html>
+    <html lang="en">
+      <head>
+        ${HeadContents({ resLocals, pageTitle: 'Assessment Modules' })}
+      </head>
+      <body>
+        ${Navbar({ resLocals })}
+        <main id="content" class="container-fluid">
+          ${CourseSyncErrorsAndWarnings({
+            authz_data: resLocals.authz_data,
+            course: resLocals.course,
+            urlPrefix: resLocals.urlPrefix,
+          })}
+          <div class="card mb-4">
+            <div class="card-header bg-primary text-white">
+              <h1>Modules</h1>
+            </div>
+            <div class="table-responsive">
+              <table class="table table-sm table-hover table-striped" aria-label="Assessment sets">
+                <thead>
+                  <tr>
+                    <th>Number</th>
+                    <th>Name</th>
+                    <th>Heading</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${modules.map(function (module) {
+                    return html`
+                      <tr>
+                        <td class="align-middle">${module.number}</td>
+                        <td>${module.name}</td>
+                        <td>${module.heading}</td>
+                      </tr>
+                    `;
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </main>
+      </body>
+    </html>
+  `.toString();
+}

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
@@ -52,6 +52,15 @@ export function InstructorCourseAdminModules({
                 </tbody>
               </table>
             </div>
+            <div class="card-footer">
+              <small>
+                Modules can represent course topics, chapters, or any assessments of related
+                content. More information on modules can be found in the
+                <a href="https://prairielearn.readthedocs.io/en/latest/course/#assessment-modules">
+                  PrairieLearn documentation</a
+                >.
+              </small>
+            </div>
           </div>
         </main>
       </body>

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.ts
@@ -54,7 +54,8 @@ export function InstructorCourseAdminModules({
             </div>
             <div class="card-footer">
               <small>
-                Modules can be used to group assessments by topic, chapter, section, or other category. More information on modules can be found in the
+                Modules can be used to group assessments by topic, chapter, section, or other
+                category. More information on modules can be found in the
                 <a href="https://prairielearn.readthedocs.io/en/latest/course/#assessment-modules">
                   PrairieLearn documentation</a
                 >.

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.sql
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.sql
@@ -1,0 +1,9 @@
+-- BLOCK select_assessment_modules
+SELECT
+  am.*
+FROM
+  assessment_modules AS am
+WHERE
+  am.course_id = $course_id
+ORDER BY
+  am.number;

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.ts
@@ -1,0 +1,26 @@
+import * as express from 'express';
+import asyncHandler from 'express-async-handler';
+
+import * as sqldb from '@prairielearn/postgres';
+
+import { AssessmentModuleSchema } from '../../lib/db-types.js';
+
+import { InstructorCourseAdminModules } from './instructorCourseAdminModules.html.js';
+
+const router = express.Router();
+const sql = sqldb.loadSqlEquiv(import.meta.url);
+
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const modules = await sqldb.queryRows(
+      sql.select_assessment_modules,
+      { course_id: res.locals.course.id },
+      AssessmentModuleSchema,
+    );
+
+    res.send(InstructorCourseAdminModules({ resLocals: res.locals, modules }));
+  }),
+);
+
+export default router;

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1268,6 +1268,13 @@ export async function initExpress() {
     },
     (await import('./pages/instructorCourseAdminSets/instructorCourseAdminSets.js')).default,
   ]);
+  app.use('/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/modules', [
+    function (req, res, next) {
+      res.locals.navSubPage = 'moduls';
+      next();
+    },
+    (await import('./pages/instructorCourseAdminModules/instructorCourseAdminModules.js')).default,
+  ]);
   app.use('/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/instances', [
     function (req, res, next) {
       res.locals.navSubPage = 'instances';
@@ -1816,6 +1823,13 @@ export async function initExpress() {
       next();
     },
     (await import('./pages/instructorCourseAdminSets/instructorCourseAdminSets.js')).default,
+  ]);
+  app.use('/pl/course/:course_id(\\d+)/course_admin/modules', [
+    function (req, res, next) {
+      res.locals.navSubPage = 'modules';
+      next();
+    },
+    (await import('./pages/instructorCourseAdminModules/instructorCourseAdminModules.js')).default,
   ]);
   app.use('/pl/course/:course_id(\\d+)/course_admin/instances', [
     function (req, res, next) {


### PR DESCRIPTION
Closes #10658. While working on #10653, it was realized that we do not have a page that displays the modules for a course. This PR intends to add that page.
![Screenshot 2024-09-13 at 2 19 09 PM](https://github.com/user-attachments/assets/c68a8707-1ea8-46e3-b705-bd002341546a)

I have added columns from the `assessment_modules` table in the DB. If there is any other information that would add value here, please let me know. 