### PR TITLE
Decrease temperature to api call for AI grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -31,7 +31,7 @@ import { createEmbedding, vectorToString } from './contextEmbeddings.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const OPEN_AI_MODEL: OpenAI.Chat.ChatModel = 'gpt-4o-2024-11-20';
-const api_temperature = 0.2;
+const API_TEMPERATURE = 0.2;
 
 const SubmissionVariantSchema = z.object({
   variant: VariantSchema,
@@ -386,7 +386,7 @@ export async function aiGrade({
           model: OPEN_AI_MODEL,
           user: `course_${course.id}`,
           response_format: zodResponseFormat(RubricGradingResultSchema, 'score'),
-          temperature: api_temperature,
+          temperature: API_TEMPERATURE,
         });
         try {
           job.info(`Tokens used for prompt: ${completion.usage?.prompt_tokens ?? 0}`);
@@ -457,7 +457,7 @@ export async function aiGrade({
           model: OPEN_AI_MODEL,
           user: `course_${course.id}`,
           response_format: zodResponseFormat(GradingResultSchema, 'score'),
-          temperature: api_temperature,
+          temperature: API_TEMPERATURE,
         });
         try {
           job.info(`Tokens used for prompt: ${completion.usage?.prompt_tokens ?? 0}`);

--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -31,6 +31,7 @@ import { createEmbedding, vectorToString } from './contextEmbeddings.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const OPEN_AI_MODEL: OpenAI.Chat.ChatModel = 'gpt-4o-2024-11-20';
+const api_temperature = 0.2;
 
 const SubmissionVariantSchema = z.object({
   variant: VariantSchema,
@@ -385,7 +386,7 @@ export async function aiGrade({
           model: OPEN_AI_MODEL,
           user: `course_${course.id}`,
           response_format: zodResponseFormat(RubricGradingResultSchema, 'score'),
-          temperature: 0.2,
+          temperature: api_temperature,
         });
         try {
           job.info(`Tokens used for prompt: ${completion.usage?.prompt_tokens ?? 0}`);
@@ -456,7 +457,7 @@ export async function aiGrade({
           model: OPEN_AI_MODEL,
           user: `course_${course.id}`,
           response_format: zodResponseFormat(GradingResultSchema, 'score'),
-          temperature: 0.2,
+          temperature: api_temperature,
         });
         try {
           job.info(`Tokens used for prompt: ${completion.usage?.prompt_tokens ?? 0}`);

--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -409,6 +409,7 @@ export async function aiGrade({
           model: OPEN_AI_MODEL,
           user: `course_${course.id}`,
           response_format: zodResponseFormat(GPTRubricScoreSchema, 'score'),
+          temperature: 0.2,
         });
         try {
           job.info(`Number of tokens used: ${completion.usage?.total_tokens ?? 0}`);
@@ -483,6 +484,7 @@ export async function aiGrade({
           model: OPEN_AI_MODEL,
           user: `course_${course.id}`,
           response_format: zodResponseFormat(GPTScoreSchema, 'score'),
+          temperature: 0.2,
         });
         try {
           job.info(`Number of tokens used: ${completion.usage?.total_tokens ?? 0}`);


### PR DESCRIPTION
In [our local testing of AI grading](https://arxiv.org/abs/2502.13337), a temperature of 0.2 is observed to result in a higher accuracy than 0.7 (default value). 