### PR TITLE
Fix popovers on assessment instance page

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -706,6 +706,7 @@ function ExamQuestionHelpBestSubmission() {
   return html`
     <button
       type="button"
+      class="btn btn-xs btn-ghost"
       data-toggle="popover"
       data-container="body"
       data-html="true"
@@ -713,7 +714,7 @@ function ExamQuestionHelpBestSubmission() {
       title="Best submission"
       data-content="The percentage score of the best submitted answer, or whether the question is <strong>unanswered</strong>, has a <strong>saved</strong> but ungraded answer, or is in <strong>grading</strong>."
     >
-      <i class="far fa-question-circle" aria-hidden="true"></i>
+      <i class="fa fa-question-circle" aria-hidden="true"></i>
     </button>
   `;
 }
@@ -722,6 +723,7 @@ function ExamQuestionHelpAvailablePoints() {
   return html`
     <button
       type="button"
+      class="btn btn-xs btn-ghost"
       data-toggle="popover"
       data-container="body"
       data-html="true"
@@ -729,7 +731,7 @@ function ExamQuestionHelpAvailablePoints() {
       title="Available points"
       data-content="The number of points that would be earned for a 100% correct answer on the next attempt. If retries are available for the question then a list of further points is shown, where the <i>n</i>-th value is the number of points that would be earned for a 100% correct answer on the <i>n</i>-th attempt."
     >
-      <i class="far fa-question-circle" aria-hidden="true"></i>
+      <i class="fa fa-question-circle" aria-hidden="true"></i>
     </button>
   `;
 }
@@ -738,6 +740,7 @@ function ExamQuestionHelpAwardedPoints() {
   return html`
     <button
       type="button"
+      class="btn btn-xs btn-ghost"
       data-toggle="popover"
       data-container="body"
       data-html="true"
@@ -745,7 +748,7 @@ function ExamQuestionHelpAwardedPoints() {
       title="Awarded points"
       data-content="The number of points already earned, as a fraction of the maximum possible points for the question."
     >
-      <i class="far fa-question-circle" aria-hidden="true"></i>
+      <i class="fa fa-question-circle" aria-hidden="true"></i>
     </button>
   `;
 }


### PR DESCRIPTION
These buttons were missing Bootstrap `btn` classes, which caused problems with the changes from #10672. This PR adds the new `btn-ghost` style from #10671.

Before:

<img width="704" alt="Screenshot 2024-09-19 at 12 38 41" src="https://github.com/user-attachments/assets/e6751296-3cbb-4680-a48a-16cf8c3bae5d">

After:

<img width="673" alt="Screenshot 2024-09-19 at 12 41 55" src="https://github.com/user-attachments/assets/cdbc46ed-2040-4345-858b-76de38b95a1c">

