### PR TITLE
Cancel other workflows if the native check fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -379,7 +379,7 @@ jobs:
       - name: Run the TypeScript typechecker for tools
         run: make typecheck-tools
 
-      # This step after all other checks, since it is common for it to fail in
+      # This step runs after all other checks, since it is common for it to fail in
       # dependabot PRs, but we still want all other tests above to run
       # in those cases.
       - name: Check for duplicate Node dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -379,11 +379,17 @@ jobs:
       - name: Run the TypeScript typechecker for tools
         run: make typecheck-tools
 
-      # This step runs at the end, since it is common for it to fail in
+      # This step after all other checks, since it is common for it to fail in
       # dependabot PRs, but we still want all other tests above to run
       # in those cases.
       - name: Check for duplicate Node dependencies
         run: yarn dedupe --check
+
+      # If the native checks fail, we cancel all other jobs to avoid wasting
+      # resources.
+      - name: Cancelling parallel jobs
+        if: failure()
+        uses: andymckay/cancel-action@0.4
 
   report-image-sizes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Saves some minutes, since if the native checks fail, we should bail early.
- The action I used relies on the github API. https://github.com/andymckay/cancel-action