### PR TITLE
Remove bottom padding on checkbox/multiple-choice answers

### DIFF
--- a/apps/prairielearn/elements/pl-checkbox/pl-checkbox.css
+++ b/apps/prairielearn/elements/pl-checkbox/pl-checkbox.css
@@ -1,3 +1,7 @@
+.pl-checkbox-answer :last-child {
+  margin-bottom: 0 !important;
+}
+
 .pl-checkbox-popover {
   width: 340px;
   max-width: 100%;

--- a/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
+++ b/apps/prairielearn/elements/pl-checkbox/pl-checkbox.mustache
@@ -10,7 +10,7 @@
 
         <label class="form-check-label d-flex align-items-center" for="{{name}}-{{key}}">
             {{^hide_letter_keys}}<div class="pl-checkbox-key-label">({{key}})</div>{{/hide_letter_keys}}
-            <div class="ml-1 mr-1">{{{html}}}</div>
+            <div class="ml-1 mr-1 pl-checkbox-answer">{{{html}}}</div>
         </label>
 
         {{#display_feedback}}

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.css
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.css
@@ -1,3 +1,7 @@
+.pl-multiple-choice-answer :last-child {
+  margin-bottom: 0 !important;
+}
+
 .pl-multiple-choice-popover {
   width: 340px;
   max-width: 100%;

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.mustache
@@ -19,7 +19,7 @@
 
             <label class="form-check-label d-flex align-items-center" for="{{name}}-{{key}}">
                 {{^hide_letter_keys}}<div class="pl-multiple-choice-key-label">({{key}})</div>{{/hide_letter_keys}}
-                <div class="ml-1 mr-1">{{{html}}}</div>
+                <div class="ml-1 mr-1 pl-multiple-choice-answer">{{{html}}}</div>
             </label>
 
             {{#display_feedback}}


### PR DESCRIPTION
Closes #10645. Tested with the example from that issue, also adapted to test `<pl-checkbox>`.

## `pl-multiple-choice`

Before:

<img width="296" alt="Screenshot 2024-10-08 at 16 26 50" src="https://github.com/user-attachments/assets/b0ffd3ed-d0bf-41c1-a8f5-d22940667dac">

After:

<img width="321" alt="Screenshot 2024-10-08 at 14 20 06" src="https://github.com/user-attachments/assets/18a7a714-d717-426a-a836-b5b28ec23e1d">

## `pl-checkbox`

Before:

<img width="315" alt="Screenshot 2024-10-08 at 16 26 33" src="https://github.com/user-attachments/assets/092ca39a-7c10-4813-873d-f5b3b8e13115">


After:

<img width="298" alt="Screenshot 2024-10-08 at 14 21 36" src="https://github.com/user-attachments/assets/8f29f885-eb12-4fbb-8af4-54cec5303d53">




