### PR TITLE
Update security policy to only call out public Slack channels

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The PrairieLearn team takes the security of our products and services seriously.
 
 ## Reporting a vulnerability
 
-If you believe you have found a vulnerability in any PrairieLearn software, please report it to us via coordinated disclosure. **Do not report suspected vulnerabilities publicly, including through GitHub issues or Slack.** Instead, please send an email to security@prairielearn.com with as much relevant information as possible, including:
+If you believe you have found a vulnerability in any PrairieLearn software, please report it to us via coordinated disclosure. **Do not report suspected vulnerabilities publicly, including through GitHub issues or public Slack channels.** Instead, please send an email to security@prairielearn.com with as much relevant information as possible, including:
 
 - The type of issue (e.g. SQL injection or cross-site scripting)
 - Any special configuration required to reproduce the issue


### PR DESCRIPTION
This brings this document into alignment with https://www.prairielearn.com/security. We don't care if someone discusses or discloses vulnerabilities in DMs.