### PR TITLE
Fix qr code button

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/qrCodeButton.ts
+++ b/apps/prairielearn/assets/scripts/lib/qrCodeButton.ts
@@ -3,18 +3,18 @@ import { observe } from 'selector-observer';
 
 import { onDocumentReady, parseHTMLElement } from '@prairielearn/browser-utils';
 
-observe('.js-qrcode-button', {
-  add(el) {
-    if (!(el instanceof HTMLElement)) return;
+onDocumentReady(() => {
+  observe('.js-qrcode-button', {
+    add(el) {
+      if (!(el instanceof HTMLElement)) return;
 
-    const content = el.dataset.qrCodeContent;
-    if (content) {
-      const qrCodeSvg = new QR({ content, width: 512, height: 512 }).svg();
+      const content = el.dataset.qrCodeContent;
+      if (content) {
+        const qrCodeSvg = new QR({ content, width: 512, height: 512 }).svg();
 
-      // BS5 delays the initialization of popovers until the document load, so
-      // delay until that happens. Once we're no longer supporting BS4, this can
-      // be replaced with a proper BS5 API call.
-      onDocumentReady(() => {
+        // BS5 delays the initialization of popovers until the document load, so
+        // delay until that happens. Once we're no longer supporting BS4, this can
+        // be replaced with a proper BS5 API call.
         // The `data-content` attribute appears to not support SVGs, so we need
         // to manually initialize the popover with the SVG content.
         $(el).popover({
@@ -23,7 +23,7 @@ observe('.js-qrcode-button', {
           trigger: 'click',
           container: 'body',
         });
-      });
-    }
-  },
+      }
+    },
+  });
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -33,7 +33,14 @@ export function InstructorAssessmentSettings({
       page: 'assessment',
       subPage: 'settings',
     },
-    headContent: html` ${compiledScriptTag('instructorAssessmentSettingsClient.ts')} `,
+    headContent: html`
+      ${compiledScriptTag('instructorAssessmentSettingsClient.ts')}
+      <style>
+        .popover {
+          max-width: 50%;
+        }
+      </style>
+    `,
     content: html`
       ${AssessmentSyncErrorsAndWarnings({
         authz_data: resLocals.authz_data,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -24,6 +24,11 @@ export function InstructorInstanceAdminSettings({
       <head>
         ${HeadContents({ resLocals })}
         ${compiledScriptTag('instructorInstanceAdminSettingsClient.ts')}
+        <style>
+          .popover {
+            max-width: 50%;
+          }
+        </style>
       </head>
       <body>
         ${Navbar({ resLocals })}


### PR DESCRIPTION
Closes #11312. There are issues with the QR code not displaying properly in different browsers. In Chrome, the popover was hangout out of the popover. In Safari and Firefox, the popover was not initializing at all. This should fix those issues. 