### PR TITLE
Run all NOT NULL constraint addition migrations outside transactions

### DIFF
--- a/apps/prairielearn/src/migrations/20230523200759_variants__course_id__nonnull.sql
+++ b/apps/prairielearn/src/migrations/20230523200759_variants__course_id__nonnull.sql
@@ -1,6 +1,11 @@
+-- prairielearn:migrations NO TRANSACTION
+---
 -- declare the new course_id column of the variants table to be not null
 -- using the approach suggested by a postgres dev here: https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
 -- to avoid a long table lock
+ALTER TABLE variants
+DROP CONSTRAINT IF EXISTS variants_course_id_not_null;
+
 ALTER TABLE variants
 ADD CONSTRAINT variants_course_id_not_null CHECK (course_id IS NOT NULL) NOT VALID;
 

--- a/apps/prairielearn/src/migrations/20240111005800_group_users__group_config_id__not_null.sql
+++ b/apps/prairielearn/src/migrations/20240111005800_group_users__group_config_id__not_null.sql
@@ -1,3 +1,5 @@
+-- prairielearn:migrations NO TRANSACTION
+--
 -- After backfilling, we still had some `group_users` rows where `group_config_id` was NULL.
 -- This is because some `groups` had a NULL `group_config_id`. We'll be fixing that separately,
 -- but we'll remove those invalid rows from `group_users` so we can add the constraint.
@@ -8,6 +10,9 @@ WHERE
 -- Declare `group_users.group_config_id` as NOT NULL, since it is now backfilled.
 -- Use the approach described here to avoid a long table lock:
 -- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
+ALTER TABLE group_users
+DROP CONSTRAINT IF EXISTS group_users_group_config_id_not_null;
+
 ALTER TABLE group_users
 ADD CONSTRAINT group_users_group_config_id_not_null CHECK (group_config_id IS NOT NULL) NOT VALID;
 

--- a/apps/prairielearn/src/migrations/20240111010531_groups__group_config_id__not_null.sql
+++ b/apps/prairielearn/src/migrations/20240111010531_groups__group_config_id__not_null.sql
@@ -1,3 +1,4 @@
+-- prairielearn:migrations NO TRANSACTION
 -- For whatever reason, we ended up with rows in the `groups` table where
 -- `group_config_id` was NULL. This is invalid, since `groups` rows aren't
 -- reachable via our joins with such a value defined. So that we can mark
@@ -9,6 +10,9 @@ WHERE
 -- Declare `groups.group_config_id` as NOT NULL, since it is now backfilled.
 -- Use the approach described here to avoid a long table lock:
 -- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
+ALTER TABLE groups
+DROP CONSTRAINT IF EXISTS groups_group_config_id_not_null;
+
 ALTER TABLE groups
 ADD CONSTRAINT groups_group_config_id_not_null CHECK (group_config_id IS NOT NULL) NOT VALID;
 

--- a/apps/prairielearn/src/migrations/20240111010531_groups__group_config_id__not_null.sql
+++ b/apps/prairielearn/src/migrations/20240111010531_groups__group_config_id__not_null.sql
@@ -1,4 +1,5 @@
 -- prairielearn:migrations NO TRANSACTION
+--
 -- For whatever reason, we ended up with rows in the `groups` table where
 -- `group_config_id` was NULL. This is invalid, since `groups` rows aren't
 -- reachable via our joins with such a value defined. So that we can mark

--- a/apps/prairielearn/src/migrations/20250117000347_variants__variant_seed_nonnull.sql
+++ b/apps/prairielearn/src/migrations/20250117000347_variants__variant_seed_nonnull.sql
@@ -1,6 +1,11 @@
+-- prairielearn:migrations NO TRANSACTION
+--
 -- Declare `variants.variant_seed` as NOT NULL; it was always required.
 -- Use the approach described here to avoid a long table lock:
 -- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
+ALTER TABLE variants
+DROP CONSTRAINT IF EXISTS variants_variant_seed_not_null;
+
 ALTER TABLE variants
 ADD CONSTRAINT variants_variant_seed_not_null CHECK (variant_seed IS NOT NULL) NOT VALID;
 

--- a/apps/prairielearn/src/migrations/20250212012249_variants__authn_user_id__nonnull.sql
+++ b/apps/prairielearn/src/migrations/20250212012249_variants__authn_user_id__nonnull.sql
@@ -1,6 +1,11 @@
+-- prairielearn:migrations NO TRANSACTION
+--
 -- Declare `variants.authn_user_id` as NOT NULL; it was always required.
 -- Use the approach described here to avoid a long table lock:
 -- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
+ALTER TABLE variants
+DROP CONSTRAINT IF EXISTS variants_authn_user_id_not_null;
+
 ALTER TABLE variants
 ADD CONSTRAINT variants_authn_user_id_not_null CHECK (authn_user_id IS NOT NULL) NOT VALID;
 


### PR DESCRIPTION
While trying to run the migration from #11351 that added a `NOT NULL` constraint to `variants.authn_user_id`, @mwest1066 and I observed that the migration would hold a lock on `variants` and block all reads/writes of the table. We confirmed that the issue is running all these statements in a transaction, which happens by default:

https://github.com/PrairieLearn/PrairieLearn/blob/81e6792bcf7c6b1b914d424396b9b7d59b865a0b/packages/migrations/README.md?plain=1#L26-L33

We confirmed that manually executing the steps one by one outside of a transaction avoid locks.

To help our future selves, we also updated all existing similar migrations to do the same. This ensures we can safely copy/paste from any one of them in the future.