### PR TITLE
Assessment switcher redirect to the same subpage

### DIFF
--- a/apps/prairielearn/src/components/AssessmentNavigation.html.ts
+++ b/apps/prairielearn/src/components/AssessmentNavigation.html.ts
@@ -2,16 +2,19 @@ import { html } from '@prairielearn/html';
 
 import type { Assessment, CourseInstance } from '../lib/db-types.js';
 import { idsEqual } from '../lib/id.js';
+import type { NavSubPage } from './Navbar.types.js';
 
 /**
  * Dropdown that lets users navigate between assessments in a
  * course instance.
  */
 export function AssessmentNavigation({
+  subPage,
   courseInstance,
   assessment,
   assessments,
 }: {
+  subPage: NavSubPage;
   courseInstance: CourseInstance;
   assessment: Assessment;
   assessments: Assessment[];
@@ -37,7 +40,7 @@ export function AssessmentNavigation({
               <a
                 class="dropdown-item ${idsEqual(assessment.id, a.id) ? 'active' : ''}"
                 aria-current="${idsEqual(assessment.id, a.id) ? 'page' : ''}"
-                href="/pl/course_instance/${courseInstance.id}/instructor/assessment/${a.id}"
+                href="/pl/course_instance/${courseInstance.id}/instructor/assessment/${a.id}/${subPage ?? ''}"
               >
                 ${a.title}
               </a>

--- a/apps/prairielearn/src/components/PageLayout.html.ts
+++ b/apps/prairielearn/src/components/PageLayout.html.ts
@@ -128,6 +128,7 @@ export function PageLayout({
                 ${resLocals.assessment &&
                 resLocals.assessments &&
                 AssessmentNavigation({
+                  subPage: navContext.subPage,
                   courseInstance: resLocals.course_instance,
                   assessment: resLocals.assessment,
                   assessments: resLocals.assessments,


### PR DESCRIPTION
Related to https://github.com/PrairieLearn/PrairieLearn/discussions/11550#discussioncomment-12501338.

When switching assessments in the new navigation experience, redirect to the same subpage.

https://github.com/user-attachments/assets/3da9fff3-90c3-4833-90bb-dca844e0aa4a




