### PR TITLE
Remove percent-based adjustments to assessment instance time limits

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.ts
@@ -420,7 +420,7 @@ onDocumentReady(() => {
             />`
           : ''}
         <select
-          class="custom-select select-time-limit"
+          class="custom-select select-time-limit mb-3"
           name="plus_minus"
           aria-label="Time limit options"
           onchange="
@@ -448,22 +448,16 @@ onDocumentReady(() => {
             ? html`<option value="expire">Expire time limit</option>`
             : ''}
         </select>
-        <p class="form-inline">
+        <div class="input-group mb-3 time-limit-field">
           <input
-            class="form-control time-limit-field"
+            class="form-control"
             type="number"
             name="time_add"
             aria-label="Time value"
-            style="width: 5em"
             value="5"
           />
-          <select class="custom-select time-limit-field" name="time_ref" aria-label="Time unit">
-            <option value="minutes">minutes</option>
-            ${row.time_remaining_sec !== null
-              ? html`<option value="percent">% total limit</option>`
-              : ''}
-          </select>
-        </p>
+          <span class="input-group-text">minutes</span>
+        </div>
         ${row.has_closed_instance
           ? html`
               <div class="form-check mb-2 reopen-closed-field">

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.sql
@@ -117,13 +117,7 @@ WITH
               WHEN $base_time = 'current_date' THEN current_timestamp
               ELSE ai.date_limit
             END
-          ) + (
-            CASE
-              WHEN $time_ref = 'minutes' THEN make_interval(mins => $time_add)
-              WHEN $time_ref = 'percent' THEN (ai.date_limit - ai.date) * $time_add / 100
-              ELSE make_interval(secs => 0)
-            END
-          )
+          ) + make_interval(mins => $time_add)
         )
       END,
       modified_at = now()
@@ -168,13 +162,7 @@ WITH
               WHEN $base_time = 'current_date' THEN current_timestamp
               ELSE ai.date_limit
             END
-          ) + (
-            CASE
-              WHEN $time_ref = 'minutes' THEN make_interval(mins => $time_add)
-              WHEN $time_ref = 'percent' THEN (ai.date_limit - ai.date) * $time_add / 100
-              ELSE make_interval(secs => 0)
-            END
-          )
+          ) + make_interval(mins => $time_add)
         )
       END,
       modified_at = now()
@@ -186,10 +174,7 @@ WITH
       AND ai.assessment_id = $assessment_id
       AND (
         ai.date_limit IS NOT NULL
-        OR (
-          $base_time != 'date_limit'
-          AND $time_ref != 'percent'
-        )
+        OR $base_time != 'date_limit'
       )
     RETURNING
       ai.open,

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -111,7 +111,6 @@ router.post(
         assessment_instance_id: req.body.assessment_instance_id,
         assessment_id: res.locals.assessment.id,
         time_add: req.body.time_add,
-        time_ref: req.body.time_ref,
         base_time: 'date_limit',
         authn_user_id: res.locals.authz_data.authn_user.user_id,
       };
@@ -120,7 +119,6 @@ router.post(
       } else if (req.body.plus_minus === 'expire') {
         params.base_time = 'current_date';
         params.time_add = 0;
-        params.time_ref = 'minutes';
       } else if (req.body.plus_minus === 'set_total') {
         params.base_time = 'start_date';
       } else if (req.body.plus_minus === 'set_rem') {
@@ -134,7 +132,6 @@ router.post(
       const params = {
         assessment_id: res.locals.assessment.id,
         time_add: req.body.time_add,
-        time_ref: req.body.time_ref,
         base_time: 'date_limit',
         reopen_closed: !!req.body.reopen_closed,
         authn_user_id: res.locals.authz_data.authn_user.user_id,
@@ -144,7 +141,6 @@ router.post(
       } else if (req.body.plus_minus === 'expire') {
         params.base_time = 'current_date';
         params.time_add = 0;
-        params.time_ref = 'minutes';
       } else if (req.body.plus_minus === 'set_total') {
         params.base_time = 'start_date';
       } else if (req.body.plus_minus === 'set_rem') {

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -1027,7 +1027,6 @@ describe('Manual Grading', function () {
             __csrf_token: token,
             plus_minus: 'unlimited',
             time_add: '0',
-            time_ref: 'minutes',
             reopen_closed: 'on',
           }).toString(),
         });


### PR DESCRIPTION
This came up while working on #10800 (https://github.com/PrairieLearn/PrairieLearn/pull/10800#discussion_r1799980596). We ultimately decided we didn't need this functionality any more. I decided to remove this in a separate PR so we could better document this removal for our future selves.

Rationale from Matt:

> I think the original use case was that we’ve got many students doing their exams, and some students have extra time allocated to them. Now we want to give everyone some extra time for some reason, but we want to maintain extra-time-accommodations, so we give 10% extra time to everyone.
>
> I guess I just don’t think that this is a very common scenario. PT handles most such cases already, so it would have to be a very special set of circumstances in PL to trigger the need for this, and then the instructor would need to be thinking very clearly in a stressful situation to realize that this was the option they wanted.
>
> So in general I think it’s just extra “noise” in the dialog for very limited gain
>
> It also doesn’t stack correctly, so if you give an extra 5% to everyone using this logic, but then realize you want to give more time, well now you are out of luck (edited) 
>
> So it’s this weird one-time use option

The "add time while maintaining accommodations" case assumes that instructors have taken the time to pre-configure access rules to give different students different amounts of time, which AFAIK almost no one is doing, mainly because PrairieTest already handles this so much better.