### PR TITLE
enforce snippets exist

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,8 @@ markdown_extensions:
 
   - tables
   # https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#snippets
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      check_paths: true
   - pymdownx.details
 
   - toc:


### PR DESCRIPTION
Changes option on https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options

> If a snippet declaration is processed, and the specified file cannot be found, then the markup will be removed.

To

> Make the build fail if a snippet can't be found.
