### PR TITLE
CI turbo build cache, uv build + cache, apt cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -400,7 +400,8 @@ jobs:
 
   native-checks:
     runs-on: ubuntu-latest
-
+    env:
+      UV_SYSTEM_PYTHON: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -417,10 +418,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          cache: pip
-          cache-dependency-path: images/plbase/python-requirements.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "images/plbase/python-requirements.txt"
       - name: Install Python dependencies
-        run: pip install -r images/plbase/python-requirements.txt
+        run: uv pip install -r images/plbase/python-requirements.txt
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -400,8 +400,6 @@ jobs:
 
   native-checks:
     runs-on: ubuntu-latest
-    env:
-      UV_SYSTEM_PYTHON: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -428,6 +426,8 @@ jobs:
           enable-cache: true
           cache-dependency-glob: 'images/plbase/python-requirements.txt'
       - name: Install Python dependencies
+        env:
+          UV_SYSTEM_PYTHON: 1
         run: uv pip install -r images/plbase/python-requirements.txt
 
       - name: Set up Node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -422,7 +422,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "images/plbase/python-requirements.txt"
+          cache-dependency-glob: 'images/plbase/python-requirements.txt'
       - name: Install Python dependencies
         run: uv pip install -r images/plbase/python-requirements.txt
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -408,7 +408,7 @@ jobs:
       - name: Install OS packages
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: graphviz graphviz-dev
+          packages: graphviz libgraphviz-dev
           version: 1.0
           execute_install_scripts: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -435,7 +435,7 @@ jobs:
       - name: Set up Turborepo cache
         uses: actions/cache@v4
         with:
-          path: ./node_modules/.cache/turbo
+          path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -406,7 +406,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install OS packages
-        run: sudo apt-get install -y graphviz graphviz-dev
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: graphviz graphviz-dev
+          version: 1.0
 
       - name: Install additional dependencies
         run: |-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -410,6 +410,7 @@ jobs:
         with:
           packages: graphviz graphviz-dev
           version: 1.0
+          execute_install_scripts: true
 
       - name: Install additional dependencies
         run: |-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -404,7 +404,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install OS packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: graphviz libgraphviz-dev
           version: 1.0
@@ -443,8 +443,7 @@ jobs:
       - name: Set up Turborepo cache
         uses: actions/cache@v4
         with:
-          # Cache is outside of node_modules to avoid confusing caching behavior.
-          path: .turbo
+          path: .turbo/cache
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -435,6 +435,7 @@ jobs:
       - name: Set up Turborepo cache
         uses: actions/cache@v4
         with:
+          # Cache is outside of node_modules to avoid confusing caching behavior.
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
           restore-keys: |

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SH_FILES := $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -pa
 .PHONY: build
 
 build:
-	@yarn turbo run build
+	@yarn turbo run build --cache-dir=.turbo
 build-sequential:
-	@yarn turbo run --concurrency 1 build
+	@yarn turbo run --concurrency 1 build --cache-dir=.turbo
 python-deps:
 	@python3 -m pip install -r images/plbase/python-requirements.txt --root-user-action=ignore
 deps:

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,16 @@ changeset:
 lint-docs: lint-d2 lint-links lint-markdown
 
 build-docs:
-	@python3 -m venv /tmp/pldocs/venv
-	@/tmp/pldocs/venv/bin/python3 -m pip install -r docs/requirements.txt
+	@if uv --version >/dev/null 2>&1; then \
+	  uv venv /tmp/pldocs/venv; \
+		. /tmp/pldocs/venv/bin/activate; \
+		uv pip install -r docs/requirements.txt; \
+	else \
+		python3 -m venv /tmp/pldocs/venv; \
+		. /tmp/pldocs/venv/bin/activate; \
+		/tmp/pldocs/venv/bin/python3 -m pip install -r docs/requirements.txt; \
+	fi
 	@/tmp/pldocs/venv/bin/python3 -m mkdocs build --strict
-
 preview-docs:
 	@mkdocs serve
 

--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,10 @@ lint-docs: lint-d2 lint-links lint-markdown
 build-docs:
 	@if uv --version >/dev/null 2>&1; then \
 		uv venv /tmp/pldocs/venv; \
-		. /tmp/pldocs/venv/bin/activate; \
-		uv pip install -r docs/requirements.txt; \
+		uv pip install -r docs/requirements.txt --python /tmp/pldocs/venv; \
 	else \
 		python3 -m venv /tmp/pldocs/venv; \
-		. /tmp/pldocs/venv/bin/activate; \
-		pip install -r docs/requirements.txt; \
+		/tmp/pldocs/venv/bin/python3 -m pip install -r docs/requirements.txt; \
 	fi
 	@/tmp/pldocs/venv/bin/mkdocs build --strict
 preview-docs:

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ SH_FILES := $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -pa
 .PHONY: build
 
 build:
-	@yarn turbo run build --cache-dir=.turbo
+	@yarn turbo run build
 build-sequential:
-	@yarn turbo run --concurrency 1 build --cache-dir=.turbo
+	@yarn turbo run --concurrency 1 build
 python-deps:
 	@python3 -m pip install -r images/plbase/python-requirements.txt --root-user-action=ignore
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 SH_FILES := $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -path "./.venv/*" ! -path "./testCourse/*")
 
-.PHONY: build
-
 build:
 	@yarn turbo run build
 build-sequential:

--- a/Makefile
+++ b/Makefile
@@ -115,15 +115,15 @@ lint-docs: lint-d2 lint-links lint-markdown
 
 build-docs:
 	@if uv --version >/dev/null 2>&1; then \
-	  uv venv /tmp/pldocs/venv; \
+		uv venv /tmp/pldocs/venv; \
 		. /tmp/pldocs/venv/bin/activate; \
 		uv pip install -r docs/requirements.txt; \
 	else \
 		python3 -m venv /tmp/pldocs/venv; \
 		. /tmp/pldocs/venv/bin/activate; \
-		/tmp/pldocs/venv/bin/python3 -m pip install -r docs/requirements.txt; \
+		pip install -r docs/requirements.txt; \
 	fi
-	@/tmp/pldocs/venv/bin/python3 -m mkdocs build --strict
+	@/tmp/pldocs/venv/bin/mkdocs build --strict
 preview-docs:
 	@mkdocs serve
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SH_FILES := $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -path "./.venv/*" ! -path "./testCourse/*")
 
+.PHONY: build
+
 build:
 	@yarn turbo run build
 build-sequential:


### PR DESCRIPTION
- CI currently wasn't caching turbo correctly: I suspect that the yarn cache wasn't playing nice. I moved the cache to a different location to avoid this problem. https://github.com/vercel/turborepo/issues/451#issuecomment-1191115427
- Use uv to shave some seconds
- Goes from 4:30 to 2:45 minutes