### PR TITLE
Add missing link for richTextEditor

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -2508,6 +2508,7 @@ that if there are many submitted answers, the page will load slowly.
 [element/prairiedrawfigure]: https://github.com/PrairieLearn/PrairieLearn/tree/master/testCourse/questions/prairieDrawFigure
 [element/pythonvariable]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/pythonVariable
 [element/dataframe]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/dataframe
+[element/richTextEditor]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/richTextEditor
 [element/stringinput]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/stringInput
 [element/symbolicinput]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/symbolicInput
 [element/template]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/template


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/934b6256-894e-441e-8dea-8c6ab7d72c8c)

Added the missing link to make richTextEditor example link to GitHub from [the docs](https://prairielearn.readthedocs.io/en/latest/elements/#pl-rich-text-editor-element)