### PR TITLE
Fix fetching of LTI 1.3 access tokens

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -307,10 +307,31 @@ export async function getAccessToken(lti13_instance_id: string) {
   const issuer = new Issuer(lti13_instance.issuer_params);
   const client = new issuer.Client(lti13_instance.client_params, lti13_instance.keystore);
 
-  tokenSet = await client.grant({
-    grant_type: 'client_credentials',
-    scope: TOKEN_SCOPES.join(' '),
-  });
+  tokenSet = await client.grant(
+    {
+      grant_type: 'client_credentials',
+      scope: TOKEN_SCOPES.join(' '),
+    },
+    {
+      clientAssertionPayload: {
+        // Canvas requires the `aud` claim the be (or contain) the token endpoint:
+        // https://github.com/instructure/canvas-lms/blob/995169713440bd8305854d440b336911a734c38f/lib/canvas/oauth/client_credentials_provider.rb#L26-L29
+        // https://github.com/instructure/canvas-lms/blob/995169713440bd8305854d440b336911a734c38f/lib/canvas/oauth/asymmetric_client_credentials_provider.rb#L24
+        //
+        // From what we can tell, the OIDC spec requires this as well, see "private key jwt"
+        // here: https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.9
+        //
+        // "The Audience SHOULD be the URL of the Authorization Server's Token Endpoint."
+        //
+        // However, `openid-client` changed their behavior in the following commit:
+        // https://github.com/panva/openid-client/commit/0b05217e7f283b75fd93c27c0f8c647f37501a33
+        //
+        // There wasn't a justification provided and this seems to deviate from the OIDC spec.
+        // See a discussion here: https://github.com/panva/openid-client/discussions/730
+        aud: [...new Set([issuer.issuer, issuer.token_endpoint].filter(Boolean))],
+      },
+    },
+  );
 
   // Store the token for reuse
   const expires_at = tokenSet.expires_at ? tokenSet.expires_at * 1000 : Date.now();


### PR DESCRIPTION
This broke with the update to 5.7.1 of `openid-client` in #10982. See inline comment for more details.