### PR TITLE
Hide JSDOM warnings from accessibility tests

### DIFF
--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -1,6 +1,6 @@
 import { A11yError } from '@sa11y/format';
 import axe from 'axe-core';
-import { JSDOM } from 'jsdom';
+import { JSDOM, VirtualConsole } from 'jsdom';
 import { test } from 'mocha';
 import fetch from 'node-fetch';
 
@@ -26,7 +26,11 @@ async function loadPageJsdom(url: string): Promise<JSDOM> {
     }
     return res.text();
   });
-  return new JSDOM(text);
+  // JSDOM can be very verbose regarding unimplemented features (e.g., canvas).
+  // We don't have a need to see these warnings, so we create a virtual console
+  // that does not log anything.
+  const virtualConsole = new VirtualConsole();
+  return new JSDOM(text, { virtualConsole });
 }
 
 /**


### PR DESCRIPTION
JSDOM is very verbose regarding unimplemented features (e.g., canvas) that make no difference from an accessibility point of view. These warnings polute the CI logs with irrelevant information. This PR changes the console of JSDOM to a virtual console that ignores all output.