### PR TITLE
Change student email placeholders to staff ones on the staff page

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.ts
@@ -263,7 +263,7 @@ function CoursePermissionsInsertForm({
           class="form-control"
           id="addUsersInputUid"
           name="uid"
-          placeholder="student1@example.com, student2@example.com"
+          placeholder="staff1@example.com, staff2@example.com"
           required
           aria-describedby="addUsersInputUidHelp"
         ></textarea>


### PR DESCRIPTION
I had to do a double take when adding a staff member because I was confused why the placeholder said student when I was adding staff. This should avoid confusion better.

