### PR TITLE
Reorder fields on course instance settings editor

### DIFF
--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.ts
@@ -54,28 +54,10 @@ export function InstructorInstanceAdminSettings({
             <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
             <input type="hidden" name="orig_hash" value="${origHash}" />
             <div class="mb-3">
-              <label class="form-label" for="long_name">Long Name</label>
-              <input
-                type="text"
-                class="form-control"
-                id="long_name"
-                name="long_name"
-                value="${resLocals.course_instance.long_name}"
-                required
-                ${resLocals.authz_data.has_course_permission_edit &&
-                !resLocals.course.example_course
-                  ? ''
-                  : 'disabled'}
-              />
-              <small class="form-text text-muted">
-                The long name of this course instance (e.g., 'Spring 2015').
-              </small>
-            </div>
-            <div class="mb-3">
               <label class="form-label" for="ciid">CIID</label>
               <input
                 type="text"
-                class="form-control"
+                class="form-control font-monospace"
                 id="ciid"
                 name="ciid"
                 value="${resLocals.course_instance.short_name}"
@@ -92,6 +74,24 @@ export function InstructorInstanceAdminSettings({
                 forward slashes to separate directories. The recommended format is
                 <code>Fa19</code> or <code>Fall2019</code>. Add suffixes if there are multiple
                 versions, like <code>Fa19honors</code>.
+              </small>
+            </div>
+            <div class="mb-3">
+              <label class="form-label" for="long_name">Long Name</label>
+              <input
+                type="text"
+                class="form-control"
+                id="long_name"
+                name="long_name"
+                value="${resLocals.course_instance.long_name}"
+                required
+                ${resLocals.authz_data.has_course_permission_edit &&
+                !resLocals.course.example_course
+                  ? ''
+                  : 'disabled'}
+              />
+              <small class="form-text text-muted">
+                The long name of this course instance (e.g., 'Spring 2015').
               </small>
             </div>
             <div class="mb-3">


### PR DESCRIPTION
While testing recent changes, I noticed that the course instance settings page had a different ordering of fields than the assessment and question settings pages, where the AID/QID fields came first. This PR reorders the fields on this page to match the others, which should make the UI more consistent and predictable.