### PR TITLE
Remove Shibboleth from authentication docs

### DIFF
--- a/docs/running-in-production/authentication.md
+++ b/docs/running-in-production/authentication.md
@@ -3,23 +3,20 @@
 PrairieLearn currently has a few ways to do user authentication.
 
 - [Google OAuth 2](#google-oauth-2)
-- [Shibboleth](#shibboleth)
 - [LTI](../courseInstance.md#lti-overview)
 
 ## Google OAuth 2
 
-Take a look in `apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.js` and `apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.js` to get an idea of what variables you need to modify.
-
-To start create a [Google Cloud account](https://cloud.google.com/) and then:
+To start, create a [Google Cloud account](https://cloud.google.com/) and then:
 
 - Click [console](https://console.cloud.google.com/) to login to your console.
 - Create a project then got to [APIs & Services](https://console.cloud.google.com/apis/dashboard).
   - Go to `OAuth consent screen` and complete the consent form.
   - Proceed to `Credentials` and create a new `OAuth client ID`.
   - Select `Web application`.
-  - Under Authorized JavaScript origins, click `ADD URI` and add in your domain address.
-  - Under Authorized redirect URIs, click `ADD URI` and add `https://yourdomain/pl/oauth2callback` which is the route to the Google OAuth callback.
-  - Click `Create` which will give you a `Client ID` and a `Client Secret`. **WARNING: DO NOT UPLOAD THESE KEYS ANYWHERE**
+  - Under Authorized JavaScript origins, click `ADD URI` and add your domain.
+  - Under Authorized redirect URIs, click `ADD URI` and add `https://yourdomain.com/pl/oauth2callback` which is the route to the Google OAuth callback.
+  - Click `Create` which will give you a `Client ID` and a `Client Secret`. **Keep these values secret.**
 
 Now add the keys to `config.json`:
 
@@ -27,16 +24,12 @@ Now add the keys to `config.json`:
 {
   "googleClientId": "Your Client ID key",
   "googleClientSecret": "Your Client Secret key",
-  "googleRedirectUrl": "https://yourdomain/pl/oauth2callback",
+  "googleRedirectUrl": "https://yourdomain.com/pl/oauth2callback",
   "hasOauth": true
 }
 ```
 
-That's it, you should be up and running with Google OAuth 2!
-
-## Shibboleth
-
-Take a look in `apps/prairielearn/src/pages/authCallbackShib/authCallbackShib.js` to get a sense of what headers you will need your reverse proxy to pass.
+You should now be able to use Google to log in to your PrairieLearn instance.
 
 ## LTI
 


### PR DESCRIPTION
The existing information isn't very useful, Shibboleth is no longer officially supported in PrairieLearn, and we plan to eventually remove that code entirely.