### PR TITLE
Remove existing feedback when grading with rubric

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -433,6 +433,7 @@ export async function aiGrade({
               {
                 // TODO: consider asking for and recording freeform feedback.
                 manual_rubric_data,
+                feedback: { manual: '' },
               },
               user_id,
             );


### PR DESCRIPTION
When there is a current feedback to a manually graded question, ai grading again on the problem using a rubric would leave the current feedback as-is, is might not match the necessary feedback. This PR will remove the existing feedback when ai grading with rubric. 