### PR TITLE
Refine instructor info panel

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -225,6 +225,7 @@ function VariantInfo({
     typeof variant.date === 'string' ? DateFromISOString.parse(variant.date) : variant.date;
 
   return html`
+    <h3 class="card-title h5">Variant</h3>
     ${questionContext !== 'public'
       ? html`
           <div class="d-flex flex-wrap">
@@ -237,7 +238,7 @@ function VariantInfo({
           </div>
         `
       : ''}
-    <div class="d-flex flex-wrap mt-2">
+    <div class="d-flex flex-wrap">
       <details class="pr-1">
         <summary>Show/Hide answer</summary>
         <pre class="mt-2 mb-0"><code>${JSON.stringify(variant.true_answer, null, 2)}</code></pre>
@@ -270,7 +271,7 @@ function AssessmentInstanceInfo({
       : assessment_instance.date;
 
   return html`
-    <h3 class="card-title h5">Assessment Instance</h3>
+    <h3 class="card-title h5">Assessment instance</h3>
     <div class="d-flex flex-wrap">
       <div class="pr-1">AID:</div>
       <div>
@@ -319,7 +320,7 @@ function ManualGradingInfo({
   const manualGradingUrl = `${config.urlPrefix}/course_instance/${assessment.course_instance_id}/instructor/assessment/${assessment.id}/manual_grading/instance_question/${instance_question.id}`;
 
   return html`
-    <h3 class="card-title h5">Manual Grading</h3>
+    <h3 class="card-title h5">Manual grading</h3>
 
     <div class="d-flex flex-wrap">
       <div class="pr-1">Status:</div>

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -99,7 +99,7 @@ function ListGroup(children: HtmlValue[]) {
 
   return html`
     <div class="list-group list-group-flush">
-      ${filteredChildren.map((child) => html`<div class="list-group-item">${child}</div>`)}
+      ${filteredChildren.map((child) => html`<div class="list-group-item py-3">${child}</div>`)}
     </div>
   `;
 }

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -1,5 +1,5 @@
 import { formatDate, formatInterval } from '@prairielearn/formatter';
-import { html } from '@prairielearn/html';
+import { html, type HtmlValue } from '@prairielearn/html';
 
 import { config } from '../lib/config.js';
 import {
@@ -74,22 +74,32 @@ export function InstructorInfoPanel({
       <div class="card-header bg-warning">
         <h2>Staff information</h2>
       </div>
-      <div class="card-body">
-        ${InstanceUserInfo({ instance_user, instance_group, instance_group_uid_list })}
-        ${QuestionInfo({
+      ${ListGroup([
+        InstanceUserInfo({ instance_user, instance_group, instance_group_uid_list }),
+        QuestionInfo({
           course,
           course_instance,
           question,
           variant,
           question_is_shared,
           questionContext,
-        })}
-        ${VariantInfo({ variant, timeZone, questionContext })}
-        ${IssueReportButton({ variant, csrfToken, questionContext })}
-        ${AssessmentInstanceInfo({ assessment, assessment_instance, timeZone })}
-        ${ManualGradingInfo({ instance_question, assessment, questionContext })}
-      </div>
+        }),
+        VariantInfo({ variant, timeZone, questionContext }),
+        IssueReportButton({ variant, csrfToken, questionContext }),
+        AssessmentInstanceInfo({ assessment, assessment_instance, timeZone }),
+        ManualGradingInfo({ instance_question, assessment, questionContext }),
+      ])}
       <div class="card-footer small">This box is not visible to students.</div>
+    </div>
+  `;
+}
+
+function ListGroup(children: HtmlValue[]) {
+  const filteredChildren = children.filter((child) => !!child);
+
+  return html`
+    <div class="list-group list-group-flush">
+      ${filteredChildren.map((child) => html`<div class="list-group-item">${child}</div>`)}
     </div>
   `;
 }
@@ -110,21 +120,20 @@ function InstanceUserInfo({
         ${instance_group != null
           ? html`
               <summary><h3 class="card-title h5">Group details</h3></summary>
-              <div class="d-flex flex-wrap pb-2">
+              <div class="d-flex flex-wrap">
                 <div class="pr-1">${instance_group.name}</div>
                 <div class="pr-1">(${instance_group_uid_list?.join(', ')})</div>
               </div>
             `
           : html`
-              <summary><h3 class="card-title d-inline-block h5">Student details</h3></summary>
-              <div class="d-flex flex-wrap pb-2">
+              <summary><h3 class="card-title d-inline-block h5 mb-0">Student details</h3></summary>
+              <div class="d-flex flex-wrap mt-2">
                 <div class="pr-1">${instance_user?.name}</div>
                 <div class="pr-1">${instance_user?.uid}</div>
               </div>
             `}
       </details>
     </div>
-    <hr />
   `;
 }
 
@@ -162,7 +171,7 @@ function QuestionInfo({
     : `@${course.sharing_name}/${question.qid}`;
 
   return html`
-    <h3 class="card-title h5">Question:</h3>
+    <h3 class="card-title h5">Question</h3>
 
     <div class="d-flex flex-wrap">
       <div class="pr-1">QID:</div>
@@ -228,10 +237,10 @@ function VariantInfo({
           </div>
         `
       : ''}
-    <div class="d-flex flex-wrap mt-2 mb-3">
+    <div class="d-flex flex-wrap mt-2">
       <details class="pr-1">
         <summary>Show/Hide answer</summary>
-        <pre><code>${JSON.stringify(variant.true_answer, null, 2)}</code></pre>
+        <pre class="mt-2 mb-0"><code>${JSON.stringify(variant.true_answer, null, 2)}</code></pre>
       </details>
     </div>
   `;
@@ -261,8 +270,7 @@ function AssessmentInstanceInfo({
       : assessment_instance.date;
 
   return html`
-    <hr />
-    <h3 class="card-title h5">Assessment Instance:</h3>
+    <h3 class="card-title h5">Assessment Instance</h3>
     <div class="d-flex flex-wrap">
       <div class="pr-1">AID:</div>
       <div>
@@ -311,8 +319,7 @@ function ManualGradingInfo({
   const manualGradingUrl = `${config.urlPrefix}/course_instance/${assessment.course_instance_id}/instructor/assessment/${assessment.id}/manual_grading/instance_question/${instance_question.id}`;
 
   return html`
-    <hr />
-    <h3 class="card-title h5">Manual Grading:</h3>
+    <h3 class="card-title h5">Manual Grading</h3>
 
     <div class="d-flex flex-wrap">
       <div class="pr-1">Status:</div>
@@ -364,23 +371,18 @@ function IssueReportButton({
   }
 
   return html`
-    <div class="row">
-      <div class="col-auto">
-        <button
-          class="btn btn-sm btn-primary"
-          type="button"
-          data-toggle="collapse"
-          data-target="#issueCollapse"
-          aria-expanded="false"
-          aria-controls="issueCollapse"
-        >
-          Report an issue with this question
-        </button>
-      </div>
-    </div>
+    <button
+      class="btn btn-sm btn-primary"
+      type="button"
+      data-toggle="collapse"
+      data-target="#issueCollapse"
+      aria-expanded="false"
+      aria-controls="issueCollapse"
+    >
+      Report an issue with this question
+    </button>
     <div class="collapse" id="issueCollapse">
-      <hr />
-      <form method="POST">
+      <form method="POST" class="mt-3">
         <div class="form-group">
           <textarea
             class="form-control"
@@ -392,11 +394,9 @@ function IssueReportButton({
         </div>
         <input type="hidden" name="__variant_id" value="${variant.id}" />
         <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-        <div class="form-group text-right">
-          <button class="btn btn-small btn-warning" name="__action" value="report_issue">
-            Report issue
-          </button>
-        </div>
+        <button class="btn btn-small btn-warning" name="__action" value="report_issue">
+          Report issue
+        </button>
       </form>
     </div>
   `;


### PR DESCRIPTION
This PR uses a [Bootstrap list group](https://getbootstrap.com/docs/5.3/components/list-group/) to render sections of the instructor question info panel, as discussed here: https://github.com/PrairieLearn/PrairieLearn/pull/10695#discussion_r1805219882

Public question preview context:

<img width="325" alt="Screenshot 2024-10-17 at 11 44 06" src="https://github.com/user-attachments/assets/b3cc2cb7-d224-4745-86b2-33a7a50b7321">

Student assessment context (as instructor):

<img width="329" alt="Screenshot 2024-10-17 at 11 44 40" src="https://github.com/user-attachments/assets/7281910e-5696-420a-8402-aa8a7b7fc1af">

Manual grading context:

<img width="845" alt="Screenshot 2024-10-17 at 11 44 26" src="https://github.com/user-attachments/assets/2d707ee1-cff4-4beb-b29d-324faaab6535">

Instructor question preview context:

<img width="327" alt="Screenshot 2024-10-17 at 11 44 15" src="https://github.com/user-attachments/assets/7ad8fc8d-2260-46bc-8b28-4da44e61f28a">