### PR TITLE
Bump indirect dependency path-to-regexp to 6.3.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -12773,9 +12773,9 @@ __metadata:
   linkType: hard
 
 "path-to-regexp@npm:^6.1.0, path-to-regexp@npm:^6.2.1":
-  version: 6.2.2
-  resolution: "path-to-regexp@npm:6.2.2"
-  checksum: 10c0/4b60852d3501fd05ca9dd08c70033d73844e5eca14e41f499f069afa8364f780f15c5098002f93bd42af8b3514de62ac6e82a53b5662de881d2b08c9ef21ea6b
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves https://github.com/PrairieLearn/PrairieLearn/security/dependabot/205. Dependabot is not able to create a PR for this because it's an indirect dependency.