### PR TITLE
Fix handling of relative paths in course directories config

### DIFF
--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
@@ -34,12 +34,13 @@ async function update(locals: Record<string, any>) {
     //
     // A set also maintains insertion order, which ensures that courses that are
     // listed in the config (and listed earlier in the config) are synced first.
-    const courseDirs = new Set<string>(config.courseDirs);
+    const courseDirs = new Set<string>(
+      config.courseDirs.map((courseDir) => path.resolve(REPOSITORY_ROOT_PATH, courseDir)),
+    );
     const courses = await queryRows(sql.select_all_courses, CourseSchema);
     courses.forEach((course) => courseDirs.add(course.path));
 
     await async.eachOfSeries(Array.from(courseDirs), async (courseDir, index) => {
-      courseDir = path.resolve(REPOSITORY_ROOT_PATH, courseDir);
       job.info(chalk.bold(courseDir));
       const infoCourseFile = path.join(courseDir, 'infoCourse.json');
       const hasInfoCourseFile = await fs.pathExists(infoCourseFile);


### PR DESCRIPTION
Resolves #11310. Ensures that directories that are listed as relative paths in the config for "courseDirs" (such as exampleCourse, testCourse and templateCourse)  are not loaded twice when "Load from disk" is invoked, by using the resolved path when comparing with existing courses.