### PR TITLE
Build workspace images in parallel

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -47,6 +47,12 @@ jobs:
           METADATA_DIR: ${{ runner.temp }}/image-metadata-${{ inputs.group }}
           ONLY_CHANGED: true
 
+      - name: Export metadata
+        if: ${{ steps.check-modified.outputs.was-modified == 'true' }}
+        run: |
+          mkdir -p ${{ runner.temp }}/image-metadata
+          touch ${{ runner.temp }}/image-metadata/${{ matrix.image }}
+
       - name: Upload metadata
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}
         run: |
-          mkdir -p ${{ runner.temp }}/image-metadata
-          touch ${{ runner.temp }}/image-metadata/${{ matrix.image }}
+          mkdir -p ${{ runner.temp }}/image-metadata/${{ matrix.image }}
+          touch ${{ runner.temp }}/image-metadata/${{ matrix.image }}/${{ runner.arch }}
 
       - name: Upload metadata
         uses: actions/upload-artifact@v4

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -3,7 +3,7 @@ set -ex
 
 # If you need to rebuild this image without actually changing anything,
 # add a dot to the following line:
-# .
+# ..
 
 dnf update -y
 

--- a/scripts/check_path_modified.sh
+++ b/scripts/check_path_modified.sh
@@ -25,9 +25,11 @@ else
     DIFF_SOURCE="remotes/origin/master"
 fi
 
-if git diff --exit-code $DIFF_SOURCE..HEAD -- ${CHECK_PATH}; then
+if git diff --exit-code $DIFF_SOURCE..HEAD -- ${CHECK_PATH} && test -e ${CHECK_PATH}; then
     echo "${CHECK_PATH} files not modified"
+    echo "was-modified=false" >> $GITHUB_OUTPUT
 else
     echo "${CHECK_PATH} files modified"
     echo "${ENV_VAR}=true" >> $GITHUB_ENV
+    echo "was-modified=true" >> $GITHUB_OUTPUT
 fi

--- a/workspaces/vscode-base/Dockerfile
+++ b/workspaces/vscode-base/Dockerfile
@@ -51,10 +51,10 @@ RUN mkdir -p "/home/coder/workspace" "/home/coder/.local/share/code-server/User"
 WORKDIR "/home/coder/workspace"
 COPY --chmod=0644 --chown=coder:coder settings.json /home/coder/.local/share/code-server/User/
 
-# Prepare the entrypoint helper that steps down to a limited user in local dev mode
+# Prepare the entrypoint helper that steps down to a limited user in local dev mode.
 COPY --chmod=0755 --chown=root:root pl-gosu-helper.sh /usr/bin/
 
-# Make sure that code-server's entrypoint doesn't run fixuid unnecessarily
+# Make sure that code-server's entrypoint doesn't run fixuid unnecessarily.
 USER root
 RUN mkdir -p /run /var/run && \
     touch /run/fixuid.ran /var/run/fixuid.ran

--- a/workspaces/vscode-cpp/Dockerfile
+++ b/workspaces/vscode-cpp/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get upgrade -y \
 USER coder
 
 # After installing C/C++ we install some VS Code extensions.
-# codelldb is installed from a downloaded file because the open-vsx version of
+# Install codelldb from a downloaded file because the open-vsx version of
 # the extension downloads the latest version of the extension upon loading,
 # which would not be appropriate in a containerized environment with restricted
 # network access.


### PR DESCRIPTION
- Saves some time in the CI pipeline
- Will cancel the rest if one fails
Blocked on #11096 

- Should key off of `build-workspace-images-results` for checks on GitHub.