### PR TITLE
Load navbar dropdown options on mouseover or focus

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -785,7 +785,8 @@ function NavbarInstructor({
         aria-expanded="false"
         ${!authz_data.overrides
           ? html`
-              hx-get="/pl/navbar/course/${course.id}/switcher" hx-trigger="show.bs.dropdown once
+              hx-get="/pl/navbar/course/${course.id}/switcher" hx-trigger="mouseover
+              once, focus once, show.bs.dropdown once
               delay:200ms" hx-target="#navbarDropdownMenuCourseAdmin"
             `
           : ''}
@@ -972,7 +973,7 @@ function NavbarInstructor({
               aria-haspopup="true"
               aria-expanded="false"
               hx-get="/pl/navbar/course/${course.id}/course_instance_switcher"
-              hx-trigger="show.bs.dropdown once delay:200ms"
+              hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
               hx-target="#navbarDropdownMenuInstanceChoose"
             >
               Choose course instance...

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -785,9 +785,8 @@ function NavbarInstructor({
         aria-expanded="false"
         ${!authz_data.overrides
           ? html`
-              hx-get="/pl/navbar/course/${course.id}/switcher" hx-trigger="mouseover
-              once, focus once, show.bs.dropdown once
-              delay:200ms" hx-target="#navbarDropdownMenuCourseAdmin"
+              hx-get="/pl/navbar/course/${course.id}/switcher" hx-trigger="mouseover once, focus
+              once, show.bs.dropdown once delay:200ms" hx-target="#navbarDropdownMenuCourseAdmin"
             `
           : ''}
       ></a>


### PR DESCRIPTION
Related to https://github.com/PrairieLearn/PrairieLearn/pull/11279#discussion_r1980328391. 

Added trigger that preloads navbar course and course instance dropdown elements on user hover/focus.