### PR TITLE
Fix checkboxes for closing issues while manual grading

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -120,9 +120,9 @@ ${submission.feedback?.manual}</textarea
         ${open_issues.length > 0 && context !== 'existing'
           ? html`
               <li class="list-group-item">
-                <div class="form-check">
-                  ${open_issues.map(
-                    (issue) => html`
+                ${open_issues.map(
+                  (issue) => html`
+                    <div class="form-check">
                       <input
                         type="checkbox"
                         id="close-issue-checkbox-${issue.id}"
@@ -133,9 +133,9 @@ ${submission.feedback?.manual}</textarea
                       <label class="w-100 form-check-label" for="close-issue-checkbox-${issue.id}">
                         Close issue #${issue.id}
                       </label>
-                    `,
-                  )}
-                </div>
+                    </div>
+                  `,
+                )}
               </li>
             `
           : ''}


### PR DESCRIPTION
I think this broke during the Bootstrap 5 upgrade. Before this PR, the checkboxes for every issue would have appeared stacked on top of each other, making them impossible to click:

<img width="200" alt="Screenshot 2024-09-25 at 10 07 42" src="https://github.com/user-attachments/assets/7405515e-ba5f-4b35-b603-555c8ce538f3">

Now, they're displayed correctly:

<img width="192" alt="Screenshot 2024-09-25 at 10 08 44" src="https://github.com/user-attachments/assets/ca643ffa-4cba-486f-a745-76a41ab63dc6">
