### PR TITLE
Remove ability to set API token via query parameter

### DIFF
--- a/apps/prairielearn/src/middlewares/authnToken.ts
+++ b/apps/prairielearn/src/middlewares/authnToken.ts
@@ -9,14 +9,9 @@ import * as Sentry from '@prairielearn/sentry';
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 export default asyncHandler(async (req, res, next) => {
-  let token: string | undefined;
-  if (req.query.private_token !== undefined) {
-    // Token was provided in a query param
-    token = req.query.private_token as string;
-  } else if (req.header('Private-Token') !== undefined) {
-    // Token was provided in a header
-    token = req.header('Private-Token');
-  } else {
+  const token = req.header('Private-Token');
+
+  if (token === undefined) {
     // No authentication token present
     res.status(401).send({
       message: 'An authentication token must be provided',

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,16 +12,10 @@ the section entitled "Personal Access Tokens", you can generate tokens for
 yourself. These tokens give you all the permissions that your normal user
 account has.
 
-You can provide your token via the `Private-Token` header:
+Provide your token via the `Private-Token` header:
 
 ```sh
 curl -H "Private-Token: TOKEN" https://us.prairielearn.com/pl/api/v1/<REST_OF_PATH>
-```
-
-You can also provide the token via a `private_token` query parameter:
-
-```sh
-curl https://us.prairielearn.com/pl/api/v1/<REST_OF_PATH>?private_token=TOKEN
 ```
 
 ## Example access script


### PR DESCRIPTION
Closes #5487. I confirmed via load balancer logs that no one has used this in the past month.