### PR TITLE
Launch file documentation for jupyterlab-python

### DIFF
--- a/workspaces/jupyterlab-python/README.md
+++ b/workspaces/jupyterlab-python/README.md
@@ -4,8 +4,8 @@ To automatically open a file on launch of this workspace, please use the `LAUNCH
 
 ```
 "environment": {
-      "LAUNCH_FILE_NAME": "some_file.ext"
-    }
+    "LAUNCH_FILE_NAME": "some_file.ext"
+}
 ```
 
 Replace `some_file.ext` with your file. It is expected that this file exists inside of the `/workspace` directory of the question. Please see the [workspaces documentation](https://prairielearn.readthedocs.io/en/latest/workspaces/) for more details on environment variable usage.

--- a/workspaces/jupyterlab-python/README.md
+++ b/workspaces/jupyterlab-python/README.md
@@ -1,0 +1,11 @@
+# workspace-jupyterlab-python
+
+To automatically open a file on launch of this workspace, please use the `LAUNCH_FILE_NAME` environment variable in your `info.json` as shown in the example below.
+
+```
+"environment": {
+      "LAUNCH_FILE_NAME": "some_file.ext"
+    }
+```
+
+Replace `some_file.ext` with your file. It is expected that this file exists inside of the `/workspace` directory of the question. Please see the [workspaces documentation](https://prairielearn.readthedocs.io/en/latest/workspaces/) for more details on environment variable usage.

--- a/workspaces/jupyterlab-python/README.md
+++ b/workspaces/jupyterlab-python/README.md
@@ -1,11 +1,16 @@
 # workspace-jupyterlab-python
 
-To automatically open a file on launch of this workspace, please use the `LAUNCH_FILE_NAME` environment variable in your `info.json` as shown in the example below.
+To automatically open a file when the workspace is started, set the `LAUNCH_FILE_NAME` environment variable in your question's `info.json`:
 
-```
-"environment": {
-    "LAUNCH_FILE_NAME": "some_file.ext"
+```json
+{
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-jupyterlab-python",
+    "environment": {
+      "LAUNCH_FILE_NAME": "some_file.ext"
+    }
+  }
 }
 ```
 
-Replace `some_file.ext` with your file. It is expected that this file exists inside of the `/workspace` directory of the question. Please see the [workspaces documentation](https://prairielearn.readthedocs.io/en/latest/workspaces/) for more details on environment variable usage.
+Replace `some_file.ext` with your file. It is expected that this file exists inside of the `/workspace` directory of the question. See the [workspaces documentation](https://prairielearn.readthedocs.io/en/latest/workspaces/) for more details on environment variable usage.


### PR DESCRIPTION
Adding in the missing documentation from #10596 explaining how to launch a file automatically when opening this workspace.

Please let me know if anything else should be included here whilst I am adding this file.