### PR TITLE
Add `automata-lib` dependency

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -1,4 +1,5 @@
 ansi2html==1.9.2
+automata-lib==9.0.0
 chevron==0.14.0
 coloraide==4.2.1
 Faker==35.2.0


### PR DESCRIPTION
Adding this as a dependency to avoid keeping a local copy of this code for questions our course would like to share. Other courses have installed and used this library on their own as well, so I think this is worth adding. Also generally very light on dependencies we don't have installed already. Happy to answer any questions about this.