### PR TITLE
Fix rendering of LaTeX by matplotlib

### DIFF
--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -46,21 +46,33 @@ drop_privileges = os.environ.get("DROP_PRIVILEGES", False)
 #
 # To work around this, we'll set `$XDG_CONFIG_HOME` and `$XDG_CACHE_HOME` to
 # directories created in `/tmp` that are world-writable. matplotlib and
-# fontconfig should respect these environment variables; other tools should as
-# well. If they don't, special cases can be added below.
+# fontconfig should respect these environment variables; other tools should too.
+#
+# Note that `mktexfmt` does _not_ respect those environment variables, so we'll
+# also set `$TEXMFCONFIG`, `$TEXMFVAR`, and `$TEXMFHOME` to directories created
+# in `/tmp` that are world-writable. This allows LaTeX to run properly.
 if drop_privileges:
     config_home_path = "/tmp/xdg_config"
     cache_home_path = "/tmp/xdg_cache"
+    texmf_config_path = "/tmp/texmf-config"
+    texmf_var_path = "/tmp/texmf-var"
+    texmf_home_path = "/tmp/texmf-home"
 
     oldmask = os.umask(000)
 
     os.makedirs(config_home_path, mode=0o777, exist_ok=True)
     os.makedirs(cache_home_path, mode=0o777, exist_ok=True)
+    os.makedirs(texmf_config_path, mode=0o777, exist_ok=True)
+    os.makedirs(texmf_var_path, mode=0o777, exist_ok=True)
+    os.makedirs(texmf_home_path, mode=0o777, exist_ok=True)
 
     os.umask(oldmask)
 
     os.environ["XDG_CONFIG_HOME"] = config_home_path
     os.environ["XDG_CACHE_HOME"] = cache_home_path
+    os.environ["TEXMFCONFIG"] = texmf_config_path
+    os.environ["TEXMFVAR"] = texmf_var_path
+    os.environ["TEXMFHOME"] = texmf_home_path
 
 # Silence matplotlib's FontManager logs; these can cause trouble with our
 # expectation that code execution doesn't log anything to stdout/stderr.


### PR DESCRIPTION
This error was reported by Scott Spurlock on Slack. For posterity, here's the full error message:

```
Traceback (most recent call last):
  File "/PrairieLearn/apps/prairielearn/python/zygote.py", line 429, in <module>
    worker_loop()
  File "/PrairieLearn/apps/prairielearn/python/zygote.py", line 337, in worker_loop
    val = method(*args)
  File "/course/questions/hw01/code_category_count_bar_plot/server.py", line 147, in file
    plt.gcf().tight_layout(pad=2)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/figure.py", line 3640, in tight_layout
    engine.execute(self)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/layout_engine.py", line 183, in execute
    kwargs = get_tight_layout_figure(
  File "/usr/local/lib/python3.10/site-packages/matplotlib/_tight_layout.py", line 266, in get_tight_layout_figure
    kwargs = _auto_adjust_subplotpars(fig, renderer,
  File "/usr/local/lib/python3.10/site-packages/matplotlib/_tight_layout.py", line 82, in _auto_adjust_subplotpars
    bb += [martist._get_tightbbox_for_layout_only(ax, renderer)]
  File "/usr/local/lib/python3.10/site-packages/matplotlib/artist.py", line 1402, in _get_tightbbox_for_layout_only
    return obj.get_tightbbox(*args, **{**kwargs, "for_layout_only": True})
  File "/usr/local/lib/python3.10/site-packages/matplotlib/axes/_base.py", line 4519, in get_tightbbox
    ba = martist._get_tightbbox_for_layout_only(axis, renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/artist.py", line 1402, in _get_tightbbox_for_layout_only
    return obj.get_tightbbox(*args, **{**kwargs, "for_layout_only": True})
  File "/usr/local/lib/python3.10/site-packages/matplotlib/axis.py", line 1364, in get_tightbbox
    self._update_label_position(renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/axis.py", line 2459, in _update_label_position
    bboxes, bboxes2 = self._get_tick_boxes_siblings(renderer=renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/axis.py", line 2252, in _get_tick_boxes_siblings
    tlb, tlb2 = axis._get_ticklabel_bboxes(ticks_to_draw, renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/axis.py", line 1343, in _get_ticklabel_bboxes
    return ([tick.label1.get_window_extent(renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/axis.py", line 1343, in <listcomp>
    return ([tick.label1.get_window_extent(renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/text.py", line 969, in get_window_extent
    bbox, info, descent = self._get_layout(self._renderer)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/text.py", line 373, in _get_layout
    _, lp_h, lp_d = _get_text_metrics_with_cache(
  File "/usr/local/lib/python3.10/site-packages/matplotlib/text.py", line 69, in _get_text_metrics_with_cache
    return _get_text_metrics_with_cache_impl(
  File "/usr/local/lib/python3.10/site-packages/matplotlib/text.py", line 77, in _get_text_metrics_with_cache_impl
    return renderer_ref().get_text_width_height_descent(text, fontprop, ismath)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/backends/_backend_pdf_ps.py", line 150, in get_text_width_height_descent
    return super().get_text_width_height_descent(s, prop, ismath)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/backend_bases.py", line 566, in get_text_width_height_descent
    return self.get_texmanager().get_text_width_height_descent(
  File "/usr/local/lib/python3.10/site-packages/matplotlib/texmanager.py", line 360, in get_text_width_height_descent
    dvifile = cls.make_dvi(tex, fontsize)
  File "/usr/local/lib/python3.10/site-packages/matplotlib/texmanager.py", line 292, in make_dvi
    cls._run_checked_subprocess(
  File "/usr/local/lib/python3.10/site-packages/matplotlib/texmanager.py", line 255, in _run_checked_subprocess
    raise RuntimeError(
RuntimeError: latex was not able to process the following string:
b'lp'

Here is the full command invocation and its output:

latex -interaction=nonstopmode --halt-on-error --output-directory=tmp9bq_n54l 844f707e0917555faafa721cd5105dbd.tex

This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=latex)
 restricted \write18 enabled.

kpathsea: Running mktexfmt latex.fmt
mktexfmt: mktexfmt is using the following fmtutil.cnf files (in precedence order):
mktexfmt:   /usr/share/texlive/texmf-dist/web2c/fmtutil.cnf
mktexfmt: mktexfmt is using the following fmtutil.cnf file for writing changes:
mktexfmt:   /root/.texlive2021/texmf-config/web2c/fmtutil.cnf
/usr/bin/mktexfmt: mkdir(/root/.texlive2021/) failed for tree /root/.texlive2021/texmf-var/web2c: Permission denied at /usr/share/texlive/tlpkg/TeXLive/TLUtils.pm line 942.
I can't find the format file `latex.fmt'!
```

This is the critical bit:

```
mkdir(/root/.texlive2021/) failed for tree /root/.texlive2021/texmf-var/web2c: Permission denied
```

Naturally, `/root/...` isn't writable! Note that this error only occurred in production where we're configured to drop to a less-privileged user.