### PR TITLE
Add highlight of tab bar inside of instance

### DIFF
--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -318,7 +318,7 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
         tabLabel: 'Statistics',
       },
       {
-        activeSubPage: 'instances',
+        activeSubPage: ['instances', 'assessment_instance'],
         urlSuffix: ({ assessment }) => `/assessment/${assessment.id}/instances`,
         iconClasses: 'fas fa-user-graduate',
         tabLabel: 'Students',


### PR DESCRIPTION
Closes #2263 by linking the instance to the same heading as instructor instances page

Not sure if this will be handled elsewhere (https://github.com/PrairieLearn/PrairieLearn/issues/2263#issuecomment-2721927051) but created the PR if not