### PR TITLE
Allow for Owner to be added at the Add User level

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -284,6 +284,7 @@ function CoursePermissionsInsertForm({
           <option value="Previewer">Previewer</option>
           <option value="Viewer">Viewer</option>
           <option value="Editor">Editor</option>
+          <option value="Owner">Owner</option>
         </select>
       </div>
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
@@ -99,9 +99,8 @@ router.post(
       // Verify there is at least one UID
       if (uids.length === 0) throw new error.HttpStatusError(400, 'Empty list of UIDs');
 
-      // Verify the requested course role is valid - we choose to disallow Owner
-      // because we want to discourage the assignment of this role to many users
-      if (!['None', 'Previewer', 'Viewer', 'Editor'].includes(req.body.course_role)) {
+      // Verify the requested course role is valid
+      if (!['None', 'Previewer', 'Viewer', 'Editor', 'Owner'].includes(req.body.course_role)) {
         throw new error.HttpStatusError(
           400,
           `Invalid requested course role: ${req.body.course_role}`,

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
@@ -114,31 +114,6 @@ function runTest(context) {
     await checkPermissions(users);
   });
 
-  step('cannot add multiple users with owner role', async () => {
-    let response = await helperClient.fetchCheerio(context.pageUrl, {
-      headers,
-    });
-    assert.isTrue(response.ok);
-    helperClient.extractAndSaveCSRFTokenFromDataContent(
-      context,
-      response.$,
-      'button[data-testid="add-users-button"]',
-    );
-    const form = {
-      __action: 'course_permissions_insert_by_user_uids',
-      __csrf_token: context.__csrf_token,
-      uid: ' staff03@example.com ,   ,   staff04@example.com',
-      course_role: 'Owner',
-    };
-    response = await helperClient.fetchCheerio(context.pageUrl, {
-      method: 'POST',
-      form,
-      headers,
-    });
-    assert.equal(response.status, 400);
-    await checkPermissions(users);
-  });
-
   step('can add multiple users', async () => {
     let response = await helperClient.fetchCheerio(context.pageUrl, {
       headers,


### PR DESCRIPTION
As discussed on Slack, allowing Owner to be added through the add user dialogue instead of requiring a second step to do this.

> IIRC at some point there was a second button for adding a single user which did allow one to set a user up as an Owner in one step. A while ago we collapsed the single + multiple user case into the form that's currently there. In light of that, I'm happy to remove this check and make "Owner" an option there. - Nathan

I left the if statement there in case changes are made in the future or if something breaks it will act as a fail safe. Please let me know if this is the right process for this change or if I need to make any changes.