### PR TITLE
Add ability to preview manual grading view from question preview page

### DIFF
--- a/apps/prairielearn/assets/scripts/behaviors/popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/popover.ts
@@ -6,11 +6,11 @@ import { focusFirstFocusableChild, onDocumentReady, trapFocus } from '@prairiele
 
 import { getPopoverContainerForTrigger, getPopoverTriggerForContainer } from '../lib/popover.js';
 
-const openPopoverTriggers = new Set<Popover>();
+const openPopovers = new Set<Popover>();
 
 function closeOpenPopovers() {
-  openPopoverTriggers.forEach((popover) => popover.hide());
-  openPopoverTriggers.clear();
+  openPopovers.forEach((popover) => popover.hide());
+  openPopovers.clear();
 }
 
 /**
@@ -86,7 +86,7 @@ onDocumentReady(() => {
   });
 
   on('click', 'body', (e) => {
-    if (openPopoverTriggers.size === 0) return;
+    if (openPopovers.size === 0) return;
 
     // If this click occurred inside a popover, do nothing.
     const closestPopover = (e.target as HTMLElement).closest('.popover');
@@ -115,10 +115,8 @@ onDocumentReady(() => {
   on('shown.bs.popover', 'body', (event) => {
     const target = event.target as HTMLElement;
 
-    const popoverInstance = window.bootstrap.Popover.getInstance(target);
-    if (popoverInstance) {
-      openPopoverTriggers.add(popoverInstance);
-    }
+    const popover = window.bootstrap.Popover.getInstance(target);
+    if (popover) openPopovers.add(popover);
 
     const container = getPopoverContainerForTrigger(target);
 
@@ -143,9 +141,7 @@ onDocumentReady(() => {
   });
 
   on('hide.bs.popover', 'body', (event) => {
-    const popoverInstance = window.bootstrap.Popover.getInstance(event.target as HTMLElement);
-    if (popoverInstance) {
-      openPopoverTriggers.delete(popoverInstance);
-    }
+    const popover = window.bootstrap.Popover.getInstance(event.target as HTMLElement);
+    if (popover) openPopovers.delete(popover);
   });
 });

--- a/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
@@ -6,7 +6,7 @@ onDocumentReady(() => {
   observe('[data-bs-toggle~="tooltip"], [data-bs-toggle-tooltip="true"]', {
     constructor: HTMLElement,
     add(el) {
-      new window.bootstrap.Tooltip(el);
+      new window.bootstrap.Tooltip(el, { trigger: 'hover' });
 
       // Bootstrap doesn't support a single element triggering multiple things.
       // There are cases where we want this behavior, e.g. to have a tooltip

--- a/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
@@ -63,13 +63,18 @@ onDocumentReady(() => {
     },
   });
 
-  on('show.bs.tooltip', 'body', (event) => {
-    // Close existing tooltips when a new one is shown.
+  // Hide other open tooltips when a new one is shown.
+  on('show.bs.tooltip', 'body', () => {
     closeOpenTooltips();
+  });
 
+  on('shown.bs.tooltip', 'body', (event) => {
     const tooltip = window.bootstrap.Tooltip.getInstance(event.target as HTMLElement);
-    if (tooltip) {
-      openTooltips.add(tooltip);
-    }
+    if (tooltip) openTooltips.add(tooltip);
+  });
+
+  on('hide.bs.tooltip', 'body', (event) => {
+    const tooltip = window.bootstrap.Tooltip.getInstance(event.target as HTMLElement);
+    if (tooltip) openTooltips.delete(tooltip);
   });
 });

--- a/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/tooltip.ts
@@ -1,12 +1,21 @@
+import { type Tooltip } from 'bootstrap';
+import { on } from 'delegated-events';
 import { observe } from 'selector-observer';
 
 import { onDocumentReady } from '@prairielearn/browser-utils';
+
+const openTooltips = new Set<Tooltip>();
+
+function closeOpenTooltips() {
+  openTooltips.forEach((tooltip) => tooltip.hide());
+  openTooltips.clear();
+}
 
 onDocumentReady(() => {
   observe('[data-bs-toggle~="tooltip"], [data-bs-toggle-tooltip="true"]', {
     constructor: HTMLElement,
     add(el) {
-      new window.bootstrap.Tooltip(el, { trigger: 'hover' });
+      new window.bootstrap.Tooltip(el);
 
       // Bootstrap doesn't support a single element triggering multiple things.
       // There are cases where we want this behavior, e.g. to have a tooltip
@@ -52,5 +61,15 @@ onDocumentReady(() => {
     remove(el) {
       window.bootstrap.Tooltip.getInstance(el)?.dispose();
     },
+  });
+
+  on('show.bs.tooltip', 'body', (event) => {
+    // Close existing tooltips when a new one is shown.
+    closeOpenTooltips();
+
+    const tooltip = window.bootstrap.Tooltip.getInstance(event.target as HTMLElement);
+    if (tooltip) {
+      openTooltips.add(tooltip);
+    }
   });
 });

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -423,7 +423,3 @@ small .user-output-invalid {
 .fixed-table-toolbar div.pagination-detail {
   margin: 0 1em 0 0 !important;
 }
-
-.dropdown-toggle-no-caret::after {
-  display: none;
-}

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -423,3 +423,7 @@ small .user-output-invalid {
 .fixed-table-toolbar div.pagination-detail {
   margin: 0 1em 0 0 !important;
 }
+
+.dropdown-toggle-no-caret::after {
+  display: none;
+}

--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -70,7 +70,7 @@ export function InstructorInfoPanel({
   const timeZone = course_instance?.display_timezone ?? course.display_timezone;
 
   return html`
-    <div class="card mb-4 border-warning">
+    <div class="card mb-3 border-warning">
       <div class="card-header bg-warning">
         <h2>Staff information</h2>
       </div>

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -642,12 +642,10 @@ function QuestionPanel({
   // Show even when question_copy_targets is empty.
   // We'll show a CTA to request a course if the user isn't an editor of any course.
   const showCopyQuestionButton =
-    (question.type === 'Freeform' &&
-      question_copy_targets != null &&
-      (course.template_course ||
-        (question.share_source_publicly && questionContext === 'public')) &&
-      questionContext !== 'manual_grading') ||
-    true;
+    question.type === 'Freeform' &&
+    question_copy_targets != null &&
+    (course.template_course || (question.share_source_publicly && questionContext === 'public')) &&
+    questionContext !== 'manual_grading';
 
   return html`
     <div class="card mb-3 question-block">

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -666,11 +666,12 @@ function QuestionPanel({
                   <button
                     class="btn btn-sm btn-outline-light"
                     type="button"
-                    data-bs-toggle="modal tooltip"
-                    data-bs-title="Copy question"
+                    aria-label="Copy question"
+                    data-bs-toggle="modal"
                     data-bs-target="#copyQuestionModal"
                   >
                     <i class="fa fa-fw fa-clone"></i>
+                    <span class="d-none d-sm-inline">Copy question</span>
                   </button>
                 `
               : ''}
@@ -678,18 +679,17 @@ function QuestionPanel({
               ? html`
                   <div class="btn-group">
                     <button
-                      class="btn btn-sm btn-outline-light dropdown-toggle dropdown-toggle-no-caret"
+                      class="btn btn-sm btn-outline-light dropdown-toggle"
                       type="button"
                       aria-expanded="false"
-                      data-bs-toggle="dropdown tooltip"
-                      data-bs-title="Preview..."
+                      data-bs-toggle="dropdown"
                     >
-                      <i class="fa fa-fw fa-eye"></i>
+                      View&hellip;
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end">
                       <li>
                         <a class="dropdown-item" href="${manualGradingPreviewUrl}">
-                          Preview manual grading view
+                          Manual grading view
                         </a>
                       </li>
                     </ul>

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -26,9 +26,11 @@ const MAX_TOP_RECENTS = 3;
 export function QuestionContainer({
   resLocals,
   questionContext,
+  manualGradingPreviewUrl,
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
+  manualGradingPreviewUrl?: string;
 }) {
   const {
     question,
@@ -47,7 +49,7 @@ export function QuestionContainer({
 
   return html`
     <div
-      class="question-container"
+      class="question-container mb-4"
       data-grading-method="${question.grading_method}"
       data-variant-id="${variant.id}"
       data-variant-token="${variantToken}"
@@ -59,12 +61,12 @@ export function QuestionContainer({
       ${question.type === 'Freeform'
         ? html`
             <form class="question-form" name="question-form" method="POST" autocomplete="off">
-              ${QuestionPanel({ resLocals, questionContext })}
+              ${QuestionPanel({ resLocals, questionContext, manualGradingPreviewUrl })}
             </form>
           `
         : QuestionPanel({ resLocals, questionContext })}
 
-      <div class="card mb-4 grading-block${showTrueAnswer ? '' : ' d-none'}">
+      <div class="card mb-3 grading-block${showTrueAnswer ? '' : ' d-none'}">
         <div class="card-header bg-secondary text-white">
           <h2>Correct answer</h2>
         </div>
@@ -82,7 +84,7 @@ export function QuestionContainer({
             })}
             ${submissions.length > MAX_TOP_RECENTS
               ? html`
-                  <div class="mb-4 d-flex justify-content-center">
+                  <div class="mb-3 d-flex justify-content-center">
                     <button
                       class="show-hide-btn btn btn-outline-secondary btn-sm collapsed"
                       type="button"
@@ -154,7 +156,7 @@ export function IssuePanel({
   }?subject=Reported%20PrairieLearn%20Issue&body=${encodeURIComponent(msgBody)}`;
 
   return html`
-    <div class="card mb-4">
+    <div class="card mb-3">
       <div class="card-header bg-danger text-white">
         ${issue.manually_reported ? 'Manually reported issue' : 'Issue'}
       </div>
@@ -629,9 +631,11 @@ function AvailablePointsNotes({
 function QuestionPanel({
   resLocals,
   questionContext,
+  manualGradingPreviewUrl,
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
+  manualGradingPreviewUrl?: string;
 }) {
   const { question, questionHtml, question_copy_targets, course, instance_question_info } =
     resLocals;
@@ -646,7 +650,7 @@ function QuestionPanel({
     true;
 
   return html`
-    <div class="card mb-4 question-block">
+    <div class="card mb-3 question-block">
       <div class="card-header bg-primary text-white d-flex align-items-center">
         <h1>
           ${QuestionTitle({
@@ -662,7 +666,7 @@ function QuestionPanel({
                   <button
                     class="btn btn-sm btn-outline-light"
                     type="button"
-                    data-bs-toggle="modal, tooltip"
+                    data-bs-toggle="modal tooltip"
                     data-bs-title="Copy question"
                     data-bs-target="#copyQuestionModal"
                   >
@@ -670,20 +674,28 @@ function QuestionPanel({
                   </button>
                 `
               : ''}
-            <div class="btn-group">
-              <button
-                class="btn btn-sm btn-outline-light dropdown-toggle dropdown-toggle-no-caret"
-                type="button"
-                aria-expanded="false"
-                aria-label="More options"
-                data-bs-toggle="dropdown"
-              >
-                <i class="fa fa-fw fa-ellipsis-v"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-end">
-                <li class="dropdown-item">Preview manual grading view</li>
-              </ul>
-            </div>
+            ${manualGradingPreviewUrl
+              ? html`
+                  <div class="btn-group">
+                    <button
+                      class="btn btn-sm btn-outline-light dropdown-toggle dropdown-toggle-no-caret"
+                      type="button"
+                      aria-expanded="false"
+                      data-bs-toggle="dropdown tooltip"
+                      data-bs-title="Preview..."
+                    >
+                      <i class="fa fa-fw fa-eye"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                      <li>
+                        <a class="dropdown-item" href="${manualGradingPreviewUrl}">
+                          Preview manual grading view
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                `
+              : ''}
           </div>
         </div>
       </div>

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -638,10 +638,12 @@ function QuestionPanel({
   // Show even when question_copy_targets is empty.
   // We'll show a CTA to request a course if the user isn't an editor of any course.
   const showCopyQuestionButton =
-    question.type === 'Freeform' &&
-    question_copy_targets != null &&
-    (course.template_course || (question.share_source_publicly && questionContext === 'public')) &&
-    questionContext !== 'manual_grading';
+    (question.type === 'Freeform' &&
+      question_copy_targets != null &&
+      (course.template_course ||
+        (question.share_source_publicly && questionContext === 'public')) &&
+      questionContext !== 'manual_grading') ||
+    true;
 
   return html`
     <div class="card mb-4 question-block">
@@ -653,19 +655,37 @@ function QuestionPanel({
             questionNumber: instance_question_info?.question_number,
           })}
         </h1>
-        ${showCopyQuestionButton
-          ? html`
+        <div class="ms-auto d-flex flex-row gap-1">
+          <div class="btn-group">
+            ${showCopyQuestionButton
+              ? html`
+                  <button
+                    class="btn btn-sm btn-outline-light"
+                    type="button"
+                    data-bs-toggle="modal, tooltip"
+                    data-bs-title="Copy question"
+                    data-bs-target="#copyQuestionModal"
+                  >
+                    <i class="fa fa-fw fa-clone"></i>
+                  </button>
+                `
+              : ''}
+            <div class="btn-group">
               <button
-                class="btn btn-light btn-sm ms-auto"
+                class="btn btn-sm btn-outline-light dropdown-toggle dropdown-toggle-no-caret"
                 type="button"
-                data-bs-toggle="modal"
-                data-bs-target="#copyQuestionModal"
+                aria-expanded="false"
+                aria-label="More options"
+                data-bs-toggle="dropdown"
               >
-                <i class="fa fa-clone"></i>
-                Copy question
+                <i class="fa fa-fw fa-ellipsis-v"></i>
               </button>
-            `
-          : ''}
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li class="dropdown-item">Preview manual grading view</li>
+              </ul>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="card-body question-body">${unsafeHtml(questionHtml)}</div>
       ${QuestionFooter({

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -26,10 +26,12 @@ const MAX_TOP_RECENTS = 3;
 export function QuestionContainer({
   resLocals,
   questionContext,
+  showFooter,
   manualGradingPreviewUrl,
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
+  showFooter?: boolean;
   manualGradingPreviewUrl?: string;
 }) {
   const {
@@ -61,10 +63,10 @@ export function QuestionContainer({
       ${question.type === 'Freeform'
         ? html`
             <form class="question-form" name="question-form" method="POST" autocomplete="off">
-              ${QuestionPanel({ resLocals, questionContext, manualGradingPreviewUrl })}
+              ${QuestionPanel({ resLocals, questionContext, showFooter, manualGradingPreviewUrl })}
             </form>
           `
-        : QuestionPanel({ resLocals, questionContext })}
+        : QuestionPanel({ resLocals, showFooter, questionContext })}
 
       <div class="card mb-3 grading-block${showTrueAnswer ? '' : ' d-none'}">
         <div class="card-header bg-secondary text-white">
@@ -317,12 +319,17 @@ interface QuestionFooterResLocals {
 
 function QuestionFooter({
   resLocals,
+  showFooter,
   questionContext,
 }: {
   resLocals: QuestionFooterResLocals;
+  showFooter?: boolean;
   questionContext: QuestionContext;
 }) {
-  if (questionContext === 'manual_grading') return '';
+  if ((questionContext === 'manual_grading' && showFooter !== true) || showFooter === false) {
+    return '';
+  }
+
   if (resLocals.question.type === 'Freeform') {
     return html`
       <div class="card-footer" id="question-panel-footer">
@@ -633,10 +640,12 @@ function AvailablePointsNotes({
 function QuestionPanel({
   resLocals,
   questionContext,
+  showFooter,
   manualGradingPreviewUrl,
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
+  showFooter?: boolean;
   manualGradingPreviewUrl?: string;
 }) {
   const { question, questionHtml, question_copy_targets, course, instance_question_info } =
@@ -704,6 +713,7 @@ function QuestionPanel({
         // TODO: propagate more precise types upwards.
         resLocals: resLocals as any,
         questionContext,
+        showFooter,
       })}
     </div>
   `;

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -26,7 +26,7 @@ const MAX_TOP_RECENTS = 3;
 export function QuestionContainer({
   resLocals,
   questionContext,
-  showFooter,
+  showFooter = true,
   manualGradingPreviewUrl,
 }: {
   resLocals: Record<string, any>;
@@ -319,17 +319,11 @@ interface QuestionFooterResLocals {
 
 function QuestionFooter({
   resLocals,
-  showFooter,
   questionContext,
 }: {
   resLocals: QuestionFooterResLocals;
-  showFooter?: boolean;
   questionContext: QuestionContext;
 }) {
-  if ((questionContext === 'manual_grading' && showFooter !== true) || showFooter === false) {
-    return '';
-  }
-
   if (resLocals.question.type === 'Freeform') {
     return html`
       <div class="card-footer" id="question-panel-footer">
@@ -645,7 +639,7 @@ function QuestionPanel({
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
-  showFooter?: boolean;
+  showFooter: boolean;
   manualGradingPreviewUrl?: string;
 }) {
   const { question, questionHtml, question_copy_targets, course, instance_question_info } =
@@ -709,12 +703,13 @@ function QuestionPanel({
         </div>
       </div>
       <div class="card-body question-body">${unsafeHtml(questionHtml)}</div>
-      ${QuestionFooter({
-        // TODO: propagate more precise types upwards.
-        resLocals: resLocals as any,
-        questionContext,
-        showFooter,
-      })}
+      ${showFooter
+        ? QuestionFooter({
+            // TODO: propagate more precise types upwards.
+            resLocals: resLocals as any,
+            questionContext,
+          })
+        : ''}
     </div>
   `;
 }

--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -223,28 +223,30 @@ export function SubmissionPanel({
               instance_question,
             })}
           </div>
-          <button
-            type="button"
-            class="btn btn-outline-dark btn-sm ms-2 me-2"
-            data-submission-id="${submission.id}"
-            data-bs-toggle="modal"
-            data-bs-target="#submissionInfoModal-${submission.id}"
-            aria-label="Submission info"
-          >
-            <i class="fa fa-info-circle fa-fw"></i>
-          </button>
-          <button
-            type="button"
-            class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap ${!expanded
-              ? 'collapsed'
-              : ''}"
-            data-bs-toggle="collapse"
-            data-bs-target="#submission-${submission.id}-body"
-            aria-expanded="${expanded ? 'true' : 'false'}"
-            aria-controls="submission-${submission.id}-body"
-          >
-            <i class="fa fa-angle-up fa-fw ms-1 expand-icon"></i>
-          </button>
+          <div class="btn-group">
+            <button
+              type="button"
+              class="btn btn-outline-dark btn-sm ms-2"
+              data-submission-id="${submission.id}"
+              data-bs-toggle="modal"
+              data-bs-target="#submissionInfoModal-${submission.id}"
+              aria-label="Submission info"
+            >
+              <i class="fa fa-info-circle fa-fw"></i>
+            </button>
+            <button
+              type="button"
+              class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap ${!expanded
+                ? 'collapsed'
+                : ''}"
+              data-bs-toggle="collapse"
+              data-bs-target="#submission-${submission.id}-body"
+              aria-expanded="${expanded ? 'true' : 'false'}"
+              aria-controls="submission-${submission.id}-body"
+            >
+              <i class="fa fa-angle-up fa-fw ms-1 expand-icon"></i>
+            </button>
+          </div>
         </div>
 
         <div

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -89,7 +89,7 @@ export function InstanceQuestion({
         : ''}
       <div class="row">
         <div class="col-lg-8 col-12">
-          ${QuestionContainer({ resLocals, questionContext: 'manual_grading' })}
+          ${QuestionContainer({ resLocals, questionContext: 'manual_grading', showFooter: false })}
         </div>
 
         <div class="col-lg-4 col-12">

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
@@ -59,15 +59,10 @@ export function InstructorQuestionPreview({
     content: html`
       ${manualGradingPreviewEnabled
         ? html`
-            <div class="alert alert-primary alert-dismissible fade show">
+            <div class="alert alert-primary">
               You are viewing this question as it will appear in the manual grading interface.
-              <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a>.
-              <button
-                type="button"
-                class="btn-close"
-                data-bs-dismiss="alert"
-                aria-label="Close"
-              ></button>
+              <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a> when
+              you are done.
             </div>
           `
         : ''}

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
@@ -70,7 +70,8 @@ export function InstructorQuestionPreview({
         <div class="col-lg-9 col-sm-12">
           ${QuestionContainer({
             resLocals,
-            questionContext: manualGradingPreviewEnabled ? 'manual_grading' : 'instructor',
+            showFooter: manualGradingPreviewEnabled ? false : undefined,
+            questionContext: 'instructor',
             manualGradingPreviewUrl: manualGradingPreviewEnabled
               ? undefined
               : manualGradingPreviewUrl,

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
@@ -70,7 +70,7 @@ export function InstructorQuestionPreview({
         <div class="col-lg-9 col-sm-12">
           ${QuestionContainer({
             resLocals,
-            questionContext: 'instructor',
+            questionContext: manualGradingPreviewEnabled ? 'manual_grading' : 'instructor',
             manualGradingPreviewUrl: manualGradingPreviewEnabled
               ? undefined
               : manualGradingPreviewUrl,

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
@@ -7,9 +7,13 @@ import { QuestionSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWar
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
 
 export function InstructorQuestionPreview({
+  normalPreviewUrl,
+  manualGradingPreviewEnabled,
   manualGradingPreviewUrl,
   resLocals,
 }: {
+  normalPreviewUrl: string;
+  manualGradingPreviewEnabled: boolean;
   manualGradingPreviewUrl: string;
   resLocals: Record<string, any>;
 }) {
@@ -53,12 +57,28 @@ export function InstructorQuestionPreview({
       </div>
     `,
     content: html`
+      ${manualGradingPreviewEnabled
+        ? html`
+            <div class="alert alert-primary alert-dismissible fade show">
+              You are viewing this question as it will appear in the manual grading interface.
+              <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a>.
+              <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="alert"
+                aria-label="Close"
+              ></button>
+            </div>
+          `
+        : ''}
       <div class="row">
         <div class="col-lg-9 col-sm-12">
           ${QuestionContainer({
             resLocals,
             questionContext: 'instructor',
-            manualGradingPreviewUrl,
+            manualGradingPreviewUrl: manualGradingPreviewEnabled
+              ? undefined
+              : manualGradingPreviewUrl,
           })}
         </div>
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
@@ -6,7 +6,13 @@ import { QuestionContainer } from '../../components/QuestionContainer.html.js';
 import { QuestionSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
 
-export function InstructorQuestionPreview({ resLocals }: { resLocals: Record<string, any> }) {
+export function InstructorQuestionPreview({
+  manualGradingPreviewUrl,
+  resLocals,
+}: {
+  manualGradingPreviewUrl: string;
+  resLocals: Record<string, any>;
+}) {
   return PageLayout({
     resLocals,
     pageTitle: 'Question Preview',
@@ -49,11 +55,15 @@ export function InstructorQuestionPreview({ resLocals }: { resLocals: Record<str
     content: html`
       <div class="row">
         <div class="col-lg-9 col-sm-12">
-          ${QuestionContainer({ resLocals, questionContext: 'instructor' })}
+          ${QuestionContainer({
+            resLocals,
+            questionContext: 'instructor',
+            manualGradingPreviewUrl,
+          })}
         </div>
 
         <div class="col-lg-3 col-sm-12">
-          <div class="card mb-4">
+          <div class="card mb-3">
             <div class="card-header bg-secondary text-white">
               <h2>Student view placeholder</h2>
             </div>

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -68,6 +68,9 @@ router.get(
   asyncHandler(async (req, res) => {
     const manualGradingPreviewEnabled = req.query.manual_grading_preview === 'true';
     if (manualGradingPreviewEnabled) {
+      // Setting this flag will set the `manualGrading: true` flag in the data
+      // dictionary passed to element render functions. It will also disable
+      // editing for all elements by settings `editable: false`.
       res.locals.manualGradingInterface = true;
     }
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -70,7 +70,7 @@ router.get(
     if (manualGradingPreviewEnabled) {
       // Setting this flag will set the `manualGrading: true` flag in the data
       // dictionary passed to element render functions. It will also disable
-      // editing for all elements by settings `editable: false`.
+      // editing for all elements by setting `editable: false`.
       res.locals.manualGradingInterface = true;
     }
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -78,19 +78,37 @@ router.get(
     await logPageView('instructorQuestionPreview', req, res);
     await setQuestionCopyTargets(res);
 
+    const searchParams = getSearchParams(req);
+
     // Construct a URL to preview the question as it would appear in the manual
     // grading interface. We need to include the `variant_id` in the URL so that
     // we show the current variant and not a new one.
-    const searchParams = getSearchParams(req);
-    searchParams.set('variant_id', res.locals.variant.id.toString());
-    searchParams.set('manual_grading_preview', 'true');
+    const manualGradingPreviewSearchParams = new URLSearchParams(searchParams);
+    manualGradingPreviewSearchParams.set('variant_id', res.locals.variant.id.toString());
+    manualGradingPreviewSearchParams.set('manual_grading_preview', 'true');
     const manualGradingPreviewUrl = url.format({
       pathname: `${res.locals.urlPrefix}/question/${res.locals.question.id}/preview`,
-      search: searchParams.toString(),
+      search: manualGradingPreviewSearchParams.toString(),
+    });
+
+    // Construct a URL for the normal preview. This will be used to exit the manual grading preview.
+    const normalPreviewSearchParams = new URLSearchParams(searchParams);
+    normalPreviewSearchParams.delete('manual_grading_preview');
+    normalPreviewSearchParams.set('variant_id', res.locals.variant.id.toString());
+    const normalPreviewUrl = url.format({
+      pathname: `${res.locals.urlPrefix}/question/${res.locals.question.id}/preview`,
+      search: normalPreviewSearchParams.toString(),
     });
 
     setRendererHeader(res);
-    res.send(InstructorQuestionPreview({ manualGradingPreviewUrl, resLocals: res.locals }));
+    res.send(
+      InstructorQuestionPreview({
+        normalPreviewUrl,
+        manualGradingPreviewEnabled,
+        manualGradingPreviewUrl,
+        resLocals: res.locals,
+      }),
+    );
   }),
 );
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -89,6 +89,7 @@ router.get(
     const manualGradingPreviewSearchParams = new URLSearchParams(searchParams);
     manualGradingPreviewSearchParams.set('variant_id', res.locals.variant.id.toString());
     manualGradingPreviewSearchParams.set('manual_grading_preview', 'true');
+    manualGradingPreviewSearchParams.delete('variant_seed');
     const manualGradingPreviewUrl = url.format({
       pathname: `${res.locals.urlPrefix}/question/${res.locals.question.id}/preview`,
       search: manualGradingPreviewSearchParams.toString(),
@@ -96,8 +97,9 @@ router.get(
 
     // Construct a URL for the normal preview. This will be used to exit the manual grading preview.
     const normalPreviewSearchParams = new URLSearchParams(searchParams);
-    normalPreviewSearchParams.delete('manual_grading_preview');
     normalPreviewSearchParams.set('variant_id', res.locals.variant.id.toString());
+    normalPreviewSearchParams.delete('manual_grading_preview');
+    normalPreviewSearchParams.delete('variant_seed');
     const normalPreviewUrl = url.format({
       pathname: `${res.locals.urlPrefix}/question/${res.locals.question.id}/preview`,
       search: normalPreviewSearchParams.toString(),

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.html.ts
@@ -43,7 +43,7 @@ export function PublicQuestionPreview({ resLocals }: { resLocals: Record<string,
         </div>
 
         <div class="col-lg-3 col-sm-12">
-          <div class="card mb-4">
+          <div class="card mb-3">
             <div class="card-header bg-secondary text-white">
               <h2>Student view placeholder</h2>
             </div>


### PR DESCRIPTION
This will soon be an important part of AI question grading: we'll want to give instructors the ability to see what context is being sent to the LLM. Though that doesn't exist yet, this establishes the UI and backend conventions for that.

This is activated with a button that I put in the upper right of the question panel (open to alternative suggestions):

<img width="284" alt="Screenshot 2025-03-07 at 15 29 59" src="https://github.com/user-attachments/assets/59f5e43e-66f8-4df0-abc8-05cd1d4e883d" />

When the preview is active, a dismissible alert is shown to inform the user of the current setting, and they're given a link to return to the normal view.

<img width="1248" alt="Screenshot 2025-03-07 at 15 38 44" src="https://github.com/user-attachments/assets/3a17c42c-0621-428a-8d27-c0b9583b2962" />
