### PR TITLE
Remove NameIDFormat from SAML metadata

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/index.ts
+++ b/apps/prairielearn/src/ee/auth/saml/index.ts
@@ -54,6 +54,10 @@ export async function getSamlOptions({
     privateKey: samlProvider.private_key,
     decryptionPvk: samlProvider.private_key,
 
+    // The identifier format will vary from institution to institution. Remove
+    // the default to avoid confusing SSO staff at institutions.
+    identifierFormat: null,
+
     // By default, `node-saml` will include a `RequestedAuthnContext`
     // element that requests password-based authentication. However,
     // some institutions use passwordless auth, so we disable this and


### PR DESCRIPTION
This came up during the integration process with UCSD, their integration folks noticed that our SAML metadata included the following:

```xml
<NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
```

This is added by default by the `@node-saml/node-saml` library that we use. Setting it to `null` will remove the property and help avoid confusion.