### PR TITLE
Remove instructor links from assessment instance page if user has no access

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { escapeHtml, html } from '@prairielearn/html';
+import { run } from '@prairielearn/run';
 
 import { EditQuestionPointsScoreButton } from '../../components/EditQuestionPointsScore.html.js';
 import { HeadContents } from '../../components/HeadContents.html.js';
@@ -13,7 +14,6 @@ import { type InstanceLogEntry } from '../../lib/assessment.js';
 import { nodeModulesAssetPath, compiledScriptTag } from '../../lib/assets.js';
 import { AssessmentQuestionSchema, IdSchema, InstanceQuestionSchema } from '../../lib/db-types.js';
 import { formatFloat, formatPoints } from '../../lib/format.js';
-import { run } from '@prairielearn/run';
 
 export const AssessmentInstanceStatsSchema = z.object({
   assessment_instance_id: IdSchema,


### PR DESCRIPTION
As of #10591, the question preview page is not accessible for users without previewer permission in the course. The assessment instance page still had links that pointed to the preview page even if the user had no access to it. This PR removes those links to avoid confusion.