### PR TITLE
Use new version of jupyter/minimal-notebook base image

### DIFF
--- a/workspaces/jupyterlab-python/Dockerfile
+++ b/workspaces/jupyterlab-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook:2023-10-20
+FROM quay.io/jupyter/minimal-notebook:2025-02-24
 
 ENV XDG_DATA_HOME=/tmp/local/share
 ENV XDG_CACHE_HOME=/tmp/cache


### PR DESCRIPTION
This change fixes some weirdness that we've observed when real-time collaboration is enabled.

To reproduce the issue (or lack of it):

- Find a question that uses the `prairielearn/workspace-jupyterlab-python` workspace image
- Enable real-time collaboration:
  ```json
  {
    "workspaceOptions": {
      "environment": {
        "ENABLE_REAL_TIME_COLLABORATION": "true"
      }
    }
  }
  ```
- Launch the workspace and open the notebook.
- Edit and then execute any cell.
- Reload the webpage.
- **Broken**: the file opens as completely empty, without even showing editor UI.
- **Fixed**: the file open as normal.