### PR TITLE
Allow optional SSL configuration options

### DIFF
--- a/apps/prairielearn/src/server.js
+++ b/apps/prairielearn/src/server.js
@@ -2139,10 +2139,16 @@ export async function startServer() {
   const app = await initExpress();
 
   if (config.serverType === 'https') {
-    const key = await fs.promises.readFile(config.sslKeyFile);
-    const cert = await fs.promises.readFile(config.sslCertificateFile);
-    const ca = [await fs.promises.readFile(config.sslCAFile)];
-    var options = { key, cert, ca };
+    var options = {};
+    if (config.sslKeyFile) {
+      options.key = await fs.promises.readFile(config.sslKeyFile);
+    }
+    if (config.sslCertificateFile) {
+      options.cert = await fs.promises.readFile(config.sslCertificateFile);
+    }
+    if (config.sslCAFile) {
+      options.ca = [await fs.promises.readFile(config.sslCAFile)];
+    }
     server = https.createServer(options, app);
     logger.verbose('server listening to HTTPS on port ' + config.serverPort);
   } else if (config.serverType === 'http') {


### PR DESCRIPTION
Exploring running bun with my local https docker development environment, I noticed two things: 

1) bun and node interpret the CA file differently. The `fullchain.pem` I had been using from LetsEncrypt as my `config.sslCAFile` works with node but not bun, browser erroring with `ERR_BAD_SSL_CLIENT_AUTH_CERT`. I presume that's because node is chaining with some system files that perhaps bun isn't?

2) I didn't actually need the CA file. When I took it out of the code (only running with options for `cert` and `key`) it worked fine in both node and bun.

This PR changes the PL `config.serverType: 'https'` to only load the configurations if they're present in the `config.json` file, allowing me to exclude the CA file.