### PR TITLE
Add TS files to nodemon watchlist in workspace host

### DIFF
--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -64,5 +64,8 @@
     "include": [
       "src/**"
     ]
+  },
+  "nodemonConfig": {
+    "ext": "js,jsx,ts,tsx,json,sql"
   }
 }


### PR DESCRIPTION
The current nodemon configuration on workspace-host uses the default settings for extensions, which does not include ts files. This means nodemon will not restart the workspace host if there are changes to interface.ts (the main file in workspace-host), which defeats the purpose of using nodemon in this context. This PR changes the settings of nodemon to use the same extensions as the prairielearn server.