### PR TITLE
Persist changes to `pl-text` in `pl-drawing`

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -1031,7 +1031,7 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
     this.label = text;
 
     if (text) {
-      this.gen_text(this.parse(this.label), options);
+      this.gen_text(this.label, options);
     }
 
     if (options.selectable) {
@@ -1042,7 +1042,7 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
           this.gen_text(this.parse(new_text), options);
 
           // Fire an event to ensure that the text is updated in the submission data.
-          this.fire('modified');
+          // this.fire('modified');
         }
       });
     }

--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -1042,7 +1042,7 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
           this.gen_text(this.parse(new_text), options);
 
           // Fire an event to ensure that the text is updated in the submission data.
-          // this.fire('modified');
+          this.fire('modified');
         }
       });
     }

--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -1534,7 +1534,6 @@ mechanicsObjects.byType['pl-text'] = class extends PLDrawingBaseElement {
     let textObj;
 
     if (options.latex) {
-      console.log('latex');
       textObj = new mechanicsObjects.LatexText(options.label, {
         left: options.left + options.offsetx,
         top: options.top + options.offsety,
@@ -1547,7 +1546,6 @@ mechanicsObjects.byType['pl-text'] = class extends PLDrawingBaseElement {
         scaleY: options.scaleY || 1,
       });
     } else {
-      console.log('non-latex');
       textObj = new fabric.Text(options.label, {
         left: options.left + options.offsetx,
         top: options.top + options.offsety,

--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -1031,7 +1031,7 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
     this.label = text;
 
     if (text) {
-      this.gen_text(this.label, options);
+      this.gen_text(this.parse(this.label), options);
     }
 
     if (options.selectable) {
@@ -1040,6 +1040,9 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
         if (new_text !== null) {
           this.label = new_text;
           this.gen_text(this.parse(new_text), options);
+
+          // Fire an event to ensure that the text is updated in the submission data.
+          this.fire('modified');
         }
       });
     }
@@ -1531,6 +1534,7 @@ mechanicsObjects.byType['pl-text'] = class extends PLDrawingBaseElement {
     let textObj;
 
     if (options.latex) {
+      console.log('latex');
       textObj = new mechanicsObjects.LatexText(options.label, {
         left: options.left + options.offsetx,
         top: options.top + options.offsety,
@@ -1543,6 +1547,7 @@ mechanicsObjects.byType['pl-text'] = class extends PLDrawingBaseElement {
         scaleY: options.scaleY || 1,
       });
     } else {
+      console.log('non-latex');
       textObj = new fabric.Text(options.label, {
         left: options.left + options.offsetx,
         top: options.top + options.offsety,


### PR DESCRIPTION
This PR fixes an issue that was reported on Slack. To reproduce on master, start with the following question:

```html
<pl-drawing width="500" height="500" gradable="true" answers-name="answer">
    <pl-drawing-answer></pl-drawing-answer>
    <pl-controls>
        <pl-controls-group label="Write text">
            <pl-drawing-button type="pl-text"></pl-drawing-button>
        </pl-controls-group>
    </pl-controls>
</pl-drawing>
```

- Click the button to add text to the canvas.
- Double click the text to edit.
- Change the text.
- Without making any other changes, click "Save" or "Save & Grade".
- Observe that after the page refreshes, the text has reverted to just "Text".