### PR TITLE
Show AI question generation in questions table empty state

### DIFF
--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -239,12 +239,29 @@ export function QuestionsTable({
                   >question documentation</a
                 >.
               </p>
-              <form class="ml-1 btn-group" method="POST">
-                <button class="btn btn-sm btn-primary">
-                  <i class="fa fa-plus" aria-hidden="true"></i>
-                  <span>Add question</span>
-                </button>
-              </form>
+              ${showAddQuestionButton
+                ? html`
+                    <div class="d-flex flex-row flex-wrap justify-content-center gap-3">
+                      <form class="ml-1 btn-group" method="POST">
+                        <button class="btn btn-sm btn-primary">
+                          <i class="fa fa-plus" aria-hidden="true"></i>
+                          Add question
+                        </button>
+                      </form>
+                      ${showAiGenerateQuestionButton
+                        ? html`
+                            <a
+                              class="btn btn-sm btn-primary"
+                              href="${urlPrefix}/ai_generate_question_drafts"
+                            >
+                              <i class="fa fa-wand-magic-sparkles" aria-hidden="true"></i>
+                              Generate question with AI
+                            </a>
+                          `
+                        : ''}
+                    </div>
+                  `
+                : ''}
             </div>
           `}
     </div>


### PR DESCRIPTION
Complements #11184 by providing a way to get to the draft questions page even when there are no other non-draft questions in the course.

<img width="662" alt="Screenshot 2025-01-21 at 16 45 22" src="https://github.com/user-attachments/assets/57e081ba-5eb1-4e4f-b878-b6a1e1d6d50a" />

This will also be useful once we turn this feature on more widely; people can create their very first question with AI!