### PR TITLE
docs: enable section indexes

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -21,9 +21,13 @@ td:not(.code) code {
 .md-nav__item--section > .md-nav__link[for],
 .md-nav__title {
   text-transform: uppercase;
-  color: var(--md-primary-fg-color);
+  color: var(--md-typeset-color);
 }
 
+.md-nav__item--section > div.md-nav__link {
+  text-transform: uppercase;
+  color: var(--md-primary-fg-color);
+}
 /* CSS for width selection */
 @media (max-width: 1220px) {
   .width-icon {

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -1,0 +1,7 @@
+# Developer Guide
+
+This section provides documentation for all aspects of using PrairieLearn as a developer.
+
+If you are developing your own elements, we reccommend running with [local source](../installingLocal.md) in docker. Then check out the [element development guide](../devElements.md).
+
+If you need to run the test suite, we reccommend running [natively](../installingNative.md).

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -2,6 +2,6 @@
 
 This section provides documentation for working with the PrairieLearn codebase.
 
-If you are developing your own elements, we recommend running with [local source](../installingLocal.md) in docker. Then check out the [element development guide](../devElements.md).
+If you are developing your own elements, we recommend running with [local source](../installingLocal.md) in Docker. Then check out the [element development guide](../devElements.md).
 
 If you need to run the test suite, we recommend running [natively](../installingNative.md).

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -2,6 +2,6 @@
 
 This section provides documentation for all aspects of using PrairieLearn as a developer.
 
-If you are developing your own elements, we reccommend running with [local source](../installingLocal.md) in docker. Then check out the [element development guide](../devElements.md).
+If you are developing your own elements, we recommend running with [local source](../installingLocal.md) in docker. Then check out the [element development guide](../devElements.md).
 
-If you need to run the test suite, we reccommend running [natively](../installingNative.md).
+If you need to run the test suite, we recommend running [natively](../installingNative.md).

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -1,6 +1,6 @@
 # Developer Guide
 
-This section provides documentation for all aspects of using PrairieLearn as a developer.
+This section provides documentation for working with the PrairieLearn codebase.
 
 If you are developing your own elements, we recommend running with [local source](../installingLocal.md) in docker. Then check out the [element development guide](../devElements.md).
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,4 +8,4 @@ Welcome to PrairieLearn! Check out the following pages to get started:
 
 - [Quick start](../getStarted.md): learn how to use and navigate the PrairieLearn interface.
 
-Afterward, you may want to check out the [instructor guide](../instructor-guide/index.md) for more details on how to use PrairieLearn.
+Next, check out the [instructor guide](../instructor-guide/index.md) for more details on how to use PrairieLearn.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -14,4 +14,4 @@ Welcome to PrairieLearn! You probably want to read / complete the following page
 
   This page explains how to use and navigate the PrairieLearn interface.
 
-Afterwards, you may want to check out the [instructor guide](../instructor-guide/index.md) for more details on how to use PrairieLearn.
+Afterward, you may want to check out the [instructor guide](../instructor-guide/index.md) for more details on how to use PrairieLearn.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome to PrairieLearn! You probably want to read / complete the following pages:
+Welcome to PrairieLearn! Check out the following pages to get started:
 
 - [Request a course space](../requestCourse/index.md): get access to your own course on PrairieLearn.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,16 +2,10 @@
 
 Welcome to PrairieLearn! You probably want to read / complete the following pages:
 
-- [Requesting a course space](../requestCourse/index.md)
+- [Request a course space](../requestCourse/index.md): get access to your own course on PrairieLearn.
 
-  This page explains how to get access to PrairieLearn.
+- [Fundamental concepts](../concepts/index.md): gain a high-level understanding of how PrairieLearn works.
 
-- [Fundamental concepts](../concepts/index.md)
-
-  This page explains at a high level how PrairieLearn works.
-
-- [Quick start](../getStarted.md)
-
-  This page explains how to use and navigate the PrairieLearn interface.
+- [Quick start](../getStarted.md): learn how to use and navigate the PrairieLearn interface.
 
 Afterward, you may want to check out the [instructor guide](../instructor-guide/index.md) for more details on how to use PrairieLearn.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,17 @@
+# Getting Started
+
+Welcome to PrairieLearn! You probably want to read / complete the following pages:
+
+- [Requesting a course space](../requestCourse/index.md)
+
+  This page explains how to get access to PrairieLearn.
+
+- [Fundamental concepts](../concepts/index.md)
+
+  This page explains at a high level how PrairieLearn works.
+
+- [Quick start](../getStarted.md)
+
+  This page explains how to use and navigate the PrairieLearn interface.
+
+Afterwards, you may want to check out the [instructor guide](../instructor-guide/index.md) for more details on how to use PrairieLearn.

--- a/docs/installingNative.md
+++ b/docs/installingNative.md
@@ -126,7 +126,7 @@ Most of these prerequisites can be installed using the package manager of your O
     mise use -g python@3.10
     ```
 
-    Or you can install it through [uv](https://github.com/astral-sh/uv) (reccomended):
+    Or you can install it through [uv](https://github.com/astral-sh/uv) (recommended):
 
     ```sh
     mise use -g uv

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -18,9 +18,10 @@ Learn more about configuring the four main aspects of your course:
 Some other important links are:
 
 - [Access control](../accessControl/index.md): learn how to control when and where students can access your course content.
-- [Element catalog](../elements.md): a reference for all elements available for use in questions
-- [Code autograders](../externalGrading.md): learn about the external code autograders
+- [Element catalog](../elements.md): a reference for all elements available for use in questions.
+- [Code autograders](../externalGrading.md): learn how to automatically grade student code.
   - [Python](../python-grader/index.md)
   - [C / C++](../c-grader/index.md)
-- [FAQ](../faq.md): Common questions and answers
-- [Editing and syncing course content](../sync.md): Tradeoffs between in-browser editing and local editing
+  - [Java](../java-grader/index.md)
+- [FAQ](../faq.md): find answers to common questions.
+- [Editing and syncing course content](../sync.md): understand tradeoffs between in-browser editing and local editing.

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -17,7 +17,7 @@ Learn more about configuring the four main aspects of your course:
 
 Some other important links are:
 
-- [Access Control](../accessControl/index.md)
+- [Access control](../accessControl/index.md): learn how to control when and where students can access your course content.
 - [Element catalog](../elements.md)
 - [Code autograders](../externalGrading.md)
   - [Python](../python-grader/index.md)

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -18,7 +18,7 @@ Learn more about configuring the four main aspects of your course:
 Some other important links are:
 
 - [Access Control](../accessControl/index.md)
-- [Element catalogue](../elements.md)
+- [Element catalog](../elements.md)
 - [Autograders](../externalGrading.md)
   - [Python](../python-grader/index.md)
   - [C / C++](../c-grader/index.md)

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -7,7 +7,7 @@ To develop questions and other course content on your own computer, see the [loc
 Learn more about configuring the four main aspects of your course:
 
 - [Courses](../course/index.md)
-- [Course Instances](../courseInstance.md)
+- [Course instances](../courseInstance.md)
 - [Assessments](../assessment/index.md)
 - [Questions](../question.md)
 

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -18,9 +18,9 @@ Learn more about configuring the four main aspects of your course:
 Some other important links are:
 
 - [Access control](../accessControl/index.md): learn how to control when and where students can access your course content.
-- [Element catalog](../elements.md)
-- [Code autograders](../externalGrading.md)
+- [Element catalog](../elements.md): a reference for all elements available for use in questions
+- [Code autograders](../externalGrading.md): learn about the external code autograders
   - [Python](../python-grader/index.md)
   - [C / C++](../c-grader/index.md)
-- [FAQ](../faq.md)
-- [syncing in-browser vs git](../sync.md)
+- [FAQ](../faq.md): Common questions and answers
+- [Editing and syncing course content](../sync.md): Tradeoffs between in-browser editing and local editing

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -1,0 +1,26 @@
+# Instructor Guide
+
+This section provides detailed documentation for all aspects of using PrairieLearn as an instructor.
+
+To run and test question development locally, see the [local installation guide](../installing.md).
+
+For more details about configuring the four main aspects of your course:
+
+- [Courses](../course/index.md)
+- [Course Instances](../courseInstance.md)
+- [Assessments](../assessment/index.md)
+- [Questions](../question.md)
+
+!!! tip
+
+    For a refresher of what these aspects are, see the [PrairieLearn concepts](../concepts/index.md).
+
+Some other important links are:
+
+- [Access Control](../accessControl/index.md)
+- [Element catalogue](../elements.md)
+- [Autograders](../externalGrading.md)
+  - [Python](../python-grader/index.md)
+  - [C / C++](../c-grader/index.md)
+- [FAQ](../faq.md)
+- [syncing in-browser vs git](../sync.md)

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -2,7 +2,7 @@
 
 This section provides detailed documentation for all aspects of using PrairieLearn as an instructor.
 
-To run and test question development locally, see the [local installation guide](../installing.md).
+To develop questions and other course content on your own computer, see the [local installation guide](../installing.md).
 
 For more details about configuring the four main aspects of your course:
 

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -4,7 +4,7 @@ This section provides detailed documentation for all aspects of using PrairieLea
 
 To develop questions and other course content on your own computer, see the [local installation guide](../installing.md).
 
-For more details about configuring the four main aspects of your course:
+Learn more about configuring the four main aspects of your course:
 
 - [Courses](../course/index.md)
 - [Course Instances](../courseInstance.md)

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -19,7 +19,7 @@ Some other important links are:
 
 - [Access Control](../accessControl/index.md)
 - [Element catalog](../elements.md)
-- [Autograders](../externalGrading.md)
+- [Code autograders](../externalGrading.md)
   - [Python](../python-grader/index.md)
   - [C / C++](../c-grader/index.md)
 - [FAQ](../faq.md)

--- a/docs/instructor-guide/index.md
+++ b/docs/instructor-guide/index.md
@@ -24,4 +24,5 @@ Some other important links are:
   - [C / C++](../c-grader/index.md)
   - [Java](../java-grader/index.md)
 - [FAQ](../faq.md): find answers to common questions.
+- [Workspaces](../workspaces/index.md): learn about workspaces, which provide students with a coding environment.
 - [Editing and syncing course content](../sync.md): understand tradeoffs between in-browser editing and local editing.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ theme:
     - navigation.instant.progress
     - navigation.tracking
     - navigation.footer
+    - navigation.indexes
     - search.suggest
     - content.action.edit
     - content.code.copy
@@ -154,6 +155,7 @@ extra:
 nav:
   - Overview: 'index.md'
   - Getting Started:
+      - getting-started/index.md
       - 'Requesting your course space': 'requestCourse/index.md'
       - 'Concepts': 'concepts/index.md'
       - 'Quick start': 'getStarted.md'
@@ -161,6 +163,7 @@ nav:
   - Student Guide:
       - 'Accessibility': 'student-guide/accessibility.md'
   - Instructor Guide:
+      - instructor-guide/index.md
       - 'Installing and running locally': 'installing.md'
       - 'Editing and syncing course content': 'sync.md'
       - 'Course configuration': 'course/index.md'
@@ -187,6 +190,7 @@ nav:
       - 'API': 'api.md'
       - 'LMS Integration': 'lmsIntegrationInstructor.md'
   - Developer Guide:
+      - developer-guide/index.md
       - 'Developer guide': 'dev-guide/index.md'
       - 'Running in Docker with local source': 'installingLocal.md'
       - 'Running natively': 'installingNative.md'


### PR DESCRIPTION
- Enables section indexes, and writes a small blurb for some.

Clickable/non-clickable indexes now differentiated by color.

![CleanShot 2025-02-14 at 14 27 03@2x](https://github.com/user-attachments/assets/bc231c20-679d-4920-93d3-44034d060d8e)
![CleanShot 2025-02-14 at 14 27 13@2x](https://github.com/user-attachments/assets/6efa606c-d52f-4dd0-98fe-14a54493b13d)
