### PR TITLE
Read some values directly from config instead of res.locals

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -19,7 +19,7 @@ export function Navbar({
   navSubPage?: NavSubPage;
   navbarType?: NavbarType;
 }) {
-  const { __csrf_token, course, urlPrefix, homeUrl } = resLocals;
+  const { __csrf_token, course, urlPrefix } = resLocals;
   navPage ??= resLocals.navPage;
   navSubPage ??= resLocals.navSubPage;
   navbarType ??= resLocals.navbarType;
@@ -55,7 +55,7 @@ export function Navbar({
 
     <nav class="navbar navbar-dark bg-dark navbar-expand-md" aria-label="Global navigation">
       <div class="container-fluid">
-        <a class="navbar-brand" href="${homeUrl}" aria-label="Homepage">
+        <a class="navbar-brand" href="${config.homeUrl}" aria-label="Homepage">
           <span class="navbar-brand-label">PrairieLearn</span>
           <span class="navbar-brand-hover-label">
             Go home <i class="fa fa-angle-right" aria-hidden="true"></i>

--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -88,7 +88,7 @@ export async function loadUser(req, res, authnParams, optionsParams = {}) {
   }
 
   if (options.redirect) {
-    let redirUrl = res.locals.homeUrl;
+    let redirUrl = config.homeUrl;
     if ('pl2_pre_auth_url' in req.cookies) {
       redirUrl = req.cookies.pl2_pre_auth_url;
       clearCookie(res, ['preAuthUrl', 'pl2_pre_auth_url']);

--- a/apps/prairielearn/src/lib/authn.js
+++ b/apps/prairielearn/src/lib/authn.js
@@ -6,6 +6,7 @@ import * as sqldb from '@prairielearn/postgres';
 import { redirectToTermsPageIfNeeded } from '../ee/lib/terms.js';
 import { clearCookie } from '../lib/cookie.js';
 
+import { config } from './config.js';
 import { InstitutionSchema, UserSchema } from './db-types.js';
 import { isEnterprise } from './license.js';
 import { HttpRedirect } from './redirect.js';
@@ -109,7 +110,7 @@ export async function loadUser(req, res, authnParams, optionsParams = {}) {
   res.locals.authn_provider_name = authnParams.provider;
   res.locals.authn_is_administrator = selectedUser.is_administrator;
 
-  const defaultAccessType = res.locals.devMode ? 'active' : 'inactive';
+  const defaultAccessType = config.devMode ? 'active' : 'inactive';
   const accessType = req.cookies.pl2_access_as_administrator || defaultAccessType;
   res.locals.access_as_administrator = accessType === 'active';
   res.locals.is_administrator =

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -595,7 +595,6 @@ export async function loadConfig(paths: string[]) {
 }
 
 export function setLocalsFromConfig(locals: Record<string, any>) {
-  locals.homeUrl = config.homeUrl;
   locals.urlPrefix = config.urlPrefix;
   locals.plainUrlPrefix = config.urlPrefix;
   locals.navbarType = 'plain';

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -600,5 +600,4 @@ export function setLocalsFromConfig(locals: Record<string, any>) {
   locals.plainUrlPrefix = config.urlPrefix;
   locals.navbarType = 'plain';
   locals.devMode = config.devMode;
-  locals.is_administrator = false;
 }

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -599,5 +599,4 @@ export function setLocalsFromConfig(locals: Record<string, any>) {
   locals.urlPrefix = config.urlPrefix;
   locals.plainUrlPrefix = config.urlPrefix;
   locals.navbarType = 'plain';
-  locals.devMode = config.devMode;
 }

--- a/apps/prairielearn/src/lib/question-render.js
+++ b/apps/prairielearn/src/lib/question-render.js
@@ -482,7 +482,7 @@ export async function getAndRenderVariant(variant_id, variant_seed, locals) {
   //
   // We'll only load the data that will be needed for this specific page render.
   // The checks here should match those in `components/QuestionContainer.html.ts`.
-  const loadExtraData = locals.devMode || locals.authz_data.has_course_permission_view;
+  const loadExtraData = config.devMode || locals.authz_data.has_course_permission_view;
   locals.issues = await sqldb.queryRows(
     sql.select_issues,
     {

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -217,7 +217,7 @@ export function AuthLogin({
     service,
     resLocals,
     children: html`
-      ${resLocals.devMode
+      ${config.devMode
         ? html`
             ${DevModeBypass()}
             <hr />

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -108,8 +108,7 @@ export function InstructorAssessmentAccess({
                           ${access_rule.pt_exam_name
                             ? html`
                                 <a
-                                  href="${resLocals.config
-                                    .ptHost}/pt/course/${access_rule.pt_course_id}/staff/exam/${access_rule.pt_exam_id}"
+                                  href="${config.ptHost}/pt/course/${access_rule.pt_course_id}/staff/exam/${access_rule.pt_exam_id}"
                                 >
                                   ${access_rule.pt_course_name}: ${access_rule.pt_exam_name}
                                 </a>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -5,6 +5,7 @@ import { html } from '@prairielearn/html';
 import { HeadContents } from '../../components/HeadContents.html.js';
 import { Navbar } from '../../components/Navbar.html.js';
 import { AssessmentSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
+import { config } from '../../lib/config.js';
 
 export const AssessmentAccessRulesSchema = z.object({
   mode: z.string(),
@@ -114,7 +115,7 @@ export function InstructorAssessmentAccess({
                                 </a>
                               `
                             : access_rule.exam_uuid
-                              ? resLocals.devMode
+                              ? config.devMode
                                 ? access_rule.exam_uuid
                                 : html`
                                     <span class="text-danger">

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
@@ -65,7 +65,7 @@ async function update(locals: Record<string, any>) {
 router.get(
   '/',
   asyncHandler(async (req, res, next) => {
-    if (!res.locals.devMode) return next();
+    if (!config.devMode) return next();
     const jobSequenceId = await update(res.locals);
     res.redirect(res.locals.urlPrefix + '/jobSequence/' + jobSequenceId);
   }),

--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -132,7 +132,6 @@ export async function initExpress() {
   // all pages including the error page (which we could jump to at
   // any point.
   app.use((req, res, next) => {
-    res.locals.config = config;
     setLocalsFromConfig(res.locals);
     next();
   });


### PR DESCRIPTION
I realized while working on #10804 that we could clean this up a little bit.

It's not obvious from the actual changes here whether all usages of these values from `res.locals` have actually been removed. I'd recommend sitting down with grep or VSCode search to check my work, though I'm pretty sure I got them all.