### PR TITLE
ruff: start linting docstrings

### DIFF
--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -137,7 +137,6 @@ def get_lexer_by_name(name: str) -> pygments.lexer.Lexer | None:
     Find a lexer by both its proper name and any aliases it has.
     Returns None if no lexer is found.
     """
-
     # Search by proper class/language names
     # This returns None if not found, and a class if found.
     lexer_class = pygments.lexers.find_lexer_class(name)

--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -51,7 +51,7 @@ ANSI_COLORS = {
 
 def parse_highlight_lines(highlight_lines: str) -> list[int] | None:
     """
-    Parses a string like "1", "1-4", "1-3,5,7-8" into a list of lines like
+    Parse a string like "1", "1-4", "1-3,5,7-8" into a list of lines like
     [1], [1,2,3,4], and [1,2,3,5,7,8]
     """
     lines = []
@@ -134,7 +134,8 @@ class HighlightingHtmlFormatter(pygments.formatters.HtmlFormatter[str]):
 @cache
 def get_lexer_by_name(name: str) -> pygments.lexer.Lexer | None:
     """
-    Tries to find a lexer by both its proper name and any aliases it has.
+    Find a lexer by both its proper name and any aliases it has.
+    Returns None if no lexer is found.
     """
 
     # Search by proper class/language names

--- a/apps/prairielearn/elements/pl-drawing/elements.py
+++ b/apps/prairielearn/elements/pl-drawing/elements.py
@@ -52,9 +52,7 @@ class BaseElement:
         return True
 
     def get_attributes():
-        """
-        Returns a list of attributes that the element may contain.
-        """
+        """Return a list of attributes that the element may contain."""
         return []
 
 

--- a/apps/prairielearn/elements/pl-matching/pl-matching.py
+++ b/apps/prairielearn/elements/pl-matching/pl-matching.py
@@ -33,7 +33,7 @@ def get_form_name(answers_name: str, index: int) -> str:
 
 
 def get_counter(i: int, counter_type: str) -> str:
-    """Converts an integer counter to the specified CSS counter type"""
+    """Convert an integer counter to the specified CSS counter type"""
     if counter_type == "lower-alpha":
         return pl.index2key(i - 1)
     elif counter_type == "upper-alpha":
@@ -49,7 +49,7 @@ def get_counter(i: int, counter_type: str) -> str:
 
 
 def legal_answer(answer: int, options: list[Any]) -> bool:
-    """Checks that the given answer is within the range of the given counter type."""
+    """Check that the given answer is within the range of the given counter type."""
     return -1 <= answer < len(options)
 
 
@@ -74,7 +74,7 @@ def partition(
     data: list[ListItem], pred: Callable[[ListItem], bool]
 ) -> tuple[list[ListItem], list[ListItem]]:
     """
-    Implements a partition function, splitting the data into two lists based on the predicate.
+    Split the data into two lists based on the predicate.
     TODO move this into prairielearn.py once it's used in another element.
     """
 

--- a/apps/prairielearn/elements/pl-matching/pl-matching.py
+++ b/apps/prairielearn/elements/pl-matching/pl-matching.py
@@ -77,7 +77,6 @@ def partition(
     Split the data into two lists based on the predicate.
     TODO move this into prairielearn.py once it's used in another element.
     """
-
     yes, no = [], []
     for d in data:
         if pred(d):

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -166,7 +166,6 @@ def get_nota_aota_attrib(
     interpretations. If the value cannot be interpreted as boolean,
     the string representation is used.
     """
-
     try:
         boolean_value = pl.get_boolean_attrib(
             element, name, default != AotaNotaType.FALSE
@@ -178,7 +177,6 @@ def get_nota_aota_attrib(
 
 def get_order_type(element: lxml.html.HtmlElement) -> OrderType:
     """Get order type in a backwards-compatible way. New display overwrites old."""
-
     if pl.has_attrib(element, "fixed-order") and pl.has_attrib(element, "order"):
         raise ValueError(
             'Setting answer choice order should be done with the "order" attribute.'
@@ -192,7 +190,6 @@ def get_order_type(element: lxml.html.HtmlElement) -> OrderType:
 
 def get_display_type(element: lxml.html.HtmlElement) -> DisplayType:
     """Get display type in a backwards-compatible way. New display overwrites old."""
-
     if pl.has_attrib(element, "inline") and pl.has_attrib(element, "display"):
         raise ValueError(
             'Setting answer choice display should be done with the "display" attribute.'

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -177,7 +177,7 @@ def get_nota_aota_attrib(
 
 
 def get_order_type(element: lxml.html.HtmlElement) -> OrderType:
-    """Gets order type in a backwards-compatible way. New display overwrites old."""
+    """Get order type in a backwards-compatible way. New display overwrites old."""
 
     if pl.has_attrib(element, "fixed-order") and pl.has_attrib(element, "order"):
         raise ValueError(
@@ -191,7 +191,7 @@ def get_order_type(element: lxml.html.HtmlElement) -> OrderType:
 
 
 def get_display_type(element: lxml.html.HtmlElement) -> DisplayType:
-    """Gets display type in a backwards-compatible way. New display overwrites old."""
+    """Get display type in a backwards-compatible way. New display overwrites old."""
 
     if pl.has_attrib(element, "inline") and pl.has_attrib(element, "display"):
         raise ValueError(

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -31,7 +31,8 @@ def validate_grouping(
 def solve_dag(
     depends_graph: Mapping[str, list[str]], group_belonging: Mapping[str, str | None]
 ) -> list[str]:
-    """Solve the given problem
+    """
+    Solve the given problem
     :param depends_graph: The dependency graph between blocks specified in the question
     :param group_belonging: which pl-block-group each block belongs to, specified in the question
     :return: a list that is a topological sort of the input DAG with blocks in the same group occuring
@@ -155,7 +156,8 @@ def grade_dag(
     depends_graph: Mapping[str, list[str]],
     group_belonging: Mapping[str, str | None],
 ) -> tuple[int, int]:
-    """In order for a student submission to a DAG graded question to be deemed correct, the student
+    """
+    In order for a student submission to a DAG graded question to be deemed correct, the student
     submission must be a topological sort of the DAG and blocks which are in the same pl-block-group
     as one another must all appear contiguously.
     :param submission: the block ordering given by the student
@@ -173,7 +175,8 @@ def grade_dag(
 
 
 def is_vertex_cover(G: nx.DiGraph, vertex_cover: Iterable[str]) -> bool:
-    """this function from
+    """
+    Taken from
     https://docs.ocean.dwavesys.com/en/stable/docs_dnx/reference/algorithms/generated/dwave_networkx.algorithms.cover.is_vertex_cover.html
     """
     cover = set(vertex_cover)
@@ -185,7 +188,8 @@ def lcs_partial_credit(
     depends_graph: Mapping[str, list[str]],
     group_belonging: Mapping[str, str | None],
 ) -> int:
-    """Computes the number of edits required to change the student solution into a correct solution using
+    """
+    Compute the number of edits required to change the student solution into a correct solution using
     largest common subsequence edit distance (allows only additions and deletions, not replacing).
     The naive solution would be to enumerate all topological sorts, then get the edit distance to each of them,
     but this would be too slow. Instead, our algorithm is as follows:

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.py
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.py
@@ -45,7 +45,7 @@ UNITS_INPUT_MUSTACHE_TEMPLATE_NAME = "pl-units-input.mustache"
 def get_with_units_atol(
     element: lxml.html.HtmlElement, data: pl.QuestionData, ureg: UnitRegistry
 ) -> str:
-    """Returns the atol string for use in the "with-units" grading mode."""
+    """Return the atol string for use in the "with-units" grading mode."""
 
     if pl.has_attrib(element, "atol"):
         return pl.get_string_attrib(element, "atol")

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.py
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.py
@@ -46,7 +46,6 @@ def get_with_units_atol(
     element: lxml.html.HtmlElement, data: pl.QuestionData, ureg: UnitRegistry
 ) -> str:
     """Return the atol string for use in the "with-units" grading mode."""
-
     if pl.has_attrib(element, "atol"):
         return pl.get_string_attrib(element, "atol")
 

--- a/apps/prairielearn/elements/pl-units-input/unit_utils.py
+++ b/apps/prairielearn/elements/pl-units-input/unit_utils.py
@@ -29,7 +29,7 @@ class ComparisonType(Enum):
 def get_only_units_grading_fn(
     *, ureg: UnitRegistry, correct_ans: str
 ) -> Callable[[str], tuple[bool, str | None]]:
-    """Returns the grading function used for units only grading mode."""
+    """Return the grading function used for units only grading mode."""
     parsed_correct_ans = ureg.Quantity(correct_ans)
 
     def grade_only_units(submitted_ans: str) -> tuple[bool, str | None]:

--- a/apps/prairielearn/python/prairielearn/colors.py
+++ b/apps/prairielearn/python/prairielearn/colors.py
@@ -142,7 +142,7 @@ PLColor.register(PrairieLearnColor(), overwrite=True)
 
 def get_css_color(name: str) -> str | None:
     """
-    Tries to look up a hex code value from a named css color, otherwise will
+    Try to look up a hex code value from a named css color, otherwise
     return None if not a valid color.
     """
     name = name.lower()

--- a/apps/prairielearn/python/prairielearn/colors.py
+++ b/apps/prairielearn/python/prairielearn/colors.py
@@ -108,7 +108,6 @@ class PrairieLearnColor(sRGB):
         **kwargs: Any,
     ) -> str:
         """Convert to string."""
-
         if names:
             # Get alpha and coordinates resolving undefined values as required
             alpha_float = serialize.get_alpha(parent, alpha, none=False, legacy=False)

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 
 class PartialScore(TypedDict):
-    "A class with type signatures for the partial scores dict"
+    """A class with type signatures for the partial scores dict"""
 
     score: float | None
     weight: NotRequired[int]
@@ -59,7 +59,7 @@ class PartialScore(TypedDict):
 # for their answer data, feedback data, etc., but TypedDicts with Generics are
 # not yet supported: https://bugs.python.org/issue44863
 class QuestionData(TypedDict):
-    "A class with type signatures for the data dictionary"
+    """A class with type signatures for the data dictionary"""
 
     params: dict[str, Any]
     correct_answers: dict[str, Any]
@@ -84,7 +84,7 @@ class ElementTestData(QuestionData):
 
 
 def check_answers_names(data: QuestionData, name: str) -> None:
-    """Checks that answers names are distinct using property in data dict."""
+    """Check that answers names are distinct using property in data dict."""
     if name in data["answers_names"]:
         raise KeyError(f'Duplicate "answers-name" attribute: "{name}"')
     data["answers_names"][name] = True
@@ -172,13 +172,13 @@ def get_enum_attrib(
     default: EnumT | None = None,
 ) -> EnumT:
     """
-    Returns the named attribute for the element parsed as an enum,
+    Return the named attribute for the element parsed as an enum,
     or the (optional) default value. If the default value is not provided
     and the attribute is missing then an exception is thrown. An exception
     is also thrown if the value for the enum provided is invalid.
-    Also, alters the enum names to comply with PL naming convention automatically
-    (replacing underscores with dashes and uppercasing). If default value is
-    provided, must be a member of the given enum.
+    Also, alter the enum names to comply with PL naming convention automatically
+    (replacing underscores with dashes and uppercasing). If a default value is
+    provided, it must be a member of the given enum.
     """
 
     enum_val, is_default = (
@@ -209,7 +209,7 @@ def get_enum_attrib(
 
 def set_weighted_score_data(data: QuestionData, weight_default: int = 1) -> None:
     """
-    Sets overall question score to be weighted average of all partial scores. Uses
+    Set overall question score to be weighted average of all partial scores. Use
     weight_default to fill in a default weight for a score if one is missing.
     """
 
@@ -229,7 +229,7 @@ def set_weighted_score_data(data: QuestionData, weight_default: int = 1) -> None
 
 
 def set_all_or_nothing_score_data(data: QuestionData) -> None:
-    """Gives points to main question score if all partial scores are correct."""
+    """Give points to main question score if all partial scores are correct."""
 
     data["score"] = 1.0 if all_partial_scores_correct(data) else 0.0
 
@@ -329,8 +329,7 @@ def to_json(
     df_encoding_version: Literal[1, 2] = 1,
     np_encoding_version: Literal[1, 2] = 1,
 ) -> Any | _JSONSerializedType:
-    """to_json(v)
-
+    """
     If v has a standard type that cannot be json serialized, it is replaced with
     a {'_type':..., '_value':...} pair that can be json serialized:
 
@@ -441,9 +440,7 @@ def to_json(
 
 
 def _has_value_fields(v: _JSONSerializedType, fields: list[str]) -> bool:
-    """
-    Helper to check for the presence of all fields in the '_value' dictionary
-    """
+    """Return True if all fields in the '_value' dictionary are present."""
     return (
         "_value" in v
         and isinstance(v["_value"], dict)
@@ -452,8 +449,7 @@ def _has_value_fields(v: _JSONSerializedType, fields: list[str]) -> bool:
 
 
 def from_json(v: _JSONSerializedType | Any) -> Any:
-    """from_json(v)
-
+    """
     If v has the format {'_type':..., '_value':...} as would have been created
     using to_json(...), then it is replaced:
 
@@ -597,16 +593,15 @@ def check_attribs(
 def _get_attrib(
     element: lxml.html.HtmlElement, name: str, *args: Any
 ) -> tuple[Any, bool]:
-    """(value, is_default) = _get_attrib(element, name, default)
-
-    Internal function, do not all. Use one of the typed variants
-    instead (e.g., get_string_attrib()).
-
-    Returns the named attribute for the element, or the default value
+    """
+    Return the named attribute for the element, or the default value
     if the attribute is missing.  The default value is optional. If no
     default value is provided and the attribute is missing then an
     exception is thrown. The second return value indicates whether the
     default value was returned.
+
+    Internal function, do not all. Use one of the typed variants
+    instead (e.g., get_string_attrib()).
     """
     # It seems like we could use keyword arguments with a default
     # value to handle the "default" argument, but we want to be able
@@ -631,9 +626,8 @@ def _get_attrib(
 
 
 def has_attrib(element: lxml.html.HtmlElement, name: str) -> bool:
-    """value = has_attrib(element, name)
-
-    Returns true if the element has an attribute of that name,
+    """
+    Return true if the element has an attribute of that name,
     false otherwise.
     """
     old_name = name.replace("-", "_")
@@ -658,9 +652,8 @@ def get_string_attrib(
 def get_string_attrib(
     element: lxml.html.HtmlElement, name: str, *args: str | None
 ) -> str | None:
-    """value = get_string_attrib(element, name, default)
-
-    Returns the named attribute for the element, or the (optional)
+    """
+    Return the named attribute for the element, or the (optional)
     default value. If the default value is not provided and the
     attribute is missing then an exception is thrown.
     """
@@ -688,9 +681,8 @@ def get_boolean_attrib(
 def get_boolean_attrib(
     element: lxml.html.HtmlElement, name: str, *args: bool | None
 ) -> bool | None:
-    """value = get_boolean_attrib(element, name, default)
-
-    Returns the named attribute for the element, or the (optional)
+    """
+    Return the named attribute for the element, or the (optional)
     default value. If the default value is not provided and the
     attribute is missing then an exception is thrown. If the attribute
     is not a valid boolean then an exception is thrown.
@@ -742,9 +734,8 @@ def get_integer_attrib(
 def get_integer_attrib(
     element: lxml.html.HtmlElement, name: str, *args: int | None
 ) -> int | None:
-    """value = get_integer_attrib(element, name, default)
-
-    Returns the named attribute for the element, or the (optional)
+    """
+    Return the named attribute for the element, or the (optional)
     default value. If the default value is not provided and the
     attribute is missing then an exception is thrown. If the attribute
     is not a valid integer then an exception is thrown.
@@ -782,9 +773,8 @@ def get_float_attrib(
 def get_float_attrib(
     element: lxml.html.HtmlElement, name: str, *args: float | None
 ) -> float | None:
-    """value = get_float_attrib(element, name, default)
-
-    Returns the named attribute for the element, or the (optional)
+    """
+    Return the named attribute for the element, or the (optional)
     default value. If the default value is not provided and the
     attribute is missing then an exception is thrown. If the attribute
     is not a valid floating-point number then an exception is thrown.
@@ -816,9 +806,8 @@ def get_color_attrib(
 def get_color_attrib(
     element: lxml.html.HtmlElement, name: str, *args: str | None
 ) -> str | None:
-    """value = get_color_attrib(element, name, default)
-
-    Returns a 3-digit or 6-digit hex RGB string in CSS format (e.g., '#123'
+    """
+    Return a 3-digit or 6-digit hex RGB string in CSS format (e.g., '#123'
     or '#1a2b3c'), or the (optional) default value. If the default value is
     not provided and the attribute is missing then an exception is thrown. If
     the attribute is not a valid RGB string then it will be checked against various
@@ -852,15 +841,14 @@ def numpy_to_matlab(
     ndigits: int = 2,
     wtype: str = "f",
 ) -> str:
-    """numpy_to_matlab(np_object, ndigits=2, wtype='f')
+    """
+    Return np_object as a MATLAB-formatted string in which each number has "ndigits"
+    digits after the decimal and is formatted as "wtype" (e.g., 'f', 'g', etc.).
 
     This function assumes that np_object is one of these things:
 
         - a number (float or complex)
         - a 2D ndarray (float or complex)
-
-    It returns np_object as a MATLAB-formatted string in which each number has "ndigits"
-    digits after the decimal and is formatted as "wtype" (e.g., 'f', 'g', etc.).
     """
     if np.isscalar(np_object):
         scalar_str = "{:.{indigits}{iwtype}}".format(
@@ -911,15 +899,14 @@ def string_from_numpy(
     presentation_type: str = "f",
     digits: int = 2,
 ):
-    """string_from_numpy(A)
+    """
+    Return A as a string.
 
     This function assumes that A is one of these things:
 
         - a number (float or complex)
         - a 1D ndarray (float or complex)
         - a 2D ndarray (float or complex)
-
-    It returns A as a string.
 
     If language is 'python' and A is a 2D ndarray, the string looks like this:
 
@@ -1048,11 +1035,9 @@ def string_from_2darray(
 
 
 def string_from_number_sigfig(a: _NumericScalarType | str, digits: int = 2) -> str:
-    """string_from_complex_sigfig(a, digits=2)
-
-    This function assumes that "a" is of type float or complex. It returns "a"
-    as a string in which the number, or both the real and imaginary parts of the
-    number, have digits significant digits.
+    """
+    Return "a" as a string in which the number, or both the real and imaginary parts of the
+    number, have digits significant digits. This function assumes that "a" is of type float or complex.
     """
 
     assert np.isscalar(a)
@@ -1069,10 +1054,9 @@ def string_from_number_sigfig(a: _NumericScalarType | str, digits: int = 2) -> s
 def _string_from_complex_sigfig(
     a: complex | np.complex64 | np.complex128, digits: int = 2
 ) -> str:
-    """_string_from_complex_sigfig(a, digits=2)
-
-    This function assumes that "a" is a complex number. It returns "a" as a string
-    in which the real and imaginary parts have digits significant digits.
+    """
+    Return "a" as a string in which the real and imaginary parts have digits significant digits.
+    This function assumes that "a" is a complex number.
     """
     re = to_precision(a.real, digits)
     im = to_precision(np.abs(a.imag), digits)
@@ -1085,15 +1069,14 @@ def _string_from_complex_sigfig(
 def numpy_to_matlab_sf(
     A: _NumericScalarType | npt.NDArray[Any], ndigits: int = 2
 ) -> str:
-    """numpy_to_matlab(A, ndigits=2)
+    """
+    Return A as a MATLAB-formatted string in which each number has
+    ndigits significant digits.
 
     This function assumes that A is one of these things:
 
         - a number (float or complex)
         - a 2D ndarray (float or complex)
-
-    It returns A as a MATLAB-formatted string in which each number has
-    ndigits significant digits.
     """
     if np.isscalar(A):
         assert not isinstance(A, memoryview | str | bytes)
@@ -1162,12 +1145,7 @@ def string_partition_outer_interval(
 
 
 def string_to_integer(s: str, base: int = 10) -> int | None:
-    """string_to_integer(s, base=10)
-
-    Parses a string that is an integer.
-
-    Returns a number with type int, or None on parse error.
-    """
+    """Parse a string that is an integer, and return a number with type int, or None on parse error."""
     if not isinstance(s, str):
         return None
 
@@ -1186,11 +1164,9 @@ def string_to_integer(s: str, base: int = 10) -> int | None:
 def string_to_number(
     s: str, *, allow_complex: bool = True
 ) -> None | np.float64 | np.complex128:
-    """string_to_number(s, allow_complex=True)
-
-    Parses a string that can be interpreted either as float or (optionally) complex.
-
-    Returns a number with type np.float64 or np.complex128, or None on parse error.
+    """
+    Parse a string that can be interpreted either as float or (optionally) complex,
+    and return a number with type np.float64 or np.complex128, or None on parse error.
     """
     # Replace unicode minus with hyphen minus wherever it occurs
     s = s.replace("\u2212", "-")
@@ -1236,9 +1212,8 @@ def string_fraction_to_number(
     tuple[None, _PartialDataFormatErrors]
     | tuple[np.float64 | np.complex128, _PartialDataSubmittedAnswers]
 ):
-    """string_fraction_to_number(a_sub, allow_fractions=True, allow_complex=True)
-
-    Parses a string containing a decimal number with support for answers expressing
+    """
+    Parse a string containing a decimal number with support for answers expressing
     as a fraction.
 
     Returns a tuple with the parsed value in the first entry and a dictionary with
@@ -1331,9 +1306,8 @@ def string_fraction_to_number(
 def string_to_2darray(
     s: str, *, allow_complex: bool = True
 ) -> tuple[None | npt.NDArray[Any], dict[str, str]]:
-    """string_to_2darray(s)
-
-    Parses a string that is either a scalar or a 2D array in matlab or python
+    """
+    Parse a string that is either a scalar or a 2D array in matlab or python
     format. Each number must be interpretable as type float or complex.
     """
     # Replace unicode minus with hyphen minus wherever it occurs
@@ -1650,7 +1624,8 @@ def latex_from_2darray(
     presentation_type: str = "f",
     digits: int = 2,
 ) -> str:
-    r"""latex_from_2darray
+    r"""
+    latex_from_2darray
     This function assumes that A is one of these things:
             - a number (float or complex)
             - a 2D ndarray (float or complex)
@@ -1812,7 +1787,7 @@ def is_correct_scalar_sf(a_sub: ArrayLike, a_tru: ArrayLike, digits: int = 2) ->
 
 def get_uuid() -> str:
     """
-    Returns the string representation of a new random UUID.
+    Return the string representation of a new random UUID.
     First character of this uuid is guaranteed to be an alpha
     (at the expense of a slight loss in randomness).
 
@@ -1828,9 +1803,7 @@ def get_uuid() -> str:
 
 def escape_unicode_string(string: str) -> str:
     """
-    escape_unicode_string(string)
-
-    Combs through any string and replaces invisible/unprintable characters with a
+    Replace invisible/unprintable characters with a
     text representation of their hex id: <U+xxxx>
 
     A character is considered invisible if its category is "control" or "format", as
@@ -1851,20 +1824,12 @@ def escape_unicode_string(string: str) -> str:
 
 
 def escape_invalid_string(string: str) -> str:
-    """
-    escape_invalid_string(string)
-
-    Wraps and escapes string in <code> tags.
-    """
+    """Wrap and escape string in <code> tags."""
     return f'<code class="user-output-invalid">{html.escape(escape_unicode_string(string))}</code>'
 
 
 def clean_identifier_name(name: str) -> str:
-    """
-    clean_identifier_name(string)
-
-    Escapes a string so that it becomes a valid Python identifier.
-    """
+    """Escapes a string so that it becomes a valid Python identifier."""
 
     # Strip invalid characters and weird leading characters so we have
     # a decent python identifier
@@ -1875,9 +1840,7 @@ def clean_identifier_name(name: str) -> str:
 
 def load_extension(data: QuestionData, extension_name: str) -> Any:
     """
-    load_extension(data, extension_name)
-
-    Loads a single specific extension by name for an element.
+    Load a single specific extension by name for an element.
     Returns a dictionary of defined variables and functions.
     """
     if "extensions" not in data:
@@ -1928,9 +1891,7 @@ def load_extension(data: QuestionData, extension_name: str) -> Any:
 
 def load_all_extensions(data: QuestionData) -> dict[str, Any]:
     """
-    load_all_extensions(data)
-
-    Loads all available extensions for a given element.
+    Load all available extensions for a given element.
     Returns an ordered dictionary mapping the extension name to its defined variables and functions
     """
 
@@ -1947,11 +1908,7 @@ def load_all_extensions(data: QuestionData) -> dict[str, Any]:
 
 
 def load_host_script(script_name: str) -> ModuleType:
-    """
-    load_host_script(script_name)
-
-    Small convenience function to load a host element script from an extension.
-    """
+    """Small convenience function to load a host element script from an extension."""
 
     # Chop off the file extension because it's unnecessary here
     script_name = script_name.removesuffix(".py")
@@ -1972,9 +1929,7 @@ def iter_keys() -> Generator[str, None, None]:
 
 def index2key(i: int) -> str:
     """
-    index2key(i)
-
-    Used when generating ordered lists of the form ['a', 'b', ..., 'z', 'aa', 'ab', ..., 'zz', 'aaa', 'aab', ...]
+    Use when generating ordered lists of the form ['a', 'b', ..., 'z', 'aa', 'ab', ..., 'zz', 'aaa', 'aab', ...]
 
     Returns alphabetic key in the form [a-z]* from a given integer (i = 0, 1, 2, ...).
     """
@@ -1986,7 +1941,7 @@ def is_int_json_serializable(n: int) -> bool:
 
 
 def add_files_format_error(data: QuestionData, error: str) -> None:
-    """Adds a format error to the data dictionary."""
+    """Add a format error to the data dictionary."""
 
     if data["format_errors"].get("_files") is None:
         data["format_errors"]["_files"] = []
@@ -2004,7 +1959,7 @@ def add_submitted_file(
     file_name: str,
     base64_contents: str,
 ) -> None:
-    """Adds a submitted file to the data dictionary."""
+    """Add a submitted file to the data dictionary."""
 
     if data["submitted_answers"].get("_files") is None:
         data["submitted_answers"]["_files"] = []

--- a/apps/prairielearn/python/prairielearn/core.py
+++ b/apps/prairielearn/python/prairielearn/core.py
@@ -92,7 +92,6 @@ def check_answers_names(data: QuestionData, name: str) -> None:
 
 def get_unit_registry() -> UnitRegistry:
     """Get a unit registry using cache folder valid on production machines."""
-
     pid = os.getpid()
     cache_dir = f"/tmp/pint_{pid}"
     return UnitRegistry(cache_folder=cache_dir)
@@ -114,7 +113,6 @@ def grade_answer_parameterized(
             - a string containing feedback
             - None, if there is no feedback (usually this should only occur if the answer is correct)
     """
-
     # Create the data dictionary at first
     data["partial_scores"][question_name] = {"score": 0.0, "weight": weight}
 
@@ -153,7 +151,6 @@ def determine_score_params(
     conventions, the return value can be used as a key/value pair in the
     dictionary passed to an element's Mustache template to display a score badge.
     """
-
     if score >= 1:
         return ("correct", True)
     elif score > 0:
@@ -180,7 +177,6 @@ def get_enum_attrib(
     (replacing underscores with dashes and uppercasing). If a default value is
     provided, it must be a member of the given enum.
     """
-
     enum_val, is_default = (
         _get_attrib(element, name)
         if default is None
@@ -212,7 +208,6 @@ def set_weighted_score_data(data: QuestionData, weight_default: int = 1) -> None
     Set overall question score to be weighted average of all partial scores. Use
     weight_default to fill in a default weight for a score if one is missing.
     """
-
     weight_total = 0
     score_total = 0.0
     for part in data["partial_scores"].values():
@@ -230,7 +225,6 @@ def set_weighted_score_data(data: QuestionData, weight_default: int = 1) -> None
 
 def set_all_or_nothing_score_data(data: QuestionData) -> None:
     """Give points to main question score if all partial scores are correct."""
-
     data["score"] = 1.0 if all_partial_scores_correct(data) else 0.0
 
 
@@ -954,7 +948,6 @@ def string_from_numpy(
 
     Otherwise, each number is formatted as '{:.{digits}{presentation_type}}'.
     """
-
     # if A is a scalar
     if np.isscalar(A):
         assert not isinstance(A, memoryview | str | bytes)
@@ -1039,7 +1032,6 @@ def string_from_number_sigfig(a: _NumericScalarType | str, digits: int = 2) -> s
     Return "a" as a string in which the number, or both the real and imaginary parts of the
     number, have digits significant digits. This function assumes that "a" is of type float or complex.
     """
-
     assert np.isscalar(a)
     assert not isinstance(a, memoryview | bytes)
 
@@ -1747,7 +1739,6 @@ def is_correct_scalar_ra(
 
 def is_correct_scalar_dd(a_sub: ArrayLike, a_tru: ArrayLike, digits: int = 2) -> bool:
     """Compare a_sub and a_tru using digits many digits after the decimal place."""
-
     # If answers are complex, check real and imaginary parts separately
     if np.iscomplexobj(a_sub) or np.iscomplexobj(a_tru):
         real_comp = is_correct_scalar_dd(a_sub.real, a_tru.real, digits=digits)  # type: ignore
@@ -1765,7 +1756,6 @@ def is_correct_scalar_dd(a_sub: ArrayLike, a_tru: ArrayLike, digits: int = 2) ->
 
 def is_correct_scalar_sf(a_sub: ArrayLike, a_tru: ArrayLike, digits: int = 2) -> bool:
     """Compare a_sub and a_tru using digits many significant figures."""
-
     # If answers are complex, check real and imaginary parts separately
     if np.iscomplexobj(a_sub) or np.iscomplexobj(a_tru):
         real_comp = is_correct_scalar_sf(a_sub.real, a_tru.real, digits=digits)  # type: ignore
@@ -1794,7 +1784,6 @@ def get_uuid() -> str:
     This is done because certain web components need identifiers to
     start with letters and not numbers.
     """
-
     uuid_string = str(uuid.uuid4())
     random_char = random.choice("abcdef")
 
@@ -1830,7 +1819,6 @@ def escape_invalid_string(string: str) -> str:
 
 def clean_identifier_name(name: str) -> str:
     """Escapes a string so that it becomes a valid Python identifier."""
-
     # Strip invalid characters and weird leading characters so we have
     # a decent python identifier
     name = re.sub("[^a-zA-Z0-9_]", "_", name)
@@ -1894,7 +1882,6 @@ def load_all_extensions(data: QuestionData) -> dict[str, Any]:
     Load all available extensions for a given element.
     Returns an ordered dictionary mapping the extension name to its defined variables and functions
     """
-
     if "extensions" not in data:
         raise ValueError("load_all_extensions() must be called from an element!")
     if len(data["extensions"]) == 0:
@@ -1909,7 +1896,6 @@ def load_all_extensions(data: QuestionData) -> dict[str, Any]:
 
 def load_host_script(script_name: str) -> ModuleType:
     """Small convenience function to load a host element script from an extension."""
-
     # Chop off the file extension because it's unnecessary here
     script_name = script_name.removesuffix(".py")
     return __import__(script_name)
@@ -1942,7 +1928,6 @@ def is_int_json_serializable(n: int) -> bool:
 
 def add_files_format_error(data: QuestionData, error: str) -> None:
     """Add a format error to the data dictionary."""
-
     if data["format_errors"].get("_files") is None:
         data["format_errors"]["_files"] = []
     if isinstance(data["format_errors"]["_files"], list):
@@ -1960,7 +1945,6 @@ def add_submitted_file(
     base64_contents: str,
 ) -> None:
     """Add a submitted file to the data dictionary."""
-
     if data["submitted_answers"].get("_files") is None:
         data["submitted_answers"]["_files"] = []
     if isinstance(data["submitted_answers"]["_files"], list):

--- a/apps/prairielearn/python/prairielearn/internal/traverse.py
+++ b/apps/prairielearn/python/prairielearn/internal/traverse.py
@@ -70,7 +70,6 @@ def traverse_and_replace(
     The top entry in count_stack is decremented every time something is moved onto result,
     and when an entry hits zero, the corresponding tag from tail_stack is moved onto result as well.
     """
-
     # Initialize result and work data structures
     result: deque[str] = deque()
 

--- a/apps/prairielearn/python/prairielearn/internal/zygote_utils.py
+++ b/apps/prairielearn/python/prairielearn/internal/zygote_utils.py
@@ -5,8 +5,8 @@ import prairielearn as pl
 
 def safe_parse_int(int_str: str) -> int | float:
     """
-    Parses a JSON string. If the string contains an integer that is too large,
-    it will be parsed as a float instead. This ensures that we don't error out
+    Parse a JSON string. If the string contains an integer that is too large,
+    parse as a float instead. This ensures that we don't error out
     if the number is later re-serialized back to JSON.
     """
     equiv_int = int(int_str)

--- a/apps/prairielearn/python/prairielearn/sympy_utils.py
+++ b/apps/prairielearn/python/prairielearn/sympy_utils.py
@@ -647,7 +647,6 @@ def validate_string_as_sympy(
     imaginary_unit: None | str = None,
 ) -> None | str:
     """Try to parse expr as a sympy expression. If it fails, return a string with an appropriate error message for display on the frontend."""
-
     try:
         expr_parsed = convert_string_to_sympy(
             expr,

--- a/apps/prairielearn/python/prairielearn/sympy_utils.py
+++ b/apps/prairielearn/python/prairielearn/sympy_utils.py
@@ -646,7 +646,7 @@ def validate_string_as_sympy(
     custom_functions: None | list[str] = None,
     imaginary_unit: None | str = None,
 ) -> None | str:
-    """Tries to parse expr as a sympy expression. If it fails, returns a string with an appropriate error message for display on the frontend."""
+    """Try to parse expr as a sympy expression. If it fails, return a string with an appropriate error message for display on the frontend."""
 
     try:
         expr_parsed = convert_string_to_sympy(

--- a/apps/prairielearn/python/prairielearn/unicode_utils.py
+++ b/apps/prairielearn/python/prairielearn/unicode_utils.py
@@ -2,5 +2,5 @@ from text_unidecode import unidecode
 
 
 def full_unidecode(input_str: str) -> str:
-    """Does unidecode of input and replaces the unicode minus with the normal one."""
+    """Do unidecode of input and replace the unicode minus with the normal one."""
     return unidecode(input_str.replace("\u2212", "-"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ ignore = [
     # These rules were discussed and disabled
     "D203", # incorrect-blank-line-before-class
     "D212", # multi-line-summary-first-line
+    "D205", # missing-blank-line-after-summary (we use a multi-line description instead of summaries sometimes)
     "D400", # missing-trailing-period
     "D415", # missing-terminal-punctuation
     "ANN401", # any-type
@@ -68,7 +69,6 @@ ignore = [
     "D103", # undocumented-public-function
     "D104", # undocumented-public-package
     "D107", # undocumented-public-init
-    "D205", # missing-blank-line-after-summary
 ]
 [tool.ruff.lint.per-file-ignores]
 # Files related to the Python autograder will often intentionally appear
@@ -105,13 +105,16 @@ ignore = [
 "exampleCourse/elementExtensions/pl-drawing/example-logo/example-logo.py" = ["N805"]
 
 "graders/**/*.py" = [
-    "FBT002", # FBT002 - Boolean default positional argument
-    "D",
+    # Boolean default positional argument
+    "FBT002",
+    "D"
 ]
-# Directoes we don't want strict docstring linting on (has no public API)
+
+# Directories we don't want strict annotation linting or docstring linting on
+# For example, code with no public API, elements with known issues, or course content.
 "apps/prairielearn/python/prairielearn/internal/**/*.py" = ["D"]
 "apps/prairielearn/python/zygote.py" = ["D"]
-# Directories we don't want strict annotation linting or docstring linting on
+"docs/hooks/*.py" = ["D"]
 "apps/prairielearn/src/tests/**/*.py" = ["D", "ANN"]
 "apps/prairielearn/python/prairielearn/to_precision.py" = ["D"]
 "tools/**/*.py" = ["ANN", "D"]
@@ -122,7 +125,6 @@ ignore = [
 "apps/prairielearn/elements/pl-prairiedraw-figure/**/*.py" = ["ANN"]
 "apps/prairielearn/elements/pl-checkbox/**/*.py" = ["ANN"]
 "apps/prairielearn/python/test/**/*.py" = ["D", "ANN"]
-"docs/hooks/*.py" = ["D"]
 
 [tool.ruff.format]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ ignore = [
 
     # These rules were discussed and disabled
     "D203", # incorrect-blank-line-before-class
+    "D212", # multi-line-summary-first-line
+    "D400", # missing-trailing-period
+    "D415", # missing-terminal-punctuation
     "ANN401", # any-type
     "ISC003", # explicit-string-concatenation
     "NPY002", # numpy-legacy-random (we use `np.random.*` in many places)
@@ -59,7 +62,14 @@ ignore = [
     "TRY003", # raise-vanilla-args (long messages in raise statements)
 
     # These rules need to be enabled
-    "D212", "D103", "D100", "D102", "D107", "D101", "D202", "D205", "D104", "D400", "D415"
+    "D100", # undocumented-public-module
+    "D101", # undocumented-public-class
+    "D102", # undocumented-public-method
+    "D103", # undocumented-public-function
+    "D104", # undocumented-public-package
+    "D107", # undocumented-public-init
+    "D202", # blank-line-after-function
+    "D205", # missing-blank-line-after-summary
 ]
 [tool.ruff.lint.per-file-ignores]
 # Files related to the Python autograder will often intentionally appear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ ignore = [
     "PTH", # flake8-use-pathlib
 
     # These rules were discussed and disabled
+    "D203", # incorrect-blank-line-before-class
     "ISC003", # explicit-string-concatenation
     "NPY002", # numpy-legacy-random (we use `np.random.*` in many places)
     "PD901", # pandas-df-variable-name (we use `df` in many places)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,9 @@ ignore = [
     # Allow boolean trap pattern in method signatures
     "FBT001", "FBT002", "FBT003",
     # ignore unused parameters in functions
-    "ARG"
+    "ARG",
+    # ignore docstring linting on functions (has no public API)
+    "D103"
 ]
 "apps/prairielearn/python/**/*.py" = ["N803"]
 # Do not require self in method params
@@ -106,9 +108,11 @@ ignore = [
     "FBT002", # FBT002 - Boolean default positional argument
     "D",
 ]
+# Directoes we don't want strict docstring linting on (has no public API)
+"apps/prairielearn/python/prairielearn/internal/**/*.py" = ["D"]
+"apps/prairielearn/python/zygote.py" = ["D"]
 # Directories we don't want strict annotation linting or docstring linting on
 "apps/prairielearn/src/tests/**/*.py" = ["D", "ANN"]
-"apps/prairielearn/python/zygote.py" = ["D"]
 "apps/prairielearn/python/prairielearn/to_precision.py" = ["D"]
 "tools/**/*.py" = ["ANN", "D"]
 "testCourse/**/*.py" = ["ANN", "D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ ignore = [
     "D103", # undocumented-public-function
     "D104", # undocumented-public-package
     "D107", # undocumented-public-init
-    "D202", # blank-line-after-function
     "D205", # missing-blank-line-after-summary
 ]
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ ignore = [
     "BLE", # flake8-blind-except
     "COM", # flake8-commas
     "C901", # mccabe (complexity checks)
-    "D", # pydocstyle
     "ERA", # eradicate (code in comments)
     "EM", # flake8-errmsg
     "EXE", # flake8-executable
@@ -57,6 +56,9 @@ ignore = [
     "TRY300", # try-consider-else (returns in try blocks)
     "TRY301", # raise-within-try
     "TRY003", # raise-vanilla-args (long messages in raise statements)
+
+    # These rules need to be enabled
+    "D212", "D103", "D100", "D102", "D107", "D101", "D202", "D205", "D104", "D400", "D415"
 ]
 [tool.ruff.lint.per-file-ignores]
 # Files related to the Python autograder will often intentionally appear
@@ -89,8 +91,18 @@ ignore = [
 # Do not require self in method params
 "apps/prairielearn/elements/pl-drawing/elements.py" = ["N805"]
 "exampleCourse/elementExtensions/pl-drawing/example-logo/example-logo.py" = ["N805"]
-# Boolean default positional argument
-"graders/**/*.py" = ["FBT002"]
+# FBT002 - Boolean default positional argument
+# D - We don't care about docstrings for any of these files
+"graders/**/*.py" = ["FBT002", "D"]
+"tools/**/*.py" = ["D"]
+"testCourse/**/*.py" = ["D"]
+"exampleCourse/**/*.py" = ["D"]
+"workspaces/**/*.py" = ["D"]
+"docs/hooks/*.py" = ["D"]
+"apps/prairielearn/src/tests/**/*.py" = ["D"]
+"apps/prairielearn/python/test/**/*.py" = ["D"]
+"apps/prairielearn/python/zygote.py" = ["D"]
+"apps/prairielearn/python/prairielearn/to_precision.py" = ["D"]
 [tool.ruff.format]
 exclude = [
     "./exampleCourse/questions/demo/autograder/python/leadingTrailing/tests/trailing_code.py",


### PR DESCRIPTION
This is going to help document our codebase in a consistent manner. Enforcing some of these rules will as a bonus, help us generate code documentation (see #11216 )

Applies:

- D200 One-line docstring should fit on one line
- D401 First line of docstring should be in imperative mood
- The rule about no function in docstring itself