### PR TITLE
Improve contrast of buttons in submission panel header

### DIFF
--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -225,7 +225,7 @@ export function SubmissionPanel({
           </div>
           <button
             type="button"
-            class="btn btn-outline-secondary btn-sm ml-2 mr-2"
+            class="btn btn-outline-dark btn-sm ml-2 mr-2"
             data-submission-id="${submission.id}"
             data-toggle="modal"
             data-target="#submissionInfoModal-${submission.id}"
@@ -235,7 +235,7 @@ export function SubmissionPanel({
           </button>
           <button
             type="button"
-            class="expand-icon-container btn btn-outline-secondary btn-sm text-nowrap ${!expanded
+            class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap ${!expanded
               ? 'collapsed'
               : ''}"
             data-toggle="collapse"


### PR DESCRIPTION
This change ensures that these buttons have sufficient contrast with their background. Before, the contrast was 4.44, which was insufficient: https://webaim.org/resources/contrastchecker/?fcolor=6C757D&bcolor=F8F9FA

Before:

<img width="177" alt="Screenshot 2024-09-16 at 11 58 46" src="https://github.com/user-attachments/assets/b0eeea98-bed8-4259-8cfe-3c23481fe02f">

After:

<img width="168" alt="Screenshot 2024-09-16 at 11 58 58" src="https://github.com/user-attachments/assets/d2e3ccaf-a170-48cb-82cb-c0d3b869d198">

