### PR TITLE
Add support for minimum size in random group assignment

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -104,8 +104,8 @@ router.post(
         res.locals.assessment.id,
         res.locals.user.user_id,
         res.locals.authn_user.user_id,
-        req.body.max_group_size,
-        req.body.min_group_size,
+        Number(req.body.max_group_size),
+        Number(req.body.min_group_size),
       );
       res.redirect(res.locals.urlPrefix + '/jobSequence/' + job_sequence_id);
     } else if (req.body.__action === 'delete_all') {


### PR DESCRIPTION
While the interface for random group assignment has support for a "minimum group size", the random assignment currently ignores this property. This PR adds support for this parameter, by reducing group sizes from larger groups if necessary to account for the minimum requirement.