### PR TITLE
Merge database and config courses for dev load from disk

### DIFF
--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.sql
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.sql
@@ -1,0 +1,7 @@
+-- BLOCK select_all_courses
+SELECt
+  *
+FROM
+  pl_courses
+WHERE
+  deleted_at IS NULL;

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.sql
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.sql
@@ -4,4 +4,6 @@ SELECT
 FROM
   pl_courses
 WHERE
-  deleted_at IS NULL;
+  deleted_at IS NULL
+ORDER BY
+  id ASC;

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.sql
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.sql
@@ -1,5 +1,5 @@
 -- BLOCK select_all_courses
-SELECt
+SELECT
   *
 FROM
   pl_courses

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
@@ -29,6 +29,11 @@ async function update(locals: Record<string, any>) {
     let anyCourseHadJsonErrors = false;
 
     // Merge the list of courses in the config with the list of courses in the database.
+    // We use a set to ensure that we don't double-count courses that are both
+    // in the config and in the database.
+    //
+    // A set also maintains insertion order, which ensures that courses that are
+    // listed in the config (and listed earlier in the config) are synced first.
     const courseDirs = new Set<string>(config.courseDirs);
     const courses = await queryRows(sql.select_all_courses, CourseSchema);
     courses.forEach((course) => courseDirs.add(course.path));

--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
@@ -5,13 +5,17 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 
+import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+
 import { chalk } from '../../lib/chalk.js';
 import { updateChunksForCourse, logChunkChangesToJob } from '../../lib/chunks.js';
 import { config } from '../../lib/config.js';
+import { CourseSchema } from '../../lib/db-types.js';
 import { REPOSITORY_ROOT_PATH } from '../../lib/paths.js';
 import { createServerJob } from '../../lib/server-jobs.js';
 import * as syncFromDisk from '../../sync/syncFromDisk.js';
 
+const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
 
 async function update(locals: Record<string, any>) {
@@ -23,7 +27,13 @@ async function update(locals: Record<string, any>) {
 
   serverJob.executeInBackground(async (job) => {
     let anyCourseHadJsonErrors = false;
-    await async.eachOfSeries(config.courseDirs || [], async (courseDir, index) => {
+
+    // Merge the list of courses in the config with the list of courses in the database.
+    const courseDirs = new Set<string>(config.courseDirs);
+    const courses = await queryRows(sql.select_all_courses, CourseSchema);
+    courses.forEach((course) => courseDirs.add(course.path));
+
+    await async.eachOfSeries(Array.from(courseDirs), async (courseDir, index) => {
       courseDir = path.resolve(REPOSITORY_ROOT_PATH, courseDir);
       job.info(chalk.bold(courseDir));
       const infoCourseFile = path.join(courseDir, 'infoCourse.json');


### PR DESCRIPTION
Complements #11184, lifting this change out of that PR. This ensures that any courses that were dynamically inserted into the database are synced via the "Load from disk" button in local dev. Previously, only courses explicitly listed in `config.json` would have been loaded.