### PR TITLE
Fix bugs in core.string_from_numpy(...)

### DIFF
--- a/apps/prairielearn/elements/pl-matrix-output/pl-matrix-output.py
+++ b/apps/prairielearn/elements/pl-matrix-output/pl-matrix-output.py
@@ -39,7 +39,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             var_data = pl.from_json(var_data)
 
             if np.isscalar(var_data):
-                assert not isinstance(var_data, memoryview)
+                assert not isinstance(var_data, memoryview | str | bytes)
                 prefix = ""
                 suffix = ""
             else:

--- a/apps/prairielearn/elements/pl-variable-output/pl-variable-output.py
+++ b/apps/prairielearn/elements/pl-variable-output/pl-variable-output.py
@@ -138,7 +138,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
 
             # Assembling Python array formatting
             if np.isscalar(var_data):
-                assert not isinstance(var_data, memoryview)
+                assert not isinstance(var_data, memoryview | str | bytes)
                 prefix = ""
                 suffix = ""
             else:

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -1055,9 +1055,12 @@ def string_from_number_sigfig(a: _NumericScalarType, digits: int = 2) -> str:
     number, have digits significant digits.
     """
 
-    # `np.iscomplexobj` isn't a proper type guard, so we need to use
-    # casting to call this function.
+    assert np.isscalar(a)
+    assert not isinstance(a, memoryview | str | bytes)
+
     if np.iscomplexobj(a):
+        # `np.iscomplexobj` isn't a proper type guard, so we need to use
+        # casting to call this function.
         return _string_from_complex_sigfig(cast(complex, a), digits=digits)
     else:
         return to_precision(a, digits)

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -983,9 +983,7 @@ def string_from_numpy(
     if np.isscalar(A):
         assert not isinstance(A, memoryview)
         if presentation_type == "sigfig":
-            if not isinstance(A, np.complexfloating) and isinstance(
-                A, np.generic | bytes | str
-            ):
+            if not isinstance(A, np.complexfloating) and isinstance(A, bytes | str):
                 raise TypeError(f"A must be a number, is {type(A)}")
             return string_from_number_sigfig(A, digits=digits)
         else:
@@ -1063,7 +1061,8 @@ def string_from_2darray(
 
 
 def string_from_number_sigfig(
-    a: complex | np.complex64 | np.complex128 | numbers.Number, digits: int = 2
+    a: numbers.Number | complex | np.generic | np.complex64 | np.complex128,
+    digits: int = 2,
 ) -> str:
     """string_from_complex_sigfig(a, digits=2)
 
@@ -1071,8 +1070,11 @@ def string_from_number_sigfig(
     as a string in which the number, or both the real and imaginary parts of the
     number, have digits significant digits.
     """
-    if not isinstance(a, numbers.Number) and np.iscomplexobj(a):
-        return _string_from_complex_sigfig(a, digits=digits)
+
+    # `np.iscomplexobj` isn't a proper type guard, nor does it work for non-numpy types.
+    # We use casting to work around this.
+    if isinstance(a, complex) or np.iscomplexobj(cast(np.generic, a)):
+        return _string_from_complex_sigfig(cast(complex, a), digits=digits)
     else:
         return to_precision(a, digits)
 

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -844,12 +844,11 @@ def get_color_attrib(
         raise ValueError(f'Attribute "{name}" must be a CSS-style RGB string: {val}')
 
 
-# This internal represents most the types that would pass a np.isscalar check
-_NumPyScalarType = bool | int | float | complex | str | bytes | np.generic
+_NumericScalarType = numbers.Number | complex | np.generic
 
 
 def numpy_to_matlab(
-    np_object: npt.NDArray[Any] | _NumPyScalarType,
+    np_object: _NumericScalarType | npt.NDArray[Any],
     ndigits: int = 2,
     wtype: str = "f",
 ) -> str:
@@ -907,7 +906,7 @@ _FormatLanguage = Literal["python", "matlab", "mathematica", "r", "sympy"]
 
 
 def string_from_numpy(
-    A: numbers.Number | _NumPyScalarType | npt.NDArray[Any],
+    A: _NumericScalarType | npt.NDArray[Any],
     language: _FormatLanguage = "python",
     presentation_type: str = "f",
     digits: int = 2,
@@ -1048,9 +1047,7 @@ def string_from_2darray(
     return result
 
 
-def string_from_number_sigfig(
-    a: numbers.Number | _NumPyScalarType, digits: int = 2
-) -> str:
+def string_from_number_sigfig(a: _NumericScalarType, digits: int = 2) -> str:
     """string_from_complex_sigfig(a, digits=2)
 
     This function assumes that "a" is of type float or complex. It returns "a"
@@ -1060,7 +1057,7 @@ def string_from_number_sigfig(
 
     # `np.iscomplexobj` isn't a proper type guard, so we need to use
     # casting to call this function.
-    if np.iscomplexobj(cast(Any, a)):
+    if not isinstance(a, numbers.Number) and np.iscomplexobj(a):
         return _string_from_complex_sigfig(cast(complex, a), digits=digits)
     else:
         return to_precision(a, digits)
@@ -1082,7 +1079,9 @@ def _string_from_complex_sigfig(
         return f"{re}-{im}j"
 
 
-def numpy_to_matlab_sf(A: _NumPyScalarType | npt.NDArray[Any], ndigits: int = 2) -> str:
+def numpy_to_matlab_sf(
+    A: _NumericScalarType | npt.NDArray[Any], ndigits: int = 2
+) -> str:
     """numpy_to_matlab(A, ndigits=2)
 
     This function assumes that A is one of these things:
@@ -1644,7 +1643,7 @@ def string_to_2darray(
 
 
 def latex_from_2darray(
-    A: numbers.Number | _NumPyScalarType | npt.NDArray[Any],
+    A: _NumericScalarType | npt.NDArray[Any],
     presentation_type: str = "f",
     digits: int = 2,
 ) -> str:

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -1057,7 +1057,7 @@ def string_from_number_sigfig(a: _NumericScalarType, digits: int = 2) -> str:
 
     # `np.iscomplexobj` isn't a proper type guard, so we need to use
     # casting to call this function.
-    if not isinstance(a, numbers.Number) and np.iscomplexobj(a):
+    if np.iscomplexobj(a):
         return _string_from_complex_sigfig(cast(complex, a), digits=digits)
     else:
         return to_precision(a, digits)

--- a/apps/prairielearn/python/test/core_test.py
+++ b/apps/prairielearn/python/test/core_test.py
@@ -529,3 +529,16 @@ def test_string_from_number_sigfig(
 )
 def test_numpy_to_matlab_sf(value: Any, args: dict, expected_output: str) -> None:
     assert pl.numpy_to_matlab_sf(value, **args) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_output"),
+    [
+        (0, "0.00"),
+        (0.0, "0.00"),
+        (complex(1, 2), "1.00+2.00j"),
+        (np.array([[1, 2], [3, 4]]), r"\begin{bmatrix}  1 & 2\\  3 & 4\\\end{bmatrix}"),
+    ],
+)
+def test_latex_from_2darray(value: Any, expected_output: str) -> None:
+    assert pl.latex_from_2darray(value) == expected_output

--- a/apps/prairielearn/python/test/core_test.py
+++ b/apps/prairielearn/python/test/core_test.py
@@ -445,3 +445,63 @@ def test_iter_keys(length: int, expected_output: list[str]) -> None:
 )
 def test_index2key(idx: int, expected_output: str) -> None:
     assert pl.index2key(idx) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("value", "args", "expected_output"),
+    [
+        (0, {}, "0.00"),
+        (0, {"digits": 1}, "0.0"),
+        (0, {"digits": 0}, "0"),
+        (0.0, {}, "0.00"),
+        (0.0, {"digits": 1}, "0.0"),
+        (0.0, {"digits": 0}, "0"),
+        (np.float64(0.0), {}, "0.00"),
+        (np.float64(0.0), {"digits": 1}, "0.0"),
+        (np.float64(0.0), {"presentation_type": "sigfig"}, "0.0"),
+        (np.zeros(2), {}, "[0.00, 0.00]"),
+        (np.zeros(2), {"digits": 1}, "[0.0, 0.0]"),
+        (np.zeros(2), {"digits": 0}, "[0, 0]"),
+        (np.zeros(2), {"language": "matlab"}, "[0.00, 0.00]"),
+        (np.zeros(2), {"language": "mathematica"}, "{0.00, 0.00}"),
+        (np.zeros(2), {"language": "r"}, "c(0.00, 0.00)"),
+        (np.zeros(2), {"language": "sympy"}, "Matrix([0.00, 0.00])"),
+        (np.zeros((2, 2)), {}, "[[0.00, 0.00], [0.00, 0.00]]"),
+        (np.zeros((2, 2)), {"digits": 1}, "[[0.0, 0.0], [0.0, 0.0]]"),
+        (np.zeros((2, 2)), {"digits": 0}, "[[0, 0], [0, 0]]"),
+        (np.zeros((2, 2)), {"language": "matlab"}, "[0.00 0.00; 0.00 0.00]"),
+        (np.zeros((2, 2)), {"language": "mathematica"}, "{{0.00, 0.00}, {0.00, 0.00}}"),
+        (
+            np.zeros((2, 2)),
+            {"language": "r"},
+            "matrix(c(0.00, 0.00, 0.00, 0.00), nrow = 2, ncol = 2, byrow = TRUE)",
+        ),
+        (
+            np.zeros((2, 2)),
+            {"language": "sympy"},
+            "Matrix([[0.00, 0.00], [0.00, 0.00]])",
+        ),
+    ],
+)
+def test_string_from_numpy(value: int, args: dict, expected_output: str) -> None:
+    assert pl.string_from_numpy(value, **args) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("value", "args", "expected_output"),
+    [
+        (0, {}, "0.0"),
+        (0, {"digits": 1}, "0."),
+        (0, {"digits": 0}, "0"),
+        (0.0, {}, "0.0"),
+        (0.0, {"digits": 1}, "0."),
+        (0.0, {"digits": 0}, "0"),
+        (complex(1, 2), {}, "1.0+2.0j"),
+        (complex(0, 2), {}, "0.0+2.0j"),
+        (complex(1, 0), {}, "1.0+0.0j"),
+    ],
+)
+def test_string_from_number_sigfig(
+    value: complex, args: dict, expected_output: str
+) -> None:
+    assert pl.string_from_number_sigfig(value, **args) == expected_output

--- a/apps/prairielearn/python/test/core_test.py
+++ b/apps/prairielearn/python/test/core_test.py
@@ -483,7 +483,7 @@ def test_index2key(idx: int, expected_output: str) -> None:
         ),
     ],
 )
-def test_string_from_numpy(value: int, args: dict, expected_output: str) -> None:
+def test_string_from_numpy(value: Any, args: dict, expected_output: str) -> None:
     assert pl.string_from_numpy(value, **args) == expected_output
 
 
@@ -499,9 +499,33 @@ def test_string_from_numpy(value: int, args: dict, expected_output: str) -> None
         (complex(1, 2), {}, "1.0+2.0j"),
         (complex(0, 2), {}, "0.0+2.0j"),
         (complex(1, 0), {}, "1.0+0.0j"),
+        (np.complex64(complex(1, 2)), {}, "1.0+2.0j"),
+        (np.complex64(complex(0, 2)), {}, "0.0+2.0j"),
+        (np.complex64(complex(1, 0)), {}, "1.0+0.0j"),
     ],
 )
 def test_string_from_number_sigfig(
-    value: complex, args: dict, expected_output: str
+    value: Any, args: dict, expected_output: str
 ) -> None:
     assert pl.string_from_number_sigfig(value, **args) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("value", "args", "expected_output"),
+    [
+        (0, {}, "0.0"),
+        (0, {"ndigits": 1}, "0."),
+        (0, {"ndigits": 0}, "0"),
+        (0.0, {}, "0.0"),
+        (0.0, {"ndigits": 1}, "0."),
+        (0.0, {"ndigits": 0}, "0"),
+        (complex(1, 2), {}, "1.0+2.0j"),
+        (complex(0, 2), {}, "0.0+2.0j"),
+        (complex(1, 0), {}, "1.0+0.0j"),
+        (np.complex64(complex(1, 2)), {}, "1.0+2.0j"),
+        (np.complex64(complex(0, 2)), {}, "0.0+2.0j"),
+        (np.complex64(complex(1, 0)), {}, "1.0+0.0j"),
+    ],
+)
+def test_numpy_to_matlab_sf(value: Any, args: dict, expected_output: str) -> None:
+    assert pl.numpy_to_matlab_sf(value, **args) == expected_output


### PR DESCRIPTION
Fixes regressions introduced in #11158. Incorrect runtime type checks were added that caused `string_from_numpy` to raise a `ValueError` when called with instances of `np.float64` and similar values.

I uncovered a second error while testing: `pl.string_from_number_sigfig(complex(1, 2))` would incorrectly produce a string like `1.0`. This was also due to incorrect runtime type checks.