### PR TITLE
Handle groups in gradebook API endpoint

### DIFF
--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.sql
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.sql
@@ -48,8 +48,7 @@ WITH
       aig.points,
       format_date_iso8601 (aig.date, ci.display_timezone) AS start_date,
       DATE_PART('epoch', aig.duration) AS duration_seconds,
-      aig.id AS assessment_instance_id,
-      aig.group_id
+      aig.id AS assessment_instance_id
     FROM
       assessment_instances_with_groups AS aig
       JOIN course_instances AS ci ON (ci.id = $course_instance_id)

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.sql
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceGradebook/index.sql
@@ -16,27 +16,48 @@ WITH
       a.deleted_at IS NULL
       AND a.course_instance_id = $course_instance_id
   ),
-  course_scores AS (
-    SELECT DISTINCT
-      ON (ai.user_id, a.id) ai.user_id,
-      a.id AS assessment_id,
+  assessment_instances_with_groups as (
+    SELECT
+      ai.id,
+      COALESCE(ai.user_id, gu.user_id) AS user_id,
+      ai.group_id,
+      ai.assessment_id,
       ai.score_perc,
       ai.max_points,
       ai.points,
-      format_date_iso8601 (ai.date, ci.display_timezone) AS start_date,
-      DATE_PART('epoch', ai.duration) AS duration_seconds,
-      ai.id AS assessment_instance_id
+      ai.date,
+      ai.duration
     FROM
       assessment_instances AS ai
       JOIN assessments AS a ON (a.id = ai.assessment_id)
-      JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+      LEFT JOIN groups AS g ON (g.id = ai.group_id)
+      LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
     WHERE
-      ci.id = $course_instance_id
+      a.course_instance_id = $course_instance_id
+      AND (
+        g.deleted_at IS NULL
+        OR g.id IS NULL
+      )
+  ),
+  course_scores AS (
+    SELECT DISTINCT
+      ON (aig.user_id, aig.assessment_id) aig.user_id,
+      aig.assessment_id,
+      aig.score_perc,
+      aig.max_points,
+      aig.points,
+      format_date_iso8601 (aig.date, ci.display_timezone) AS start_date,
+      DATE_PART('epoch', aig.duration) AS duration_seconds,
+      aig.id AS assessment_instance_id,
+      aig.group_id
+    FROM
+      assessment_instances_with_groups AS aig
+      JOIN course_instances AS ci ON (ci.id = $course_instance_id)
     ORDER BY
-      ai.user_id,
-      a.id,
-      ai.score_perc DESC,
-      ai.id
+      aig.user_id,
+      aig.assessment_id,
+      aig.score_perc DESC,
+      aig.id
   ),
   user_ids AS (
     (


### PR DESCRIPTION
Closes #11204. This fixes a bug that was not showing scores from group assessments in the gradebook API endpoint. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced gradebook reporting now integrates group data, ensuring assessment records reflect accurate user and group associations.
  
- **Refactor**
  - Optimized data processing logic to consistently prioritize relevant identifiers and filter out outdated entries, resulting in more reliable course results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->