### PR TITLE
Hide question title on student exam instance questions

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -279,7 +279,7 @@ export function QuestionTitle({
   if (questionContext === 'student_homework') {
     return `${questionNumber}. ${question.title}`;
   } else if (questionContext === 'student_exam') {
-    return `Question ${questionNumber}: ${question.title}`;
+    return `Question ${questionNumber}`;
   } else {
     return question.title;
   }


### PR DESCRIPTION
Closes #3150. It's _possible_ that someone could be relying on us currently showing the titles? It'd be helpful to hear from folks who use PL and might rely on this. One case I can think of is someone wanting students to post questions about questions to Piazza or the like, and having no way for instructors to tie a screenshot to a question if we just show "Question 7".