### PR TITLE
Handle failed grading jobs when computing course instance usage

### DIFF
--- a/apps/prairielearn/src/models/course-instance-usages.sql
+++ b/apps/prairielearn/src/models/course-instance-usages.sql
@@ -77,6 +77,8 @@ WHERE
   -- Avoid inserting anything if we'd compute a NULL duration.
   AND gj.grading_received_at IS NOT NULL
   AND gj.grading_finished_at IS NOT NULL
+  -- Avoid inserting negative durations.
+  AND gj.grading_finished_at > gj.grading_received_at
 ON CONFLICT (
   type,
   course_id,

--- a/apps/prairielearn/src/models/course-instance-usages.sql
+++ b/apps/prairielearn/src/models/course-instance-usages.sql
@@ -74,6 +74,9 @@ FROM
   LEFT JOIN course_instances AS ci ON (ci.course_id = a.course_instance_id)
 WHERE
   gj.id = $grading_job_id
+  -- Avoid inserting anything if we'd compute a NULL duration.
+  AND gj.grading_received_at IS NOT NULL
+  AND gj.grading_finished_at IS NOT NULL
 ON CONFLICT (
   type,
   course_id,


### PR DESCRIPTION
As reported on Slack, the previous code would error out if the grading job itself failed (for instance, if one forgot to mount the Docker socket into the PrairieLearn Docker container in local development):

> Error processing results for grading job 1 null value in column "duration" of relation "course_instance_usages" violates not-null constraint