### PR TITLE
Add issue count to enhanced navigation sidebar

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -823,7 +823,7 @@ function NavbarInstructor({
               ${ProgressCircle({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
-                className: 'mx-1'
+                className: 'mx-1',
               })}
             </a>
           </li>

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -823,6 +823,9 @@ function NavbarInstructor({
               ${ProgressCircle({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
+                options: {
+                  mx1: true
+                }
               })}
             </a>
           </li>

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -824,7 +824,7 @@ function NavbarInstructor({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
                 options: {
-                  mx1: true,
+                  className: 'mx-1'
                 },
               })}
             </a>

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -823,9 +823,7 @@ function NavbarInstructor({
               ${ProgressCircle({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
-                options: {
-                  className: 'mx-1'
-                },
+                className: 'mx-1'
               })}
             </a>
           </li>

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -824,8 +824,8 @@ function NavbarInstructor({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
                 options: {
-                  mx1: true
-                }
+                  mx1: true,
+                },
               })}
             </a>
           </li>

--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -8,13 +8,10 @@ export function ProgressCircle({
   value: number;
   maxValue: number;
   options?: {
-    mx1?: boolean;
+    className?: string;
     mlAuto?: boolean;
   };
 }) {
-  // Whether or not the ProgressCircle should have mx-1 added to it.
-  const mx1 = options.mx1 ?? false;
-
   // Whether or not the ProgressCircle should have ml-auto (margin-left: auto) applied to it.
   const mlAuto = options.mlAuto ?? false;
 
@@ -52,7 +49,7 @@ export function ProgressCircle({
     width="20px"
     height="20px"
     viewBox="0 0 20 20"
-    class="mx-1 ${mlAuto ? 'ml-auto' : ''}"
+    class="${options.className ? options.className : ''} ${mlAuto ? 'ml-auto' : ''}"
   >
     <circle
       cx="10px"

--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -3,7 +3,7 @@ import { html } from '@prairielearn/html';
 export function ProgressCircle({
   value,
   maxValue,
-  className
+  className,
 }: {
   value: number;
   maxValue: number;

--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -43,7 +43,7 @@ export function ProgressCircle({
     width="20px"
     height="20px"
     viewBox="0 0 20 20"
-    class="${className ? className : ''}"
+    class="${className ?? ''}"
   >
     <circle
       cx="10px"

--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -8,9 +8,13 @@ export function ProgressCircle({
   value: number;
   maxValue: number;
   options?: {
+    mx1?: boolean;
     mlAuto?: boolean;
   };
 }) {
+  // Whether or not the ProgressCircle should have mx-1 (horizontal margin) applied to it.
+  const mx1 = options.mx1 ?? false;
+
   // Whether or not the ProgressCircle should have ml-auto (margin-left: auto) applied to it.
   const mlAuto = options.mlAuto ?? false;
 
@@ -48,7 +52,7 @@ export function ProgressCircle({
     width="20px"
     height="20px"
     viewBox="0 0 20px 20px"
-    class="mx-1 ${mlAuto ? 'ml-auto' : ''}"
+    class="${mx1 ? 'mx-1' : ''} ${mlAuto ? 'ml-auto' : ''}"
   >
     <circle
       cx="10px"

--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -3,18 +3,12 @@ import { html } from '@prairielearn/html';
 export function ProgressCircle({
   value,
   maxValue,
-  options = {},
+  className
 }: {
   value: number;
   maxValue: number;
-  options?: {
-    className?: string;
-    mlAuto?: boolean;
-  };
+  className?: string;
 }) {
-  // Whether or not the ProgressCircle should have ml-auto (margin-left: auto) applied to it.
-  const mlAuto = options.mlAuto ?? false;
-
   // The progress circle has radius of 8px, so its circumference is 2 * PI * 8px.
   const progressCircleCircumference = 2 * Math.PI * 8;
 
@@ -49,7 +43,7 @@ export function ProgressCircle({
     width="20px"
     height="20px"
     viewBox="0 0 20 20"
-    class="${options.className ? options.className : ''} ${mlAuto ? 'ml-auto' : ''}"
+    class="${className ? className : ''}"
   >
     <circle
       cx="10px"

--- a/apps/prairielearn/src/components/ProgressCircle.html.ts
+++ b/apps/prairielearn/src/components/ProgressCircle.html.ts
@@ -12,7 +12,7 @@ export function ProgressCircle({
     mlAuto?: boolean;
   };
 }) {
-  // Whether or not the ProgressCircle should have mx-1 (horizontal margin) applied to it.
+  // Whether or not the ProgressCircle should have mx-1 added to it.
   const mx1 = options.mx1 ?? false;
 
   // Whether or not the ProgressCircle should have ml-auto (margin-left: auto) applied to it.

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -70,7 +70,7 @@ const sideNavPagesTabs = {
       iconClasses: 'fas fa-bug fa-fw',
       tabLabel: 'Issues',
       htmlSuffix: ({ navbarOpenIssueCount }) =>
-        IssueBadge({ count: navbarOpenIssueCount, suppressLink: true, className: 'ml-auto mr-1' }),
+        IssueBadge({ count: navbarOpenIssueCount, suppressLink: true, className: 'ms-auto' }),
     },
     {
       activePages: ['course_admin'],

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -40,7 +40,7 @@ const sideNavPagesTabs = {
         ProgressCircle({
           value: navbarCompleteGettingStartedTasksCount,
           maxValue: navbarTotalGettingStartedTasksCount,
-          className: 'ms-auto'
+          className: 'ms-auto',
         }),
       renderCondition: ({ authz_data, course }) =>
         authz_data.has_course_permission_edit && course.show_getting_started,

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -2,6 +2,7 @@ import { html, type HtmlValue } from '@prairielearn/html';
 
 import type { NavPage, NavSubPage } from './Navbar.types.js';
 import { ProgressCircle } from './ProgressCircle.html.js';
+import { IssueBadge } from './IssueBadge.html.js';
 
 interface SideNavTabInfo {
   /** For the side nav tab to be active, the current navPage must be in activePages. */
@@ -68,6 +69,8 @@ const sideNavPagesTabs = {
       urlSuffix: '/course_admin/issues',
       iconClasses: 'fas fa-bug fa-fw',
       tabLabel: 'Issues',
+      htmlSuffix: ({ navbarOpenIssueCount }) =>
+        IssueBadge({ count: navbarOpenIssueCount, suppressLink: true, className: 'ml-auto mr-1' })
     },
     {
       activePages: ['course_admin'],

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -70,7 +70,7 @@ const sideNavPagesTabs = {
       iconClasses: 'fas fa-bug fa-fw',
       tabLabel: 'Issues',
       htmlSuffix: ({ navbarOpenIssueCount }) =>
-        IssueBadge({ count: navbarOpenIssueCount, suppressLink: true, className: 'ml-auto mr-1' })
+        IssueBadge({ count: navbarOpenIssueCount, suppressLink: true, className: 'ml-auto mr-1' }),
     },
     {
       activePages: ['course_admin'],

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -1,8 +1,8 @@
 import { html, type HtmlValue } from '@prairielearn/html';
 
+import { IssueBadge } from './IssueBadge.html.js';
 import type { NavPage, NavSubPage } from './Navbar.types.js';
 import { ProgressCircle } from './ProgressCircle.html.js';
-import { IssueBadge } from './IssueBadge.html.js';
 
 interface SideNavTabInfo {
   /** For the side nav tab to be active, the current navPage must be in activePages. */

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -40,10 +40,7 @@ const sideNavPagesTabs = {
         ProgressCircle({
           value: navbarCompleteGettingStartedTasksCount,
           maxValue: navbarTotalGettingStartedTasksCount,
-          options: {
-            mlAuto: true,
-            className: 'mx-1'
-          },
+          className: 'ms-auto'
         }),
       renderCondition: ({ authz_data, course }) =>
         authz_data.has_course_permission_edit && course.show_getting_started,

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -42,6 +42,7 @@ const sideNavPagesTabs = {
           maxValue: navbarTotalGettingStartedTasksCount,
           options: {
             mlAuto: true,
+            className: 'mx-1'
           },
         }),
       renderCondition: ({ authz_data, course }) =>

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -168,7 +168,7 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
               ProgressCircle({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
-                className: 'mx-1'
+                className: 'mx-1',
               }),
             renderCondition: ({ authz_data, course }) =>
               authz_data.has_course_permission_edit && course.show_getting_started,

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -168,9 +168,7 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
               ProgressCircle({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
-                options: {
-                  className: 'mx-1'
-                },
+                className: 'mx-1'
               }),
             renderCondition: ({ authz_data, course }) =>
               authz_data.has_course_permission_edit && course.show_getting_started,

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -168,6 +168,9 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
               ProgressCircle({
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
+                options: {
+                  mx1: true
+                }
               }),
             renderCondition: ({ authz_data, course }) =>
               authz_data.has_course_permission_edit && course.show_getting_started,

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -169,8 +169,8 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
                 options: {
-                  mx1: true
-                }
+                  mx1: true,
+                },
               }),
             renderCondition: ({ authz_data, course }) =>
               authz_data.has_course_permission_edit && course.show_getting_started,

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -169,7 +169,7 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
                 value: navbarCompleteGettingStartedTasksCount,
                 maxValue: navbarTotalGettingStartedTasksCount,
                 options: {
-                  mx1: true,
+                  className: 'mx-1'
                 },
               }),
             renderCondition: ({ authz_data, course }) =>


### PR DESCRIPTION
Closes #11510. 

- Added issue count to enhanced navigation sidebar.

Here's what it looks like when the getting started sidebar tab is shown:

![image](https://github.com/user-attachments/assets/a2ebf2f2-cd16-4319-9697-bf6a0409cf28)

and when it is hidden:

![image](https://github.com/user-attachments/assets/6904483f-17fb-4399-8e43-d92591b38758)
