### PR TITLE
Rename random group generation for clarity

### DIFF
--- a/apps/prairielearn/src/lib/group-update.ts
+++ b/apps/prairielearn/src/lib/group-update.ts
@@ -118,7 +118,7 @@ export async function uploadInstanceGroups(
 }
 
 /**
- * Auto generate group settings from input
+ * Randomly assign students to groups.
  *
  * @param assessment_id - The assessment to update.
  * @param user_id - The current user performing the update.
@@ -127,7 +127,7 @@ export async function uploadInstanceGroups(
  * @param min_group_size - min size of the group
  * @returns The job sequence ID.
  */
-export async function autoGroups(
+export async function randomGroups(
   assessment_id: string,
   user_id: string,
   authn_user_id: string,
@@ -150,8 +150,8 @@ export async function autoGroups(
     assessmentId: assessment_id,
     userId: user_id,
     authnUserId: authn_user_id,
-    type: 'auto_generate_groups',
-    description: `Auto generate group settings for ${assessment_label}`,
+    type: 'random_generate_groups',
+    description: `Randomly generate groups for ${assessment_label}`,
   });
 
   serverJob.executeInBackground(async (job) => {
@@ -167,7 +167,7 @@ export async function autoGroups(
       },
       async () => {
         job.verbose(`Acquired lock ${lockName}`);
-        job.verbose('Auto generate group settings for ' + assessment_label);
+        job.verbose('Randomly generate groups for ' + assessment_label);
         job.verbose('----------------------------------------');
         job.verbose('Fetching the enrollment lists...');
         const studentsToGroup = await queryRows(

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -420,7 +420,9 @@ function RandomAssessmentGroupsModal({
       <div class="form-group">
         <label for="formMin">Min number of members in a group</label>
         <input
-          type="text"
+          type="number"
+          required
+          min="1"
           value="${groupMin}"
           class="form-control"
           id="formMin"
@@ -430,7 +432,9 @@ function RandomAssessmentGroupsModal({
       <div class="form-group">
         <label for="formMax">Max number of members in a group</label>
         <input
-          type="text"
+          type="number"
+          required
+          min="1"
           value="${groupMax}"
           class="form-control"
           id="formMax"

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -134,7 +134,7 @@ export function InstructorAssessmentGroups({
                                 data-toggle="modal"
                                 data-target="#randomAssessmentGroupsModal"
                               >
-                                <i class="fas fa-robot" aria-hidden="true"></i> Random
+                                <i class="fas fa-shuffle" aria-hidden="true"></i> Random
                               </button>
                               <div class="mt-2">Randomly assign students to groups.</div>
                             </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -439,7 +439,7 @@ function RandomAssessmentGroupsModal({
       </div>
     `,
     footer: html`
-      <input type="hidden" name="__action" value="auto_assessment_groups" />
+      <input type="hidden" name="__action" value="random_assessment_groups" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
       <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
       <button type="submit" class="btn btn-primary">Group</button>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.ts
@@ -73,7 +73,7 @@ export function InstructorAssessmentGroups({
                 ${resLocals.authz_data.has_course_instance_permission_edit
                   ? html`
                       ${UploadAssessmentGroupsModal({ csrfToken: resLocals.__csrf_token })}
-                      ${AutoAssessmentGroupsModal({
+                      ${RandomAssessmentGroupsModal({
                         groupMin: groupConfigInfo.minimum ? groupConfigInfo.minimum : 2,
                         groupMax: groupConfigInfo.maximum ? groupConfigInfo.maximum : 5,
                         csrfToken: resLocals.__csrf_token,
@@ -132,11 +132,11 @@ export function InstructorAssessmentGroups({
                                 type="button"
                                 class="btn btn-primary text-nowrap"
                                 data-toggle="modal"
-                                data-target="#autoAssessmentGroupsModal"
+                                data-target="#randomAssessmentGroupsModal"
                               >
-                                <i class="fas fa-robot" aria-hidden="true"></i> Auto
+                                <i class="fas fa-robot" aria-hidden="true"></i> Random
                               </button>
-                              <div class="mt-2">Automatically assign students to groups.</div>
+                              <div class="mt-2">Randomly assign students to groups.</div>
                             </div>
                           </div>
                         </div>
@@ -404,7 +404,7 @@ function UploadAssessmentGroupsModal({ csrfToken }: { csrfToken: string }) {
   });
 }
 
-function AutoAssessmentGroupsModal({
+function RandomAssessmentGroupsModal({
   groupMin,
   groupMax,
   csrfToken,
@@ -414,8 +414,8 @@ function AutoAssessmentGroupsModal({
   csrfToken: string;
 }) {
   return Modal({
-    id: 'autoAssessmentGroupsModal',
-    title: 'Auto new group setting',
+    id: 'randomAssessmentGroupsModal',
+    title: 'Random group assignments',
     body: html`
       <div class="form-group">
         <label for="formMin">Min number of members in a group</label>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -99,7 +99,7 @@ router.post(
         res.locals.authn_user.user_id,
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
-    } else if (req.body.__action === 'auto_assessment_groups') {
+    } else if (req.body.__action === 'random_assessment_groups') {
       const job_sequence_id = await randomGroups(
         res.locals.assessment.id,
         res.locals.user.user_id,

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -7,7 +7,7 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 
 import { GroupConfigSchema } from '../../lib/db-types.js';
-import { uploadInstanceGroups, autoGroups } from '../../lib/group-update.js';
+import { uploadInstanceGroups, randomGroups } from '../../lib/group-update.js';
 import {
   GroupOperationError,
   addUserToGroup,
@@ -100,7 +100,7 @@ router.post(
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
     } else if (req.body.__action === 'auto_assessment_groups') {
-      const job_sequence_id = await autoGroups(
+      const job_sequence_id = await randomGroups(
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.ts
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.ts
@@ -13,7 +13,7 @@ import * as helperServer from './helperServer.js';
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const locals: Record<string, any> = {};
 
-describe('test auto group and delete groups', function () {
+describe('test random groups and delete groups', function () {
   this.timeout(20000);
   before('set up testing server', helperServer.before(TEST_COURSE_PATH));
   after('shut down testing server', helperServer.after);
@@ -30,12 +30,12 @@ describe('test auto group and delete groups', function () {
     assert.equal(result.length, 500);
   });
 
-  step('auto assign groups', async () => {
+  step('randomly assign groups', async () => {
     const user_id = '1';
     const authn_user_id = '1';
     const max_group_size = 10;
     const min_group_size = 10;
-    const job_sequence_id = await groupUpdate.autoGroups(
+    const job_sequence_id = await groupUpdate.randomGroups(
       locals.assessment_id,
       user_id,
       authn_user_id,

--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -325,7 +325,7 @@ groupB,four@example.com
 
 The assessment's "Downloads" tab has an `<assessment>_group_configs.csv` file that contains the current group assignments. This can be used to copy group assignments from one assessment to another.
 
-Alternatively, the "Auto" button can be used to randomly assign students to groups based on a desired minimum/maximum group size.
+Alternatively, the "Random" button can be used to randomly assign students to groups based on a desired minimum/maximum group size.
 
 ### Student options for group work
 

--- a/docs/assessment.md
+++ b/docs/assessment.md
@@ -323,7 +323,7 @@ groupB,three@example.com
 groupB,four@example.com
 ```
 
-The assessment's "Downloads" tab has an `<assessment>_group_configs.csv` file that contains the current group assignments. This can be used to copy group assignments from one assessment to another.
+The assessment's "Downloads" tab has an `<assessment>_groups.csv` file that contains the current group assignments. This can be used to copy group assignments from one assessment to another. The same file is also listed at the bottom of the groups page.
 
 Alternatively, the "Random" button can be used to randomly assign students to groups based on a desired minimum/maximum group size.
 


### PR DESCRIPTION
As discussed in https://github.com/PrairieLearn/PrairieLearn/pull/10985#discussion_r1873717565. The feature for random group generation in assessments was named "Auto", which is misleading and unclear. This PR changes the button and related labels to use the term "Random", as it more clearly indicates what the feature is about.

While the function name in the related library has been changed, the action name in the form was kept the same. This is mostly to avoid problems with old clients accessing new servers. This should not affect the general functionality of the code, since the action name is not generally visible to users.