### PR TITLE
Fix colspan attribute on homework assessment instance page

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -63,7 +63,7 @@ export function StudentAssessmentInstance({
         ? 6
         : 2 + trailingColumnsCount
       : resLocals.has_auto_grading_question && resLocals.has_manual_grading_question
-        ? 5
+        ? 6
         : 1 + trailingColumnsCount;
   });
 
@@ -614,7 +614,7 @@ function InstanceQuestionTableHeader({ resLocals }: { resLocals: Record<string, 
             ? html`
                 <tr>
                   <th rowspan="2">Question</th>
-                  <th class="text-center" colspan="2">Auto-grading</th>
+                  <th class="text-center" colspan="3">Auto-grading</th>
                   <th class="text-center" rowspan="2">Manual grading points</th>
                   <th class="text-center" rowspan="2">Total points</th>
                 </tr>


### PR DESCRIPTION
I broke this in #10668. The removal of the "Best submission" column only impacted the display for Exam-type assessments, but I accidentally changed the way Homework-type assessments displayed too.

Here's how things looked before that PR:

![Screenshot 2024-10-10 at 15 46 39](https://github.com/user-attachments/assets/1be06dd3-c4da-4213-b144-1e920f0640cf)

And here's how they looked after the PR:

![Screenshot 2024-10-10 at 15 47 17](https://github.com/user-attachments/assets/41cb32ef-3c96-48ed-a997-00883020950b)

After this PR, things should look as expected again:

<img width="1135" alt="Screenshot 2024-10-10 at 16 00 28" src="https://github.com/user-attachments/assets/d28b2f5a-abe6-42f5-a69b-1feb4d183836">

