### PR TITLE
Use ulimit to avoid lsof hanging when Docker image runs on Ubuntu 24.10

### DIFF
--- a/docker/start_s3rver.sh
+++ b/docker/start_s3rver.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Ubuntu 24.10 needs help with ulimit,
+# cf https://github.com/amazonlinux/container-images/issues/123
+ulimit -Sn 4096
+
 # exit if s3rver is already running
 PID=$(lsof -i :5000 -t)
 if [ -n "$PID" ]; then

--- a/docker/start_s3rver.sh
+++ b/docker/start_s3rver.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Ubuntu 24.10 needs help with ulimit,
-# cf https://github.com/amazonlinux/container-images/issues/123
+# When the Docker image runs on an Ubuntu 24.10 host, `lsof` will hang and
+# prevent the container from starting. This is possibly a bug in the
+# `amazonlinux:2023` base image. See the following issue:
+# https://github.com/amazonlinux/container-images/issues/123
 ulimit -Sn 4096
 
 # exit if s3rver is already running


### PR DESCRIPTION
See the issue [123 in the amazonlinux repo](https://github.com/amazonlinux/container-images/issues/123) for context.  PR sets a `ulimit` in the one script `lsof` is called it, this unplugs an issue seen on Ubuntu 24.10 (and so far only on Ubuntu 24.10).