### PR TITLE
Update redis installation / WSL package list

### DIFF
--- a/docker/start_redis.sh
+++ b/docker/start_redis.sh
@@ -5,4 +5,4 @@ if redis-cli ping > /dev/null 2>&1 ; then
     exit
 fi
 
-redis6-server --daemonize yes > /dev/null
+redis-server --daemonize yes > /dev/null

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -23,7 +23,7 @@ Most of these prerequisites can be installed using the package manager of your O
     sudo apt install git gcc libc6-dev graphviz libgraphviz-dev redis postgresql postgresql-contrib
     ```
 
-    Make sure you startup postgres:
+    Make sure you start Postgres:
 
     ```sh
     sudo systemctl start postgresql.service

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -20,7 +20,13 @@ Most of these prerequisites can be installed using the package manager of your O
     On Ubuntu, use `apt` for the main prerequisites:
 
     ```sh
-    sudo apt install git gcc libc6-dev graphviz libgraphviz-dev redis postgresql
+    sudo apt install git gcc libc6-dev graphviz libgraphviz-dev redis postgresql postgresql-contrib
+    ```
+
+    Make sure you startup postgres:
+
+    ```sh
+    sudo systemctl start postgresql.service
     ```
 
     Python 3.10 is not available in the default Ubuntu repositories -- you can install it through the [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -20,7 +20,7 @@ Most of these prerequisites can be installed using the package manager of your O
     On Ubuntu, use `apt` for the main prerequisites:
 
     ```sh
-    sudo apt install git gcc libc6-dev graphviz graphviz-dev redis6 postgresql16 postgresql16-server postgresql16-contrib
+    sudo apt install git gcc libc6-dev graphviz libgraphviz-dev redis postgresql
     ```
 
     Python 3.10 is not available in the default Ubuntu repositories -- you can install it through the [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -35,6 +35,7 @@ dnf -y install \
     texlive-type1cm \
     tmux
 
+ln -s /usr/bin/redis6-cli /usr/bin/redis-cli && ln -s /usr/bin/redis6-server /usr/bin/redis-server
 echo "installing node via nvm"
 git clone https://github.com/creationix/nvm.git /nvm
 cd /nvm

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -35,7 +35,10 @@ dnf -y install \
     texlive-type1cm \
     tmux
 
+# Redis 7 isn't available on Amazon Linux 2023. Symlink the versioned
+# executables to make them work with scripts that expect unversioned ones.
 ln -s /usr/bin/redis6-cli /usr/bin/redis-cli && ln -s /usr/bin/redis6-server /usr/bin/redis-server
+
 echo "installing node via nvm"
 git clone https://github.com/creationix/nvm.git /nvm
 cd /nvm


### PR DESCRIPTION
- resolves an inconsistency between `redis6`  / `redis`: almost all systems use `redis-cli` not `redis6-cli`, etc.
- updates package list to be valid