### PR TITLE
Improve interface when workspace fails to load

### DIFF
--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -89,7 +89,7 @@ $(function () {
       workspaceFrame.src = 'about:blank';
       if (previousState === 'running') {
         showStoppedFrame();
-      } else if (previousState === 'launching') {
+      } else {
         showFailedFrame();
       }
     }

--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -34,26 +34,38 @@ $(function () {
   });
   const loadingFrame = document.getElementById('loading') as HTMLDivElement;
   const stoppedFrame = document.getElementById('stopped') as HTMLDivElement;
+  const failedFrame = document.getElementById('failed') as HTMLDivElement;
   const workspaceFrame = document.getElementById('workspace') as HTMLIFrameElement;
   const stateBadge = document.getElementById('state') as HTMLSpanElement;
   const messageBadge = document.getElementById('message') as HTMLSpanElement;
+  const failedMessageParagraph = document.getElementById('failed-message') as HTMLElement;
   const reloadButton = document.getElementById('reload') as HTMLButtonElement;
 
   const showStoppedFrame = () => {
     loadingFrame.style.setProperty('display', 'none', 'important');
     stoppedFrame.style.setProperty('display', 'flex', 'important');
+    failedFrame.style.setProperty('display', 'none', 'important');
+    workspaceFrame.style.setProperty('display', 'none', 'important');
+  };
+
+  const showFailedFrame = () => {
+    loadingFrame.style.setProperty('display', 'none', 'important');
+    stoppedFrame.style.setProperty('display', 'none', 'important');
+    failedFrame.style.setProperty('display', 'flex', 'important');
     workspaceFrame.style.setProperty('display', 'none', 'important');
   };
 
   const showWorkspaceFrame = () => {
     loadingFrame.style.setProperty('display', 'none', 'important');
     stoppedFrame.style.setProperty('display', 'none', 'important');
+    failedFrame.style.setProperty('display', 'none', 'important');
     workspaceFrame.style.setProperty('display', 'flex', 'important');
   };
 
   function setMessage(message: string) {
     console.log('message', message);
     messageBadge.textContent = message;
+    failedMessageParagraph.textContent = message;
     if (message) {
       stateBadge.classList.add('badge-prepend');
     } else {
@@ -77,6 +89,8 @@ $(function () {
       workspaceFrame.src = 'about:blank';
       if (previousState === 'running') {
         showStoppedFrame();
+      } else if (previousState === 'launching') {
+        showFailedFrame();
       }
     }
     stateBadge.textContent = state;

--- a/apps/prairielearn/assets/scripts/workspaceClient.ts
+++ b/apps/prairielearn/assets/scripts/workspaceClient.ts
@@ -38,7 +38,7 @@ $(function () {
   const workspaceFrame = document.getElementById('workspace') as HTMLIFrameElement;
   const stateBadge = document.getElementById('state') as HTMLSpanElement;
   const messageBadge = document.getElementById('message') as HTMLSpanElement;
-  const failedMessageParagraph = document.getElementById('failed-message') as HTMLElement;
+  const failedMessage = document.getElementById('failed-message') as HTMLElement;
   const reloadButton = document.getElementById('reload') as HTMLButtonElement;
 
   const showStoppedFrame = () => {
@@ -65,7 +65,7 @@ $(function () {
   function setMessage(message: string) {
     console.log('message', message);
     messageBadge.textContent = message;
-    failedMessageParagraph.textContent = message;
+    failedMessage.textContent = message;
     if (message) {
       stateBadge.classList.add('badge-prepend');
     } else {

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -170,6 +170,14 @@ export function Workspace({
             <p>Your data was automatically saved. Reload the page to restart the workspace.</p>
             <button id="reload" class="btn btn-primary">Reload</button>
           </div>
+          <div
+            id="failed"
+            class="d-none h-100 flex-grow flex-column justify-content-center align-items-center"
+          >
+            <i class="d-block fa fa-10x fa-xmark text-danger" aria-hidden="true"></i>
+            <h2>Workspace failed to load</h2>
+            <p id="failed-message"></p>
+          </div>
           <iframe id="workspace" class="d-none flex-grow h-100 border-0"></iframe>
         </main>
       </body>

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -164,7 +164,7 @@ export function Workspace({
           </div>
           <div
             id="stopped"
-            class="d-none h-100 flex-grow flex-column justify-content-center align-items-center"
+            class="d-none h-100 flex-grow flex-column justify-content-center align-items-center p-2 text-center"
           >
             <h2>Workspace stopped due to inactivity</h2>
             <p>Your data was automatically saved. Reload the page to restart the workspace.</p>
@@ -172,7 +172,7 @@ export function Workspace({
           </div>
           <div
             id="failed"
-            class="d-none h-100 flex-grow flex-column justify-content-center align-items-center"
+            class="d-none h-100 flex-grow flex-column justify-content-center align-items-center p-2 text-center"
           >
             <i class="d-block fa fa-10x fa-xmark text-danger" aria-hidden="true"></i>
             <h2>Workspace failed to load</h2>


### PR DESCRIPTION
Fixes #11120. If a workspace fails to load (e.g., the image is invalid), changes the spinning circle interface to an error message instead.

![image](https://github.com/user-attachments/assets/b47d364d-3d3a-4ab2-b39e-b2b7338021c6)

![image](https://github.com/user-attachments/assets/d887be9f-a6ea-41e4-a7e5-890533632332)
