### PR TITLE
Ruff: misc ruff rules

### DIFF
--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -15,7 +15,7 @@ import uuid
 from collections.abc import Callable, Generator
 from enum import Enum
 from io import StringIO
-from typing import Any, Literal, TypedDict, TypeVar, overload
+from typing import Any, Literal, NamedTuple, TypedDict, TypeVar, overload
 
 import lxml.html
 import networkx as nx
@@ -1738,9 +1738,7 @@ def load_extension(data, extension_name):
     }
 
     # Return functions and variables as a namedtuple, so we get the nice dot access syntax
-    module_tuple = collections.namedtuple(
-        clean_identifier_name(extension_name), loaded.keys()
-    )
+    module_tuple = NamedTuple(clean_identifier_name(extension_name), loaded.keys())
     return module_tuple(**loaded)
 
 

--- a/apps/prairielearn/python/prairielearn.py
+++ b/apps/prairielearn/python/prairielearn.py
@@ -12,10 +12,11 @@ import re
 import string
 import unicodedata
 import uuid
+from collections import namedtuple
 from collections.abc import Callable, Generator
 from enum import Enum
 from io import StringIO
-from typing import Any, Literal, NamedTuple, TypedDict, TypeVar, overload
+from typing import Any, Literal, TypedDict, TypeVar, overload
 
 import lxml.html
 import networkx as nx
@@ -1738,7 +1739,7 @@ def load_extension(data, extension_name):
     }
 
     # Return functions and variables as a namedtuple, so we get the nice dot access syntax
-    module_tuple = NamedTuple(clean_identifier_name(extension_name), loaded.keys())
+    module_tuple = namedtuple(clean_identifier_name(extension_name), loaded.keys())  # noqa: PYI024
     return module_tuple(**loaded)
 
 

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -1,8 +1,8 @@
 import json
 import os
 import unittest
+from collections import namedtuple
 from os.path import join
-from typing import NamedTuple
 
 # Needed to ensure matplotlib runs on Docker
 import matplotlib as mpl
@@ -50,9 +50,9 @@ class PLTestCase(unittest.TestCase):
             cls.iter_num,
             cls.ipynb_key,
         )
-        answerTuple = NamedTuple("answerTuple", ref_result.keys())
+        answerTuple = namedtuple("answerTuple", ref_result.keys())  # noqa: PYI024
         cls.ref = answerTuple(**ref_result)
-        studentTuple = NamedTuple("studentTuple", student_result.keys())
+        studentTuple = namedtuple("studentTuple", student_result.keys())  # noqa: PYI024
         cls.st = studentTuple(**student_result)
         cls.plt = plot_value
         if cls.include_plt:

--- a/graders/python/python_autograder/pl_unit_test.py
+++ b/graders/python/python_autograder/pl_unit_test.py
@@ -1,8 +1,8 @@
 import json
 import os
 import unittest
-from collections import namedtuple
 from os.path import join
+from typing import NamedTuple
 
 # Needed to ensure matplotlib runs on Docker
 import matplotlib as mpl
@@ -50,9 +50,9 @@ class PLTestCase(unittest.TestCase):
             cls.iter_num,
             cls.ipynb_key,
         )
-        answerTuple = namedtuple("answerTuple", ref_result.keys())
+        answerTuple = NamedTuple("answerTuple", ref_result.keys())
         cls.ref = answerTuple(**ref_result)
-        studentTuple = namedtuple("studentTuple", student_result.keys())
+        studentTuple = NamedTuple("studentTuple", student_result.keys())
         cls.st = studentTuple(**student_result)
         cls.plt = plot_value
         if cls.include_plt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,27 @@ select = [
     # refurb
     "FURB",
     # pylint
-    "PLR5501"
+    "PLR5501",
+    # flake8-2020
+    "YTT",
+    # flake8-async
+    "ASYNC",
+    # flake8-datetimez
+    "DTZ",
+    # flake8-debugger
+    "T10",
+    # flake8-logging
+    "LOG",
+    # flake8-pyi
+    # "PYI",
+    # flake8-slots
+    "SLOT",
+    # flake8-gettext
+    "INT",
+    # pygrep-hooks
+    # "PGH",
+    # flynt
+    "FLY"
 ]
 ignore = [
     # Ignore line length errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,13 +57,11 @@ select = [
     # flake8-logging
     "LOG",
     # flake8-pyi
-    # "PYI",
+    "PYI",
     # flake8-slots
     "SLOT",
     # flake8-gettext
     "INT",
-    # pygrep-hooks
-    # "PGH",
     # flynt
     "FLY"
 ]


### PR DESCRIPTION
```
    # flake8-2020
    "YTT",
    # flake8-async
    "ASYNC",
    # flake8-datetimez
    "DTZ",
    # flake8-debugger
    "T10",
    # flake8-logging
    "LOG",
    # flake8-pyi
    "PYI",
    # flake8-slots
    "SLOT",
    # flake8-gettext
    "INT",
    # flynt
    "FLY"
 ```
 
 These rules barely affect us; but they felt useful to enable to catch future issues. Only `flake8-pyi` affects our codebase.