### PR TITLE
Show hidden files in file browser

### DIFF
--- a/apps/prairielearn/src/components/FileBrowser.html.ts
+++ b/apps/prairielearn/src/components/FileBrowser.html.ts
@@ -136,6 +136,8 @@ export async function browseDirectory({
           sync_warnings: sync_data.warnings,
         } as DirectoryEntryFile;
       } else if (stats.isDirectory()) {
+        // The .git directory is hidden in the browser interface.
+        if (file.name === '.git') return null;
         return {
           id: file.index,
           name: file.name,

--- a/apps/prairielearn/src/components/FileBrowser.html.ts
+++ b/apps/prairielearn/src/components/FileBrowser.html.ts
@@ -98,10 +98,6 @@ interface FileRenameInfo {
   dir: string;
 }
 
-function isHidden(item: string) {
-  return item[0] === '.';
-}
-
 export async function browseDirectory({
   paths,
 }: {
@@ -109,10 +105,7 @@ export async function browseDirectory({
 }): Promise<DirectoryListings> {
   const filenames = await fs.readdir(paths.workingPath);
   const all_files = await async.mapLimit(
-    filenames
-      .sort()
-      .map((name, index) => ({ name, index }))
-      .filter((f) => !isHidden(f.name)),
+    filenames.sort().map((name, index) => ({ name, index })),
     3,
     async (file: { name: string; index: number }) => {
       const filepath = path.join(paths.workingPath, file.name);

--- a/apps/prairielearn/src/lib/instructorFiles.ts
+++ b/apps/prairielearn/src/lib/instructorFiles.ts
@@ -48,7 +48,11 @@ function getContextPaths(
     const rootPath = coursePath;
     return {
       rootPath,
-      invalidRootPaths: [path.join(rootPath, 'questions'), path.join(rootPath, 'courseInstances')],
+      invalidRootPaths: [
+        path.join(rootPath, '.git'),
+        path.join(rootPath, 'questions'),
+        path.join(rootPath, 'courseInstances'),
+      ],
       cannotMove: [path.join(rootPath, 'infoCourse.json')],
       clientDir: path.join(rootPath, 'clientFilesCourse'),
       serverDir: path.join(rootPath, 'serverFilesCourse'),
@@ -174,15 +178,28 @@ export function getPaths(
   const found = invalidRootPaths.find((invalidRootPath) => contains(invalidRootPath, workingPath));
   if (found) {
     throw new error.AugmentedError('Invalid working directory', {
-      info: html`
-        <p>The working directory</p>
-        <div class="container">
-          <pre class="bg-dark text-white rounded p-2">${workingPath}</pre>
-        </div>
-        <p>must <em>not</em> be inside the directory</p>
-        <div class="container"><pre class="bg-dark text-white rounded p-2">${found}</pre></div>
-        <p>when looking at <code>${locals.navPage}</code> files.</p>
-      `,
+      info:
+        found === workingPath
+          ? html`
+              <p>The working directory</p>
+              <div class="container">
+                <pre class="bg-dark text-white rounded p-2">${workingPath}</pre>
+              </div>
+              <p>
+                cannot be accessed directly when looking at <code>${locals.navPage}</code> files.
+              </p>
+            `
+          : html`
+              <p>The working directory</p>
+              <div class="container">
+                <pre class="bg-dark text-white rounded p-2">${workingPath}</pre>
+              </div>
+              <p>must <em>not</em> be inside the directory</p>
+              <div class="container">
+                <pre class="bg-dark text-white rounded p-2">${found}</pre>
+              </div>
+              <p>when looking at <code>${locals.navPage}</code> files.</p>
+            `,
     });
   }
 

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -126,6 +126,7 @@ const courseInstanceQuestionHtmlEditUrl =
 const courseInstanceQuestionPythonEditUrl =
   courseInstanceUrl + `/question/1/file_edit/${encodePath(questionPythonPath)}`;
 const badPathUrl = assessmentUrl + '/file_edit/' + encodePath('../PrairieLearn/config.json');
+const gitPathUrl = courseAdminUrl + '/file_edit/' + encodePath('.git/HEAD');
 const badExampleCoursePathUrl = courseAdminUrl + '/file_edit/' + encodePath('infoCourse.json');
 
 const findEditUrlData = [
@@ -299,6 +300,10 @@ describe('test file editor', function () {
 
     describe('disallow edits outside course directory', function () {
       badGet(badPathUrl, 500, false);
+    });
+
+    describe('disallow edits in .git directory', function () {
+      badGet(gitPathUrl, 500, false);
     });
 
     describe('verify file handlers', function () {


### PR DESCRIPTION
Fixes #11579. Shows all hidden files in the file browser.

Given the potential for issues if a user accesses files in the .git directory, this directory is also changed to become invalid, using the same mechanism that blocks direct access to e.g., question files from course admin. The directory is still visible, but no link it provided and access to it becomes blocked (it was previously allowed if the URL were typed with its name). An alternative would be to hide it altogether, which I'm happy to do if requested.

The test change has been tested in master, and it fails there, but succeeds in this branch.