### PR TITLE
Use default font size for workspace-vscode-python image

### DIFF
--- a/workspaces/vscode-python/settings.json
+++ b/workspaces/vscode-python/settings.json
@@ -11,7 +11,6 @@
   "extensions.autoUpdate": false,
   "telemetry.enableTelemetry": false,
   "telemetry.telemetryLevel": "off",
-  "editor.fontSize": 16,
   "window.menuBarVisibility": "visible",
   "workbench.colorTheme": "Default Dark Modern"
 }


### PR DESCRIPTION
This has bugged me for a little bit, the font size seems unnaturally big compared to the rest of the UI:

<img width="283" alt="Screenshot 2024-12-03 at 11 01 38" src="https://github.com/user-attachments/assets/eff87cba-dc55-43e6-8b79-594c887fd1e4">

This PR restores it to the default. The user can always adjust this as needed.