### PR TITLE
Fix MathJax typesetting race

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -8,7 +8,7 @@ declare global {
   }
 }
 
-const mathjaxPromise = new Promise<void>((resolve) => {
+const mathjaxPromise = new Promise<void>((resolve, reject) => {
   window.MathJax = {
     options: {
       // We previously documented the `tex2jax_ignore` class, so we'll keep
@@ -59,8 +59,10 @@ const mathjaxPromise = new Promise<void>((resolve) => {
         };
       },
       pageReady: () => {
-        window.MathJax.startup.defaultPageReady();
-        resolve();
+        return window.MathJax.startup.defaultPageReady().then(
+          () => resolve(),
+          (err: any) => reject(err),
+        );
       },
     },
   };

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -124,7 +124,7 @@ window.PLFileEditor.prototype.updatePreview = async function (preview_type) {
       sanitized_contents.includes('\\[') ||
       sanitized_contents.includes('\\]')
     ) {
-      MathJax.typesetPromise();
+      MathJax.typesetPromise([preview]);
     }
   }
 };

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
@@ -140,7 +140,7 @@
                     notebookPreview.classList.remove('d-none');
 
                     // Typeset any math that might be in the notebook.
-                    window.MathJax.typesetPromise();
+                    window.MathJax.typesetPromise([notebookPreview]);
                   });
                 } else {
                   code.textContent = text;


### PR DESCRIPTION
#10692 uncovered an issue with the MathJax typesetting process: `<pl-file-editor>` typesetting would in some cases race against the initial global typesetting that MathJax does once it has loaded. This race meant that typesetting was performed before the [`braket` extension](https://docs.mathjax.org/en/latest/input/tex/extensions/braket.html) that handles `\set{...}` had loaded.

The solution is to avoid running any "custom" typesetting until the page as a whole has been typeset. This is achieved by waiting for the Promise returned from `MathJax.startup.defaultPageReady()` to resolve. MathJax even mentions some of this in its documentation: https://docs.mathjax.org/en/latest/web/configuration.html#performing-actions-after-typesetting

While I was here, I updated elements to typeset only the element they care about, as this should be more efficient than typesetting the entire page.

Closes #10692.