### PR TITLE
Upgrade base image and docs to use Postgres 16

### DIFF
--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -2571,7 +2571,7 @@ if (esMain(import.meta) && config.startServer) {
       },
       async () => {
         // We create and activate a random DB schema name
-        // (https://www.postgresql.org/docs/12/ddl-schemas.html)
+        // (https://www.postgresql.org/docs/current/ddl-schemas.html)
         // after we have run the migrations but before we create
         // the sprocs. This means all tables (from migrations) are
         // in the public schema, but all sprocs are in the random

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -184,7 +184,7 @@ const question = await queryRow(sql.select_question, { question_id: 45 }, Questi
   await sqldb.callAsync('workspaces_message_update', [workspace_id, message]);
   ```
 
-- The stored procedures are all contained in a separate [database schema](https://www.postgresql.org/docs/12/ddl-schemas.html) with a name like `server_2021-07-07T20:25:04.779Z_T75V6Y`. To see a list of the schemas use the `\dn` command in `psql`.
+- The stored procedures are all contained in a separate [database schema](https://www.postgresql.org/docs/current/ddl-schemas.html) with a name like `server_2021-07-07T20:25:04.779Z_T75V6Y`. To see a list of the schemas use the `\dn` command in `psql`.
 
 - To be able to use the stored procedures from the `psql` command line it is necessary to get the most recent schema name using `\dn` and set the `search_path` to use this _quoted_ schema name and the `public` schema:
 
@@ -314,7 +314,7 @@ WHERE
     ($points_list::INTEGER[]);
   ```
 
-- To use a JavaScript array for membership testing in SQL use [`unnest()`](https://www.postgresql.org/docs/9.5/static/functions-array.html) like:
+- To use a JavaScript array for membership testing in SQL use [`unnest()`](https://www.postgresql.org/docs/current/functions-array.html) like:
 
   ```javascript
   const questions = await sqldb.queryRows(

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -111,7 +111,7 @@ In general we prefer simplicity. We standardize on JavaScript/TypeScript (Node.j
 
 ## SQL usage
 
-- [PostgreSQL](https://www.postgresql.org) v15 is used as the database.
+- [PostgreSQL](https://www.postgresql.org) v16 is used as the database.
 
 - The [PostgreSQL manual](https://www.postgresql.org/docs/manuals/) is an excellent reference.
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -8,7 +8,7 @@ This page describes the procedure to install and run PrairieLearn without any us
   - [Node.js 20](https://nodejs.org)
   - [Yarn](https://yarnpkg.com)
   - [Python 3.10](https://www.python.org)
-  - [PostgreSQL 15](https://www.postgresql.org)
+  - [PostgreSQL 16](https://www.postgresql.org)
   - [Redis 6](https://redis.io)
   - [Graphviz](https://graphviz.org)
   - [d2](https://d2lang.com)

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -24,9 +24,9 @@ dnf -y install \
     lsof \
     make \
     openssl \
-    postgresql15 \
-    postgresql15-server \
-    postgresql15-contrib \
+    postgresql16 \
+    postgresql16-server \
+    postgresql16-contrib \
     procps-ng \
     redis6 \
     tar \
@@ -50,7 +50,7 @@ mkdir /var/postgres && chown postgres:postgres /var/postgres
 su postgres -c "initdb -D /var/postgres"
 
 echo "installing pgvector..."
-dnf -y install postgresql15-server-devel
+dnf -y install postgresql16-server-devel
 cd /tmp
 git clone --branch v0.7.0 https://github.com/pgvector/pgvector.git
 cd pgvector
@@ -61,7 +61,7 @@ cd pgvector
 make OPTFLAGS=""
 make install
 rm -rf /tmp/pgvector
-dnf -y remove postgresql15-server-devel
+dnf -y remove postgresql16-server-devel
 dnf -y autoremove
 
 # TODO: use standard OS Python installation? The only reason we switched to Conda

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -133,7 +133,7 @@ function escapeIdentifier(identifier: string): string {
   // Note that as of 2021-06-29 escapeIdentifier() is undocumented. See:
   // https://github.com/brianc/node-postgres/pull/396
   // https://github.com/brianc/node-postgres/issues/1978
-  // https://www.postgresql.org/docs/12/sql-syntax-lexical.html
+  // https://www.postgresql.org/docs/current/sql-syntax-lexical.html
   return pg.Client.prototype.escapeIdentifier(identifier);
 }
 


### PR DESCRIPTION
We're now running with Postgres 16 in production; time to update our image to reflect that!

We didn't jump to Postgres 17 yet for two reasons:

- AWS Aurora Serverless v2 doesn't yet support it
- It's not present in the Amazon Linux 2023 package repository