### PR TITLE
Specify Node version and database creation in native install docs

### DIFF
--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -5,7 +5,7 @@ This page describes the procedure to install and run PrairieLearn without any us
 - Install the prerequisites:
 
   - [Git](https://git-scm.com)
-  - [Node.js](https://nodejs.org)
+  - [Node.js 20](https://nodejs.org)
   - [Yarn](https://classic.yarnpkg.com)
   - [Python 3.10](https://www.python.org)
   - [PostgreSQL 15](https://www.postgresql.org)
@@ -51,6 +51,7 @@ This page describes the procedure to install and run PrairieLearn without any us
   ```sh
   psql -c "CREATE USER postgres;"
   psql -c "ALTER USER postgres WITH SUPERUSER;"
+  createdb postgres
   ```
 
 - Run the test suite:


### PR DESCRIPTION
We rely on Node 20 for things like [`import.meta.dirname`](https://nodejs.org/api/esm.html#importmetadirname).

If the `postgres` user didn't already exist, creating a database is necessary.