### PR TITLE
Log info in AI grading more frequently

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -287,8 +287,6 @@ export async function aiGrade({
     job.info(`Found ${result.length} submissions to grade!`);
 
     let error_count = 0;
-    let output_count = 0;
-    let output: string | null = null;
 
     // Grade each instance question.
     for (const instance_question of result) {
@@ -387,17 +385,7 @@ export async function aiGrade({
         job.error(err);
         error_count++;
       }
-      output = (output == null ? '' : `${output}\n`) + msg;
-      output_count++;
-      if (output_count >= 5) {
-        job.info(output);
-        output = null;
-        output_count = 0;
-      }
-    }
-
-    if (output != null) {
-      job.info(output);
+      job.info(msg);
     }
     if (error_count > 0) {
       job.error('Number of errors: ' + error_count);


### PR DESCRIPTION
This is a simple modification to AI grading. In earlier versions, AI grading job information is logged once every 5 graded submissions to allow for higher IO performance. With more output information added in each iteration, and potentially more time needed for iterations for different models, I'm changing the logging to happen after each submission is graded. This would help instructors better keep track of the status of the grading tasks. 