### PR TITLE
Ensure esbuild dev server works with proxied requests

### DIFF
--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -76,7 +76,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
       entryNames: '[dir]/[name]',
     });
 
-    esbuildServer = await esbuildContext.serve({ host: '127.0.0.1' });
+    esbuildServer = await esbuildContext.serve({ host: '0.0.0.0' });
   }
 }
 
@@ -117,16 +117,29 @@ export function handler(): RequestHandler {
 
   const { port } = esbuildServer;
 
-  // We're running in dev mode, so we need to boot up ESBuild to start building
+  // We're running in dev mode, so we need to boot up esbuild to start building
   // and watching our assets.
   return function (req, res) {
+    // esbuild will reject requests that come from hosts other than the host on
+    // which the esbuild dev server is listening:
+    // https://github.com/evanw/esbuild/commit/de85afd65edec9ebc44a11e245fd9e9a2e99760d
+    // https://github.com/evanw/esbuild/releases/tag/v0.25.0
+    // We work around this by modifying the request headers to make it look like
+    // the request is coming from localhost, which esbuild won't reject.
+    const headers = structuredClone(req.headers);
+    headers.host = 'localhost';
+    delete headers['x-forwarded-for'];
+    delete headers['x-forwarded-host'];
+    delete headers['x-forwarded-proto'];
+    delete headers['referer'];
+
     const proxyReq = http.request(
       {
         hostname: '127.0.0.1',
         port,
         path: req.url,
         method: req.method,
-        headers: req.headers,
+        headers,
       },
       (proxyRes) => {
         res.writeHead(proxyRes.statusCode ?? 500, proxyRes.headers);


### PR DESCRIPTION
When the PrairieLearn dev server is running behind a reverse proxy, e.g. to serve it from a "real" domain on the internet, esbuild rejects requests because the host on the request doesn't match the host that the esbuild dev server is running on. This was changed in https://github.com/evanw/esbuild/releases/tag/v0.25.0 to prevent a security issue.

This would also impact people who are using local DNS overrides to serve from a non-localhost domain.

This PR fixes that by modifying the proxied request to make it seem like it came from localhost.