### PR TITLE
Correctly backfill `variants.authn_user_id` and add `NOT NULL` constraint

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.sql
@@ -3,4 +3,6 @@ UPDATE variants
 SET
   authn_user_id = user_id
 WHERE
-  authn_user_id IS NULL;
+  authn_user_id IS NULL
+  AND id >= $start
+  AND id <= $end;

--- a/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.sql
@@ -1,3 +1,22 @@
+-- BLOCK select_bounds
+--
+-- Note that Postgres generates a bad query plan if we try to do the select
+-- directly. We use a CTE to trick it into generating a faster plan.
+WITH
+  null_variants AS (
+    SELECT
+      id
+    FROM
+      variants
+    WHERE
+      authn_user_id IS NULL
+  )
+SELECT
+  MIN(id) AS min,
+  MAX(id) AS max
+FROM
+  null_variants;
+
 -- BLOCK backfill_authn_user_id
 UPDATE variants
 SET

--- a/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.sql
@@ -1,0 +1,6 @@
+-- BLOCK backfill_authn_user_id
+UPDATE variants
+SET
+  authn_user_id = user_id
+WHERE
+  authn_user_id IS NULL;

--- a/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.ts
@@ -5,10 +5,7 @@ const sql = loadSqlEquiv(import.meta.url);
 
 export default makeBatchedMigration({
   async getParameters() {
-    const results = await queryAsync(
-      'SELECT MIN(id) AS min, MAX(id) AS max FROM variants WHERE authn_user_id IS NULL;',
-      {},
-    );
+    const results = await queryAsync(sql.select_bounds, {});
     return {
       min: results.rows[0].min,
       max: results.rows[0].max,

--- a/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250212010945_variants__authn_user_id__backfill.ts
@@ -1,0 +1,21 @@
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const results = await queryAsync(
+      'SELECT MIN(id) AS min, MAX(id) AS max FROM variants WHERE authn_user_id IS NULL;',
+      {},
+    );
+    return {
+      min: results.rows[0].min,
+      max: results.rows[0].max,
+      batchSize: 1000,
+    };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.backfill_authn_user_id, { start, end });
+  },
+});

--- a/apps/prairielearn/src/migrations/20250206202509_variants__authn_user_id__nonnull.sql
+++ b/apps/prairielearn/src/migrations/20250206202509_variants__authn_user_id__nonnull.sql
@@ -1,33 +1,6 @@
--- We had a few old rows in the `variants` table where `authn_user_id` was NULL.
--- We'll copy the values over from `variants.user_id` which is always non-NULL in the rows we care about.
-UPDATE variants
-SET
-  authn_user_id = user_id
-WHERE
-  authn_user_id IS NULL;
-
--- Declare `variants.authn_user_id` as NOT NULL; it was always required.
--- Use the approach described here to avoid a long table lock:
--- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
-ALTER TABLE variants
-ADD CONSTRAINT variants_authn_user_id_not_null CHECK (authn_user_id IS NOT NULL) NOT VALID;
-
-ALTER TABLE variants VALIDATE CONSTRAINT variants_authn_user_id_not_null;
-
-DO $$
-BEGIN
-    IF (SELECT convalidated FROM pg_constraint WHERE conname = 'variants_authn_user_id_not_null') THEN
-        ALTER TABLE variants
-        ALTER COLUMN authn_user_id
-        SET NOT NULL;
-
-        ALTER TABLE variants
-        DROP CONSTRAINT variants_authn_user_id_not_null;
-    ELSE
-        ALTER TABLE variants
-        DROP CONSTRAINT variants_authn_user_id_not_null;
-
-        RAISE EXCEPTION 'NULL row(s) exist in column, unable to add NOT NULL constraint';
-    END IF;
-END;
-$$;
+-- This migration failed; it took too long to run in production.
+--
+-- See `20250212012249_variants__authn_user_id__nonnull` for the new approach.
+-- It's preceded by a batched migration to backfill `variants.authn_user_id`.
+--
+-- This did already run in some environments, but that's fine.

--- a/apps/prairielearn/src/migrations/20250212010945_variants__authn_user_id__backfill.ts
+++ b/apps/prairielearn/src/migrations/20250212010945_variants__authn_user_id__backfill.ts
@@ -1,5 +1,5 @@
 import { enqueueBatchedMigration } from '@prairielearn/migrations';
 
 export default async function () {
-  await enqueueBatchedMigration('20241018171312_questions__share_publicly__backfill');
+  await enqueueBatchedMigration('20250212010945_variants__authn_user_id__backfill');
 }

--- a/apps/prairielearn/src/migrations/20250212011728_variants__authn_user_id__backfill__finalize.ts
+++ b/apps/prairielearn/src/migrations/20250212011728_variants__authn_user_id__backfill__finalize.ts
@@ -1,0 +1,5 @@
+import { finalizeBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await finalizeBatchedMigration('20250212010945_variants__authn_user_id__backfill');
+}

--- a/apps/prairielearn/src/migrations/20250212012249_variants__authn_user_id__nonnull.sql
+++ b/apps/prairielearn/src/migrations/20250212012249_variants__authn_user_id__nonnull.sql
@@ -1,0 +1,25 @@
+-- Declare `variants.authn_user_id` as NOT NULL; it was always required.
+-- Use the approach described here to avoid a long table lock:
+-- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
+ALTER TABLE variants
+ADD CONSTRAINT variants_authn_user_id_not_null CHECK (authn_user_id IS NOT NULL) NOT VALID;
+
+ALTER TABLE variants VALIDATE CONSTRAINT variants_authn_user_id_not_null;
+
+DO $$
+BEGIN
+    IF (SELECT convalidated FROM pg_constraint WHERE conname = 'variants_authn_user_id_not_null') THEN
+        ALTER TABLE variants
+        ALTER COLUMN authn_user_id
+        SET NOT NULL;
+
+        ALTER TABLE variants
+        DROP CONSTRAINT variants_authn_user_id_not_null;
+    ELSE
+        ALTER TABLE variants
+        DROP CONSTRAINT variants_authn_user_id_not_null;
+
+        RAISE EXCEPTION 'NULL row(s) exist in column, unable to add NOT NULL constraint';
+    END IF;
+END;
+$$;


### PR DESCRIPTION
#11314 failed in production. The entire database locked up, presumably because we tried to rewrite ~1.6 million rows at once. From what we can tell, locking wasn't involved, it was just the write load that killed us.

This PR does what we probably should have done in the first place: it adds a batched migration to backfill `variants.authn_user_id`, finalizes it, and then does the usual thing to actually mark the column as `NOT NULL`.