### PR TITLE
Add a mise config file

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+node = "20"
+"npm:yarn" = "latest"
+python = "3.10"
+"ubi:terrastruct/d2" = "latest"


### PR DESCRIPTION
If you don't use mise, this doesn't affect your workflow and is just a small dotfile. If you do use mise, this ensures you are using the right versions of python and node when you are working on PrairieLearn. This lets you replace pyenv/nvm with just one file.

If we don't want to add this, we can close, but perhaps I can add `mise.toml` to the `.gitignore` instead.

Additionally, if we *really* like this, I can change up some of the docker images to use the mise file to install instead of nvm.