### PR TITLE
Upgrade to Python 3.12

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -70,8 +70,7 @@ dnf -y autoremove
 echo "setting up conda..."
 cd /
 arch=`uname -m`
-# Pinning the Conda version so the default Python version is 3.10. Later conda versions use 3.12 as the default.
-curl -LO https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge3-Linux-${arch}.sh
+curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${arch}.sh
 bash Miniforge3-Linux-${arch}.sh -b -p /usr/local -f
 
 echo "installing Python packages..."


### PR DESCRIPTION
If we want to merge this, we should do so between semesters. At this point, I'm mostly interested in seeing if CI passes in light of the fact that `pyarrow` no longer uses `jemalloc` as the default memory pool (see https://github.com/PrairieLearn/PrairieLearn/issues/9817).