### PR TITLE
Revert bad type annotation in cgrader

### DIFF
--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -102,7 +102,7 @@ class CGrader:
         input: Any | None = None,  # noqa: A002
         sandboxed: bool = True,  # noqa: FBT001
         timeout: float | None = None,
-        env: subprocess._ENV | None = None,
+        env: Any | None = None,
     ) -> str:
         if isinstance(command, str):
             command = shlex.split(command)

--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -102,7 +102,7 @@ class CGrader:
         input: Any | None = None,  # noqa: A002
         sandboxed: bool = True,  # noqa: FBT001
         timeout: float | None = None,
-        env: Any | None = None,
+        env: dict[str, str] | None = None,
     ) -> str:
         if isinstance(command, str):
             command = shlex.split(command)


### PR DESCRIPTION
Tested with correctly tagged docker image.


![CleanShot 2025-01-14 at 22 21 02@2x](https://github.com/user-attachments/assets/07a08219-2a95-42d1-968e-d0e51547ecd2)
![CleanShot 2025-01-14 at 22 22 23@2x](https://github.com/user-attachments/assets/a729acb3-e2ab-4919-8ff1-b891aa4eeb56)


`docker build --platform linux/amd64 -t cgrader .`
