### PR TITLE
Backfill usage data from submissions

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
@@ -6,7 +6,6 @@ WHERE
 
 -- BLOCK select_bounds
 SELECT
-  min(id),
   max(id)
 FROM
   submissions

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
@@ -1,7 +1,8 @@
 -- BLOCK delete_old_usages
 DELETE FROM course_instance_usages
 WHERE
-  date < $CUTOFF_DATE;
+  type = 'Submission'
+  AND date < $CUTOFF_DATE;
 
 -- BLOCK select_bounds
 SELECT

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
@@ -1,0 +1,25 @@
+-- BLOCK delete_old_usages
+DELETE FROM course_instance_usages
+WHERE
+  date < $CUTOFF_DATE;
+
+-- BLOCK select_bounds
+SELECT
+  min(id),
+  max(id)
+FROM
+  submissions
+WHERE
+  date < $CUTOFF_DATE;
+
+-- BLOCK select_user_id_for_submission_id
+SELECT
+  -- Use the variant authn_user_id to ensure that it is non-NULL. This might not
+  -- be the submitting effective user for group work, but we don't care about
+  -- getting this correct for historical data.
+  v.authn_user_id
+FROM
+  submissions AS s
+  JOIN variants AS v ON (v.id = s.variant_id)
+WHERE
+  s.id = $submission_id;

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.sql
@@ -13,14 +13,46 @@ FROM
 WHERE
   date < $CUTOFF_DATE;
 
--- BLOCK select_user_id_for_submission_id
+-- BLOCK update_course_instance_usages_for_submissions
+INSERT INTO
+  course_instance_usages (
+    type,
+    institution_id,
+    course_id,
+    course_instance_id,
+    date,
+    user_id,
+    include_in_statistics
+  )
 SELECT
-  -- Use the variant authn_user_id to ensure that it is non-NULL. This might not
-  -- be the submitting effective user for group work, but we don't care about
-  -- getting this correct for historical data.
-  v.authn_user_id
+  'Submission',
+  i.id,
+  c.id,
+  ci.id,
+  date_trunc('day', s.date, 'UTC'),
+  -- We use `v.authn_user_id` for backfill, because this is guaranteed to be
+  -- non-null and should virtually always be the same as `ai.user_id` for
+  -- students (we want to match the user_id for student submissions, to avoid
+  -- counting course staff as students).
+  v.authn_user_id,
+  coalesce(ai.include_in_statistics, false)
 FROM
   submissions AS s
   JOIN variants AS v ON (v.id = s.variant_id)
+  JOIN questions AS q ON (q.id = v.question_id)
+  JOIN pl_courses AS c ON (c.id = q.course_id)
+  JOIN institutions AS i ON (i.id = c.institution_id)
+  LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+  LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+  LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
+  LEFT JOIN course_instances AS ci ON (ci.course_id = a.course_instance_id)
 WHERE
-  s.id = $submission_id;
+  s.id >= $start
+  AND s.id <= $end
+ON CONFLICT (
+  type,
+  course_id,
+  course_instance_id,
+  date,
+  user_id
+) DO NOTHING;

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
@@ -13,15 +13,12 @@ export default makeBatchedMigration({
     await queryAsync(sql.delete_old_usages, { CUTOFF_DATE });
 
     // Only backfill from submissions that are older than the cutoff date
-    const { min, max } = await queryRow(
+    const max = await queryRow(
       sql.select_bounds,
       { CUTOFF_DATE },
-      z.object({
-        min: z.bigint({ coerce: true }).nullable(),
-        max: z.bigint({ coerce: true }).nullable(),
-      }),
+      z.bigint({ coerce: true }).nullable(),
     );
-    return { min, max, batchSize: 1000 };
+    return { min: 1n, max, batchSize: 1000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {
     await queryAsync(sql.update_course_instance_usages_for_submissions, { start, end });

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+import { updateCourseInstanceUsagesForSubmission } from '../models/course-instance-usages.js';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const CUTOFF_DATE = '2025-02-15T00:00:00Z';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    // First delete usage data older than a hard-coded date
+    await queryAsync(sql.delete_old_usages, { CUTOFF_DATE });
+
+    // Only backfill from submissions that are older than the cutoff date
+    const { min, max } = await queryRow(
+      sql.select_bounds,
+      { CUTOFF_DATE },
+      z.object({
+        min: z.bigint({ coerce: true }).nullable(),
+        max: z.bigint({ coerce: true }).nullable(),
+      }),
+    );
+    return { min, max, batchSize: 1000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    for (let i = start; i <= end; i++) {
+      const user_id = await queryRow(
+        sql.select_user_id_for_submission_id,
+        { submission_id: i },
+        z.string(),
+      );
+      await updateCourseInstanceUsagesForSubmission({
+        submission_id: i.toString(),
+        user_id,
+      });
+    }
+  },
+});

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
@@ -18,7 +18,7 @@ export default makeBatchedMigration({
       { CUTOFF_DATE },
       z.bigint({ coerce: true }).nullable(),
     );
-    return { min: 1n, max, batchSize: 1000 };
+    return { min: 1n, max, batchSize: 100_000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {
     await queryAsync(sql.update_course_instance_usages_for_submissions, { start, end });

--- a/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250214035153_course_instance_usages__submissions__backfill.ts
@@ -3,8 +3,6 @@ import { z } from 'zod';
 import { makeBatchedMigration } from '@prairielearn/migrations';
 import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 
-import { updateCourseInstanceUsagesForSubmission } from '../models/course-instance-usages.js';
-
 const sql = loadSqlEquiv(import.meta.url);
 
 const CUTOFF_DATE = '2025-02-15T00:00:00Z';
@@ -26,16 +24,6 @@ export default makeBatchedMigration({
     return { min, max, batchSize: 1000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {
-    for (let i = start; i <= end; i++) {
-      const user_id = await queryRow(
-        sql.select_user_id_for_submission_id,
-        { submission_id: i },
-        z.string(),
-      );
-      await updateCourseInstanceUsagesForSubmission({
-        submission_id: i.toString(),
-        user_id,
-      });
-    }
+    await queryAsync(sql.update_course_instance_usages_for_submissions, { start, end });
   },
 });

--- a/apps/prairielearn/src/migrations/20250214035153_course_instance_usages__submissions__backfill.ts
+++ b/apps/prairielearn/src/migrations/20250214035153_course_instance_usages__submissions__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20250214035153_course_instance_usages__submissions__backfill');
+}


### PR DESCRIPTION
Part of #11289, following on from #11298

Our strategy here is to delete all submission usage data older than `CUTOFF_DATE` and then regenerate it from submissions which are also older than `CUTOFF_DATE`.