### PR TITLE
Refactor fetchCheerio to remove form property

### DIFF
--- a/apps/prairielearn/src/tests/access.test.ts
+++ b/apps/prairielearn/src/tests/access.test.ts
@@ -204,15 +204,16 @@ describe('Access control', function () {
   /**********************************************************************/
 
   async function postAssessment(cookies, includePassword, expectedStatusCode) {
-    const form: Record<string, string> = {
+    const body = new URLSearchParams({
       __action: 'new_instance',
       __csrf_token,
-    };
-    if (includePassword) form.password = 'secret';
-    const res = await fetchCookie(fetch, cookies)(assessmentUrl, {
-      method: 'POST',
-      body: new URLSearchParams(form),
     });
+
+    if (includePassword) {
+      body.append('password', 'secret');
+    }
+
+    const res = await fetchCookie(fetch, cookies)(assessmentUrl, { method: 'POST', body });
     assert.equal(res.status, expectedStatusCode);
     page = await res.text();
   }
@@ -331,14 +332,13 @@ describe('Access control', function () {
       wx: 0,
       wy: 0,
     };
-    const form = {
-      __action: 'save',
-      __csrf_token,
-      postData: JSON.stringify({ variant, submittedAnswer }),
-    };
     const res = await fetchCookie(fetch, cookies)(q1Url, {
       method: 'POST',
-      body: new URLSearchParams(form),
+      body: new URLSearchParams({
+        __action: 'save',
+        __csrf_token,
+        postData: JSON.stringify({ variant, submittedAnswer }),
+      }),
     });
     assert.equal(res.status, expectedStatusCode);
   }

--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.ts
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.ts
@@ -143,13 +143,12 @@ describe('Exam and homework assessment with active access restriction', function
   });
 
   step('start the exam and access a question', async () => {
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.examUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -184,13 +183,12 @@ describe('Exam and homework assessment with active access restriction', function
   });
 
   step('simulate a time limit expiration', async () => {
-    const form = {
-      __action: 'timeLimitFinish',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.examInstanceUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'timeLimitFinish',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
 
@@ -462,16 +460,14 @@ describe('Exam and homework assessment with active access restriction', function
   step('submit an answer to a question when active is false', async () => {
     headers.cookie = 'pl_test_date=2021-06-01T00:00:01Z';
 
-    const form = {
-      __action: 'grade',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      s: '75', // To get 75% of the question
-    };
-
     const response = await helperClient.fetchCheerio(context.hwQuestionUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'grade',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        s: '75', // To get 75% of the question
+      }),
       headers,
     });
     assert.equal(response.status, 400);
@@ -506,17 +502,15 @@ describe('Exam and homework assessment with active access restriction', function
   step('try to attach a file to a question when active is false', async () => {
     headers.cookie = 'pl_test_date=2021-06-01T00:00:01Z';
 
-    const form = {
-      __action: 'attach_file',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      filename: 'testfile.txt',
-      contents: 'This is the test text',
-    };
-
     const response = await helperClient.fetchCheerio(context.hwQuestionUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'attach_file',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        filename: 'testfile.txt',
+        contents: 'This is the test text',
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -536,17 +530,15 @@ describe('Exam and homework assessment with active access restriction', function
   step('try to attach a file to the assessment when active is false', async () => {
     headers.cookie = 'pl_test_date=2021-06-01T00:00:01Z';
 
-    const form = {
-      __action: 'attach_file',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      filename: 'testfile.txt',
-      contents: 'This is the test text',
-    };
-
     const response = await helperClient.fetchCheerio(context.hwInstanceUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'attach_file',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        filename: 'testfile.txt',
+        contents: 'This is the test text',
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -567,17 +559,15 @@ describe('Exam and homework assessment with active access restriction', function
   step('try to attach text to a question when active is false', async () => {
     headers.cookie = 'pl_test_date=2021-06-01T00:00:01Z';
 
-    const form = {
-      __action: 'attach_text',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      filename: 'testfile.txt',
-      contents: 'This is the test text',
-    };
-
     const response = await helperClient.fetchCheerio(context.hwQuestionUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'attach_text',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        filename: 'testfile.txt',
+        contents: 'This is the test text',
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -597,17 +587,15 @@ describe('Exam and homework assessment with active access restriction', function
   step('try to attach text to the assessment when active is false', async () => {
     headers.cookie = 'pl_test_date=2021-06-01T00:00:01Z';
 
-    const form = {
-      __action: 'attach_text',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      filename: 'testfile.txt',
-      contents: 'This is the test text',
-    };
-
     const response = await helperClient.fetchCheerio(context.hwInstanceUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'attach_text',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        filename: 'testfile.txt',
+        contents: 'This is the test text',
+      }),
       headers,
     });
     assert.equal(response.status, 403);

--- a/apps/prairielearn/src/tests/administratorQueries.test.ts
+++ b/apps/prairielearn/src/tests/administratorQueries.test.ts
@@ -48,7 +48,7 @@ describe('AdministratorQuery page', function () {
 
     const postResponse = await helperClient.fetchCheerio(queryUuidsUrl, {
       method: 'POST',
-      form: { count: '3', __csrf_token },
+      body: new URLSearchParams({ count: '3', __csrf_token }),
     });
     assert.isTrue(postResponse.ok);
 

--- a/apps/prairielearn/src/tests/bonusPoints.test.ts
+++ b/apps/prairielearn/src/tests/bonusPoints.test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 
 import * as sqldb from '@prairielearn/postgres';
 
@@ -50,15 +51,14 @@ describe('Exam assessment with bonus points', function () {
   });
 
   step('submit an answer to the first question', async () => {
-    const form = {
-      __action: 'grade',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      s: '75', // To get 75% of the question
-    };
-    const response = await helperClient.fetchCheerio(context.question1Url, {
+    const response = await fetch(context.question1Url, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'grade',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        s: '75', // To get 75% of the question
+      }),
     });
     assert.isTrue(response.ok);
   });
@@ -82,15 +82,14 @@ describe('Exam assessment with bonus points', function () {
   });
 
   step('submit an answer to the second question', async () => {
-    const form = {
-      __action: 'grade',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      s: '100', // To get 100% of the question
-    };
-    const response = await helperClient.fetchCheerio(context.question2Url, {
+    const response = await fetch(context.question2Url, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'grade',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        s: '100', // To get 100% of the question
+      }),
     });
 
     assert.isTrue(response.ok);

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -350,14 +350,13 @@ function testEdit(params) {
 
   describe(`POST to ${params.url} with action ${params.action}`, function () {
     it('should load successfully', async () => {
-      const form = {
-        __action: params.action,
-        __csrf_token: locals.__csrf_token,
-        ...(params?.data ?? {}),
-      };
       const res = await fetch(params.url || locals.url, {
         method: 'POST',
-        body: new URLSearchParams(form),
+        body: new URLSearchParams({
+          __action: params.action,
+          __csrf_token: locals.__csrf_token,
+          ...(params?.data ?? {}),
+        }),
       });
       assert.isOk(res.ok);
       locals.url = res.url;

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -1049,14 +1049,16 @@ function testRenameFile(params: {
 
   describe(`POST to ${params.url} with action rename_file`, function () {
     it('should load successfully', async () => {
-      const form = {
-        __action: 'rename_file',
-        __csrf_token: locals.__csrf_token,
-        working_path: locals.working_path,
-        old_file_name: locals.old_file_name,
-        new_file_name: params.new_file_name,
-      };
-      const res = await fetch(params.url, { method: 'POST', body: new URLSearchParams(form) });
+      const res = await fetch(params.url, {
+        method: 'POST',
+        body: new URLSearchParams({
+          __action: 'rename_file',
+          __csrf_token: locals.__csrf_token,
+          working_path: locals.working_path,
+          old_file_name: locals.old_file_name,
+          new_file_name: params.new_file_name,
+        }),
+      });
       assert.isOk(res.ok);
       locals.$ = cheerio.load(await res.text());
     });
@@ -1094,12 +1096,14 @@ function testDeleteFile(params: { url: string; path: string }) {
 
   describe(`POST to ${params.url} with action delete_file`, function () {
     it('should load successfully', async () => {
-      const form = {
-        __action: 'delete_file',
-        __csrf_token: locals.__csrf_token,
-        file_path: locals.file_path,
-      };
-      const res = await fetch(params.url, { method: 'POST', body: new URLSearchParams(form) });
+      const res = await fetch(params.url, {
+        method: 'POST',
+        body: new URLSearchParams({
+          __action: 'delete_file',
+          __csrf_token: locals.__csrf_token,
+          file_path: locals.file_path,
+        }),
+      });
       assert.isOk(res.ok);
     });
   });

--- a/apps/prairielearn/src/tests/gradeRate.test.ts
+++ b/apps/prairielearn/src/tests/gradeRate.test.ts
@@ -36,13 +36,12 @@ describe('Exam assessment with grade rate set', function () {
   });
 
   step('start the exam', async () => {
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
     });
     assert.isTrue(response.ok);
 
@@ -70,15 +69,14 @@ describe('Exam assessment with grade rate set', function () {
   });
 
   step('submit an answer to the question', async () => {
-    const form = {
-      __action: 'grade',
-      __csrf_token: context.__csrf_token,
-      __variant_id: context.__variant_id,
-      s: '50', // To get 50% of the question
-    };
-    const response = await helperClient.fetchCheerio(context.question1Url, {
+    const response = await fetch(context.question1Url, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'grade',
+        __csrf_token: context.__csrf_token,
+        __variant_id: context.__variant_id,
+        s: '50', // To get 50% of the question
+      }),
     });
 
     assert.isTrue(response.ok);

--- a/apps/prairielearn/src/tests/groupRole.test.ts
+++ b/apps/prairielearn/src/tests/groupRole.test.ts
@@ -61,14 +61,13 @@ async function switchUserAndLoadAssessment(
  * Joins group as current user with CSRF token and loads page with cheerio.
  */
 async function joinGroup(assessmentUrl: string, joinCode: string) {
-  const form = {
-    __action: 'join_group',
-    __csrf_token: locals.__csrf_token,
-    join_code: joinCode,
-  };
   const res = await fetch(assessmentUrl, {
     method: 'POST',
-    body: new URLSearchParams(form),
+    body: new URLSearchParams({
+      __action: 'join_group',
+      __csrf_token: locals.__csrf_token,
+      join_code: joinCode,
+    }),
   });
   assert.isOk(res.ok);
   locals.$ = cheerio.load(await res.text());
@@ -78,13 +77,12 @@ async function joinGroup(assessmentUrl: string, joinCode: string) {
  * Leaves group as current user
  */
 async function leaveGroup(assessmentUrl: string) {
-  const form = {
-    __action: 'leave_group',
-    __csrf_token: locals.__csrf_token,
-  };
   const res = await fetch(assessmentUrl, {
     method: 'POST',
-    body: new URLSearchParams(form),
+    body: new URLSearchParams({
+      __action: 'leave_group',
+      __csrf_token: locals.__csrf_token,
+    }),
   });
   assert.isOk(res.ok);
 }
@@ -159,14 +157,13 @@ async function updateGroupRoles(
   for (let i = 0; i < elemList.length; i++) {
     checkedElementIds[elemList[i.toString()].attribs.id] = 'on';
   }
-  const form = {
-    __action: 'update_group_roles',
-    __csrf_token: locals.__csrf_token,
-    ...checkedElementIds,
-  };
   const res = await fetch(assessmentUrl, {
     method: 'POST',
-    body: new URLSearchParams(form),
+    body: new URLSearchParams({
+      __action: 'update_group_roles',
+      __csrf_token: locals.__csrf_token,
+      ...checkedElementIds,
+    }),
   });
   assert.isOk(res.ok);
 }
@@ -237,14 +234,13 @@ describe('Test group based assessments with custom group roles from student side
   step('can create a group as first user', async function () {
     await switchUserAndLoadAssessment(locals.studentUsers[0], locals.assessmentUrl, '00000001', 2);
     locals.group_name = 'groupBB';
-    const form = {
-      __action: 'create_group',
-      __csrf_token: locals.__csrf_token,
-      groupName: locals.group_name,
-    };
     const res = await fetch(locals.assessmentUrl, {
       method: 'POST',
-      body: new URLSearchParams(form),
+      body: new URLSearchParams({
+        __action: 'create_group',
+        __csrf_token: locals.__csrf_token,
+        groupName: locals.group_name,
+      }),
     });
     assert.isOk(res.ok);
     locals.$ = cheerio.load(await res.text());
@@ -414,14 +410,13 @@ describe('Test group based assessments with custom group roles from student side
     for (const { roleId, groupUserId } of roleUpdates) {
       checkedElementIds[`user_role_${groupUserId}-${roleId}`] = 'on';
     }
-    const form = {
-      __action: 'update_group_roles',
-      __csrf_token: locals.__csrf_token,
-      ...checkedElementIds,
-    };
     const res = await fetch(locals.assessmentUrl, {
       method: 'POST',
-      body: new URLSearchParams(form),
+      body: new URLSearchParams({
+        __action: 'update_group_roles',
+        __csrf_token: locals.__csrf_token,
+        ...checkedElementIds,
+      }),
     });
 
     // Second user cannot update group roles
@@ -1027,14 +1022,13 @@ describe('Test group based assessments with custom group roles from student side
 
   step('first user can create a group in assessment without roles', async function () {
     locals.group_name = 'groupAA';
-    const form = {
-      __action: 'create_group',
-      __csrf_token: locals.__csrf_token,
-      groupName: locals.group_name,
-    };
     const res = await fetch(locals.assessmentUrlWithoutRoles, {
       method: 'POST',
-      body: new URLSearchParams(form),
+      body: new URLSearchParams({
+        __action: 'create_group',
+        __csrf_token: locals.__csrf_token,
+        groupName: locals.group_name,
+      }),
     });
     assert.isOk(res.ok);
     locals.$ = cheerio.load(await res.text());
@@ -1145,14 +1139,13 @@ describe('Test group role reassignments with role of minimum > 1', function () {
 
   step('create group as first user', async function () {
     locals.group_name = 'groupBB';
-    const form = {
-      __action: 'create_group',
-      __csrf_token: locals.__csrf_token,
-      groupName: locals.group_name,
-    };
     const joinRes = await fetch(assessmentUrl, {
       method: 'POST',
-      body: new URLSearchParams(form),
+      body: new URLSearchParams({
+        __action: 'create_group',
+        __csrf_token: locals.__csrf_token,
+        groupName: locals.group_name,
+      }),
     });
     assert.isOk(joinRes.ok);
     locals.$ = cheerio.load(await joinRes.text());

--- a/apps/prairielearn/src/tests/helperAttachFiles.ts
+++ b/apps/prairielearn/src/tests/helperAttachFiles.ts
@@ -164,15 +164,14 @@ export function deleteAttachedFile(locals) {
 
   describe('deleteAttachedFile-3. POST to delete attached file', () => {
     it('should load successfully', async () => {
-      const form = {
-        __action: locals.__action,
-        __csrf_token: locals.__csrf_token,
-        __variant_id: locals.__variant_id,
-        file_id: locals.file_id,
-      };
       const res = await fetch(locals.attachFilesUrl, {
         method: 'POST',
-        body: new URLSearchParams(form),
+        body: new URLSearchParams({
+          __action: locals.__action,
+          __csrf_token: locals.__csrf_token,
+          __variant_id: locals.__variant_id,
+          file_id: locals.file_id,
+        }),
       });
       assert.isOk(res.ok);
       locals.$ = cheerio.load(await res.text());

--- a/apps/prairielearn/src/tests/helperClient.ts
+++ b/apps/prairielearn/src/tests/helperClient.ts
@@ -21,16 +21,8 @@ interface CheerioResponse extends Response {
  */
 export async function fetchCheerio(
   url: string | URL,
-  options: RequestInit & { form?: Record<string, any> } = {},
+  options: RequestInit = {},
 ): Promise<CheerioResponse> {
-  if (options.form) {
-    options.body = JSON.stringify(options.form);
-    options.headers = {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    };
-    delete options.form;
-  }
   const response = await fetch(url, options);
   const text = await response.text();
 

--- a/apps/prairielearn/src/tests/helperExam.ts
+++ b/apps/prairielearn/src/tests/helperExam.ts
@@ -125,14 +125,13 @@ export function startExam(locals: Record<string, any>) {
     it('should load successfully', async function () {
       assert(locals.assessmentUrl);
       assert(locals.__csrf_token);
-      const form = {
-        __action: 'new_instance',
-        __csrf_token: locals.__csrf_token,
-      };
       locals.preStartTime = Date.now();
       const response = await fetch(locals.assessmentUrl, {
         method: 'POST',
-        body: new URLSearchParams(form),
+        body: new URLSearchParams({
+          __action: 'new_instance',
+          __csrf_token: locals.__csrf_token,
+        }),
       });
       locals.postStartTime = Date.now();
       assert.equal(response.status, 200);

--- a/apps/prairielearn/src/tests/instructorAssessmentSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentSettings.test.ts
@@ -4,6 +4,7 @@ import { assert } from 'chai';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 import * as tmp from 'tmp';
 import { z } from 'zod';
 
@@ -69,21 +70,21 @@ describe('Editing assessment settings', () => {
     );
     assert.equal(settingsPageResponse.status, 200);
 
-    const response = await fetchCheerio(
+    const response = await fetch(
       `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
       {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_assessment',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           title: 'Test Title',
           type: 'Homework',
           set: 'Practice Quiz',
           number: '1',
           module: 'Module2',
           aid: 'HW2',
-        },
+        }),
       },
     );
 
@@ -107,21 +108,21 @@ describe('Editing assessment settings', () => {
     );
     assert.equal(settingsPageResponse.status, 200);
 
-    const response = await fetchCheerio(
+    const response = await fetch(
       `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
       {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_assessment',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           title: 'Test Title',
           type: 'Homework',
           set: 'Practice Quiz',
           number: '1',
           module: 'Module2',
           aid: 'nestedPath/HW2',
-        },
+        }),
       },
     );
 
@@ -140,21 +141,21 @@ describe('Editing assessment settings', () => {
     );
     assert.equal(settingsPageResponse.status, 200);
 
-    const response = await fetchCheerio(
+    const response = await fetch(
       `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
       {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_assessment',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           title: 'Test Title',
           type: 'Homework',
           set: 'Practice Quiz',
           number: '1',
           module: 'Module2',
           aid: 'HW2',
-        },
+        }),
       },
     );
 
@@ -209,21 +210,21 @@ describe('Editing assessment settings', () => {
       );
       assert.equal(settingsPageResponse.status, 200);
 
-      const response = await fetchCheerio(
+      const response = await fetch(
         `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
         {
           method: 'POST',
-          form: {
+          body: new URLSearchParams({
             __action: 'update_assessment',
-            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
             title: 'Test Title - Unauthorized',
             type: 'Homework',
             set: 'Homework',
             number: '1',
             module: 'Module1',
             aid: 'HW1',
-          },
+          }),
         },
       );
       assert.equal(response.status, 403);
@@ -238,21 +239,21 @@ describe('Editing assessment settings', () => {
       );
       assert.equal(settingsPageResponse.status, 200);
 
-      const response = await fetchCheerio(
+      const response = await fetch(
         `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
         {
           method: 'POST',
-          form: {
+          body: new URLSearchParams({
             __action: 'update_assessment',
-            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
             title: 'Test Title - No Course Info',
             type: 'Homework',
             set: 'Homework',
             number: '1',
             module: 'Module1',
             aid: 'HW1',
-          },
+          }),
         },
       );
       assert.equal(response.status, 400);
@@ -266,21 +267,21 @@ describe('Editing assessment settings', () => {
     const settingsPageResponse = await fetchCheerio(
       `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
     );
-    const response = await fetchCheerio(
+    const response = await fetch(
       `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
       {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_assessment',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           title: assessmentInfo.title,
           type: assessmentInfo.type,
           set: assessmentInfo.set,
           number: assessmentInfo.number,
           module: assessmentInfo.module,
           aid: 'HW2',
-        },
+        }),
       },
     );
     assert.equal(response.status, 200);
@@ -302,21 +303,21 @@ describe('Editing assessment settings', () => {
     });
     await execa('git', ['push', 'origin', 'master'], { cwd: courseDevDir, env: process.env });
 
-    const response = await fetchCheerio(
+    const response = await fetch(
       `${siteUrl}/pl/course_instance/1/instructor/assessment/1/settings`,
       {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_assessment',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           title: 'Test Title2',
           type: 'Homework',
           set: 'Homework',
           number: '1',
           module: 'Module1',
           aid: 'HW1',
-        },
+        }),
       },
     );
     assert.equal(response.status, 200);

--- a/apps/prairielearn/src/tests/instructorCourseAdminSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorCourseAdminSettings.test.ts
@@ -4,6 +4,7 @@ import { assert } from 'chai';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 import * as tmp from 'tmp';
 
 import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
@@ -66,16 +67,16 @@ describe('Editing course settings', () => {
     const settingsPageResponse = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`);
     assert.equal(settingsPageResponse.status, 200);
 
-    const response = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`, {
+    const response = await fetch(`${siteUrl}/pl/course/1/course_admin/settings`, {
       method: 'POST',
-      form: {
+      body: new URLSearchParams({
         __action: 'update_configuration',
-        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
         short_name: 'TEST 102',
         title: 'Test Course 102',
         display_timezone: 'America/Los_Angeles',
-      },
+      }),
     });
     assert.equal(response.status, 200);
     assert.equal(response.url, `${siteUrl}/pl/course/1/course_admin/settings`);
@@ -125,16 +126,16 @@ describe('Editing course settings', () => {
       );
       assert.equal(settingsPageResponse.status, 200);
 
-      const response = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`, {
+      const response = await fetch(`${siteUrl}/pl/course/1/course_admin/settings`, {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_configuration',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           short_name: 'TEST 103',
           title: 'Test Course 103',
           display_timezone: 'America/Los_Angeles',
-        },
+        }),
       });
       assert.equal(response.status, 403);
     });
@@ -148,16 +149,16 @@ describe('Editing course settings', () => {
       );
       assert.equal(settingsPageResponse.status, 200);
 
-      const response = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`, {
+      const response = await fetch(`${siteUrl}/pl/course/1/course_admin/settings`, {
         method: 'POST',
-        form: {
+        body: new URLSearchParams({
           __action: 'update_configuration',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
           short_name: 'TEST 104',
           title: 'Test Course 104',
           display_timezone: 'America/Los_Angeles',
-        },
+        }),
       });
       assert.equal(response.status, 400);
     } finally {
@@ -168,16 +169,16 @@ describe('Editing course settings', () => {
   step('should be able to submit without any changes', async () => {
     const courseInfo = JSON.parse(await fs.readFile(courseLiveInfoPath, 'utf8'));
     const settingsPageResponse = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`);
-    const response = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`, {
+    const response = await fetch(`${siteUrl}/pl/course/1/course_admin/settings`, {
       method: 'POST',
-      form: {
+      body: new URLSearchParams({
         __action: 'update_configuration',
-        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
         short_name: courseInfo.name,
         title: courseInfo.title,
         display_timezone: courseInfo.timezone,
-      },
+      }),
     });
     assert.equal(response.status, 200);
     assert.match(response.url, /\/pl\/course\/1\/course_admin\/settings$/);
@@ -196,16 +197,16 @@ describe('Editing course settings', () => {
     });
     await execa('git', ['push', 'origin', 'master'], { cwd: courseDevDir, env: process.env });
 
-    const response = await fetchCheerio(`${siteUrl}/pl/course/1/course_admin/settings`, {
+    const response = await fetch(`${siteUrl}/pl/course/1/course_admin/settings`, {
       method: 'POST',
-      form: {
+      body: new URLSearchParams({
         __action: 'update_configuration',
-        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
         short_name: 'TEST 108',
         title: 'Test Course 108',
         display_timezone: 'America/Los_Angeles',
-      },
+      }),
     });
     assert.equal(response.status, 200);
     assert.match(response.url, /\/pl\/course\/1\/edit_error\/\d+$/);

--- a/apps/prairielearn/src/tests/instructorQuestionSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorQuestionSettings.test.ts
@@ -4,6 +4,7 @@ import { assert } from 'chai';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 import * as tmp from 'tmp';
 
 import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
@@ -68,20 +69,17 @@ describe('Editing question settings', () => {
     );
     assert.equal(settingsPageResponse.status, 200);
 
-    const response = await fetchCheerio(
-      `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`,
-      {
-        method: 'POST',
-        form: {
-          __action: 'update_question',
-          __csrf_token: settingsPageResponse.$('input[name=__csrf_token]').val(),
-          orig_hash: settingsPageResponse.$('input[name=orig_hash]').val(),
-          title: 'New title',
-          qid: 'question',
-          topic: 'Test2',
-        },
-      },
-    );
+    const response = await fetch(`${siteUrl}/pl/course_instance/1/instructor/question/1/settings`, {
+      method: 'POST',
+      body: new URLSearchParams({
+        __action: 'update_question',
+        __csrf_token: settingsPageResponse.$('input[name=__csrf_token]').val() as string,
+        orig_hash: settingsPageResponse.$('input[name=orig_hash]').val() as string,
+        title: 'New title',
+        qid: 'question',
+        topic: 'Test2',
+      }),
+    });
 
     assert.equal(response.status, 200);
     assert.equal(response.url, `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`);
@@ -99,20 +97,17 @@ describe('Editing question settings', () => {
     );
     assert.equal(settingsPageResponse.status, 200);
 
-    const response = await fetchCheerio(
-      `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`,
-      {
-        method: 'POST',
-        form: {
-          __action: 'update_question',
-          __csrf_token: settingsPageResponse.$('input[name=__csrf_token]').val(),
-          orig_hash: settingsPageResponse.$('input[name=orig_hash]').val(),
-          title: 'New title',
-          qid: 'test/question1',
-          topic: 'Test',
-        },
-      },
-    );
+    const response = await fetch(`${siteUrl}/pl/course_instance/1/instructor/question/1/settings`, {
+      method: 'POST',
+      body: new URLSearchParams({
+        __action: 'update_question',
+        __csrf_token: settingsPageResponse.$('input[name=__csrf_token]').val() as string,
+        orig_hash: settingsPageResponse.$('input[name=orig_hash]').val() as string,
+        title: 'New title',
+        qid: 'test/question1',
+        topic: 'Test',
+      }),
+    });
 
     assert.equal(response.status, 200);
     assert.equal(response.url, `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`);
@@ -154,17 +149,17 @@ describe('Editing question settings', () => {
       );
       assert.equal(settingsPageResponse.status, 200);
 
-      const response = await fetchCheerio(
+      const response = await fetch(
         `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`,
         {
           method: 'POST',
-          form: {
+          body: new URLSearchParams({
             __action: 'update_question',
-            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
             title: 'Test Title - Unauthorized',
             qid: 'test/question',
-          },
+          }),
         },
       );
       assert.equal(response.status, 403);
@@ -180,17 +175,17 @@ describe('Editing question settings', () => {
       );
       assert.equal(settingsPageResponse.status, 200);
 
-      const response = await fetchCheerio(
+      const response = await fetch(
         `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`,
         {
           method: 'POST',
-          form: {
+          body: new URLSearchParams({
             __action: 'update_question',
-            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
+            __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+            orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
             title: 'Test title - no info file',
             qid: 'test/question',
-          },
+          }),
         },
       );
       assert.equal(response.status, 400);
@@ -215,19 +210,16 @@ describe('Editing question settings', () => {
     });
     await execa('git', ['push', 'origin', 'master'], { cwd: courseLiveDir, env: process.env });
 
-    const response = await fetchCheerio(
-      `${siteUrl}/pl/course_instance/1/instructor/question/1/settings`,
-      {
-        method: 'POST',
-        form: {
-          __action: 'update_question',
-          __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val(),
-          orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val(),
-          title: 'Test title - changed',
-          qid: 'test/question',
-        },
-      },
-    );
+    const response = await fetch(`${siteUrl}/pl/course_instance/1/instructor/question/1/settings`, {
+      method: 'POST',
+      body: new URLSearchParams({
+        __action: 'update_question',
+        __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
+        orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
+        title: 'Test title - changed',
+        qid: 'test/question',
+      }),
+    });
     assert.equal(response.status, 200);
     assert.match(response.url, /\/pl\/course_instance\/1\/instructor\/edit_error\/\d+$/);
   });

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
@@ -124,15 +124,14 @@ function runTest(context) {
       response.$,
       'button[data-testid="add-users-button"]',
     );
-    const form = {
-      __action: 'course_permissions_insert_by_user_uids',
-      __csrf_token: context.__csrf_token,
-      uid: ' staff03@example.com ,   ,   staff04@example.com',
-      course_role: 'Viewer',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_insert_by_user_uids',
+        __csrf_token: context.__csrf_token,
+        uid: ' staff03@example.com ,   ,   staff04@example.com',
+        course_role: 'Viewer',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -151,15 +150,14 @@ function runTest(context) {
       response.$,
       'button[data-testid="add-users-button"]',
     );
-    const form = {
-      __action: 'course_permissions_insert_by_user_uids',
-      __csrf_token: context.__csrf_token,
-      uid: `staff03@example.com, staff05@example.com, ${new_user}`,
-      course_role: 'None',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_insert_by_user_uids',
+        __csrf_token: context.__csrf_token,
+        uid: `staff03@example.com, staff05@example.com, ${new_user}`,
+        course_role: 'None',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -178,15 +176,14 @@ function runTest(context) {
       response.$,
       'form[name=student-data-access-add-3]',
     );
-    const form = {
-      __action: 'course_instance_permissions_insert',
-      __csrf_token: context.__csrf_token,
-      user_id: 3,
-      course_instance_id: 1,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_instance_permissions_insert',
+        __csrf_token: context.__csrf_token,
+        user_id: '3',
+        course_instance_id: '1',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -204,14 +201,13 @@ function runTest(context) {
       response.$,
       'form[name=course-content-access-form-3]',
     );
-    const form = {
-      __action: 'course_permissions_delete',
-      __csrf_token: context.__csrf_token,
-      user_id: 3,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_delete',
+        __csrf_token: context.__csrf_token,
+        user_id: '3',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -226,14 +222,13 @@ function runTest(context) {
     assert.isTrue(response.ok);
     const __csrf_token = response.$('span[id=test_csrf_token]').text();
     assert.lengthOf(response.$(`form[name=course-content-access-form-${context.userId}]`), 0);
-    const form = {
-      __action: 'course_permissions_delete',
-      __csrf_token,
-      user_id: 2,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_delete',
+        __csrf_token,
+        user_id: '2',
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -250,15 +245,14 @@ function runTest(context) {
       response.$,
       'form[name=course-content-access-form-4]',
     );
-    const form = {
-      __action: 'course_permissions_update_role',
-      __csrf_token: context.__csrf_token,
-      user_id: 4,
-      course_role: 'Owner',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_update_role',
+        __csrf_token: context.__csrf_token,
+        user_id: '4',
+        course_role: 'Owner',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -273,15 +267,14 @@ function runTest(context) {
     assert.isTrue(response.ok);
     const __csrf_token = response.$('span[id=test_csrf_token]').text();
     assert.lengthOf(response.$(`form[name=course-content-access-form-${context.userId}]`), 0);
-    const form = {
-      __action: 'course_permissions_update_role',
-      __csrf_token,
-      user_id: context.userId,
-      course_role: 'None',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_update_role',
+        __csrf_token,
+        user_id: context.userId,
+        course_role: 'None',
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -298,14 +291,13 @@ function runTest(context) {
     assert.isTrue(response.ok);
     const __csrf_token = response.$('span[id=test_csrf_token]').text();
     assert.lengthOf(response.$(`form[name=course-content-access-form-${context.userId}]`), 0);
-    const form = {
-      __action: 'course_permissions_delete',
-      __csrf_token,
-      user_id: context.userId,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_delete',
+        __csrf_token,
+        user_id: context.userId,
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -322,15 +314,14 @@ function runTest(context) {
     assert.isTrue(response.ok);
     const __csrf_token = response.$('span[id=test_csrf_token]').text();
     assert.lengthOf(response.$(`form[name=course-content-access-form-${context.userId}]`), 0);
-    const form = {
-      __action: 'course_permissions_update_role',
-      __csrf_token,
-      user_id: context.userId,
-      course_role: 'None',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_update_role',
+        __csrf_token,
+        user_id: context.userId,
+        course_role: 'None',
+      }),
       headers,
     });
     assert.equal(response.status, 403);
@@ -347,15 +338,14 @@ function runTest(context) {
       response.$,
       'button[data-testid="add-users-button"]',
     );
-    const form = {
-      __action: 'course_permissions_insert_by_user_uids',
-      __csrf_token: context.__csrf_token,
-      uid: 'staff03@example.com',
-      course_role: 'None',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_insert_by_user_uids',
+        __csrf_token: context.__csrf_token,
+        uid: 'staff03@example.com',
+        course_role: 'None',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -373,15 +363,14 @@ function runTest(context) {
       response.$,
       'form[name=student-data-access-add-3]',
     );
-    const form = {
-      __action: 'course_instance_permissions_insert',
-      __csrf_token: context.__csrf_token,
-      user_id: 3,
-      course_instance_id: 1,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_instance_permissions_insert',
+        __csrf_token: context.__csrf_token,
+        user_id: '3',
+        course_instance_id: '1',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -399,16 +388,15 @@ function runTest(context) {
       response.$,
       'form[name=student-data-access-change-3-1]',
     );
-    const form = {
-      __action: 'course_instance_permissions_update_role_or_delete',
-      __csrf_token: context.__csrf_token,
-      user_id: 3,
-      course_instance_id: 1,
-      course_instance_role: 'Student Data Editor',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_instance_permissions_update_role_or_delete',
+        __csrf_token: context.__csrf_token,
+        user_id: '3',
+        course_instance_id: '1',
+        course_instance_role: 'Student Data Editor',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -426,15 +414,14 @@ function runTest(context) {
       response.$,
       'form[name=student-data-access-add-5]',
     );
-    const form = {
-      __action: 'course_instance_permissions_insert',
-      __csrf_token: context.__csrf_token,
-      user_id: 5,
-      course_instance_id: 1,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_instance_permissions_insert',
+        __csrf_token: context.__csrf_token,
+        user_id: '5',
+        course_instance_id: '1',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -452,15 +439,14 @@ function runTest(context) {
       response.$,
       'form[name=student-data-access-change-5-1]',
     );
-    const form = {
-      __action: 'course_instance_permissions_update_role_or_delete',
-      __csrf_token: context.__csrf_token,
-      user_id: 5,
-      course_instance_id: 1,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_instance_permissions_update_role_or_delete',
+        __csrf_token: context.__csrf_token,
+        user_id: '5',
+        course_instance_id: '1',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -478,13 +464,12 @@ function runTest(context) {
       response.$,
       'button[data-testid="remove-all-student-data-access-button"]',
     );
-    const form = {
-      __action: 'remove_all_student_data_access',
-      __csrf_token: context.__csrf_token,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'remove_all_student_data_access',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -502,15 +487,14 @@ function runTest(context) {
       response.$,
       'form[name=student-data-access-add-5]',
     );
-    const form = {
-      __action: 'course_instance_permissions_insert',
-      __csrf_token: context.__csrf_token,
-      user_id: 5,
-      course_instance_id: 1,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_instance_permissions_insert',
+        __csrf_token: context.__csrf_token,
+        user_id: '5',
+        course_instance_id: '1',
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -528,13 +512,12 @@ function runTest(context) {
       response.$,
       'button[data-testid="delete-users-with-no-access-button"]',
     );
-    const form = {
-      __action: 'delete_no_access',
-      __csrf_token: context.__csrf_token,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'delete_no_access',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -553,13 +536,12 @@ function runTest(context) {
       response.$,
       'button[data-testid="delete-non-owners-button"]',
     );
-    const form = {
-      __action: 'delete_non_owners',
-      __csrf_token: context.__csrf_token,
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'delete_non_owners',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -577,15 +559,14 @@ function runTest(context) {
       response.$,
       'form[name=course-content-access-form-4]',
     );
-    const form = {
-      __action: 'course_permissions_update_role',
-      __csrf_token: context.__csrf_token,
-      user_id: 4,
-      course_role: 'Editor',
-    };
     response = await helperClient.fetchCheerio(context.pageUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'course_permissions_update_role',
+        __csrf_token: context.__csrf_token,
+        user_id: '4',
+        course_role: 'Editor',
+      }),
       headers,
     });
     assert.isTrue(response.ok);

--- a/apps/prairielearn/src/tests/permissions/studentData.test.ts
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.ts
@@ -97,13 +97,12 @@ describe('student data access', function () {
 
   step('student can start E1 in exam mode', async () => {
     const headers = { cookie: 'pl_test_user=test_student; pl_test_mode=Exam' };
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.examAssessmentUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -216,15 +215,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('form[class=attach-text-form]'), 0);
-      const form = {
-        __action: 'attach_text',
-        __csrf_token,
-        filename: 'notes.txt',
-        contents: 'This is a test.',
-      };
       response = await helperClient.fetchCheerio(context.homeworkAssessmentInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'attach_text',
+          __csrf_token,
+          filename: 'notes.txt',
+          contents: 'This is a test.',
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -241,15 +239,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('button[name=__action][value=grade]'), 0);
-      const form = {
-        __action: 'grade',
-        __csrf_token,
-        __variant_id: context.homeworkQuestionVariant.id,
-        c: context.homeworkQuestionVariant.true_answer.c,
-      };
       response = await helperClient.fetchCheerio(context.homeworkQuestionInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token,
+          __variant_id: context.homeworkQuestionVariant.id,
+          c: context.homeworkQuestionVariant.true_answer.c,
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -266,15 +263,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('form[class=attach-text-form]'), 0);
-      const form = {
-        __action: 'attach_text',
-        __csrf_token,
-        filename: 'notes.txt',
-        contents: 'This is a test.',
-      };
       response = await helperClient.fetchCheerio(context.examAssessmentInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'attach_text',
+          __csrf_token,
+          filename: 'notes.txt',
+          contents: 'This is a test.',
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -289,15 +285,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('button[name=__action][value=grade]'), 0);
-      const form = {
-        __action: 'grade',
-        __csrf_token,
-        __variant_id: context.examQuestionVariant.id,
-        c: context.examQuestionVariant.true_answer.c,
-      };
       response = await helperClient.fetchCheerio(context.examQuestionInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token,
+          __variant_id: context.examQuestionVariant.id,
+          c: context.examQuestionVariant.true_answer.c,
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -331,15 +326,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('form[class=attach-text-form]'), 0);
-      const form = {
-        __action: 'attach_text',
-        __csrf_token,
-        filename: 'notes.txt',
-        contents: 'This is a test.',
-      };
       response = await helperClient.fetchCheerio(context.homeworkAssessmentInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'attach_text',
+          __csrf_token,
+          filename: 'notes.txt',
+          contents: 'This is a test.',
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -356,15 +350,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('button[name=__action][value=grade]'), 0);
-      const form = {
-        __action: 'grade',
-        __csrf_token,
-        __variant_id: context.homeworkQuestionVariant.id,
-        c: context.homeworkQuestionVariant.true_answer.c,
-      };
       response = await helperClient.fetchCheerio(context.homeworkQuestionInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token,
+          __variant_id: context.homeworkQuestionVariant.id,
+          c: context.homeworkQuestionVariant.true_answer.c,
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -381,15 +374,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('form[class=attach-text-form]'), 0);
-      const form = {
-        __action: 'attach_text',
-        __csrf_token,
-        filename: 'notes.txt',
-        contents: 'This is a test.',
-      };
       response = await helperClient.fetchCheerio(context.examAssessmentInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'attach_text',
+          __csrf_token,
+          filename: 'notes.txt',
+          contents: 'This is a test.',
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -404,15 +396,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       const __csrf_token = response.$('span[id=test_csrf_token]').text();
       assert.lengthOf(response.$('button[name=__action][value=grade]'), 0);
-      const form = {
-        __action: 'grade',
-        __csrf_token,
-        __variant_id: context.examQuestionVariant.id,
-        c: context.examQuestionVariant.true_answer.c,
-      };
       response = await helperClient.fetchCheerio(context.examQuestionInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token,
+          __variant_id: context.examQuestionVariant.id,
+          c: context.examQuestionVariant.true_answer.c,
+        }),
         headers,
       });
       assert.equal(response.status, 403);
@@ -430,15 +421,14 @@ describe('student data access', function () {
       });
       assert.isTrue(response.ok);
       helperClient.extractAndSaveCSRFToken(context, response.$, 'form[class=attach-text-form]');
-      const form = {
-        __action: 'attach_text',
-        __csrf_token: context.__csrf_token,
-        filename: 'notes.txt',
-        contents: 'This is a test.',
-      };
       response = await helperClient.fetchCheerio(context.homeworkAssessmentInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'attach_text',
+          __csrf_token: context.__csrf_token,
+          filename: 'notes.txt',
+          contents: 'This is a test.',
+        }),
         headers,
       });
       assert.isTrue(response.ok);
@@ -457,15 +447,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       helperClient.extractAndSaveCSRFToken(context, response.$, 'form[name=question-form]');
       assert.lengthOf(response.$('button[name=__action][value=grade]'), 1);
-      const form = {
-        __action: 'grade',
-        __csrf_token: context.__csrf_token,
-        __variant_id: context.homeworkQuestionVariant.id,
-        c: context.homeworkQuestionVariant.true_answer.c,
-      };
       response = await helperClient.fetchCheerio(context.homeworkQuestionInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token: context.__csrf_token,
+          __variant_id: context.homeworkQuestionVariant.id,
+          c: context.homeworkQuestionVariant.true_answer.c,
+        }),
         headers,
       });
       assert.isTrue(response.ok);
@@ -484,15 +473,14 @@ describe('student data access', function () {
       });
       assert.isTrue(response.ok);
       helperClient.extractAndSaveCSRFToken(context, response.$, 'form[class=attach-text-form]');
-      const form = {
-        __action: 'attach_text',
-        __csrf_token: context.__csrf_token,
-        filename: 'notes.txt',
-        contents: 'This is a test.',
-      };
       response = await helperClient.fetchCheerio(context.examAssessmentInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'attach_text',
+          __csrf_token: context.__csrf_token,
+          filename: 'notes.txt',
+          contents: 'This is a test.',
+        }),
         headers,
       });
       assert.isTrue(response.ok);
@@ -510,15 +498,14 @@ describe('student data access', function () {
       assert.isTrue(response.ok);
       helperClient.extractAndSaveCSRFToken(context, response.$, 'form[name=question-form]');
       assert.lengthOf(response.$('button[name=__action][value=grade]'), 1);
-      const form = {
-        __action: 'grade',
-        __csrf_token: context.__csrf_token,
-        __variant_id: context.examQuestionVariant.id,
-        c: context.examQuestionVariant.true_answer.c,
-      };
       response = await helperClient.fetchCheerio(context.examQuestionInstanceUrl, {
         method: 'POST',
-        form,
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token: context.__csrf_token,
+          __variant_id: context.examQuestionVariant.id,
+          c: context.examQuestionVariant.true_answer.c,
+        }),
         headers,
       });
       assert.isTrue(response.ok);

--- a/apps/prairielearn/src/tests/realTimeGradingDisabled.test.ts
+++ b/apps/prairielearn/src/tests/realTimeGradingDisabled.test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import { step } from 'mocha-steps';
+import fetch from 'node-fetch';
 
 import * as sqldb from '@prairielearn/postgres';
 
@@ -36,13 +37,12 @@ describe('Exam assessment with real-time grading disabled', function () {
   });
 
   step('start the exam', async () => {
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
     });
     assert.isTrue(response.ok);
 
@@ -72,13 +72,12 @@ describe('Exam assessment with real-time grading disabled', function () {
   });
 
   step('try to manually grade request on the question page', async () => {
-    const form = {
-      __action: 'grade',
-      __csrf_token: context.__csrf_token,
-    };
-    const response = await helperClient.fetchCheerio(context.assessmentInstanceUrl, {
+    const response = await fetch(context.assessmentInstanceUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'grade',
+        __csrf_token: context.__csrf_token,
+      }),
     });
 
     assert.isFalse(response.ok);

--- a/apps/prairielearn/src/tests/showClosedAssessment.test.ts
+++ b/apps/prairielearn/src/tests/showClosedAssessment.test.ts
@@ -59,13 +59,12 @@ describe('Exam assessment with showCloseAssessment access rule', function () {
   });
 
   step('start the exam', async () => {
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -83,13 +82,12 @@ describe('Exam assessment with showCloseAssessment access rule', function () {
   });
 
   step('simulate a time limit expiration', async () => {
-    const form = {
-      __action: 'timeLimitFinish',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentInstanceUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'timeLimitFinish',
+        __csrf_token: context.__csrf_token,
+      }),
       headers: headersTimeLimit,
     });
     assert.equal(response.status, 403);

--- a/apps/prairielearn/src/tests/showClosedAssessmentScore.test.ts
+++ b/apps/prairielearn/src/tests/showClosedAssessmentScore.test.ts
@@ -60,13 +60,12 @@ describe('Exam assessment with showClosedAssessment AND showClosedAssessmentScor
   });
 
   step('start the exam', async () => {
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
       headers,
     });
     assert.isTrue(response.ok);
@@ -84,13 +83,12 @@ describe('Exam assessment with showClosedAssessment AND showClosedAssessmentScor
   });
 
   step('simulate a time limit expiration', async () => {
-    const form = {
-      __action: 'timeLimitFinish',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentInstanceUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'timeLimitFinish',
+        __csrf_token: context.__csrf_token,
+      }),
       headers: headersTimeLimit,
     });
     assert.equal(response.status, 403);

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.ts
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.ts
@@ -62,13 +62,12 @@ describe('Assessment that forces students to complete questions in-order', funct
     // Generate assessment instance
     const assessmentCreateResponse = await helperClient.fetchCheerio(context.assessmentUrl);
     helperClient.extractAndSaveCSRFToken(context, assessmentCreateResponse.$, 'form');
-    const form = {
-      __action: 'new_instance',
-      __csrf_token: context.__csrf_token,
-    };
     const response = await helperClient.fetchCheerio(context.assessmentUrl, {
       method: 'POST',
-      form,
+      body: new URLSearchParams({
+        __action: 'new_instance',
+        __csrf_token: context.__csrf_token,
+      }),
     });
     assert.isTrue(response.ok);
 
@@ -142,14 +141,15 @@ describe('Assessment that forces students to complete questions in-order', funct
     context.__variant_id = preSubmissionResponse
       .$('.question-form input[name="__variant_id"]')
       .attr('value');
-    const form = {
-      __action: 'grade',
-      __variant_id: context.__variant_id,
-      s: String(score),
-      __csrf_token: context.__csrf_token,
-    };
-
-    const response = await helperClient.fetchCheerio(question.url, { method: 'POST', form });
+    const response = await helperClient.fetchCheerio(question.url, {
+      method: 'POST',
+      body: new URLSearchParams({
+        __action: 'grade',
+        __variant_id: context.__variant_id,
+        s: String(score),
+        __csrf_token: context.__csrf_token,
+      }),
+    });
     assert.isTrue(response.ok);
 
     return response;


### PR DESCRIPTION
This PR standardizes us on using `body: new URLSearchParams({ ... })` to construct form data in our tests. This uses web standards with well-defined behavior instead of our custom JSON-based `form` property that doesn't reflect the way browsers will actually submit data from form submissions.