### PR TITLE
Publicly share source of all example course template questions

### DIFF
--- a/exampleCourse/questions/template/checkbox/feedback/info.json
+++ b/exampleCourse/questions/template/checkbox/feedback/info.json
@@ -2,5 +2,6 @@
   "uuid": "642FF892-499C-4026-9055-3494FE8832C9",
   "title": "Checkbox: feedback on each response",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/checkbox/random-prompt/info.json
+++ b/exampleCourse/questions/template/checkbox/random-prompt/info.json
@@ -2,5 +2,6 @@
   "uuid": "f555b053-6d49-4719-a850-7e4b2a4d2016",
   "title": "Checkboxes: random prompt",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/figure/dynamic/info.json
+++ b/exampleCourse/questions/template/figure/dynamic/info.json
@@ -2,5 +2,6 @@
   "uuid": "8FC8FB0E-0C9F-42F8-BDDA-A966C566302A",
   "title": "Figure: dynamic image",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/integer-input/random/info.json
+++ b/exampleCourse/questions/template/integer-input/random/info.json
@@ -2,5 +2,6 @@
   "uuid": "5E64666F-1588-4EBB-8E8D-C1FA4141F20D",
   "title": "Integer input: random parameters and correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/matrix-component-input/random-graph/info.json
+++ b/exampleCourse/questions/template/matrix-component-input/random-graph/info.json
@@ -2,5 +2,6 @@
   "uuid": "3c5fc412-8bf2-45e2-bae4-f8e7a5faede5",
   "title": "Matrix component input: random graph",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/matrix-input/random/info.json
+++ b/exampleCourse/questions/template/matrix-input/random/info.json
@@ -2,5 +2,6 @@
   "uuid": "af445c37-1126-43b0-aba5-627eeb2e10a7",
   "title": "Matrix input: random parameters and correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/multiple-choice/images/info.json
+++ b/exampleCourse/questions/template/multiple-choice/images/info.json
@@ -2,5 +2,6 @@
   "uuid": "44ABEAD3-3AFE-4097-B877-91319B35C22E",
   "title": "Multiple choice: images as choices",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/multiple-choice/numeric/info.json
+++ b/exampleCourse/questions/template/multiple-choice/numeric/info.json
@@ -2,5 +2,6 @@
   "uuid": "d776ae4b-8b8b-4e40-9054-926e3464bb79",
   "title": "Multiple choice: random numeric answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/info.json
+++ b/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/info.json
@@ -2,5 +2,6 @@
   "uuid": "65581157-89fc-4dcc-9544-368166d6759e",
   "title": "Multiple choice: random true/false question from list",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/multiple-choice/random-prompt/info.json
+++ b/exampleCourse/questions/template/multiple-choice/random-prompt/info.json
@@ -2,5 +2,6 @@
   "uuid": "fd9d93ad-0658-4586-9c24-83480e4c8bb7",
   "title": "Multiple choice: random question from list",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/multiple-choice/random/info.json
+++ b/exampleCourse/questions/template/multiple-choice/random/info.json
@@ -2,5 +2,6 @@
   "uuid": "f24e0597-bb8c-42aa-abef-6a96b6afcca8",
   "title": "Multiple choice: random correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/number-input/multiple-answer-inputs/info.json
+++ b/exampleCourse/questions/template/number-input/multiple-answer-inputs/info.json
@@ -2,5 +2,6 @@
   "uuid": "E7C8851C-4E2F-4D2B-AA53-7382AC9F365B",
   "title": "Number input: multiple answer inputs",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/number-input/random-prompt/info.json
+++ b/exampleCourse/questions/template/number-input/random-prompt/info.json
@@ -2,5 +2,6 @@
   "uuid": "9b90ecf4-4580-54be-9a51-bafd47d7d1e6",
   "title": "Number input: random parameters and correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/number-input/random/info.json
+++ b/exampleCourse/questions/template/number-input/random/info.json
@@ -2,5 +2,6 @@
   "uuid": "9b90ecf4-4580-44be-9a51-bafd47d7d1e6",
   "title": "Number input: random parameters and correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/string-input/random/info.json
+++ b/exampleCourse/questions/template/string-input/random/info.json
@@ -2,5 +2,6 @@
   "uuid": "C88B8131-1FB4-4234-A94F-0B49B3AA09CF",
   "title": "String input: random parameters and correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }

--- a/exampleCourse/questions/template/symbolic-input/random/info.json
+++ b/exampleCourse/questions/template/symbolic-input/random/info.json
@@ -2,5 +2,6 @@
   "uuid": "16620404-1340-42ef-9897-20687adebaf8",
   "title": "Symbolic input: random parameters and correct answer",
   "topic": "Template",
-  "type": "v3"
+  "type": "v3",
+  "shareSourcePublicly": true
 }


### PR DESCRIPTION
These were already shared in the US production environment; we need to reflect that in the JSON. Note that they're currently configured with `share_publicly`; I'll change that to `share_source_publicly` in the database by hand so that this will sync.