### PR TITLE
Fix flash message errors

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -1,5 +1,6 @@
 import { flash, type FlashMessageType } from '@prairielearn/flash';
 import { html, HtmlValue, unsafeHtml } from '@prairielearn/html';
+import { run } from '@prairielearn/run';
 
 import { config } from '../lib/config.js';
 
@@ -262,9 +263,20 @@ function FlashMessages() {
     error: 'danger',
   } as const;
 
+  // We might fail to fetch flash messages if this ends up running before the
+  // flash middleware has run for this particular request. In that case, we
+  // just assume that there are no flash messages.
+  const flashMessages = run(() => {
+    try {
+      return flash(Object.keys(globalFlashColors) as FlashMessageType[]);
+    } catch {
+      return [];
+    }
+  });
+
   return html`
     <div class="mb-3">
-      ${flash(Object.keys(globalFlashColors) as FlashMessageType[]).map(
+      ${flashMessages.map(
         ({ type, message }) => html`
           <div
             class="alert alert-${globalFlashColors[

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -154,6 +154,18 @@ export async function initExpress() {
     }),
   );
 
+  // Attach the flash middleware immediately after the session middleware so
+  // that all future handlers can write flash messages. This must come after
+  // the session middleware so that it can access the session.
+  app.use(flashMiddleware());
+  app.use((req, res, next) => {
+    // This is so that the `navbar` partial can access the flash messages. If
+    // you want to add a flash message, you should import and use `flash`
+    // directly from `@prairielearn/flash`.
+    res.locals.flash = flash;
+    next();
+  });
+
   // This middleware helps ensure that sessions remain alive (un-expired) as
   // long as users are somewhat frequently active. See the documentation for
   // `config.sessionStoreAutoExtendThrottleSeconds` for more information.
@@ -476,14 +488,6 @@ export async function initExpress() {
   });
 
   // More middlewares
-  app.use(flashMiddleware());
-  app.use((req, res, next) => {
-    // This is so that the `navbar` partial can access the flash messages. If
-    // you want to add a flash message, you should import and use `flash`
-    // directly from `@prairielearn/flash`.
-    res.locals.flash = flash;
-    next();
-  });
   app.use((await import('./middlewares/logResponse.js')).default); // defers to end of response
   app.use((await import('./middlewares/cors.js')).default);
   app.use((await import('./middlewares/content-security-policy.js')).default);


### PR DESCRIPTION
This PR makes two improvements to the flash message system:

- `flashMiddleware` now runs as soon possible during the request lifecycle to maximize the chance that it'll have run when something else wants to either read or write flash messages.
- The `Navbar` component will now gracefully handle the case where the flash messages cannot be read. This ensures that we can render meaningful error pages even for errors that occur before the flash middleware runs, such as session store failures.

Closes #10745.