### PR TITLE
Update new question processor data validation to match old one

### DIFF
--- a/apps/prairielearn/python/prairielearn/internal/question_phases.py
+++ b/apps/prairielearn/python/prairielearn/internal/question_phases.py
@@ -158,7 +158,18 @@ def process(
             # Restore the tail text.
             element.tail = temp_tail
 
-            check_data(original_data, data, phase)
+            if phase not in ("render", "file"):
+                # For legacy reasons, we don't validate `data` during the,
+                # `render` or `file` phases, since the old question processor
+                # didn't either. These phases will never produce new data
+                # that's stored anywhere, so this should technically be fine,
+                # though the lack of an error could mislead instructors into
+                # thinking that any changed data will be persisted.
+                #
+                # TODO: Once we have a system for reporting warnings to instructors,
+                # we should restore this check and emit a warning if it fails.
+                # See https://github.com/PrairieLearn/PrairieLearn/issues/7337
+                check_data(original_data, data, phase)
 
             # Clean up changes to `data` and `original_data` for the next iteration.
             restore_data(data)


### PR DESCRIPTION
In the old question processor, we don't check `data` during either `render()` or `file()`:

https://github.com/PrairieLearn/PrairieLearn/blob/97a877d300df072c2c3dcd7c04f93c2cc503653f/apps/prairielearn/src/question-servers/freeform.js#L612-L647

This PR updates the new one to match this behavior for backwards compatibility.