### PR TITLE
Fix regression with plots in Python grader

### DIFF
--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -205,13 +205,13 @@ def execute_code(
                 and student_code[key].__dict__["__name__"] == "matplotlib.pyplot"
             ):
                 plot_value = student_code[key]
+
         if not plot_value:
             import matplotlib as mpl
+            import matplotlib.pyplot as plt
 
             mpl.use("Agg")
-            import matplotlib as mpl
-
-            plot_value = mpl.pyplot
+            plot_value = plt
 
     # Re-seed before running tests
     set_random_seed()


### PR DESCRIPTION
#11142 introduced a regression here. `matplotlib.pyplot` must be imported before one can read it. The original code was written like this:

```py
            import matplotlib

            matplotlib.use("Agg")
            import matplotlib.pyplot

            plot_value = matplotlib.pyplot
```

However, that would cause some linter complaints, so I changed it slightly here. I think the new version is slightly clearer anyways.