### PR TITLE
Fix typo for modules navSubPage

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -1271,7 +1271,7 @@ export async function initExpress() {
   ]);
   app.use('/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/modules', [
     function (req, res, next) {
-      res.locals.navSubPage = 'moduls';
+      res.locals.navSubPage = 'modules';
       next();
     },
     (await import('./pages/instructorCourseAdminModules/instructorCourseAdminModules.js')).default,


### PR DESCRIPTION
Fixes #10838 

This was causing the Modules tab to not be shown active if selected after choosing a course instance.