### PR TITLE
Consistently use double quotes in docs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -88,7 +88,7 @@ In production, PrairieLearn runs external grading jobs and workspaces on a distr
 
 In order to run external grading jobs when PrairieLearn is running locally inside Docker, there are a few additional preparation steps that are necessary:
 
-- We need a way of starting up Docker containers on the host machine from within another Docker container. We achieve this by mounting the Docker socket from the host into the Docker container running PrairieLearn; this allows us to run 'sibling' containers.
+- We need a way of starting up Docker containers on the host machine from within another Docker container. We achieve this by mounting the Docker socket from the host into the Docker container running PrairieLearn; this allows us to run "sibling" containers.
 - We need to get job files from inside the Docker container running PrairieLearn to the host machine so that Docker can mount them to `/grade` on the grading machine. We achieve this by mounting a directory on the host machine to `/jobs` on the grading machine, and setting an environment variable `HOST_JOBS_DIR` containing the absolute path of that directory on the host machine.
 
 To run PrairieLearn locally with external grader and workspace support, create an empty directory to use to share job data between containers. This directory can live anywhere, but needs to be created first and referenced in the docker launch command. This directory only needs to be created once. If you are running Windows, the directory should be created inside the WSL 2 instance. You can create this directory using a command like:

--- a/docs/lti13.md
+++ b/docs/lti13.md
@@ -54,4 +54,4 @@ You must configure your LMS to send user identifying claims. Anonymous logins ar
 
 ### Placements
 
-PrairieLearn recommends 'Course Navigation' placements, as described in the configuration JSON. More placements may be added in the future.
+PrairieLearn recommends "Course Navigation" placements, as described in the configuration JSON. More placements may be added in the future.

--- a/docs/questionSharing.md
+++ b/docs/questionSharing.md
@@ -6,7 +6,7 @@ In order to avoid instructors needing to copy question files in between courses,
 
 ## Sharing names
 
-In order for another course to use questions from your course into their assessments, you must have chosen a _sharing name_ for your course that they will use as a prefix to your question IDs when using them. This sharing name will be unique across all PrairieLearn instances and because it will be used in the JSON files for other courses, there will be no way to change the sharing name for your course once you have chosen it. It is recommended that you choose something short but descriptive. For example, if you're teaching a calculus course at a university that goes by the abbreviation 'XYZ', then you could choose the sharing name 'xyz-calculus'. Then other courses will use questions from your course with the syntax `@xyz-calculus/qid`.
+In order for another course to use questions from your course into their assessments, you must have chosen a _sharing name_ for your course that they will use as a prefix to your question IDs when using them. This sharing name will be unique across all PrairieLearn instances and because it will be used in the JSON files for other courses, there will be no way to change the sharing name for your course once you have chosen it. It is recommended that you choose something short but descriptive. For example, if you're teaching a calculus course at a university that goes by the abbreviation "XYZ", then you could choose the sharing name "xyz-calculus". Then other courses will use questions from your course with the syntax `@xyz-calculus/qid`.
 
 ## Two ways to share: Publicly or through "Sharing sets"
 
@@ -20,9 +20,9 @@ Access to shared questions which are not shared publicly is controlled through *
 
 ## Sharing a sharing set with another course
 
-For security reasons, establishing the connection for one course to share questions with another course requires coordinated action by owners of the course sharing the questions (which we will refer to hereafter as the 'sharing course') and the course that is using the questions that are being shared ('which we will refer to hereafter as the 'consuming course')
+For security reasons, establishing the connection for one course to share questions with another course requires coordinated action by owners of the course sharing the questions (which we will refer to hereafter as the "sharing course") and the course that is using the questions that are being shared ('which we will refer to hereafter as the "consuming course")
 
-In order to allow someone to share their questions with your course, you must provide them with the 'Sharing Token' listed on the 'Sharing' tab of your instructor settings page. Then the sharing course must use the sharing token which you provide to them to add your course as a consumer of one of their sharing sets.
+In order to allow someone to share their questions with your course, you must provide them with the "Sharing Token" listed on the "Sharing" tab of your instructor settings page. Then the sharing course must use the sharing token which you provide to them to add your course as a consumer of one of their sharing sets.
 
 ## Using shared questions
 
@@ -55,10 +55,10 @@ Just as anyone with access to a question in your course can access any file in `
 
 **Note:** Once a question is added to a sharing set, the question cannot be renamed, deleted, or removed from the sharing set because doing so could break the assessments of people who have used the shared question.
 
-1. On your course admin page, visit the 'sharing' tab.
+1. On your course admin page, visit the "Sharing" tab.
 2. Choose a sharing name for your course.
 3. Create a sharing set by adding it to your course's `infoCourse.json` file.
-4. Have the instructor or the course you would like to share your question with visit the 'sharing' tab on their course admin page and provide you with their course's sharing token.
+4. Have the instructor or the course you would like to share your question with visit the "Sharing" tab on their course admin page and provide you with their course's sharing token.
 5. Use the provided sharing token to add the other instructor's course as a consumer of the sharing set you created.
 6. Add the sharing set to the `sharingSets` list in `info.json` file of the questions you would like to share.
 7. The course you have shared the question with may now use it by referencing it in their assessments.
@@ -67,7 +67,7 @@ Just as anyone with access to a question in your course can access any file in `
 
 **Note:** Once a question is publicly shared, the question cannot be renamed, deleted, or un-publicly shared because doing so could break the assessments of people who have used the shared question. Sharing the source code of a question may be un-done.
 
-1. On your course admin page, visit the 'sharing' tab.
+1. On your course admin page, visit the "Sharing" tab.
 2. Choose a sharing name for your course.
 3. Add `"sharePublicly": true` to the `info.json` file of questions you would like to share publicly.
 4. Optionally, add `"shareSourcePublicly": true` to the `info.json` file if you would like people to also be able to view and copy the source code of your question.


### PR DESCRIPTION
Minor nit I noticed while reviewing #10730.

This doesn't address the elements documentation, which is tracked by #10767.