### PR TITLE
Center scorebar on student gradebook page

### DIFF
--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.html.ts
@@ -75,7 +75,7 @@ export function StudentGradebook({
                       </td>
                       <td class="text-center align-middle">
                         ${row.show_closed_assessment_score
-                          ? Scorebar(row.assessment_instance_score_perc)
+                          ? Scorebar(row.assessment_instance_score_perc, { classes: 'mx-auto' })
                           : 'Score not shown'}
                       </td>
                     </tr>


### PR DESCRIPTION
Applies similar fix from #10708 to the student gradebook page

Before:

![image](https://github.com/user-attachments/assets/e7471530-004c-4dca-89b2-92129ce25fdd)

After:

![image](https://github.com/user-attachments/assets/cfd52946-aa7b-4c6e-9b5e-af22dcfad662)
