### PR TITLE
LTI 1.3 fetchRetry refactor for better pagination support

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -493,11 +493,12 @@ const STATUS_CODE_RESPONSE = {
 };
 
 /**
+ * Make HTTP fetch requests with retries and pagination handling
  *
- * @param input
- * @param opts
- * @param incomingfetchRetryOpts
- * @param previousResults
+ * @param input URL to visit
+ * @param opts fetch options
+ * @param incomingfetchRetryOpts options specific to fetchRetry
+ * @param previousResults Used for paginated content
  * @returns Array of JSON responses from fetch
  */
 export async function fetchRetry(
@@ -581,7 +582,9 @@ type ContextMembership = z.infer<typeof ContextMembershipSchema>;
 
 const ContextMembershipContainerSchema = z.object({
   id: z.string(),
-  //context: z.object(),
+  context: z.object({
+    id: z.string(),
+  }),
   members: ContextMembershipSchema.array(),
 });
 

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -507,7 +507,7 @@ export async function fetchRetry(
     retryLeft?: number;
     sleepMs?: number;
   },
-  previousResults: any[] = [],
+  previousResults: unknown[] = [],
 ): Promise<unknown[]> {
   const fetchRetryOpts = {
     retryLeft: 5,

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -53,8 +53,8 @@ export const LineitemSchema = z.object({
   resourceId: z.string().optional(),
   resourceLinkId: z.string().optional(),
   tag: z.string().optional(),
-  startDateTime: DateFromISOString.optional(),
-  endDateTime: DateFromISOString.optional(),
+  startDateTime: z.string().datetime({ offset: true }).optional(),
+  endDateTime: z.string().datetime({ offset: true }).optional(),
   gradesReleased: z.boolean().optional(),
   'https://canvas.instructure.com/lti/submission_type': z
     .object({

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -536,12 +536,16 @@ export async function fetchRetry(
 export async function fetchRetryPaginated(
   input: RequestInfo | URL,
   opts?: RequestInit | undefined,
+  incomingfetchRetryOpts?: {
+    retryLeft?: number;
+    sleepMs?: number;
+  },
 ): Promise<unknown[]> {
   const output: unknown[] = [];
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const res = await fetchRetry(input, opts);
+    const res = await fetchRetry(input, opts, incomingfetchRetryOpts);
     output.push(await res.json());
 
     const parsed = parseLinkHeader(res.headers.get('link')) ?? {};

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -484,12 +484,12 @@ export async function linkAssessment(
 */
 
 /**
- * Make HTTP fetch requests with retries and pagination handling
+ * Make HTTP fetch requests with retries
  *
  * @param input URL to visit
  * @param opts fetch options
  * @param incomingfetchRetryOpts options specific to fetchRetry
- * @returns Array of JSON responses from fetch
+ * @returns Node fetch response object
  */
 export async function fetchRetry(
   input: RequestInfo | URL,
@@ -533,6 +533,17 @@ export async function fetchRetry(
   }
 }
 
+/**
+ * Pagination wrapper around fetchRetry
+ *
+ * @param input
+ * @param opts
+ * @param incomingfetchRetryOpts
+ * @param input URL to visit
+ * @param opts fetch options
+ * @param incomingfetchRetryOpts options specific to fetchRetry
+ * @returns Array of JSON responses from fetch
+ */
 export async function fetchRetryPaginated(
   input: RequestInfo | URL,
   opts?: RequestInit | undefined,

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -508,7 +508,7 @@ export async function fetchRetry(
     const response = await fetch(input, opts);
 
     switch (response.status) {
-      // 422 Unprocessable Content, like POSTING a grade to a non-student
+      // 422 Unprocessable Entity, User not found in course or is not a student
       case 422:
         return response;
     }
@@ -753,7 +753,7 @@ export async function updateLti13Scores(
         userId,
       };
 
-      await fetchRetry(assessment.lti13_lineitem_id_url + '/scores', {
+      const res = await fetchRetry(assessment.lti13_lineitem_id_url + '/scores', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -761,6 +761,8 @@ export async function updateLti13Scores(
         },
         body: JSON.stringify(score),
       });
+
+      job.info(`\t${res.statusText}`);
     }
   }
 }

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -53,8 +53,8 @@ export const LineitemSchema = z.object({
   resourceId: z.string().optional(),
   resourceLinkId: z.string().optional(),
   tag: z.string().optional(),
-  startDateTime: z.string().datetime({ offset: true }).optional(),
-  endDateTime: z.string().datetime({ offset: true }).optional(),
+  startDateTime: DateFromISOString.optional(),
+  endDateTime: DateFromISOString.optional(),
   gradesReleased: z.boolean().optional(),
   'https://canvas.instructure.com/lti/submission_type': z
     .object({


### PR DESCRIPTION
The LTI 1.3 `fetchRetry` function now returns an array of responses if the response was paginated. The calling function must unpack that.

Replaces #10711 fixing some LTI 1.3 bugs we found with larger classes than in my test suite.