### PR TITLE
Fix submit button on settings forms

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.ts
@@ -43,6 +43,11 @@ export function InstructorAssessmentSettings({
         course: resLocals.course,
         urlPrefix: resLocals.urlPrefix,
       })}
+      ${QRCodeModal({
+        id: 'studentLinkModal',
+        title: 'Student Link QR Code',
+        content: studentLink,
+      })}
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex">
           <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Settings</h1>
@@ -181,11 +186,6 @@ export function InstructorAssessmentSettings({
                 The link that students will use to access this assessment.
               </small>
             </div>
-            ${QRCodeModal({
-              id: 'studentLinkModal',
-              title: 'Student Link QR Code',
-              content: studentLink,
-            })}
             ${resLocals.authz_data.has_course_permission_view
               ? canEdit
                 ? html`

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -36,6 +36,11 @@ export function InstructorInstanceAdminSettings({
         course: resLocals.course,
         urlPrefix: resLocals.urlPrefix,
       })}
+      ${QRCodeModal({
+        id: 'studentLinkModal',
+        title: 'Student Link QR Code',
+        content: studentLink,
+      })}
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex">
           <h1>
@@ -123,11 +128,6 @@ export function InstructorInstanceAdminSettings({
                 to share with students.
               </small>
             </div>
-            ${QRCodeModal({
-              id: 'studentLinkModal',
-              title: 'Student Link QR Code',
-              content: studentLink,
-            })}
             ${EditConfiguration({
               hasCoursePermissionView: resLocals.authz_data.has_course_permission_view,
               hasCoursePermissionEdit: resLocals.authz_data.has_course_permission_edit,


### PR DESCRIPTION
The use of `QRCodeModal` (which itself renders a `<form>`) inside another `<form>` resulted in an HTML document that parsed with the submit button outside of the form, which broke editing. Moving the modal outside of the form fixes this.

In another PR, I want to introduce an HTML validator that will help catch these things during automated testing. **Edit**: #11522