### PR TITLE
Fix name of AiQuestionGenerationPromptSchema

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.html.ts
@@ -6,7 +6,7 @@ import { Modal } from '../../../components/Modal.html.js';
 import { Navbar } from '../../../components/Navbar.html.js';
 import { QuestionContainer } from '../../../components/QuestionContainer.html.js';
 import { compiledScriptTag, nodeModulesAssetPath } from '../../../lib/assets.js';
-import { type Question, type AiGenerationPrompt } from '../../../lib/db-types.js';
+import { type Question, type AiQuestionGenerationPrompt } from '../../../lib/db-types.js';
 
 export function InstructorAiGenerateDraftEditor({
   resLocals,
@@ -15,7 +15,7 @@ export function InstructorAiGenerateDraftEditor({
   variantId,
 }: {
   resLocals: Record<string, any>;
-  prompts: AiGenerationPrompt[];
+  prompts: AiQuestionGenerationPrompt[];
   question: Question;
   variantId?: string | undefined;
 }) {
@@ -155,7 +155,7 @@ function PromptHistory({
   prompts,
   urlPrefix,
 }: {
-  prompts: AiGenerationPrompt[];
+  prompts: AiQuestionGenerationPrompt[];
   urlPrefix: string;
 }) {
   return prompts

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -8,7 +8,7 @@ import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 import { config } from '../../../lib/config.js';
 import { setQuestionCopyTargets } from '../../../lib/copy-question.js';
 import { getCourseFilesClient } from '../../../lib/course-files-api.js';
-import { AiGenerationPromptSchema, IdSchema } from '../../../lib/db-types.js';
+import { AiQuestionGenerationPromptSchema, IdSchema } from '../../../lib/db-types.js';
 import { features } from '../../../lib/features/index.js';
 import { idsEqual } from '../../../lib/id.js';
 import { getAndRenderVariant, setRendererHeader } from '../../../lib/question-render.js';
@@ -102,7 +102,7 @@ router.get(
         question_id: req.params.question_id,
         course_id: res.locals.course.id,
       },
-      AiGenerationPromptSchema,
+      AiQuestionGenerationPromptSchema,
     );
 
     if (prompts.length === 0) {
@@ -169,7 +169,7 @@ router.post(
           question_id: req.params.question_id,
           course_id: res.locals.course.id,
         },
-        AiGenerationPromptSchema,
+        AiQuestionGenerationPromptSchema,
       );
 
       if (prompts.length < 1) {
@@ -209,7 +209,7 @@ router.post(
           question_id: question.id,
           course_id: res.locals.course.id,
         },
-        AiGenerationPromptSchema,
+        AiQuestionGenerationPromptSchema,
       );
 
       if (prompts.length === 0) {

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -500,7 +500,7 @@ export const FileEditSchema = z.object({
 });
 export type FileEdit = z.infer<typeof FileEditSchema>;
 
-export const AiGenerationPromptSchema = z.object({
+export const AiQuestionGenerationPromptSchema = z.object({
   completion: z.any(),
   system_prompt: z.string().nullable(),
   errors: z.array(z.string()),
@@ -515,7 +515,7 @@ export const AiGenerationPromptSchema = z.object({
   job_sequence_id: z.string().nullable(),
 });
 
-export type AiGenerationPrompt = z.infer<typeof AiGenerationPromptSchema>;
+export type AiQuestionGenerationPrompt = z.infer<typeof AiQuestionGenerationPromptSchema>;
 
 export const FileTransferSchema = z.object({
   created_at: DateFromISOString,


### PR DESCRIPTION
Lifting this out of #11184. Conventionally, these schemas/types should match the underlying table name.