### PR TITLE
pyright: add rule improvements

### DIFF
--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -148,17 +148,15 @@ def get_formatter(
             highlight_lines_color or BaseStyle.highlight_color or "#b3d7ff"
         )
 
-    formatter_opts = {
-        "style": CustomStyleWithAnsiColors,
-        "nobackground": True,
-        "noclasses": True,
+    return HighlightingHtmlFormatter(
+        style=CustomStyleWithAnsiColors,
+        nobackground=True,
+        noclasses=True,
         # We'll unconditionally render the line numbers, but we'll hide them if
         # they aren't specifically enabled. This means we only have to deal with
         # one markup "shape" in our CSS, not two.
-        "linenos": "table",
-    }
-
-    return HighlightingHtmlFormatter(**formatter_opts)
+        linenos="table",
+    )
 
 
 def prepare(element_html: str, data: pl.QuestionData) -> None:

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -1789,7 +1789,7 @@ def load_extension(data: QuestionData, extension_name: str) -> Any:
     }
 
     # Return functions and variables as a namedtuple, so we get the nice dot access syntax
-    module_tuple = namedtuple(clean_identifier_name(extension_name), loaded.keys())  # noqa: PYI024
+    module_tuple = namedtuple(clean_identifier_name(extension_name), loaded.keys())  # noqa: PYI024 # pyright: ignore[reportUntypedNamedTuple]
     return module_tuple(**loaded)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,19 +127,13 @@ reportMissingTypeStubs = "none"
 # These rules don't provide much value
 reportPrivateUsage = "none"
 reportUnnecessaryIsInstance = "none"
-# These rules can be enabled alongside typing improvements
 reportUnknownLambdaType = "none"
+# These rules can be enabled alongside typing / code improvements
 reportUnusedVariable = "none"
 reportMissingParameterType = "none"
 reportMissingTypeArgument = "none"
 reportArgumentType = "none"
-# These rules indicate that the code can be improved
-reportAttributeAccessIssue = "information"
-reportOperatorIssue = "information"
 reportUnnecessaryComparison = "information"
-reportIndexIssue = "information"
-reportCallIssue = "information"
-reportUntypedNamedTuple = "information"
 reportUnnecessaryCast = "information"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
- Makes pyright rules stricter
- pl-code change wasn't tested, but the constructor unpacks with `**options` so it seems unlikely to break it?