### PR TITLE
Workspace reboot nav fix: avoid failed check for 'running' workspace

### DIFF
--- a/apps/prairielearn/src/pages/workspace/workspace.sql
+++ b/apps/prairielearn/src/pages/workspace/workspace.sql
@@ -2,13 +2,15 @@
 UPDATE workspaces AS w
 SET
   version = version + 1,
-  reset_at = now()
+  reset_at = now(),
+  state = 'running'
 WHERE
   w.id = $workspace_id;
 
 -- BLOCK update_workspace_rebooted_at_now
 UPDATE workspaces AS w
 SET
-  rebooted_at = now()
+  rebooted_at = now(),
+  state = 'running'
 WHERE
   w.id = $workspace_id;

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -346,7 +346,7 @@ export async function initExpress() {
 
       const workspace_id = match[1];
       const result = await sqldb.queryZeroOrOneRowAsync(
-        "SELECT hostname FROM workspaces WHERE id = $workspace_id AND state = 'running';",
+        "SELECT hostname FROM workspaces WHERE id = $workspace_id;",
         { workspace_id },
       );
 

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -346,7 +346,7 @@ export async function initExpress() {
 
       const workspace_id = match[1];
       const result = await sqldb.queryZeroOrOneRowAsync(
-        "SELECT hostname FROM workspaces WHERE id = $workspace_id;",
+        'SELECT hostname FROM workspaces WHERE id = $workspace_id;',
         { workspace_id },
       );
 


### PR DESCRIPTION
Fixes #10716 

Working locally (at least), after rebooting a workspace, it temporarily has state `'stopped'`, which causes nav to fail as this expects `'running'`. (Or, when resetting, the state is temporarily `'uninitialized'`.) Also the database query failure crashes the PL server hard (but not the workspace host)! This doesn't seem to be a problem in deployment for some reason, but I don't know why not. Maybe the sequence of updates to the workspace state happen more quickly in deployment.

This PR sets the state to `'running'` sooner and also removes the search criterion for `'running'` during the nav lookup. Actually either measure alone solves the problem, it seems. Is it better to only use one fix or the other? I would think that maybe it's sufficient to just remove the search criterion, and if the workspace still isn't running when the page loads, let whatever error message appear to the user naturally.