### PR TITLE
Make multi-part file edits atomic

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -593,7 +593,7 @@ export class AssessmentCopyEditor extends Editor {
 
     super({
       ...params,
-      description: `${course_instance.short_name}: copy assessment ${assessment.tid}`,
+      description: `${course_instance.short_name}: Copy assessment ${assessment.tid}`,
     });
 
     this.assessment = assessment;
@@ -668,7 +668,7 @@ export class AssessmentDeleteEditor extends Editor {
 
     super({
       ...params,
-      description: `${course_instance.short_name}: delete assessment ${assessment.tid}`,
+      description: `${course_instance.short_name}: Delete assessment ${assessment.tid}`,
     });
 
     this.course_instance = course_instance;
@@ -710,7 +710,7 @@ export class AssessmentRenameEditor extends Editor {
 
     super({
       ...params,
-      description: `${course_instance.short_name}: rename assessment ${assessment.tid}`,
+      description: `${course_instance.short_name}: Rename assessment ${assessment.tid}`,
     });
 
     this.tid_new = params.tid_new;
@@ -785,7 +785,7 @@ export class AssessmentAddEditor extends Editor {
 
     super({
       ...params,
-      description: `${course_instance.short_name}: add assessment`,
+      description: `${course_instance.short_name}: Add assessment`,
     });
 
     this.course_instance = course_instance;
@@ -1747,7 +1747,7 @@ export class FileDeleteEditor extends Editor {
 
     super({
       ...params,
-      description: `${prefix}delete ${path.relative(container.rootPath, deletePath)}`,
+      description: `${prefix}Delete ${path.relative(container.rootPath, deletePath)}`,
     });
 
     this.container = container;
@@ -1830,7 +1830,7 @@ export class FileRenameEditor extends Editor {
 
     super({
       ...params,
-      description: `${prefix}rename ${relativeOldPath} to ${relativeNewPath}`,
+      description: `${prefix}Rename ${relativeOldPath} to ${relativeNewPath}`,
     });
 
     this.container = container;
@@ -1948,7 +1948,7 @@ export class FileUploadEditor extends Editor {
     }
     super({
       ...params,
-      description: `${prefix}upload ${path.relative(container.rootPath, params.filePath)}`,
+      description: `${prefix}Upload ${path.relative(container.rootPath, params.filePath)}`,
     });
 
     this.container = container;
@@ -2083,7 +2083,7 @@ export class FileModifyEditor extends Editor {
 
     super({
       ...params,
-      description: `${prefix}modify ${path.relative(container.rootPath, filePath)}`,
+      description: `${prefix}Modify ${path.relative(container.rootPath, filePath)}`,
     });
 
     this.container = container;

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -2211,6 +2211,10 @@ export class MultiEditor extends Editor {
   }
 
   assertCanEdit() {
+    // This should be handled automatically by the individual editors, but
+    // we'll check it here just in case.
+    this.assertCanEdit();
+
     for (const editor of this.editors) {
       editor.assertCanEdit();
     }

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1482,6 +1482,9 @@ export class QuestionRenameEditor extends Editor {
     const oldPath = path.join(questionsPath, this.question.qid);
     const newPath = path.join(questionsPath, this.qid_new);
 
+    // Skip editing if the paths are the same.
+    if (oldPath === newPath) return null;
+
     // Ensure that the updated question folder path is fully contained in the questions directory
     if (!contains(questionsPath, newPath)) {
       throw new AugmentedError('Invalid folder path', {
@@ -2213,7 +2216,7 @@ export class MultiEditor extends Editor {
   assertCanEdit() {
     // This should be handled automatically by the individual editors, but
     // we'll check it here just in case.
-    this.assertCanEdit();
+    super.assertCanEdit();
 
     for (const editor of this.editors) {
       editor.assertCanEdit();

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -2204,11 +2204,8 @@ export class CourseInfoCreateEditor extends Editor {
 export class MultiEditor extends Editor {
   private editors: Editor[];
 
-  constructor(params: BaseEditorOptions, editors: Editor[]) {
-    super({
-      ...params,
-      description: editors.map((editor) => editor.description).join('; '),
-    });
+  constructor(params: BaseEditorOptions & { description: string }, editors: Editor[]) {
+    super(params);
 
     this.editors = editors;
   }

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1375,18 +1375,22 @@ export class QuestionModifyEditor extends Editor {
   private files: Record<string, string>;
 
   constructor(
-    params: BaseEditorOptions & {
+    params: BaseEditorOptions<{ question: Question }> & {
       files: Record<string, string>;
     },
   ) {
+    const {
+      locals: { question },
+      files,
+    } = params;
+
     super({
       ...params,
-      description: `Modify question ${params.locals.question.qid}`,
+      description: `Modify question ${question.qid}`,
     });
 
-    this.question = params.locals.question;
-    this.files = params.files;
-    this.description = `Modify question ${this.question.qid}`;
+    this.question = question;
+    this.files = files;
   }
 
   async write() {
@@ -1422,11 +1426,15 @@ export class QuestionModifyEditor extends Editor {
 export class QuestionDeleteEditor extends Editor {
   private question: Question;
 
-  constructor(params: BaseEditorOptions) {
-    super(params);
+  constructor(params: BaseEditorOptions<{ question: Question }>) {
+    const { question } = params.locals;
 
-    this.question = params.locals.question;
-    this.description = `Delete question ${this.question.qid}`;
+    super({
+      ...params,
+      description: `Delete question ${question.qid}`,
+    });
+
+    this.question = question;
   }
 
   async write() {
@@ -1450,12 +1458,19 @@ export class QuestionRenameEditor extends Editor {
   private qid_new: string;
   private question: Question;
 
-  constructor(params: BaseEditorOptions & { qid_new: string }) {
-    super(params);
+  constructor(params: BaseEditorOptions<{ question: Question }> & { qid_new: string }) {
+    const {
+      locals: { question },
+      qid_new,
+    } = params;
 
-    this.qid_new = params.qid_new;
-    this.question = params.locals.question;
-    this.description = `Rename question ${this.question.qid}`;
+    super({
+      ...params,
+      description: `Rename question ${question.qid}`,
+    });
+
+    this.qid_new = qid_new;
+    this.question = question;
   }
 
   async write() {
@@ -1549,11 +1564,17 @@ export class QuestionCopyEditor extends Editor {
 
   public readonly uuid: string;
 
-  constructor(params: BaseEditorOptions) {
-    super(params);
+  constructor(params: BaseEditorOptions<{ question: Question }>) {
+    const {
+      locals: { question },
+    } = params;
 
-    this.question = params.locals.question;
-    this.description = `Copy question ${this.question.qid}`;
+    super({
+      ...params,
+      description: `Copy question ${question.qid}`,
+    });
+
+    this.question = question;
 
     this.uuid = uuidv4();
   }

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -140,7 +140,6 @@ router.post(
       if (!(await fs.pathExists(infoAssessmentPath))) {
         throw new error.HttpStatusError(400, 'infoAssessment.json does not exist');
       }
-      const paths = getPaths(undefined, res.locals);
 
       if (!req.body.aid) {
         throw new error.HttpStatusError(400, `Invalid TID (was falsy): ${req.body.aid}`);
@@ -151,6 +150,8 @@ router.post(
           `Invalid TID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.id}`,
         );
       }
+
+      const paths = getPaths(undefined, res.locals);
 
       const assessmentInfo = JSON.parse(await fs.readFile(infoAssessmentPath, 'utf8'));
       assessmentInfo.title = req.body.title;

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -97,7 +97,7 @@ router.post(
   asyncHandler(async (req, res) => {
     if (req.body.__action === 'copy_assessment') {
       const editor = new AssessmentCopyEditor({
-        locals: res.locals,
+        locals: res.locals as any,
       });
       const serverJob = await editor.prepareServerJob();
       try {
@@ -119,7 +119,7 @@ router.post(
       res.redirect(res.locals.urlPrefix + '/assessment/' + assessmentId + '/settings');
     } else if (req.body.__action === 'delete_assessment') {
       const editor = new AssessmentDeleteEditor({
-        locals: res.locals,
+        locals: res.locals as any,
       });
       const serverJob = await editor.prepareServerJob();
       try {
@@ -175,7 +175,7 @@ router.post(
       // Each of these editors will no-op if there wasn't any change.
       const editors: Editor[] = [
         new FileModifyEditor({
-          locals: res.locals,
+          locals: res.locals as any,
           container: {
             rootPath: paths.rootPath,
             invalidRootPaths: paths.invalidRootPaths,
@@ -184,10 +184,10 @@ router.post(
           editContents: b64EncodeUnicode(formattedJson),
           origHash: req.body.orig_hash,
         }),
-        new AssessmentRenameEditor({ locals: res.locals, tid_new }),
+        new AssessmentRenameEditor({ locals: res.locals as any, tid_new }),
       ];
 
-      const editor = new MultiEditor({ locals: res.locals }, editors);
+      const editor = new MultiEditor({ locals: res.locals as any }, editors);
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -18,7 +18,6 @@ import {
   AssessmentRenameEditor,
   AssessmentDeleteEditor,
   FileModifyEditor,
-  type Editor,
   MultiEditor,
 } from '../../lib/editors.js';
 import { getPaths } from '../../lib/instructorFiles.js';
@@ -173,8 +172,8 @@ router.post(
         }
       });
 
-      // Each of these editors will no-op if there wasn't any change.
-      const editors: Editor[] = [
+      const editor = new MultiEditor({ locals: res.locals as any }, [
+        // Each of these editors will no-op if there wasn't any change.
         new FileModifyEditor({
           locals: res.locals as any,
           container: {
@@ -186,9 +185,7 @@ router.post(
           origHash: req.body.orig_hash,
         }),
         new AssessmentRenameEditor({ locals: res.locals as any, tid_new }),
-      ];
-
-      const editor = new MultiEditor({ locals: res.locals as any }, editors);
+      ]);
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -172,20 +172,27 @@ router.post(
         }
       });
 
-      const editor = new MultiEditor({ locals: res.locals as any }, [
-        // Each of these editors will no-op if there wasn't any change.
-        new FileModifyEditor({
+      const editor = new MultiEditor(
+        {
           locals: res.locals as any,
-          container: {
-            rootPath: paths.rootPath,
-            invalidRootPaths: paths.invalidRootPaths,
-          },
-          filePath: infoAssessmentPath,
-          editContents: b64EncodeUnicode(formattedJson),
-          origHash: req.body.orig_hash,
-        }),
-        new AssessmentRenameEditor({ locals: res.locals as any, tid_new }),
-      ]);
+          // This won't reflect if the operation is an update or a rename; we think that's OK.
+          description: `${res.locals.course_instance.short_name}: Update assessment ${res.locals.assessment.tid}`,
+        },
+        [
+          // Each of these editors will no-op if there wasn't any change.
+          new FileModifyEditor({
+            locals: res.locals as any,
+            container: {
+              rootPath: paths.rootPath,
+              invalidRootPaths: paths.invalidRootPaths,
+            },
+            filePath: infoAssessmentPath,
+            editContents: b64EncodeUnicode(formattedJson),
+            origHash: req.body.orig_hash,
+          }),
+          new AssessmentRenameEditor({ locals: res.locals as any, tid_new }),
+        ],
+      );
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
@@ -224,7 +224,7 @@ router.post(
       }
 
       const editor = new AssessmentAddEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         title: req.body.title,
         aid: req.body.aid,
         type: req.body.type,

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
@@ -94,7 +94,7 @@ router.post(
       }
 
       const editor = new CourseInstanceAddEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         short_name: req.body.short_name,
         long_name: req.body.long_name,
         start_access_date: startAccessDate,

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -80,35 +80,29 @@ router.post(
         await fs.readFile(path.join(res.locals.course.path, 'infoCourse.json'), 'utf8'),
       );
 
-      if (
-        req.body.short_name !== courseInfo.name ||
-        req.body.title !== courseInfo.title ||
-        req.body.display_timezone !== courseInfo.timezone
-      ) {
-        const origHash = req.body.orig_hash;
+      const origHash = req.body.orig_hash;
 
-        const courseInfoEdit = courseInfo;
-        courseInfoEdit.name = req.body.short_name;
-        courseInfoEdit.title = req.body.title;
-        courseInfoEdit.timezone = req.body.display_timezone;
+      const courseInfoEdit = courseInfo;
+      courseInfoEdit.name = req.body.short_name;
+      courseInfoEdit.title = req.body.title;
+      courseInfoEdit.timezone = req.body.display_timezone;
 
-        const editor = new FileModifyEditor({
-          locals: res.locals as any,
-          container: {
-            rootPath: paths.rootPath,
-            invalidRootPaths: paths.invalidRootPaths,
-          },
-          filePath: path.join(res.locals.course.path, 'infoCourse.json'),
-          editContents: b64EncodeUnicode(JSON.stringify(courseInfoEdit, null, 2)),
-          origHash,
-        });
+      const editor = new FileModifyEditor({
+        locals: res.locals as any,
+        container: {
+          rootPath: paths.rootPath,
+          invalidRootPaths: paths.invalidRootPaths,
+        },
+        filePath: path.join(res.locals.course.path, 'infoCourse.json'),
+        editContents: b64EncodeUnicode(JSON.stringify(courseInfoEdit, null, 2)),
+        origHash,
+      });
 
-        const serverJob = await editor.prepareServerJob();
-        try {
-          await editor.executeWithServerJob(serverJob);
-        } catch {
-          return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
-        }
+      const serverJob = await editor.prepareServerJob();
+      try {
+        await editor.executeWithServerJob(serverJob);
+      } catch {
+        return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
       flash('success', 'Course configuration updated successfully');
       return res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -93,7 +93,7 @@ router.post(
         courseInfoEdit.timezone = req.body.display_timezone;
 
         const editor = new FileModifyEditor({
-          locals: res.locals,
+          locals: res.locals as any,
           container: {
             rootPath: paths.rootPath,
             invalidRootPaths: paths.invalidRootPaths,
@@ -125,7 +125,7 @@ router.post(
         topics: [],
       };
       const editor = new CourseInfoCreateEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         infoJson,
       });
       const serverJob = await editor.prepareServerJob();

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
@@ -77,7 +77,7 @@ router.post(
         throw new Error(`Invalid file path: ${req.body.file_path}`);
       }
       const editor = new FileDeleteEditor({
-        locals: res.locals,
+        locals: res.locals as any as any,
         container,
         deletePath,
       });
@@ -126,7 +126,7 @@ router.post(
       }
 
       const editor = new FileRenameEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         container,
         oldPath,
         newPath,
@@ -165,7 +165,7 @@ router.post(
         }
       }
       const editor = new FileUploadEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         container,
         filePath,
         fileContents: req.file.buffer,

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ts
@@ -196,7 +196,7 @@ router.post(
       });
 
       const editor = new FileModifyEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         container,
         filePath: paths.workingPath,
         editContents: req.body.file_edit_contents,

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
@@ -51,7 +51,7 @@ router.get(
     const questions_dir_idx = question_exploded.findIndex((x) => x === 'questions');
     const qid = question_exploded.slice(questions_dir_idx + 1).join(path.sep);
     const editor = new QuestionTransferEditor({
-      locals: res.locals,
+      locals: res.locals as any,
       from_qid: qid,
       from_course_short_name: from_course.short_name,
       from_path: path.join(config.filesRoot, file_transfer.storage_filename),

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -60,7 +60,7 @@ router.post(
   asyncHandler(async (req, res) => {
     if (req.body.__action === 'copy_course_instance') {
       const editor = new CourseInstanceCopyEditor({
-        locals: res.locals,
+        locals: res.locals as any,
       });
 
       const serverJob = await editor.prepareServerJob();
@@ -89,7 +89,7 @@ router.post(
       );
     } else if (req.body.__action === 'delete_course_instance') {
       const editor = new CourseInstanceDeleteEditor({
-        locals: res.locals,
+        locals: res.locals as any,
       });
 
       const serverJob = await editor.prepareServerJob();
@@ -124,7 +124,7 @@ router.post(
         res.redirect(req.originalUrl);
       } else {
         const editor = new CourseInstanceRenameEditor({
-          locals: res.locals,
+          locals: res.locals as any,
           ciid_new,
         });
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -123,6 +123,27 @@ export function InstructorQuestionSettings({
                 <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
                 <input type="hidden" name="orig_hash" value="${origHash}" />
                 <div class="form-group">
+                  <label for="qid">QID</label>
+                  ${questionGHLink
+                    ? html`<a target="_blank" href="${questionGHLink}"> view on GitHub </a>`
+                    : ''}
+                  <input
+                    type="text"
+                    class="form-control text-monospace"
+                    id="qid"
+                    name="qid"
+                    value="${resLocals.question.qid}"
+                    pattern="[\\-A-Za-z0-9_\\/]+"
+                    data-other-values="${qids.join(',')}"
+                    ${canEdit ? '' : 'disabled'}
+                  />
+                  <small class="form-text text-muted">
+                    This is a unique identifier for the question, e.g. "addNumbers". Use only
+                    letters, numbers, dashes, and underscores, with no spaces. You may use forward
+                    slashes to separate directories.
+                  </small>
+                </div>
+                <div class="form-group">
                   <h2 class="h4">General</h2>
                   <label for="title">Title</label>
                   <input
@@ -135,27 +156,6 @@ export function InstructorQuestionSettings({
                   />
                   <small class="form-text text-muted">
                     The title of the question (e.g., "Add two numbers").
-                  </small>
-                </div>
-                <div class="form-group">
-                  <label for="qid">QID</label>
-                  ${questionGHLink
-                    ? html`<a target="_blank" href="${questionGHLink}"> view on GitHub </a>`
-                    : ''}
-                  <input
-                    type="text"
-                    class="form-control"
-                    id="qid"
-                    name="qid"
-                    value="${resLocals.question.qid}"
-                    pattern="[\\-A-Za-z0-9_\\/]+"
-                    data-other-values="${qids.join(',')}"
-                    ${canEdit ? '' : 'disabled'}
-                  />
-                  <small class="form-text text-muted">
-                    This is a unique identifier for the question, e.g. "addNumbers". Use only
-                    letters, numbers, dashes, and underscores, with no spaces. You may use forward
-                    slashes to separate directories.
                   </small>
                 </div>
                 <div class="table-responsive card mb-3 overflow-visible">

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -152,23 +152,30 @@ router.post(
         }
       });
 
-      const editor = new MultiEditor({ locals: res.locals as any }, [
-        // Each of these editors will no-op if there wasn't any change.
-        new FileModifyEditor({
+      const editor = new MultiEditor(
+        {
           locals: res.locals as any,
-          container: {
-            rootPath: paths.rootPath,
-            invalidRootPaths: paths.invalidRootPaths,
-          },
-          filePath: path.join(paths.rootPath, 'info.json'),
-          editContents: b64EncodeUnicode(formattedJson),
-          origHash,
-        }),
-        new QuestionRenameEditor({
-          locals: res.locals as any,
-          qid_new,
-        }),
-      ]);
+          // This won't reflect if the operation is an update or a rename; we think that's OK.
+          description: `Update question ${res.locals.question.qid}`,
+        },
+        [
+          // Each of these editors will no-op if there wasn't any change.
+          new FileModifyEditor({
+            locals: res.locals as any,
+            container: {
+              rootPath: paths.rootPath,
+              invalidRootPaths: paths.invalidRootPaths,
+            },
+            filePath: path.join(paths.rootPath, 'info.json'),
+            editContents: b64EncodeUnicode(formattedJson),
+            origHash,
+          }),
+          new QuestionRenameEditor({
+            locals: res.locals as any,
+            qid_new,
+          }),
+        ],
+      );
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -132,7 +132,7 @@ router.post(
       const formattedJson = await formatJsonWithPrettier(JSON.stringify(questionInfo));
 
       const editor = new FileModifyEditor({
-        locals: res.locals,
+        locals: res.locals as any,
         container: {
           rootPath: paths.rootPath,
           invalidRootPaths: paths.invalidRootPaths,
@@ -170,7 +170,7 @@ router.post(
       }
       if (res.locals.question.qid !== qid_new) {
         const editor = new QuestionRenameEditor({
-          locals: res.locals,
+          locals: res.locals as any,
           qid_new,
         });
         const serverJob = await editor.prepareServerJob();
@@ -186,7 +186,7 @@ router.post(
       if (idsEqual(req.body.to_course_id, res.locals.course.id)) {
         // In this case, we are making a duplicate of this question in the same course
         const editor = new QuestionCopyEditor({
-          locals: res.locals,
+          locals: res.locals as any,
         });
         const serverJob = await editor.prepareServerJob();
         try {
@@ -214,7 +214,7 @@ router.post(
       }
     } else if (req.body.__action === 'delete_question') {
       const editor = new QuestionDeleteEditor({
-        locals: res.locals,
+        locals: res.locals as any,
       });
       const serverJob = await editor.prepareServerJob();
       try {

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -20,7 +20,6 @@ import {
   QuestionRenameEditor,
   QuestionDeleteEditor,
   QuestionCopyEditor,
-  type Editor,
   MultiEditor,
 } from '../../lib/editors.js';
 import { features } from '../../lib/features/index.js';
@@ -153,7 +152,8 @@ router.post(
         }
       });
 
-      const editors: Editor[] = [
+      const editor = new MultiEditor({ locals: res.locals as any }, [
+        // Each of these editors will no-op if there wasn't any change.
         new FileModifyEditor({
           locals: res.locals as any,
           container: {
@@ -168,9 +168,7 @@ router.post(
           locals: res.locals as any,
           qid_new,
         }),
-      ];
-
-      const editor = new MultiEditor({ locals: res.locals as any }, editors);
+      ]);
       const serverJob = await editor.prepareServerJob();
       try {
         await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
+import { run } from '@prairielearn/run';
 import { generateSignedToken } from '@prairielearn/signed-token';
 
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
@@ -19,6 +20,8 @@ import {
   QuestionRenameEditor,
   QuestionDeleteEditor,
   QuestionCopyEditor,
+  type Editor,
+  MultiEditor,
 } from '../../lib/editors.js';
 import { features } from '../../lib/features/index.js';
 import { httpPrefixForCourseRepo } from '../../lib/github.js';
@@ -110,46 +113,7 @@ router.post(
       if (!(await fs.pathExists(infoPath))) {
         throw new error.HttpStatusError(400, 'Question info file does not exist');
       }
-      const paths = getPaths(undefined, res.locals);
 
-      const questionInfo = JSON.parse(await fs.readFile(infoPath, 'utf8'));
-
-      const origHash = req.body.orig_hash;
-      questionInfo.title = req.body.title;
-      questionInfo.topic = req.body.topic;
-      // If only a single tag is provided, it will be a string. If multiple tags are provided, it will be an array.
-      if (req.body.tags) {
-        if (Array.isArray(req.body.tags)) {
-          questionInfo.tags = req.body.tags;
-        } else {
-          questionInfo.tags = [req.body.tags];
-        }
-      } else {
-        // If no tags are provided, we remove this propoerty from questionInfo.
-        delete questionInfo.tags;
-      }
-
-      const formattedJson = await formatJsonWithPrettier(JSON.stringify(questionInfo));
-
-      const editor = new FileModifyEditor({
-        locals: res.locals as any,
-        container: {
-          rootPath: paths.rootPath,
-          invalidRootPaths: paths.invalidRootPaths,
-        },
-        filePath: path.join(paths.rootPath, 'info.json'),
-        editContents: b64EncodeUnicode(formattedJson),
-        origHash,
-      });
-
-      const serverJob = await editor.prepareServerJob();
-      try {
-        await editor.executeWithServerJob(serverJob);
-      } catch {
-        return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
-      }
-
-      // QID is not maintained in the info.json file, we must handle this separately.
       if (!req.body.qid) {
         throw new error.HttpStatusError(400, `Invalid QID (was falsy): ${req.body.qid}`);
       }
@@ -159,27 +123,61 @@ router.post(
           `Invalid QID (was not only letters, numbers, dashes, slashes, and underscores, with no spaces): ${req.body.qid}`,
         );
       }
-      let qid_new;
-      try {
-        qid_new = path.normalize(req.body.qid);
-      } catch {
-        throw new error.HttpStatusError(
-          400,
-          `Invalid QID (could not be normalized): ${req.body.qid}`,
-        );
-      }
-      if (res.locals.question.qid !== qid_new) {
-        const editor = new QuestionRenameEditor({
+
+      const paths = getPaths(undefined, res.locals);
+
+      const questionInfo = JSON.parse(await fs.readFile(infoPath, 'utf8'));
+
+      const origHash = req.body.orig_hash;
+      questionInfo.title = req.body.title;
+      questionInfo.topic = req.body.topic;
+      questionInfo.tags = run(() => {
+        // If no tags are provided, remove the entire property.
+        if (!req.body.tags) return undefined;
+
+        // Handle multiple and single tags.
+        if (Array.isArray(req.body.tags)) return req.body.tags;
+        return [req.body.tags];
+      });
+
+      const formattedJson = await formatJsonWithPrettier(JSON.stringify(questionInfo));
+
+      const qid_new = run(() => {
+        try {
+          return path.normalize(req.body.qid);
+        } catch {
+          throw new error.HttpStatusError(
+            400,
+            `Invalid QID (could not be normalized): ${req.body.qid}`,
+          );
+        }
+      });
+
+      const editors: Editor[] = [
+        new FileModifyEditor({
+          locals: res.locals as any,
+          container: {
+            rootPath: paths.rootPath,
+            invalidRootPaths: paths.invalidRootPaths,
+          },
+          filePath: path.join(paths.rootPath, 'info.json'),
+          editContents: b64EncodeUnicode(formattedJson),
+          origHash,
+        }),
+        new QuestionRenameEditor({
           locals: res.locals as any,
           qid_new,
-        });
-        const serverJob = await editor.prepareServerJob();
-        try {
-          await editor.executeWithServerJob(serverJob);
-        } catch {
-          return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
-        }
+        }),
+      ];
+
+      const editor = new MultiEditor({ locals: res.locals as any }, editors);
+      const serverJob = await editor.prepareServerJob();
+      try {
+        await editor.executeWithServerJob(serverJob);
+      } catch {
+        return res.redirect(res.locals.urlPrefix + '/edit_error/' + serverJob.jobSequenceId);
       }
+
       flash('success', 'Question settings updated successfully');
       return res.redirect(req.originalUrl);
     } else if (req.body.__action === 'copy_question') {

--- a/apps/prairielearn/src/tests/instructorAssessmentSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentSettings.test.ts
@@ -335,10 +335,15 @@ describe('Editing assessment settings', () => {
       {
         method: 'POST',
         body: new URLSearchParams({
-          __action: 'change_id',
+          __action: 'update_assessment',
           __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
           orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
-          id: 'A1',
+          title: 'Test Title',
+          type: 'Homework',
+          set: 'Homework',
+          number: '1',
+          module: 'Module1',
+          aid: 'A1',
         }),
       },
     );
@@ -365,10 +370,15 @@ describe('Editing assessment settings', () => {
         {
           method: 'POST',
           body: new URLSearchParams({
-            __action: 'change_id',
+            __action: 'update_assessment',
             __csrf_token: settingsPageResponse.$('input[name="__csrf_token"]').val() as string,
             orig_hash: settingsPageResponse.$('input[name="orig_hash"]').val() as string,
-            id: '../A2',
+            title: 'Test Title',
+            type: 'Homework',
+            set: 'Homework',
+            number: '1',
+            module: 'Module1',
+            aid: '../A2',
           }),
         },
       );


### PR DESCRIPTION
Closes #11222.

As proposed in that issue, this PR introduces a new `MultiEditor` that itself can execute multiple editors.

As part of this, I removed some dead code related to a `change_id` action that was since removed. I also did some refactoring of editors as a whole to improve type safety.