### PR TITLE
Pyright: Invert rules, execution environments

### DIFF
--- a/apps/prairielearn/python/python_helper_sympy/__init__.py
+++ b/apps/prairielearn/python/python_helper_sympy/__init__.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedImport=false
 # WARNING: This file is deprecated and will be removed in the future.
 # Please import from prairielearn.sympy_utils instead.
 

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedImport=false
+
 # This program is the glue between python-runner JavaScript code and Python code
 #
 # It will enter an infinite loop waiting for input. For each input, it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,16 @@ exclude = [
 ]
 extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
+executionEnvironments = [
+    { root = "./graders/python", pythonVersion = "3.12" },
+    { root = "./graders/c", pythonVersion = "3.12" }
+]
 reportUnnecessaryTypeIgnoreComment = "error"
+reportUnknownMemberType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"
+reportUnknownParameterType = "none"
+typeCheckingMode = "strict"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ exclude = [
 extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
 executionEnvironments = [
+    # TODO: after https://github.com/tamasfe/taplo/issues/332, split with newlines
     { root = "./graders/python", pythonVersion = "3.12", reportUntypedNamedTuple = "none", reportUntypedFunctionDecorator = "none", reportUnnecessaryComparison = "none", reportUnnecessaryIsInstance = "none" },
     { root = "./graders/c", pythonVersion = "3.12", reportArgumentType = "none", reportOperatorIssue = "none", reportAttributeAccessIssue = "none", reportIndexIssue = "none", reportCallIssue = "none" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ exclude = [
 ]
 
 [tool.pyright]
+typeCheckingMode = "strict"
 include = [
     "./apps/prairielearn/elements",
     "./apps/prairielearn/python",
@@ -112,15 +113,33 @@ exclude = [
 extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
 executionEnvironments = [
-    { root = "./graders/python", pythonVersion = "3.12" },
-    { root = "./graders/c", pythonVersion = "3.12" }
+    { root = "./graders/python", pythonVersion = "3.12", reportUntypedNamedTuple = "none", reportUntypedFunctionDecorator = "none", reportUnnecessaryComparison = "none", reportUnnecessaryIsInstance = "none" },
+    { root = "./graders/c", pythonVersion = "3.12", reportArgumentType = "none", reportOperatorIssue = "none", reportAttributeAccessIssue = "none", reportIndexIssue = "none", reportCallIssue = "none" },
 ]
 reportUnnecessaryTypeIgnoreComment = "error"
+# These rules would require significant changes
 reportUnknownMemberType = "none"
 reportUnknownArgumentType = "none"
 reportUnknownVariableType = "none"
 reportUnknownParameterType = "none"
-typeCheckingMode = "strict"
+reportMissingTypeStubs = "none"
+# These rules don't provide much value
+reportPrivateUsage = "none"
+reportUnnecessaryIsInstance = "none"
+# These rules can be enabled alongside typing improvements
+reportUnknownLambdaType = "none"
+reportUnusedVariable = "none"
+reportMissingParameterType = "none"
+reportMissingTypeArgument = "none"
+reportArgumentType = "none"
+# These rules indicate that the code can be improved
+reportAttributeAccessIssue = "information"
+reportOperatorIssue = "information"
+reportUnnecessaryComparison = "information"
+reportIndexIssue = "information"
+reportCallIssue = "information"
+reportUntypedNamedTuple = "information"
+reportUnnecessaryCast = "information"
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
- Enables `typeCheckingMode = "strict"`
- Silences most strict rules
- Allows for incremental type improvements
- Adds a separate `3.12` execution environment for the graders