### PR TITLE
Remove useless JOIN from questions.share_publicly backfill

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20241018171312_questions__share_publicly__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20241018171312_questions__share_publicly__backfill.sql
@@ -3,5 +3,6 @@ UPDATE questions
 SET
   share_publicly = shared_publicly
 WHERE
-  id >= $start
+  shared_publicly IS TRUE
+  AND id >= $start
   AND id <= $end;

--- a/apps/prairielearn/src/batched-migrations/20241018171312_questions__share_publicly__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20241018171312_questions__share_publicly__backfill.sql
@@ -1,9 +1,7 @@
 -- BLOCK backfill_share_publicly
-UPDATE questions AS q
+UPDATE questions
 SET
-  share_publicly = q.shared_publicly
-FROM
-  questions
+  share_publicly = shared_publicly
 WHERE
-  q.id >= $start
-  AND q.id <= $end;
+  id >= $start
+  AND id <= $end;


### PR DESCRIPTION
This caused two big problems in production:

- This forced us to unnecessarily rewrite the entire `questions` table because the `WHERE` clause didn't exclude non-shared questions.
- More importantly, `FROM questions` caused us to compute and materialize the cross product of all the questions in the ID range and _all the questions_. In practice, this was 139 million rows per batch.

This PR drops the execution time of a batch of 1000 questions from 610596ms to ~1ms.