### PR TITLE
Refine LTI 1.3 linking flow

### DIFF
--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
@@ -27,7 +27,7 @@ export function Lti13CourseNavigationInstructor({
         ${Navbar({ resLocals, navPage: 'lti13_course_navigation' })} ${TerminologyModal()}
         <script>
           $(() => {
-            $('#onepicker').one('change', () => {
+            $('#connect_course_instance').one('change', () => {
               $('#saveButton').prop('disabled', false);
             });
           });
@@ -87,9 +87,15 @@ export function Lti13CourseNavigationInstructor({
                 </ul>
                 <form method="POST">
                   <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                  <label>Connect ${courseName} with:
-                  <div class="input-group">
-                    <select class="custom-select" id="onepicker" name="unsafe_course_instance_id">
+                  <div class="form-group">
+                    <label class="form-label" for="connect_course_instance">
+                      Connect ${courseName} with:
+                    </label>
+                    <select
+                      class="custom-select"
+                      id="connect_course_instance"
+                      name="unsafe_course_instance_id"
+                    >
                       <option value="" disabled selected>
                         Select an existing course instance...
                       </option>
@@ -108,7 +114,6 @@ export function Lti13CourseNavigationInstructor({
                         `;
                       })}
                     </select>
-                    </label>
                   </div>
                   <button class="btn btn-primary" id="saveButton" disabled>Save</button>
                 </form>
@@ -172,12 +177,11 @@ export function Lti13CourseNavigationDone({
             <strong>You're all set.</strong> Next time you or students click on the link in your
             LMS, they will be taken directly to your PrairieLearn course instance.
           </p>
-          <ul>
-            <li>
-              The course instance <code>allowAccess</code> rules still apply and may need to be
-              configured.
-            </li>
-          </ul>
+
+          <div class="alert alert-warning">
+            The course instance and assessment <code>allowAccess</code> rules still apply and may
+            need to be configured.
+          </div>
 
           <p>To change this connection, go to your course instance LTI 1.3 page.</p>
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
@@ -188,7 +188,7 @@ export function Lti13CourseNavigationDone({
           <p>
             <a
               href="/pl/lti13_instance/${lti13_instance_id}/course_navigation"
-              class="btn btn-success"
+              class="btn btn-primary"
             >
               Continue to your course instance
             </a>


### PR DESCRIPTION
This PR makes a couple of opinionated UI changes to the LTI 1.3 course instance linking flow.

Before:

<img width="386" alt="Screenshot 2024-10-09 at 10 46 23" src="https://github.com/user-attachments/assets/eb9a76a4-e14b-47e6-8b39-3d5945fd740e">

<img width="996" alt="Screenshot 2024-10-09 at 10 46 38" src="https://github.com/user-attachments/assets/16333b72-4efe-4e65-96de-61c759c97f22">

After:

<img width="516" alt="Screenshot 2024-10-09 at 10 44 07" src="https://github.com/user-attachments/assets/8763f108-3813-4036-a144-5ea94e5f644e">

<img width="999" alt="Screenshot 2024-10-09 at 10 48 46" src="https://github.com/user-attachments/assets/b087488d-3869-4516-9259-cb28c61844bd">


