### PR TITLE
Optimize handling of data in freeform questions

### DIFF
--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -449,7 +449,6 @@ function checkData(data, origData, phase) {
     }
     if (!editPhases.includes(phase)) {
       if (!_.has(origData, prop)) return '"' + prop + '" is missing from "origData"';
-
       if (!_.isEqual(data[prop], origData[prop])) {
         return `data.${prop} has been illegally modified, new value: "${JSON.stringify(
           data[prop],

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -452,7 +452,7 @@ function checkData(data, origData, phase) {
 
       // If `data` and `origData` are the same object, we can skip the expensive
       // deep comparison of them. We rely on this optimization in `processQuestionHtml`.
-      if (data !== origData && !_.isEqual(data[prop], origData[prop])) {
+      if (data[prop] !== origData[prop] && !_.isEqual(data[prop], origData[prop])) {
         return `data.${prop} has been illegally modified, new value: "${JSON.stringify(
           data[prop],
         )}", original value: "${JSON.stringify(origData[prop])}"`;

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -450,9 +450,7 @@ function checkData(data, origData, phase) {
     if (!editPhases.includes(phase)) {
       if (!_.has(origData, prop)) return '"' + prop + '" is missing from "origData"';
 
-      // If `data` and `origData` are the same object, we can skip the expensive
-      // deep comparison of them. We rely on this optimization in `processQuestionHtml`.
-      if (data[prop] !== origData[prop] && !_.isEqual(data[prop], origData[prop])) {
+      if (!_.isEqual(data[prop], origData[prop])) {
         return `data.${prop} has been illegally modified, new value: "${JSON.stringify(
           data[prop],
         )}", original value: "${JSON.stringify(origData[prop])}"`;

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -449,7 +449,10 @@ function checkData(data, origData, phase) {
     }
     if (!editPhases.includes(phase)) {
       if (!_.has(origData, prop)) return '"' + prop + '" is missing from "origData"';
-      if (!_.isEqual(data[prop], origData[prop])) {
+
+      // If `data` and `origData` are the same object, we can skip the expensive
+      // deep comparison of them. We rely on this optimization in `processQuestionHtml`.
+      if (data !== origData && !_.isEqual(data[prop], origData[prop])) {
         return `data.${prop} has been illegally modified, new value: "${JSON.stringify(
           data[prop],
         )}", original value: "${JSON.stringify(origData[prop])}"`;
@@ -552,7 +555,7 @@ async function experimentalProcess(phase, codeCaller, data, context, html) {
 }
 
 async function traverseQuestionAndExecuteFunctions(phase, codeCaller, data, context, html) {
-  const origData = JSON.parse(JSON.stringify(data));
+  const origData = structuredClone(data);
   const renderedElementNames = [];
   const courseIssues = [];
   let fileData = Buffer.from('');
@@ -679,7 +682,7 @@ async function traverseQuestionAndExecuteFunctions(phase, codeCaller, data, cont
 }
 
 async function legacyTraverseQuestionAndExecuteFunctions(phase, codeCaller, data, context, $) {
-  const origData = JSON.parse(JSON.stringify(data));
+  const origData = structuredClone(data);
   const renderedElementNames = [];
   const courseIssues = [];
   let fileData = Buffer.from('');
@@ -808,9 +811,9 @@ async function legacyTraverseQuestionAndExecuteFunctions(phase, codeCaller, data
  * @param {QuestionProcessingContext} context
  */
 async function processQuestionHtml(phase, codeCaller, data, context) {
-  const origData = JSON.parse(JSON.stringify(data));
-
-  const checkErr = checkData(data, origData, phase);
+  // We deliberately reuse the same `data` object for both the "new" and "original"
+  // arguments to avoid an unnecessary deep clone and comparison.
+  const checkErr = checkData(data, data, phase);
   if (checkErr) {
     return {
       courseIssues: [
@@ -893,7 +896,7 @@ async function processQuestionHtml(phase, codeCaller, data, context) {
 
 async function processQuestionServer(phase, codeCaller, data, html, fileData, context) {
   const courseIssues = [];
-  const origData = JSON.parse(JSON.stringify(data));
+  const origData = structuredClone(data);
 
   const checkErrBefore = checkData(data, origData, phase);
   if (checkErrBefore) {


### PR DESCRIPTION
This PR makes several optimizations to the way the `data` object is handled in freeform questions:

- Rather than deep coping the data with `JSON.parse(JSON.stringify(...))`, we now use `structuredClone`. This should generally be more efficient for large/complex objects, and crucially, it avoids creating copies of large strings like we might see in `raw_submitted_answers`/`submitted_answers` when large files are submitted. This will help minimize memory usage. `structuredClone` has been available since Node 17, so i's available in all our supported versions (v20+).
- `processQuestionHtml` now avoids unnecessary clones of data. Before, we were cloning an object and then essentially asserting that the clone was equal to the original, which was pointless.
- ~`checkData` now only does an expensive `_.isEqual(...)` deep equality check if `data` and `origData` are not the same object, as if they're the same object, their contents are inherently identical. `processQuestionHtml` now takes advantage of that.~ Lodash already has this optimization built in: https://github.com/lodash/lodash/blob/f299b52f39486275a9e6483b60a410e06520c538/lodash.js#L3310