### PR TITLE
Make docs tabs named instead of numbered

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,9 @@ markdown_extensions:
   - attr_list
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/?h=tabbed#tabbed
   - pymdownx.tabbed:
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
       alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true


### PR DESCRIPTION
Currently in the docs tabs create odd numbered anchors.

![numbered anchor for wsl](https://github.com/user-attachments/assets/1e9ed1d0-676e-4fe4-8356-593092ef41b8)

This update automates named tabs based on the content of the tab title.

![named anchor for wsl](https://github.com/user-attachments/assets/6c57529e-4372-4972-b5c7-273b290059f2)

![named anchor for macos](https://github.com/user-attachments/assets/2632f723-d5e2-4e7b-a85d-ca022d1b9f87)
