### PR TITLE
Clarify availability of LTI 1.3 integration

### DIFF
--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -2,7 +2,7 @@
 
 Integrating Learning Management Systems (LMSes) with PrairieLearn uses [LTI 1.3](https://www.1edtech.org/standards/lti) technology to connect LMS courses with PrairieLearn course instances. This allows for programmatic assignment linking and grade syncing.
 
-Integration with Canvas via LTI 1.3 is currently available as a public preview. General availability of Canvas integration support as well as support for other LMS platforms will be coming in the future.
+Canvas integration via LTI 1.3 is currently available as a public preview. General availability of Canvas integration as well as support for other LMS platforms will be coming in the future.
 
 ## Prerequisites
 

--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -1,10 +1,12 @@
 # LMS integration for instructors
 
-Integrating Learning Management Systems (LMSes) with PrairieLearn uses [LTI 1.3](https://www.1edtech.org/standards/lti) technology to connect LMS courses with PrairieLearn course instances. This allows for programmatic assignment linking and grade passback.
+Integrating Learning Management Systems (LMSes) with PrairieLearn uses [LTI 1.3](https://www.1edtech.org/standards/lti) technology to connect LMS courses with PrairieLearn course instances. This allows for programmatic assignment linking and grade syncing.
 
-PrairieLearn currently has "Public Preview" support for integration with Learning
-Management Systems, starting with Canvas. General availability of Canvas integration
-support as well as support for other LMS platforms will be coming in the future.
+Integration with Canvas via LTI 1.3 is currently available as a public preview. General availability of Canvas integration support as well as support for other LMS platforms will be coming in the future.
+
+## Prerequisites
+
+LTI 1.3 integration is configured on an institution level. Institution administrators will need to follow the [setup instructions](lti13.md) to establish a trust relationship between the LMS and PrairieLearn.
 
 ## Setting up your Canvas course for PrairieLearn
 

--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -4,10 +4,6 @@ PrairieLearn can connect to Learning Management Systems (LMSes) using [LTI 1.3](
 
 Canvas integration via LTI 1.3 is currently available as a public preview. General availability of Canvas integration as well as support for other LMS platforms will be coming in the future.
 
-## Prerequisites
-
-LTI 1.3 integration is configured on an institution level. Institution administrators will need to follow the [setup instructions](lti13.md) to establish a trust relationship between the LMS and PrairieLearn.
-
 ## Setting up your Canvas course for PrairieLearn
 
 The first step is to enable PrairieLearn in your Canvas course. In your Canvas course,

--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -1,6 +1,6 @@
 # LMS integration for instructors
 
-Integrating Learning Management Systems (LMSes) with PrairieLearn uses [LTI 1.3](https://www.1edtech.org/standards/lti) technology to connect LMS courses with PrairieLearn course instances. This allows for programmatic assignment linking and grade syncing.
+PrairieLearn can connect to Learning Management Systems (LMSes) using [LTI 1.3](https://www.1edtech.org/standards/lti) technology. This allows for assignment linking and grade syncing.
 
 Canvas integration via LTI 1.3 is currently available as a public preview. General availability of Canvas integration as well as support for other LMS platforms will be coming in the future.
 

--- a/docs/lti13.md
+++ b/docs/lti13.md
@@ -1,6 +1,6 @@
 # LTI 1.3 configuration
 
-LTI 1.3 is available in early beta. Reach out to support@prairielearn.com to get it set up.
+Learning Management System (LMS) integration via LTI 1.3 is available as a public preview. Reach out to support@prairielearn.com to get it set up.
 
 Learning Tools Interoperability (LTI) provides app integration between Learning Management Systems (LMSes) like Canvas, Moodle, etc. and PrairieLearn. It includes single sign on from the LMS with additional features like course context information and roles. Version 1.3 enhances LTI to include an API for asynchronous two-way updates for assessments, scores, and rosters.
 


### PR DESCRIPTION
We recently decided to use the term "public preview" instead of "early beta" to describe the availability of LTI 1.3 integration. This PR updates the admin-facing docs to use that same terminology. I also tweaked the instructor documentation a bit.