### PR TITLE
Upgrade Pint

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -10,7 +10,7 @@ numpy==1.26.4
 openpyxl==3.1.5
 pandas-stubs==2.2.3.241009
 pandas==2.2.3
-Pint==0.24.3
+Pint==0.24.4
 psutil==6.1.0
 PuLP==2.9.0
 pycryptodome==3.21.0


### PR DESCRIPTION
See https://github.com/hgrecco/pint/commit/d592aff209a0eeae9383042368906dfb5edc5f54, this should fix the following error that we've been seeing in CI this morning:

```
ImportError while loading conftest '/home/runner/work/PrairieLearn/PrairieLearn/apps/prairielearn/python/conftest.py'.
apps/prairielearn/python/conftest.py:2: in <module>
    from prairielearn import QuestionData
apps/prairielearn/python/prairielearn.py:28: in <module>
    from pint import UnitRegistry
/opt/hostedtoolcache/Python/3.10.[15](https://github.com/PrairieLearn/PrairieLearn/actions/runs/11729274949/job/32674566763?pr=10906#step:16:16)/x64/lib/python3.10/site-packages/pint/__init__.py:18: in <module>
    from .delegates.formatter._format_helpers import formatter
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/pint/delegates/__init__.py:12: in <module>
    from . import txt_defparser
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/pint/delegates/txt_defparser/__init__.py:12: in <module>
    from .defparser import DefParser
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/pint/delegates/txt_defparser/defparser.py:10: in <module>
    from . import block, common, context, defaults, group, plain, system
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/pint/delegates/txt_defparser/common.py:24: in <module>
    class DefinitionSyntaxError(errors.DefinitionSyntaxError, fp.ParsingError):
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/dataclasses.py:1[17](https://github.com/PrairieLearn/PrairieLearn/actions/runs/11729274949/job/32674566763?pr=10906#step:16:18)5: in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/dataclasses.py:990: in _process_class
    raise TypeError('cannot inherit frozen dataclass from a '
E   TypeError: cannot inherit frozen dataclass from a non-frozen one
```