### PR TITLE
Fix retries for LTI 1.3 fetches

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -517,21 +517,19 @@ export async function fetchRetry(
         data: {
           status: response.status,
           statusText: response.statusText,
-          body: response.text(),
+          body: await response.text(),
         },
       });
     }
 
-    const parsed = parseLinkHeader(response.headers.get('link')) ?? {};
-    if ('next' in parsed) {
-      const results = await response.json();
+    const results = await response.json();
 
-      if (Array.isArray(results)) {
-        return results.concat(await fetchRetry(parsed.next.url, opts, fetchRetryOpts));
-      }
+    const parsed = parseLinkHeader(response.headers.get('link')) ?? {};
+    if ('next' in parsed && Array.isArray(results)) {
+      return results.concat(await fetchRetry(parsed.next.url, opts, fetchRetryOpts));
     }
 
-    return await response.json();
+    return results;
   } catch (err) {
     fetchRetryOpts.retryLeft -= 1;
     if (fetchRetryOpts.retryLeft === 0) {


### PR DESCRIPTION
This failed while reading `https://umich.instructure.com/api/lti/courses/709940/names_and_roles`.

The `names_and_roles` endpoint returns something that is not a top-level array (docs: https://canvas.instructure.com/doc/api/names_and_role.html#NamesAndRoleMemberships):

```json
{
  "id": "https://example.instructure.com/api/lti/courses/1/names_and_roles?tlid=f91ca4d8-fa84-4a9b-b08e-47d5527416b0",
  "context": {"id":"4dde05e8ca1973bcca9bffc13e1548820eee93a3","label":"CS-101","title":"Computer Science 101"},
  "members": [...]
}
```

@trombonekenny I'm going to guess that in your testing, you never actually tested a course with enough members where pagination kicked in, is that correct?

This PR doesn't aim to address the above issue, but it will stop this particular crash and hopefully better reveal the actual underlying issue.