### PR TITLE
Ensure pl-order-blocks doesn't mutate submitted answers during render

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -468,9 +468,15 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             element, "solution-header", SOLUTION_HEADER_DEFAULT
         )
 
-        all_blocks = data["params"][answer_name]
-        student_previous_submission = data["submitted_answers"].get(answer_name, [])
+        # We aren't allowed to mutate the `data` object during render, so we'll
+        # make a deep copy of the submitted answer so we can update the `indent`
+        # to a value suitable for rendering.
+        student_previous_submission = deepcopy(
+            data["submitted_answers"].get(answer_name, [])
+        )
         submitted_block_ids = {block["uuid"] for block in student_previous_submission}
+
+        all_blocks = data["params"][answer_name]
         source_blocks = [
             block for block in all_blocks if block["uuid"] not in submitted_block_ids
         ]


### PR DESCRIPTION
The experimental question processor behind the `process-questions-in-worker` feature flag has stricter checks for modifications to `data`. Specifically, it runs the checks during `render()` to make sure no one is mutating data. This broke with `pl-order-blocks`, which _did_ incorrectly mutate `data["submitted_answers"]` while rendering. This PR fixes that.

I considered removing the stricter check to be fully backwards compatible with the current question processor. However, this check lets us enable a key performance optimization: we can avoid copying the entire `data` object before each element is processed. This is valuable enough that I'm willing to enforce this stricter checking even if it will cause some problems in the meantime.