### PR TITLE
Add grader UID to staff information panel

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -24,6 +24,8 @@ export function InstructorInfoPanel({
   assessment,
   assessment_instance,
   instance_question,
+  assignedGrader,
+  lastGrader,
   question,
   variant,
   instance_group,
@@ -38,10 +40,9 @@ export function InstructorInfoPanel({
   course_instance?: CourseInstance;
   assessment?: Assessment;
   assessment_instance?: AssessmentInstance;
-  instance_question?: InstanceQuestion & {
-    assigned_grader_name?: string | null;
-    last_grader_name?: string | null;
-  };
+  instance_question?: InstanceQuestion;
+  assignedGrader?: User | null;
+  lastGrader?: User | null;
   question?: Question;
   variant?: Variant;
   instance_group?: Group | null;
@@ -87,7 +88,13 @@ export function InstructorInfoPanel({
         VariantInfo({ variant, timeZone, questionContext }),
         IssueReportButton({ variant, csrfToken, questionContext }),
         AssessmentInstanceInfo({ assessment, assessment_instance, timeZone }),
-        ManualGradingInfo({ instance_question, assessment, questionContext }),
+        ManualGradingInfo({
+          instance_question,
+          assignedGrader,
+          lastGrader,
+          assessment,
+          questionContext,
+        }),
       ])}
       <div class="card-footer small">This box is not visible to students.</div>
     </div>
@@ -299,15 +306,14 @@ function AssessmentInstanceInfo({
 
 function ManualGradingInfo({
   instance_question,
+  assignedGrader,
+  lastGrader,
   assessment,
   questionContext,
 }: {
-  instance_question?:
-    | (InstanceQuestion & {
-        assigned_grader_name?: string | null;
-        last_grader_name?: string | null;
-      })
-    | null;
+  instance_question?: InstanceQuestion | null;
+  assignedGrader?: User | null;
+  lastGrader?: User | null;
   assessment?: Assessment | null;
   questionContext: QuestionContext;
 }) {
@@ -333,15 +339,21 @@ function ManualGradingInfo({
       ? html`
           <div class="d-flex flex-wrap">
             <div class="pe-1">Assigned to:</div>
-            <div>${instance_question.assigned_grader_name ?? 'Unassigned'}</div>
+            <div>
+              ${assignedGrader?.name
+                ? `${assignedGrader.name} (${assignedGrader.uid})`
+                : (assignedGrader?.uid ?? 'Unassigned')}
+            </div>
           </div>
         `
       : ''}
-    ${instance_question.last_grader
+    ${lastGrader
       ? html`
           <div class="d-flex flex-wrap">
             <div class="pe-1">Graded by:</div>
-            <div>${instance_question.last_grader_name}</div>
+            <div>
+              ${lastGrader.name ? `${lastGrader.name} (${lastGrader.uid})` : lastGrader.uid}
+            </div>
           </div>
         `
       : ''}

--- a/apps/prairielearn/src/lib/question-render.sql
+++ b/apps/prairielearn/src/lib/question-render.sql
@@ -249,15 +249,7 @@ SELECT
       )
     )
   ) AS assessment_instance,
-  jsonb_set(
-    jsonb_set(
-      to_jsonb(iq.*),
-      '{assigned_grader_name}',
-      to_jsonb(COALESCE(agu.name, agu.uid))
-    ),
-    '{last_grader_name}',
-    to_jsonb(COALESCE(lgu.name, lgu.uid))
-  ) AS instance_question
+  to_jsonb(iq.*) AS instance_question
 FROM
   variants as v
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
@@ -265,8 +257,6 @@ FROM
   LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
   LEFT JOIN course_instances AS ci ON (ci.id = v.course_instance_id)
   JOIN pl_courses AS c ON (c.id = v.course_id)
-  LEFT JOIN users AS agu ON (agu.user_id = iq.assigned_grader)
-  LEFT JOIN users AS lgu ON (lgu.user_id = iq.last_grader)
 WHERE
   v.id = $variant_id
   AND v.question_id = $question_id

--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -61,10 +61,7 @@ const VariantSelectResultSchema = VariantSchema.extend({
   assessment_instance: AssessmentInstanceSchema.extend({
     formatted_date: z.string().nullable(),
   }).nullable(),
-  instance_question: InstanceQuestionSchema.extend({
-    assigned_grader_name: z.string().nullable(),
-    last_grader_name: z.string().nullable(),
-  }).nullable(),
+  instance_question: InstanceQuestionSchema.nullable(),
   formatted_date: z.string(),
 });
 

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -76,12 +76,7 @@ SELECT
   users_get_displayed_role (u.user_id, ci.id) AS instance_role,
   to_jsonb(g) AS instance_group,
   groups_uid_list (g.id) AS instance_group_uid_list,
-  to_jsonb(iq) || to_jsonb(iqnag) || jsonb_build_object(
-    'assigned_grader_name',
-    COALESCE(uag.name, uag.uid),
-    'last_grader_name',
-    COALESCE(ulg.name, ulg.uid)
-  ) AS instance_question,
+  to_jsonb(iq) || to_jsonb(iqnag) AS instance_question,
   jsonb_build_object(
     'id',
     iqi.id,
@@ -119,8 +114,6 @@ FROM
     AND g.deleted_at IS NULL
   )
   LEFT JOIN users AS u ON (u.user_id = ai.user_id)
-  LEFT JOIN users AS uag ON (uag.user_id = iq.assigned_grader)
-  LEFT JOIN users AS ulg ON (ulg.user_id = iq.last_grader)
   JOIN LATERAL authz_assessment_instance (
     ai.id,
     $authz_data,

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts
@@ -24,10 +24,14 @@ export function InstanceQuestion({
   resLocals,
   conflict_grading_job,
   graders,
+  assignedGrader,
+  lastGrader,
 }: {
   resLocals: Record<string, any>;
   conflict_grading_job: GradingJobData | null;
   graders: User[] | null;
+  assignedGrader: User | null;
+  lastGrader: User | null;
 }) {
   return PageLayout({
     resLocals: {
@@ -85,7 +89,7 @@ export function InstanceQuestion({
           `
         : ''}
       ${conflict_grading_job
-        ? ConflictGradingJobModal({ resLocals, conflict_grading_job, graders })
+        ? ConflictGradingJobModal({ resLocals, conflict_grading_job, graders, lastGrader })
         : ''}
       <div class="row">
         <div class="col-lg-8 col-12">
@@ -118,6 +122,8 @@ export function InstanceQuestion({
             assessment: resLocals.assessment,
             assessment_instance: resLocals.assessment_instance,
             instance_question: resLocals.instance_question,
+            assignedGrader,
+            lastGrader,
             question: resLocals.question,
             variant: resLocals.variant,
             instance_group: resLocals.instance_group,
@@ -139,11 +145,14 @@ function ConflictGradingJobModal({
   resLocals,
   conflict_grading_job,
   graders,
+  lastGrader,
 }: {
   resLocals: Record<string, any>;
   conflict_grading_job: GradingJobData;
   graders: User[] | null;
+  lastGrader: User | null;
 }) {
+  const lastGraderName = lastGrader?.name ?? lastGrader?.uid ?? 'an unknown grader';
   return html`
     <div id="conflictGradingJobModal" class="modal fade">
       <div class="modal-dialog modal-xl">
@@ -159,9 +168,9 @@ function ConflictGradingJobModal({
           </div>
           <div class="modal-body">
             <div class="alert alert-danger" role="alert">
-              The submission you have just graded has already been graded by
-              ${resLocals.instance_question.last_grader_name}. Your score and feedback have not been
-              applied. Please review the feedback below and select how you would like to proceed.
+              The submission you have just graded has already been graded by ${lastGraderName}. Your
+              score and feedback have not been applied. Please review the feedback below and select
+              how you would like to proceed.
             </div>
             <div class="row mb-2">
               <div class="col-lg-6 col-12">
@@ -172,7 +181,7 @@ function ConflictGradingJobModal({
                     DateFromISOString.parse(resLocals.instance_question.modified_at),
                     resLocals.course_instance.display_timezone,
                   )},
-                  by ${resLocals.instance_question.last_grader_name}
+                  by ${lastGraderName}
                 </div>
                 <div class="card">
                   ${GradingPanel({

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -12,6 +12,7 @@ import { reportIssueFromForm } from '../../../lib/issues.js';
 import * as manualGrading from '../../../lib/manualGrading.js';
 import { getAndRenderVariant, renderPanelsForSubmission } from '../../../lib/question-render.js';
 import { selectCourseInstanceGraderStaff } from '../../../models/course-instances.js';
+import { selectUserById } from '../../../models/user.js';
 
 import { GradingPanel } from './gradingPanel.html.js';
 import {
@@ -70,7 +71,19 @@ router.get(
       throw new error.HttpStatusError(403, 'Access denied (must be a student data viewer)');
     }
 
-    res.send(InstanceQuestion(await prepareLocalsForRender(req.query, res.locals)));
+    const assignedGrader = res.locals.instance_question.assigned_grader
+      ? await selectUserById(res.locals.instance_question.assigned_grader)
+      : null;
+    const lastGrader = res.locals.instance_question.last_grader
+      ? await selectUserById(res.locals.instance_question.last_grader)
+      : null;
+    res.send(
+      InstanceQuestion({
+        ...(await prepareLocalsForRender(req.query, res.locals)),
+        assignedGrader,
+        lastGrader,
+      }),
+    );
   }),
 );
 

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.html.ts
@@ -14,14 +14,19 @@ import { QuestionContainer, QuestionTitle } from '../../components/QuestionConta
 import { QuestionNavSideGroup } from '../../components/QuestionNavigation.html.js';
 import { QuestionScorePanel } from '../../components/QuestionScore.html.js';
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
+import type { User } from '../../lib/db-types.js';
 import { getRoleNamesForUser } from '../../lib/groups.js';
 
 export function StudentInstanceQuestion({
   resLocals,
   userCanDeleteAssessmentInstance,
+  assignedGrader,
+  lastGrader,
 }: {
   resLocals: Record<string, any>;
   userCanDeleteAssessmentInstance: boolean;
+  assignedGrader?: User | null;
+  lastGrader?: User | null;
 }) {
   const questionContext =
     resLocals.assessment.type === 'Exam' ? 'student_exam' : 'student_homework';
@@ -187,6 +192,8 @@ export function StudentInstanceQuestion({
                 assessment: resLocals.assessment,
                 assessment_instance: resLocals.assessment_instance,
                 instance_question: resLocals.instance_question,
+                assignedGrader,
+                lastGrader,
                 question: resLocals.question,
                 variant: resLocals.variant,
                 instance_group: resLocals.instance_group,

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -23,6 +23,7 @@ import { enterpriseOnly } from '../../middlewares/enterpriseOnly.js';
 import { logPageView } from '../../middlewares/logPageView.js';
 import selectAndAuthzInstanceQuestion from '../../middlewares/selectAndAuthzInstanceQuestion.js';
 import studentAssessmentAccess from '../../middlewares/studentAssessmentAccess.js';
+import { selectUserById } from '../../models/user.js';
 import {
   validateVariantAgainstQuestion,
   selectVariantsByInstanceQuestion,
@@ -321,10 +322,18 @@ router.get(
       }
     }
     setRendererHeader(res);
+    const assignedGrader = res.locals.instance_question.assigned_grader
+      ? await selectUserById(res.locals.instance_question.assigned_grader)
+      : null;
+    const lastGrader = res.locals.instance_question.last_grader
+      ? await selectUserById(res.locals.instance_question.last_grader)
+      : null;
     res.send(
       StudentInstanceQuestion({
         resLocals: res.locals,
         userCanDeleteAssessmentInstance: canDeleteAssessmentInstance(res.locals),
+        assignedGrader,
+        lastGrader,
       }),
     );
   }),


### PR DESCRIPTION
Resolves #11574. Adds the UID info to assigned grader and last grader information in the Staff information panel.

This PR also takes the opportunity to remove the assigned grader/last grader from res.locals, and move them to local variables computed when needed.

Only the instance question page has been updated. The assessment question list of instances still only shows the name.

![image](https://github.com/user-attachments/assets/8e17725a-c5df-4e4a-9b48-94492dcf5568)
