### PR TITLE
Fix backwards compatibility with legacy question functions

### DIFF
--- a/apps/prairielearn/python/prairielearn/internal/question_phases.py
+++ b/apps/prairielearn/python/prairielearn/internal/question_phases.py
@@ -8,9 +8,10 @@ from inspect import signature
 from typing import Any, Literal, TypedDict
 
 import lxml.html
+from typing_extensions import assert_never
+
 from prairielearn.internal.check_data import Phase, check_data
 from prairielearn.internal.traverse import traverse_and_execute, traverse_and_replace
-from typing_extensions import assert_never
 
 PYTHON_PATH = pathlib.Path(__file__).parent.parent.parent.resolve()
 CORE_ELEMENTS_PATH = (PYTHON_PATH.parent / "elements").resolve()

--- a/apps/prairielearn/python/prairielearn/internal/question_phases.py
+++ b/apps/prairielearn/python/prairielearn/internal/question_phases.py
@@ -150,12 +150,7 @@ def process(
             # The second argument is `element_index`; we'll pass `None`. This is
             # consistent with the same backwards-compatibility logic in `zygote.py`.
             arg_names = list(signature(mod[phase]).parameters.keys())
-            if (
-                len(arg_names) == 3
-                and arg_names[0] == "element_html"
-                and arg_names[1] == "element_index"
-                and arg_names[2] == "data"
-            ):
+            if arg_names == ["element_html", "element_index", "data"]:
                 args.insert(1, None)
 
             element_value = mod[phase](*args)

--- a/apps/prairielearn/python/prairielearn/internal/question_phases.py
+++ b/apps/prairielearn/python/prairielearn/internal/question_phases.py
@@ -4,13 +4,13 @@ import io
 import os
 import pathlib
 import sys
+from inspect import signature
 from typing import Any, Literal, TypedDict
 
 import lxml.html
-from typing_extensions import assert_never
-
 from prairielearn.internal.check_data import Phase, check_data
 from prairielearn.internal.traverse import traverse_and_execute, traverse_and_replace
+from typing_extensions import assert_never
 
 PYTHON_PATH = pathlib.Path(__file__).parent.parent.parent.resolve()
 CORE_ELEMENTS_PATH = (PYTHON_PATH.parent / "elements").resolve()
@@ -143,7 +143,21 @@ def process(
             temp_tail = element.tail
             element.tail = None
 
-            element_value = mod[phase](lxml.html.tostring(element), data)
+            args = [lxml.html.tostring(element), data]
+
+            # We need to support legacy element functions, which take three arguments.
+            # The second argument is `element_index`; we'll pass `None`. This is
+            # consistent with the same backwards-compatibility logic in `zygote.py`.
+            arg_names = list(signature(mod[phase]).parameters.keys())
+            if (
+                len(arg_names) == 3
+                and arg_names[0] == "element_html"
+                and arg_names[1] == "element_index"
+                and arg_names[2] == "data"
+            ):
+                args.insert(1, None)
+
+            element_value = mod[phase](*args)
 
             # Restore the tail text.
             element.tail = temp_tail

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -326,12 +326,7 @@ def worker_loop() -> None:
                 # check if the desired function is a legacy element function - if
                 # so, we add an argument for element_index
                 arg_names = list(signature(method).parameters.keys())
-                if (
-                    len(arg_names) == 3
-                    and arg_names[0] == "element_html"
-                    and arg_names[1] == "element_index"
-                    and arg_names[2] == "data"
-                ):
+                if arg_names == ["element_html", "element_index", "data"]:
                     args.insert(1, None)
 
                 # call the desired function in the loaded module


### PR DESCRIPTION
We have this same little snippet in `zygote.py`:

https://github.com/PrairieLearn/PrairieLearn/blob/65fb2c39a51c69508d94ff9149f324fb0f77969d/apps/prairielearn/python/zygote.py#L326-L335

We neglected to carry over this behavior into the new question processor, which caused problems with courses that were using ancient custom elements.

I tested this by changing the `pl-number-input` implementation to include the other parameter. I confirmed that it was broken without this change and worked correctly after this change.