### PR TITLE
Fix styling of SAML settings checkboxes

### DIFF
--- a/apps/prairielearn/assets/scripts/behaviors/bootstrap-compat.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/bootstrap-compat.ts
@@ -365,6 +365,7 @@ makeMigrator({
   selector: 'label',
   migrate(el, { addClass }) {
     if (el.closest('.form-group') == null) return;
+    if (el.classList.contains('form-check-label')) return;
 
     addClass(
       el,

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -171,10 +171,10 @@ ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICAT
                 aria-describedBy="validateAudienceHelp"
               />
               <label class="form-check-label" for="validate_audience">Validate audience</label>
-              <small id="validateAudienceHelp" class="form-text text-muted mt-0">
+              <div id="validateAudienceHelp" class="small text-muted">
                 Whether or not to validate the audience of the SAML response. This should be enabled
                 unless the Identity Provider doesn't send a correct value for the audience.
-              </small>
+              </div>
             </div>
 
             <div class="form-group form-check">
@@ -190,10 +190,10 @@ ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICAT
               <label class="form-check-label" for="want_assertions_signed">
                 Require signed assertions
               </label>
-              <small id="wantAssertionsSignedHelp" class="form-text text-muted mt-0">
+              <div id="wantAssertionsSignedHelp" class="small text-muted">
                 Whether or not to require that assertions are signed. This should be enabled unless
                 the Identity Provider doesn't sign assertions.
-              </small>
+              </div>
             </div>
 
             <div class="form-group form-check">
@@ -209,10 +209,10 @@ ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICAT
               <label class="form-check-label" for="want_authn_response_signed">
                 Require signed response
               </label>
-              <small id="wantAuthnResponseSignedHelp" class="form-text text-muted mt-0">
+              <div id="wantAuthnResponseSignedHelp" class="small text-muted">
                 Whether or not to require that the response is signed. This should be enabled unless
                 the Identity Provider doesn't sign responses.
-              </small>
+              </div>
             </div>
 
             <h3 class="h5">Attribute mappings</h3>


### PR DESCRIPTION
This doesn't really matter, but I frequently use these pages to copy/paste things from, so I want to make sure they're demonstrating the right way to do things.

Before:

<img width="455" alt="Screenshot 2025-01-16 at 10 14 57" src="https://github.com/user-attachments/assets/8cba639c-c6f1-464a-a6a8-273a7112a8f5" />

After:

<img width="549" alt="Screenshot 2025-01-16 at 10 14 35" src="https://github.com/user-attachments/assets/cc0e2fb7-fdd4-4d12-98cd-f31d24958768" />

I also updated the Bootstrap 5 compat script to avoid adding a `form-label` class to a `<label>` if the `form-check-label` class was already present.