### PR TITLE
docs: Update instructions to install Docker Engine in WSL

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -12,7 +12,7 @@ Here are the instructions to install WSL 2 and enable its integration with Docke
 
 - Install WSL 2. For current instructions, [follow the Microsoft documentation](https://learn.microsoft.com/en-us/windows/wsl/install).
 - Enable the Docker Desktop WSL 2 backend. For current instructions, [follow the Docker documentation](https://docs.docker.com/desktop/windows/wsl/).
-- On the shell of your WSL 2 instance, make sure the instance has the Docker Engine installed. The installation process may depend on the distribution of your WSL 2 instance. For current instructions, [follow the Docker documentation](https://docs.docker.com/engine/install/).
+- On the shell of your WSL 2 instance, make sure Docker Engine is installed. The installation process may depend on the distribution of your WSL 2 instance. For current instructions, [follow the Docker documentation](https://docs.docker.com/engine/install/).
 
 **NOTE**: We do not currently support a Windows environment without WSL 2, due to extreme performance issues, limitations related to file permissions in job folders, as well as issues associated to file formats. While there are ways to run PrairieLearn in this environment, it may not provide the same experience that a student would see in a production environment, and as such it is discouraged and not documented. In all cases below, the Windows examples assume that WSL 2 is installed.
 


### PR DESCRIPTION
As reported on Slack, Ubuntu 24.04 does not have the `docker` package available by default.