### PR TITLE
Remove Bootstrap 4 backwards-compat

### DIFF
--- a/apps/prairielearn/assets/scripts/behaviors/popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/popover.ts
@@ -1,3 +1,4 @@
+import { type Popover } from 'bootstrap';
 import { on } from 'delegated-events';
 import { observe } from 'selector-observer';
 
@@ -5,10 +6,10 @@ import { focusFirstFocusableChild, onDocumentReady, trapFocus } from '@prairiele
 
 import { getPopoverContainerForTrigger, getPopoverTriggerForContainer } from '../lib/popover.js';
 
-const openPopoverTriggers = new Set<HTMLElement>();
+const openPopoverTriggers = new Set<Popover>();
 
 function closeOpenPopovers() {
-  openPopoverTriggers.forEach((popover) => $(popover).popover('hide'));
+  openPopoverTriggers.forEach((popover) => popover.hide());
   openPopoverTriggers.clear();
 }
 
@@ -19,13 +20,6 @@ function closeOpenPopovers() {
  * If the trigger mode cannot be determined, an empty array is returned.
  */
 function getPopoverTriggerModes(trigger: HTMLElement): string[] {
-  // Bootstrap 4 uses jQuery data to store popover configuration.
-  const config = $(trigger).data('bs.popover');
-  if (config) {
-    return config.config?.trigger?.split?.(' ') ?? [];
-  }
-
-  // Bootstrap 5 allows us to access the popover instance more directly.
   const instance = window.bootstrap?.Popover?.getInstance?.(trigger);
   if (instance) {
     return (instance as any)._config?.trigger?.split?.(' ') ?? [];
@@ -50,23 +44,10 @@ onDocumentReady(() => {
   observe('[data-toggle="popover"]', {
     constructor: HTMLElement,
     add(el) {
-      // We continue to use the jQuery interface to ensure compatibility with Bootstrap 4.
-      $(el).popover({ sanitize: false });
+      new window.bootstrap.Popover(el, { sanitize: false });
     },
     remove(el) {
-      // We continue to use the jQuery interface to ensure compatibility with Bootstrap 4.
-      $(el).popover('dispose');
-
-      // There can be race conditions when a popover trigger is removed where
-      // Bootstrap seems to lose track of the connection between the open popover
-      // and its trigger. To ensure that we aren't left with dangling popovers,
-      // we'll forcefully remove the popover container if it exists.
-      //
-      // TODO: Remove this once we're using the native Bootstrap 5 API.
-      const container = getPopoverContainerForTrigger(el);
-      if (container) {
-        container.remove();
-      }
+      window.bootstrap.Popover.getInstance(el)?.dispose();
     },
   });
 
@@ -80,7 +61,7 @@ onDocumentReady(() => {
     const trigger = getPopoverTriggerForContainer(popoverContainer);
     if (!trigger) return;
 
-    $(trigger).popover('hide');
+    window.bootstrap.Popover.getInstance(trigger)?.hide();
   });
 
   // Close open popovers if the user hits the escape key.
@@ -104,15 +85,14 @@ onDocumentReady(() => {
     closeOpenPopovers();
   });
 
-  // We continue to use the jQuery API for event handling to ensure compatibility with Bootstrap 4.
-
   // Hide other open popovers when a new popover is opened.
-  $(document.body).on('show.bs.popover', () => {
+  on('show.bs.popover', 'body', () => {
     closeOpenPopovers();
   });
 
-  $(document.body).on('inserted.bs.popover', (event) => {
-    const container = getPopoverContainerForTrigger(event.target);
+  on('inserted.bs.popover', 'body', (event) => {
+    const target = event.target as HTMLElement;
+    const container = getPopoverContainerForTrigger(target);
 
     // If MathJax is loaded on this page, attempt to typeset any math
     // that may be in the popover.
@@ -121,12 +101,15 @@ onDocumentReady(() => {
     }
   });
 
-  $(document.body).on('shown.bs.popover', (event) => {
+  on('shown.bs.popover', 'body', (event) => {
     const target = event.target as HTMLElement;
 
-    openPopoverTriggers.add(event.target);
+    const popoverInstance = window.bootstrap.Popover.getInstance(target);
+    if (popoverInstance) {
+      openPopoverTriggers.add(popoverInstance);
+    }
 
-    const container = getPopoverContainerForTrigger(event.target);
+    const container = getPopoverContainerForTrigger(target);
 
     // If the popover is focus-triggered, we'll skip the focus trap and
     // autofocus logic. If we move the focus off the trigger, the popover
@@ -138,9 +121,9 @@ onDocumentReady(() => {
       // Remove focus trap when this popover is ultimately hidden.
       const removeFocusTrap = () => {
         trap.deactivate();
-        $(target).off('hide.bs.popover', removeFocusTrap);
+        target.removeEventListener('hide.bs.popover', removeFocusTrap);
       };
-      $(target).on('hide.bs.popover', removeFocusTrap);
+      target.addEventListener('hide.bs.popover', removeFocusTrap);
 
       // Attempt to place focus on the correct item inside the popover.
       const popoverBody = container.querySelector('.popover-body') as HTMLElement;
@@ -148,7 +131,10 @@ onDocumentReady(() => {
     }
   });
 
-  $(document.body).on('hide.bs.popover', (event) => {
-    openPopoverTriggers.delete(event.target);
+  on('hide.bs.popover', 'body', (event) => {
+    const popoverInstance = window.bootstrap.Popover.getInstance(event.target as HTMLElement);
+    if (popoverInstance) {
+      openPopoverTriggers.delete(popoverInstance);
+    }
   });
 });

--- a/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
@@ -2,19 +2,13 @@ import { observe } from 'selector-observer';
 
 import { onDocumentReady } from '@prairielearn/browser-utils';
 
-// We need to wrap this in `onDocumentReady` because Bootstrap doesn't
-// add its jQuery API to the jQuery object until after this event.
-// `selector-observer` will start running its callbacks immediately, so they'd
-// otherwise execute too soon.
 onDocumentReady(() => {
   observe('[data-toggle="tooltip"]', {
     add(el) {
-      // We continue to use the jQuery interface to ensure compatibility with Bootstrap 4.
-      $(el).tooltip();
+      new window.bootstrap.Tooltip(el);
     },
     remove(el) {
-      // We continue to use the jQuery interface to ensure compatibility with Bootstrap 4.
-      $(el).tooltip('dispose');
+      window.bootstrap.Tooltip.getInstance(el)?.dispose();
     },
   });
 });

--- a/apps/prairielearn/assets/scripts/navbarClient.ts
+++ b/apps/prairielearn/assets/scripts/navbarClient.ts
@@ -12,23 +12,6 @@ onDocumentReady(() => {
   // The navbar is not present in some pages (e.g., workspace pages), in that case we do nothing.
   if (!usernameNav) return;
 
-  // Ideally we'd have HTMX listen for the `show.bs.dropdown` event, but
-  // Bootstrap 4 doesn't use native browser events. Once we upgrade to
-  // Bootstrap 5, we can update the HTMX trigger to use the native event.
-  $('#navbar-course-switcher').on('show.bs.dropdown', () => {
-    document
-      .getElementById('navbarDropdownMenuCourseAdminLink')
-      ?.dispatchEvent(new Event('show-course-switcher'));
-  });
-  $('#navbar-course-instance-switcher').on('show.bs.dropdown', () => {
-    document
-      .getElementById('navbarDropdownMenuInstanceAdminLink')
-      ?.dispatchEvent(new Event('show-course-instance-switcher'));
-    document
-      .getElementById('navbarDropdownMenuInstanceChooseLink')
-      ?.dispatchEvent(new Event('show-course-instance-switcher'));
-  });
-
   // Old cookies did not have a domain.
   const OldCookies = CookiesModule.withAttributes({
     path: '/',

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -278,7 +278,7 @@ a.badge {
 
 /* Supports a color accent at the tops of nav tabs, github-style */
 .nav-tabs.pl-nav-tabs-bar .nav-link.active {
-  border-top-color: var(--primary, var(--bs-primary));
+  border-top-color: var(--bs-primary);
   border-top-width: 0.2rem;
   padding-top: 0.4rem;
 }
@@ -503,13 +503,13 @@ small .user-output-invalid {
 .table > :not(caption) > * > .sticky-column {
   position: sticky;
   left: 0;
-  background-color: var(--bs-body-bg, white);
+  background-color: var(--bs-body-bg);
   background-clip: padding-box;
   box-shadow: inset -1px 0 #dee2e6;
 }
 
 .table.table-hover > tbody > tr:hover > td.sticky-column {
-  color: var(--bs-table-hover-color, #212529);
+  color: var(--bs-table-hover-color);
   /* This must be opaque, to ensure the cell shows on top of others.
      TODO: compute this value by combining --bs-body-bg (opaque) with --bs-table-hover-bg (semi-transparent). */
   background-color: #efefef;

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -648,7 +648,7 @@ function NavbarInstructor({
         aria-expanded="false"
         ${!authz_data.overrides
           ? html`
-              hx-get="/pl/navbar/course/${course.id}/switcher" hx-trigger="show-course-switcher once
+              hx-get="/pl/navbar/course/${course.id}/switcher" hx-trigger="show.bs.dropdown once
               delay:200ms" hx-target="#navbarDropdownMenuCourseAdmin"
             `
           : ''}
@@ -721,7 +721,7 @@ function NavbarInstructor({
               aria-haspopup="true"
               aria-expanded="false"
               hx-get="/pl/navbar/course/${course.id}/course_instance_switcher/${course_instance.id}"
-              hx-trigger="show-course-instance-switcher once delay:200ms"
+              hx-trigger="show.bs.dropdown once delay:200ms"
               hx-target="#navbarDropdownMenuInstanceAdmin"
             ></button>
             <div
@@ -814,7 +814,7 @@ function NavbarInstructor({
               aria-haspopup="true"
               aria-expanded="false"
               hx-get="/pl/navbar/course/${course.id}/course_instance_switcher"
-              hx-trigger="show-course-instance-switcher once delay:200ms"
+              hx-trigger="show.bs.dropdown once delay:200ms"
               hx-target="#navbarDropdownMenuInstanceChoose"
             >
               Choose course instance...

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -53,7 +53,7 @@ function LoginPageContainer({
           @media (min-width: 576px) {
             html,
             body {
-              background-color: var(--bs-dark, #212529);
+              background-color: var(--bs-dark);
             }
 
             .login-container-wrapper {

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -96,8 +96,7 @@ export function InstructorQuestionSettings({
           }
 
           .ts-wrapper.multi .ts-control > span.active {
-            /* Fallback for Bootstrap 4; we can remove when we drop support for it. */
-            background-color: var(--bs-primary, #0d6efd) !important;
+            background-color: var(--bs-primary) !important;
             color: white !important;
           }
         </style>

--- a/docs/dev-guide/index.md
+++ b/docs/dev-guide/index.md
@@ -103,7 +103,7 @@ In general we prefer simplicity. We standardize on JavaScript/TypeScript (Node.j
 
 ## HTML style
 
-- Use [Bootstrap](http://getbootstrap.com) as the style. As of 2024-06-05 we are using v4.
+- Use [Bootstrap](http://getbootstrap.com) as the style. As of 2025-01-01 we are using Bootstrap 5.
 
 - Local CSS rules go in `public/stylesheets/local.css`. Try to minimize use of this and use plain Bootstrap styling wherever possible.
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1160,7 +1160,7 @@ Displays question content within a card-styled component. Optionally displays a 
 
 #### Details
 
-The `pl-card` attributes mirror the options of [Bootstrap 4 cards](https://getbootstrap.com/docs/4.6/components/card/).
+The `pl-card` attributes mirror the options of [Bootstrap cards](https://getbootstrap.com/docs/5.3/components/card/).
 
 #### Example implementations
 


### PR DESCRIPTION
Part of #11088. This PR removes all code that made our application code backwards-compatible with Bootstrap 4. I tested these changes as follows:

- Popover changes were tested on the course instances page; there are two popover triggers in table headers, and I was able to test all the behavior with those (even focus traps, since they include focusable content).
- Tooltip changes were tested by opening an issue on a student instance of a question and then opening the manual grading page for that assessment question. There are tooltips to warn about the issue _and_ an open assessment instance, both of them work.
- Navbar changes were tested by navigating to a course and then opening the course and course instance switchers. Both work correctly.
- Table styling changes were tested on the "Students" tab of an assessment with an instance.
- Other styling changes were tested on their respective pages.

This does _not_ remove `apps/prairielearn/assets/scripts/behaviors/bootstrap-compat.ts`, which is necessary for _forwards_ compatibility of question/application code with Bootstrap 5.