### PR TITLE
Add explicit wildcard to issues QID search

### DIFF
--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -409,8 +409,8 @@ function FilterHelpModal() {
               <code>user:<em>UID</em></code>
             </td>
             <td>
-              Shows all issues that were reported by a user with UID <code>UID</code>. For example,
-              <code>user:student@example.com</code> shows all issues that were reported by
+              Shows all issues that were reported by a user with a UID like <code>UID</code>. For
+              example, <code>user:student@example.com</code> shows all issues that were reported by
               <code>student@example.com</code>.
             </td>
           </tr>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -399,8 +399,8 @@ function FilterHelpModal() {
               Shows all issues with a question ID like <code>QID</code>; supports <code>*</code> as
               a wildcard. For example, <code>qid:graphConnectivity</code> shows all issues
               associated with the question <code>graphConnectivity</code>, and
-              <code>qid:graph*</code> shows all issues associated with any question that starts
-              with <code>graph</code>, such as <code>graphConnectivity</code> and
+              <code>qid:graph*</code> shows all issues associated with any question that starts with
+              <code>graph</code>, such as <code>graphConnectivity</code> and
               <code>graphTheory</code>.
             </td>
           </tr>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -397,9 +397,9 @@ function FilterHelpModal() {
             </td>
             <td>
               Shows all issues with a question ID like <code>QID</code>; supports <code>*</code> as
-              a wildcard. For example <code>qid:graphConnectivity</code> would show all issues
+              a wildcard. For example, <code>qid:graphConnectivity</code> shows all issues
               associated with the question <code>graphConnectivity</code>, and
-              <code>qid:graph*</code> would show all issues associated with any question that starts
+              <code>qid:graph*</code> shows all issues associated with any question that starts
               with <code>graph</code>, such as <code>graphConnectivity</code> and
               <code>graphTheory</code>.
             </td>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -396,21 +396,22 @@ function FilterHelpModal() {
               <code>qid:<em>QID</em></code>
             </td>
             <td>
-              Shows all issues with a question ID like <code>QID</code>.
-              <br />
-              <strong>Example:</strong> <code>qid:graph</code> shows all issues associated with
-              questions such as <code>graphConnectivity</code> and <code>speedTimeGraph</code>.
+              Shows all issues with a question ID like <code>QID</code>; supports <code>*</code> as
+              a wildcard. For example <code>qid:graphConnectivity</code> would show all issues
+              associated with the question <code>graphConnectivity</code>, and
+              <code>qid:graph*</code> would show all issues associated with any question that starts
+              with <code>graph</code>, such as <code>graphConnectivity</code> and
+              <code>graphTheory</code>.
             </td>
           </tr>
           <tr>
             <td>
-              <code>user:<em>USER</em></code>
+              <code>user:<em>UID</em></code>
             </td>
             <td>
-              Shows all issues that were reported by a user ID like <code>USER</code>.
-              <br />
-              <strong>Example:</strong> <code>user:student@example.com</code> shows all issues that
-              were reported by <code>student@example.com</code>.
+              Shows all issues that were reported by a user with UID <code>UID</code>. For example,
+              <code>user:student@example.com</code> shows all issues that were reported by
+              <code>student@example.com</code>.
             </td>
           </tr>
         </tbody>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -62,11 +62,11 @@ WITH
       )
       AND (
         $filter_users::text[] IS NULL
-        OR u.uid LIKE ANY ($filter_users::text[])
+        OR u.uid ILIKE ANY ($filter_users::text[])
       )
       AND (
         $filter_not_users::text[] IS NULL
-        OR u.uid NOT LIKE ANY ($filter_not_users::text[])
+        OR u.uid NOT ILIKE ANY ($filter_not_users::text[])
       )
       AND (
         $filter_query_text::text IS NULL

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -62,11 +62,11 @@ WITH
       )
       AND (
         $filter_users::text[] IS NULL
-        OR u.uid ILIKE ANY ($filter_users::text[])
+        OR u.uid = ANY ($filter_users::text[])
       )
       AND (
         $filter_not_users::text[] IS NULL
-        OR u.uid NOT ILIKE ANY ($filter_not_users::text[])
+        OR u.uid != ANY ($filter_not_users::text[])
       )
       AND (
         $filter_query_text::text IS NULL

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -62,11 +62,11 @@ WITH
       )
       AND (
         $filter_users::text[] IS NULL
-        OR u.uid = ANY ($filter_users::text[])
+        OR u.uid LIKE ANY ($filter_users::text[])
       )
       AND (
         $filter_not_users::text[] IS NULL
-        OR u.uid != ANY ($filter_not_users::text[])
+        OR u.uid NOT LIKE ANY ($filter_not_users::text[])
       )
       AND (
         $filter_query_text::text IS NULL

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
@@ -71,10 +71,10 @@ function parseRawQuery(str: string) {
       case 'user':
         if (!option.negated) {
           filters.filter_users = filters.filter_users || [];
-          filters.filter_users.push(option.value);
+          filters.filter_users.push(formatForLikeClause(option.value));
         } else {
           filters.filter_not_users = filters.filter_not_users || [];
-          filters.filter_not_users.push(option.value);
+          filters.filter_not_users.push(formatForLikeClause(option.value));
         }
         break;
     }

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
@@ -19,7 +19,8 @@ const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 function formatForLikeClause(str: string) {
-  return str.replace('*', '%');
+  // https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
+  return str.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_').replace('*', '%');
 }
 
 function parseRawQuery(str: string) {

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
@@ -20,7 +20,11 @@ const sql = loadSqlEquiv(import.meta.url);
 
 function formatForLikeClause(str: string) {
   // https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
-  return str.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_').replace('*', '%');
+  return str
+    .replaceAll('\\', '\\\\')
+    .replaceAll('%', '\\%')
+    .replaceAll('_', '\\_')
+    .replaceAll('*', '%');
 }
 
 function parseRawQuery(str: string) {

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
@@ -19,7 +19,7 @@ const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 function formatForLikeClause(str: string) {
-  return `%${str}%`;
+  return str.replace('*', '%');
 }
 
 function parseRawQuery(str: string) {
@@ -71,10 +71,10 @@ function parseRawQuery(str: string) {
       case 'user':
         if (!option.negated) {
           filters.filter_users = filters.filter_users || [];
-          filters.filter_users.push(formatForLikeClause(option.value));
+          filters.filter_users.push(option.value);
         } else {
           filters.filter_not_users = filters.filter_not_users || [];
-          filters.filter_not_users.push(formatForLikeClause(option.value));
+          filters.filter_not_users.push(option.value);
         }
         break;
     }


### PR DESCRIPTION
Previously, searching for a QID in issues added implicit wildcards, e.g. searching for `foo` would match any question with `foo` in the QID. This caused problems if one QID was a substring of another. For instance, searching for `qid:graph` would show issues for `qid:graph-search` as well.

Now, it defaults to an exact match, with `*` supported as a wildcard character. This allows exact match to be the default, while still supporting wildcards when needed.

I removed `LIKE` matching for issues; searching for `user:foo@example.com` is now an exact match on the user UID. I couldn't see a good reason to either have substring matching be the default behavior, or to support wildcard matching at all.