### PR TITLE
Fix escaping of trailing text in question HTML

### DIFF
--- a/apps/prairielearn/python/prairielearn/internal/traverse.py
+++ b/apps/prairielearn/python/prairielearn/internal/traverse.py
@@ -58,6 +58,19 @@ def get_source_definition(element: lxml.html.HtmlElement) -> str:
     return f"<{' '.join((element.tag, *attributes))}>"
 
 
+# `lxml` uses `libxml2` under the hood, which does not support the full set
+# of HTML5 named entities:
+# https://gitlab.gnome.org/GNOME/libxml2/-/issues/857
+# This means that with a naive approach, we'd end up double escaping entities
+# like `&langle;` into `&amp;langle;`. To work around this (at least until
+# `libxml2` hopefully adds support for HTML5 named entities), we first
+# unescape the text to get the actual Unicode characters, and then escape them
+# again. Escaping will only escape `&`, `<`, and `>`; it won't escape everything
+# that could possibly be represented by a named entity.
+def prepare_text(text: str) -> str:
+    return html_escape(html_unescape(text))
+
+
 def traverse_and_replace(
     html: str, replace: Callable[[lxml.html.HtmlElement], ElementReplacement]
 ) -> str:
@@ -125,7 +138,7 @@ def traverse_and_replace(
                 )
                 result.append(f"<!--?{instruction}?-->")
                 if tail:
-                    result.append(tail)
+                    result.append(prepare_text(tail))
             else:
                 if not isinstance(new_elements.tag, str):
                     raise TypeError(f"Invalid tag type: {type(new_elements.tag)}")
@@ -136,17 +149,7 @@ def traverse_and_replace(
                     if new_elements.tag in UNESCAPED_ELEMENTS:
                         result.append(new_elements.text)
                     else:
-                        # `lxml` uses `libxml2` under the hood, which does not support
-                        # the full set of HTML5 named entities:
-                        # https://gitlab.gnome.org/GNOME/libxml2/-/issues/857
-                        # This means that with a naive approach, we'd end up double
-                        # escaping entities like `&langle;` into `&amp;langle;`. To work
-                        # around this (at least until `libxml2` hopefully adds support for
-                        # HTML5 named entities), we first unescape the text to get the
-                        # actual Unicode characters, and then escape them again. Escaping
-                        # will only escape `&`, `<`, and `>`; it won't escape everything
-                        # that could possibly be represented by a named entity.
-                        result.append(html_escape(html_unescape(new_elements.text)))
+                        result.append(prepare_text(new_elements.text))
 
                 # Add all children to the work stack
                 children = list(new_elements)
@@ -155,7 +158,10 @@ def traverse_and_replace(
                     work_stack.extend(reversed(children))
 
                 count_stack.append(len(children))
-                tail_stack.append((new_elements.tag, element.tail))
+                tail_stack.append((
+                    new_elements.tag,
+                    prepare_text(element.tail) if element.tail is not None else None,
+                ))
 
         # Close all closable tags
         while count_stack[-1] == 0:

--- a/apps/prairielearn/python/test/traverse_test.py
+++ b/apps/prairielearn/python/test/traverse_test.py
@@ -333,6 +333,32 @@ def test_traverse_and_replace_angle_brackets() -> None:
     assert html == "<pre><code>&lt;div&gt;</code></pre>"
 
 
+def test_traverse_and_replace_trailing_entity() -> None:
+    def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
+        if e.tag == "div":
+            return "<span><span>Goodbye</span> &amp;</span>"
+        return e
+
+    html = traverse_and_replace("<div>Hello</div>", replace)
+    assert html == "<span><span>Goodbye</span> &amp;</span>"
+
+
+def test_traverse_and_replace_comment_trailing_entity() -> None:
+    def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
+        return e
+
+    html = traverse_and_replace("hello <!-- comment --> &amp;", replace)
+    assert html == "hello <!-- comment --> &amp;"
+
+
+def test_traverse_and_replace_processing_instruction_trailing_entity() -> None:
+    def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
+        return e
+
+    html = traverse_and_replace('hello <?xml version="1.0"?> &amp;', replace)
+    assert html == 'hello <!--?xml version="1.0"?--> &amp;'
+
+
 def test_traverse_and_replace_xml_processing_instruction() -> None:
     def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
         return e


### PR DESCRIPTION
#11302 missed the case of trailing text. This PR adds test cases that failed with the previous implementation and fixes the underlying issue.

Closes #11326.