### PR TITLE
Render new contents for async panel rendering

### DIFF
--- a/apps/prairielearn/src/lib/externalGradingSocket.ts
+++ b/apps/prairielearn/src/lib/externalGradingSocket.ts
@@ -92,7 +92,6 @@ export function connection(socket: Socket) {
       user_id: msg.user_id,
       urlPrefix: msg.url_prefix,
       questionContext: msg.question_context,
-      csrfToken: msg.csrf_token,
       authorizedEdit: msg.authorized_edit,
       renderScorePanels: true,
     }).then(

--- a/apps/prairielearn/src/lib/externalGradingSocket.ts
+++ b/apps/prairielearn/src/lib/externalGradingSocket.ts
@@ -74,7 +74,6 @@ export function connection(socket: Socket) {
         'submission_id',
         'url_prefix',
         'question_context',
-        'csrf_token',
         'authorized_edit',
       ])
     ) {
@@ -155,8 +154,8 @@ function checkToken(token: string, variantId: string): boolean {
   const data = { variantId };
   const valid = checkSignedToken(token, data, config.secretKey, { maxAge: 24 * 60 * 60 * 1000 });
   if (!valid) {
-    logger.error(`CSRF token for variant ${variantId} failed validation.`);
-    Sentry.captureException(new Error(`CSRF token for variant ${variantId} failed validation.`));
+    logger.error(`Token for variant ${variantId} failed validation.`);
+    Sentry.captureException(new Error(`Token for variant ${variantId} failed validation.`));
   }
   return valid;
 }

--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -8,10 +8,10 @@ import { run } from '@prairielearn/run';
 import { generateSignedToken } from '@prairielearn/signed-token';
 
 import { AssessmentScorePanel } from '../components/AssessmentScorePanel.html.js';
-import { QuestionFooter, QuestionFooterContent } from '../components/QuestionContainer.html.js';
+import { QuestionFooterContent } from '../components/QuestionContainer.html.js';
 import { type QuestionContext } from '../components/QuestionContainer.types.js';
 import { QuestionNavSideButton } from '../components/QuestionNavigation.html.js';
-import { QuestionScorePanel, QuestionScorePanelContent } from '../components/QuestionScore.html.js';
+import { QuestionScorePanelContent } from '../components/QuestionScore.html.js';
 import {
   SubmissionPanel,
   SubmissionBasicSchema,

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -90,7 +90,7 @@ router.get(
       // The score panels never need to be live-updated in this context.
       renderScorePanels: false,
     });
-    res.send(panels);
+    res.json(panels);
   }),
 );
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -77,7 +77,7 @@ router.get(
 router.get(
   '/variant/:variant_id(\\d+)/submission/:submission_id(\\d+)',
   asyncHandler(async (req, res) => {
-    const { submissionPanel, extraHeadersHtml } = await renderPanelsForSubmission({
+    const panels = await renderPanelsForSubmission({
       submission_id: req.params.submission_id,
       question_id: res.locals.question.id,
       instance_question_id: res.locals.instance_question.id,
@@ -85,11 +85,12 @@ router.get(
       user_id: res.locals.user.user_id,
       urlPrefix: res.locals.urlPrefix,
       questionContext: 'manual_grading',
-      csrfToken: null,
-      authorizedEdit: null,
+      // This is only used by score panels, which are not rendered in this context.
+      authorizedEdit: false,
+      // The score panels never need to be live-updated in this context.
       renderScorePanels: false,
     });
-    res.send({ submissionPanel, extraHeadersHtml });
+    res.send(panels);
   }),
 );
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -49,8 +49,9 @@ router.get(
       user_id: res.locals.user.user_id,
       urlPrefix: res.locals.urlPrefix,
       questionContext: 'instructor',
-      csrfToken: null,
-      authorizedEdit: null,
+      // This is only used by score panels, which are not rendered in this context.
+      authorizedEdit: false,
+      // score panels are never rendered on the instructor question preview page.
       renderScorePanels: false,
     });
     res.send({ submissionPanel, extraHeadersHtml });

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -41,7 +41,7 @@ router.post(
 router.get(
   '/variant/:variant_id(\\d+)/submission/:submission_id(\\d+)',
   asyncHandler(async (req, res) => {
-    const { submissionPanel, extraHeadersHtml } = await renderPanelsForSubmission({
+    const panels = await renderPanelsForSubmission({
       submission_id: req.params.submission_id,
       question_id: res.locals.question.id,
       instance_question_id: null,
@@ -54,7 +54,7 @@ router.get(
       // score panels are never rendered on the instructor question preview page.
       renderScorePanels: false,
     });
-    res.send({ submissionPanel, extraHeadersHtml });
+    res.json(panels);
   }),
 );
 

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -67,7 +67,7 @@ router.get(
   '/variant/:variant_id(\\d+)/submission/:submission_id(\\d+)',
   asyncHandler(async (req, res) => {
     await setLocals(req, res);
-    const { submissionPanel, extraHeadersHtml } = await renderPanelsForSubmission({
+    const panels = await renderPanelsForSubmission({
       submission_id: req.params.submission_id,
       question_id: res.locals.question.id,
       instance_question_id: null,
@@ -80,7 +80,7 @@ router.get(
       // Score panels are never rendered on the public question preview page.
       renderScorePanels: false,
     });
-    res.send({ submissionPanel, extraHeadersHtml });
+    res.json(panels);
   }),
 );
 

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -75,8 +75,9 @@ router.get(
       user_id: res.locals.user.user_id,
       urlPrefix: res.locals.urlPrefix,
       questionContext: 'public',
-      csrfToken: null,
-      authorizedEdit: null,
+      // This is only used by score panels, which are not rendered in this context.
+      authorizedEdit: false,
+      // Score panels are never rendered on the public question preview page.
       renderScorePanels: false,
     });
     res.send({ submissionPanel, extraHeadersHtml });

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -254,7 +254,7 @@ router.post(
 router.get(
   '/variant/:variant_id(\\d+)/submission/:submission_id(\\d+)',
   asyncHandler(async (req, res) => {
-    const { submissionPanel, extraHeadersHtml } = await renderPanelsForSubmission({
+    const panels = await renderPanelsForSubmission({
       submission_id: req.params.submission_id,
       question_id: res.locals.question.id,
       instance_question_id: res.locals.instance_question.id,
@@ -265,7 +265,7 @@ router.get(
       authorizedEdit: res.locals.authz_result.authorized_edit,
       renderScorePanels: req.query.render_score_panels === 'true',
     });
-    res.send({ submissionPanel, extraHeadersHtml });
+    res.json(panels);
   }),
 );
 

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -262,9 +262,8 @@ router.get(
       user_id: res.locals.user.user_id,
       urlPrefix: res.locals.urlPrefix,
       questionContext: res.locals.question.type === 'Exam' ? 'student_exam' : 'student_homework',
-      csrfToken: null,
-      authorizedEdit: null,
-      renderScorePanels: false,
+      authorizedEdit: res.locals.authz_result.authorized_edit,
+      renderScorePanels: req.query.render_score_panels === 'true',
     });
     res.send({ submissionPanel, extraHeadersHtml });
   }),


### PR DESCRIPTION
Part of #10792. Uses the new components introduced in #10942, which removes the need to have a CSRF token in this context. Because of the work done in #10936, this will be backwards-compatible with clients that are out there in the wild.