### PR TITLE
Tweak documentation for self-hosting

### DIFF
--- a/docs/running-in-production/docker-compose.md
+++ b/docs/running-in-production/docker-compose.md
@@ -1,5 +1,7 @@
 # Using Docker Compose
 
+This page documents the basic steps to use Docker Compose to run PrairieLearn. It does not cover vital information for production usage such as database backups or high availability.
+
 ## Getting started
 
 Follow the steps to [install PrairieLearn with local source code](../installingLocal.md). Then run this command in the root folder:
@@ -21,15 +23,15 @@ PrairieLearn can be configured by a `config.json` in the root of the repository.
   - ./config.json:/PrairieLearn/config.json
   ```
 
-The `config.json` file should contain appropriate overrides for the keys in [`lib/config.ts`](`https://github.com/PrairieLearn/PrairieLearn/blob/master/apps/prairielearn/src/lib/config.ts`). At a minimum, you'll probably want to update the various `postgres*` options to point it at your database.
+The `config.json` file should contain appropriate overrides for the keys in [`lib/config.ts`](https://github.com/PrairieLearn/PrairieLearn/blob/master/apps/prairielearn/src/lib/config.ts).
 
 ## Reverse Proxy
 
-For implementing a reverse proxy read more [here](./setup.md#reverse-proxy).
+Read more about implementing a reverse proxy in the [general setup documentation](./setup.md#reverse-proxy).
 
 ## Authentication
 
-PrairieLearn currently has 4 ways to do user authentication. Read more at [authentication](./authentication.md).
+Read more in the [authentication documentation](./authentication.md).
 
 ## Admin User
 

--- a/docs/running-in-production/setup.md
+++ b/docs/running-in-production/setup.md
@@ -2,6 +2,8 @@
 
 As the PrairieLearn source code is publicly-available, it's possible to run PrairieLearn on your own infrastructure. Running a single instance of the PrairieLearn server may be appropriate for tens or hundreds of total users, and a number of universities have done this successfully.
 
+This documentation does not cover vital information for production usage such as database backups or high availability.
+
 ## Running in Production with Docker
 
 PrairieLearn can also be run in production mode in a Docker container [using Docker Compose](./docker-compose.md).
@@ -18,7 +20,7 @@ PrairieLearn can be configured by a `config.json` in the root of the repository.
 NODE_ENV=production node apps/prairielearn/dist/server.js --config /path/to/config.json
 ```
 
-The `config.json` file should contain appropriate overrides for the keys in [`lib/config.ts`](`https://github.com/PrairieLearn/PrairieLearn/blob/master/apps/prairielearn/src/lib/config.ts`). At a minimum, you'll probably want to update the various `postgres*` options to point it at your database.
+The `config.json` file should contain appropriate overrides for the keys in [`lib/config.ts`](https://github.com/PrairieLearn/PrairieLearn/blob/master/apps/prairielearn/src/lib/config.ts). At a minimum, you'll probably want to update the various `postgres*` options to point it at your database.
 
 ### Reverse Proxy
 
@@ -34,7 +36,7 @@ In `config.json` to configure your domain add:
 
 ### Authentication
 
-PrairieLearn currently has 4 ways to do user authentication. Read more at [authentication](./authentication.md).
+Read more in the [authentication documentation](./authentication.md).
 
 ### Admin User
 


### PR DESCRIPTION
The Docker Compose setup relies on the version of Postgres that's bundled in the Docker container, so the note about setting Postgres config options is irrelevant.