### PR TITLE
Trust token expiration date for termination webhook

### DIFF
--- a/apps/prairielearn/src/webhooks/terminate.ts
+++ b/apps/prairielearn/src/webhooks/terminate.ts
@@ -35,7 +35,6 @@ router.post('/', async (req, res) => {
     try {
       const key = crypto.createSecretKey(config.secretKey, 'utf-8');
       await jose.jwtVerify(jwt, key, {
-        maxTokenAge: 60,
         issuer: 'PrairieLearn',
         subject: 'terminate',
       });


### PR DESCRIPTION
We want to fully trust the expiration date so we can adjust this without changes to PrairieLearn.