### PR TITLE
Ensure points are summed with full precision

### DIFF
--- a/apps/prairielearn/src/sprocs/assessment_instances_grade.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_grade.sql
@@ -53,9 +53,8 @@ BEGIN
         t_points_by_zone AS (SELECT * FROM assessment_instances_points(assessment_instance_id)),
         t_used_for_grade AS (SELECT unnest(iq_ids) AS iq_ids FROM t_points_by_zone),
         v_used_for_grade AS (SELECT array_agg(iq_ids) AS iq_ids FROM t_used_for_grade),
-        -- `points` is converted to `numeric` to force Postgres to use full-precision
-        -- arithmetic. This will avoid accumulating floating-point errors when summing
-        -- non-integer points.
+        -- `points` is converted to `numeric` so that we avoid accumulating
+        -- floating-point errors when summing non-integer points.
         v_total_points AS (SELECT sum(t_points_by_zone.points::numeric) AS total_points FROM t_points_by_zone)
     SELECT
         v_total_points.total_points, v_used_for_grade.iq_ids

--- a/apps/prairielearn/src/sprocs/assessment_instances_grade.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_grade.sql
@@ -53,7 +53,10 @@ BEGIN
         t_points_by_zone AS (SELECT * FROM assessment_instances_points(assessment_instance_id)),
         t_used_for_grade AS (SELECT unnest(iq_ids) AS iq_ids FROM t_points_by_zone),
         v_used_for_grade AS (SELECT array_agg(iq_ids) AS iq_ids FROM t_used_for_grade),
-        v_total_points AS (SELECT sum(t_points_by_zone.points) AS total_points FROM t_points_by_zone)
+        -- `points` is converted to `numeric` to force Postgres to use full-precision
+        -- arithmetic. This will avoid accumulating floating-point errors when summing
+        -- non-integer points.
+        v_total_points AS (SELECT sum(t_points_by_zone.points::numeric) AS total_points FROM t_points_by_zone)
     SELECT
         v_total_points.total_points, v_used_for_grade.iq_ids
     INTO

--- a/apps/prairielearn/src/sprocs/assessment_instances_points.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_points.sql
@@ -77,8 +77,7 @@ BEGIN
         ), points_zones AS (
             SELECT
                 ptsq.zid,
-                -- We convert `points` to `numeric` to force Postgres to use
-                -- full-precision arithmetic. This will avoid accumulating
+                -- We convert `points` to `numeric` to avoid accumulating
                 -- floating-point errors when summing non-integer points.
                 LEAST(sum(ptsq.points::numeric), ptsq.zone_max_points) AS points,
                 array_agg(ptsq.iq_id) AS iq_ids

--- a/apps/prairielearn/src/sprocs/assessment_instances_points.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_points.sql
@@ -77,7 +77,10 @@ BEGIN
         ), points_zones AS (
             SELECT
                 ptsq.zid,
-                LEAST(sum(ptsq.points), ptsq.zone_max_points) AS points,
+                -- We convert `points` to `numeric` to force Postgres to use
+                -- full-precision arithmetic. This will avoid accumulating
+                -- floating-point errors when summing non-integer points.
+                LEAST(sum(ptsq.points::numeric), ptsq.zone_max_points) AS points,
                 array_agg(ptsq.iq_id) AS iq_ids
             FROM
                 points_questions AS ptsq
@@ -87,7 +90,9 @@ BEGIN
         ), max_points_zones AS (
             SELECT
                 ptsq.zid,
-                LEAST(sum(ptsq.max_points), ptsq.zone_max_points) AS max_points,
+                -- As above, `max_points` is converted to `numeric` to avoid
+                -- accumulating floating-point errors.
+                LEAST(sum(ptsq.max_points::numeric), ptsq.zone_max_points) AS max_points,
                 array_agg(ptsq.iq_id) AS max_iq_ids
             FROM
                 max_points_questions AS ptsq

--- a/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
@@ -18,6 +18,7 @@ DECLARE
     correct boolean;
     current_auto_value double precision;
     init_auto_points double precision;
+    auto_points_accumulator numeric;
     constant_question_value boolean;
     length integer;
     var_points_old double precision;
@@ -67,13 +68,13 @@ BEGIN
 
     -- points is the sum of all elements in variants_points_list (which now must be non-empty)
     length := cardinality(variants_points_list);
-    auto_points := 0;
+    auto_points_accumulator := 0;
     FOR i in 1..length LOOP
         -- We convert values to `numeric` to avoid accumulating floating-point
         -- errors when summing non-integer points.
-        auto_points := auto_points::numeric + variants_points_list[i]::numeric;
+        auto_points_accumulator := auto_points_accumulator + variants_points_list[i]::numeric;
     END LOOP;
-    auto_points := least(auto_points, aq.max_auto_points);
+    auto_points := least(auto_points_accumulator, aq.max_auto_points);
 
     -- status
     IF auto_points >= aq.max_auto_points AND aq.max_manual_points = 0 THEN

--- a/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
@@ -69,7 +69,9 @@ BEGIN
     length := cardinality(variants_points_list);
     auto_points := 0;
     FOR i in 1..length LOOP
-        auto_points := auto_points + variants_points_list[i];
+        -- We convert values to `numeric` to force Postgres to use full-precision arithmetic.
+        -- This will avoid accumulating floating-point errors when summing non-integer points.
+        auto_points := auto_points::numeric + variants_points_list[i]::numeric;
     END LOOP;
     auto_points := least(auto_points, aq.max_auto_points);
 

--- a/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
@@ -69,8 +69,8 @@ BEGIN
     length := cardinality(variants_points_list);
     auto_points := 0;
     FOR i in 1..length LOOP
-        -- We convert values to `numeric` to force Postgres to use full-precision arithmetic.
-        -- This will avoid accumulating floating-point errors when summing non-integer points.
+        -- We convert values to `numeric` to avoid accumulating floating-point
+        -- errors when summing non-integer points.
         auto_points := auto_points::numeric + variants_points_list[i]::numeric;
     END LOOP;
     auto_points := least(auto_points, aq.max_auto_points);


### PR DESCRIPTION
Closes https://github.com/PrairieLearn/PrairieLearn/issues/10928.

I left comments everywhere since this is not very obvious and since we definitely want to remember to handle this if/when we convert these things to TypeScript.

I didn't originally identify the need to change `instance_question_points_homework` in #10928. However, it came up in my grep, and I was able to reproduce a "failure" that involved it:

- Update the `points` of the first question in `testCourse/courseInstances/Sp15/assessments/hw3-partialCredit/infoAssessment.json` to `0.1`
- Start the assessment as a student.
- Make 3 100% submissions to the first question.
- Open the assessment log page and click the pencil to edit the points on the first question.
- Observe that the value is `0.3000000000...`.

After this change, that's correctly computed as `0.3` after following the same steps.

I also tested the original issue. I updated the same `testCourse/courseInstances/Sp15/assessments/hw3-partialCredit/infoAssessment.json` to have `"
type": "Exam"` and updated the questions to the following:

```json
{
  "zones": [
    {
      "questions": [
        { "id": "partialCredit1", "points": [2] },
        { "id": "partialCredit2", "points": [2] },
        { "id": "partialCredit3", "points": [1.6] },
        { "id": "partialCredit4_v2", "points": [1.6] }
      ]
    }
  ]
}
```

I then started the assessment as a student, submitted 100% to everything, and then checked the score on the assessment instance log page:

<img width="393" alt="Screenshot 2024-11-15 at 16 32 24" src="https://github.com/user-attachments/assets/67c54ffb-7014-4d9f-843c-46e613754478">

After making these changes, both `points` and `max_points` are correctly computed as 7.2.

I've focused exclusively on sums in this PR. It's possible that there's also issues with how we use multiplication, e.g. to compute percentages? I didn't observe any issues in my testing that weren't fixed by ensuring that points are always computed exactly.