### PR TITLE
Fix regression in instance_questions_grade sproc

### DIFF
--- a/apps/prairielearn/src/sprocs/instance_questions_grade.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_grade.sql
@@ -28,6 +28,9 @@ BEGIN
             false,
             jsonb_build_object('grading_job_id', grading_job_id),
             '{}'::jsonb,
+            -- The first one is user_id, the second is authn_user_id. We can't
+            -- differentiate between the two at this point, so we just use the
+            -- same value for both.
             instance_questions_grade.authn_user_id,
             instance_questions_grade.authn_user_id
         )

--- a/apps/prairielearn/src/sprocs/instance_questions_grade.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_grade.sql
@@ -22,12 +22,12 @@ BEGIN
         -- farther upstream, and avoid recording an issue here.
         PERFORM issues_insert_for_variant(
             v.id,
-            'Submission when instance question is closed',
-            '',
-            false,
-            false,
-            jsonb_build_object('grading_job_id', grading_job_id),
-            '{}'::jsonb,
+            'Submission when instance question is closed', -- student message
+            '', -- instructor message
+            false, -- manually reported
+            false, -- course-caused
+            jsonb_build_object('grading_job_id', grading_job_id), -- course data
+            '{}'::jsonb, -- system data
             -- The first one is user_id, the second is authn_user_id. We can't
             -- differentiate between the two at this point, so we just use the
             -- same value for both.

--- a/apps/prairielearn/src/sprocs/instance_questions_grade.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_grade.sql
@@ -17,10 +17,20 @@ BEGIN
 
     IF NOT instance_question_open THEN
         -- this shouldn't happen, so log an error
+        --
+        -- TODO: We should actually work to prevent this from happening
+        -- farther upstream, and avoid recording an issue here.
         PERFORM issues_insert_for_variant(
-            v.id, 'Submission when instance question is closed', '', false,
-            false, jsonb_build_object('grading_job_id', grading_job_id),
-            '{}'::jsonb, instance_questions_grade.authn_user_id)
+            v.id,
+            'Submission when instance question is closed',
+            '',
+            false,
+            false,
+            jsonb_build_object('grading_job_id', grading_job_id),
+            '{}'::jsonb,
+            instance_questions_grade.authn_user_id,
+            instance_questions_grade.authn_user_id
+        )
         FROM
             grading_jobs AS gj
             JOIN submissions AS s ON (s.id = gj.submission_id)


### PR DESCRIPTION
Fixes a regression introduced in #10840. The `issues_insert_for_variant` sproc now takes two separate user IDs, but this callsite wasn't updated to account for that.