### PR TITLE
Improve source-only sharing of questions

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -56,9 +56,10 @@ onDocumentReady(() => {
         output: question.sync_warnings,
       });
     }
+    const prefix = qidPrefix && question.shared_publicly ? qidPrefix : '';
     text += html`
       <a class="formatter-data" href="${urlPrefix}/question/${question.id}/preview">
-        ${qidPrefix}${question.qid}
+        ${prefix}${question.qid}
       </a>
     `;
     if (question.open_issue_count > 0) {
@@ -84,6 +85,9 @@ onDocumentReady(() => {
   window.sharingSetFormatter = function (sharing_sets, question) {
     return (
       (question.shared_publicly ? html`<span class="badge color-green3">Public</span> ` : '') +
+      (question.share_source_publicly
+        ? html`<span class="badge color-green3">Public source</span>`
+        : '') +
       _.map(question.sharing_sets ?? [], (sharing_set) =>
         html`<span class="badge color-gray1">${sharing_set.name}</span>`.toString(),
       ).join(' ')

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -166,9 +166,13 @@ function QuestionInfo({
   //
   // In the future, this should use some kind of "allow import" flag on the
   // question so that this behavior can be achieved within other courses.
-  const sharingQid = course.example_course
-    ? question.qid
-    : `@${course.sharing_name}/${question.qid}`;
+  //
+  // We also don't show the sharing name in the QID if the question is not
+  // shared publicly for importing, such as if only `share_source_publicly` is set.
+  const sharingQid =
+    course.example_course || !question.shared_publicly
+      ? question.qid
+      : `@${course.sharing_name}/${question.qid}`;
 
   return html`
     <h3 class="card-title h5">Question</h3>

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -188,7 +188,7 @@ function QuestionInfo({
       ? html`
           <div class="d-flex flex-wrap">
             <div class="pr-1">Shared As:</div>
-            ${question.shared_publicly
+            ${question.shared_publicly || question.share_source_publicly
               ? html`
                   <div>
                     <a href="${publicPreviewUrl}">${sharingQid}</a>

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -161,14 +161,12 @@ function QuestionInfo({
   }/question/${question.id}?variant_seed=${variant.variant_seed}`;
   const publicPreviewUrl = `${config.urlPrefix}/public/course/${course.id}/question/${question.id}/preview`;
 
-  // Example course questions can be publicly shared, but we don't allow them to
-  // be imported into courses, so we won't show the sharing name in the QID.
+  // We don't show the sharing name in the QID if the question is not shared
+  // publicly for importing, such as if only `share_source_publicly` is set.
   //
-  // In the future, this should use some kind of "allow import" flag on the
-  // question so that this behavior can be achieved within other courses.
-  //
-  // We also don't show the sharing name in the QID if the question is not
-  // shared publicly for importing, such as if only `share_source_publicly` is set.
+  // TODO: Remove the special-casing of the example course once its questions
+  // have been updated to use `share_source_publicly`. This special-casing
+  // predates the ability to share questions only for copying, not importing.
   const sharingQid =
     course.example_course || !question.shared_publicly
       ? question.qid

--- a/apps/prairielearn/src/models/questions.sql
+++ b/apps/prairielearn/src/models/questions.sql
@@ -37,6 +37,7 @@ SELECT
       qt.question_id = q.id
   ) AS tags,
   q.shared_publicly,
+  q.share_source_publicly,
   (
     SELECT
       jsonb_agg(to_jsonb(ss))
@@ -81,14 +82,19 @@ SELECT
       JOIN tags ON (tags.id = qt.tag_id)
     WHERE
       qt.question_id = q.id
-  ) AS tags
+  ) AS tags,
+  q.shared_publicly,
+  q.share_source_publicly
 FROM
   questions AS q
   JOIN topics AS top ON (top.id = q.topic_id)
 WHERE
   q.course_id = $course_id
   AND q.deleted_at IS NULL
-  AND q.shared_publicly
+  AND (
+    q.shared_publicly
+    OR q.share_source_publicly
+  )
 GROUP BY
   q.id,
   top.id

--- a/apps/prairielearn/src/models/questions.ts
+++ b/apps/prairielearn/src/models/questions.ts
@@ -22,7 +22,8 @@ const QuestionsPageDataSchema = z.object({
   open_issue_count: z.number().default(0),
   topic: TopicSchema,
   tags: z.array(TagSchema).nullable(),
-  shared_publicly: z.boolean().optional(),
+  shared_publicly: z.boolean(),
+  share_source_publicly: z.boolean(),
   sharing_sets: z.array(SharingSetSchema).nullable().optional(),
   assessments: AssessmentsFormatForQuestionSchema.nullable().optional(),
 });

--- a/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.ts
+++ b/apps/prairielearn/src/pages/clientFilesQuestion/clientFilesQuestion.ts
@@ -25,7 +25,7 @@ export default function (options = { publicEndpoint: false }) {
         res.locals.question = await selectQuestionById(req.params.question_id);
 
         if (
-          !res.locals.question.shared_publicly ||
+          !(res.locals.question.shared_publicly || res.locals.question.share_source_publicly) ||
           res.locals.course.id !== res.locals.question.course_id
         ) {
           throw new HttpStatusError(404, 'Not Found');

--- a/apps/prairielearn/src/pages/elementFiles/elementFiles.sql
+++ b/apps/prairielearn/src/pages/elementFiles/elementFiles.sql
@@ -31,7 +31,10 @@ SELECT
     FROM
       questions AS q
     WHERE
-      q.shared_publicly
+      (
+        q.shared_publicly
+        OR q.share_source_publicly
+      )
       AND course_id = $course_id
       AND q.deleted_at IS NULL
   );

--- a/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.ts
+++ b/apps/prairielearn/src/pages/generatedFilesQuestion/generatedFilesQuestion.ts
@@ -21,7 +21,7 @@ export default function (options = { publicEndpoint: false }) {
         res.locals.question = await selectQuestionById(req.params.question_id);
 
         if (
-          !res.locals.question.shared_publicly ||
+          !(res.locals.question.shared_publicly || res.locals.question.share_source_publicly) ||
           res.locals.course.id !== res.locals.question.course_id
         ) {
           throw new HttpStatusError(404, 'Not Found');

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { escapeHtml, html } from '@prairielearn/html';
+import { escapeHtml, html, type HtmlValue } from '@prairielearn/html';
 
 import { AssessmentBadge } from '../../components/AssessmentBadge.html.js';
 import { HeadContents } from '../../components/HeadContents.html.js';
@@ -11,7 +11,12 @@ import { TagBadgeList } from '../../components/TagBadge.html.js';
 import { TopicBadge } from '../../components/TopicBadge.html.js';
 import { compiledScriptTag } from '../../lib/assets.js';
 import { config } from '../../lib/config.js';
-import { AssessmentSchema, AssessmentSetSchema, IdSchema } from '../../lib/db-types.js';
+import {
+  AssessmentSchema,
+  AssessmentSetSchema,
+  IdSchema,
+  type Question,
+} from '../../lib/db-types.js';
 import { idsEqual } from '../../lib/id.js';
 import { type CourseWithPermissions } from '../../models/course.js';
 
@@ -183,7 +188,7 @@ export function InstructorQuestionSettings({
                       <h2 class="h4">Sharing</h2>
                       <div data-testid="shared-with">
                         ${QuestionSharing({
-                          questionSharedPublicly: resLocals.question.shared_publicly,
+                          question: resLocals.question,
                           sharingSetsIn,
                         })}
                       </div>
@@ -403,36 +408,51 @@ function QuestionTestsForm({
 }
 
 function QuestionSharing({
-  questionSharedPublicly,
+  question,
   sharingSetsIn,
 }: {
-  questionSharedPublicly: boolean;
+  question: Question;
   sharingSetsIn: SharingSetRow[];
 }) {
-  if (questionSharedPublicly) {
-    return html`
-      <p>
-        <span class="badge color-green3 mr-1">Public</span>
-        This question is publicly shared.
-      </p>
-    `;
+  if (!question.shared_publicly && !question.share_source_publicly && sharingSetsIn.length === 0) {
+    return html`<p>This question is not being shared.</p>`;
   }
 
-  const sharedWithLabel =
-    sharingSetsIn.length === 1 ? '1 sharing set' : `${sharingSetsIn.length} sharing sets`;
+  const details: HtmlValue[] = [];
 
-  return html`
-    ${sharingSetsIn.length === 0
-      ? html`<p>This question is not being shared.</p>`
-      : html`
-          <p>
-            Shared with ${sharedWithLabel}:
-            ${sharingSetsIn.map((sharing_set) => {
-              return html` <span class="badge color-gray1">${sharing_set.name}</span> `;
-            })}
-          </p>
-        `}
-  `;
+  if (question.shared_publicly) {
+    details.push(html`
+      <p>
+        <span class="badge color-green3 mr-1">Public</span>
+        This question is publicly shared and can be imported by other courses.
+      </p>
+    `);
+  }
+
+  if (question.share_source_publicly) {
+    details.push(html`
+      <p>
+        <span class="badge color-green3 mr-1">Public source</span>
+        This question's source is publicly shared.
+      </p>
+    `);
+  }
+
+  if (sharingSetsIn.length > 0) {
+    const sharedWithLabel =
+      sharingSetsIn.length === 1 ? '1 sharing set' : `${sharingSetsIn.length} sharing sets`;
+
+    details.push(html`
+      <p>
+        Shared with ${sharedWithLabel}:
+        ${sharingSetsIn.map((sharing_set) => {
+          return html` <span class="badge color-gray1">${sharing_set.name}</span> `;
+        })}
+      </p>
+    `);
+  }
+
+  return details;
 }
 
 function AssessmentBadges({

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -37,7 +37,7 @@ async function setLocals(req, res) {
   }
 
   if (
-    !res.locals.question.shared_publicly ||
+    !(res.locals.question.shared_publicly || res.locals.question.share_source_publicly) ||
     res.locals.course.id !== res.locals.question.course_id
   ) {
     throw new error.HttpStatusError(404, 'Not Found');

--- a/apps/prairielearn/src/pages/submissionFile/submissionFile.ts
+++ b/apps/prairielearn/src/pages/submissionFile/submissionFile.ts
@@ -40,7 +40,7 @@ export default function (options = { publicEndpoint: false }) {
         res.locals.question = await selectQuestionById(req.params.question_id);
 
         if (
-          !res.locals.question.shared_publicly ||
+          !(res.locals.question.shared_publicly || res.locals.question.share_source_publicly) ||
           res.locals.course.id !== res.locals.question.course_id
         ) {
           res.sendStatus(404);


### PR DESCRIPTION
This PR improves the behavior when a question is shared for copying but not importing (that is, with `"sharePublicly": false, "shareSourcePublicly": true`). The following changes were made:

- Such questions are now displayed on the public questions page and viewable on the public question preview page. Note that these questions don't display the sharing name prefix on the QID. This is our stopgap solution to try to differentiate between "shared for importing" and "shared for copying".
  <img width="1135" alt="Screenshot 2024-10-22 at 14 05 35" src="https://github.com/user-attachments/assets/0081eef1-40d0-426f-8afb-3f67e300ff48">
- The "Sharing" column of the course questions table now displays a "Public source" badge for `"shareSourcePublicly": true` questions, to complement the existing "Public" badge. A similar change was made to the "Sharing" section of the question settings page.
  <img width="619" alt="Screenshot 2024-10-22 at 13 51 21" src="https://github.com/user-attachments/assets/6870b022-c7d1-4c22-9158-defd51076662">


