### PR TITLE
fix Jupyter workspace entrypoint to reflect base image changes

### DIFF
--- a/workspaces/jupyterlab-python/Dockerfile
+++ b/workspaces/jupyterlab-python/Dockerfile
@@ -17,4 +17,4 @@ RUN /bin/bash /install.sh
 COPY jupyter_server_config.py /etc/jupyter/
 
 USER jovyan
-CMD ["pl-gosu-helper.sh", "start.sh", "jupyter", "lab"]
+ENTRYPOINT ["tini", "-g", "--", "pl-gosu-helper.sh", "start.sh", "jupyter", "lab"]

--- a/workspaces/jupyterlab-python/Dockerfile
+++ b/workspaces/jupyterlab-python/Dockerfile
@@ -17,4 +17,8 @@ RUN /bin/bash /install.sh
 COPY jupyter_server_config.py /etc/jupyter/
 
 USER jovyan
+# This is replicating the entrypoint that Jupyter had specified in their base
+# image, but we inject our pl-gosu-helper.sh before the Jupyter start script.
+# Jupyter chose to use tini for benefits like "reaping zombies and performing
+# signal forwarding" (quoting from the tini GitHub page).
 ENTRYPOINT ["tini", "-g", "--", "pl-gosu-helper.sh", "start.sh", "jupyter", "lab"]

--- a/workspaces/jupyterlab-python/pl-gosu-helper.sh
+++ b/workspaces/jupyterlab-python/pl-gosu-helper.sh
@@ -4,6 +4,11 @@
 # you are testing in the local PrairieLearn Docker container and it attempts
 # to launch workspaces as root.
 
+# This shouldn't be strictly necessary, but it may resolve future edge cases
+# with Jupyter's own entrypoint scripts if they arise in future base image
+# updates. It also quiets some warnings in Jupyter's logging.
+export NB_UID=1001 NB_GID=1001
+
 if [ "$(id -u)" -eq 0 ] ; then
     NORMAL_USER="$(id -un 1001)"
     set -eu

--- a/workspaces/jupyterlab-python/pl-gosu-helper.sh
+++ b/workspaces/jupyterlab-python/pl-gosu-helper.sh
@@ -19,8 +19,8 @@ elif [ "$(id -u)" -eq "$NB_UID" ] ; then
     exec "$@"
 else
     echo " ERROR:" >&2
-    echo "This image can only be executed as user 1001 or as user 0 (root)." >&2
-    echo "Running as user 0 will automatically step down to run as user 1001." >&2
+    echo "This image can only be executed as user $NB_UID or as user 0 (root)." >&2
+    echo "Running as user 0 will automatically step down to run as user $NB_UID." >&2
     echo "Cannot continue as current user $(id -u); exiting." >&2
     exit 1
 fi

--- a/workspaces/jupyterlab-python/pl-gosu-helper.sh
+++ b/workspaces/jupyterlab-python/pl-gosu-helper.sh
@@ -4,18 +4,18 @@
 # you are testing in the local PrairieLearn Docker container and it attempts
 # to launch workspaces as root.
 
-# This shouldn't be strictly necessary, but it may resolve future edge cases
-# with Jupyter's own entrypoint scripts if they arise in future base image
-# updates. It also quiets some warnings in Jupyter's logging.
+# Exporting these variables shouldn't be strictly necessary, but there are
+# some edge cases where Jupyter's own entrypoint scripts behave better with
+# them set, and it also quiets some warnings.
 export NB_UID=1001 NB_GID=1001
 
 if [ "$(id -u)" -eq 0 ] ; then
-    NORMAL_USER="$(id -un 1001)"
+    NORMAL_USER="$(id -un $NB_UID)"
     set -eu
-    find "/home/${NORMAL_USER:-NO_USER_1001}" -not -user 1001 -exec chown 1001:1001 {} +
+    find "/home/${NORMAL_USER:-NO_USER_1001}" -not -user $NB_UID -exec chown "$NB_UID":"$NB_GID" {} +
     set +eu
-    exec gosu 1001:1001 "$@"
-elif [ "$(id -u)" -eq 1001 ] ; then
+    exec gosu "$NB_UID":"$NB_GID" "$@"
+elif [ "$(id -u)" -eq "$NB_UID" ] ; then
     exec "$@"
 else
     echo " ERROR:" >&2

--- a/workspaces/jupyterlab-python/pl-gosu-helper.sh
+++ b/workspaces/jupyterlab-python/pl-gosu-helper.sh
@@ -11,8 +11,12 @@ export NB_UID=1001 NB_GID=1001
 
 if [ "$(id -u)" -eq 0 ] ; then
     NORMAL_USER="$(id -un $NB_UID)"
+    if [[ -z "$NORMAL_USER" ]] ; then
+        echo "Error: Expected to find a username for UID $NB_UID" >&2
+        exit 1
+    fi
     set -eu
-    find "/home/${NORMAL_USER:-NO_USER_1001}" -not -user "$NB_UID" -exec chown "$NB_UID":"$NB_GID" {} +
+    find "/home/${NORMAL_USER:-NORMAL_USER_NOT_FOUND}" -not -user "$NB_UID" -exec chown "$NB_UID":"$NB_GID" {} +
     set +eu
     exec gosu "$NB_UID":"$NB_GID" "$@"
 elif [ "$(id -u)" -eq "$NB_UID" ] ; then

--- a/workspaces/jupyterlab-python/pl-gosu-helper.sh
+++ b/workspaces/jupyterlab-python/pl-gosu-helper.sh
@@ -12,7 +12,7 @@ export NB_UID=1001 NB_GID=1001
 if [ "$(id -u)" -eq 0 ] ; then
     NORMAL_USER="$(id -un $NB_UID)"
     set -eu
-    find "/home/${NORMAL_USER:-NO_USER_1001}" -not -user $NB_UID -exec chown "$NB_UID":"$NB_GID" {} +
+    find "/home/${NORMAL_USER:-NO_USER_1001}" -not -user "$NB_UID" -exec chown "$NB_UID":"$NB_GID" {} +
     set +eu
     exec gosu "$NB_UID":"$NB_GID" "$@"
 elif [ "$(id -u)" -eq "$NB_UID" ] ; then


### PR DESCRIPTION
Jupyter changed their base image entrypoint formulation in a way that broke our assumptions. This caused the local behavior to break where we start as 0:0 and step down to 1001:1001 dynamically. With this fix, things behave as they did before.