### PR TITLE
Fix overlayMap example question; improve pl-overlay docs

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1751,7 +1751,7 @@ The `pl-background` child tag does not have any extra attributes that need to be
 
 An overlay is pre-defined as a "overlay area" with a static size. By default, elements that exceed these boundaries will get partially or totally cut off.
 
-A background can be specified by wrapping HTML in a `<pl-background>` tag. If the contents of `<pl-background>` don't have a fixed size (e.g. using `<pl-figure>`, which uses a responsive width), then you should explicitly specify at least a `width` on `<pl-figure>` to ensure that children will be displayed at the expected location no matter how big the browser viewport is. However, if the contents of `<pl-background>` have a fixed size (e.g. using `<pl-drawing width="500">`), then manually specifying a `width`/`height` on `<pl-overlay>` is not necessary.
+A background can be specified by wrapping HTML in a `<pl-background>` tag. If the contents of `<pl-background>` don't have a fixed size (e.g. using `<pl-figure>`, which uses a responsive width), then you should explicitly specify at least a `width` on `<pl-overlay>` to ensure that children will be displayed at the expected location no matter how big the browser viewport is. However, if the contents of `<pl-background>` have a fixed size (e.g. using `<pl-drawing width="500">`), then manually specifying a `width`/`height` on `<pl-overlay>` is not necessary.
 
 Floating child elements are wrapped with a `<pl-location>` tag that specifies the position relative to some defined edge of the overlay area using `left`, `right`, `top`, and `bottom`. Anything inside the location tag will be displayed at that position. Children are layered in the order they are specified, with later child elements being displayed on top of those defined earlier.
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1726,11 +1726,11 @@ The overlay element allows existing PrairieLearn and HTML elements to be layered
 
 #### `pl-overlay` Customizations
 
-| Attribute | Type    | Default | Description                                                                              |
-| --------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
-| `width`   | float   | -       | The width of the overlay canvas in pixels. Required only if no background is specified.  |
-| `height`  | float   | -       | The height of the overlay canvas in pixels. Required only if no background is specified. |
-| `clip`    | boolean | true    | If true, children will be cut off when exceeding overlay boundaries.                     |
+| Attribute | Type    | Default | Description                                                          |
+| --------- | ------- | ------- | -------------------------------------------------------------------- |
+| `width`   | float   | -       | The width of the overlay canvas in pixels.                           |
+| `height`  | float   | -       | The height of the overlay canvas in pixels.                          |
+| `clip`    | boolean | true    | If true, children will be cut off when exceeding overlay boundaries. |
 
 #### `pl-location` Customizations
 
@@ -1749,7 +1749,11 @@ The `pl-background` child tag does not have any extra attributes that need to be
 
 #### Details
 
-An overlay is pre-defined as a "overlay area" with a static size. By default, elements that exceed these boundaries will get partially or totally cut off. A background can be specified by wrapping HTML in a `<pl-background>` tag, in this case the overlay will automatically size itself to fit the background and a `width` and `height` do not need to be specified. Floating child elements are wrapped with a `<pl-location>` tag that specifies the position relative to some defined edge of the overlay area using `left`, `right`, `top`, and `bottom`. Anything inside the location tag will be displayed at that position. Children are layered in the order they are specified, with later child elements being displayed on top of those defined earlier.
+An overlay is pre-defined as a "overlay area" with a static size. By default, elements that exceed these boundaries will get partially or totally cut off.
+
+A background can be specified by wrapping HTML in a `<pl-background>` tag. If the contents of `<pl-background>` don't have a fixed size (e.g. using `<pl-figure>`, which uses a responsive width), then you should explicitly specify at least a `width` on `<pl-figure>` to ensure that children will be displayed at the expected location no matter how big the browser viewport is. However, if the contents of `<pl-background>` have a fixed size (e.g. using `<pl-drawing width="500">`), then manually specifying a `width`/`height` on `<pl-overlay>` is not necessary.
+
+Floating child elements are wrapped with a `<pl-location>` tag that specifies the position relative to some defined edge of the overlay area using `left`, `right`, `top`, and `bottom`. Anything inside the location tag will be displayed at that position. Children are layered in the order they are specified, with later child elements being displayed on top of those defined earlier.
 
 #### Example implementations
 

--- a/exampleCourse/questions/demo/annotated/engLogic/question.html
+++ b/exampleCourse/questions/demo/annotated/engLogic/question.html
@@ -7,7 +7,7 @@ Construct a correct logic diagram using the image provided below. There are more
 
 <p>
 <pl-hide-in-panel answer="true">
-<pl-overlay width=500 clip="false">
+<pl-overlay width="500" clip="false">
     <pl-background>
       <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion"></pl-figure>
     </pl-background>

--- a/exampleCourse/questions/demo/overlayMap/question.html
+++ b/exampleCourse/questions/demo/overlayMap/question.html
@@ -26,7 +26,7 @@
     </p>
 </pl-question-panel>
 
-<pl-overlay clip="false">
+<pl-overlay width="773" clip="false">
     <pl-background>
         <pl-figure file-name="us_states_blank.png" directory="clientFilesQuestion"></pl-figure>
     </pl-background>

--- a/exampleCourse/questions/workshop/Lesson3_example4_v2/question.html
+++ b/exampleCourse/questions/workshop/Lesson3_example4_v2/question.html
@@ -3,7 +3,7 @@
 Determine the output of the logic diagram below.
 </p>
 
-<pl-overlay width=410 clip="true">
+<pl-overlay width="410" clip="true">
     <pl-background>
       <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion"></pl-figure>
     </pl-background>

--- a/exampleCourse/questions/workshop/Lesson4_example2/question.html
+++ b/exampleCourse/questions/workshop/Lesson4_example2/question.html
@@ -5,7 +5,7 @@ Complete the empty boxes below with either $0$ or $1$ to obtain a correct logic 
 
 </pl-question-panel>
 
-<pl-overlay width=500 clip="false">
+<pl-overlay width="500" clip="false">
     <pl-background>
       <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion"></pl-figure>
     </pl-background>


### PR DESCRIPTION
#11097 reported that the `demo/overlayMap` question didn't work correctly at different screen sizes. This PR fixes that question and improves the documentation for `<pl-overlay>` to better reflect when an explicit width/height is needed.

Closes #11097.