### PR TITLE
Show example course without course instances on homepage

### DIFF
--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -29,12 +29,15 @@ WITH
             d.start_date DESC NULLS LAST,
             d.end_date DESC NULLS LAST,
             ci.id DESC
+        ) FILTER (
+          WHERE
+            ci.id IS NOT NULL
         ),
         '[]'::jsonb
       ) AS course_instances
     FROM
       pl_courses AS c
-      JOIN course_instances AS ci ON (
+      LEFT JOIN course_instances AS ci ON (
         ci.course_id = c.id
         AND ci.deleted_at IS NULL
       ),


### PR DESCRIPTION
I noticed while testing https://github.com/PrairieLearn/PrairieLearn/pull/11003 that the example course disappeared from the homepage if I removed all the course instances from it. This PR changes that to match the behavior of other courses: it will still be shown even if there aren't any course instances.