### PR TITLE
Add role to mini histogram

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/histmini.ts
+++ b/apps/prairielearn/assets/scripts/lib/histmini.ts
@@ -56,6 +56,8 @@ export function histmini(
     .attr('width', width + margin.left + margin.right)
     .attr('height', height + margin.top + margin.bottom)
     .attr('class', 'center-block statsPlot')
+    // We are deliberately setting role="none" here as we do not have any meaningful information to expose to screen readers.
+    .attr('role', 'none')
     .append('g')
     .attr('transform', `translate(${margin.left},${margin.top})`);
 


### PR DESCRIPTION
When working on #11390, I did not realize I needed to add a role to `histmini` as well. This adds that role of `none` which will satisfy accessibility requirements for the SVGs. 