### PR TITLE
Ruff: flake8-import-conventions, flake8-implicit-str-concat

### DIFF
--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import chevron
 import lxml.html
-import numpy
+import numpy as np
 import prairielearn as pl
 from typing_extensions import assert_never
 
@@ -167,7 +167,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 else:
                     a_sub_parsed = pl.from_json(a_sub)
                 a_sub_display = (
-                    numpy.base_repr(a_sub_parsed, base)
+                    np.base_repr(a_sub_parsed, base)
                     if base > 0
                     else data["raw_submitted_answers"].get(name, str(a_sub_parsed))
                 )
@@ -205,7 +205,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         if isinstance(a_tru, str):
             a_tru_str = a_tru
         else:
-            a_tru_str = numpy.base_repr(a_tru, base if base > 0 else 10)
+            a_tru_str = np.base_repr(a_tru, base if base > 0 else 10)
         html_params = {
             "answer": True,
             "label": label,
@@ -326,15 +326,15 @@ def test(element_html: str, data: pl.ElementTestData) -> None:
     result = data["test_type"]
     if result == "correct":
         if base > 0:
-            data["raw_submitted_answers"][name] = numpy.base_repr(a_tru_parsed, base)
+            data["raw_submitted_answers"][name] = np.base_repr(a_tru_parsed, base)
         elif random.choice([True, False]):
-            data["raw_submitted_answers"][name] = numpy.base_repr(a_tru_parsed, 10)
+            data["raw_submitted_answers"][name] = np.base_repr(a_tru_parsed, 10)
         else:
             # Use 0x format
             data["raw_submitted_answers"][name] = f"{a_tru_parsed:#x}"
         data["partial_scores"][name] = {"score": 1, "weight": weight}
     elif result == "incorrect":
-        data["raw_submitted_answers"][name] = numpy.base_repr(
+        data["raw_submitted_answers"][name] = np.base_repr(
             a_tru_parsed + (random.randint(1, 11) * random.choice([-1, 1])),
             base if base > 0 else 10,
         )

--- a/apps/prairielearn/elements/pl-python-variable/pl-python-variable.py
+++ b/apps/prairielearn/elements/pl-python-variable/pl-python-variable.py
@@ -1,7 +1,7 @@
 import pprint
 
 import lxml.html
-import pandas
+import pandas as pd
 import prairielearn as pl
 
 NO_HIGHLIGHT_DEFAULT = False
@@ -97,7 +97,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     var_out = pl.from_json(data["params"][varname])
 
     # Passthrough legacy support for pl-dataframe
-    if isinstance(var_out, pandas.DataFrame) and not force_text:
+    if isinstance(var_out, pd.DataFrame) and not force_text:
         return (
             f'<pl-dataframe params-name="{varname}" show-header="{show_header}" show-index="{show_index}" '
             f'show-dimensions="{show_dimensions}" show-python="false"></pl-dataframe>'

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -20,7 +20,7 @@ from typing import Any, Literal, TypedDict, TypeVar, overload
 import lxml.html
 import networkx as nx
 import numpy as np
-import pandas
+import pandas as pd
 import python_helper_sympy as phs
 import sympy
 import to_precision
@@ -306,7 +306,7 @@ def to_json(v, *, df_encoding_version=1, np_encoding_version=1):
             "_variables": s,
             "_shape": [num_rows, num_cols],
         }
-    elif isinstance(v, pandas.DataFrame):
+    elif isinstance(v, pd.DataFrame):
         if df_encoding_version == 1:
             return {
                 "_type": "dataframe",
@@ -435,7 +435,7 @@ def from_json(v):
                 and ("data" in v["_value"])
             ):
                 val = v["_value"]
-                return pandas.DataFrame(
+                return pd.DataFrame(
                     index=val["index"], columns=val["columns"], data=val["data"]
                 )
             else:
@@ -446,7 +446,7 @@ def from_json(v):
             # Convert native JSON back to a string representation so that
             # pandas read_json() can process it.
             value_str = StringIO(json.dumps(v["_value"]))
-            return pandas.read_json(value_str, orient="table")
+            return pd.read_json(value_str, orient="table")
         elif v["_type"] == "networkx_graph":
             return nx.adjacency_graph(v["_value"])
         else:

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -74,15 +74,14 @@ import random
 
 import chevron
 import lxml.html
-import matplotlib
-import matplotlib.font_manager
+import matplotlib as mpl
 import nltk
-import numpy
+import numpy as np
 import pint
 import prairielearn
 import sklearn
 
-matplotlib.use("PDF")
+mpl.use("PDF")
 
 # Construct initial unit registry to create initial cache file.
 prairielearn.get_unit_registry()
@@ -262,7 +261,7 @@ def worker_loop() -> None:
             if type(args[-1]) is dict and not seeded:
                 variant_seed = args[-1].get("variant_seed", None)
                 random.seed(variant_seed)
-                numpy.random.seed(variant_seed)
+                np.random.seed(variant_seed)
                 sys.meta_path.insert(0, FakerInitializeMetaPathFinder(variant_seed))
                 seeded = True
 

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/server.py
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/server.py
@@ -1,10 +1,10 @@
 import io
 
-import matplotlib as ml
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-ml.rcParams["text.usetex"] = True
+mpl.rcParams["text.usetex"] = True
 plt.rcParams.update({"font.size": 14})
 
 

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/server.py
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/server.py
@@ -1,11 +1,11 @@
 import io
 import random
 
-import matplotlib as ml
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
-ml.rcParams["text.usetex"] = True
+mpl.rcParams["text.usetex"] = True
 plt.rcParams.update({"font.size": 14})
 
 

--- a/exampleCourse/questions/demo/randomPlot/server.py
+++ b/exampleCourse/questions/demo/randomPlot/server.py
@@ -2,20 +2,20 @@ import io
 import random
 
 import matplotlib.pyplot as plt
-import numpy
+import numpy as np
 
 
 def file(data):
     if data["filename"] == "figure.png":
         # Create the figure
-        x = numpy.linspace(-5, 5)
+        x = np.linspace(-5, 5)
         f = data["params"]["m"] * x + data["params"]["b"]
         fig = plt.figure()
         plt.plot(x, f)
         plt.xticks([x for x in range(-5, 6, 1)], fontsize=14)
 
-        fmin = int(numpy.floor(min(f)) - 1)
-        fmax = int(numpy.ceil(max(f)) + 1)
+        fmin = int(np.floor(min(f)) - 1)
+        fmax = int(np.ceil(max(f)) + 1)
         if fmax - fmin > 12:
             plt.yticks([y for y in range(fmin, fmax + 4, 4)], fontsize=14)
             plt.gca().set_yticks([y for y in range(fmin, fmax + 1, 1)], minor=True)

--- a/exampleCourse/questions/gallery/includeFigure/complex/server.py
+++ b/exampleCourse/questions/gallery/includeFigure/complex/server.py
@@ -1,12 +1,12 @@
 import io
 import random
 
-import matplotlib as ml
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import sympy as sym
 
-ml.rcParams["text.usetex"] = True
+mpl.rcParams["text.usetex"] = True
 
 
 def func(x, a, b, c):

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -206,12 +206,12 @@ def execute_code(
             ):
                 plot_value = student_code[key]
         if not plot_value:
-            import matplotlib
+            import matplotlib as mpl
 
-            matplotlib.use("Agg")
-            import matplotlib.pyplot
+            mpl.use("Agg")
+            import matplotlib as mpl
 
-            plot_value = matplotlib.pyplot
+            plot_value = mpl.pyplot
 
     # Re-seed before running tests
     set_random_seed()

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -5,12 +5,12 @@ from collections import namedtuple
 from os.path import join
 
 # Needed to ensure matplotlib runs on Docker
-import matplotlib
+import matplotlib as mpl
 from code_feedback import Feedback
 from pl_execute import execute_code
 from pl_helpers import GradingSkipped, name, save_plot
 
-matplotlib.use("Agg")
+mpl.use("Agg")
 
 
 class PLTestCase(unittest.TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ select = [
     "PERF",
     # ruff-specific rules
     "RUF",
+    # flake8-import-conventions
+    "ICN",
+    # flake8-implicit-str-concat
+    "ISC",
     # refurb
     "FURB",
     # pylint
@@ -45,7 +49,9 @@ ignore = [
     # Ignore line length errors
     "E501",
     # if-else blocks that could be shortened (https://docs.astral.sh/ruff/rules/if-else-block-instead-of-if-exp/)
-    "SIM108"
+    "SIM108",
+    # Explicit string concatenation
+    "ISC003"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/testCourse/questions/differentiatePolynomial/server.py
+++ b/testCourse/questions/differentiatePolynomial/server.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import sympy
 
 
@@ -7,10 +7,10 @@ def generate(data):
     x = sympy.symbols("x")
 
     # Randomize the degree
-    degree = numpy.random.random_integers(1, 5)
+    degree = np.random.random_integers(1, 5)
 
     # Randomize the coefficients (make sure the leading coefficient is non-zero)
-    coeffs = numpy.random.random_integers(-9, 9, degree + 1)
+    coeffs = np.random.random_integers(-9, 9, degree + 1)
     if coeffs[0] == 0:
         coeffs[0] = 1
 


### PR DESCRIPTION
- Enforces imports of `pandas`, `matplotlib`, `numpy`.
- This PR also introduces the flake8-implicit-str-concat ruleset, which does not affect any of our code.
- All changes were automated