### PR TITLE
Refine styles of tabbed content in docs

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -70,3 +70,43 @@ foreignObject .md pre {
 .doc h3.doc-heading {
   margin: 1em 0 0.5em;
 }
+
+.tabbed-set {
+  border: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-content__inner > .tabbed-set .tabbed-labels {
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.tabbed-set .tabbed-content > .tabbed-block {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.tabbed-set .tabbed-content > .tabbed-block:has(> .highlight:only-child),
+.tabbed-set .tabbed-content > .tabbed-block:has(> pre:only-child) {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.tabbed-set > .tabbed-content > .tabbed-block > .highlight:first-child > pre,
+.tabbed-set > .tabbed-content > .tabbed-block > pre:first-child {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.tabbed-set > .tabbed-content .tabbed-block > .highlight:first-child > pre,
+.tabbed-set > .tabbed-block > pre:first-child {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.tabbed-set > .tabbed-content > .tabbed-block > .highlight:only-child > pre,
+.tabbed-set > .tabbed-content > .tabbed-block > pre:only-child {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -71,6 +71,12 @@ foreignObject .md pre {
   margin: 1em 0 0.5em;
 }
 
+/**
+ * Add a border to tabbed content. This also requires adding padding, which
+ * in turn requires conditionally adding/removing other padding/margins to
+ * ensure that tabbed code blocks look their nicest.
+ */
+
 .tabbed-set {
   border: 1px solid var(--md-default-fg-color--lightest);
 }

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -35,13 +35,9 @@ Most of these prerequisites can be installed using the package manager of your O
     brew install git graphviz postgresql@15 redis@6.2
     ```
 
----
-
 Now you can install the other dependencies.
 
 === "Ubuntu (WSL2)"
-
-    Python 3.10 is not available in the default Ubuntu repositories -- you can install it through the [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):
 
     ```sh
     sudo add-apt-repository ppa:deadsnakes/ppa
@@ -120,8 +116,6 @@ Now you can install the other dependencies.
 
     !!! note
         `uv` does not override the system Python, it is only active inside a `venv`.
-
----
 
 - Clone the latest code:
 

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -39,6 +39,8 @@ Now you can install the other dependencies.
 
 === "Ubuntu (WSL2)"
 
+    Python 3.10 is not available in the default Ubuntu repositories -- you can install it through the [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):
+
     ```sh
     sudo add-apt-repository ppa:deadsnakes/ppa
     sudo apt update


### PR DESCRIPTION
Addresses my comment here: https://github.com/PrairieLearn/PrairieLearn/pull/11012#discussion_r1931238196. So far, this just adds a light border that matches that below the tabs.

Before:

<img width="791" alt="Screenshot 2025-01-27 at 12 54 32" src="https://github.com/user-attachments/assets/946b65f0-9336-472e-b041-01776290ed9c" />

After:

<img width="714" alt="Screenshot 2025-01-27 at 12 51 50" src="https://github.com/user-attachments/assets/6085750a-6b5f-435a-ad09-142e6eac8c1b" />

After (dark mode):

<img width="712" alt="Screenshot 2025-01-27 at 12 51 58" src="https://github.com/user-attachments/assets/42e5abfe-0a8f-45df-81df-1f8d3e76985c" />
