### PR TITLE
Lazily find shell files in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SH_FILES := $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -path "./.venv/*" ! -path "./testCourse/*")
-
 build:
 	@yarn turbo run build
 build-sequential:
@@ -83,7 +81,7 @@ lint-links:
 lint-docker:
 	@hadolint ./graders/**/Dockerfile ./workspaces/**/Dockerfile ./images/**/Dockerfile Dockerfile
 lint-shell:
-	@shellcheck -S error $(SH_FILES)
+	@shellcheck -S error $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -path "./.venv/*" ! -path "./testCourse/*")
 lint-actions:
 	@actionlint
 


### PR DESCRIPTION
This PR fixes a performance regression in our Makefile introduced by #11333. After that PR, `make` would have to eagerly find all shell files before it could do _anything_, even report that a target didn't exist, which dramatically slowed things down:

```
$ time make foo
make: *** No rule to make target 'foo'.  Stop.
make foo  0.12s user 1.38s system 33% cpu 4.432 total
```

Now, they're computed only when `make lint-shellcheck` is run:

```
$ time make foo
make: *** No rule to make target 'foo'.  Stop.
make foo  0.00s user 0.00s system 66% cpu 0.007 total
```