### PR TITLE
Stop reading/writing `submissions.grading_method`

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -935,7 +935,6 @@ export const SubmissionSchema = z.object({
   format_errors: z.record(z.string(), z.any()).nullable(),
   gradable: z.boolean().nullable(),
   graded_at: DateFromISOString.nullable(),
-  grading_method: z.enum(['Internal', 'External', 'Manual']).nullable(),
   grading_requested_at: DateFromISOString.nullable(),
   id: IdSchema,
   manual_rubric_grading_id: IdSchema.nullable(),

--- a/apps/prairielearn/src/lib/question-render.sql
+++ b/apps/prairielearn/src/lib/question-render.sql
@@ -57,7 +57,6 @@ SELECT
   s.duration,
   s.gradable,
   s.graded_at,
-  s.grading_method,
   s.grading_requested_at,
   s.id,
   s.mode,

--- a/apps/prairielearn/src/sprocs/grading_jobs_insert.sql
+++ b/apps/prairielearn/src/sprocs/grading_jobs_insert.sql
@@ -87,9 +87,7 @@ BEGIN
     -- update the submission
 
     UPDATE submissions AS s
-    SET
-        grading_requested_at = now(),
-        grading_method = main.grading_method
+    SET grading_requested_at = now()
     WHERE s.id = submission_id;
 
     -- ######################################################################

--- a/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql
+++ b/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql
@@ -122,8 +122,7 @@ BEGIN
         v2_score = new_v2_score,
         correct = new_correct,
         feedback = new_feedback,
-        submitted_answer = COALESCE(new_submitted_answer, submitted_answer),
-        grading_method = main.grading_method
+        submitted_answer = COALESCE(new_submitted_answer, submitted_answer)
     WHERE id = grading_job.submission_id;
 
     UPDATE variants AS v

--- a/apps/prairielearn/src/sync/tests.md
+++ b/apps/prairielearn/src/sync/tests.md
@@ -154,5 +154,5 @@ The following tables are potentially modified during a sync:
 - Questions have a ton of default/implicit behavior, including...
   - `grading_method` is inferred
   - `client_files` defaults to `[ 'client.js', 'question.html', 'answer.html' ]`
-  - `single_varient` defaults to false
+  - `single_variant` defaults to false
   - `partial_credit` defaults to true for `v3`


### PR DESCRIPTION
Once this is deployed, we can remove this column entirely. It's currently not being used at all, and is just causing confusion for us.