### PR TITLE
Remove websocket rendering of question panels

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -34,15 +34,10 @@ export function QuestionContainer({
     question,
     issues,
     variant,
-    instance_question,
-    user,
     variantToken,
-    __csrf_token,
     questionJsonBase64,
-    urlPrefix,
     course_instance,
     authz_data,
-    authz_result,
     is_administrator,
     showTrueAnswer,
     showSubmissions,
@@ -56,14 +51,7 @@ export function QuestionContainer({
       class="question-container"
       data-grading-method="${question.grading_method}"
       data-variant-id="${variant.id}"
-      data-question-id="${question.id}"
-      data-instance-question-id="${instance_question?.id ?? ''}"
-      data-user-id="${user.user_id}"
       data-variant-token="${variantToken}"
-      data-url-prefix="${urlPrefix}"
-      data-question-context="${questionContext}"
-      data-csrf-token="${__csrf_token}"
-      data-authorized-edit="${authz_result?.authorized_edit !== false}"
     >
       ${question.type !== 'Freeform'
         ? html`<div hidden="true" class="question-data">${questionJsonBase64}</div>`
@@ -326,7 +314,7 @@ interface QuestionFooterResLocals {
   __csrf_token: string;
 }
 
-export function QuestionFooter({
+function QuestionFooter({
   resLocals,
   questionContext,
 }: {

--- a/apps/prairielearn/src/lib/externalGradingSocket.ts
+++ b/apps/prairielearn/src/lib/externalGradingSocket.ts
@@ -11,7 +11,6 @@ import { gradingJobStatus } from '../models/grading-job.js';
 import { config } from './config.js';
 import { GradingJobSchema, IdSchema } from './db-types.js';
 import type { StatusMessage } from './externalGradingSocket.types.js';
-import { renderPanelsForSubmission } from './question-render.js';
 import * as socketServer from './socket-server.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/externalGradingSocket.ts
+++ b/apps/prairielearn/src/lib/externalGradingSocket.ts
@@ -63,45 +63,6 @@ export function connection(socket: Socket) {
       },
     );
   });
-
-  socket.on('getResults', (msg, callback) => {
-    if (
-      !ensureProps(msg, [
-        'question_id',
-        'instance_question_id',
-        'variant_id',
-        'variant_token',
-        'submission_id',
-        'url_prefix',
-        'question_context',
-        'authorized_edit',
-      ])
-    ) {
-      return callback(null);
-    }
-    if (!checkToken(msg.variant_token, msg.variant_id)) {
-      return callback(null);
-    }
-
-    renderPanelsForSubmission({
-      submission_id: msg.submission_id,
-      question_id: msg.question_id,
-      instance_question_id: msg.instance_question_id,
-      variant_id: msg.variant_id,
-      user_id: msg.user_id,
-      urlPrefix: msg.url_prefix,
-      questionContext: msg.question_context,
-      authorizedEdit: msg.authorized_edit,
-      renderScorePanels: true,
-    }).then(
-      (panels) => callback(panels),
-      (err) => {
-        logger.error('Error rendering panels for submission', err);
-        Sentry.captureException(err);
-        callback(null);
-      },
-    );
-  });
 }
 
 export async function getVariantSubmissionsStatus(variant_id: string) {

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -27,61 +27,32 @@ const mockStudents = [
   { authUid: 'student4', authName: 'Student User 4', authUin: '00000004' },
 ];
 
-async function waitForExternalGrader($questionsPage): Promise<any> {
-  const {
-    variantId,
-    questionId,
-    instanceQuestionId,
-    userId,
-    variantToken,
-    urlPrefix,
-    questionContext,
-    csrfToken,
-    authorizedEdit,
-  } = $questionsPage('.question-container').data();
+async function waitForExternalGrader($questionsPage): Promise<void> {
+  const { variantId, variantToken } = $questionsPage('.question-container').data();
   const socket = io(`http://localhost:${config.serverPort}/external-grading`);
 
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     socket.on('connect_error', (err) => reject(err));
 
-    function handleStatusChange(msg) {
-      msg.submissions.forEach((s) => {
-        if (s.grading_job_status === 'graded') {
-          socket.emit(
-            'getResults',
-            {
-              // Cheerio converts data attributes to numbers based on format, but
-              // the socket expects them as strings
-              question_id: questionId.toString(),
-              instance_question_id: instanceQuestionId.toString(),
-              variant_id: variantId.toString(),
-              user_id: userId.toString(),
-              variant_token: variantToken.toString(),
-              submission_id: s.id.toString(),
-              url_prefix: urlPrefix.toString(),
-              question_context: questionContext.toString(),
-              csrf_token: csrfToken.toString(),
-              authorized_edit: authorizedEdit,
-            },
-            (resultsMsg: any) => resolve(resultsMsg),
-          );
+    function handleStatusChange(msg: any) {
+      for (const submission of msg.submissions) {
+        if (submission.grading_job_status === 'graded') {
+          resolve();
           return;
         }
-      });
+      }
     }
 
     socket.emit(
       'init',
       { variant_id: variantId.toString(), variant_token: variantToken.toString() },
-      function (msg) {
+      (msg: any) => {
         if (!msg) return reject(new Error('Socket initialization failed'));
         handleStatusChange(msg);
       },
     );
 
-    socket.on('change:status', function (msg) {
-      handleStatusChange(msg);
-    });
+    socket.on('change:status', (msg) => handleStatusChange(msg));
   }).finally(() => {
     // Whether or not we actually got a valid result, we should close the
     // socket to allow the test process to exit.
@@ -291,16 +262,24 @@ describe('Grading method(s)', function () {
           ]);
           assert.equal(gradeRes.status, 200);
         });
-        it('should retrieve results via socket', async () => {
+        it('should wait for results and render the updated panels', async () => {
           questionsPage = await gradeRes.text();
           $questionsPage = cheerio.load(questionsPage);
 
           iqId = parseInstanceQuestionId(iqUrl);
-          const socketResult = await waitForExternalGrader($questionsPage);
-          assert.isNotNull(socketResult);
-          assert.isNotNull(socketResult.submissionPanel);
+          await waitForExternalGrader($questionsPage);
 
-          const $submissionPanel = cheerio.load(socketResult.submissionPanel);
+          // Now that the grading job is done, we can check the results.
+          const submissionBody = $questionsPage('.js-submission-body').first();
+          const dynamicRenderUrl = new URL(submissionBody.attr('data-dynamic-render-url'), siteUrl);
+          dynamicRenderUrl.searchParams.set('render_score_panels', 'true');
+          const dynamicRenderPanels = await fetch(dynamicRenderUrl).then((res) => {
+            assert.ok(res.ok);
+            return res.json() as any;
+          });
+
+          assert.ok(dynamicRenderPanels.submissionPanel);
+          const $submissionPanel = cheerio.load(dynamicRenderPanels.submissionPanel);
           assert.lengthOf($submissionPanel('[data-testid="submission-block"]'), 1);
           assert.equal(getLatestSubmissionStatus($submissionPanel), '100%');
           assert.lengthOf($submissionPanel('.pl-external-grader-results'), 1);
@@ -378,11 +357,19 @@ describe('Grading method(s)', function () {
           $questionsPage = cheerio.load(questionsPage);
 
           iqId = parseInstanceQuestionId(iqUrl);
-          const socketResult = await waitForExternalGrader($questionsPage);
-          assert.isNotNull(socketResult);
-          assert.isNotNull(socketResult.submissionPanel);
+          await waitForExternalGrader($questionsPage);
 
-          const $submissionPanel = cheerio.load(socketResult.submissionPanel);
+          // Now that the grading job is done, we can check the results.
+          const submissionBody = $questionsPage('.js-submission-body').first();
+          const dynamicRenderUrl = new URL(submissionBody.attr('data-dynamic-render-url'), siteUrl);
+          dynamicRenderUrl.searchParams.set('render_score_panels', 'true');
+          const dynamicRenderPanels = await fetch(dynamicRenderUrl).then((res) => {
+            assert.ok(res.ok);
+            return res.json() as any;
+          });
+
+          assert.ok(dynamicRenderPanels.submissionPanel);
+          const $submissionPanel = cheerio.load(dynamicRenderPanels.submissionPanel);
           assert.lengthOf($submissionPanel('[data-testid="submission-block"]'), 1);
           assert.equal(getLatestSubmissionStatus($submissionPanel), '100%');
           assert.lengthOf($submissionPanel('.pl-external-grader-results'), 1);


### PR DESCRIPTION
Second-to-last part of #10792. In the final PR, I'll update `renderPanelsForSubmission` to use the objects we get from middleware instead of the IDs that it currently uses, which will simplify the implementation.