### PR TITLE
Get PrairieLearn running in Bun

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -2161,17 +2161,21 @@ export async function startServer() {
   });
   server.on('connection', () => connectionCounter.add(1));
 
-  opentelemetry.createObservableValueGauges(
-    meter,
-    'http.connections.active',
-    {
-      valueType: opentelemetry.ValueType.INT,
-      interval: 1000,
-    },
-    () => {
-      return util.promisify(server.getConnections.bind(server))();
-    },
-  );
+  // Hack to get us running in Bun, which doesn't currently support `getConnections`:
+  // https://github.com/oven-sh/bun/issues/4459
+  if (server.getConnections) {
+    opentelemetry.createObservableValueGauges(
+      meter,
+      'http.connections.active',
+      {
+        valueType: opentelemetry.ValueType.INT,
+        interval: 1000,
+      },
+      () => {
+        return util.promisify(server.getConnections.bind(server))();
+      },
+    );
+  }
 
   const serverSocketActivity = new SocketActivityMetrics(meter, 'http');
   server.on('connection', (socket) => serverSocketActivity.addSocket(socket));


### PR DESCRIPTION
This minor change will allow PrairieLearn to run in Bun with the following:

```sh
cd apps/prairielearn
bun --watch src/server.js
```

This change will be necessary until Bun supports `Server#getConnections`: https://github.com/oven-sh/bun/issues/4459

In my local testing, starting/restarting with Bun was roughly 2x faster than in Node (~4s instead of ~8s).