### PR TITLE
Fix bug in Canvas question conversion script

### DIFF
--- a/contrib/question_converters/canvas/canvas.py
+++ b/contrib/question_converters/canvas/canvas.py
@@ -214,7 +214,7 @@ class Course(Canvas):
         return students
 
 
-class CourseSubObject(Course):
+class CourseSubObject(Canvas):
     # If not provided, the request_param_name defaults to the lower-cased class name.
     def __init__(
         self, parent, route_name, data, id_field="id", request_param_name=None
@@ -425,7 +425,7 @@ class QuizQuestion(CourseSubObject):
                 raise RuntimeError(
                     f"No quiz provided and cannot find quiz id for: {quiz_question_data}"
                 )
-            quiz = self.quiz(quiz_question_data)
+            quiz = self.get_course().quiz(quiz_question_data)
         super().__init__(
             quiz, "questions", quiz_question_data, request_param_name="question"
         )


### PR DESCRIPTION
Introduced in #11143. Not sure what I was thinking with that change, I hadn't tested it, and it will obviously fail on the basis of a `__init__` call.

Apologies for introducing a change without testing -- I was reminded about the unresolved comment on that PR when this was mentioned on Slack.

This also isn't tested, but this at least won't make things more broken (i.e. `course.quiz` and `self.get_course().quiz` might both throw an error).