### PR TITLE
Downgrade quill to 2.0.2

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -154,7 +154,7 @@
     "prettier": "3.4.2",
     "qrcode-svg": "^1.1.0",
     "qs": "^6.13.1",
-    "quill": "^2.0.3",
+    "quill": "2.0.2",
     "quilljs-markdown": "^1.2.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3918,7 +3918,7 @@ __metadata:
     prettier: "npm:3.4.2"
     qrcode-svg: "npm:^1.1.0"
     qs: "npm:^6.13.1"
-    quill: "npm:^2.0.3"
+    quill: "npm:2.0.2"
     quilljs-markdown: "npm:^1.2.0"
     remark-gfm: "npm:^4.0.0"
     remark-parse: "npm:^11.0.0"
@@ -13956,15 +13956,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quill@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "quill@npm:2.0.3"
+"quill@npm:2.0.2":
+  version: 2.0.2
+  resolution: "quill@npm:2.0.2"
   dependencies:
     eventemitter3: "npm:^5.0.1"
     lodash-es: "npm:^4.17.21"
     parchment: "npm:^3.0.0"
     quill-delta: "npm:^5.1.0"
-  checksum: 10c0/9897468b3e2b0fbf9c91471deea745d7b6494f866cb8caace63267769b2c4c6128e49da0988c4ed64f1a91a171fbf91c84009b663b1256a3caca0755204bb6b5
+  checksum: 10c0/6d680a87b683041524ea3dcb2a04a9620562e36367bcd0492fc4c1db66238375ac76a65c5e89ef1eb65e7aacd8c1a49b04cef48feeb5d52b4fc8d91a07d0ec8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The 2.0.3 release of quill introduced an issue that affects our users: https://github.com/slab/quill/issues/4509. As reported on Slack: https://prairielearn.slack.com/archives/C266KEH9A/p1738552017444899