### PR TITLE
Restore default placeholder for integer input with base 0

### DIFF
--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.mustache
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.mustache
@@ -107,7 +107,7 @@
 {{#format}}
 <p>
 Your answer must be an integer{{^default_base}} in base {{base}}{{/default_base}}{{#zero_base}} in base 10. You may also use an integer in base 16 with the prefix <code>0x</code> (e.g., 0x1a), in base 2 with the prefix <code>0b</code> (e.g. 0b1101), or in base 8 with the prefix <code>0o</code> (e.g., 0o777){{/zero_base}}.
-It must not contain a decimal, though it may contain underscores (which are ignored).
+It must not contain a decimal point, though it may contain underscores (which are ignored).
 No symbolic expressions (those that involve fractions, square roots, variables, etc.) will be accepted.
 Scientific notation is not accepted.
 </p>

--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
@@ -111,7 +111,9 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             placeholder = pl.get_string_attrib(element, "placeholder")
         else:
             placeholder = (
-                "integer" if base == BASE_DEFAULT else f"integer in base {base}"
+                "integer"
+                if base == BASE_DEFAULT or base == 0
+                else f"integer in base {base}"
             )
 
         html_params = {


### PR DESCRIPTION
Fixes #10725. Restores the default placeholder from before #6980 for cases with base zero (i.e., base 10 with option of using a different base with a corresponding prefix).