### PR TITLE
Respect manual grading mode when async rendering submissions

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -28,11 +28,13 @@ export function QuestionContainer({
   questionContext,
   showFooter = true,
   manualGradingPreviewUrl,
+  renderSubmissionSearchParams,
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
   showFooter?: boolean;
   manualGradingPreviewUrl?: string;
+  renderSubmissionSearchParams?: URLSearchParams;
 }) {
   const {
     question,
@@ -83,6 +85,7 @@ export function QuestionContainer({
               submissions: submissions.slice(0, MAX_TOP_RECENTS),
               submissionHtmls,
               submissionCount: submissions.length,
+              renderSubmissionSearchParams,
             })}
             ${submissions.length > MAX_TOP_RECENTS
               ? html`
@@ -107,6 +110,7 @@ export function QuestionContainer({
                       submissions: submissions.slice(MAX_TOP_RECENTS),
                       submissionHtmls: submissionHtmls.slice(MAX_TOP_RECENTS),
                       submissionCount: submissions.length,
+                      renderSubmissionSearchParams,
                     })}
                   </div>
                 `
@@ -720,12 +724,14 @@ function SubmissionList({
   submissions,
   submissionHtmls,
   submissionCount,
+  renderSubmissionSearchParams,
 }: {
   resLocals: Record<string, any>;
   questionContext: QuestionContext;
   submissions: SubmissionForRender[];
   submissionHtmls: string[];
   submissionCount: number;
+  renderSubmissionSearchParams?: URLSearchParams;
 }) {
   return submissions.map((submission, idx) =>
     SubmissionPanel({
@@ -740,6 +746,7 @@ function SubmissionList({
       submissionCount,
       rubric_data: resLocals.rubric_data,
       urlPrefix: resLocals.urlPrefix,
+      renderSubmissionSearchParams,
     }),
   );
 }

--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -1,3 +1,5 @@
+import * as url from 'node:url';
+
 import { differenceInMilliseconds } from 'date-fns';
 import { z } from 'zod';
 
@@ -56,6 +58,7 @@ export function SubmissionPanel({
   rubric_data,
   urlPrefix,
   expanded,
+  renderSubmissionSearchParams,
 }: {
   questionContext: QuestionContext;
   question: Question;
@@ -69,15 +72,22 @@ export function SubmissionPanel({
   rubric_data?: RubricData | null;
   urlPrefix: string;
   expanded?: boolean;
+  renderSubmissionSearchParams?: URLSearchParams;
 }) {
   const isLatestSubmission = submission.submission_number === submissionCount;
   expanded = expanded || isLatestSubmission;
+
   const renderUrlPrefix =
     questionContext === 'instructor' || questionContext === 'public'
       ? `${urlPrefix}/question/${question.id}/preview`
       : questionContext === 'manual_grading'
         ? `${urlPrefix}/assessment/${assessment_question?.assessment_id}/manual_grading/instance_question/${instance_question?.id}`
         : `${urlPrefix}/instance_question/${instance_question?.id}`;
+  const renderUrl = url.format({
+    pathname: `${renderUrlPrefix}/variant/${variant_id}/submission/${submission.id}`,
+    search: renderSubmissionSearchParams?.toString(),
+  });
+
   return html`
     <div
       data-testid="submission-with-feedback"
@@ -256,11 +266,7 @@ export function SubmissionPanel({
             : ''}"
           data-submission-id="${submission.id}"
           id="submission-${submission.id}-body"
-          ${question.type === 'Freeform'
-            ? html`
-                data-dynamic-render-url="${renderUrlPrefix}/variant/${variant_id}/submission/${submission.id}"
-              `
-            : ''}
+          ${question.type === 'Freeform' ? html`data-dynamic-render-url="${renderUrl}" ` : ''}
         >
           <div class="card-body submission-body">
             ${submissionHtml == null

--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -630,6 +630,7 @@ export async function renderPanelsForSubmission({
   authorizedEdit,
   renderScorePanels,
   groupRolePermissions,
+  localsOverrides,
 }: {
   submission_id: string;
   question: Question;
@@ -641,6 +642,9 @@ export async function renderPanelsForSubmission({
   authorizedEdit: boolean;
   renderScorePanels: boolean;
   groupRolePermissions: { can_view: boolean; can_submit: boolean } | null;
+  localsOverrides?: {
+    manualGradingInterface?: boolean;
+  };
 }): Promise<SubmissionPanels> {
   const submissionInfo = await sqldb.queryOptionalRow(
     sql.select_submission_info,
@@ -700,6 +704,7 @@ export async function renderPanelsForSubmission({
       assessment_question,
       group_config,
     }),
+    ...localsOverrides,
   };
 
   await async.parallel([

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -91,6 +91,9 @@ router.get(
       renderScorePanels: false,
       // Group role permissions are not used in this context.
       groupRolePermissions: null,
+      localsOverrides: {
+        manualGradingInterface: true,
+      },
     });
     res.json(panels);
   }),

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.ts
@@ -10,11 +10,13 @@ export function InstructorQuestionPreview({
   normalPreviewUrl,
   manualGradingPreviewEnabled,
   manualGradingPreviewUrl,
+  renderSubmissionSearchParams,
   resLocals,
 }: {
   normalPreviewUrl: string;
   manualGradingPreviewEnabled: boolean;
   manualGradingPreviewUrl: string;
+  renderSubmissionSearchParams: URLSearchParams;
   resLocals: Record<string, any>;
 }) {
   return PageLayout({
@@ -75,6 +77,7 @@ export function InstructorQuestionPreview({
             manualGradingPreviewUrl: manualGradingPreviewEnabled
               ? undefined
               : manualGradingPreviewUrl,
+            renderSubmissionSearchParams,
           })}
         </div>
 

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.ts
@@ -42,28 +42,6 @@ router.post(
 );
 
 router.get(
-  '/variant/:variant_id(\\d+)/submission/:submission_id(\\d+)',
-  asyncHandler(async (req, res) => {
-    const panels = await renderPanelsForSubmission({
-      submission_id: req.params.submission_id,
-      question: res.locals.question,
-      instance_question: null,
-      variant_id: req.params.variant_id,
-      user: res.locals.user,
-      urlPrefix: res.locals.urlPrefix,
-      questionContext: 'instructor',
-      // This is only used by score panels, which are not rendered in this context.
-      authorizedEdit: false,
-      // score panels are never rendered on the instructor question preview page.
-      renderScorePanels: false,
-      // Group role permissions are not used in this context.
-      groupRolePermissions: null,
-    });
-    res.json(panels);
-  }),
-);
-
-router.get(
   '/',
   asyncHandler(async (req, res) => {
     const manualGradingPreviewEnabled = req.query.manual_grading_preview === 'true';
@@ -105,15 +83,49 @@ router.get(
       search: normalPreviewSearchParams.toString(),
     });
 
+    const renderSubmissionSearchParams = new URLSearchParams();
+    if (manualGradingPreviewEnabled) {
+      renderSubmissionSearchParams.set('manual_grading_preview', 'true');
+    }
+
     setRendererHeader(res);
     res.send(
       InstructorQuestionPreview({
         normalPreviewUrl,
         manualGradingPreviewEnabled,
         manualGradingPreviewUrl,
+        renderSubmissionSearchParams,
         resLocals: res.locals,
       }),
     );
+  }),
+);
+
+router.get(
+  '/variant/:variant_id(\\d+)/submission/:submission_id(\\d+)',
+  asyncHandler(async (req, res) => {
+    // As with the normal route, we need to respect the `manual_grading_preview` flag.
+    const manualGradingPreviewEnabled = req.query.manual_grading_preview === 'true';
+
+    const panels = await renderPanelsForSubmission({
+      submission_id: req.params.submission_id,
+      question: res.locals.question,
+      instance_question: null,
+      variant_id: req.params.variant_id,
+      user: res.locals.user,
+      urlPrefix: res.locals.urlPrefix,
+      questionContext: 'instructor',
+      // This is only used by score panels, which are not rendered in this context.
+      authorizedEdit: false,
+      // score panels are never rendered on the instructor question preview page.
+      renderScorePanels: false,
+      // Group role permissions are not used in this context.
+      groupRolePermissions: null,
+      localsOverrides: {
+        manualGradingInterface: manualGradingPreviewEnabled,
+      },
+    });
+    res.json(panels);
   }),
 );
 


### PR DESCRIPTION
Any submissions but the three most recent aren't rendered until they're actually viewed. However, the routes that handled rendering those submissions previously weren't aware of if the panel was being rendered in the context of manual grading. This PR resolves that by propagating a value for `manualGradingInterface` into `renderPanelsForSubmission`.

When we force the instructor question preview to show the manual grading interface as implemented in #11528, we need to propagate the fact that we've been forced into that state back into the route that serves the submission HTML. This PR adds such a parameter to `QuestionContainer` and drills it down to `SubmissionPanel`.