### PR TITLE
Cache expensive data in `pl-code` element

### DIFF
--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -1,4 +1,5 @@
 import os
+from functools import cache
 from html import escape, unescape
 from typing import Any, Generator, Iterable, Iterator, Optional
 
@@ -9,6 +10,7 @@ import pygments
 import pygments.formatters
 import pygments.lexer
 import pygments.lexers
+import pygments.style
 import pygments.util
 from code_utils import parse_highlight_lines
 from pygments.styles import STYLE_MAP, get_style_by_name
@@ -47,6 +49,10 @@ ANSI_COLORS = {
 }
 
 
+# Computing this is relatively expensive, so we'll do it once here and reuse it.
+ansi_color_tokens = color_tokens(ANSI_COLORS, ANSI_COLORS)
+
+
 class NoHighlightingLexer(pygments.lexer.Lexer):
     """
     Dummy lexer for when syntax highlighting is not wanted, but we still
@@ -68,6 +74,12 @@ class HighlightingHtmlFormatter(pygments.formatters.HtmlFormatter):
     Subclass of the default HTML formatter to provide more flexibility
     with highlighted lines.
     """
+
+    def set_highlighted_lines(self, hl_lines: Optional[list[int]]) -> None:
+        self.hl_lines.clear()
+        if hl_lines:
+            for line in hl_lines:
+                self.hl_lines.add(line)
 
     def _highlight_lines(
         self, tokensource: Iterable[tuple[int, str]]
@@ -93,10 +105,16 @@ class HighlightingHtmlFormatter(pygments.formatters.HtmlFormatter):
         return ""
 
 
+# Selecting and instantiating a lexer is actually reasonably expensive
+# (on the order of 5-10ms). We cache a resolution from a language name to a
+# lexers to avoid this cost if `<pl-code>` is used with the same language
+# multiple times in the same question.
+@cache
 def get_lexer_by_name(name: str) -> Optional[pygments.lexer.Lexer]:
     """
     Tries to find a lexer by both its proper name and any aliases it has.
     """
+
     # Search by proper class/language names
     # This returns None if not found, and a class if found.
     lexer_class = pygments.lexers.find_lexer_class(name)
@@ -110,6 +128,31 @@ def get_lexer_by_name(name: str) -> Optional[pygments.lexer.Lexer]:
             return pygments.lexers.get_lexer_by_name(name)
         except pygments.util.ClassNotFound:
             return None
+
+
+@cache
+def get_formatter(
+    BaseStyle: type[pygments.style.Style], highlight_lines_color: Optional[str]
+):
+    class CustomStyleWithAnsiColors(BaseStyle):
+        styles = dict(BaseStyle.styles)
+        styles.update(ansi_color_tokens)
+
+        highlight_color = (
+            highlight_lines_color or BaseStyle.highlight_color or "#b3d7ff"
+        )
+
+    formatter_opts = {
+        "style": CustomStyleWithAnsiColors,
+        "nobackground": True,
+        "noclasses": True,
+        # We'll unconditionally render the line numbers, but we'll hide them if
+        # they aren't specifically enabled. This means we only have to deal with
+        # one markup "shape" in our CSS, not two.
+        "linenos": "table",
+    }
+
+    return HighlightingHtmlFormatter(**formatter_opts)
 
 
 def prepare(element_html: str, data: pl.QuestionData) -> None:
@@ -224,28 +267,10 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     background_color = pygments_style.background_color or "transparent"
     line_number_color = pygments_style.line_number_color
 
-    class CustomStyleWithAnsiColors(pygments_style):
-        styles = dict(pygments_style.styles)
-        styles.update(color_tokens(ANSI_COLORS, ANSI_COLORS))
-
-        highlight_color = (
-            pygments_style.highlight_color or highlight_lines_color or "#b3d7ff"
-        )
-
-    formatter_opts = {
-        "style": CustomStyleWithAnsiColors,
-        "nobackground": True,
-        "noclasses": True,
-        # We'll unconditionally render the line numbers, but we'll hide them if
-        # they aren't specifically enabled. This means we only have to deal with
-        # one markup "shape" in our CSS, not two.
-        "linenos": "table",
-    }
-
-    if highlight_lines is not None:
-        formatter_opts["hl_lines"] = parse_highlight_lines(highlight_lines)
-
-    formatter = HighlightingHtmlFormatter(**formatter_opts)
+    formatter = get_formatter(pygments_style, highlight_lines_color)
+    formatter.set_highlighted_lines(
+        parse_highlight_lines(highlight_lines) if highlight_lines else None
+    )
 
     code = pygments.highlight(unescape(code), lexer, formatter)
 

--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -49,10 +49,6 @@ ANSI_COLORS = {
 }
 
 
-# Computing this is relatively expensive, so we'll do it once here and reuse it.
-ansi_color_tokens = color_tokens(ANSI_COLORS, ANSI_COLORS)
-
-
 class NoHighlightingLexer(pygments.lexer.Lexer):
     """
     Dummy lexer for when syntax highlighting is not wanted, but we still
@@ -130,6 +126,12 @@ def get_lexer_by_name(name: str) -> Optional[pygments.lexer.Lexer]:
             return None
 
 
+# Computing this is relatively expensive, so we'll do it once here and reuse it.
+@cache
+def get_ansi_color_tokens():
+    return color_tokens(ANSI_COLORS, ANSI_COLORS)
+
+
 # Instantiating a style/formatter is also expensive, so we'll cache it as well.
 # Note that sharing an instance means we'll also share the `hl_lines` instance
 # member, so the caller must take care to set or clear it as needed before use.
@@ -139,7 +141,7 @@ def get_formatter(
 ):
     class CustomStyleWithAnsiColors(BaseStyle):
         styles = dict(BaseStyle.styles)
-        styles.update(ansi_color_tokens)
+        styles.update(get_ansi_color_tokens())
 
         highlight_color = (
             highlight_lines_color or BaseStyle.highlight_color or "#b3d7ff"

--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -138,7 +138,7 @@ def get_ansi_color_tokens():
 @cache
 def get_formatter(
     BaseStyle: type[pygments.style.Style], highlight_lines_color: Optional[str]
-):
+) -> HighlightingHtmlFormatter:
     class CustomStyleWithAnsiColors(BaseStyle):
         styles = dict(BaseStyle.styles)
         styles.update(get_ansi_color_tokens())

--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -130,6 +130,9 @@ def get_lexer_by_name(name: str) -> Optional[pygments.lexer.Lexer]:
             return None
 
 
+# Instantiating a style/formatter is also expensive, so we'll cache it as well.
+# Note that sharing an instance means we'll also share the `hl_lines` instance
+# member, so the caller must take care to set or clear it as needed before use.
 @cache
 def get_formatter(
     BaseStyle: type[pygments.style.Style], highlight_lines_color: Optional[str]

--- a/exampleCourse/questions/element/code/question.html
+++ b/exampleCourse/questions/element/code/question.html
@@ -28,7 +28,7 @@ def square(x):
 <pl-question-panel>
 <markdown>
 Another useful feature of `pl-code` is the ability to highlight specific lines. This is done by using
-`highlight-lines="low-high"` attribute. Moreover, one can disable selecting the code region by
+`highlight-lines="..."` attribute. Moreover, one can disable selecting the code region by
 adding `prevent-select="true"`.
 </markdown>
 <pl-code language="python" highlight-lines="4-5" prevent-select="true">


### PR DESCRIPTION
This PR builds on the changes from #10759 to improve the performance of questions that use a lot of `pl-code` elements with the same language/style.

The following numbers are using the `matlab/practice assessment questions/sas_checkbox/image_manipulation/crop_and_highlight` question from UMich's ENGR 101 course. Testing was done with `process-questions-in-worker` feature enabled.

Master:

```
freeform.generate: 15.00ms
freeform.prepare: 505.75ms
freeform.render: 874.15ms
freeform.generate: 13.43ms
freeform.prepare: 480.76ms
freeform.render: 898.65ms
freeform.generate: 10.20ms
freeform.prepare: 476.02ms
freeform.render: 879.08ms
freeform.generate: 14.67ms
freeform.prepare: 479.53ms
freeform.render: 877.84ms
freeform.generate: 15.20ms
freeform.prepare: 475.83ms
freeform.render: 874.03ms
```

On this branch:

```
freeform.generate: 11.11ms
freeform.prepare: 286.16ms
freeform.render: 291.82ms
freeform.generate: 10.55ms
freeform.prepare: 263.29ms
freeform.render: 284.92ms
freeform.generate: 15.15ms
freeform.prepare: 264.59ms
freeform.render: 287.95ms
freeform.generate: 16.61ms
freeform.prepare: 274.62ms
freeform.render: 283.91ms
freeform.generate: 15.70ms
freeform.prepare: 272.00ms
freeform.render: 283.25ms
```

Summary (blame ChatGPT for any wrong numbers):

| operation | `master` average | branch average | diff |
|--------|--------|--------|--------|
| `generate` | 13.70ms | 13.82ms | -1% |
| `prepare` | 483.57ms | 272.13ms | 44% |
| `render` | 880.75ms | 286.37ms | 67% |

This is a very very good improvement: overall, we're now almost 60% faster on the initial generate/prepare/render for this question.

This also yields a smaller gain for the `element/code` question in `exampleCourse`, with the full generate/prepare/render running 70ms faster (roughly a 12% decrease). This is a smaller win because it's using a wider variety of languages/styles so caching doesn't matter as much.