### PR TITLE
Rename "Submission status" to "Status"

### DIFF
--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -57,7 +57,7 @@ export function QuestionScorePanel({
           ${assessment.type === 'Exam'
             ? html`
                 <tr>
-                  <td>Submission status:</td>
+                  <td>Status:</td>
                   <td>${ExamQuestionStatus({ instance_question })}</td>
                 </tr>
               `

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -446,11 +446,10 @@ export function StudentAssessmentInstance({
                               the question page.
                             </li>
                             <li>
-                              Look at <strong>Submission status</strong> to confirm that each
-                              question has been graded. Questions with
-                              <strong>Available points</strong> can be attempted again for more
-                              points. Attempting questions again will never reduce the points you
-                              already have.
+                              Look at <strong>Status</strong> to confirm that each question has been
+                              graded. Questions with <strong>Available points</strong> can be
+                              attempted again for more points. Attempting questions again will never
+                              reduce the points you already have.
                             </li>
                             ${resLocals.authz_result.password != null ||
                             !resLocals.authz_result.show_closed_assessment
@@ -596,7 +595,7 @@ function InstanceQuestionTableHeader({ resLocals }: { resLocals: Record<string, 
             ? html`
                 <tr>
                   <th rowspan="2">Question</th>
-                  <th class="text-center" rowspan="2">Submission status</th>
+                  <th class="text-center" rowspan="2">Status</th>
                   <th class="text-center" colspan="2">Auto-grading</th>
                   <th class="text-center" rowspan="2">Manual grading points</th>
                   <th class="text-center" rowspan="2">Total points</th>
@@ -608,7 +607,7 @@ function InstanceQuestionTableHeader({ resLocals }: { resLocals: Record<string, 
             : html`
                 <tr>
                   <th>Question</th>
-                  <th class="text-center">Submission status</th>
+                  <th class="text-center">Status</th>
                   ${trailingColumns}
                 </tr>
               `}

--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -590,7 +590,6 @@ Compared to the normal assessment, there are a number of differences:
 - A warning explaining that real-time grading has been disabled is shown
 - Total points is listed as a number, not as an "X/Y" score
 - The percentage bar is not displayed
-- The "Best submission" column is renamed to "Submission status"
 - The "Available points" column has been removed
 - The "Awarded points" column has been renamed to "Points" and only shows the max points
 


### PR DESCRIPTION
This change will give us a little more breathing room for the long "saved for manual grading" badge that's coming in #10686. As discussed here: https://github.com/PrairieLearn/PrairieLearn/pull/10686#discussion_r1795922248

Before:

<img width="502" alt="Screenshot 2024-10-17 at 09 12 39" src="https://github.com/user-attachments/assets/0fbaebb6-3b4b-44aa-816e-5adaa2cea0a4">

<br/>

<img width="326" alt="Screenshot 2024-10-17 at 09 12 30" src="https://github.com/user-attachments/assets/16f32bf3-7429-42dc-879c-aaa3f37d11be">


After:

<img width="446" alt="Screenshot 2024-10-17 at 09 11 48" src="https://github.com/user-attachments/assets/7040c861-4173-404b-a1a9-4d36b3d04c26">

<br/>

<img width="327" alt="Screenshot 2024-10-17 at 09 11 55" src="https://github.com/user-attachments/assets/8c3016a1-4370-4dbc-b6ad-0fcc6cd8139e">
