### PR TITLE
Introduce "ghost button" styles

### DIFF
--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -126,6 +126,23 @@ mjx-container {
   max-width: min(800px, 90vw);
 }
 
+.btn.btn-ghost {
+  --bs-btn-color: #000;
+  --bs-btn-bg: transparent;
+  --bs-btn-border-color: transparent;
+  --bs-btn-hover-color: #000;
+  --bs-btn-hover-bg: #d3d4d5;
+  --bs-btn-hover-border-color: #c6c7c8;
+  --bs-btn-focus-shadow-rgb: 211, 212, 213;
+  --bs-btn-active-color: #000;
+  --bs-btn-active-bg: #c6c7c8;
+  --bs-btn-active-border-color: #babbbc;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #000;
+  --bs-btn-disabled-bg: #f8f9fa;
+  --bs-btn-disabled-border-color: #f8f9fa;
+}
+
 /**
  * Remove the bottom border from the final row of the last table in a card.
  */
@@ -368,7 +385,8 @@ small .user-output-invalid {
   outline-offset: -2px !important;
 }
 
-.btn.btn-light:focus:focus-visible {
+.btn.btn-light:focus:focus-visible,
+.btn.btn-ghost:focus:focus-visible {
   outline-style: solid !important;
   outline-color: var(--bs-btn-hover-color, #000000) !important;
   outline-width: 2px !important;

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -126,6 +126,12 @@ mjx-container {
   max-width: min(800px, 90vw);
 }
 
+/**
+ * Identical to the variables for `btn-light`, except with a transparent
+ * background and border in the default state. This style is useful for
+ * buttons that should carry little visual weight, while still ensuring
+ * that they have hover/focus/active styles.
+ */
 .btn.btn-ghost {
   --bs-btn-color: #000;
   --bs-btn-bg: transparent;

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -406,7 +406,7 @@ function QuestionFooterContent({
             ? html`
                 <button
                   type="button"
-                  class="btn btn-xs order-3"
+                  class="btn btn-xs btn-ghost mr-1"
                   data-toggle="popover"
                   data-trigger="focus"
                   data-content="Your group role (${assessment_instance.user_group_roles}) is not allowed to submit this question."
@@ -445,7 +445,7 @@ function QuestionFooterContent({
                       Additional attempts available with new variants
                     </small>
                     <a
-                      class="btn btn-xs align-self-center"
+                      class="btn btn-xs btn-ghost align-self-center ml-1"
                       data-toggle="popover"
                       data-trigger="focus"
                       data-container="body"

--- a/apps/prairielearn/src/components/QuestionNavigation.html.ts
+++ b/apps/prairielearn/src/components/QuestionNavigation.html.ts
@@ -66,7 +66,7 @@ export function QuestionNavSideButton({
 
   if (instanceQuestionId == null) {
     return html`
-      <button id="${buttonId}" class="btn mb-3 btn-primary disabled" disabled>
+      <button id="${buttonId}" class="btn btn-primary mb-3 disabled" disabled>
         ${buttonLabel}
       </button>
     `;
@@ -85,7 +85,7 @@ export function QuestionNavSideButton({
     return html`
       <button
         id="${buttonId}"
-        class="btn mb-3 btn-secondary pl-sequence-locked"
+        class="btn btn-secondary mb-3 pl-sequence-locked"
         data-toggle="popover"
         data-trigger="focus"
         data-container="body"
@@ -101,7 +101,7 @@ export function QuestionNavSideButton({
   return html`
     <a
       id="${buttonId}"
-      class="btn mb-3 btn-primary"
+      class="btn btn-primary mb-3"
       href="${urlPrefix}/instance_question/${instanceQuestionId}/"
     >
       ${buttonLabel}

--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -442,7 +442,7 @@ export function ExamQuestionAvailablePoints({
     <a
       tabindex="0"
       type="button"
-      class="btn btn-xs js-available-points-popover"
+      class="btn btn-xs btn-xs-light js-available-points-popover"
       data-toggle="popover"
       data-trigger="focus"
       data-container="body"

--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -151,7 +151,7 @@ export function SubmissionPanel({
                                     ? html`
                                         <button
                                           type="button"
-                                          class="btn btn-xs text-info"
+                                          class="btn btn-xs btn-ghost"
                                           data-toggle="popover"
                                           data-content="${item.explanation_rendered}"
                                           data-html="true"

--- a/apps/prairielearn/src/components/SyncProblemButton.html.ts
+++ b/apps/prairielearn/src/components/SyncProblemButton.html.ts
@@ -18,7 +18,7 @@ ${unsafeHtml(ansiUp.ansi_to_html(output))}</pre
 
   return html`
     <button
-      class="btn btn-xs mr-1"
+      class="btn btn-xs btn-ghost mr-1"
       data-toggle="popover"
       data-trigger="hover"
       data-container="body"

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
@@ -134,6 +134,17 @@ export function AdministratorSettings({ resLocals }) {
               <div class="p-4 bg-dark">
                 <button type="button" class="btn btn-outline-light">Light</button>
               </div>
+              <h3>Ghost button</h3>
+              <p>
+                This is a custom button style that's meant to be used when we don't want the full
+                visual weight of a typical button. Useful for popover triggers.
+              </p>
+              <div>
+                <button type="button" class="btn btn-xs btn-ghost">Extra small</button>
+                <button type="button" class="btn btn-sm btn-ghost">Small</button>
+                <button type="button" class="btn btn btn-ghost">Default</button>
+                <button type="button" class="btn btn-lg btn-ghost">Large</button>
+              </div>
             </div>
           </div>
         </main>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -176,8 +176,9 @@ export function InstructorAssessmentGroups({
                                     <div class="dropdown js-group-action-dropdown">
                                       <button
                                         type="button"
-                                        class="btn btn-xs dropdown-toggle"
+                                        class="btn btn-xs btn-ghost dropdown-toggle"
                                         data-toggle="dropdown"
+                                        data-boundary="window"
                                         aria-haspopup="true"
                                         aria-expanded="false"
                                       >

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricSettingsModal.html.ts
@@ -19,7 +19,7 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
           <input type="hidden" name="use_rubric" value="true" />
 
           <div class="modal-content">
-            <div class="modal-header bg-info text-light">
+            <div class="modal-header bg-info">
               <h5 class="modal-title">Rubric settings</h5>
               <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
@@ -49,12 +49,12 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                           </label>
                           <button
                             type="button"
-                            class="btn btn-sm"
+                            class="btn btn-sm btn-ghost"
                             data-toggle="tooltip"
                             data-placement="bottom"
                             title="If the rubric is applied to manual points only, then a student's auto points are kept, and the rubric items will be added to (or subtracted from) the autograder results."
                           >
-                            <i class="text-info fas fa-circle-info"></i>
+                            <i class="fas fa-circle-info"></i>
                           </button>
                         </div>
                       </div>
@@ -78,13 +78,13 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                           </label>
                           <button
                             type="button"
-                            class="btn btn-sm"
+                            class="btn btn-sm btn-ghost"
                             data-toggle="tooltip"
                             data-placement="bottom"
                             title="If the rubric is applied to total points, then a student's auto points will be ignored, and the rubric items will be based on the total points of the question (${resLocals
                               .assessment_question.max_points} points)."
                           >
-                            <i class="text-info fas fa-circle-info"></i>
+                            <i class="fas fa-circle-info"></i>
                           </button>
                         </div>
                       </div>
@@ -122,12 +122,12 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                     </label>
                     <button
                       type="button"
-                      class="btn btn-sm"
+                      class="btn btn-sm btn-ghost"
                       data-toggle="tooltip"
                       data-placement="bottom"
                       title="This setting only affects starting points. Rubric items may always be added with positive or negative points."
                     >
-                      <i class="text-info fas fa-circle-info"></i>
+                      <i class="fas fa-circle-info"></i>
                     </button>
                   </div>
                 </div>
@@ -136,12 +136,12 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                     Minimum rubric score
                     <button
                       type="button"
-                      class="btn btn-sm"
+                      class="btn btn-sm btn-ghost"
                       data-toggle="tooltip"
                       data-placement="bottom"
                       title="By default, penalties applied by rubric items cannot cause the rubric to have negative points. This value overrides this limit, e.g., for penalties that affect auto points or the assessment as a whole."
                     >
-                      <i class="text-info fas fa-circle-info"></i>
+                      <i class="fas fa-circle-info"></i>
                     </button>
                     <input
                       class="form-control js-rubric-item-limits"
@@ -157,12 +157,12 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                     Maximum extra credit
                     <button
                       type="button"
-                      class="btn btn-sm"
+                      class="btn btn-sm btn-ghost"
                       data-toggle="tooltip"
                       data-placement="bottom"
                       title="By default, points are limited to the maximum points assigned to the question, and credit assigned by rubric items do not violate this limit. This value allows rubric points to extend beyond this limit, e.g., for bonus credit."
                     >
-                      <i class="text-info fas fa-circle-info"></i>
+                      <i class="fas fa-circle-info"></i>
                     </button>
                     <input
                       class="form-control js-rubric-item-limits"
@@ -234,12 +234,12 @@ export function RubricSettingsModal({ resLocals }: { resLocals: Record<string, a
                 </label>
                 <button
                   type="button"
-                  class="btn btn-sm"
+                  class="btn btn-sm btn-ghost"
                   data-toggle="tooltip"
                   data-placement="top"
                   title="Changes in rubric item values update the points for all previously graded submissions. If this option is selected, these submissions will also be tagged for manual grading, requiring a review by a grader."
                 >
-                  <i class="text-info fas fa-circle-info"></i>
+                  <i class="fas fa-circle-info"></i>
                 </button>
               </div>
             </div>
@@ -279,7 +279,7 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
   const namePrefix = item ? `rubric_item[cur${item.id}]` : 'rubric_item[new]';
   return html`
     <tr>
-      <td class="text-nowrap">
+      <td class="text-nowrap align-middle">
         ${item ? html`<input type="hidden" name="${namePrefix}[id]" value="${item.id}" />` : ''}
         <input
           type="hidden"
@@ -287,21 +287,24 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
           name="${namePrefix}[order]"
           value="${index}"
         />
-        <button type="button" class="btn btn-sm js-rubric-item-move-button" draggable="true">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost js-rubric-item-move-button"
+          draggable="true"
+        >
           <i class="fas fa-arrows-up-down"></i>
         </button>
-        <button type="button" class="btn btn-sm sr-only js-rubric-item-move-down-button">
-          Move down
-        </button>
-        <button type="button" class="btn btn-sm sr-only js-rubric-item-move-up-button">
-          Move up
-        </button>
-        <button type="button" class="btn btn-sm js-rubric-item-delete text-danger">
-          <i class="fas fa-trash"></i>
-          <span class="sr-only">Delete</span>
+        <button type="button" class="sr-only js-rubric-item-move-down-button">Move down</button>
+        <button type="button" class="sr-only js-rubric-item-move-up-button">Move up</button>
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost js-rubric-item-delete text-danger"
+          aria-label="Delete"
+        >
+          <i class="fas fa-trash text-danger"></i>
         </button>
       </td>
-      <td>
+      <td class="align-middle">
         <input
           type="number"
           class="form-control js-rubric-item-points"
@@ -313,7 +316,7 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
           aria-label="Points"
         />
       </td>
-      <td>
+      <td class="align-middle">
         <input
           type="text"
           class="form-control js-rubric-item-description"
@@ -325,7 +328,7 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
           aria-label="Description"
         />
       </td>
-      <td>
+      <td class="align-middle">
         ${item?.explanation
           ? html` <label
               for="rubric-item-explanation-button-${item.id}"
@@ -336,14 +339,14 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
         <button
           ${item ? html`id="rubric-item-explanation-button-${item.id}"` : ''}
           type="button"
-          class="btn btn-sm js-rubric-item-long-text-field js-rubric-item-explanation"
+          class="btn btn-sm btn-ghost js-rubric-item-long-text-field js-rubric-item-explanation"
           data-input-name="${namePrefix}[explanation]"
           data-current-value="${item?.explanation}"
         >
           <i class="fas fa-pencil"></i>
         </button>
       </td>
-      <td>
+      <td class="align-middle">
         ${item?.grader_note
           ? html`<label
               for="rubric-item-grader-note-button-${item.id}"
@@ -354,14 +357,14 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
         <button
           ${item ? html`id="rubric-item-grader-note-button-${item.id}"` : ''}
           type="button"
-          class="btn btn-sm js-rubric-item-long-text-field js-rubric-item-grader-note"
+          class="btn btn-sm btn-ghost js-rubric-item-long-text-field js-rubric-item-grader-note"
           data-input-name="${namePrefix}[grader_note]"
           data-current-value="${item?.grader_note}"
         >
           <i class="fas fa-pencil"></i>
         </button>
       </td>
-      <td>
+      <td class="align-middle">
         <div class="form-check form-check-inline">
           <label class="form-check-label text-nowrap">
             <input
@@ -387,7 +390,7 @@ function RubricItemRow(item: RubricData['rubric_items'][0] | null, index: number
           </label>
         </div>
       </td>
-      <td class="text-nowrap">
+      <td class="text-nowrap align-middle">
         ${!item
           ? 'New'
           : !item.num_submissions


### PR DESCRIPTION
We have a habit of using Bootstrap's [`btn` base class](https://getbootstrap.com/docs/5.3/components/buttons/#base-class) without any corresponding variant or color. This produced buttons that have no hover/focus styles, which is an accessibility issue.

This PR introduces a "ghost" button variant. It's the same as `btn-light`, except it doesn't have any background/border color in its normal state (not hovered, not focused, not active).

I'm open to an argument that we should in fact be using one of the "standard" Bootstrap variants in some or all of these places, probably `btn-light` or `btn-secondary` in most of these places. For reference, here's `btn-ghost` in both "normal" and "focused" state:

<img width="107" alt="Screenshot 2024-09-16 at 14 11 11" src="https://github.com/user-attachments/assets/d77f4f97-0eb7-4fed-b587-aa17c2e633aa">

And here's `btn-light`:

<img width="110" alt="Screenshot 2024-09-16 at 14 11 40" src="https://github.com/user-attachments/assets/05716fe7-b13f-4767-9d48-4198f144ef3e">
