### PR TITLE
Add pillow library

### DIFF
--- a/images/plbase/python-requirements.txt
+++ b/images/plbase/python-requirements.txt
@@ -11,6 +11,7 @@ numpy==1.26.4
 openpyxl==3.1.5
 pandas-stubs==2.2.3.241126
 pandas==2.2.3
+Pillow==11.1.0
 Pint==0.24.4
 psutil==6.1.1
 PuLP==2.9.0


### PR DESCRIPTION
Adds the python pillow library so it can be used to generate images in questions. Would be nice to add an example question which does this (but that can optionally be moved to a later PR).