### PR TITLE
Increase card header height for pl-order-blocks

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
@@ -110,7 +110,6 @@ div.pl-order-blocks-container {
 }
 
 div.pl-order-blocks-header {
-  height: 5rem;
   display: flex;
   align-items: center;
 }

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
@@ -110,7 +110,7 @@ div.pl-order-blocks-container {
 }
 
 div.pl-order-blocks-header {
-  height: 3rem;
+  height: 5rem;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
On mobile, the text for pl-order-blocks overflows outside the blue box. This tiny change increases the height of the card header so that the "Construct your solution here" text can fit inside the box.  

Before: 
<img width="319" alt="Capture d’écran, le 2024-10-01 à 23 14 17" src="https://github.com/user-attachments/assets/fa4b0f42-98be-4ab3-b505-07a3c3bb7548">

After:
<img width="300" alt="Capture d’écran, le 2024-10-01 à 23 07 00" src="https://github.com/user-attachments/assets/44e8b4c6-ee56-4798-9cef-06db92ee5f39">

For Desktop, this would look something like this:
<img width="990" alt="Capture d’écran, le 2024-10-01 à 23 15 14" src="https://github.com/user-attachments/assets/0d1b04fa-501f-4f61-9a37-b5f2c249b18e">


Fixes #9861 