### PR TITLE
Mark enrollments.created_at as nullable in Zod schema

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -382,7 +382,7 @@ export type DraftQuestionMetadata = z.infer<typeof DraftQuestionMetadataSchema>;
 
 export const EnrollmentSchema = z.object({
   course_instance_id: IdSchema,
-  created_at: DateFromISOString,
+  created_at: DateFromISOString.nullable(),
   id: IdSchema,
   user_id: IdSchema,
 });


### PR DESCRIPTION
This is necessary to accurately reflect the database schema itself:

https://github.com/PrairieLearn/PrairieLearn/blob/975da6547c50b68a1afdbd3c78818cd89c7ac559/database/tables/enrollments.pg#L3