### PR TITLE
Cache instantiated Python modules

### DIFF
--- a/apps/prairielearn/python/question_phases.py
+++ b/apps/prairielearn/python/question_phases.py
@@ -118,7 +118,6 @@ def process(
             sys.path.insert(0, str(element_path))
 
             mod = mod_cache.get(element_controller_path, None)
-
             if mod is None:
                 mod = {}
                 with open(element_controller_path, encoding="utf-8") as inf:

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -308,9 +308,9 @@ def worker_loop() -> None:
             if mod is None:
                 mod = {}
                 with open(file_path, encoding="utf-8") as inf:
-                    # use compile to associate filename with code object, so the
-                    # filename appears in the traceback if there is an error
-                    # (https://stackoverflow.com/a/437857)
+                    # Use `compile` to associate filename with code object, so the
+                    # filename appears in the traceback if there is an error:
+                    # https://stackoverflow.com/a/437857
                     code = compile(inf.read(), file_path, "exec")
                     exec(code, mod)
                     mod_cache[file_path] = mod

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -158,6 +158,13 @@ def worker_loop() -> None:
     path_finder = ForbidModuleMetaPathFinder()
     sys.meta_path.insert(0, path_finder)
 
+    # We'll cache instantiated modules for two reasons:
+    # - This allows us to avoid re-reading/compiling/executing them if the same
+    #   element is used multiple times.
+    # - This allows element code to maintain state across multiple calls. This is useful
+    #   specifically for elements that want to maintain a cache of expensive-to-compute data.
+    mod_cache: dict[str, dict[str, Any]] = {}
+
     # file descriptor 3 is for output data
     with open(3, "w", encoding="utf-8") as outf:
         # Infinite loop where we wait for an input command, do it, and
@@ -295,14 +302,18 @@ def worker_loop() -> None:
 
                 continue
 
-            mod = {}
             file_path = os.path.join(cwd, file + ".py")
-            with open(file_path, encoding="utf-8") as inf:
-                # use compile to associate filename with code object, so the
-                # filename appears in the traceback if there is an error
-                # (https://stackoverflow.com/a/437857)
-                code = compile(inf.read(), file_path, "exec")
-                exec(code, mod)
+
+            mod = mod_cache.get(file_path, None)
+            if mod is None:
+                mod = {}
+                with open(file_path, encoding="utf-8") as inf:
+                    # use compile to associate filename with code object, so the
+                    # filename appears in the traceback if there is an error
+                    # (https://stackoverflow.com/a/437857)
+                    code = compile(inf.read(), file_path, "exec")
+                    exec(code, mod)
+                    mod_cache[file_path] = mod
 
             # check whether we have the desired fcn in the module
             if fcn in mod:


### PR DESCRIPTION
I'm making this change to support some upcoming changes that will optimize the `pl-code` element to cache expensive-to-compute data. However, even on its own, this change already yields some nice improvements. I tested these changes on the `element/multipleChoice` question in the example course with five trials. I ran these tests with the `process-questions-in-worker` feature flag enabled.

Master:

```
freeform.generate: 0.74ms
freeform.prepare: 38.25ms
freeform.render: 35.43ms
freeform.generate: 0.55ms
freeform.prepare: 44.61ms
freeform.render: 41.02ms
freeform.generate: 0.27ms
freeform.prepare: 37.71ms
freeform.render: 38.84ms
freeform.generate: 0.34ms
freeform.prepare: 38.50ms
freeform.render: 32.91ms
freeform.generate: 0.49ms
freeform.prepare: 43.66ms
freeform.render: 36.21ms
```

On this branch:

```
freeform.generate: 0.77ms
freeform.prepare: 18.27ms
freeform.render: 19.76ms
freeform.generate: 0.65ms
freeform.prepare: 18.12ms
freeform.render: 23.98ms
freeform.generate: 0.11ms
freeform.prepare: 10.44ms
freeform.render: 16.50ms
freeform.generate: 0.59ms
freeform.prepare: 19.64ms
freeform.render: 22.99ms
freeform.generate: 0.62ms
freeform.prepare: 20.08ms
freeform.render: 25.06ms
```

Summary (blame ChatGPT for any wrong numbers):

| operation | `master` average | branch average | diff |
|--------|--------|--------|--------|
| `generate` | 0.48ms | 0.55ms | -14% |
| `prepare` | 40.55ms | 17.31ms | 57% |
| `render` | 36.88ms | 21.66ms | 41% |

`generate` is already very fast and doesn't use elements to begin with, so I'm inclined to say that the difference here is just due to normal variation.

Note that these changes will really only help with questions that use a given element multiple times. The improvement this will yield is proportional to the number of times an element is reused.