### PR TITLE
Fix assessment rename process

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -657,7 +657,7 @@ export class AssessmentRenameEditor extends Editor {
     const newPath = path.join(basePath, this.tid_new);
     debug(`Move files\n from ${oldPath}\n to ${newPath}`);
     await fs.move(oldPath, newPath, { overwrite: false });
-    await this.removeEmptyPrecedingSubfolders(basePath, this.course_instance.short_name);
+    await this.removeEmptyPrecedingSubfolders(basePath, this.assessment.tid);
 
     return {
       pathsToAdd: [oldPath, newPath],


### PR DESCRIPTION
As reported by @MeiyingQin. Renaming an assessment's AID causes it to fail with an error. Debugging indicates the error was related to an attempt to delete empty preceding subfolders, which was being done with the wrong subdirectory structure, using the CIID instead of AID.

I believe the issue happened here because, in this course, we are using a subdirectory structure for the course instance (i.e., the CIID contains a /), which caused the problem. In the past this never caused a major issue because no parent directory was ever found, though the rename would fail to delete extraneous empty folders in the process, since the wrong directory structure was used to check for empty folders.

It seems this has been a bug since AID subdirectories were introduced 4 years ago.