### PR TITLE
Redirect to question settings page after question copy between courses

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -491,6 +491,19 @@ export const FileEditSchema = z.object({
 });
 export type FileEdit = z.infer<typeof FileEditSchema>;
 
+export const FileTransferSchema = z.object({
+  created_at: DateFromISOString,
+  deleted_at: DateFromISOString.nullable(),
+  from_course_id: IdSchema,
+  from_filename: z.string(),
+  id: IdSchema,
+  storage_filename: z.string(),
+  to_course_id: IdSchema,
+  transfer_type: z.enum(['CopyQuestion']),
+  user_id: IdSchema,
+});
+export type FileTransfer = z.infer<typeof FileTransferSchema>;
+
 export const GradingJobSchema = z.object({
   auth_user_id: IdSchema.nullable(),
   auto_points: z.number().nullable(),

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1244,7 +1244,7 @@ export class QuestionCopyEditor extends Editor {
 
 export class QuestionTransferEditor extends Editor {
   private from_qid: string;
-  private from_course_short_name: string;
+  private from_course: string;
   private from_path: string;
 
   public readonly uuid: string;
@@ -1252,16 +1252,19 @@ export class QuestionTransferEditor extends Editor {
   constructor(
     params: BaseEditorOptions & {
       from_qid: string;
-      from_course_short_name: string;
+      from_course_short_name: Course['short_name'];
       from_path: string;
     },
   ) {
     super(params);
 
     this.from_qid = params.from_qid;
-    this.from_course_short_name = params.from_course_short_name;
+    this.from_course =
+      params.from_course_short_name == null
+        ? 'unknown course'
+        : `course ${params.from_course_short_name}`;
     this.from_path = params.from_path;
-    this.description = `Copy question ${this.from_qid} from course ${this.from_course_short_name}`;
+    this.description = `Copy question ${this.from_qid} from ${this.from_course}`;
 
     this.uuid = uuidv4();
   }
@@ -1320,7 +1323,7 @@ export class QuestionTransferEditor extends Editor {
 
     return {
       pathsToAdd: [questionPath],
-      commitMessage: `copy question ${this.from_qid} (from course ${this.from_course_short_name}) to ${qid}`,
+      commitMessage: `copy question ${this.from_qid} (from ${this.from_course}) to ${qid}`,
     };
   }
 }

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.js
@@ -82,7 +82,7 @@ router.get(
       'success',
       'Question copied successfully. You are now viewing your copy of the question.',
     );
-    res.redirect(res.locals.urlPrefix + '/question/' + question.id);
+    res.redirect(`${res.locals.urlPrefix}/question/${question.id}/settings`);
   }),
 );
 

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.sql
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.sql
@@ -17,12 +17,3 @@ WHERE
   AND ft.deleted_at IS NULL
 RETURNING
   ft.id;
-
--- BLOCK select_course_from_course_id
-SELECT
-  c.*
-FROM
-  pl_courses as c
-WHERE
-  c.id = $course_id
-  AND c.deleted_at IS NULL;

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
@@ -1,4 +1,3 @@
-// @ts-check
 import * as path from 'path';
 
 import debugfn from 'debug';
@@ -9,20 +8,25 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
+import { type Course, type FileTransfer, FileTransferSchema } from '../../lib/db-types.js';
 import { QuestionTransferEditor } from '../../lib/editors.js';
 import { idsEqual } from '../../lib/id.js';
+import { selectCourseById } from '../../models/course.js';
 import { selectQuestionByUuid } from '../../models/question.js';
 
 const router = express.Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:instructorFileTransfer');
 
-async function getFileTransfer(file_transfer_id, user_id) {
-  let file_transfer;
-  const result = await sqldb.queryOneRowAsync(sql.select_file_transfer, {
-    id: file_transfer_id,
-  });
-  file_transfer = result.rows[0];
+async function getFileTransfer(
+  file_transfer_id: string,
+  user_id: string,
+): Promise<FileTransfer & { from_course: Course }> {
+  const file_transfer = await sqldb.queryRow(
+    sql.select_file_transfer,
+    { id: file_transfer_id },
+    FileTransferSchema,
+  );
   if (file_transfer.transfer_type !== 'CopyQuestion') {
     throw new Error(`bad transfer_type: ${file_transfer.transfer_type}`);
   }
@@ -33,17 +37,14 @@ async function getFileTransfer(file_transfer_id, user_id) {
       } and ${user_id} (types: ${typeof file_transfer.user_id}, ${typeof user_id})`,
     );
   }
-  const courseResult = await sqldb.queryOneRowAsync(sql.select_course_from_course_id, {
-    course_id: file_transfer.from_course_id,
-  });
-  file_transfer.from_course = courseResult.rows[0];
-  return file_transfer;
+  const from_course = await selectCourseById(file_transfer.from_course_id);
+  return { ...file_transfer, from_course };
 }
 
 router.get(
   '/:file_transfer_id',
-  asyncHandler(async (req, res, next) => {
-    if (config.filesRoot == null) return next(new Error('config.filesRoot is null'));
+  asyncHandler(async (req, res) => {
+    if (config.filesRoot == null) throw new Error('config.filesRoot is null');
     const file_transfer = await getFileTransfer(
       req.params.file_transfer_id,
       res.locals.user.user_id,
@@ -55,7 +56,7 @@ router.get(
     const editor = new QuestionTransferEditor({
       locals: res.locals,
       from_qid: qid,
-      from_course_short_name: file_transfer.from_course.short_name,
+      from_course_short_name: file_transfer.from_course.short_name ?? '',
       from_path: path.join(config.filesRoot, file_transfer.storage_filename),
     });
     const serverJob = await editor.prepareServerJob();


### PR DESCRIPTION
Resolves #10931. Changes the redirection target after a successful question copy operation to the question settings page instead of the question preview page. This change makes the operation consistent with a copy within a course, which already redirects to the settings page:
https://github.com/PrairieLearn/PrairieLearn/blob/35ecc8f9a8fbca79963bd13ef33394e860c618c2/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts#L191