### PR TITLE
Fix exam completion message when showCorrectAnswer is false

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -327,7 +327,6 @@ function QuestionFooterContent({
   questionContext: QuestionContext;
 }) {
   const {
-    showTrueAnswer,
     showSaveButton,
     showGradeButton,
     disableSaveButton,
@@ -350,9 +349,10 @@ function QuestionFooterContent({
     __csrf_token,
   } = resLocals;
 
-  if (showTrueAnswer && questionContext === 'student_exam') {
+  if (questionContext === 'student_exam' && variantAttemptsLeft === 0) {
     return 'This question is complete and cannot be answered again.';
   }
+
   if (authz_result?.authorized_edit === false) {
     return html`<div class="alert alert-warning mt-2" role="alert">
       You are viewing the question instance of a different user and so are not authorized to save


### PR DESCRIPTION
This PR fixes a bug reported by @trombonekenny: when a question is configured with `"showCorrectAnswer": false` and is used on an Exam assessment, we'd show an incorrect message in the question footer when the question is "complete" (has 100% credit or no more attempts):

<img width="1316" alt="Screenshot 2024-10-11 at 09 35 23" src="https://github.com/user-attachments/assets/bb77b112-990e-4c5d-9783-d3d5c9ce98ee">

This is because we were using `showTrueAnswer` to determine when the question is complete. However, when this is forced to false by `showCorrectAnswer`, we miss the early return and thus render with nonsensical data.

This PR changes the conditional to check `varianAttemptsLeft`, which is defined here:

https://github.com/PrairieLearn/PrairieLearn/blob/488fbcae1049e6235761719f4196386910e97f6a/apps/prairielearn/src/lib/question-render.js#L229-L264

AFAICT, this will in fact be reliably `0` when a question is complete. Here's how the same situation as above renders after this change:

<img width="1314" alt="Screenshot 2024-10-11 at 09 35 12" src="https://github.com/user-attachments/assets/dbf3265d-38d4-4da1-aa64-39902a8f4789">

To test this, I updated `exampleCourse/questions/demo/autograder/codeEditor/info.json` to include `"showCorrectAnswer": false`, then updated `exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/infoAssessment.json` to include that question with `"points": [5,5,5,5,5]`. I then submitted a correct answer as my first submission.