### PR TITLE
AI grading without rubric should only update manual score

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading.ts
@@ -472,7 +472,7 @@ export async function aiGrade({
               submission.id,
               null, // check_modified_at
               {
-                score_perc: response.parsed.score,
+                manual_score_perc: response.parsed.score,
                 feedback: { manual: response.parsed.feedback },
               },
               user_id,


### PR DESCRIPTION
In the current setup of AI grading, a problem with both manual graded and autograded parts will be overwritten by the AI grade when using it, but AI grade should only modify the manual score. 

Note that this doesn't stop the AI from seeing the autograded parts and attempting to give scores. This will be dealt with in a later PR. 