### PR TITLE
Added button role

### DIFF
--- a/apps/prairielearn/src/components/QuestionNavigation.html.ts
+++ b/apps/prairielearn/src/components/QuestionNavigation.html.ts
@@ -101,6 +101,7 @@ export function QuestionNavSideButton({
     <a
       id="${buttonId}"
       class="btn btn-primary mb-3"
+      role="button"
       href="${urlPrefix}/instance_question/${instanceQuestionId}/"
     >
       ${buttonLabel}


### PR DESCRIPTION
Fixed it for real this time

Does the same thing as #11515, but without unintentional other changes.

Does what #11497 attempted to do.

Previously, screen readers would not pick up the "Next Question" button as a button element since it was a hyperlink.

Adding the `role="button"` tag to the element resolves this (See https://www.w3.org/TR/html-aria/#docconformance)