### PR TITLE
Backfill usage data from submissions v2

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20250226004222_course_instance_usages__submissions__backfill_v2.sql
+++ b/apps/prairielearn/src/batched-migrations/20250226004222_course_instance_usages__submissions__backfill_v2.sql
@@ -1,0 +1,60 @@
+-- BLOCK delete_old_usages
+DELETE FROM course_instance_usages
+WHERE
+  type = 'Submission'
+  AND date < $CUTOFF_DATE;
+
+-- BLOCK select_bounds
+SELECT
+  max(id)
+FROM
+  submissions
+WHERE
+  date < $CUTOFF_DATE;
+
+-- BLOCK update_course_instance_usages_for_submissions
+INSERT INTO
+  course_instance_usages (
+    type,
+    institution_id,
+    course_id,
+    course_instance_id,
+    date,
+    user_id,
+    include_in_statistics
+  )
+SELECT
+  'Submission',
+  i.id,
+  c.id,
+  ci.id,
+  date_trunc('day', s.date, 'UTC'),
+  -- We use `v.authn_user_id` for backfill, because this is guaranteed to be
+  -- non-null and should virtually always be the same as `ai.user_id` for
+  -- students (we want to match the user_id for student submissions, to avoid
+  -- counting course staff as students).
+  v.authn_user_id,
+  coalesce(ai.include_in_statistics, false)
+FROM
+  submissions AS s
+  JOIN variants AS v ON (v.id = s.variant_id)
+  JOIN questions AS q ON (q.id = v.question_id)
+  JOIN pl_courses AS c ON (c.id = q.course_id)
+  JOIN institutions AS i ON (i.id = c.institution_id)
+  LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+  LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+  LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
+  -- The original query (in
+  -- `20250214035153_course_instance_usages__submissions__backfill.sql`) had a
+  -- typo on the following line, using `ci.course_id` instead of `ci.id`.
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+  s.id >= $start
+  AND s.id <= $end
+ON CONFLICT (
+  type,
+  course_id,
+  course_instance_id,
+  date,
+  user_id
+) DO NOTHING;

--- a/apps/prairielearn/src/batched-migrations/20250226004222_course_instance_usages__submissions__backfill_v2.ts
+++ b/apps/prairielearn/src/batched-migrations/20250226004222_course_instance_usages__submissions__backfill_v2.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const CUTOFF_DATE = '2025-02-15T00:00:00Z';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    // First delete usage data older than a hard-coded date
+    await queryAsync(sql.delete_old_usages, { CUTOFF_DATE });
+
+    // Only backfill from submissions that are older than the cutoff date
+    const max = await queryRow(
+      sql.select_bounds,
+      { CUTOFF_DATE },
+      z.bigint({ coerce: true }).nullable(),
+    );
+    return { min: 1n, max, batchSize: 100_000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.update_course_instance_usages_for_submissions, { start, end });
+  },
+});

--- a/apps/prairielearn/src/migrations/20250226004222_course_instance_usages__submissions__backfill_v2.ts
+++ b/apps/prairielearn/src/migrations/20250226004222_course_instance_usages__submissions__backfill_v2.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20250226004222_course_instance_usages__submissions__backfill_v2');
+}


### PR DESCRIPTION
This is a repeat of the backfill in #11366 but with a bug fixed. Unfortunately we need to run the backfill again. The backfill itself is idempotent because we delete the previously backfilled data before starting it.