### PR TITLE
Fix handling of HTML5 named entities in new question processor

### DIFF
--- a/apps/prairielearn/python/prairielearn/internal/traverse.py
+++ b/apps/prairielearn/python/prairielearn/internal/traverse.py
@@ -1,6 +1,7 @@
 from collections import deque
 from collections.abc import Callable
 from html import escape as html_escape
+from html import unescape as html_unescape
 from itertools import chain
 
 import lxml.html
@@ -138,7 +139,17 @@ def traverse_and_replace(
                     if new_elements.tag in UNESCAPED_ELEMENTS:
                         result.append(new_elements.text)
                     else:
-                        result.append(html_escape(new_elements.text))
+                        # `lxml` uses `libxml2` under the hood, which does not support
+                        # the full set of HTML5 named entities:
+                        # https://gitlab.gnome.org/GNOME/libxml2/-/issues/857
+                        # This means that with a naive approach, we'd end up double
+                        # escaping entities like `&langle;` into `&amp;langle;`. To work
+                        # around this (at least until `libxml2` hopefully adds support for
+                        # HTML5 named entities), we first unescape the text to get the
+                        # actual Unicode characters, and then escape them again. Escaping
+                        # will only escape `&`, `<`, and `>`; it won't escape everything
+                        # that could possibly be represented by a named entity.
+                        result.append(html_escape(html_unescape(new_elements.text)))
 
                 # Add all children to the work stack
                 children = list(new_elements)

--- a/apps/prairielearn/python/test/traverse_test.py
+++ b/apps/prairielearn/python/test/traverse_test.py
@@ -253,6 +253,29 @@ def test_traverse_indentation() -> None:
     assert html == original_html
 
 
+def test_traverse_pre_html4_entities() -> None:
+    original_html = "<pre>1 &lt; 2 &amp;&amp; 3 &gt; 2</pre>"
+    html = traverse_and_replace(
+        original_html,
+        lambda e: e,
+    )
+    assert html == original_html
+
+
+# This test specifically checks for HTML5 entity handling, which `lxml`
+# doesn't natively support: https://gitlab.gnome.org/GNOME/libxml2/-/issues/857
+#
+# We specifically expect to get back the actual Unicode characters, not the
+# original named entities.
+def test_traverse_pre_html5_entities() -> None:
+    original_html = "<pre>&langle;v, w&rangle;</pre>"
+    html = traverse_and_replace(
+        original_html,
+        lambda e: e,
+    )
+    assert html == "<pre>⟨v, w⟩</pre>"
+
+
 def test_traverse_and_replace_attribute_quotes() -> None:
     def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
         if e.tag == "span":


### PR DESCRIPTION
@ffund reported that the following example broke when rendered with the new question processor:

```html
<pre>&langle; something &rangle;</pre>
```

She used to see this:

```
⟨ something ⟩
```

But now saw this:

```
&langle; something &rangle;
```

This occurs because `libxml2` (and this `lxml`) only knows about HTML4 named entities, but `&langle;` and `&rangle;` were only defined in HTML5. See this issue: https://gitlab.gnome.org/GNOME/libxml2/-/issues/857

This wasn't a problem with the old question processor, which used `parse5` and properly supported these out of the box.

The easiest way to fix this was to eagerly resolve named entities to their actual Unicode characters, and then re-escape to just handle `&`, `<`, and `>`. We explicitly declare all our documents as being `utf-8`, so this should be safe:

https://github.com/PrairieLearn/PrairieLearn/blob/14acf47f6df79fc04e64e6cb7ab41a57f2f43101/apps/prairielearn/src/components/HeadContents.html.ts#L29