### PR TITLE
Remove submission status from homework question score panel

### DIFF
--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -54,10 +54,14 @@ export function QuestionScorePanel({
       </div>
       <table class="table table-sm two-column-description-no-header" aria-label="Question score">
         <tbody>
-          <tr>
-            <td>Submission status:</td>
-            <td>${ExamQuestionStatus({ instance_question })}</td>
-          </tr>
+          ${assessment.type === 'Exam'
+            ? html`
+                <tr>
+                  <td>Submission status:</td>
+                  <td>${ExamQuestionStatus({ instance_question })}</td>
+                </tr>
+              `
+            : ''}
           ${assessment.allow_real_time_grading &&
           (assessment_question.max_auto_points || !assessment_question.max_manual_points)
             ? html`


### PR DESCRIPTION
Part of #10667.

@mwest1066 I didn't actually have this change in our notes from our conversation last week, but I do think we want to drop this:

- This removes a green thing from the panel that could be misinterpreted as "I'm all done!"
- We don't show this on the assessment instance page, and in general we're trying to always show the same information on both that page and the individual question pages.

Does that all sound correct?