### PR TITLE
Upgrade jupyterlab base image

### DIFF
--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:hub-4.0.2
+FROM quay.io/jupyter/datascience-notebook:lab-4.3.5
 COPY jupyter_notebook_config.py /etc/jupyter/
 
 ENV XDG_DATA_HOME=/tmp/local/share

--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/datascience-notebook:lab-4.3.5
+FROM jupyter/datascience-notebook:a85bfad8ca54
 COPY jupyter_notebook_config.py /etc/jupyter/
 
 ENV XDG_DATA_HOME=/tmp/local/share

--- a/workspaces/jupyterlab/Dockerfile
+++ b/workspaces/jupyterlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:aec555e49be6
+FROM jupyter/datascience-notebook:hub-4.0.2
 COPY jupyter_notebook_config.py /etc/jupyter/
 
 ENV XDG_DATA_HOME=/tmp/local/share


### PR DESCRIPTION
- The current image we build off of only has a x86 variant, but for #11102 we need both variants available.
- Not tested
- https://hub.docker.com/r/jupyter/datascience-notebook/tags
- https://hub.docker.com/layers/jupyter/datascience-notebook/a85bfad8ca54/images/sha256-3fba9d079ea2077cdd2844a6aaf8d9acdf2c6c79c50fec4cec938ef48c01ecda is the oldest multiplatform image I see

Alternatively, in #11102 I can exclude building the arm variant for this image. @nwalters512 any opinions?