### PR TITLE
Always use performance.now() to measure elapsed time

### DIFF
--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -388,9 +388,9 @@ async function tryJobWithTime(job: CronJob, cronUuid: string) {
 async function runJob(job: CronJob, cronUuid: string) {
   debug(`runJob(): ${job.name}`);
   logger.verbose('cron: starting ' + job.name, { cronUuid });
-  const startTime = Date.now();
+  const startTime = performance.now();
   await job.module.run();
-  const endTime = Date.now();
+  const endTime = performance.now();
   const elapsedTimeMS = endTime - startTime;
   debug(`runJob(): ${job.name}: success, duration ${elapsedTimeMS} ms`);
   logger.verbose('cron: ' + job.name + ' success', {

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.js
@@ -83,7 +83,7 @@ async function ensureImage() {
   } catch (e) {
     if (e.statusCode === 404) {
       logger.info('Image not found, pulling from registry');
-      const start = Date.now();
+      const start = performance.now();
       const ecr = new ECRClient(makeAwsClientConfig());
       const dockerAuth = config.cacheImageRegistry ? await setupDockerAuth(ecr) : null;
       const stream = await docker.createImage(dockerAuth, { fromImage: imageName });
@@ -91,7 +91,7 @@ async function ensureImage() {
         docker.modem.followProgress(
           stream,
           (err) => {
-            const elapsed = Math.round((Date.now() - start) / 1000);
+            const elapsed = Math.round((performance.now() - start) / 1000);
             if (err) {
               logger.error(`Error pulling image after ${elapsed} seconds`, err);
               reject(err);

--- a/apps/workspace-host/src/interface.js
+++ b/apps/workspace-host/src/interface.js
@@ -508,7 +508,7 @@ function _checkServer(workspace) {
   const healthCheckInterval = config.workspaceHealthCheckIntervalSec * 1000;
   const healthCheckTimeout = config.workspaceHealthCheckTimeoutSec * 1000;
 
-  const startTime = new Date().getTime();
+  const startTime = performance.now();
   return new Promise((resolve, reject) => {
     function checkWorkspace() {
       fetch(
@@ -523,7 +523,7 @@ function _checkServer(workspace) {
         })
         .catch(() => {
           // Do nothing, because errors are expected while the container is launching.
-          const endTime = new Date().getTime();
+          const endTime = performance.now();
           if (endTime - startTime > startTimeout) {
             const { id, version, launch_uuid } = workspace;
             reject(


### PR DESCRIPTION
This is a best practice to avoid clock skew, timezone changes, and other potential problems with `Date.now()`.