### PR TITLE
Use test course for accessibility tests

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -164,7 +164,9 @@ export function InstructorQuestionSettings({
                     aria-label="Question topic, tags, and assessments"
                   >
                     <tr>
-                      <th class="align-middle">Topic</th>
+                      <th class="align-middle">
+                        <label for="topic">Topic</label>
+                      </th>
                       <!-- The style attribute is necessary until we upgrade to Bootstrap 5.3 -->
                       <!-- This is used by tom-select to style the active item in the dropdown -->
                       <td style="--bs-tertiary-bg: #f8f9fa">
@@ -188,7 +190,9 @@ export function InstructorQuestionSettings({
                       </td>
                     </tr>
                     <tr>
-                      <th class="align-middle">Tags</th>
+                      <th class="align-middle">
+                        <label for="tags">Tags</label>
+                      </th>
                       <td>
                         ${canEdit
                           ? html`
@@ -417,7 +421,7 @@ function DeleteQuestionModal({
               ${assessmentsWithQuestion.map((a_with_q) => {
                 return html`
                   <li class="list-group-item">
-                    <h6>${a_with_q.short_name} (${a_with_q.long_name})</h6>
+                    <div class="h6">${a_with_q.short_name} (${a_with_q.long_name})</div>
                     ${a_with_q.assessments.map((assessment) =>
                       AssessmentBadge({
                         plainUrlPrefix: config.urlPrefix,

--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -9,7 +9,7 @@ import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../../lib/config.js';
 import { features } from '../../lib/features/index.js';
-import { EXAMPLE_COURSE_PATH } from '../../lib/paths.js';
+import { TEST_COURSE_PATH } from '../../lib/paths.js';
 import * as news_items from '../../news_items/index.js';
 import * as server from '../../server.js';
 import * as helperServer from '../helperServer.js';
@@ -46,7 +46,7 @@ async function checkPage(url: string) {
 
 const STATIC_ROUTE_PARAMS = {
   // These are trivially known because there will only be one course and course
-  // instance in the database after syncing the example course.
+  // instance in the database after syncing the test course.
   course_id: 1,
   course_instance_id: 1,
 };
@@ -243,8 +243,6 @@ const SKIP_ROUTES = [
   '/pl/course/:course_id/grading_job/:job_id',
 
   // TODO: create a test course with AI generation feature flag enabled to test page
-  '/pl/course_instance/:course_instance_id/instructor/ai_generate_question',
-  '/pl/course/:course_id/ai_generate_question',
   '/pl/course_instance/:course_instance_id/instructor/ai_generate_editor/:question_id',
   '/pl/course/:course_id/ai_generate_editor/:question_id',
   '/pl/course_instance/:course_instance_id/instructor/ai_generate_question_drafts/:job_id',
@@ -267,7 +265,9 @@ describe('accessibility', () => {
   let routeParams: Record<string, any> = {};
   before('set up testing server', async function () {
     config.cronActive = false;
-    await helperServer.before(EXAMPLE_COURSE_PATH).call(this);
+    // We use the test course since editing functionality is disabled in the
+    // example course.
+    await helperServer.before(TEST_COURSE_PATH).call(this);
     config.cronActive = true;
 
     // We want to test a news item page, so we need to "init" them.
@@ -285,17 +285,17 @@ describe('accessibility', () => {
       {},
     );
 
-    const questionGalleryAssessmentResult = await sqldb.queryOneRowAsync(
+    const assessmentResult = await sqldb.queryOneRowAsync(
       'SELECT id FROM assessments WHERE tid = $tid',
       {
-        tid: 'gallery/elements',
+        tid: 'hw1-automaticTestSuite',
       },
     );
 
-    const codeElementQuestionResult = await sqldb.queryOneRowAsync(
+    const questionResult = await sqldb.queryOneRowAsync(
       'SELECT id FROM questions WHERE qid = $qid',
       {
-        qid: 'element/code',
+        qid: 'downloadFile',
       },
     );
 
@@ -304,8 +304,8 @@ describe('accessibility', () => {
     routeParams = {
       ...STATIC_ROUTE_PARAMS,
       news_item_id: firstNewsItemResult.rows[0].id,
-      assessment_id: questionGalleryAssessmentResult.rows[0].id,
-      question_id: codeElementQuestionResult.rows[0].id,
+      assessment_id: assessmentResult.rows[0].id,
+      question_id: questionResult.rows[0].id,
     };
 
     await sqldb.queryOneRowAsync(

--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -243,6 +243,8 @@ const SKIP_ROUTES = [
   '/pl/course/:course_id/grading_job/:job_id',
 
   // TODO: create a test course with AI generation feature flag enabled to test page
+  '/pl/course_instance/:course_instance_id/instructor/ai_generate_question',
+  '/pl/course/:course_id/ai_generate_question',
   '/pl/course_instance/:course_instance_id/instructor/ai_generate_editor/:question_id',
   '/pl/course/:course_id/ai_generate_editor/:question_id',
   '/pl/course_instance/:course_instance_id/instructor/ai_generate_question_drafts/:job_id',


### PR DESCRIPTION
This is needed to test pages that are unavailable in the example course (where editing is generally disabled).

This had the benefit of catching some genuine accessibility issues on the question settings page!