### PR TITLE
Document that `Feedback.not_allowed` is insecure

### DIFF
--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -181,18 +181,20 @@ Note that the first argument of the `Feedback.check_xx` functions is the name of
 
 Be careful not to switch the ordering of the student and reference arguments. The student answer is subject to more strict type checking, and there have been instances in the past where the grader has been broken by poorly formatted student answers.
 
-## Banning/Disallowing library functions
+## Disallowing library functions
+
+**Note that because Python is a highly-dynamic language, the following method can be bypassed by students with sufficient knowledge of Python. For stronger guarantees about which functions are or are not used, consider using more advanced static analysis techniques, which are beyond the scope of what this autograder offers. You can also perform verification by hand with manual grading.**
 
 One can hook into library functions in the setup code to disallow students from accessing certain functions. This example is taken from the [demo/autograder/python/numpy] question.
 
-By setting the library functions equal to `Feedback.not_allowed`:
+One can set library functions equal to `Feedback.not_allowed`:
 
 ```python
 numpy.linalg.inv = Feedback.not_allowed
 numpy.linalg.pinv = Feedback.not_allowed
 ```
 
-the `inv` and `pinv` functions will be effectively banned from use. Any time the student tries to use the functions their code will raise an exception. This will survive library reimports.
+Now, any time the student tries to use the functions, their code will raise an exception.
 
 ## Overview
 

--- a/docs/python-grader/sphinx-docs.md
+++ b/docs/python-grader/sphinx-docs.md
@@ -132,10 +132,15 @@ Complete grading immediately, additionally outputting the message in fb_text.
 
 #### _static_ not_allowed(\*args, \*\*kwargs)
 
-library_function = Feedback.not_allowed
-
 Used to hook into disallowed functions, raises an exception if
 the student tries to call it.
+
+Note that because Python is a highly-dynamic language, this method can
+be bypassed by students with sufficient knowledge of Python. For stronger
+guarantees about which functions are or are not used, consider using more
+advanced static analysis techniques, which are beyond the scope of what
+this autograder offers. You can also perform verification by hand with
+manual grading.
 
 #### _classmethod_ set_score(percentage)
 

--- a/graders/python/python_autograder/code_feedback.py
+++ b/graders/python/python_autograder/code_feedback.py
@@ -104,10 +104,15 @@ class Feedback:
     @staticmethod
     def not_allowed(*args, **kwargs):
         """
-        library_function = Feedback.not_allowed
-
         Used to hook into disallowed functions, raises an exception if
         the student tries to call it.
+
+        Note that because Python is a highly-dynamic language, this method can
+        be bypassed by students with sufficient knowledge of Python. For stronger
+        guarantees about which functions are or are not used, consider using more
+        advanced static analysis techniques, which are beyond the scope of what
+        this autograder offers. You can also perform verification by hand with
+        manual grading.
         """
         raise RuntimeError("The use of this function is not allowed.")
 


### PR DESCRIPTION
We might consider ways to make function disallowing more reliable in future versions of the Python autograder for now. In the meantime, we want to be upfront with instructors that this method is not fully secure and can be bypassed by students.