### PR TITLE
Allow pl-card header and footer to use HTML tags

### DIFF
--- a/apps/prairielearn/elements/pl-card/pl-card.mustache
+++ b/apps/prairielearn/elements/pl-card/pl-card.mustache
@@ -27,7 +27,7 @@
   {{/img-bottom-src}}
   {{#footer}}
   <div class="card-footer">
-    {{footer}}
+    {{{footer}}}
   </div>
   {{/footer}}
 </div>

--- a/apps/prairielearn/elements/pl-card/pl-card.mustache
+++ b/apps/prairielearn/elements/pl-card/pl-card.mustache
@@ -4,7 +4,7 @@
   {{/img-top-src}}
   {{#header}}
   <div class="card-header">
-    {{header}}
+    {{{header}}}
   </div>
   {{/header}}
   <div class="card-body">

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1123,7 +1123,7 @@ Displays question content within a card-styled component. Optionally displays a 
 
 #### Details
 
-The `pl-card` attributes mirror the options of [Bootstrap cards](https://getbootstrap.com/docs/5.3/components/card/). The `header` and `footer` tag attributes accept HTML tags to allow for styling of their content.
+The `pl-card` attributes mirror the options of [Bootstrap cards](https://getbootstrap.com/docs/5.3/components/card/). The `header` and `footer` tag attributes can include HTML tags alongside plaintext to allow for styling of their content.
 
 #### Example implementations
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1123,7 +1123,7 @@ Displays question content within a card-styled component. Optionally displays a 
 
 #### Details
 
-The `pl-card` attributes mirror the options of [Bootstrap cards](https://getbootstrap.com/docs/5.3/components/card/).
+The `pl-card` attributes mirror the options of [Bootstrap cards](https://getbootstrap.com/docs/5.3/components/card/). The `header` and `footer` tag attributes accept HTML tags to allow for styling of their content.
 
 #### Example implementations
 

--- a/exampleCourse/questions/element/card/question.html
+++ b/exampleCourse/questions/element/card/question.html
@@ -4,14 +4,20 @@
   </pl-question-panel>
 </pl-card>
 
-<pl-card header="Header" title="Title" img-bottom-src="https://via.placeholder.com/720x480" width="50%">
+<pl-card header="Header" title="Title" img-bottom-src="https://placehold.co/720x480" width="50%">
   <pl-question-panel>
     This is a 50%-width card with a header and a bottom image.
   </pl-question-panel>
 </pl-card>
 
-<pl-card img-top-src="https://via.placeholder.com/1920x1080" title="Title" footer="Footer" width="75%">
+<pl-card img-top-src="https://placehold.co/1920x1080" title="Title" footer="Footer" width="75%">
   <pl-question-panel>
     This is a 75%-width card with a top image and a footer.
+  </pl-question-panel>
+</pl-card>
+
+<pl-card header="A <strong>Stylised</strong> <code>pl-card</code> header.">
+  <pl-question-panel>
+    HTML tags can be used to style the header.
   </pl-question-panel>
 </pl-card>

--- a/exampleCourse/questions/element/card/question.html
+++ b/exampleCourse/questions/element/card/question.html
@@ -16,8 +16,8 @@
   </pl-question-panel>
 </pl-card>
 
-<pl-card header="A <strong>Stylised</strong> <code>pl-card</code> header.">
+<pl-card header="A <strong>Stylised</strong> <code>pl-card</code> header." footer="The footer can also be <em>styled</em>">
   <pl-question-panel>
-    HTML tags can be used to style the header.
+    HTML tags can be used to style the header and footer.
   </pl-question-panel>
 </pl-card>


### PR DESCRIPTION
This change allows HTML tags such as `<strong>` and `<code>` to be used inside of the pl-card `header` attribute.

It also updates the element question with an example showing this and changes the URL to a new website for the placeholder images due to the previous one being taken down.

Was

![without style](https://github.com/user-attachments/assets/f850e413-5870-4c29-a1f0-141bc32cf042)

Now

![after style option](https://github.com/user-attachments/assets/67c24bf7-c5da-4121-85b3-222d791d4bc9)


Edit: update for footer - https://github.com/PrairieLearn/PrairieLearn/pull/11384#issuecomment-2661912711
