### PR TITLE
Add route to redirect to question based on QID

### DIFF
--- a/apps/prairielearn/src/ee/lib/aiQuestionGeneration.sql
+++ b/apps/prairielearn/src/ee/lib/aiQuestionGeneration.sql
@@ -64,13 +64,3 @@ VALUES
     $completion,
     $job_sequence_id
   );
-
--- BLOCK select_question_by_qid_and_course
-SELECT
-  *
-FROM
-  questions as q
-WHERE
-  q.qid = $qid
-  AND q.course_id = $course_id
-  AND q.deleted_at IS NULL;

--- a/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
+++ b/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
@@ -5,15 +5,11 @@ import { loadSqlEquiv, queryRows, queryRow, queryAsync } from '@prairielearn/pos
 
 import * as b64Util from '../../lib/base64-util.js';
 import { getCourseFilesClient } from '../../lib/course-files-api.js';
-import {
-  type Issue,
-  QuestionGenerationContextEmbeddingSchema,
-  QuestionSchema,
-} from '../../lib/db-types.js';
+import { type Issue, QuestionGenerationContextEmbeddingSchema } from '../../lib/db-types.js';
 import { getAndRenderVariant } from '../../lib/question-render.js';
 import { type ServerJob, createServerJob } from '../../lib/server-jobs.js';
 import { selectCourseById } from '../../models/course.js';
-import { selectQuestionById } from '../../models/question.js';
+import { selectQuestionById, selectQuestionByQid } from '../../models/question.js';
 import { selectUserById } from '../../models/user.js';
 
 import { createEmbedding, openAiUserFromAuthn, vectorToString } from './contextEmbeddings.js';
@@ -620,11 +616,7 @@ export async function regenerateQuestion(
     authnUserId,
   });
 
-  const question = await queryRow(
-    sql.select_question_by_qid_and_course,
-    { qid: questionQid, course_id: courseId },
-    QuestionSchema,
-  );
+  const question = await selectQuestionByQid({ qid: questionQid, course_id: courseId });
 
   const jobData = await serverJob.execute(async (job) => {
     job.data['questionQid'] = questionQid;

--- a/apps/prairielearn/src/lib/url.ts
+++ b/apps/prairielearn/src/lib/url.ts
@@ -6,3 +6,7 @@ export function getCanonicalHost(req: Request): string {
   if (config.serverCanonicalHost) return config.serverCanonicalHost;
   return `${req.protocol}://${req.get('host')}`;
 }
+
+export function getSearchParams(req: Request): URLSearchParams {
+  return new URL(req.originalUrl, getCanonicalHost(req)).searchParams;
+}

--- a/apps/prairielearn/src/models/question.sql
+++ b/apps/prairielearn/src/models/question.sql
@@ -6,6 +6,16 @@ FROM
 WHERE
   id = $question_id;
 
+-- BLOCK select_question_by_qid
+SELECT
+  *
+FROM
+  questions
+WHERE
+  course_id = $course_id
+  AND qid = $qid
+  AND deleted_at IS NULL;
+
 -- BLOCK select_question_by_uuid
 SELECT
   *

--- a/apps/prairielearn/src/models/question.ts
+++ b/apps/prairielearn/src/models/question.ts
@@ -1,4 +1,4 @@
-import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryRow, queryOptionalRow } from '@prairielearn/postgres';
 
 import { type Question, QuestionSchema } from '../lib/db-types.js';
 
@@ -6,6 +6,26 @@ const sql = loadSqlEquiv(import.meta.url);
 
 export async function selectQuestionById(question_id: string): Promise<Question> {
   return await queryRow(sql.select_question_by_id, { question_id }, QuestionSchema);
+}
+
+export async function selectQuestionByQid({
+  qid,
+  course_id,
+}: {
+  qid: string;
+  course_id: string;
+}): Promise<Question> {
+  return await queryRow(sql.select_question_by_qid, { qid, course_id }, QuestionSchema);
+}
+
+export async function selectOptionalQuestionByQid({
+  qid,
+  course_id,
+}: {
+  qid: string;
+  course_id: string;
+}): Promise<Question | null> {
+  return await queryOptionalRow(sql.select_question_by_qid, { qid, course_id }, QuestionSchema);
 }
 
 export async function selectQuestionByUuid({

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -242,7 +242,7 @@ router.get(
     // `originalUrl` so that this router doesn't have to be aware of where it's
     // mounted.
     const host = getCanonicalHost(req);
-    let questionTestPath = new URL(`${host}${req.originalUrl}`).pathname;
+    let questionTestPath = new URL(req.originalUrl, host).pathname;
     if (!questionTestPath.endsWith('/')) {
       questionTestPath += '/';
     }

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -13,6 +13,7 @@ import { features } from '../../lib/features/index.js';
 import { isEnterprise } from '../../lib/license.js';
 import { EXAMPLE_COURSE_PATH } from '../../lib/paths.js';
 import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
+import { selectOptionalQuestionByQid } from '../../models/question.js';
 import { selectQuestionsForCourse } from '../../models/questions.js';
 import { loadQuestions } from '../../sync/course-db.js';
 
@@ -70,6 +71,21 @@ router.get(
           requiredPermissions: 'Previewer',
         }),
       );
+      return;
+    }
+
+    if (req.query.qid && typeof req.query.qid === 'string') {
+      // Find the question they're after.
+      const question = await selectOptionalQuestionByQid({
+        qid: req.query.qid,
+        course_id: res.locals.course.id,
+      });
+
+      if (!question) {
+        throw new error.HttpStatusError(404, 'Question not found');
+      }
+
+      res.redirect(`${res.locals.urlPrefix}/question/${question.id}/preview`);
       return;
     }
 

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -73,6 +73,7 @@ import * as serverJobs from './lib/server-jobs.js';
 import { PostgresSessionStore } from './lib/session-store.js';
 import * as socketServer from './lib/socket-server.js';
 import { SocketActivityMetrics } from './lib/telemetry/socket-activity-metrics.js';
+import { getSearchParams } from './lib/url.js';
 import * as workspace from './lib/workspace.js';
 import { markAllWorkspaceHostsUnhealthy } from './lib/workspaceHost.js';
 import { enterpriseOnly } from './middlewares/enterpriseOnly.js';
@@ -1111,7 +1112,7 @@ export async function initExpress(): Promise<Express> {
       res.redirect(
         url.format({
           pathname: `${req.params[0]}/preview`,
-          search: url.parse(req.originalUrl).search,
+          search: getSearchParams(req).toString(),
         }),
       );
     },
@@ -1583,7 +1584,7 @@ export async function initExpress(): Promise<Express> {
     res.redirect(
       url.format({
         pathname: `${req.params[0]}/preview`,
-        search: new URL(req.originalUrl, `${req.protocol}://${req.headers.host}/`).search,
+        search: getSearchParams(req).toString(),
       }),
     );
   });

--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -196,8 +196,10 @@ const SKIP_ROUTES = [
 
   // These pages just redirect to other pages and thus don't have to be tested.
   '/pl/course_instance/:course_instance_id/instructor/assessment/:assessment_id/manual_grading/assessment_question/:assessment_question_id/next_ungraded',
+  '/pl/course_instance/:course_instance_id/instructor/course_admin/questions/qid/*',
   '/pl/course_instance/:course_instance_id/instructor/loadFromDisk',
   '/pl/course_instance/:course_instance_id/loadFromDisk',
+  '/pl/course/:course_id/course_admin/questions/qid/*',
   '/pl/course/:course_id/file_transfer/:file_transfer_id',
   '/pl/course/:course_id/loadFromDisk',
   '/pl/loadFromDisk',

--- a/apps/prairielearn/src/tests/instructorQuestions.test.ts
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.ts
@@ -147,4 +147,24 @@ describe('Instructor questions', function () {
     testFileDownloads(previewPageInfo, downloadFile, true);
     testElementClientFiles(previewPageInfo, customElement);
   });
+
+  describe('QID redirect routes', () => {
+    it('redirects to the correct question from course route', async () => {
+      const res = await fetch(`${questionsUrlCourse}?qid=addNumbers&variant_seed=1234`);
+      assert.equal(res.status, 200);
+      assert.equal(
+        res.url,
+        `${baseUrl}/course/1/question/${addNumbers.id}/preview?variant_seed=1234`,
+      );
+    });
+
+    it('redirects to the correct question from instance route', async () => {
+      const res = await fetch(`${questionsUrl}?qid=addNumbers&variant_seed=1234`);
+      assert.equal(res.status, 200);
+      assert.equal(
+        res.url,
+        `${baseUrl}/course_instance/1/instructor/question/${addNumbers.id}/preview?variant_seed=1234`,
+      );
+    });
+  });
 });

--- a/apps/prairielearn/src/tests/instructorQuestions.test.ts
+++ b/apps/prairielearn/src/tests/instructorQuestions.test.ts
@@ -150,7 +150,7 @@ describe('Instructor questions', function () {
 
   describe('QID redirect routes', () => {
     it('redirects to the correct question from course route', async () => {
-      const res = await fetch(`${questionsUrlCourse}?qid=addNumbers&variant_seed=1234`);
+      const res = await fetch(`${questionsUrlCourse}/qid/addNumbers?variant_seed=1234`);
       assert.equal(res.status, 200);
       assert.equal(
         res.url,
@@ -159,7 +159,7 @@ describe('Instructor questions', function () {
     });
 
     it('redirects to the correct question from instance route', async () => {
-      const res = await fetch(`${questionsUrl}?qid=addNumbers&variant_seed=1234`);
+      const res = await fetch(`${questionsUrl}/qid/addNumbers?variant_seed=1234`);
       assert.equal(res.status, 200);
       assert.equal(
         res.url,


### PR DESCRIPTION
This adds support for a route like `/pl/course/1/course_admin/questions/qid/demo/addHTMLtable`, which will redirect to the specified question based on its QID. This is designed primarily for automated testing use cases, where one wouldn't want to jump through hoops to try to get a database ID based on a QID on disk.