### PR TITLE
Fix accessibility labels

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorQuestionSettingsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorQuestionSettingsClient.ts
@@ -23,7 +23,7 @@ onDocumentReady(() => {
     valueField: 'name',
     searchField: ['name', 'description'],
     closeAfterSelect: true,
-    plugins: ['dropdown_input', 'no_backspace_delete'],
+    plugins: ['no_backspace_delete'],
     maxItems: 1,
     render: {
       option(data: Topic) {
@@ -45,7 +45,7 @@ onDocumentReady(() => {
   new TomSelect('#tags', {
     valueField: 'name',
     searchField: ['name', 'description'],
-    plugins: ['dropdown_input', 'remove_button'],
+    plugins: ['remove_button'],
     render: {
       option(data: Tag) {
         return html`

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -18,7 +18,7 @@
           {{^editable}}disabled{{/editable}}
           {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
           aria-describedby="pl-number-input-{{uuid}}-suffix"
-          aria-labelledby="pl-integer-input-{{uuid}}-label"
+          aria-labelledby="pl-number-input-{{uuid}}-label"
           placeholder="{{placeholder}}" />
 
           <span class="input-group-append">

--- a/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
+++ b/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
@@ -16,12 +16,12 @@
             autocorrect="off"
             {{^editable}}disabled{{/editable}}
             {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
-            aria-describedby="pl-symbolic-input-{{uuid}}-suffix"
-            aria-labelledby="pl-symbolic-input-{{uuid}}-label"
+            aria-describedby="pl-string-input-{{uuid}}-suffix"
+            aria-labelledby="pl-string-input-{{uuid}}-label"
             placeholder="{{placeholder}}"
         />
         <span class="input-group-append">
-            {{#suffix}}<span class="input-group-text" id="pl-symbolic-input-{{uuid}}-suffix">{{suffix}}</span>{{/suffix}}
+            {{#suffix}}<span class="input-group-text" id="pl-string-input-{{uuid}}-suffix">{{suffix}}</span>{{/suffix}}
 
             {{#show_info}}
                 <button type="button" class="btn btn-light border d-flex align-items-center" data-toggle="popover" data-html="true" title="String" data-content="{{info}}" data-placement="auto">

--- a/apps/prairielearn/src/components/SyncProblemButton.html.ts
+++ b/apps/prairielearn/src/components/SyncProblemButton.html.ts
@@ -23,10 +23,9 @@ ${unsafeHtml(ansiUp.ansi_to_html(output))}</pre
       data-trigger="hover"
       data-container="body"
       data-html="true"
-      data-title="${title}"
+      title="${title}"
       data-content="${escapeHtml(popoverContent)}"
       data-custom-class="popover-wide"
-      aria-label="${title}"
     >
       <i class="fa ${classes}" aria-hidden="true"></i>
     </button>

--- a/apps/prairielearn/src/components/SyncProblemButton.html.ts
+++ b/apps/prairielearn/src/components/SyncProblemButton.html.ts
@@ -26,6 +26,7 @@ ${unsafeHtml(ansiUp.ansi_to_html(output))}</pre
       data-title="${title}"
       data-content="${escapeHtml(popoverContent)}"
       data-custom-class="popover-wide"
+      aria-label="${title}"
     >
       <i class="fa ${classes}" aria-hidden="true"></i>
     </button>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -180,6 +180,7 @@ export function InstructorIssues({
                   title="Show filter help"
                   data-toggle="modal"
                   data-target="#filterHelpModal"
+                  aria-label="Show filter help"
                 >
                   <i class="fa fa-question-circle" aria-hidden="true"></i>
                 </button>

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.ts
@@ -167,14 +167,19 @@ export function InstructorQuestionSettings({
               >
                 <tr>
                   <th class="align-middle">
-                    <label for="topic">Topic</label>
+                    <label id="topic-label" for="topic">Topic</label>
                   </th>
                   <!-- The style attribute is necessary until we upgrade to Bootstrap 5.3 -->
                   <!-- This is used by tom-select to style the active item in the dropdown -->
                   <td style="--bs-tertiary-bg: #f8f9fa">
                     ${canEdit
                       ? html`
-                          <select id="topic" name="topic" placeholder="Select a topic">
+                          <select
+                            id="topic"
+                            name="topic"
+                            placeholder="Select a topic"
+                            aria-labelledby="topic-label"
+                          >
                             ${courseTopics.map((topic) => {
                               return html`
                                 <option
@@ -193,12 +198,18 @@ export function InstructorQuestionSettings({
                 </tr>
                 <tr>
                   <th class="align-middle">
-                    <label for="tags">Tags</label>
+                    <label id="tags-label" for="tags">Tags</label>
                   </th>
                   <td>
                     ${canEdit
                       ? html`
-                          <select id="tags" name="tags" placeholder="Select tags" multiple>
+                          <select
+                            id="tags"
+                            name="tags"
+                            placeholder="Select tags"
+                            aria-labelledby="tags-label"
+                            multiple
+                          >
                             ${courseTags.length > 0
                               ? courseTags.map((tag) => {
                                   return html`


### PR DESCRIPTION
This PR addresses several of the bullet points in #11360 regarding issues with labeling for accessibility. In this PR I have addressed the following issues:
- The `pl-string-input` element and `pl-number-input` element were pointed to incorrect elements in `aria-describedby` and `aria-labelledby`.
- The "Warning" trying on the course instances page did not have a label.
- The "?" button on the issues page does not have a label.
- The "Topic" and "Tags" dropdowns on the question settings page did not have labels.