### PR TITLE
Standardize query check for array membership

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.sql
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.sql
@@ -4,10 +4,7 @@ WITH
     DELETE FROM institution_authn_providers
     WHERE
       institution_id = $institution_id
-      AND authn_provider_id NOT IN (
-        SELECT
-          unnest($enabled_authn_provider_ids::bigint[])
-      )
+      AND authn_provider_id != ALL ($enabled_authn_provider_ids::bigint[])
     RETURNING
       *
   ),

--- a/apps/prairielearn/src/lib/question-render.sql
+++ b/apps/prairielearn/src/lib/question-render.sql
@@ -114,10 +114,7 @@ SELECT
 FROM
   submissions AS s
 WHERE
-  s.id IN (
-    SELECT
-      UNNEST($submission_ids::bigint[])
-  )
+  s.id = ANY ($submission_ids::bigint[])
 ORDER BY
   s.date DESC;
 

--- a/apps/prairielearn/src/lib/server-jobs.sql
+++ b/apps/prairielearn/src/lib/server-jobs.sql
@@ -259,7 +259,4 @@ UPDATE jobs AS j
 SET
   heartbeat_at = CURRENT_TIMESTAMP
 WHERE
-  j.id IN (
-    SELECT
-      UNNEST($job_ids::bigint[])
-  );
+  j.id = ANY ($job_ids::bigint[]);

--- a/apps/prairielearn/src/lib/workspaceHost.sql
+++ b/apps/prairielearn/src/lib/workspaceHost.sql
@@ -259,7 +259,7 @@ WITH
       state = 'terminated',
       terminated_at = NOW()
     WHERE
-      wh.instance_id = ANY ($instance_ids)
+      wh.instance_id = ANY ($instance_ids::text[])
       AND wh.state != 'launching'
     RETURNING
       wh.id,

--- a/apps/prairielearn/src/lib/workspaceHost.sql
+++ b/apps/prairielearn/src/lib/workspaceHost.sql
@@ -259,10 +259,7 @@ WITH
       state = 'terminated',
       terminated_at = NOW()
     WHERE
-      wh.instance_id IN (
-        SELECT
-          UNNEST($instance_ids)
-      )
+      wh.instance_id = ANY ($instance_ids)
       AND wh.state != 'launching'
     RETURNING
       wh.id,

--- a/apps/prairielearn/src/sprocs/assessment_instances_grade.sql
+++ b/apps/prairielearn/src/sprocs/assessment_instances_grade.sql
@@ -98,7 +98,7 @@ BEGIN
 
     UPDATE instance_questions AS iq
     SET
-        used_for_grade = (iq.id = ANY(instance_questions_used_for_grade))
+        used_for_grade = (iq.id = ANY (instance_questions_used_for_grade))
     WHERE
         iq.assessment_instance_id = assessment_instances_grade.assessment_instance_id;
 

--- a/apps/prairielearn/src/sprocs/sync_assessment_modules.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessment_modules.sql
@@ -61,7 +61,7 @@ BEGIN
         ('Default', 0, syncing_course_id)
     ON CONFLICT (name, course_id) DO NOTHING;
 
-    IF ('Default' != ALL(used_assessment_module_names)) THEN
+    IF ('Default' != ALL (used_assessment_module_names)) THEN
         used_assessment_module_names := used_assessment_module_names || '{Default}';
     END IF;
 
@@ -104,7 +104,7 @@ BEGIN
         DELETE FROM assessment_modules AS am
         WHERE
             am.course_id = syncing_course_id
-            AND am.name != ALL(used_assessment_module_names)
+            AND am.name != ALL (used_assessment_module_names)
             AND am.number != 0;
     END IF;
 

--- a/apps/prairielearn/src/sprocs/sync_assessment_modules.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessment_modules.sql
@@ -104,7 +104,7 @@ BEGIN
         DELETE FROM assessment_modules AS am
         WHERE
             am.course_id = syncing_course_id
-            AND am.name NOT IN (SELECT unnest(used_assessment_module_names))
+            AND am.name != ALL(used_assessment_module_names)
             AND am.number != 0;
     END IF;
 

--- a/apps/prairielearn/src/sprocs/sync_assessment_sets.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessment_sets.sql
@@ -64,7 +64,7 @@ BEGIN
     ) VALUES ('Unknown', 'U',          'Unknown', 'red3', 1,      syncing_course_id)
     ON CONFLICT (name, course_id) DO NOTHING;
 
-    IF ('Unknown' != ALL(used_assessment_set_names)) THEN
+    IF ('Unknown' != ALL (used_assessment_set_names)) THEN
         used_assessment_set_names := used_assessment_set_names || 'Unknown';
     END IF;
 
@@ -112,7 +112,7 @@ BEGIN
         DELETE FROM assessment_sets AS aset
         WHERE
             aset.course_id = syncing_course_id
-            AND aset.name != ALL(used_assessment_set_names);
+            AND aset.name != ALL (used_assessment_set_names);
     END IF;
 
     -- Internal consistency check. All assessments should have an

--- a/apps/prairielearn/src/sprocs/sync_assessment_sets.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessment_sets.sql
@@ -112,7 +112,7 @@ BEGIN
         DELETE FROM assessment_sets AS aset
         WHERE
             aset.course_id = syncing_course_id
-            AND aset.name NOT IN (SELECT unnest(used_assessment_set_names));
+            AND aset.name != ALL(used_assessment_set_names);
     END IF;
 
     -- Internal consistency check. All assessments should have an

--- a/apps/prairielearn/src/sprocs/sync_assessments.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessments.sql
@@ -246,7 +246,7 @@ BEGIN
             DELETE FROM group_roles
             WHERE
                 assessment_id = new_assessment_id
-                AND role_name NOT IN (SELECT unnest(new_group_role_names));
+                AND role_name != ALL(new_group_role_names);
 
         ELSE
             UPDATE group_configs

--- a/apps/prairielearn/src/sprocs/sync_assessments.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessments.sql
@@ -246,7 +246,7 @@ BEGIN
             DELETE FROM group_roles
             WHERE
                 assessment_id = new_assessment_id
-                AND role_name != ALL(new_group_role_names);
+                AND role_name != ALL (new_group_role_names);
 
         ELSE
             UPDATE group_configs

--- a/apps/prairielearn/src/sprocs/sync_course_tags.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_tags.sql
@@ -88,7 +88,7 @@ BEGIN
         DELETE FROM tags AS t
         WHERE
             t.course_id = syncing_course_id
-            AND t.name NOT IN (SELECT UNNEST(used_tag_names));
+            AND t.name != ALL(used_tag_names);
     END IF;
 
     -- Make a map from tag name to ID to return to the caller

--- a/apps/prairielearn/src/sprocs/sync_course_tags.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_tags.sql
@@ -88,7 +88,7 @@ BEGIN
         DELETE FROM tags AS t
         WHERE
             t.course_id = syncing_course_id
-            AND t.name != ALL(used_tag_names);
+            AND t.name != ALL (used_tag_names);
     END IF;
 
     -- Make a map from tag name to ID to return to the caller

--- a/apps/prairielearn/src/sprocs/sync_topics.sql
+++ b/apps/prairielearn/src/sprocs/sync_topics.sql
@@ -87,7 +87,7 @@ BEGIN
         DELETE FROM topics AS t
         WHERE
             t.course_id = syncing_course_id
-            AND t.name NOT IN (SELECT UNNEST(used_topic_names));
+            AND t.name != ALL(used_topic_names);
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/apps/prairielearn/src/sprocs/sync_topics.sql
+++ b/apps/prairielearn/src/sprocs/sync_topics.sql
@@ -87,7 +87,7 @@ BEGIN
         DELETE FROM topics AS t
         WHERE
             t.course_id = syncing_course_id
-            AND t.name != ALL(used_topic_names);
+            AND t.name != ALL (used_topic_names);
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -314,7 +314,7 @@ WHERE
     ($points_list::INTEGER[]);
   ```
 
-- To use a JavaScript array for membership testing in SQL use [`unnest()`](https://www.postgresql.org/docs/current/functions-array.html) like:
+- To use a JavaScript array for membership testing in SQL use `= ANY ($array)` (or its negative form `!= ALL ($array)`) like:
 
   ```javascript
   const questions = await sqldb.queryRows(
@@ -331,10 +331,7 @@ WHERE
   FROM
     questions
   WHERE
-    id IN (
-      SELECT
-        unnest($id_list::INTEGER[])
-    );
+    id = ANY ($id_list::INTEGER[]);
   ```
 
 - To pass a lot of data to SQL a useful pattern is to send a JSON object array and unpack it in SQL to the equivalent of a table. This is the pattern used by the "sync" code, such as [sprocs/sync_news_items.sql](https://github.com/PrairieLearn/PrairieLearn/blob/master/apps/prairielearn/src/sprocs/sync_news_items.sql). For example:

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -331,7 +331,7 @@ WHERE
   FROM
     questions
   WHERE
-    id = ANY ($id_list::INTEGER[]);
+    id = ANY ($id_list::BIGINT[]);
   ```
 
 - To pass a lot of data to SQL a useful pattern is to send a JSON object array and unpack it in SQL to the equivalent of a table. This is the pattern used by the "sync" code, such as [sprocs/sync_news_items.sql](https://github.com/PrairieLearn/PrairieLearn/blob/master/apps/prairielearn/src/sprocs/sync_news_items.sql). For example:


### PR DESCRIPTION
Based on discussion in https://github.com/PrairieLearn/PrairieLearn/pull/11081#discussion_r1901168880. Replaces all cases where `UNNEST` is used to convert an array to a set to be used with `IN`, when the direct equivalent `= ANY` (or `!= ALL`) can be used instead. We had been slowly moving in this direction, this change updates both the docs and the remaining uses of the old pattern.