### PR TITLE
Retry NOT NULL variants.authn_user_id migration

### DIFF
--- a/apps/prairielearn/src/migrations/20250212012249_variants__authn_user_id__nonnull.sql
+++ b/apps/prairielearn/src/migrations/20250212012249_variants__authn_user_id__nonnull.sql
@@ -1,30 +1,4 @@
--- prairielearn:migrations NO TRANSACTION
---
--- Declare `variants.authn_user_id` as NOT NULL; it was always required.
--- Use the approach described here to avoid a long table lock:
--- https://dba.stackexchange.com/questions/267947/how-can-i-set-a-column-to-not-null-without-locking-the-table-during-a-table-scan/268128#268128
-ALTER TABLE variants
-DROP CONSTRAINT IF EXISTS variants_authn_user_id_not_null;
-
-ALTER TABLE variants
-ADD CONSTRAINT variants_authn_user_id_not_null CHECK (authn_user_id IS NOT NULL) NOT VALID;
-
-ALTER TABLE variants VALIDATE CONSTRAINT variants_authn_user_id_not_null;
-
-DO $$
-BEGIN
-    IF (SELECT convalidated FROM pg_constraint WHERE conname = 'variants_authn_user_id_not_null') THEN
-        ALTER TABLE variants
-        ALTER COLUMN authn_user_id
-        SET NOT NULL;
-
-        ALTER TABLE variants
-        DROP CONSTRAINT variants_authn_user_id_not_null;
-    ELSE
-        ALTER TABLE variants
-        DROP CONSTRAINT variants_authn_user_id_not_null;
-
-        RAISE EXCEPTION 'NULL row(s) exist in column, unable to add NOT NULL constraint';
-    END IF;
-END;
-$$;
+-- This migration also failed! We'll try again with the migration split into two parts:
+-- 
+-- 20250213014138_variants__authn_user_id__nonnull_constraint_add.sql
+-- 20250213014139_variants__authn_user_id__nonnull_constraint_validate.sql

--- a/apps/prairielearn/src/migrations/20250213014138_variants__authn_user_id__nonnull_constraint_add.sql
+++ b/apps/prairielearn/src/migrations/20250213014138_variants__authn_user_id__nonnull_constraint_add.sql
@@ -1,0 +1,5 @@
+ALTER TABLE variants
+DROP CONSTRAINT IF EXISTS variants_authn_user_id_not_null;
+
+ALTER TABLE variants
+ADD CONSTRAINT variants_authn_user_id_not_null CHECK (authn_user_id IS NOT NULL) NOT VALID;

--- a/apps/prairielearn/src/migrations/20250213014139_variants__authn_user_id__nonnull_constraint_validate.sql
+++ b/apps/prairielearn/src/migrations/20250213014139_variants__authn_user_id__nonnull_constraint_validate.sql
@@ -1,0 +1,11 @@
+-- Completes the work started in `20250213014138_variants__authn_user_id__nonnull_constraint_add`.
+-- This is done in a separate migration because we were running into issues with a table
+-- lock being held for too long when the constraint was created and validated in the same query.
+ALTER TABLE variants VALIDATE CONSTRAINT variants_authn_user_id_not_null;
+
+ALTER TABLE variants
+ALTER COLUMN authn_user_id
+SET NOT NULL;
+
+ALTER TABLE variants
+DROP CONSTRAINT variants_authn_user_id_not_null;


### PR DESCRIPTION
The change in #11357 wasn't enough to run the migration. We think we need to split it in half. Based on our observations, Postgres will run all parts of a multi-statement query as part of an implicit transaction.