### PR TITLE
Update file editors to use formatJsonWithPrettier

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1989,11 +1989,11 @@ export class CourseInfoCreateEditor extends Editor {
     debug('CourseInfoEditor: write()');
     const infoPath = path.join(this.course.path, 'infoCourse.json');
 
-    // This will error if:
-    // - this.course.path does not exist (use of writeJson)
-    // - Creating a new file and infoPath does exist (use of 'wx')
-
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(this.infoJson));
+
+    // This will error if:
+    // - this.course.path does not exist (use of writeFile)
+    // - Creating a new file and infoPath does exist (use of 'wx')
     await fs.writeFile(infoPath, formattedJson, { flag: 'wx' });
 
     return {

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -637,7 +637,6 @@ export class AssessmentCopyEditor extends Editor {
     infoJson.uuid = this.uuid;
 
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
-
     await fs.writeFile(path.join(assessmentPath, 'infoAssessment.json'), formattedJson);
 
     return {
@@ -899,7 +898,6 @@ export class CourseInstanceCopyEditor extends Editor {
     infoJson.uuid = this.uuid;
 
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
-
     await fs.writeFile(path.join(courseInstancePath, 'infoCourseInstance.json'), formattedJson);
 
     return {
@@ -1230,7 +1228,6 @@ export class QuestionAddEditor extends Editor {
     delete infoJson.tags;
 
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
-
     await fs.writeFile(path.join(questionPath, 'info.json'), formattedJson);
 
     return {
@@ -1471,7 +1468,6 @@ export class QuestionCopyEditor extends Editor {
     delete infoJson['shareSourcePublicly'];
 
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
-
     await fs.writeFile(path.join(questionPath, 'info.json'), formattedJson);
 
     return {
@@ -1560,7 +1556,6 @@ export class QuestionTransferEditor extends Editor {
     delete infoJson['shareSourcePublicly'];
 
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
-
     await fs.writeFile(path.join(questionPath, 'info.json'), formattedJson);
 
     return {
@@ -1999,7 +1994,6 @@ export class CourseInfoCreateEditor extends Editor {
     // - Creating a new file and infoPath does exist (use of 'wx')
 
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(this.infoJson));
-
     await fs.writeFile(infoPath, formattedJson, { flag: 'wx' });
 
     return {

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -635,9 +635,10 @@ export class AssessmentCopyEditor extends Editor {
     debug('Write infoAssessment.json with new title and uuid');
     infoJson.title = assessmentTitle;
     infoJson.uuid = this.uuid;
-    await fs.writeJson(path.join(assessmentPath, 'infoAssessment.json'), infoJson, {
-      spaces: 4,
-    });
+
+    const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
+
+    await fs.writeFile(path.join(assessmentPath, 'infoAssessment.json'), formattedJson);
 
     return {
       pathsToAdd: [assessmentPath],
@@ -896,9 +897,10 @@ export class CourseInstanceCopyEditor extends Editor {
     debug('Write infoCourseInstance.json with new longName and uuid');
     infoJson.longName = names.longName;
     infoJson.uuid = this.uuid;
-    await fs.writeJson(path.join(courseInstancePath, 'infoCourseInstance.json'), infoJson, {
-      spaces: 4,
-    });
+
+    const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
+
+    await fs.writeFile(path.join(courseInstancePath, 'infoCourseInstance.json'), formattedJson);
 
     return {
       pathsToAdd: [courseInstancePath],
@@ -1226,7 +1228,10 @@ export class QuestionAddEditor extends Editor {
     infoJson.uuid = this.uuid;
     // The template question contains tags that shouldn't be copied to the new question.
     delete infoJson.tags;
-    await fs.writeJson(path.join(questionPath, 'info.json'), infoJson, { spaces: 4 });
+
+    const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
+
+    await fs.writeFile(path.join(questionPath, 'info.json'), formattedJson);
 
     return {
       pathsToAdd: [questionPath],
@@ -1465,7 +1470,9 @@ export class QuestionCopyEditor extends Editor {
     delete infoJson['sharePublicly'];
     delete infoJson['shareSourcePublicly'];
 
-    await fs.writeJson(path.join(questionPath, 'info.json'), infoJson, { spaces: 4 });
+    const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
+
+    await fs.writeFile(path.join(questionPath, 'info.json'), formattedJson);
 
     return {
       pathsToAdd: [questionPath],
@@ -1552,7 +1559,9 @@ export class QuestionTransferEditor extends Editor {
     delete infoJson['sharePublicly'];
     delete infoJson['shareSourcePublicly'];
 
-    await fs.writeJson(path.join(questionPath, 'info.json'), infoJson, { spaces: 4 });
+    const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
+
+    await fs.writeFile(path.join(questionPath, 'info.json'), formattedJson);
 
     return {
       pathsToAdd: [questionPath],
@@ -1988,7 +1997,10 @@ export class CourseInfoCreateEditor extends Editor {
     // This will error if:
     // - this.course.path does not exist (use of writeJson)
     // - Creating a new file and infoPath does exist (use of 'wx')
-    await fs.writeJson(infoPath, this.infoJson, { spaces: 4, flag: 'wx' });
+
+    const formattedJson = await formatJsonWithPrettier(JSON.stringify(this.infoJson));
+
+    await fs.writeFile(infoPath, formattedJson, { flag: 'wx' });
 
     return {
       pathsToAdd: [infoPath],


### PR DESCRIPTION
Based off this suggestion: https://github.com/PrairieLearn/PrairieLearn/pull/11117#discussion_r1909369992

- Adjusted editors to use `formatJsonWithPrettier` and `writeFile` instead of using `writeJson`.