### PR TITLE
Add IDs for dynamically-rendered elements

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -336,14 +336,20 @@ export function QuestionFooter({
   if (resLocals.question.type === 'Freeform') {
     return html`
       <div class="card-footer" id="question-panel-footer">
-        ${QuestionFooterContent({ resLocals, questionContext })}
+        <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+        <div id="question-footer-content">
+          ${QuestionFooterContent({ resLocals, questionContext })}
+        </div>
       </div>
     `;
   } else {
     return html`
       <div class="card-footer" id="question-panel-footer">
         <form class="question-form" name="question-form" method="POST">
-          ${QuestionFooterContent({ resLocals, questionContext })}
+          <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+          <div id="question-footer-content">
+            ${QuestionFooterContent({ resLocals, questionContext })}
+          </div>
         </form>
       </div>
     `;
@@ -354,7 +360,7 @@ function QuestionFooterContent({
   resLocals,
   questionContext,
 }: {
-  resLocals: QuestionFooterResLocals;
+  resLocals: Omit<QuestionFooterResLocals, '__csrf_token'>;
   questionContext: QuestionContext;
 }) {
   const {
@@ -379,7 +385,6 @@ function QuestionFooterContent({
     group_info,
     group_role_permissions,
     user,
-    __csrf_token,
   } = resLocals;
 
   if (questionContext === 'student_exam' && variantAttemptsLeft === 0) {
@@ -457,7 +462,6 @@ function QuestionFooterContent({
                 <input type="hidden" name="postData" class="postData" />
                 <input type="hidden" name="__action" class="__action" />
               `}
-          <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
           ${showNewVariantButton
             ? html`
                 <a href="${newVariantUrl}" class="btn btn-primary disable-on-click ml-1">

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -1,5 +1,6 @@
 import { EncodedData } from '@prairielearn/browser-utils';
 import { html, unsafeHtml, escapeHtml } from '@prairielearn/html';
+import { run } from '@prairielearn/run';
 
 import { config } from '../lib/config.js';
 import type {
@@ -337,9 +338,7 @@ export function QuestionFooter({
     return html`
       <div class="card-footer" id="question-panel-footer">
         <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-        <div id="question-panel-footer-content">
-          ${QuestionFooterContent({ resLocals, questionContext })}
-        </div>
+        ${QuestionFooterContent({ resLocals, questionContext })}
       </div>
     `;
   } else {
@@ -347,9 +346,7 @@ export function QuestionFooter({
       <div class="card-footer" id="question-panel-footer">
         <form class="question-form" name="question-form" method="POST">
           <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-          <div id="question-panel-footer-content">
-            ${QuestionFooterContent({ resLocals, questionContext })}
-          </div>
+          ${QuestionFooterContent({ resLocals, questionContext })}
         </form>
       </div>
     `;
@@ -387,127 +384,131 @@ function QuestionFooterContent({
     user,
   } = resLocals;
 
-  if (questionContext === 'student_exam' && variantAttemptsLeft === 0) {
-    return 'This question is complete and cannot be answered again.';
-  }
+  const contents = run(() => {
+    if (questionContext === 'student_exam' && variantAttemptsLeft === 0) {
+      return 'This question is complete and cannot be answered again.';
+    }
 
-  if (authz_result?.authorized_edit === false) {
-    return html`<div class="alert alert-warning mt-2" role="alert">
-      You are viewing the question instance of a different user and so are not authorized to save
-      answers, to submit answers for grading, or to try a new variant of this same question.
-    </div>`;
-  }
+    if (authz_result?.authorized_edit === false) {
+      return html`<div class="alert alert-warning mt-2" role="alert">
+        You are viewing the question instance of a different user and so are not authorized to save
+        answers, to submit answers for grading, or to try a new variant of this same question.
+      </div>`;
+    }
 
-  return html`
-    <div class="row">
-      <div class="col d-flex justify-content-between">
-        <span class="d-flex align-items-center">
-          ${showSaveButton
-            ? html`
-                <button
-                  class="btn btn-info question-save disable-on-submit order-2"
-                  ${disableSaveButton ? 'disabled' : ''}
-                  ${question.type === 'Freeform' ? html`name="__action" value="save"` : ''}
-                >
-                  ${showGradeButton ? 'Save only' : 'Save'}
-                </button>
-              `
-            : ''}
-          ${showGradeButton
-            ? html`
-                <button
-                  class="btn btn-primary question-grade disable-on-submit order-1 mr-1"
-                  ${disableGradeButton ? 'disabled' : ''}
-                  ${question.type === 'Freeform' ? html`name="__action" value="grade"` : ''}
-                >
-                  Save &amp; Grade
-                  ${variantAttemptsTotal > 0
-                    ? variantAttemptsLeft > 1
-                      ? html`
-                          <small class="font-italic ml-2">
-                            ${variantAttemptsLeft} attempts left
-                          </small>
-                        `
-                      : variantAttemptsLeft === 1 && variantAttemptsTotal > 1
-                        ? html`<small class="font-italic ml-2">Last attempt</small>`
-                        : variantAttemptsLeft === 1
-                          ? html`<small class="font-italic ml-2">Single attempt</small>`
-                          : ''
-                    : questionContext === 'student_homework'
-                      ? html`<small class="font-italic ml-2">Unlimited attempts</small>`
-                      : ''}
-                </button>
-              `
-            : ''}
-          ${group_config?.has_roles && !group_role_permissions?.can_submit && group_info
-            ? html`
-                <button
-                  type="button"
-                  class="btn btn-xs btn-ghost mr-1"
-                  data-toggle="popover"
-                  data-content="Your group role (${getRoleNamesForUser(group_info, user).join(
-                    ', ',
-                  )}) is not allowed to submit this question."
-                  aria-label="Submission blocked"
-                >
-                  <i class="fa fa-lock" aria-hidden="true"></i>
-                </button>
-              `
-            : ''}
-        </span>
-        <span class="d-flex">
-          ${question.type === 'Freeform'
-            ? html` <input type="hidden" name="__variant_id" value="${variant.id}" /> `
-            : html`
-                <input type="hidden" name="postData" class="postData" />
-                <input type="hidden" name="__action" class="__action" />
-              `}
-          ${showNewVariantButton
-            ? html`
-                <a href="${newVariantUrl}" class="btn btn-primary disable-on-click ml-1">
-                  New variant
-                </a>
-              `
-            : showTryAgainButton
+    return html`
+      <div class="row">
+        <div class="col d-flex justify-content-between">
+          <span class="d-flex align-items-center">
+            ${showSaveButton
               ? html`
-                  <a href="${tryAgainUrl}" class="btn btn-primary disable-on-click ml-1">
-                    ${instance_question_info.previous_variants?.some((variant) => variant.open)
-                      ? 'Go to latest variant'
-                      : 'Try a new variant'}
+                  <button
+                    class="btn btn-info question-save disable-on-submit order-2"
+                    ${disableSaveButton ? 'disabled' : ''}
+                    ${question.type === 'Freeform' ? html`name="__action" value="save"` : ''}
+                  >
+                    ${showGradeButton ? 'Save only' : 'Save'}
+                  </button>
+                `
+              : ''}
+            ${showGradeButton
+              ? html`
+                  <button
+                    class="btn btn-primary question-grade disable-on-submit order-1 mr-1"
+                    ${disableGradeButton ? 'disabled' : ''}
+                    ${question.type === 'Freeform' ? html`name="__action" value="grade"` : ''}
+                  >
+                    Save &amp; Grade
+                    ${variantAttemptsTotal > 0
+                      ? variantAttemptsLeft > 1
+                        ? html`
+                            <small class="font-italic ml-2">
+                              ${variantAttemptsLeft} attempts left
+                            </small>
+                          `
+                        : variantAttemptsLeft === 1 && variantAttemptsTotal > 1
+                          ? html`<small class="font-italic ml-2">Last attempt</small>`
+                          : variantAttemptsLeft === 1
+                            ? html`<small class="font-italic ml-2">Single attempt</small>`
+                            : ''
+                      : questionContext === 'student_homework'
+                        ? html`<small class="font-italic ml-2">Unlimited attempts</small>`
+                        : ''}
+                  </button>
+                `
+              : ''}
+            ${group_config?.has_roles && !group_role_permissions?.can_submit && group_info
+              ? html`
+                  <button
+                    type="button"
+                    class="btn btn-xs btn-ghost mr-1"
+                    data-toggle="popover"
+                    data-content="Your group role (${getRoleNamesForUser(group_info, user).join(
+                      ', ',
+                    )}) is not allowed to submit this question."
+                    aria-label="Submission blocked"
+                  >
+                    <i class="fa fa-lock" aria-hidden="true"></i>
+                  </button>
+                `
+              : ''}
+          </span>
+          <span class="d-flex">
+            ${question.type === 'Freeform'
+              ? html` <input type="hidden" name="__variant_id" value="${variant.id}" /> `
+              : html`
+                  <input type="hidden" name="postData" class="postData" />
+                  <input type="hidden" name="__action" class="__action" />
+                `}
+            ${showNewVariantButton
+              ? html`
+                  <a href="${newVariantUrl}" class="btn btn-primary disable-on-click ml-1">
+                    New variant
                   </a>
                 `
-              : hasAttemptsOtherVariants
+              : showTryAgainButton
                 ? html`
-                    <small class="font-italic align-self-center">
-                      Additional attempts available with new variants
-                    </small>
-                    <button
-                      type="button"
-                      class="btn btn-xs btn-ghost align-self-center ml-1"
-                      data-toggle="popover"
-                      data-container="body"
-                      data-html="true"
-                      data-content="${escapeHtml(
-                        NewVariantInfo({ variantAttemptsLeft, variantAttemptsTotal }),
-                      )}"
-                      data-placement="auto"
-                    >
-                      <i class="fa fa-question-circle" aria-hidden="true"></i>
-                    </button>
+                    <a href="${tryAgainUrl}" class="btn btn-primary disable-on-click ml-1">
+                      ${instance_question_info.previous_variants?.some((variant) => variant.open)
+                        ? 'Go to latest variant'
+                        : 'Try a new variant'}
+                    </a>
                   `
-                : ''}
-          ${AvailablePointsNotes({ questionContext, instance_question, assessment_question })}
-        </span>
+                : hasAttemptsOtherVariants
+                  ? html`
+                      <small class="font-italic align-self-center">
+                        Additional attempts available with new variants
+                      </small>
+                      <button
+                        type="button"
+                        class="btn btn-xs btn-ghost align-self-center ml-1"
+                        data-toggle="popover"
+                        data-container="body"
+                        data-html="true"
+                        data-content="${escapeHtml(
+                          NewVariantInfo({ variantAttemptsLeft, variantAttemptsTotal }),
+                        )}"
+                        data-placement="auto"
+                      >
+                        <i class="fa fa-question-circle" aria-hidden="true"></i>
+                      </button>
+                    `
+                  : ''}
+            ${AvailablePointsNotes({ questionContext, instance_question, assessment_question })}
+          </span>
+        </div>
       </div>
-    </div>
-    ${SubmitRateFooter({
-      questionContext,
-      showGradeButton,
-      disableGradeButton,
-      assessment_question,
-      allowGradeLeftMs: instance_question?.allow_grade_left_ms ?? 0,
-    })}
-  `;
+      ${SubmitRateFooter({
+        questionContext,
+        showGradeButton,
+        disableGradeButton,
+        assessment_question,
+        allowGradeLeftMs: instance_question?.allow_grade_left_ms ?? 0,
+      })}
+    `;
+  });
+
+  return html`<div id="question-panel-footer-content">${contents}</div>`;
 }
 
 function SubmitRateFooter({

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -337,7 +337,7 @@ export function QuestionFooter({
     return html`
       <div class="card-footer" id="question-panel-footer">
         <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-        <div id="question-footer-content">
+        <div id="question-panel-footer-content">
           ${QuestionFooterContent({ resLocals, questionContext })}
         </div>
       </div>
@@ -347,7 +347,7 @@ export function QuestionFooter({
       <div class="card-footer" id="question-panel-footer">
         <form class="question-form" name="question-form" method="POST">
           <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-          <div id="question-footer-content">
+          <div id="question-panel-footer-content">
             ${QuestionFooterContent({ resLocals, questionContext })}
           </div>
         </form>

--- a/apps/prairielearn/src/components/QuestionScore.html.ts
+++ b/apps/prairielearn/src/components/QuestionScore.html.ts
@@ -53,7 +53,11 @@ export function QuestionScorePanel({
       <div class="card-header bg-secondary text-white">
         <h2>Question ${instance_question_info.question_number}</h2>
       </div>
-      <table class="table table-sm two-column-description-no-header" aria-label="Question score">
+      <table
+        class="table table-sm two-column-description-no-header"
+        aria-label="Question score"
+        id="question-score-panel-content"
+      >
         <tbody>
           ${assessment.type === 'Exam'
             ? html`


### PR DESCRIPTION
This is being done as part of the implementation of #10792. Unfortunately that change requires us to make changes gradually so as to not break clients.

This PR adds `id` attributes that will be used in future PRs to change which parts of the page are updated after external grading completes for a submission. The next PR will change the question client JS to be forwards-compatible with receiving these "content" bits of HTML.