### PR TITLE
Fix filter by assessment in questions table

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.js
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.js
@@ -129,7 +129,7 @@ onDocumentReady(() => {
     }
     var values = $('<div>')
       .html(value)
-      .find('.badge')
+      .find('.badge, .btn-badge')
       .filter(
         (i, elem) => $(elem).text().trim().toUpperCase() === search.trim().toUpperCase(),
       ).length;


### PR DESCRIPTION
Issue introduced in #10860. The questions table assessments filter relied on the badge class of each assessment to compare with the value of the filter. This is a bandaid solution to get a fix fast, a better way to handle it would probably require a more robust search that doesn't rely on the formatting of the data. This could be something like tabulator (see #8171), or an intermediate solution that reviews the use of filters in this page and others using bootstrap-table.