### PR TITLE
Allow strings in string_from_number_sigfig

### DIFF
--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -97,6 +97,14 @@ def format_true_ans(
             element, "comparison", ComparisonType, COMPARISON_DEFAULT
         )
 
+        # Correct answers may be specified as strings, so we need to convert them
+        # to numbers for formatting. See the note in `grade()` for why we cast to
+        # these specific types.
+        if np.iscomplexobj(correct_answer):
+            correct_answer = np.complex128(correct_answer)
+        else:
+            correct_answer = np.float64(correct_answer)
+
         if custom_format is not None:
             correct_answer = ("{:" + custom_format + "}").format(correct_answer)
         elif comparison is ComparisonType.RELABS:

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -1047,7 +1047,7 @@ def string_from_2darray(
     return result
 
 
-def string_from_number_sigfig(a: _NumericScalarType, digits: int = 2) -> str:
+def string_from_number_sigfig(a: _NumericScalarType | str, digits: int = 2) -> str:
     """string_from_complex_sigfig(a, digits=2)
 
     This function assumes that "a" is of type float or complex. It returns "a"
@@ -1056,7 +1056,7 @@ def string_from_number_sigfig(a: _NumericScalarType, digits: int = 2) -> str:
     """
 
     assert np.isscalar(a)
-    assert not isinstance(a, memoryview | str | bytes)
+    assert not isinstance(a, memoryview | bytes)
 
     if np.iscomplexobj(a):
         # `np.iscomplexobj` isn't a proper type guard, so we need to use

--- a/apps/prairielearn/python/test/core_test.py
+++ b/apps/prairielearn/python/test/core_test.py
@@ -502,6 +502,10 @@ def test_string_from_numpy(value: Any, args: dict, expected_output: str) -> None
         (np.complex64(complex(1, 2)), {}, "1.0+2.0j"),
         (np.complex64(complex(0, 2)), {}, "0.0+2.0j"),
         (np.complex64(complex(1, 0)), {}, "1.0+0.0j"),
+        # For legacy reasons, we must also support strings.
+        ("0", {}, "0.0"),
+        ("0", {"digits": 1}, "0."),
+        ("0", {"digits": 0}, "0"),
     ],
 )
 def test_string_from_number_sigfig(


### PR DESCRIPTION
This was another regression introduced by recent changes to the `string_from_number_sigfig` function. Historically, it allowed and correctly handled strings, though this wasn't documented and thus didn't make its way into our types. This manifests as a problem when someone specifies a string correct answer for `<pl-number-input comparison="sigfig">`. We'd pass the string to `string_from_number_sigfig`, which would fail at the newly-added type assertion.

This PR makes two changes to make things work:

- It changes `string_from_number_sigfig` to support strings as the first argument.
- It changes the `format_true_ans` function in `pl-number-input` to support string correct answers. Previously, this was (maybe accidentally) allowed when `comparision="sigfig"`, but would otherwise fail. Now, we always cast/parse the correct answer to a `np.float64` or a `np.complex128` before trying to render it. This should be safe, as we always do the same in `grade()` before comparing it with the submitted answer.