### PR TITLE
Fix bugs with code caller initialization

### DIFF
--- a/apps/prairielearn/src/executor.js
+++ b/apps/prairielearn/src/executor.js
@@ -113,14 +113,19 @@ if (Number.isNaN(pingTimeoutMilliseconds)) {
   pingTimeoutMilliseconds = 60_000;
 }
 
-(async () => {
-  let codeCaller = new CodeCallerNative({
+async function prepareCodeCaller() {
+  const codeCaller = new CodeCallerNative({
     dropPrivileges: true,
     questionTimeoutMilliseconds,
     pingTimeoutMilliseconds,
     errorLogger: console.error,
   });
   await codeCaller.ensureChild();
+  return codeCaller;
+}
+
+(async () => {
+  let codeCaller = await prepareCodeCaller();
 
   // Our overall loop looks like this: read a line of input from stdin, spin
   // off a python worker to handle it, and write the results back to stdout.
@@ -140,8 +145,7 @@ if (Number.isNaN(pingTimeoutMilliseconds)) {
     console.log(JSON.stringify(rest));
     if (needsFullRestart) {
       codeCaller.done();
-      codeCaller = new CodeCallerNative();
-      await codeCaller.ensureChild();
+      codeCaller = await prepareCodeCaller();
     }
   }
 })().catch((err) => {

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.js
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.js
@@ -99,7 +99,7 @@ export class CodeCallerNative {
       // communication. This is incompatible with the default behavior of our
       // logger, which will only write to stdout. So, we allow a different
       // logging function to be provided.
-      errorLogger: logger.error,
+      errorLogger: logger.error.bind(logger),
     },
   ) {
     /** @type {CodeCallerState} */


### PR DESCRIPTION
This PR fixes two bugs with code caller initialization:

- The default options `CodeCallerNative` included `logger.error`. This needs to be `logger.error.bind(logger)` to ensure that the logger's `this` reference is set correctly. We already did this elsewhere:
  https://github.com/PrairieLearn/PrairieLearn/blob/71d2178ab170731745146279ccc34f2cbf04db2a/apps/prairielearn/src/lib/code-caller/index.ts#L58
- The in-container executor was in some cases constructing a new code caller without setting the appropriate options.