### PR TITLE
docs: Fix invalid heading levels

### DIFF
--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -4,7 +4,7 @@ See [`elements/`](https://github.com/PrairieLearn/PrairieLearn/tree/master/apps/
 
 Element code uses the libraries in [the `python/` module](https://github.com/PrairieLearn/PrairieLearn/tree/master/apps/prairielearn/python).
 
-### Anatomy of an element
+## Anatomy of an element
 
 The system-wide elements available in the current build of the PrairieLearn server
 live in `[PrairieLearn directory]/elements` inside a folder corresponding to the element name.
@@ -46,7 +46,7 @@ And an `info.json` with the following contents:
 }
 ```
 
-### Element functions
+## Element functions
 
 All element functions are of the following form:
 
@@ -105,7 +105,7 @@ The element functions are:
 
 The above table describes the purpose of each function and the values in `data` that are allowed to be modified. Any permitted changes to the values in `data` will be persisted to the database. No function is allowed to add or delete keys in `data`.
 
-### Element dependencies
+## Element dependencies
 
 It's likely that your element will depend on certain client-side assets, such as scripts or stylesheets. To keep clean separation of HTML, CSS, and JS, you can place those dependencies in other files. If you depend on libraries like `lodash` or `d3`, you can also link to node modules containing these libraries. PrairieLearn will compile a list of all dependencies needed by all elements on a page, deduplicate the dependencies, and ensure they are loaded on the page.
 

--- a/docs/elementExtensions.md
+++ b/docs/elementExtensions.md
@@ -37,7 +37,7 @@ A host element can call the `load_extension()` function to load one specific ext
 
 A two-way flow of logic and information exists between elements and their extensions.
 
-##### Importing an Extension From an Element
+#### Importing an Extension From an Element
 
 Loading extension Python scripts returns a named tuple of all globally defined functions and variables. Loading all extensions will return a dictionary mapping the extension name to its named tuple. For example, if an extension were to define the following in their controller:
 
@@ -59,7 +59,7 @@ def render(element_html, data):
 
 This small example above will render `"hello world!"` to the question page. Note that when loading all extensions with `load_all_extensions()`, modules are returned in ascending alphabetical order.
 
-##### Importing a Host Element From an Extension
+#### Importing a Host Element From an Extension
 
 Extensions can also import files from their host element with the `load_host_script()` function. This can be used to obtain helper functions, class definitions, constant variables, etc.
 If the host element were to contain, for example:

--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -92,7 +92,7 @@ This config file specifies the following things:
 - The script `/grade/serverFilesCourse/python_autograder/run.sh` will be executed when your container starts up
 - If grading takes longer that 5 seconds, the container will be killed
 
-#### Special directories
+### Special directories
 
 There are several ways that you can load files from PrairieLearn into your container if you don't want to build the files directly into your image.
 

--- a/docs/getStarted.md
+++ b/docs/getStarted.md
@@ -14,7 +14,7 @@ This tutorial will show you how to create:
 - [questions using templates from outside courses](#start-a-new-question-from-an-existing-one-outside-your-own-course)
 - [assessments](#creating-a-new-assessment)
 
-### Creating a course instance
+## Creating a course instance
 
 A course instance corresponds to a single offering of a course, such as "Fall 2024", or possibly "Fall 2024, Section M". Follow the steps below to create a new course instance:
 
@@ -45,9 +45,9 @@ A course instance corresponds to a single offering of a course, such as "Fall 20
 
 - You will be able to see the new course instance from the course home page. You can always return to the course home page by clicking your course number from the top menu, next to the PrairieLearn button.
 
-### Creating questions from scratch
+## Creating questions from scratch
 
-#### Add a new question
+### Add a new question
 
 - go to the `Questions` tab. Your questions page should be similar to the example below:
 
@@ -117,7 +117,7 @@ To provide a simple example, here we first create a question without any randomi
 
 Note that this question does not use any server side code, and for that reason, the file `server.py` is not needed. Indeed, you could just delete `server.py` for this question. (we will not remove the file for the purpose of the following steps of this tutorial).
 
-### Start a new question from an existing one _inside_ your own course
+## Start a new question from an existing one _inside_ your own course
 
 - from the `Questions` tab, select the question you want to copy. As an example, we will use the question with QID `find_rectangle_area`.
 
@@ -185,9 +185,9 @@ We will add randomization to the previous question, using the file [server.py](q
 
 - go to the `Preview` tab to see your question. Try it out! Check a different variant and see how the variables change.
 
-### Start a new question from an existing one _outside_ your own course
+## Start a new question from an existing one _outside_ your own course
 
-#### Copying questions from the example course (XC 101)
+### Copying questions from the example course (XC 101)
 
 You should also have access to the example course `XC 101`. From the top menu, next to the PrairieLearn homepage button, you can select other courses that you were allowed access to. Select `XC 101`. If you cannot see the example course, contact us on Slack (`#pl-help`) and we will make sure you gain access.
 
@@ -201,7 +201,7 @@ Once you find a question that you want to use as template, you can follow these 
 
 - That is it! You are now viewing a copy of the question inside your course. You can modify the question following the steps from the section above.
 
-#### Copying questions from www.prairielearn.com
+### Copying questions from www.prairielearn.com
 
 - Go to <https://www.prairielearn.com/catalog/questions>
 
@@ -211,7 +211,7 @@ Once you find a question that you want to use as template, you can follow these 
 
 - That is it! You are now viewing a copy of the question inside your course. You can modify the question following the steps from the section above.
 
-### Creating a new assessment
+## Creating a new assessment
 
 Before you create an assessment, make sure you are in the desired course instance.
 
@@ -260,7 +260,7 @@ Before you create an assessment, make sure you are in the desired course instanc
 
 - click `Save and sync`.
 
-### Check how a student will see the assessment
+## Check how a student will see the assessment
 
 Follow these steps to preview an assessment as a student:
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -112,7 +112,7 @@ docker run -it --rm -p 3000:3000 \
     prairielearn/prairielearn
 ```
 
-###### Troubleshooting the --add-host option and network timeouts
+#### Troubleshooting the --add-host option and network timeouts
 
 If you are an advanced Docker user, or if your organization's network policies require it, then you might have previously adjusted the address pool used by Docker. If this conflicts with the Docker defaults, you might get a network timeout error when attempting to launch a workspace locally. In that case, you might need to adjust the IP address for the `--add-host=` option. You can find more technical details here: [PL issue #9805](https://github.com/PrairieLearn/PrairieLearn/issues/9805#issuecomment-2093299949), [moby/moby PR 29376](https://github.com/moby/moby/pull/29376), [docker/docs issue 8663](https://github.com/docker/docs/issues/8663).
 

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -1775,7 +1775,7 @@ This button deletes objects that were previously placed on the canvas.
 </pl-drawing-initial>
 ```
 
-#### Example implementations
+### Example implementations
 
 - [demo/drawing/graphs]: Example that highlights graph sketching
 

--- a/docs/workshop/index.md
+++ b/docs/workshop/index.md
@@ -17,15 +17,15 @@ In this training course, we will provide an introduction to the following topics
 
 ## Workshop Schedule
 
-#### [Lesson 1](lesson1.md): creating simple questions
+### [Lesson 1](lesson1.md): creating simple questions
 
-#### [Lesson 2](lesson2.md): creating assessments
+### [Lesson 2](lesson2.md): creating assessments
 
-#### [Lesson 3](lesson3.md): looking at more specialized elements
+### [Lesson 3](lesson3.md): looking at more specialized elements
 
-#### [Lesson 4](lesson4.md): customizing the grading method
+### [Lesson 4](lesson4.md): customizing the grading method
 
-#### [Lesson 5](lesson5.md): using graphical/drawing elements
+### [Lesson 5](lesson5.md): using graphical/drawing elements
 
 ## Workshop Videos
 

--- a/docs/workshop/lesson4.md
+++ b/docs/workshop/lesson4.md
@@ -4,7 +4,7 @@
 
 ## Customize your grade function using `server.py`
 
-#### Example 1:
+### Example 1:
 
 Ask students to provide a matrix $A$ such that $A^2$ is the zero matrix.
 
@@ -14,7 +14,7 @@ Since there is more than one solution that satisfies this problem, you will need
 
 - [workshop/Lesson4_example1](https://us.prairielearn.com/pl/course/108/question/8211634/preview)
 
-#### Example 2:
+### Example 2:
 
 Modify the example from Lesson 3 below:
 
@@ -26,7 +26,7 @@ Now ask students to enter three input values and one output that makes this logi
 
 - [workshop/Lesson4_example2](https://us.prairielearn.com/pl/course/108/question/8211635/preview)
 
-#### Example 3:
+### Example 3:
 
 This is an example of a question that expects data collected from an experiment.
 
@@ -47,7 +47,7 @@ Students will calculate the convective heat transfer based on the data described
 
 Take a look at the documentation for the [python auto grader](https://prairielearn.readthedocs.io/en/latest/python-grader/) first.
 
-#### Example 4:
+### Example 4:
 
 Write a question that provides students with a matrix $A$, and asks them to compute the following:
 

--- a/docs/workshop/lesson5.md
+++ b/docs/workshop/lesson5.md
@@ -4,7 +4,7 @@
 
 ## pl-graph
 
-#### Example 1:
+### Example 1:
 
 Create a question with a decision tree. Think about ways to create dynamic versions of the question. You can use `pl-figure` to load images, but here we want to explore the use of `pl-graph` ([check the documentation](https://prairielearn.readthedocs.io/en/latest/elements/#pl-graph-element)).
 
@@ -16,7 +16,7 @@ Create a question with a decision tree. Think about ways to create dynamic versi
 
 - [workshop/Lesson5_example1](https://us.prairielearn.com/pl/course_instance/4970/instructor/question/8211638/preview)
 
-#### Example 2:
+### Example 2:
 
 Write a question that provides the outgoing links from a set of websites and use the PageRank algorithm to determine the most popular website.
 
@@ -32,7 +32,7 @@ Your question should provide the Google Matrix in the form of a graph like the c
 
 ## pl-drawing
 
-#### Example 3:
+### Example 3:
 
 Write a question that uses the drawing canvas to collect input from student. Take a look at the `pl-drawing` [documentation](https://prairielearn.readthedocs.io/en/latest/pl-drawing/) before you start writing questions.
 
@@ -44,7 +44,7 @@ In this example, ask students to add a vector providing the position and directi
 
 - [workshop/Lesson5_example3](https://us.prairielearn.com/pl/course_instance/4970/instructor/question/8211641/preview)
 
-#### Example 4:
+### Example 4:
 
 Add a shape to the drawing canvas, and ask students to mark the centroid using a point (`pl-point`). You can use the pre-defined shapes `pl-circle`, `pl-triangle`, `pl-rectanle` or create a polygon using `pl-polygon`.
 


### PR DESCRIPTION
This fix was found through a local check using axe-linter, which has a [free version for local execution](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter) but unfortunately the CI version is not free.