### PR TITLE
Update course instance settings page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -33,14 +33,7 @@ export function InstructorAssessmentSettings({
       page: 'assessment',
       subPage: 'settings',
     },
-    headContent: html`
-      ${compiledScriptTag('instructorAssessmentSettingsClient.ts')}
-      <style>
-        .popover {
-          max-width: 50%;
-        }
-      </style>
-    `,
+    headContent: html` ${compiledScriptTag('instructorAssessmentSettingsClient.ts')} `,
     content: html`
       ${AssessmentSyncErrorsAndWarnings({
         authz_data: resLocals.authz_data,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -41,77 +41,94 @@ export function InstructorInstanceAdminSettings({
           })}
           <div class="card mb-4">
             <div class="card-header bg-primary text-white d-flex">
-              <h1>Course instance ${resLocals.course_instance.short_name}</h1>
+              <h1>Course instance settings</h1>
             </div>
-            <table
-              class="table table-sm table-hover two-column-description"
-              aria-label="Course instance settings"
-            >
-              <tbody>
-                <tr>
-                  <th>Long Name</th>
-                  <td>${resLocals.course_instance.long_name}</td>
-                </tr>
-                <tr>
-                  <th>CIID</th>
-                  <td>
-                    <span class="pr-2">${resLocals.course_instance.short_name}</span>
-                    ${resLocals.authz_data.has_course_permission_edit &&
-                    !resLocals.course.example_course
-                      ? ChangeIdButton({
-                          label: 'CIID',
-                          currentValue: resLocals.course_instance.short_name,
-                          otherValues: shortNames,
-                          extraHelpText: html`The recommended format is <code>Fa19</code> or
-                            <code>Fall2019</code>. Add suffixes if there are multiple versions, like
-                            <code>Fa19honors</code>.`,
-                          csrfToken: resLocals.__csrf_token,
-                        })
-                      : ''}
-                  </td>
-                </tr>
-                <tr>
-                  <th>Configuration</th>
-                  <td>
-                    ${EditConfiguration({
-                      hasCoursePermissionView: resLocals.authz_data.has_course_permission_view,
-                      hasCoursePermissionEdit: resLocals.authz_data.has_course_permission_edit,
-                      exampleCourse: resLocals.course.example_course,
-                      urlPrefix: resLocals.urlPrefix,
-                      navPage: resLocals.navPage,
-                      infoCourseInstancePath,
-                    })}
-                  </td>
-                </tr>
-                <tr>
-                  <th class="align-middle">Student Link</th>
-                  <td class="form-inline align-middle">
-                    <span class="input-group">
-                      <span readonly class="form-control form-control-sm">${studentLink}</span>
-                      <div class="input-group-append">
-                        <button
-                          type="button"
-                          class="btn btn-sm btn-outline-secondary btn-copy"
-                          data-clipboard-text="${studentLink}"
-                          aria-label="Copy student link"
-                        >
-                          <i class="far fa-clipboard"></i>
-                        </button>
-                        <button
-                          type="button"
-                          title="Student Link QR Code"
-                          aria-label="Student Link QR Code"
-                          class="btn btn-sm btn-outline-secondary js-qrcode-button"
-                          data-qr-code-content="${studentLink}"
-                        >
-                          <i class="fas fa-qrcode"></i>
-                        </button>
-                      </div>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+            <div class="card-body">
+              <div class="form-group">
+                <label for="long_name">Long Name</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="long_name"
+                  name="long_name"
+                  value="${resLocals.course_instance.long_name}"
+                  required
+                  disabled
+                />
+                <small class="form-text text-muted">
+                  The long name of this course instance (e.g., 'Spring 2015').
+                </small>
+              </div>
+              <div class="form-group">
+                <label for="CIID"
+                  >CIID
+                  ${resLocals.authz_data.has_course_permission_edit &&
+                  !resLocals.course.example_course
+                    ? ChangeIdButton({
+                        label: 'CIID',
+                        currentValue: resLocals.course_instance.short_name,
+                        otherValues: shortNames,
+                        extraHelpText: html`The recommended format is <code>Fa19</code> or
+                          <code>Fall2019</code>. Add suffixes if there are multiple versions, like
+                          <code>Fa19honors</code>.`,
+                        csrfToken: resLocals.__csrf_token,
+                      })
+                    : ''}</label
+                >
+                <input
+                  type="text"
+                  class="form-control"
+                  id="CIID"
+                  name="CIID"
+                  value="${resLocals.course_instance.short_name}"
+                  required
+                  disabled
+                />
+                <small class="form-text text-muted">
+                  Use only letters, numbers, dashes, and underscores, with no spaces. You may use
+                  forward slashes to separate directories. The recommended format is
+                  <code>Fa19</code> or <code>Fall2019</code>. Add suffixes if there are multiple
+                  versions, like <code>Fa19honors</code>.
+                </small>
+              </div>
+              <div class="form-group">
+                <label for="student_link">Student Link</label>
+                <span class="input-group">
+                  <span readonly class="form-control form-control-sm">${studentLink}</span>
+                  <div class="input-group-append">
+                    <button
+                      type="button"
+                      class="btn btn-sm btn-outline-secondary btn-copy"
+                      data-clipboard-text="${studentLink}"
+                      aria-label="Copy student link"
+                    >
+                      <i class="far fa-clipboard"></i>
+                    </button>
+                    <button
+                      type="button"
+                      title="Student Link QR Code"
+                      aria-label="Student Link QR Code"
+                      class="btn btn-sm btn-outline-secondary js-qrcode-button"
+                      data-qr-code-content="${studentLink}"
+                    >
+                      <i class="fas fa-qrcode"></i>
+                    </button>
+                  </div>
+                </span>
+                <small class="form-text text-muted">
+                  This is the link that students will use to access the course. You can copy this
+                  link to share with students.
+                </small>
+              </div>
+              ${EditConfiguration({
+                hasCoursePermissionView: resLocals.authz_data.has_course_permission_view,
+                hasCoursePermissionEdit: resLocals.authz_data.has_course_permission_edit,
+                exampleCourse: resLocals.course.example_course,
+                urlPrefix: resLocals.urlPrefix,
+                navPage: resLocals.navPage,
+                infoCourseInstancePath,
+              })}
+            </div>
             ${resLocals.authz_data.has_course_permission_edit && !resLocals.course.example_course
               ? CopyCourseInstanceForm({
                   csrfToken: resLocals.__csrf_token,
@@ -141,28 +158,26 @@ function EditConfiguration({
   infoCourseInstancePath: string;
 }) {
   if (!hasCoursePermissionView && !hasCoursePermissionEdit) {
-    return 'infoCourseInstance.json';
+    return '';
   }
 
-  if (hasCoursePermissionEdit && !exampleCourse) {
+  if (!hasCoursePermissionEdit || exampleCourse) {
     return html`
-      <a href="${urlPrefix}/${navPage}/file_view/${infoCourseInstancePath}">
-        infoCourseInstance.json
-      </a>
-      <a
-        class="btn btn-xs btn-secondary mx-2"
-        role="button"
-        href="${urlPrefix}/${navPage}/file_edit/${infoCourseInstancePath}"
-      >
-        <i class="fa fa-edit"></i>
-        <span>Edit</span>
-      </a>
+      <p class="mb-0">
+        <a href="${urlPrefix}/${navPage}/file_view/${infoCourseInstancePath}">
+          View course instance configuration
+        </a>
+        in <code>infoCourseInstance.json</code>
+      </p>
     `;
   } else {
     return html`
-      <a href="${urlPrefix}/${navPage}/file_view/${infoCourseInstancePath}">
-        infoCourseInstance.json
-      </a>
+      <p class="mb-0">
+        <a href="${urlPrefix}/${navPage}/file_edit/${infoCourseInstancePath}">
+          Edit course instance configuration
+        </a>
+        in <code>infoCourseInstance.json</code>
+      </p>
     `;
   }
 }

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -24,11 +24,6 @@ export function InstructorInstanceAdminSettings({
       <head>
         ${HeadContents({ resLocals })}
         ${compiledScriptTag('instructorInstanceAdminSettingsClient.ts')}
-        <style>
-          .popover {
-            max-width: 50%;
-          }
-        </style>
       </head>
       <body>
         ${Navbar({ resLocals })}
@@ -176,7 +171,8 @@ function EditConfiguration({
         <a
           data-testid="edit-course-instance-configuration-link"
           href="${urlPrefix}/${navPage}/file_edit/${infoCourseInstancePath}"
-        >Edit course instance configuration</a>
+          >Edit course instance configuration</a
+        >
         in <code>infoCourseInstance.json</code>
       </p>
     `;

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -176,9 +176,7 @@ function EditConfiguration({
         <a
           data-testid="edit-course-instance-configuration-link"
           href="${urlPrefix}/${navPage}/file_edit/${infoCourseInstancePath}"
-        >
-          Edit course instance configuration
-        </a>
+        >Edit course instance configuration</a>
         in <code>infoCourseInstance.json</code>
       </p>
     `;

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -60,8 +60,8 @@ export function InstructorInstanceAdminSettings({
                 </small>
               </div>
               <div class="form-group">
-                <label for="CIID"
-                  >CIID
+                <label for="CIID">
+                  CIID
                   ${resLocals.authz_data.has_course_permission_edit &&
                   !resLocals.course.example_course
                     ? ChangeIdButton({
@@ -73,8 +73,8 @@ export function InstructorInstanceAdminSettings({
                           <code>Fa19honors</code>.`,
                         csrfToken: resLocals.__csrf_token,
                       })
-                    : ''}</label
-                >
+                    : ''}
+                </label>
                 <input
                   type="text"
                   class="form-control"

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -173,7 +173,10 @@ function EditConfiguration({
   } else {
     return html`
       <p class="mb-0">
-        <a href="${urlPrefix}/${navPage}/file_edit/${infoCourseInstancePath}">
+        <a
+          data-testid="edit-course-instance-configuration-link"
+          href="${urlPrefix}/${navPage}/file_edit/${infoCourseInstancePath}"
+        >
           Edit course instance configuration
         </a>
         in <code>infoCourseInstance.json</code>

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -95,10 +95,6 @@ export function InstructorQuestionSettings({
     headContent: html`
       ${compiledScriptTag('instructorQuestionSettingsClient.ts')}
       <style>
-        .popover {
-          max-width: 50%;
-        }
-
         .ts-wrapper.multi .ts-control > span {
           cursor: pointer;
         }

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -149,7 +149,7 @@ const findEditUrlData = [
   },
   {
     name: 'instance admin',
-    selector: 'a:contains("infoCourseInstance.json") + a:contains("Edit")',
+    selector: '[data-testid="edit-course-instance-configuration-link"]',
     url: courseInstanceInstanceAdminSettingsUrl,
     expectedEditUrl: courseInstanceInstanceAdminEditUrl,
   },


### PR DESCRIPTION
This PR updates the course instance settings (`instructorInstanceAdminSettings`) page to include form fields. This is a stepping stone to adding an editor to this page. As we have done with other settings pages, we are first converting the main card to include form fields. These will be updated to be editable in a future PR. I have used the course settings (`instructorCourseAdminSettings`) page as a template for the changes here. 

<img width="1330" alt="Screenshot 2025-02-04 at 2 49 44 PM" src="https://github.com/user-attachments/assets/b873f482-9d16-4172-8d04-1915bbed677f" />
