### PR TITLE
Override rubric requirement for instance questions without submission

### DIFF
--- a/apps/prairielearn/src/components/EditQuestionPointsScore.html.ts
+++ b/apps/prairielearn/src/components/EditQuestionPointsScore.html.ts
@@ -63,7 +63,10 @@ function EditQuestionPointsScoreForm({
   csrfToken: string;
 }) {
   const manualGradingUrl = `${urlPrefix}/assessment/${assessment_question.assessment_id}/manual_grading/instance_question/${instance_question.id}`;
-  if (assessment_question.manual_rubric_id != null) {
+  // If the question is configured to use rubrics, don't allow editing the
+  // points, unless there is no submission, in which case we allow editing the
+  // points manually since the manual grading page will not be available.
+  if (assessment_question.manual_rubric_id != null && instance_question.status !== 'unanswered') {
     return html`
       <div>
         <p>
@@ -110,9 +113,11 @@ function EditQuestionPointsScoreForm({
       <p>
         <small>
           This will also recalculate the total points and total score at 100% credit. This change
-          will be overwritten if the question is answered again by the student. You may also update
-          the score
-          <a href="${manualGradingUrl}">via the manual grading page</a>.
+          will be overwritten if the question is answered again by the student.
+          ${instance_question.status !== 'unanswered'
+            ? html`You may also update the score
+                <a href="${manualGradingUrl}">via the manual grading page</a>.`
+            : ''}
         </small>
       </p>
       <div class="text-right">


### PR DESCRIPTION
A recent question on Slack prompted this solution. This is a proposal, and I won't be offended if it's rejected.

Currently, in the assessment instance page, an instructor can manually set the points/score for an instance question by using the edit (pencil) button beside the points/score for the question. However, the component that enables the update form blocks the update via the form if the question is set up to use rubrics. This makes sense, since we want to ensure some consistency in the grading of the question if rubrics are involved. The instructor still has the option of adding a manual adjustment to the score in the manual grading interface.

This workflow, however, causes problems in questions that were never opened by the student (thus have no variant), or that have no submissions. While in such cases the student usually would be expected to get a zero, there might be cases where an instructor would like to manually adjust the score due to other cases (errors in the question, accommodations, student provided material externally, etc.). In these cases, however, the manual grading interface would not be able to open the question, since there is no submission. Rubric grading is set at the submission level, as is the feedback text.

In order to allow instructors to manually override the instance question score/points in this context, this PR changes the validation to bypass the rubric check if the status is unanswered (i.e., if there is no submission). The manual grading interface already supports this manual update of points/score without a submission, so only the UI needs to be addressed.

The same component also includes a link to the manual grading page at the bottom, this PR hides the link if the manual grading page would not be expected to work (i.e., if there is no submission).