### PR TITLE
Remove build-docs from ci Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,4 +100,4 @@ build-docs:
 	@/tmp/pldocs/venv/bin/python3 -m pip install -r docs/requirements.txt
 	@/tmp/pldocs/venv/bin/python3 -m mkdocs build --strict
 
-ci: lint typecheck check-dependencies test build-docs
+ci: lint typecheck check-dependencies test


### PR DESCRIPTION
As suggested by @trombonekenny in #11125. `build-docs` will fail unless `d2` is installed, and it isn't installed in the `prairielearn/prairielearn` image. We don't want to install `d2` there since we don't want that to become part of the "API" we offer to questions.

Closes #11125.