### PR TITLE
Add course and course instance links to institution admin course page

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -126,6 +126,7 @@ export function AdministratorInstitutionCourse({
               Save
             </button>
           </form>
+          <p><a href="/pl/course/${course.id}/">Course instructor view</a></p>
 
           <h2 class="h4">Course instances</h2>
           <div class="table-responsive">
@@ -148,8 +149,12 @@ export function AdministratorInstitutionCourse({
                         <a
                           href="/pl/administrator/institution/${institution.id}/course_instance/${course_instance.id}"
                         >
-                          ${course_instance.short_name ?? '—'}: ${course_instance.long_name ?? '—'}
-                        </a>
+                          ${course_instance.short_name ?? '—'}:
+                          ${course_instance.long_name ?? '—'}</a
+                        >
+                        (<a href="/pl/course_instance/${course_instance.id}/instructor"
+                          >instructor view</a
+                        >)
                       </td>
                       <td>${enrollment_count}</td>
                       <td>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -50,6 +50,8 @@ export function AdministratorInstitutionCourse({
           </ol>
         </nav>
         <main id="content" class="container mb-4">
+          <p><a href="/pl/course/${course.id}">View as instructor</a></p>
+
           <h2 class="h4">Limits</h2>
           <form method="POST" class="mb-3">
             <div class="form-group">
@@ -126,7 +128,6 @@ export function AdministratorInstitutionCourse({
               Save
             </button>
           </form>
-          <p><a href="/pl/course/${course.id}/">Course instructor view</a></p>
 
           <h2 class="h4">Course instances</h2>
           <div class="table-responsive">
@@ -149,12 +150,8 @@ export function AdministratorInstitutionCourse({
                         <a
                           href="/pl/administrator/institution/${institution.id}/course_instance/${course_instance.id}"
                         >
-                          ${course_instance.short_name ?? '—'}:
-                          ${course_instance.long_name ?? '—'}</a
-                        >
-                        (<a href="/pl/course_instance/${course_instance.id}/instructor"
-                          >instructor view</a
-                        >)
+                          ${course_instance.short_name ?? '—'}: ${course_instance.long_name ?? '—'}
+                        </a>
                       </td>
                       <td>${enrollment_count}</td>
                       <td>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.ts
@@ -57,6 +57,10 @@ export function AdministratorInstitutionCourseInstance({
           </ol>
         </nav>
         <main id="content" class="container mb-4">
+          <p>
+            <a href="/pl/course_instance/${course_instance.id}/instructor">View as instructor</a>
+          </p>
+
           <h2 class="h4">Limits</h2>
           <form method="POST" class="mb-3">
             <div class="form-group">

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.ts
@@ -21,18 +21,15 @@ const router = Router({ mergeParams: true });
 
 async function selectCourseInstanceAndCourseInInstitution({
   institution_id,
-  unsafe_course_id,
   unsafe_course_instance_id,
 }: {
   institution_id: string;
-  unsafe_course_id: string;
   unsafe_course_instance_id: string;
 }) {
   return await queryRow(
     sql.select_course_and_instance,
     {
       institution_id,
-      course_id: unsafe_course_id,
       course_instance_id: unsafe_course_instance_id,
     },
     z.object({
@@ -48,7 +45,6 @@ router.get(
     const institution = await getInstitution(req.params.institution_id);
     const { course, course_instance } = await selectCourseInstanceAndCourseInInstitution({
       institution_id: req.params.institution_id,
-      unsafe_course_id: req.params.course_id,
       unsafe_course_instance_id: req.params.course_instance_id,
     });
     const planGrants = await getPlanGrantsForCourseInstance({
@@ -72,7 +68,6 @@ router.post(
   asyncHandler(async (req, res) => {
     const { course_instance } = await selectCourseInstanceAndCourseInInstitution({
       institution_id: req.params.institution_id,
-      unsafe_course_id: req.params.course_id,
       unsafe_course_instance_id: req.params.course_instance_id,
     });
 


### PR DESCRIPTION
I noticed from the institutional admin view we didn't have an easy way to link into the courses or courses instances. This PR add links near the bottom of the page.

![image](https://github.com/user-attachments/assets/6cdcd95f-b47a-412f-ab35-9d34aa70c48a)
