### PR TITLE
Remove unnecessary pl-external-grader-results elements

### DIFF
--- a/exampleCourse/questions/demo/manualGrade/codeUpload/question.html
+++ b/exampleCourse/questions/demo/manualGrade/codeUpload/question.html
@@ -32,5 +32,4 @@ def fib(n):               # Note the function name
 
 <pl-submission-panel>
   <pl-file-preview></pl-file-preview>
-  <pl-external-grader-results></pl-external-grader-results>
 </pl-submission-panel>

--- a/testCourse/questions/manualGrade/codeUpload/question.html
+++ b/testCourse/questions/manualGrade/codeUpload/question.html
@@ -15,5 +15,4 @@
 
 <pl-submission-panel>
   <pl-file-preview></pl-file-preview>
-  <pl-external-grader-results></pl-external-grader-results>
 </pl-submission-panel>


### PR DESCRIPTION
These questions are strictly manually-graded and aren't configured for external grading at all. This PR ensures that we don't show a "Grading failed" message after manual grading feedback has been added:

<img width="990" alt="Screenshot 2024-10-17 at 13 29 30" src="https://github.com/user-attachments/assets/e4f8e94b-599e-4953-8e8b-78e0093eb46f">
