### PR TITLE
Fix `api_download.py` bug with `content-length`

### DIFF
--- a/tools/api_download.py
+++ b/tools/api_download.py
@@ -131,7 +131,7 @@ def get_and_save_json(endpoint, filename, args, logfile):
     end_time = time.time()
     log(
         logfile,
-        f"successfully downloaded {r.headers['content-length']} bytes in {end_time - start_time} seconds",
+        f"successfully downloaded {len(r.text)} bytes in {end_time - start_time} seconds",
     )
 
     full_filename = os.path.join(args.output_dir, filename + ".json")


### PR DESCRIPTION
As @mfsilva22 pointed out to me, `content-length` doesn't appear to be in the headers anymore. We were only using it for informational purposes so we can replace it with another measure of download size.