### PR TITLE
Fix RNG seeding in experimental question processor

### DIFF
--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -281,8 +281,8 @@ def worker_loop() -> None:
                 # be much faster than the current implementation that does an IPC
                 # call for each element.
 
-                data = args[0]
-                context = args[1]
+                context = args[0]
+                data = args[1]
 
                 result, processed_elements = question_phases.process(fcn, data, context)
                 val = {

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -525,7 +525,7 @@ async function experimentalProcess(phase, codeCaller, data, context, html) {
       context.question.directory,
       'question.html',
       phase,
-      [data, pythonContext],
+      [pythonContext, data],
     );
     result = res.result;
     output = res.output;


### PR DESCRIPTION
This was reported as an issue on Slack. In short, we weren't correctly seeding the random number generator when the `process-questions-in-worker` feature is turned on. This is because the RNG-seeding code assumes that the last thing in `args` will be the `data` object containing the `variant_seed`:

https://github.com/PrairieLearn/PrairieLearn/blob/ac67ff0eacefd4ed2ed730e72e758f2e6076f864/apps/prairielearn/python/zygote.py#L257-L267

However, when I implemented the experimental processor, I changed that convention and instead passed a different object as the last element in `args`.

For simplicity's sake, to fix this, I just swapped the order so that `data` would once again be the last thing.