### PR TITLE
Disallow depracated property sharedSourcePublicly in JSON files

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1161,7 +1161,6 @@ export class QuestionCopyEditor extends Editor {
     delete infoJson['sharePublicly'];
     delete infoJson['sharedPublicly'];
     delete infoJson['shareSourcePublicly'];
-    delete infoJson['sharedSourcePublicly'];
     await fs.writeJson(path.join(questionPath, 'info.json'), infoJson, { spaces: 4 });
 
     return {
@@ -1245,7 +1244,6 @@ export class QuestionTransferEditor extends Editor {
     delete infoJson['sharePublicly'];
     delete infoJson['sharedPublicly'];
     delete infoJson['shareSourcePublicly'];
-    delete infoJson['sharedSourcePublicly'];
     await fs.writeJson(path.join(questionPath, 'info.json'), infoJson, { spaces: 4 });
 
     return {

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -271,10 +271,6 @@
     "shareSourcePublicly": {
       "description": "Whether this questions's source code is publicly shared.",
       "type": "boolean"
-    },
-    "sharedSourcePublicly": {
-      "description": "[DEPRECATED, DO NOT USE] Whether this questions's source code is publicly shared.",
-      "type": "boolean"
     }
   }
 }

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -390,7 +390,6 @@ export interface Question {
   sharePublicly: boolean;
   sharedPublicly: boolean;
   shareSourcePublicly: boolean;
-  sharedSourcePublicly: boolean;
 }
 
 export interface CourseInstanceData {
@@ -1056,16 +1055,6 @@ async function validateQuestion(
       errors.push('Cannot specify both "sharedPublicly" and "sharePublicly" in one question.');
     } else {
       warnings.push('"sharedPublicly" is deprecated; use "sharePublicly" instead.');
-    }
-  }
-
-  if ('sharedSourcePublicly' in question) {
-    if ('shareSourcePublicly' in question) {
-      errors.push(
-        'Cannot specify both "sharedSourcePublicly" and "shareSourcePublicly" in one question.',
-      );
-    } else {
-      warnings.push('"sharedSourcePublicly" is deprecated; use "shareSourcePublicly" instead.');
     }
   }
 

--- a/apps/prairielearn/src/sync/fromDisk/questions.ts
+++ b/apps/prairielearn/src/sync/fromDisk/questions.ts
@@ -48,7 +48,7 @@ function getParamsForQuestion(q: Question | null | undefined) {
     workspace_enable_networking: q.workspaceOptions && q.workspaceOptions.enableNetworking,
     workspace_environment: q.workspaceOptions?.environment ?? {},
     shared_publicly: q.sharePublicly ?? q.sharedPublicly ?? false,
-    share_source_publicly: q.shareSourcePublicly ?? q.sharedSourcePublicly ?? false,
+    share_source_publicly: q.shareSourcePublicly ?? false,
   };
 }
 

--- a/apps/prairielearn/src/tests/sync/util.ts
+++ b/apps/prairielearn/src/tests/sync/util.ts
@@ -189,7 +189,6 @@ export interface Question {
   sharePublicly?: boolean;
   sharedPublicly?: boolean;
   shareSourcePublicly?: boolean;
-  sharedSourcePublicly?: boolean;
   clientFiles?: string[];
   clientTemplates?: string[];
   template?: string;


### PR DESCRIPTION
This was briefly introduced in #10029 , but as no one has used it yet we should be safe to deprecate and remove immediately.