### PR TITLE
Remove references to unsupported server file directories

### DIFF
--- a/apps/prairielearn/src/lib/instructorFiles.ts
+++ b/apps/prairielearn/src/lib/instructorFiles.ts
@@ -12,7 +12,7 @@ export interface InstructorFilePaths {
   invalidRootPaths: string[];
   cannotMove: string[];
   clientDir: string;
-  serverDir: string;
+  serverDir?: string;
   testsDir?: string;
   urlPrefix: string;
   workingPath: string;
@@ -61,7 +61,6 @@ function getContextPaths(
       invalidRootPaths: [path.join(rootPath, 'assessments')],
       cannotMove: [path.join(rootPath, 'infoCourseInstance.json')],
       clientDir: path.join(rootPath, 'clientFilesCourseInstance'),
-      serverDir: path.join(rootPath, 'serverFilesCourseInstance'),
       urlPrefix: `${locals.urlPrefix}/instance_admin`,
     };
   } else if (locals.navPage === 'assessment') {
@@ -77,7 +76,6 @@ function getContextPaths(
       invalidRootPaths: [],
       cannotMove: [path.join(rootPath, 'infoAssessment.json')],
       clientDir: path.join(rootPath, 'clientFilesAssessment'),
-      serverDir: path.join(rootPath, 'serverFilesAssessment'),
       urlPrefix: `${locals.urlPrefix}/assessment/${locals.assessment.id}`,
     };
   } else if (locals.navPage === 'question') {
@@ -87,7 +85,6 @@ function getContextPaths(
       invalidRootPaths: [],
       cannotMove: [path.join(rootPath, 'info.json')],
       clientDir: path.join(rootPath, 'clientFilesQuestion'),
-      serverDir: path.join(rootPath, 'serverFilesQuestion'),
       testsDir: path.join(rootPath, 'tests'),
       urlPrefix: `${locals.urlPrefix}/question/${locals.question.id}`,
     };
@@ -125,36 +122,37 @@ export function getPaths(
   const workingDirectory = path.dirname(workingPathRelativeToCourse);
   const workingFilename = path.basename(workingPathRelativeToCourse);
 
-  const specialDirs =
-    workingPath === rootPath
-      ? [
-          {
-            label: 'Client',
-            path: clientDir,
-            info: html`This file will be placed in the subdirectory
-              <code>${path.basename(clientDir)}</code> and will be accessible from the student's web
-              browser.`,
-          },
-          {
-            label: 'Server',
-            path: serverDir,
-            info: html`This file will be placed in the subdirectory
-              <code>${path.basename(serverDir)}</code> and will be accessible only from the server.
-              It will not be accessible from the student's web browser.`,
-          },
-        ]
-      : [];
-  if (workingPath === rootPath && testsDir) {
+  const specialDirs: InstructorFilePaths['specialDirs'] = [];
+  if (workingPath === rootPath) {
     specialDirs.push({
-      label: 'Test',
-      path: testsDir,
+      label: 'Client',
+      path: clientDir,
       info: html`This file will be placed in the subdirectory
-        <code>${path.basename(testsDir)}</code> and will be accessible only from the server. It will
-        not be accessible from the student's web browser. This is appropriate for code to support
-        <a href="https://prairielearn.readthedocs.io/en/latest/externalGrading/">
-          externally graded questions</a
-        >.`,
+        <code>${path.basename(clientDir)}</code> and will be accessible from the student's web
+        browser.`,
     });
+    if (serverDir) {
+      specialDirs.push({
+        label: 'Server',
+        path: serverDir,
+        info: html`This file will be placed in the subdirectory
+          <code>${path.basename(serverDir)}</code> and will be accessible only from the server. It
+          will not be accessible from the student's web browser.`,
+      });
+    }
+    if (testsDir) {
+      specialDirs.push({
+        label: 'Test',
+        path: testsDir,
+        info: html`This file will be placed in the subdirectory
+          <code>${path.basename(testsDir)}</code> and will be accessible only from the server. It
+          will not be accessible from the student's web browser. This is appropriate for code to
+          support
+          <a href="https://prairielearn.readthedocs.io/en/latest/externalGrading/">
+            externally graded questions</a
+          >.`,
+      });
+    }
   }
 
   if (!contains(rootPath, workingPath)) {

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -224,7 +224,6 @@ const verifyFileData = [
     url: courseInstanceQuestionUrl + '/file_view',
     path: questionPath,
     clientFilesDir: 'clientFilesQuestion',
-    serverFilesDir: 'serverFilesQuestion',
     testFilesDir: 'tests',
   },
   {
@@ -232,14 +231,12 @@ const verifyFileData = [
     url: assessmentUrl + '/file_view',
     path: assessmentPath,
     clientFilesDir: 'clientFilesAssessment',
-    serverFilesDir: 'serverFilesAssessment',
   },
   {
     title: 'course instance',
     url: courseInstanceInstanceAdminUrl + '/file_view',
     path: courseInstancePath,
     clientFilesDir: 'clientFilesCourseInstance',
-    serverFilesDir: 'serverFilesCourseInstance',
   },
   {
     title: 'course (through course instance)',
@@ -758,7 +755,7 @@ function doFiles(data: {
   url: string;
   path: string;
   clientFilesDir: string;
-  serverFilesDir: string;
+  serverFilesDir?: string;
   testFilesDir?: string;
 }) {
   describe(`test file handlers for ${data.title}`, function () {
@@ -823,34 +820,36 @@ function doFiles(data: {
       });
     });
     describe('Server Files', function () {
-      testUploadFile({
-        fileViewBaseUrl: data.url,
-        url: data.url,
-        path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
-        newButtonId: 'NewServer',
-        contents: 'This is a line of text.',
-        filename: 'testfile.txt',
-      });
+      if (data.serverFilesDir) {
+        testUploadFile({
+          fileViewBaseUrl: data.url,
+          url: data.url,
+          path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
+          newButtonId: 'NewServer',
+          contents: 'This is a line of text.',
+          filename: 'testfile.txt',
+        });
 
-      testUploadFile({
-        fileViewBaseUrl: data.url,
-        url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
-        path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
-        contents: 'This is a different line of text.',
-        filename: 'anotherfile.txt',
-      });
+        testUploadFile({
+          fileViewBaseUrl: data.url,
+          url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
+          path: path.join(data.path, data.serverFilesDir, 'testfile.txt'),
+          contents: 'This is a different line of text.',
+          filename: 'anotherfile.txt',
+        });
 
-      testRenameFile({
-        url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
-        path: path.join(data.path, data.serverFilesDir, 'subdir', 'testfile.txt'),
-        contents: 'This is a different line of text.',
-        new_file_name: path.join('subdir', 'testfile.txt'),
-      });
+        testRenameFile({
+          url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir)),
+          path: path.join(data.path, data.serverFilesDir, 'subdir', 'testfile.txt'),
+          contents: 'This is a different line of text.',
+          new_file_name: path.join('subdir', 'testfile.txt'),
+        });
 
-      testDeleteFile({
-        url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir, 'subdir')),
-        path: path.join(data.path, data.serverFilesDir, 'subdir', 'testfile.txt'),
-      });
+        testDeleteFile({
+          url: data.url + '/' + encodePath(path.join(data.path, data.serverFilesDir, 'subdir')),
+          path: path.join(data.path, data.serverFilesDir, 'subdir', 'testfile.txt'),
+        });
+      }
     });
     if (data.testFilesDir) {
       describe('Test Files', function () {

--- a/docs/clientServerFiles.md
+++ b/docs/clientServerFiles.md
@@ -8,7 +8,7 @@ There are multiple locations within each course where files can be stored for ac
 
 ## Directory layout
 
-The `clientFiles` subdirectory can be associated with the course, a question, a course instance, or an assessment, as shown below. The `serverFiles` subdirectory can be associated with the course.
+A `clientFiles*` subdirectory can be associated with the course, a question, a course instance, or an assessment, as shown below. The `serverFilesCourse` subdirectory is associated with the course as a whole.
 
 ```text
 exampleCourse
@@ -32,7 +32,7 @@ exampleCourse
 
 ## Access control
 
-Each different `clientFiles` directory is accessible under the same [access control rules](accessControl.md) for the course instances and assessments. That is, `clientFilesCourse` is accessible to any student who has access to some course instance, while `clientFilesQuestion`, `clientFilesCourseInstance`, and `clientFilesAssessment` are accessible to students with access to the corresponding question, course instance, or assessment.
+Each different `clientFiles*` directory is accessible under the same [access control rules](accessControl.md) for the course instances and assessments. That is, `clientFilesCourse` is accessible to any student who has access to some course instance, while `clientFilesQuestion`, `clientFilesCourseInstance`, and `clientFilesAssessment` are accessible to students with access to the corresponding question, course instance, or assessment.
 
 ## Accessing files from HTML templates
 

--- a/docs/clientServerFiles.md
+++ b/docs/clientServerFiles.md
@@ -8,7 +8,7 @@ There are multiple locations within each course where files can be stored for ac
 
 ## Directory layout
 
-The `clientFiles` and `serverFiles` subdirectories can be associated with the course, a question, a course instance, or an assessment, as shown below.
+The `clientFiles` subdirectory can be associated with the course, a question, a course instance, or an assessment, as shown below. The `serverFiles` subdirectory can be associated with the course.
 
 ```text
 exampleCourse
@@ -20,25 +20,19 @@ exampleCourse
 |   `-- fossilFuels
 |       +-- clientFilesQuestion           # client files for the fossilFuels question
 |       |   `-- power-station.jpg
-|       `-- serverFilesQuestion           # server files for the fossilFuels question
-|           `--
 `-- courseInstances
     `-- Fa16
        +-- clientFilesCourseInstance      # client files for the Fall 2016 course instance
        |   `-- Fa16_rules.pdf
-       +-- serverFilesCourseInstance
-       |   `-- secret2.js                 # server files for the Fall 2016 course instance
        `-- assessments
            `-- hw01
                `-- clientFilesAssessment  # client files for the Homework 1 assessment
                    `-- formulaSheet.pdf
-               `-- serverFilesAssessment  # server for the Homework 1 assessment
-                   `-- ...
 ```
 
 ## Access control
 
-Each different `clientFiles` or `serverFiles` directory is accessible under the same [access control rules](accessControl.md) for the course instances and assessments. That is, `clientFilesCourse` is accessible to any student who has access to some course instance, while `clientFilesQuestion`, `clientFilesCourseInstance`, and `clientFilesAssessment` are accessible to students with access to the corresponding question, course instance, or assessment.
+Each different `clientFiles` directory is accessible under the same [access control rules](accessControl.md) for the course instances and assessments. That is, `clientFilesCourse` is accessible to any student who has access to some course instance, while `clientFilesQuestion`, `clientFilesCourseInstance`, and `clientFilesAssessment` are accessible to students with access to the corresponding question, course instance, or assessment.
 
 ## Accessing files from HTML templates
 

--- a/docs/courseInstance.md
+++ b/docs/courseInstance.md
@@ -18,21 +18,17 @@ exampleCourse
     |   |       `-- ...               # files for Homework 2
     |   +-- clientFilesCourseInstance
     |   |   `-- Fa16_rules.pdf        # files for Fall 2016
-    |   `-- serverFilesCourseInstance
-    |       `-- secret2.js            # files only accessible from the server
     `-- Sp17
         +-- infoCourseInstance.json   # Spring 2017 configuration
         +-- assessments
         |   `-- ...                   # Spring 2017 assessments
         +-- clientFilesCourseInstance
         |   `-- ...                   # files for Spring 2017
-        `-- serverFilesCourseInstance
-            `-- ...                   # files only accessible from the server
 ```
 
 - See an [example course instances directory](https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances) in PrairieLearn
 
-- See [clientFiles and serverFiles](clientServerFiles.md) for information on the `clientFilesCourseInstance` and `serverFilesCourseInstance` directories.
+- See [clientFiles and serverFiles](clientServerFiles.md) for information on the `clientFilesCourseInstance` directory.
 
 ## `infoCourseInstance.json`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -164,7 +164,7 @@ Otherwise, for cheatsheets in `clientFilesAssessment`, use:
 
 To learn more about where files are stored, please see [clientFiles and serverFiles](clientServerFiles.md).
 
-## How can I reference material in `serverFilesQuestion` and `clientFilesQuestion` from the `server.py`?
+## How can I reference material in `clientFilesQuestion` from the `server.py`?
 
 To reference a question in the `clientFilesQuestion` folder from `server.py`,
 use the relative path from the base of the question.
@@ -173,7 +173,7 @@ use the relative path from the base of the question.
 ./clientFilesQuestion/<your_file_here>
 ```
 
-The same pattern holds for referencing material in a `serverFilesQuestion`.
+The same pattern holds for referencing material in any subdirectory of the question directory.
 
 To learn more about where files are stored, please see
 [clientFiles and serverFiles](https://prairielearn.readthedocs.io/en/latest/clientServerFiles/).

--- a/docs/questionSharing.md
+++ b/docs/questionSharing.md
@@ -41,7 +41,7 @@ To refer to a question from another course, use the question id (qid) prefixed b
 
 ## Client and server files
 
-Questions that make use of `clientFilesQuestion`, `serverFilesQuestion`, and `serverFilesCourse` will work as expected. Using `clientFilesCourse` in a question is not supported at this time.
+Questions that make use of `clientFilesQuestion` and `serverFilesCourse` will work as expected. Using `clientFilesCourse` in a question is not supported at this time.
 
 If a sharing course attempts to share a question which accesses client or server files associated with a course instance or an assessment, the question will not work as expected because the consuming course can not use it within the context of the sharing course's course instance or assessment.
 


### PR DESCRIPTION
serverFilesCourseInstance and serverFilesAssessment are not accessible through any means. The only code reference for these directories is in the file editor code, where it is used in the button for "Add server file", even though there isn't a use for that file in these contexts. serverFilesQuestion is in a similar boat, though it is accessible by question code already as a regular directory (i.e., it's not a special directory).

This PR removes references to these directories in the file editor, corresponding tests, and docs. 

