### PR TITLE
Fix viewBox attribute of ProgressCircle svg

### DIFF
--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -47,7 +47,7 @@ export function ProgressCircle({
     style="transform:rotate(-90deg)"
     width="20px"
     height="20px"
-    viewBox="0 0 20px 20px"
+    viewBox="0 0 20 20"
     class="mx-1 ${mlAuto ? 'ml-auto' : ''}"
   >
     <circle


### PR DESCRIPTION
This PR fixes the following error that I observed in the browser dev tools when the course getting started page is shown:

```
Error: <svg> attribute viewBox: Expected number, "0 0 20px 20px".
```