### PR TITLE
Support adding course server files to workspaces

### DIFF
--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -69,6 +69,7 @@ interface DynamicWorkspaceFile {
   contents?: string;
   encoding?: BufferEncoding;
   questionFile?: string;
+  serverFilesCourseFile?: string;
 }
 
 interface InitializeResult {
@@ -375,6 +376,7 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
 
   // local workspace files
   const questionBasePath = path.join(course_path, 'questions', question.qid);
+  const serverFilesCoursePath = path.join(course_path, 'serverFilesCourse');
 
   // base workspace directory wherever we are uploading to
   const remoteDirName = `workspace-${workspace_id}-${workspace.version}`;
@@ -385,6 +387,7 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
   const sourcePath = `${destinationPath}-${uuidv4()}`;
 
   const { fileGenerationErrors } = await generateWorkspaceFiles({
+    serverFilesCoursePath,
     questionBasePath,
     params: variant.params,
     correctAnswers: variant.true_answer,
@@ -429,11 +432,13 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
 }
 
 export async function generateWorkspaceFiles({
+  serverFilesCoursePath,
   questionBasePath,
   params,
   correctAnswers,
   targetPath,
 }: {
+  serverFilesCoursePath: string;
   questionBasePath: string;
   params: Record<string, any> | null;
   correctAnswers: Record<string, any> | null;
@@ -515,13 +520,17 @@ export async function generateWorkspaceFiles({
           }
           const normalizedFilename = path.normalize(file.name);
 
-          if (file.questionFile) {
-            const localPath = path.join(questionBasePath, file.questionFile);
+          if (file.questionFile || file.serverFilesCourseFile) {
+            const basePath = file.questionFile ? questionBasePath : serverFilesCoursePath;
+            const localPath = path.join(
+              basePath,
+              file.questionFile ?? file.serverFilesCourseFile ?? '',
+            );
             // Discard paths with directory traversal outside the question
-            if (!contains(questionBasePath, localPath, false)) {
+            if (!contains(basePath, localPath, false)) {
               fileGenerationErrors.push({
                 file: file.name,
-                msg: 'Dynamic workspace file points to a local file outside the question directory. File ignored.',
+                msg: `Dynamic workspace file points to a local file outside the ${file.questionFile ? 'question' : 'serverFilesCourse'} directory. File ignored.`,
                 data: file,
               });
               return null;
@@ -547,7 +556,7 @@ export async function generateWorkspaceFiles({
           if (!('contents' in file)) {
             fileGenerationErrors.push({
               file: file.name,
-              msg: 'Dynamic workspace file has neither "contents" nor "questionFile". Blank file created.',
+              msg: 'Dynamic workspace file has neither "contents" nor "questionFile" nor "serverFilesCourseFile". Blank file created.',
               data: file,
             });
           }

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -179,7 +179,7 @@ starting_value = 17
 For more fine-tuned randomized files, the `_workspace_files` parameter can also be set in `server.py`, containing an array of potentially dynamic files to be created in the workspace home directory. Each element of the array must include a `name` property, containing the file name (which can include a path with directories), and one of the following:
 
 - a `contents` property, containing the contents of the file.
-- a `questionFile` or `serverFilesCourseFile` property, pointing to an existing file in a different location in the question directory or the course's `serverFilesCourse` directory, respectively.
+- a `questionFile` or `serverFilesCourseFile` property, pointing to an existing file in the question directory or the course's `serverFilesCourse` directory, respectively.
 
 For example:
 
@@ -211,7 +211,7 @@ def generate(data):
         },
         # A question file can also be added by using its path in the question instead of its contents
         {"name": "provided.txt", "questionFile": "clientFilesQuestion/provided.txt"},
-        # A file can also be added by using its path in the serverFilesCourse
+        # A file can also be added by using its path in serverFilesCourse
         {"name": "course.txt", "serverFilesCourseFile": "data.txt"},
         # To make an empty file, set `contents` to None or an empty string
         {"name": "empty.txt", "contents": None}

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -176,7 +176,12 @@ starting_value = 17
 # ...
 ```
 
-For more fine-tuned randomized files, the `_workspace_files` parameter can also be set in `server.py`, containing an array of potentially dynamic files to be created in the workspace home directory. Each element of the array must include a `name` property, containing the file name (which can include a path with directories), and either a `contents` property, containing the contents of the file, or a `questionFile` property, pointing to an existing file in a different location in the question directory. For example:
+For more fine-tuned randomized files, the `_workspace_files` parameter can also be set in `server.py`, containing an array of potentially dynamic files to be created in the workspace home directory. Each element of the array must include a `name` property, containing the file name (which can include a path with directories), and one of the following:
+
+- a `contents` property, containing the contents of the file.
+- a `questionFile` or `serverFilesCourseFile` property, pointing to an existing file in a different location in the question directory or the course's `serverFilesCourse` directory, respectively.
+
+For example:
 
 ```py
 def generate(data):
@@ -206,12 +211,14 @@ def generate(data):
         },
         # A question file can also be added by using its path in the question instead of its contents
         {"name": "provided.txt", "questionFile": "clientFilesQuestion/provided.txt"},
+        # A file can also be added by using its path in the serverFilesCourse
+        {"name": "course.txt", "serverFilesCourseFile": "data.txt"},
         # To make an empty file, set `contents` to None or an empty string
         {"name": "empty.txt", "contents": None}
     ]
 ```
 
-By default, `contents` is expected to be a string in UTF-8 format. To provide binary content, the value must be encoded using base64 or hex, as shown in the example above. In this case, the `encoding` property must also be provided. Either `questionFile` or `contents` must be provided, but not both. If an empty file is expected, `contents` may be set to `None` or an empty string.
+By default, `contents` is expected to be a string in UTF-8 format. To provide binary content, the value must be encoded using base64 or hex, as shown in the example above. In this case, the `encoding` property must also be provided. Exactly one of `questionFile`, `serverFilesCourseFile` or `contents` must be provided. If an empty file is expected, `contents` may be set to `None` or an empty string.
 
 If a file name appears in multiple locations, the following precedence takes effect:
 

--- a/exampleCourse/questions/demo/workspace/dynamicFiles/server.py
+++ b/exampleCourse/questions/demo/workspace/dynamicFiles/server.py
@@ -32,4 +32,6 @@ def generate(data):
         },
         # A question file can also be added by using its path in the question instead of its contents
         {"name": "provided.txt", "questionFile": "clientFilesQuestion/provided.txt"},
+        # A file can also be added by using its path in the serverFilesCourse
+        {"name": "course.txt", "serverFilesCourseFile": "workspace_file.txt"},
     ]

--- a/exampleCourse/serverFilesCourse/workspace_file.txt
+++ b/exampleCourse/serverFilesCourse/workspace_file.txt
@@ -1,0 +1,1 @@
+Content in server files

--- a/testCourse/questions/workspace/server.py
+++ b/testCourse/questions/workspace/server.py
@@ -25,6 +25,10 @@ def generate(data):
             "questionFile": "path/with/another/file.txt",
         },
         {
+            "name": "server_file.txt",
+            "serverFilesCourseFile": "workspace_file.txt",
+        },
+        {
             "name": "path/../not_normalized.txt",
             "contents": "File identified by path that is not normalized\n",
         },

--- a/testCourse/questions/workspaceInvalidDynamicFiles/server.py
+++ b/testCourse/questions/workspaceInvalidDynamicFiles/server.py
@@ -39,6 +39,11 @@ def generate(data):
             "questionFile": "../workspace/server.py",
         },
         {
+            # File that points outside the serverFilesCourse directory in serverFilesCourseFile
+            "name": "course.json",
+            "serverFilesCourseFile": "../infoCourse.json",
+        },
+        {
             # File without contents or questionFile
             "name": "no_contents.txt",
         },

--- a/testCourse/serverFilesCourse/workspace_file.txt
+++ b/testCourse/serverFilesCourse/workspace_file.txt
@@ -1,0 +1,1 @@
+Content in server files


### PR DESCRIPTION
This came about from a Slack discussion, where an instructor needed the same file to be made available to workspaces and external graders in multiple questions. External graders already have support for serverFilesCourse. Workspaces can currently support server files by reading the content and adding it directly to params, but this causes params to become unnecessarily large if the file is large enough. This PR adds support for a `serverFilesCourseFile` to the dynamic workspace process, allowing these files to be referenced instead of copied to params.

Closes #10874.