### PR TITLE
Add NOT NULL constraints for tags/topics/modules

### DIFF
--- a/apps/prairielearn/src/migrations/20250210225102_tags__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20250210225102_tags__not_null_constraints__add.sql
@@ -1,0 +1,22 @@
+ALTER TABLE tags
+ALTER COLUMN name
+SET NOT NULL;
+
+ALTER TABLE tags
+ALTER COLUMN color
+SET NOT NULL;
+
+ALTER TABLE tags
+ALTER COLUMN description
+SET DEFAULT '';
+
+UPDATE tags
+SET
+  description = ''
+WHERE
+  description IS NULL;
+
+-- TODO: before deploying this, ensure all writes use a non-null description.
+ALTER TABLE tags
+ALTER COLUMN description
+SET NOT NULL;

--- a/apps/prairielearn/src/migrations/20250210225102_tags__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20250210225102_tags__not_null_constraints__add.sql
@@ -16,7 +16,10 @@ SET
 WHERE
   description IS NULL;
 
--- TODO: before deploying this, ensure all writes use a non-null description.
 ALTER TABLE tags
 ALTER COLUMN description
 SET NOT NULL;
+
+-- At this point, `number` is still nullable, as we have NULL values in production.
+-- We'll add a `NOT NULL` constraint once we've stopped writing NULL values and
+-- backfilled all existing NULL values.

--- a/apps/prairielearn/src/migrations/20250210225102_tags__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20250210225102_tags__not_null_constraints__add.sql
@@ -6,10 +6,6 @@ ALTER TABLE tags
 ALTER COLUMN color
 SET NOT NULL;
 
-ALTER TABLE tags
-ALTER COLUMN description
-SET DEFAULT '';
-
 UPDATE tags
 SET
   description = ''

--- a/apps/prairielearn/src/migrations/20250210225433_topics__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20250210225433_topics__not_null_constraints__add.sql
@@ -6,10 +6,6 @@ ALTER TABLE topics
 ALTER COLUMN color
 SET NOT NULL;
 
-ALTER TABLE topics
-ALTER COLUMN description
-SET DEFAULT '';
-
 UPDATE topics
 SET
   description = ''

--- a/apps/prairielearn/src/migrations/20250210225433_topics__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20250210225433_topics__not_null_constraints__add.sql
@@ -16,7 +16,10 @@ SET
 WHERE
   description IS NULL;
 
--- TODO: before deploying this, ensure all writes use a non-null description.
 ALTER TABLE topics
 ALTER COLUMN description
 SET NOT NULL;
+
+-- At this point, `number` is still nullable, as we have NULL values in production.
+-- We'll add a `NOT NULL` constraint once we've stopped writing NULL values and
+-- backfilled all existing NULL values.

--- a/apps/prairielearn/src/migrations/20250210225433_topics__not_null_constraints__add.sql
+++ b/apps/prairielearn/src/migrations/20250210225433_topics__not_null_constraints__add.sql
@@ -1,0 +1,22 @@
+ALTER TABLE topics
+ALTER COLUMN name
+SET NOT NULL;
+
+ALTER TABLE topics
+ALTER COLUMN color
+SET NOT NULL;
+
+ALTER TABLE topics
+ALTER COLUMN description
+SET DEFAULT '';
+
+UPDATE topics
+SET
+  description = ''
+WHERE
+  description IS NULL;
+
+-- TODO: before deploying this, ensure all writes use a non-null description.
+ALTER TABLE topics
+ALTER COLUMN description
+SET NOT NULL;

--- a/apps/prairielearn/src/migrations/20250211000848_assessment_modules__heading__nonnull.sql
+++ b/apps/prairielearn/src/migrations/20250211000848_assessment_modules__heading__nonnull.sql
@@ -1,0 +1,3 @@
+ALTER TABLE assessment_modules
+ALTER COLUMN heading
+SET NOT NULL;

--- a/database/tables/assessment_modules.pg
+++ b/database/tables/assessment_modules.pg
@@ -1,6 +1,6 @@
 columns
     course_id: bigint not null
-    heading: text default 'Default module'::text
+    heading: text not null default 'Default module'::text
     id: bigint not null default nextval('assessment_modules_id_seq'::regclass)
     implicit: boolean not null default false
     name: text not null default 'Default'::text

--- a/database/tables/tags.pg
+++ b/database/tables/tags.pg
@@ -1,10 +1,10 @@
 columns
-    color: text
+    color: text not null
     course_id: bigint not null
-    description: text
+    description: text not null default ''::text
     id: bigint not null default nextval('tags_id_seq'::regclass)
     implicit: boolean not null default false
-    name: text
+    name: text not null
     number: integer
 
 indexes

--- a/database/tables/tags.pg
+++ b/database/tables/tags.pg
@@ -1,7 +1,7 @@
 columns
     color: text not null
     course_id: bigint not null
-    description: text not null default ''::text
+    description: text not null
     id: bigint not null default nextval('tags_id_seq'::regclass)
     implicit: boolean not null default false
     name: text not null

--- a/database/tables/topics.pg
+++ b/database/tables/topics.pg
@@ -1,10 +1,10 @@
 columns
-    color: text
+    color: text not null
     course_id: bigint not null
-    description: text
+    description: text not null default ''::text
     id: bigint not null default nextval('topics_id_seq'::regclass)
     implicit: boolean not null default false
-    name: text
+    name: text not null
     number: integer
 
 indexes

--- a/database/tables/topics.pg
+++ b/database/tables/topics.pg
@@ -1,7 +1,7 @@
 columns
     color: text not null
     course_id: bigint not null
-    description: text not null default ''::text
+    description: text not null
     id: bigint not null default nextval('topics_id_seq'::regclass)
     implicit: boolean not null default false
     name: text not null


### PR DESCRIPTION
This is necessary for some upcoming improvements of tags/topics/modules syncing. We already did this for `assessment_sets` in #9972.