### PR TITLE
Use click as trigger for all popovers

### DIFF
--- a/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.mustache
+++ b/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.mustache
@@ -22,9 +22,9 @@
                         class="input-group-text"
                         id="pl-big-o-input-{{uuid}}-suffix">$)$</span>
                     {{#show_info}}
-                    <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+                    <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto">
                         <i class="fa fa-question-circle" aria-hidden="true"></i>
-                    </a>
+                    </button>
                     {{/show_info}}
                     {{#correct}}
                         <span class="input-group-text">
@@ -42,19 +42,17 @@
                         </span>
                     {{/incorrect}}
                     {{#parse_error}}
-                        <a
-                            role="button"
+                        <button
+                            type="button"
                             class="btn btn-light border d-flex align-items-center text-danger"
                             data-toggle="popover"
                             data-html="true"
                             title="Format Error"
                             data-placement="auto"
-                            data-trigger="focus"
-                            tabindex="0"
                             data-content="{{parse_error}}"
                         >
                             <span class="mr-1">Invalid</span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                        </a>
+                        </button>
                     {{/parse_error}}
                 </span>
             </span>
@@ -70,25 +68,24 @@
         {{#raw_submitted_answer}}
             <code class="user-output-invalid">{{raw_submitted_answer}}</code>
         {{/raw_submitted_answer}}
-        <a
-            href="javascript:void(0);"
-            role="button"
+        <button
+            type="button"
             class="badge text-danger badge-invalid btn btn-sm btn-secondary small border"
             data-placement="auto"
-            data-trigger="focus"
             data-toggle="popover"
             data-html="true"
             title="Format Error"
-            tabindex="0"
             data-content="{{parse_error}}"
-        > Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
+        >
+            Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+        </button>
     {{/parse_error}}
 
     {{#missing_input}}
         <span class="badge text-dark badge-missing-input"><i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input</span>
 
-        <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
-        </a>
+        <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+        </button>
     {{/missing_input}}
     </span>
 
@@ -98,12 +95,12 @@
     ${{type}}({{a_sub}})$
 
     <!-- Show submitted answer submission was parsed from -->
-    <a href="javascript:void(0);" role="button" class="ml-1 btn btn-sm btn-secondary small border"
-        data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true"
-        title="Original Input" tabindex="0"
+    <button type="button" class="ml-1 btn btn-sm btn-secondary small border"
+        data-placement="auto" data-toggle="popover" data-html="true"
+        title="Original Input"
         data-content="Parsed from <samp class=user-output>{{raw_submitted_answer}}</samp>">
         <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
 
     {{#feedback}}
         <div class="big-o-input-feedback">

--- a/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
+++ b/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
@@ -34,9 +34,9 @@
 <span class="form-inline">
     <span class="input-group pl-checkbox">
         <span> {{{helptext}}} </span>
-        <a role="button" class="btn btn-light btn-sm" data-toggle="popover" data-html="true" title="Checkbox" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+        <button type="button" class="btn btn-light btn-sm" data-toggle="popover" data-html="true" title="Checkbox" data-content="{{info}}" data-placement="auto">
             <i class="fa fa-question-circle" aria-hidden="true"></i>
-        </a>
+        </button>
     </span>
 </span>
 {{/helptext}}
@@ -59,7 +59,7 @@
 {{^inline}}<div class="d-block">{{/inline}}
     <span >
         <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-        <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+        <button type="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto" data-toggle="popover" data-html="true" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
     </span>
 </div>
 {{#inline}}</span>{{/inline}}

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
@@ -6,7 +6,7 @@
 {{#parse_error}}
 <span>
     <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-    <a tabindex="0" type="button" role="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <button type="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto"data-toggle="popover" data-html="true" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
 </span>
 {{/parse_error}}
 {{^parse_error}}

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
@@ -6,7 +6,7 @@
 {{#parse_error}}
 <span>
     <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-    <button type="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto"data-toggle="popover" data-html="true" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <button type="button" class="btn btn-sm btn-secondary small border ml-1" data-placement="auto"data-toggle="popover" data-html="true" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
 </span>
 {{/parse_error}}
 {{^parse_error}}

--- a/apps/prairielearn/elements/pl-dropdown/pl-dropdown.mustache
+++ b/apps/prairielearn/elements/pl-dropdown/pl-dropdown.mustache
@@ -1,4 +1,3 @@
-
 {{#question}}
     <span class="d-inline-block form-group form-inline">
         <select name="{{answers-name}}" class="custom-select w-auto" {{^editable}}disabled{{/editable}}>
@@ -35,11 +34,17 @@
 
         {{#parse-error}}
             <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-            <button class="btn btn-sm btn-secondary small border ml-1"
-                    data-placement="auto" data-trigger="focus" data-toggle="popover"
-                    data-html="true" title="Format Error" tabindex="0" data-container="body"
-                    data-content="{{parse-error}}">
-              Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+            <button 
+                type="button"
+                class="btn btn-sm btn-secondary small border ml-1"
+                data-placement="auto"
+                data-toggle="popover"
+                data-html="true"
+                title="Format Error"
+                data-container="body"
+                data-content="{{parse-error}}"
+            >
+                Why <i class="fa fa-question-circle" aria-hidden="true"></i>
             </button>
         {{/parse-error}}
     </span>

--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.mustache
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.mustache
@@ -26,9 +26,9 @@
             {{/suffix}}
 
             {{#show_info}}
-            <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Integer" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+            <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Integer" data-content="{{info}}" data-placement="auto">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
             {{/show_info}}
             {{#correct}}
                 <span class="input-group-text">
@@ -46,17 +46,17 @@
                 </span>
             {{/incorrect}}
             {{#parse_error}}
-                <a role="button"
-                   class="btn btn-light border d-flex align-items-center text-danger"
-                   data-toggle="popover"
-                   data-html="true"
-                   title="Format Error"
-                   data-placement="auto"
-                   data-trigger="focus"
-                   tabindex="0"
-                   data-content="{{parse_error}}">
+                <button
+                    type="button"
+                    class="btn btn-light border d-flex align-items-center text-danger"
+                    data-toggle="popover"
+                    data-html="true"
+                    title="Format Error"
+                    data-placement="auto"
+                    data-content="{{parse_error}}"
+                >
                     <span class="mr-1">Invalid</span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                </a>
+                </button>
             {{/parse_error}}
         </span>
     </span>
@@ -73,15 +73,15 @@
     {{#label}}<span>{{{label}}}</span>{{/label}}
     {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
 
-    <a href="javascript:void(0);" role="button" class="badge text-danger badge-invalid btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
+    <button type="button" class="badge text-danger badge-invalid btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-content="{{parse_error}}"> Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></button>
 {{/parse_error}}
 {{#missing_input}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
 
     <span class="badge text-dark badge-missing-input"><i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input</span>
 
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+    </button>
 {{/missing_input}}
 
 </span>

--- a/apps/prairielearn/elements/pl-matching/pl-matching.mustache
+++ b/apps/prairielearn/elements/pl-matching/pl-matching.mustache
@@ -54,7 +54,7 @@
         </div>
         {{#parse_error}}
             <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-            <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+            <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto"  data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
         {{/parse_error}}
         {{#display_score_badge}}
         <div>

--- a/apps/prairielearn/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
+++ b/apps/prairielearn/elements/pl-matrix-component-input/pl-matrix-component-input.mustache
@@ -9,13 +9,13 @@
             {{{input_array}}}
         </div>
         <div class="input-group-append">
-            <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+            <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
                 {{#correct}}&nbsp;<span class="badge badge-success"><i class="fa fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
                 {{#partial}}&nbsp;<span class="badge badge-warning"><i class="far fa-circle" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
                 {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
 
-            </a>
+            </button>
         </div>
     </div>
 </span>
@@ -35,15 +35,15 @@
 
     <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
 
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
 {{/parse_error}}
 {{#missing_input}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
 
     <span class="badge text-dark badge-missing-input"><i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input</span>
 
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+    </button>
 {{/missing_input}}
 
 </span>

--- a/apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -8,7 +8,7 @@
     <input name="{{name}}" type="text" class="form-control pl-matrix-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" aria-labelledby="pl-matrix-input-{{uuid}}-label" />
     <div class="input-group-append">
         {{#show_info}}
-        <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+        <button class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto">
         <i class="fa fa-question-circle" aria-hidden="true"></i>
         {{/show_info}}
         {{^show_info}}
@@ -20,7 +20,7 @@
         {{#incorrect}}&nbsp;<span class="badge badge-danger"><i class="fa fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
 
         {{#show_info}}
-        </a>
+        </button>
         {{/show_info}}
         {{#show_info}}
         </span>
@@ -39,15 +39,15 @@
     
     <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
     
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-content="{{parse_error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
 {{/parse_error}}
 {{#missing_input}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
 
     <span class="badge text-dark badge-missing-input"><i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input</span>
     
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+    </button>
 {{/missing_input}}
 
 </span>

--- a/apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.mustache
+++ b/apps/prairielearn/elements/pl-matrix-input/pl-matrix-input.mustache
@@ -8,7 +8,7 @@
     <input name="{{name}}" type="text" class="form-control pl-matrix-input-input {{^display_append_span}}rounded-right{{/display_append_span}}" {{^editable}}disabled{{/editable}} {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}} placeholder="{{shortinfo}}" aria-labelledby="pl-matrix-input-{{uuid}}-label" />
     <div class="input-group-append">
         {{#show_info}}
-        <button class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto">
+        <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Matrix" data-content="{{info}}" data-placement="auto">
         <i class="fa fa-question-circle" aria-hidden="true"></i>
         {{/show_info}}
         {{^show_info}}

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -110,19 +110,17 @@
 {{#submission}}
 {{#parse_error}}
 <span>
-    <a
-        href="javascript:void(0);"
-        role="button"
+    <button
+        type="button"
         class="badge text-danger badge-invalid btn btn-sm btn-secondary small border"
         data-placement="auto"
-        data-trigger="focus"
         data-toggle="popover"
         data-html="true"
         title="Format Error"
-        tabindex="0"
         data-content="{{parse_error}}"
-    > Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-    </a>
+    >
+        Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    </button>
 </span>
 {{/parse_error}}
 {{^parse_error}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -26,22 +26,22 @@
             <span class="input-group-text" id="pl-number-input-{{uuid}}-suffix">{{suffix}}</span>
             {{/suffix}}
             {{#show_info}}
-              <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="{{popup_title}}" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+              <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="{{popup_title}}" data-content="{{info}}" data-placement="auto">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
-              </a>
+              </button>
             {{/show_info}}
             {{#parse_error}}
-                 <a role="button"
-                   class="btn btn-light border d-flex align-items-center text-danger"
-                   data-toggle="popover"
-                   data-html="true"
-                   title="Format Error"
-                   data-placement="auto"
-                   data-trigger="focus"
-                   tabindex="0"
-                   data-content="{{parse_error}}">
+                 <button
+                    type="button"
+                    class="btn btn-light border d-flex align-items-center text-danger"
+                    data-toggle="popover"
+                    data-html="true"
+                    title="Format Error"
+                    data-placement="auto"
+                    data-content="{{parse_error}}"
+                >
                     <span class="mr-1">Invalid </span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                </a>
+                </button>
             {{/parse_error}}
             {{#show_score}}
                 {{#correct}}
@@ -75,15 +75,15 @@
 {{#parse_error}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
     {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
-    <a href="javascript:void(0);" role="button" class="badge text-danger badge-invalid btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Format Error" tabindex="0" data-content="{{parse_error}}"> Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
+    <button type="button" class="badge text-danger badge-invalid btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" title="Format Error" data-content="{{parse_error}}"> Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></button>
 {{/parse_error}}
 {{#missing_input}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
 
     <span class="badge text-dark badge-missing-input"><i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input</span>
 
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i>
+    </button>
 {{/missing_input}}
 
 </span>

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache
@@ -29,9 +29,9 @@ $(function() {
         <div class="pl-order-blocks-container {{block_layout}} {{dropzone_layout}} ">
             <div class="card-header pl-order-blocks-header list-group-item-primary">
                 <span class="mr-2">{{solution-header}}</span>
-                <a role="button" style="vertical-align:middle;" class="btn btn-light btn-sm" data-toggle="popover" data-html="true" title="Order Blocks" data-content="{{help_text}}" data-trigger="focus" tabindex="0">
+                <button type="button" style="vertical-align:middle;" class="btn btn-light btn-sm" data-toggle="popover" data-html="true" title="Order Blocks" data-content="{{help_text}}">
                     <i class="fa fa-question-circle" aria-hidden="true"></i>
-                </a>
+                </button>
             </div>
             <ul id="order-blocks-dropzone-{{uuid}}" name="{{answer_name}}" class="card-body list-group pl-order-blocks-connected-sortable dropzone">
                 {{#submission_dict}}
@@ -106,7 +106,7 @@ $(function() {
         <strong>Your answer: </strong>
         <div id="pl-order-blocks" class="d-inline-block">
             <span class="badge text-danger badge-invalid"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Invalid</span>
-            <a role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" tabindex="0" data-content="{{parse-error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+            <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" style="margin-left: 5px" title="Format Error" data-content="{{parse-error}}"> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
         </div>
     {{/parse-error}}
 {{/submission}}

--- a/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
+++ b/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
@@ -24,9 +24,9 @@
             {{#suffix}}<span class="input-group-text" id="pl-symbolic-input-{{uuid}}-suffix">{{suffix}}</span>{{/suffix}}
 
             {{#show_info}}
-                <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="String" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+                <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="String" data-content="{{info}}" data-placement="auto">
                     <i class="fa fa-question-circle" aria-hidden="true"></i>
-                </a>
+                </button>
             {{/show_info}}
 
             {{#correct}}
@@ -45,19 +45,17 @@
                 </span>
             {{/incorrect}}
             {{#parse_error}}
-                <a
-                    role="button"
+                <button
+                    type="button"
                     class="btn btn-light border d-flex align-items-center text-danger"
                     data-toggle="popover"
                     data-html="true"
                     title="Format Error"
                     data-placement="auto"
-                    data-trigger="focus"
-                    tabindex="0"
                     data-content="{{parse_error}}"
                 >
                     <span class="mr-1">Invalid</span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                </a>
+                </button>
             {{/parse_error}}
         </span>
     </span>
@@ -72,23 +70,21 @@
 {{#parse_error}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
     {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
-    <a
-        href="javascript:void(0);"
-        role="button"
+    <button
         class="badge text-danger badge-invalid btn btn-sm btn-secondary small border"
         data-placement="auto"
-        data-trigger="focus"
         data-toggle="popover"
         data-html="true"
         title="Format Error"
-        tabindex="0"
         data-content="{{parse_error}}"
-    > Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
+    >
+        Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    </button>
     {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{/parse_error}}
 {{#missing_input}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
     {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{/missing_input}}
 

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -45,6 +45,7 @@
             {{/incorrect}}
             {{#parse_error}}
                 <button
+                    type="button"
                     class="btn btn-light border d-flex align-items-center text-danger"
                     data-toggle="popover"
                     data-html="true"

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -24,9 +24,9 @@
             <span class="input-group-text" id="pl-symbolic-input-{{uuid}}-suffix">{{suffix}}</span>
             {{/suffix}}
             {{#show_info}}
-            <a role="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+            <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="Symbolic" data-content="{{info}}" data-placement="auto">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
             {{/show_info}}
             {{#correct}}
                 <span class="input-group-text">
@@ -44,19 +44,16 @@
                 </span>
             {{/incorrect}}
             {{#parse_error}}
-                <a
-                    role="button"
+                <button
                     class="btn btn-light border d-flex align-items-center text-danger"
                     data-toggle="popover"
                     data-html="true"
                     title="Format Error"
                     data-placement="auto"
-                    data-trigger="focus"
-                    tabindex="0"
                     data-content="{{parse_error}}"
                 >
                     <span class="mr-1">Invalid</span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                </a>
+                </button>
             {{/parse_error}}
         </span>
     </span>
@@ -74,25 +71,24 @@
     {{#label}}<span>{{{label}}}</span>{{/label}}
     {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
     {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-    <a
-        href="javascript:void(0);"
-        role="button"
+    <button
+        type="button"
         class="badge text-danger badge-invalid btn btn-sm btn-secondary small border"
         data-placement="auto"
-        data-trigger="focus"
         data-toggle="popover"
         data-html="true"
         title="Format Error"
-        tabindex="0"
         data-content="{{parse_error}}"
-    > Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
+    >
+        Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    </button>
 {{/parse_error}}
 {{#missing_input}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
 
     <span class="badge text-dark badge-missing-input"><i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input</span>
 
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true" title="Missing Input" tabindex="0" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i></a>
+    <button type="button" class="btn btn-sm btn-secondary small border" data-placement="auto" data-toggle="popover" data-html="true" title="Missing Input" data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."> Why <i class="fa fa-question-circle" aria-hidden="true"></i></button>
 
     {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 {{/missing_input}}
@@ -105,12 +101,13 @@
 ${{a_sub}}$
 
 <!-- Show submitted answer submission was parsed from -->
-<a href="javascript:void(0);" role="button" class="ml-1 btn btn-sm btn-secondary small border"
-    data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true"
-    title="Original Input" tabindex="0"
-    data-content="Parsed from <samp class=user-output>{{raw_submitted_answer}}</samp>">
+<button type="button" class="ml-1 btn btn-sm btn-secondary small border"
+    data-placement="auto" data-toggle="popover" data-html="true"
+    title="Original Input" 
+    data-content="Parsed from <samp class=user-output>{{raw_submitted_answer}}</samp>"
+>
     <i class="fa fa-question-circle" aria-hidden="true"></i>
-</a>
+</button>
 
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
@@ -102,7 +102,7 @@
         data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted.">
         Why
         <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
     {{/missing_input}}
 </span>
 {{/error}}

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
@@ -30,10 +30,10 @@
             {{/suffix}}
 
             {{#show_info}}
-            <a role="button" class="btn btn-light border d-flex align-items-center"
-                data-toggle="popover" data-html="true" title="Units" data-content="{{info}}" data-placement="auto" data-trigger="focus" tabindex="0">
+            <button type="button" class="btn btn-light border d-flex align-items-center"
+                data-toggle="popover" data-html="true" title="Units" data-content="{{info}}" data-placement="auto">
                 <i class="fa fa-question-circle" aria-hidden="true"></i>
-            </a>
+            </button>
             {{/show_info}}
 
             {{#correct}}
@@ -52,16 +52,17 @@
                 </span>
             {{/incorrect}}
             {{#parse_error}}
-                <a role="button"
-                   class="btn btn-light border d-flex align-items-center text-danger"
-                   data-toggle="popover"
-                   data-html="true"
-                   title="Format Error"
-                   data-placement="auto"
-                   data-trigger="focus"
-                   tabindex="0"
-                   data-content="{{parse_error}}"
-                ><span class="mr-1">Invalid</span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
+                <button
+                    type="button"
+                    class="btn btn-light border d-flex align-items-center text-danger"
+                    data-toggle="popover"
+                    data-html="true"
+                    title="Format Error"
+                    data-placement="auto"
+                    data-content="{{parse_error}}"
+                >
+                    <span class="mr-1">Invalid</span> <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                </button>
             {{/parse_error}}
         </span>
     </span>
@@ -77,19 +78,17 @@
     {{#parse_error}}
     {{#label}}<span>{{{label}}}</span>{{/label}}
     {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
-    <a
-        href="javascript:void(0);"
-        role="button"
+    <button
+        type="button"
         class="badge text-danger badge-invalid btn btn-sm btn-secondary small border"
         data-placement="auto"
-        data-trigger="focus"
         data-toggle="popover"
         data-html="true"
         title="Format Error"
-        tabindex="0"
         data-content="{{parse_error}}"
-    > Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-    </a>
+    >
+        Invalid <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    </button>
     {{/parse_error}}
 
     {{#missing_input}}
@@ -97,9 +96,9 @@
     <span class="badge text-dark badge-missing-input">
         <i class="fa fa-question-circle" aria-hidden="true"></i> Missing Input
     </span>
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border"
-        data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true"
-        style="margin-left: 5px" title="Format Error" tabindex="0"
+    <button type="button" class="btn btn-sm btn-secondary small border"
+        data-placement="auto" data-toggle="popover" data-html="true"
+        style="margin-left: 5px" title="Format Error"
         data-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted.">
         Why
         <i class="fa fa-question-circle" aria-hidden="true"></i>
@@ -115,12 +114,12 @@
     {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 
     <!-- Show submitted answer submission was parsed from -->
-    <a href="javascript:void(0);" role="button" class="btn btn-sm btn-secondary small border"
-        data-placement="auto" data-trigger="focus" data-toggle="popover" data-html="true"
-        style="margin-left: 5px" title="Original Input" tabindex="0"
+    <button type="button" class="btn btn-sm btn-secondary small border"
+        data-placement="auto" data-toggle="popover" data-html="true"
+        style="margin-left: 5px" title="Original Input"
         data-content="Parsed from <samp class=user-output>{{raw_submitted_answer}}</samp>">
         <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
 </div>
 
 {{#feedback}}

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -408,7 +408,6 @@ function QuestionFooterContent({
                   type="button"
                   class="btn btn-xs order-3"
                   data-toggle="popover"
-                  data-trigger="focus"
                   data-content="Your group role (${assessment_instance.user_group_roles}) is not allowed to submit this question."
                   aria-label="Submission blocked"
                 >
@@ -444,20 +443,19 @@ function QuestionFooterContent({
                     <small class="font-italic align-self-center">
                       Additional attempts available with new variants
                     </small>
-                    <a
+                    <button
+                      type="button"
                       class="btn btn-xs align-self-center"
                       data-toggle="popover"
-                      data-trigger="focus"
                       data-container="body"
                       data-html="true"
                       data-content="${escapeHtml(
                         NewVariantInfo({ variantAttemptsLeft, variantAttemptsTotal }),
                       )}"
                       data-placement="auto"
-                      tabindex="0"
                     >
                       <i class="fa fa-question-circle" aria-hidden="true"></i>
-                    </a>
+                    </button>
                   `
                 : ''}
           ${AvailablePointsNotes({ questionContext, instance_question, assessment_question })}
@@ -527,18 +525,17 @@ function SubmitRateFooter({
             Can only be graded once every ${assessment_question.grade_rate_minutes}
             ${assessment_question.grade_rate_minutes > 1 ? 'minutes' : 'minute'}
           </small>
-          <a
+          <button
+            type="button"
             class="btn btn-xs"
             data-toggle="popover"
-            data-trigger="focus"
             data-container="body"
             data-html="true"
             data-content="${escapeHtml(popoverContent)}"
             data-placement="auto"
-            tabindex="0"
           >
             <i class="fa fa-question-circle" aria-hidden="true"></i>
-          </a>
+          </button>
         </span>
       </div>
     </div>

--- a/apps/prairielearn/src/components/QuestionNavigation.html.ts
+++ b/apps/prairielearn/src/components/QuestionNavigation.html.ts
@@ -87,7 +87,6 @@ export function QuestionNavSideButton({
         id="${buttonId}"
         class="btn mb-3 btn-secondary pl-sequence-locked"
         data-toggle="popover"
-        data-trigger="focus"
         data-container="body"
         data-html="true"
         data-content="${disabledExplanation}"

--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -270,6 +270,7 @@ export function ExamQuestionStatus({
       ${(instance_question.allow_grade_left_ms ?? 0) > 0
         ? html`
             <button
+              type="button"
               class="grade-rate-limit-popover btn btn-xs"
               data-toggle="popover"
               data-container="body"

--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -269,18 +269,16 @@ export function ExamQuestionStatus({
 
       ${(instance_question.allow_grade_left_ms ?? 0) > 0
         ? html`
-            <a
+            <button
               class="grade-rate-limit-popover btn btn-xs"
               data-toggle="popover"
-              data-trigger="focus"
               data-container="body"
               data-html="true"
               data-content="This question limits the rate of submissions. Further grade allowed ${instance_question.allow_grade_interval} (as of the loading of this page)."
               data-placement="auto"
-              tabindex="0"
             >
               <i class="fa fa-hourglass-half" aria-hidden="true"></i>
-            </a>
+            </button>
           `
         : ''}
     </span>
@@ -439,18 +437,16 @@ export function ExamQuestionAvailablePoints({
       ? formatPoints(pointsList[0])
       : html`${formatPoints(pointsList[0])},
           <span class="text-muted">${formatPointsOrList(pointsList.slice(1))}</span>`}
-    <a
-      tabindex="0"
+    <button
       type="button"
       class="btn btn-xs js-available-points-popover"
       data-toggle="popover"
-      data-trigger="focus"
       data-container="body"
       data-html="true"
       data-content="${escapeHtml(popoverContent)}"
       data-placement="auto"
     >
       <i class="fa fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
   `;
 }

--- a/apps/prairielearn/src/components/StudentAccessRulesPopover.html.ts
+++ b/apps/prairielearn/src/components/StudentAccessRulesPopover.html.ts
@@ -16,12 +16,10 @@ export type AuthzAccessRule = z.infer<typeof AuthzAccessRuleSchema>;
 
 export function StudentAccessRulesPopover({ accessRules }: { accessRules: AuthzAccessRule[] }) {
   return html`
-    <a
-      tabindex="0"
+    <button
+    type="button"
       class="btn btn-xs"
-      role="button"
       data-toggle="popover"
-      data-trigger="focus"
       data-container="body"
       data-html="true"
       title="Access details"

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
@@ -238,7 +238,6 @@ function ImageTable({
                           data-html="true"
                           title="Questions using ${image.image}"
                           data-content="${escapeHtml(ListQuestionsPopover({ image, urlPrefix }))}"
-                          data-trigger="focus"
                         >
                           Show
                         </button>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -84,19 +84,17 @@ export function InstructorAssessmentAccess({
                           resLocals.authz_data.has_course_instance_permission_view
                             ? access_rule.uids
                             : html`
-                                <a
-                                  role="button"
+                                <button
+                                  type="button"
                                   class="btn btn-xs btn-warning"
-                                  tabindex="0"
                                   data-toggle="popover"
-                                  data-trigger="focus"
                                   data-container="body"
                                   data-placement="auto"
                                   title="Hidden UIDs"
                                   data-content="This access rule is specific to individual students. You need permission to view student data in order to see which ones."
                                 >
                                   Hidden
-                                </a>
+                                </button>
                               `}
                         </td>
                         <td>${access_rule.start_date}</td>

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -170,7 +170,7 @@ export function InstructorAssessmentInstance({
                         <td colspan="2">
                           ${resLocals.assessment_instance.client_fingerprint_id_change_count}
                           <button
-                          type="button
+                            type="button"
                             class="btn btn-xs"
                             id="fingerprintDescriptionPopover"
                             data-toggle="popover"

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -169,19 +169,18 @@ export function InstructorAssessmentInstance({
                         <th>Fingerprint Changes</th>
                         <td colspan="2">
                           ${resLocals.assessment_instance.client_fingerprint_id_change_count}
-                          <a
-                            tabindex="0"
+                          <button
+                          type="button
                             class="btn btn-xs"
-                            role="button"
                             id="fingerprintDescriptionPopover"
                             data-toggle="popover"
                             data-container="body"
                             data-html="false"
                             title="Client Fingerprint Changes"
                             aria-label="Client Fingerprint Changes"
-                            data-content="Client fingerprints are a record of a user's IP address, user agent and sesssion. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
+                            data-content="Client fingerprints are a record of a user's IP address, user agent and session. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
                             ><i class="fa fa-question-circle"></i
-                          ></a>
+                          ></button>
                         </td>
                       </tr>
                     `
@@ -258,31 +257,31 @@ export function InstructorAssessmentInstance({
                     ${resLocals.assessment_instance.include_in_statistics
                       ? html`
                           Included
-                          <a
-                            tabindex="0"
+                          <button
+                            type="button"
                             class="btn btn-xs"
-                            role="button"
                             data-toggle="popover"
                             data-container="body"
                             data-html="true"
                             title="Included in statistics"
                             data-content="This assessment is included in the calculation of assessment and question statistics"
-                            ><i class="fa fa-question-circle"></i
-                          ></a>
+                          >
+                            <i class="fa fa-question-circle"></i>
+                          </button>
                         `
                       : html`
                           Not included
-                          <a
-                            tabindex="0"
+                          <button
+                            type="button"
                             class="btn btn-xs"
-                            role="button"
                             data-toggle="popover"
                             data-container="body"
                             data-html="true"
                             title="Not included in statistics"
                             data-content="This assessment is not included in the calculation of assessment and question statistics because it was created by a course staff member"
-                            ><i class="fa fa-question-circle"></i
-                          ></a>
+                          >
+                            <i class="fa fa-question-circle"></i>
+                          </button>
                         `}
                   </td>
                 </tr>
@@ -580,12 +579,11 @@ export function InstructorAssessmentInstance({
                         ? row.client_fingerprint && row.client_fingerprint_number !== null
                           ? html`
                               <td>
-                                <a
-                                  tabindex="0"
+                                <button
+                                  type="button"
                                   class="badge color-${FINGERPRINT_COLORS[
                                     row.client_fingerprint_number % 6
                                   ]} color-hover"
-                                  role="button"
                                   id="fingerprintPopover${row.client_fingerprint?.id}-${index}"
                                   data-toggle="popover"
                                   data-container="body"
@@ -608,7 +606,7 @@ export function InstructorAssessmentInstance({
                                   `)}"
                                 >
                                   ${row.client_fingerprint_number}
-                                </a>
+                                </button>
                               </td>
                             `
                           : html`<td>&mdash;</td>`

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -179,8 +179,9 @@ export function InstructorAssessmentInstance({
                             title="Client Fingerprint Changes"
                             aria-label="Client Fingerprint Changes"
                             data-content="Client fingerprints are a record of a user's IP address, user agent and session. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
-                            ><i class="fa fa-question-circle"></i
-                          ></button>
+                          >
+                            <i class="fa fa-question-circle"></i>
+                          </button>
                         </td>
                       </tr>
                     `

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.ts
@@ -218,7 +218,7 @@ function FingerprintChangesHelpModal() {
     title: 'Client Fingerprints',
     body: html`
       <p>
-        Client fingerprints are a record of a user's IP address, user agent and sesssion. These
+        Client fingerprints are a record of a user's IP address, user agent and session. These
         attributes are tracked while a user is accessing an assessment. This value indicates the
         amount of times that those attributes changed as the student accessed the assessment, while
         the assessment was active. Some changes may naturally occur during an assessment, such as if

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.html.ts
@@ -62,7 +62,6 @@ export function InstructorCourseAdminInstances({
                       <button
                         class="btn btn-xs btn-light"
                         data-toggle="popover"
-                        data-trigger="focus"
                         data-container="body"
                         data-placement="bottom"
                         data-html="true"
@@ -78,7 +77,6 @@ export function InstructorCourseAdminInstances({
                       <button
                         class="btn btn-xs btn-light"
                         data-toggle="popover"
-                        data-trigger="focus"
                         data-container="body"
                         data-placement="bottom"
                         data-html="true"

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -88,19 +88,17 @@ function AccessRuleRow({
             hasCourseInstancePermissionView
             ? accessRule.uids.join(', ')
             : html`
-                <a
-                  role="button"
+                <button
+                  type="button"
                   class="btn btn-xs btn-warning"
-                  tabindex="0"
                   data-toggle="popover"
-                  data-trigger="focus"
                   data-container="body"
                   data-placement="auto"
                   title="Hidden UIDs"
                   data-content="This access rule is specific to individual students. You need permission to view student data in order to see which ones."
                 >
                   Hidden
-                </a>
+                </button>
               `}
       </td>
       <td>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.ts
@@ -164,12 +164,10 @@ function LtiCredentialsCard({
                     <td>
                       ${tc.deleted ||
                       html`
-                        <a
-                          tabindex="0"
+                        <button
+                          type="button"
                           class="btn btn-sm btn-danger"
-                          role="button"
                           data-toggle="popover"
-                          data-trigger="focus"
                           data-container="body"
                           data-html="true"
                           data-placement="auto"
@@ -184,7 +182,7 @@ function LtiCredentialsCard({
                           `)}"
                         >
                           Delete
-                        </a>
+                        </button>
                       `}
                     </td>
                   </tr>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -261,15 +261,15 @@ function IssueRow({
                   (<a href="${questionPreviewUrl}?variant_seed=${issue.variant_seed}"
                     >instructor view</a
                   >)
-                  <a
-                    tabindex="0"
+                  <button
+                    type="button"
                     class="badge badge-warning badge-sm"
                     data-toggle="tooltip"
                     data-html="true"
                     title="This issue was raised in course instance <strong>${issue.course_instance_short_name}</strong>. You do not have student data access for ${issue.course_instance_short_name}, so you can't view some of the issue details. Student data access can be granted by a course owner on the Staff page."
                   >
                     No student data access
-                  </a>
+                  </button>
                 `}
         </div>
         <p class="mb-0">${getFormattedMessage(issue)}</p>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -630,18 +630,16 @@ function ZoneInfoBadge({
   mainContent: string;
 }) {
   return html`
-    <a
-      tabindex="0"
+    <button
+      type="button"
       class="btn btn-xs btn-secondary badge badge-secondary text-white font-weight-normal py-1"
-      role="button"
       data-toggle="popover"
-      data-trigger="focus"
       data-container="body"
       data-html="true"
       data-content="${popoverContent}"
     >
       ${mainContent}&nbsp;<i class="far fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
   `;
 }
 
@@ -670,12 +668,10 @@ function RowLabel({
     ${lockedPopoverText != null
       ? html`
           <span class="text-muted">${rowLabelText}</span>
-          <a
-            tabindex="0"
+          <button
+            type="button"
             class="btn btn-xs border text-secondary ml-1"
-            role="button"
             data-toggle="popover"
-            data-trigger="focus"
             data-container="body"
             data-html="true"
             data-content="${lockedPopoverText}"
@@ -683,26 +679,24 @@ function RowLabel({
             aria-label="Locked"
           >
             <i class="fas fa-lock" aria-hidden="true"></i>
-          </a>
+          </button>
         `
       : html`
           <a href="${urlPrefix}/instance_question/${instance_question.id}/">${rowLabelText}</a>
         `}
     ${instance_question.file_count > 0
       ? html`
-          <a
-            tabindex="0"
+          <button
+            type="button"
             class="btn btn-xs border text-secondary ml-1"
-            role="button"
             data-toggle="popover"
-            data-trigger="focus"
             data-container="body"
             data-html="true"
             data-content="Personal notes: ${instance_question.file_count}"
             aria-label="Has personal note attachments"
           >
             <i class="fas fa-paperclip"></i>
-          </a>
+          </button>
         `
       : ''}
   `;
@@ -710,11 +704,9 @@ function RowLabel({
 
 function ExamQuestionHelpBestSubmission() {
   return html`
-    <a
-      tabindex="0"
-      role="button"
+    <button
+      type="button"
       data-toggle="popover"
-      data-trigger="focus"
       data-container="body"
       data-html="true"
       data-placement="auto"
@@ -722,17 +714,15 @@ function ExamQuestionHelpBestSubmission() {
       data-content="The percentage score of the best submitted answer, or whether the question is <strong>unanswered</strong>, has a <strong>saved</strong> but ungraded answer, or is in <strong>grading</strong>."
     >
       <i class="far fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
   `;
 }
 
 function ExamQuestionHelpAvailablePoints() {
   return html`
-    <a
-      tabindex="0"
-      role="button"
+    <button
+      type="button"
       data-toggle="popover"
-      data-trigger="focus"
       data-container="body"
       data-html="true"
       data-placement="auto"
@@ -740,17 +730,15 @@ function ExamQuestionHelpAvailablePoints() {
       data-content="The number of points that would be earned for a 100% correct answer on the next attempt. If retries are available for the question then a list of further points is shown, where the <i>n</i>-th value is the number of points that would be earned for a 100% correct answer on the <i>n</i>-th attempt."
     >
       <i class="far fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
   `;
 }
 
 function ExamQuestionHelpAwardedPoints() {
   return html`
-    <a
-      tabindex="0"
-      role="button"
+    <button
+      type="button"
       data-toggle="popover"
-      data-trigger="focus"
       data-container="body"
       data-html="true"
       data-placement="auto"
@@ -758,7 +746,7 @@ function ExamQuestionHelpAwardedPoints() {
       data-content="The number of points already earned, as a fraction of the maximum possible points for the question."
     >
       <i class="far fa-question-circle" aria-hidden="true"></i>
-    </a>
+    </button>
   `;
 }
 

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -137,19 +137,17 @@ export function Workspace({
                     `
                   : null}
                 <li class="nav-item ml-2 ml-md-3 my-1">
-                  <a
-                    tabindex="0"
+                  <button
                     type="button"
                     class="nav-item btn btn-light"
                     data-toggle="popover"
-                    data-trigger="focus"
                     data-container="body"
                     data-placement="bottom"
                     data-html="true"
                     data-content="${escapeHtml(HelpButtonContents())}"
                   >
                     <i class="fas fa-question-circle text-secondary" aria-hidden="true"></i>
-                  </a>
+                  </button>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
Focus-triggered popovers have been a frequent source of strange UX issues, accessibility problems, and browser-specific bugs. Using clicks (and/or <kbd>Enter</kbd> and <kbd>Space</kbd>) to open and dismiss popovers should provide for a more reliable and consistent experience across the board.

Closes #6272.

> [!IMPORTANT]
> Please pay close attention to and check for the following while reviewing:
> - Ensure that all `<button>` tags have `type="button"`
> - Ensure that all opening/closing tags match