### PR TITLE
Clarify documentation regarding Linux native installation

### DIFF
--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -9,7 +9,7 @@ This page describes the procedure to install and run PrairieLearn without any us
   - [Yarn](https://yarnpkg.com)
   - [Python 3.10](https://www.python.org)
   - [PostgreSQL 15](https://www.postgresql.org)
-  - [Redis](https://redis.io)
+  - [Redis 6](https://redis.io)
   - [Graphviz](https://graphviz.org)
   - [d2](https://d2lang.com)
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -6,20 +6,20 @@ This page describes the procedure to install and run PrairieLearn without any us
 
   - [Git](https://git-scm.com)
   - [Node.js 20](https://nodejs.org)
-  - [Yarn](https://classic.yarnpkg.com)
+  - [Yarn](https://yarnpkg.com)
   - [Python 3.10](https://www.python.org)
   - [PostgreSQL 15](https://www.postgresql.org)
   - [Redis](https://redis.io)
   - [Graphviz](https://graphviz.org)
   - [d2](https://d2lang.com)
 
-  On macOS, these can be installed with [Homebrew](http://brew.sh/). On Linux, these should all be standard packages from the OS distribution.
-
-  On macOS, you should ensure you have installed the XCode command line tools:
+  On macOS, these can be installed with [Homebrew](http://brew.sh/). You should also ensure you have installed the XCode command line tools:
 
   ```sh
   xcode-select --install
   ```
+
+On Linux, most of these prerequisites should be standard packages from the OS distribution, though in some cases the distribution may not include the latest version by default. In cases where your distribution does not include the corresponding package or it is outdated, you should follow the instructions in the corresponding page above.
 
 - Clone the latest code:
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -1,6 +1,6 @@
 # Running natively
 
-This page describes the procedure to install and run PrairieLearn without any use of Docker. This means that PrairieLearn is running fully natively on the local OS.
+This page describes the procedure to install and run PrairieLearn without any use of Docker. This means that PrairieLearn is running fully natively on the local OS. PrairieLearn supports native execution on macOS and Linux.
 
 - Install the prerequisites:
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -19,7 +19,7 @@ This page describes the procedure to install and run PrairieLearn without any us
   xcode-select --install
   ```
 
-On Linux, most of these prerequisites should be standard packages from the OS distribution, though in some cases the distribution may not include the latest version by default. In cases where your distribution does not include the corresponding package or it is outdated, you should follow the instructions in the corresponding page above.
+  On Linux, most of these prerequisites should be standard packages from the OS distribution, though in some cases the distribution may not include the latest version by default. In cases where your distribution does not include the corresponding package or it is outdated, you should follow the instructions in the corresponding page above.
 
 - Clone the latest code:
 


### PR DESCRIPTION
The documentation currently assumes Linux has all the dependencies in packages, but that is not the case. For Ubuntu 24.04 in particular:

* d2 is not a package;
* nodejs uses version 18.19 (we need 20);
* redis uses version 5 (we need 6);
* yarn uses version 1.22 (this is not an actual issue since yarn defers to the release found in .yarn).

The PR also changes the link to Yarn to the newest version (it was still pointing to the 1.x version). While the installation of the proper version should not matter much (see above), it probably makes sense to point users to the docs version that matches what we're actually using.