### PR TITLE
Warn when points == 0 and maxPoints > 0

### DIFF
--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1235,24 +1235,12 @@ async function validateAssessment(
           }
 
           if (!courseInstanceExpired) {
-            if (
-              alternative.points !== undefined &&
-              alternative.points === 0 &&
-              alternative.maxPoints !== undefined &&
-              alternative.maxPoints > 0
-            ) {
-              warnings.push('Specifying "points": 0 when "maxPoints" > 0 is probably a mistake');
+            if (alternative.points === 0 && alternative.maxPoints > 0) {
+              errors.push('Cannot specify "points": 0 when "maxPoints" > 0');
             }
 
-            if (
-              alternative.autoPoints !== undefined &&
-              alternative.autoPoints === 0 &&
-              alternative.maxAutoPoints !== undefined &&
-              alternative.maxAutoPoints > 0
-            ) {
-              warnings.push(
-                'Specifying "autoPoints": 0 when "maxAutoPoints" > 0 is probably a mistake',
-              );
+            if (alternative.autoPoints === 0 && alternative.maxAutoPoints > 0) {
+              errors.push('Cannot specify "autoPoints": 0 when "maxAutoPoints" > 0');
             }
           }
         }

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1227,10 +1227,33 @@ async function validateAssessment(
               'Cannot specify "maxPoints" for a question if "autoPoints", "manualPoints" or "maxAutoPoints" are specified',
             );
           }
+
           if (Array.isArray(alternative.autoPoints ?? alternative.points)) {
             errors.push(
               'Cannot specify "points" or "autoPoints" as a list for a question in a "Homework" assessment',
             );
+          }
+
+          if (!courseInstanceExpired) {
+            if (
+              alternative.points !== undefined &&
+              alternative.points === 0 &&
+              alternative.maxPoints !== undefined &&
+              alternative.maxPoints > 0
+            ) {
+              warnings.push('Specifying "points": 0 when "maxPoints" > 0 is probably a mistake');
+            }
+
+            if (
+              alternative.autoPoints !== undefined &&
+              alternative.autoPoints === 0 &&
+              alternative.maxAutoPoints !== undefined &&
+              alternative.maxAutoPoints > 0
+            ) {
+              warnings.push(
+                'Specifying "autoPoints": 0 when "maxAutoPoints" > 0 is probably a mistake',
+              );
+            }
           }
         }
       });

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1738,10 +1738,7 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('fail');
-    assert.match(
-      syncedAssessment?.sync_warnings,
-      /Specifying "points": 0 when "maxPoints" > 0 is probably a mistake/,
-    );
+    assert.match(syncedAssessment?.sync_errors, /Cannot specify "points": 0 when "maxPoints" > 0/);
   });
 
   it('records a warning if a question has zero autoPoints and non-zero maxAutoPoints on a Homework-type assessment', async () => {
@@ -1761,8 +1758,8 @@ describe('Assessment syncing', () => {
     await util.writeAndSyncCourseData(courseData);
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
-      syncedAssessment?.sync_warnings,
-      /Specifying "autoPoints": 0 when "maxAutoPoints" > 0 is probably a mistake/,
+      syncedAssessment?.sync_errors,
+      /Cannot specify "autoPoints": 0 when "maxAutoPoints" > 0/,
     );
   });
 

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1614,7 +1614,7 @@ describe('Assessment syncing', () => {
     );
   });
 
-  it('records an error if a question does not specify points on an Homework-type assessment', async () => {
+  it('records an error if a question does not specify points on a Homework-type assessment', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData, 'Homework');
     assessment.zones?.push({
@@ -1700,7 +1700,7 @@ describe('Assessment syncing', () => {
     );
   });
 
-  it('records an error if a question specifies points as an array an Homework-type assessment', async () => {
+  it('records an error if a question specifies points as an array on a Homework-type assessment', async () => {
     const courseData = util.getCourseData();
     const assessment = makeAssessment(courseData, 'Homework');
     assessment.zones?.push({
@@ -1719,6 +1719,50 @@ describe('Assessment syncing', () => {
     assert.match(
       syncedAssessment?.sync_errors,
       /Cannot specify "points" or "autoPoints" as a list for a question in a "Homework" assessment/,
+    );
+  });
+
+  it('records a warning if a question has zero points and non-zero maxPoints on a Homework-type assessment', async () => {
+    const courseData = util.getCourseData();
+    const assessment = makeAssessment(courseData, 'Homework');
+    assessment.zones?.push({
+      title: 'test zone',
+      questions: [
+        {
+          id: util.QUESTION_ID,
+          maxPoints: 10,
+          points: 0,
+        },
+      ],
+    });
+    courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
+    await util.writeAndSyncCourseData(courseData);
+    const syncedAssessment = await findSyncedAssessment('fail');
+    assert.match(
+      syncedAssessment?.sync_warnings,
+      /Specifying "points": 0 when "maxPoints" > 0 is probably a mistake/,
+    );
+  });
+
+  it('records a warning if a question has zero autoPoints and non-zero maxAutoPoints on a Homework-type assessment', async () => {
+    const courseData = util.getCourseData();
+    const assessment = makeAssessment(courseData, 'Homework');
+    assessment.zones?.push({
+      title: 'test zone',
+      questions: [
+        {
+          id: util.QUESTION_ID,
+          maxAutoPoints: 10,
+          autoPoints: 0,
+        },
+      ],
+    });
+    courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
+    await util.writeAndSyncCourseData(courseData);
+    const syncedAssessment = await findSyncedAssessment('fail');
+    assert.match(
+      syncedAssessment?.sync_warnings,
+      /Specifying "autoPoints": 0 when "maxAutoPoints" > 0 is probably a mistake/,
     );
   });
 


### PR DESCRIPTION
As suggested here: https://github.com/PrairieLearn/PrairieLearn/pull/10682#issuecomment-2420134966

I checked the production database for violations of this with the following query:

```sql
SELECT
  aq.assessment_id,
  aq.init_points,
  aq.max_points,
  a.course_instance_id,
  ci.course_id,
  MIN(ciar.start_date) AS start_date,
  MAX(ciar.end_date) AS end_date
FROM
  assessment_questions AS aq
  JOIN assessments AS a ON (aq.assessment_id = a.id)
  JOIN course_instance_access_rules AS ciar ON (ciar.course_instance_id = a.course_instance_id)
  JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
  JOIN pl_courses AS c ON (c.id = ci.course_id)
WHERE
  aq.init_points = 0
  AND aq.max_auto_points > 0
  AND aq.deleted_at IS NULL
  AND a.deleted_at IS NULL
GROUP BY
  aq.assessment_id,
  aq.init_points,
  aq.max_points,
  a.course_instance_id,
  ci.course_id;
```

This yielded 29 rows. Most of the course instances had `MAX(end_date)` in 2021; the remaining one had it in 2023. Given that, this should not impact any active course instances.