### PR TITLE
Ensure tabs are shown on the instructor gradebook

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.html.ts
@@ -34,7 +34,7 @@ export function InstructorGradebook({
     pageTitle: 'Gradebook',
     navContext: {
       type: 'instructor',
-      page: 'gradebook',
+      page: 'instance_admin',
       subPage: 'gradebook',
     },
     options: {


### PR DESCRIPTION
This regressed in #11209. Before this change, the instructor course instance gradebook page wouldn't show the usual navigation tabs.