### PR TITLE
Make sure that the next/previous question buttons are always an HTML button

### DIFF
--- a/apps/prairielearn/src/components/QuestionNavigation.html.ts
+++ b/apps/prairielearn/src/components/QuestionNavigation.html.ts
@@ -98,12 +98,12 @@ export function QuestionNavSideButton({
   }
 
   return html`
-    <a
+    <button
       id="${buttonId}"
       class="btn btn-primary mb-3"
       href="${urlPrefix}/instance_question/${instanceQuestionId}/"
     >
       ${buttonLabel}
-    </a>
+    </button>
   `;
 }


### PR DESCRIPTION
Next/previous questions should always be a `button` and never an `a` tag. 

This issue was found by @peter-fowles when doing a user study with a user using a screen reader. 

They were not able to find the 'next question' button when using the 'jump to buttons' with their screenreader, because the next button was an `a` rather than a `button`.