### PR TITLE
Upgrade cookie dependency

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -92,7 +92,7 @@
     "ejs": "^3.1.10",
     "es-main": "^1.3.0",
     "execa": "^9.3.1",
-    "express": "^4.19.2",
+    "express": "^4.21.1",
     "express-async-handler": "^1.2.0",
     "fabric": "4.6.0-browser",
     "fast-glob": "^3.3.2",

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -77,7 +77,7 @@
     "chalk": "^5.3.0",
     "cheerio": "^1.0.0",
     "clipboard": "^2.0.11",
-    "cookie-parser": "^1.4.6",
+    "cookie-parser": "^1.4.7",
     "crypto-js": "^4.2.0",
     "csv-parse": "^5.5.6",
     "csvtojson": "^2.0.10",

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -31,7 +31,7 @@
     "body-parser": "^1.20.3",
     "debug": "^4.3.6",
     "dockerode": "^4.0.2",
-    "express": "^4.19.2",
+    "express": "^4.21.1",
     "express-async-handler": "^1.2.0",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",

--- a/packages/compiled-assets/package.json
+++ b/packages/compiled-assets/package.json
@@ -18,7 +18,7 @@
     "@prairielearn/html": "workspace:^",
     "commander": "^12.1.0",
     "esbuild": "^0.23.1",
-    "express": "^4.19.2",
+    "express": "^4.21.1",
     "express-static-gzip": "^2.1.7",
     "fs-extra": "^11.2.0",
     "globby": "^14.0.2",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -34,7 +34,7 @@
     "@types/uid-safe": "^2.1.5",
     "c8": "^10.1.2",
     "chai": "^5.1.1",
-    "express": "^4.19.2",
+    "express": "^4.21.1",
     "fetch-cookie": "^3.0.1",
     "mocha": "^10.7.3",
     "node-fetch": "^3.3.2",

--- a/workspaces/desktop/server/package.json
+++ b/workspaces/desktop/server/package.json
@@ -9,7 +9,7 @@
     "@novnc/novnc": "1.4.0",
     "command-line-args": "^6.0.0",
     "command-line-usage": "^7.0.2",
-    "express": "^5.0.0",
+    "express": "^5.0.1",
     "express-ws": "^5.0.2",
     "http-proxy": "^1.18.1",
     "spin.js": "^4.1.1"

--- a/workspaces/desktop/server/yarn.lock
+++ b/workspaces/desktop/server/yarn.lock
@@ -137,10 +137,10 @@ cookie-signature@^1.2.1:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.1.tgz#790dea2cce64638c7ae04d9fabed193bd7ccf3b4"
   integrity sha512-78KWk9T26NhzXtuL26cIJ8/qNHANyJ/ZYrmEXFzUmhZdjpBv+DlWlOANRTGBt48YcyslsLrj0bMLFTmXvLRCOw==
 
-cookie@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+cookie@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
+  integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
 
 debug@2.6.9:
   version "2.6.9"
@@ -238,16 +238,16 @@ express-ws@^5.0.2:
   dependencies:
     ws "^7.4.6"
 
-express@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-5.0.0.tgz#744f9ec86025a01aeca99e4300aa4fc050d493c7"
-  integrity sha512-V4UkHQc+B7ldh1YC84HCXHwf60M4BOMvp9rkvTUWCK5apqDC1Esnbid4wm6nFyVuDy8XMfETsJw5lsIGBWyo0A==
+express@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.0.1.tgz#5d359a2550655be33124ecbc7400cd38436457e9"
+  integrity sha512-ORF7g6qGnD+YtUG9yx4DFoqCShNMmUKiXuT5oWMHiOvt/4WFbHC6yCwQMTSBMno7AqntNCAzzcnnjowRkTL9eQ==
   dependencies:
     accepts "^2.0.0"
     body-parser "^2.0.1"
     content-disposition "^1.0.0"
     content-type "~1.0.4"
-    cookie "0.6.0"
+    cookie "0.7.1"
     cookie-signature "^1.2.1"
     debug "4.3.6"
     depd "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3046,7 +3046,7 @@ __metadata:
     chai: "npm:^5.1.1"
     commander: "npm:^12.1.0"
     esbuild: "npm:^0.23.1"
-    express: "npm:^4.19.2"
+    express: "npm:^4.21.1"
     express-static-gzip: "npm:^2.1.7"
     fs-extra: "npm:^11.2.0"
     get-port: "npm:^7.1.0"
@@ -3613,7 +3613,7 @@ __metadata:
     ejs: "npm:^3.1.10"
     es-main: "npm:^1.3.0"
     execa: "npm:^9.3.1"
-    express: "npm:^4.19.2"
+    express: "npm:^4.21.1"
     express-async-handler: "npm:^1.2.0"
     fabric: "npm:4.6.0-browser"
     fast-glob: "npm:^3.3.2"
@@ -3789,7 +3789,7 @@ __metadata:
     chai: "npm:^5.1.1"
     cookie: "npm:^0.7.1"
     cookie-signature: "npm:^1.2.1"
-    express: "npm:^4.19.2"
+    express: "npm:^4.21.1"
     express-async-handler: "npm:^1.2.0"
     fetch-cookie: "npm:^3.0.1"
     mocha: "npm:^10.7.3"
@@ -3850,7 +3850,7 @@ __metadata:
     chai: "npm:^5.1.1"
     debug: "npm:^4.3.6"
     dockerode: "npm:^4.0.2"
-    express: "npm:^4.19.2"
+    express: "npm:^4.21.1"
     express-async-handler: "npm:^1.2.0"
     ioredis: "npm:^5.4.1"
     lodash: "npm:^4.17.21"
@@ -7302,17 +7302,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.7.1, cookie@npm:^0.7.1":
+"cookie@npm:0.7.1":
   version: 0.7.1
   resolution: "cookie@npm:0.7.1"
   checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
   languageName: node
   linkType: hard
 
-"cookie@npm:~0.4.1":
-  version: 0.4.2
-  resolution: "cookie@npm:0.4.2"
-  checksum: 10c0/beab41fbd7c20175e3a2799ba948c1dcc71ef69f23fe14eeeff59fc09f50c517b0f77098db87dbb4c55da802f9d86ee86cdc1cd3efd87760341551838d53fca2
+"cookie@npm:^0.7.1, cookie@npm:~0.7.2":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
   languageName: node
   linkType: hard
 
@@ -8320,21 +8320,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"engine.io@npm:~6.5.2":
-  version: 6.5.5
-  resolution: "engine.io@npm:6.5.5"
+"engine.io@npm:~6.6.0":
+  version: 6.6.2
+  resolution: "engine.io@npm:6.6.2"
   dependencies:
     "@types/cookie": "npm:^0.4.1"
     "@types/cors": "npm:^2.8.12"
     "@types/node": "npm:>=10.0.0"
     accepts: "npm:~1.3.4"
     base64id: "npm:2.0.0"
-    cookie: "npm:~0.4.1"
+    cookie: "npm:~0.7.2"
     cors: "npm:~2.8.5"
     debug: "npm:~4.3.1"
     engine.io-parser: "npm:~5.2.1"
     ws: "npm:~8.17.1"
-  checksum: 10c0/b0994134917c5d3649fd7aea283492eaf092131e572a8d379c7c9081548b42cff756730b4641edd0d1598148dd3be253c4d634cea2ba5c59622d175d9e567469
+  checksum: 10c0/e9ac3cba49badb6905259df3b019fbcbe53e2a389c930fb9fbc10eebc8839554b189706206bba2509a4a3a7d78a32f7e027f73230f31662c7efd215276432dad
   languageName: node
   linkType: hard
 
@@ -8865,7 +8865,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.19.2, express@npm:^4.21.0":
+"express@npm:^4.21.0, express@npm:^4.21.1":
   version: 4.21.1
   resolution: "express@npm:4.21.1"
   dependencies:
@@ -14167,17 +14167,17 @@ __metadata:
   linkType: hard
 
 "socket.io@npm:^4.7.5":
-  version: 4.7.5
-  resolution: "socket.io@npm:4.7.5"
+  version: 4.8.0
+  resolution: "socket.io@npm:4.8.0"
   dependencies:
     accepts: "npm:~1.3.4"
     base64id: "npm:~2.0.0"
     cors: "npm:~2.8.5"
     debug: "npm:~4.3.2"
-    engine.io: "npm:~6.5.2"
+    engine.io: "npm:~6.6.0"
     socket.io-adapter: "npm:~2.5.2"
     socket.io-parser: "npm:~4.2.4"
-  checksum: 10c0/221a2cd25f6077d6672cb8b19921336e1acf06788d4bade74953dc96dbfd8b788a5f721b051341a34ee81ef8e1b2028d39ad5257516776400a3f8f3f01255c5e
+  checksum: 10c0/eab8a0da617f2583a0003883155f252f814c59324f4b174b5e940fcce2bd3a553ab9c6d7f128c7b515a537f776b1b4e34293b8324ec048c4b8df2bf8930ce8bf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3598,7 +3598,7 @@ __metadata:
     chalk: "npm:^5.3.0"
     cheerio: "npm:^1.0.0"
     clipboard: "npm:^2.0.11"
-    cookie-parser: "npm:^1.4.6"
+    cookie-parser: "npm:^1.4.7"
     crypto-js: "npm:^4.2.0"
     csv-parse: "npm:^5.5.6"
     csvtojson: "npm:^2.0.10"
@@ -7271,13 +7271,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie-parser@npm:^1.4.6":
-  version: 1.4.6
-  resolution: "cookie-parser@npm:1.4.6"
+"cookie-parser@npm:^1.4.7":
+  version: 1.4.7
+  resolution: "cookie-parser@npm:1.4.7"
   dependencies:
-    cookie: "npm:0.4.1"
+    cookie: "npm:0.7.2"
     cookie-signature: "npm:1.0.6"
-  checksum: 10c0/9c2ade5459290802cd472a2d2a6e46fbd7de3e8514e02bfed5edfde892d77733c7f89d9d2015f752a9087680429b416972d7aba748bf6824e21eb680c8556383
+  checksum: 10c0/46bef553de409031b69a6074ce512d131a98e4fa12612669f1a9c3dd98d56897a31db86a3f4338d4a3a895c6f8d5cfd6fa4d99cdf588e0e8eda655efc3f384dc
   languageName: node
   linkType: hard
 
@@ -7295,13 +7295,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.4.1":
-  version: 0.4.1
-  resolution: "cookie@npm:0.4.1"
-  checksum: 10c0/4d7bc798df3d0f34035977949cd6b7d05bbab47d7dcb868667f460b578a550cd20dec923832b8a3a107ef35aba091a3975e14f79efacf6e39282dc0fed6db4a1
-  languageName: node
-  linkType: hard
-
 "cookie@npm:0.7.1":
   version: 0.7.1
   resolution: "cookie@npm:0.7.1"
@@ -7309,7 +7302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.1, cookie@npm:~0.7.2":
+"cookie@npm:0.7.2, cookie@npm:^0.7.1, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2


### PR DESCRIPTION
This should keep Dependabot happy with some low-severity security alerts.