### PR TITLE
Drop course_instances.ps_linked column from Zod schema

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -390,7 +390,6 @@ export const CourseInstanceSchema = z.object({
   hide_in_enroll_page: z.boolean().nullable(),
   id: IdSchema,
   long_name: z.string().nullable(),
-  ps_linked: z.boolean(),
   short_name: z.string().nullable(),
   sync_errors: z.string().nullable(),
   sync_job_sequence_id: IdSchema.nullable(),

--- a/apps/prairielearn/src/migrations/20241219173221_course_instances__ps_linked__drop.sql
+++ b/apps/prairielearn/src/migrations/20241219173221_course_instances__ps_linked__drop.sql
@@ -1,0 +1,2 @@
+ALTER TABLE course_instances
+DROP COLUMN ps_linked;

--- a/apps/prairielearn/src/migrations/20241219173221_course_instances__ps_linked__drop.sql
+++ b/apps/prairielearn/src/migrations/20241219173221_course_instances__ps_linked__drop.sql
@@ -1,2 +1,0 @@
-ALTER TABLE course_instances
-DROP COLUMN ps_linked;


### PR DESCRIPTION
This was called out as a remaining task in #3373. This column is no longer read anywhere.

We can't drop the column from the database until it's no longer being expected in the schema. Once this is deployed, we can land a PR that drops the column itself.