### PR TITLE
C grader: fix types for expected output

### DIFF
--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -420,7 +420,10 @@ class CGrader:
         | Iterable[str | re.Pattern[str]]
         | None = None,
         must_match_all_outputs: OutputMatchingOption | bool = "any",  # noqa: FBT001
-        reject_output: str | Iterable[str] | None = None,
+        reject_output: str
+        | re.Pattern[str]
+        | Iterable[str | re.Pattern[str]]
+        | None = None,
         field: str | None = None,
         ignore_case: bool = True,  # noqa: FBT001
         timeout: float = 1,

--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -415,7 +415,10 @@ class CGrader:
         self,
         command: str | Iterable[str],
         input: str | None = None,  # noqa: A002
-        exp_output: str | Iterable[str] | None = None,
+        exp_output: str
+        | re.Pattern[str]
+        | Iterable[str | re.Pattern[str]]
+        | None = None,
         must_match_all_outputs: OutputMatchingOption | bool = "any",  # noqa: FBT001
         reject_output: str | Iterable[str] | None = None,
         field: str | None = None,
@@ -447,12 +450,12 @@ class CGrader:
         if exp_output is None:
             exp_output = []
             must_match_all_outputs = True
-        elif isinstance(exp_output, str):
+        elif isinstance(exp_output, str | re.Pattern):
             exp_output = [exp_output]
 
         if reject_output is None:
             reject_output = []
-        elif isinstance(reject_output, str):
+        elif isinstance(reject_output, str | re.Pattern):
             reject_output = [reject_output]
 
         if must_match_all_outputs is True:
@@ -466,7 +469,7 @@ class CGrader:
             # If t is not a string, convert it to its string representation
             t = str(t)
             return (
-                t.strip(),
+                t.strip() if ignore_consec_spaces else t.rstrip(),
                 re.compile(
                     (
                         r"\s+".join(map(re.escape, re.split(r"\s+", t)))

--- a/graders/c/cgrader/cgrader.py
+++ b/graders/c/cgrader/cgrader.py
@@ -49,6 +49,7 @@ INVALID_PRIMITIVES = frozenset(("no_sanitize", "disable_sanitizer_instrumentatio
 ASAN_FLAGS = ("-fsanitize=address", "-static-libasan", "-g", "-O0")
 
 
+OutputMatch = str | re.Pattern[str] | Iterable[str | re.Pattern[str]]
 OutputMatchingOption = Literal["all", "partial", "any"]
 
 
@@ -415,15 +416,9 @@ class CGrader:
         self,
         command: str | Iterable[str],
         input: str | None = None,  # noqa: A002
-        exp_output: str
-        | re.Pattern[str]
-        | Iterable[str | re.Pattern[str]]
-        | None = None,
+        exp_output: OutputMatch | None = None,
         must_match_all_outputs: OutputMatchingOption | bool = "any",  # noqa: FBT001
-        reject_output: str
-        | re.Pattern[str]
-        | Iterable[str | re.Pattern[str]]
-        | None = None,
+        reject_output: OutputMatch | None = None,
         field: str | None = None,
         ignore_case: bool = True,  # noqa: FBT001
         timeout: float = 1,


### PR DESCRIPTION
The C grader was implemented to accept, in `exp_output` and `reject_output`, regular expressions instead of just strings, however in #11119, when types were added to the autograder code, these arguments did not have the appropriate types added to type annotation. Moreover, that PR changed a check if the argument was not a list to replace it with a check if the argument was a string, which left out regular expressions. This PR fixes this omission allowing regular expressions to be used in the grader.

This also resolves #11507.