### PR TITLE
Add missing dependency to workspace-utils

### DIFF
--- a/packages/workspace-utils/package.json
+++ b/packages/workspace-utils/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@prairielearn/path-utils": "workspace:^",
     "@prairielearn/postgres": "workspace:^",
+    "@prairielearn/zod": "workspace:^",
     "@socket.io/redis-emitter": "^5.1.0",
     "fast-glob": "^3.3.3",
     "filesize": "^10.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,6 +4116,7 @@ __metadata:
     "@prairielearn/path-utils": "workspace:^"
     "@prairielearn/postgres": "workspace:^"
     "@prairielearn/tsconfig": "workspace:^"
+    "@prairielearn/zod": "workspace:^"
     "@socket.io/redis-emitter": "npm:^5.1.0"
     "@types/node": "npm:^20.17.16"
     fast-glob: "npm:^3.3.3"


### PR DESCRIPTION
This ensures that `turbo` builds things in the correct order. Without this, there's a race condition where `@prairielearn/workspace-utils` might be built before `@prairielearn/zod`. This would fail, since the expected types wouldn't be present. We observed this in the wild here: https://github.com/PrairieLearn/PrairieLearn/actions/runs/13400788552/job/37430902112