### PR TITLE
Fix bug in cgrader.py

### DIFF
--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -108,12 +108,12 @@ class CGrader:
         finally:
             proc.kill()
             try:
-                out = proc.communicate(timeout=timeout)[0]
+                out = proc.communicate(timeout=timeout)[0].decode(
+                    "utf-8", "backslashreplace"
+                )
             except subprocess.TimeoutExpired:
                 tostr = TIMEOUT_MESSAGE
 
-            if out:
-                out = out.decode("utf-8", "backslashreplace")
         return out + tostr
 
     def compile_file(


### PR DESCRIPTION
![CleanShot 2025-01-05 at 14 37 42@2x](https://github.com/user-attachments/assets/5148f2fb-7108-4e44-8366-9451a4ec2be6)

Reported by James Foster.

Always decode the output into a string, which avoids a bug where the empty bytestring is not decoded.