### PR TITLE
Create a cron job to clean up user_sessions rows

### DIFF
--- a/apps/prairielearn/src/cron/cleanUserSessions.sql
+++ b/apps/prairielearn/src/cron/cleanUserSessions.sql
@@ -1,0 +1,5 @@
+-- BLOCK clean_user_sessions
+DELETE FROM user_sessions
+WHERE
+  user_id IS NULL
+  AND created_at < now() - '1 hour'::interval;

--- a/apps/prairielearn/src/cron/cleanUserSessions.ts
+++ b/apps/prairielearn/src/cron/cleanUserSessions.ts
@@ -1,0 +1,19 @@
+import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+/**
+ * The `user_sessions` table is used to store user sessions. If a request is
+ * received that doesn't have a session cookie, a new session is created and
+ * persisted. However, if the user never logs in (as is common with scrapers),
+ * the session will sit there forever. We need to retain records of logged-in
+ * sessions forever for forensic purposes and also because fingerprints rely
+ * on them, but if a given session never logs in, it won't ever be useful and
+ * thus can be cleaned up.
+ *
+ * This cron job deletes all user sessions that have never been logged in to
+ * (that is, that have a null `user_id`) and that were created more than an hour ago.
+ */
+export async function run() {
+  await queryAsync(sql.clean_user_sessions, {});
+}

--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -114,6 +114,11 @@ export async function init() {
       module: await import('./cleanTimeSeries.js'),
       intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalCleanTimeSeriesSec,
     },
+    {
+      name: 'cleanUserSessions',
+      module: await import('./cleanUserSessions.js'),
+      intervalSec: config.cronOverrideAllIntervalsSec || config.cronIntervalCleanUserSessionsSec,
+    },
   ];
 
   if (isEnterprise()) {

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -167,6 +167,7 @@ const ConfigSchema = z.object({
   cronIntervalWorkspaceHostTransitionsSec: z.number().default(10),
   cronIntervalChunksHostAutoScalingSec: z.number().default(10),
   cronIntervalCleanTimeSeriesSec: z.number().default(10 * 60),
+  cronIntervalCleanUserSessionsSec: z.number().default(10 * 60),
   cronDailySec: z.number().default(8 * 60 * 60),
   /**
    * Controls how much history is retained when removing old rows


### PR DESCRIPTION
I discussed this in passing with Matt recently. We currently have millions of sessions that don't have an associated user and thus can be safely cleaned up.