### PR TITLE
Fix alignment in pl-external-grader-results

### DIFF
--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
@@ -68,13 +68,13 @@
       {{#tests}}
         <div class="card mb-1 mt-1">
           <button class="card-header d-flex collapsed border-top-0 border-start-0 border-end-0 text-start" data-bs-toggle="collapse" data-bs-target="#card-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="card-{{uuid}}-{{index}}">
-            <span class="card-title mb-0 me-auto d-flex align-items-center">
+            <div class="card-title mb-0 me-auto d-flex align-items-center">
               {{#show_points}}
                 <i class="fa {{results_icon}} me-2" aria-hidden="true" style="color: {{results_color}}"></i>
                 <span class="me-2" style="color: {{results_color}};"><strong>[{{points}}/{{max_points}}]</strong></span>
               {{/show_points}}
               <span>{{name}}</span>
-            </span>
+            </div>
             <div class="ms-2">
               <span class="fa fa-angle-down"></span>
             </div>

--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
@@ -67,17 +67,15 @@
       {{/tests_missing_points}}
       {{#tests}}
         <div class="card mb-1 mt-1">
-          <button class="card-header d-flex collapsed border-top-0 border-start-0 border-end-0" data-bs-toggle="collapse" data-bs-target="#card-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="card-{{uuid}}-{{index}}">
-            <div class="me-auto">
-              <span class="card-title">
-                {{#show_points}}
-                  <i class="fa {{results_icon}}" aria-hidden="true" style="color: {{results_color}}"></i>
-                  <span style="color: {{results_color}}; margin-left: 5px;"><strong>[{{points}}/{{max_points}}]</strong></span>
-                {{/show_points}}
-                <span style="margin-left: 5px;">{{name}}</span>
-              </span>
-            </div>
-            <div>
+          <button class="card-header d-flex collapsed border-top-0 border-start-0 border-end-0 text-start" data-bs-toggle="collapse" data-bs-target="#card-{{uuid}}-{{index}}" aria-expanded="false" aria-controls="card-{{uuid}}-{{index}}">
+            <span class="card-title mb-0 me-auto d-flex align-items-center">
+              {{#show_points}}
+                <i class="fa {{results_icon}} me-2" aria-hidden="true" style="color: {{results_color}}"></i>
+                <span class="me-2" style="color: {{results_color}};"><strong>[{{points}}/{{max_points}}]</strong></span>
+              {{/show_points}}
+              <span>{{name}}</span>
+            </span>
+            <div class="ms-2">
               <span class="fa fa-angle-down"></span>
             </div>
           </button>


### PR DESCRIPTION
Closes #11549.

With normal-length titles:

<img width="984" alt="Screenshot 2025-03-12 at 15 26 35" src="https://github.com/user-attachments/assets/14b50c26-773d-4705-957a-f96cd3ed98ff" />

With very long titles:

<img width="982" alt="Screenshot 2025-03-12 at 15 26 14" src="https://github.com/user-attachments/assets/a984cc8b-f323-4cc5-8a5a-20681133db5b" />
