### PR TITLE
Side nav course instance switching from course pages

### DIFF
--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -251,12 +251,17 @@ function CourseInstanceNav({
             aria-expanded="false"
             data-bs-toggle="dropdown"
             data-bs-boundary="window"
-            hx-get="/pl/navbar/course/${resLocals.course.id}/course_instance_switcher/${resLocals.course_instance ? resLocals.course_instance.id : ''}"
+            hx-get="/pl/navbar/course/${resLocals.course
+              .id}/course_instance_switcher/${resLocals.course_instance
+              ? resLocals.course_instance.id
+              : ''}"
             hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
             hx-target="#sideNavCourseInstancesDropdownContent"
           >
-            <span> 
-              ${resLocals.course_instance ? resLocals.course_instance.short_name : "Select a course instance..."} 
+            <span>
+              ${resLocals.course_instance
+                ? resLocals.course_instance.short_name
+                : 'Select a course instance...'}
             </span>
           </button>
           <div class="dropdown-menu py-0 overflow-hidden">
@@ -273,14 +278,16 @@ function CourseInstanceNav({
             </div>
           </div>
         </div>
-        ${resLocals.course_instance ? courseInstanceSideNavPageTabs.map((tabInfo) =>
-          SideNavLink({
-            resLocals,
-            navPage: page,
-            navSubPage: subPage,
-            tabInfo,
-          }),
-        ) : ''}
+        ${resLocals.course_instance
+          ? courseInstanceSideNavPageTabs.map((tabInfo) =>
+              SideNavLink({
+                resLocals,
+                navPage: page,
+                navSubPage: subPage,
+                tabInfo,
+              }),
+            )
+          : ''}
       </div>
     </div>
   `;

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -251,14 +251,12 @@ function CourseInstanceNav({
             aria-expanded="false"
             data-bs-toggle="dropdown"
             data-bs-boundary="window"
-            hx-get="/pl/navbar/course/${resLocals.course
-              .id}/course_instance_switcher/${resLocals.course_instance?.id ?? ''}"
+            hx-get="/pl/navbar/course/${resLocals.course.id}/course_instance_switcher/${resLocals
+              .course_instance?.id ?? ''}"
             hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
             hx-target="#sideNavCourseInstancesDropdownContent"
           >
-            <span>
-              ${resLocals.course_instance?.short_name ?? 'Select a course instance...'}
-            </span>
+            <span> ${resLocals.course_instance?.short_name ?? 'Select a course instance...'} </span>
           </button>
           <div class="dropdown-menu py-0 overflow-hidden">
             <div

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -161,7 +161,7 @@ export function SideNav({
         page,
         subPage,
       })}
-      ${resLocals.course_instance
+      ${resLocals.course_has_course_instances
         ? CourseInstanceNav({
             resLocals,
             page,
@@ -251,12 +251,13 @@ function CourseInstanceNav({
             aria-expanded="false"
             data-bs-toggle="dropdown"
             data-bs-boundary="window"
-            hx-get="/pl/navbar/course/${resLocals.course.id}/course_instance_switcher/${resLocals
-              .course_instance.id}"
+            hx-get="/pl/navbar/course/${resLocals.course.id}/course_instance_switcher/${resLocals.course_instance ? resLocals.course_instance.id : ''}"
             hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
             hx-target="#sideNavCourseInstancesDropdownContent"
           >
-            <span> ${resLocals.course_instance.short_name} </span>
+            <span> 
+              ${resLocals.course_instance ? resLocals.course_instance.short_name : "Select a course instance..."} 
+            </span>
           </button>
           <div class="dropdown-menu py-0 overflow-hidden">
             <div
@@ -272,14 +273,14 @@ function CourseInstanceNav({
             </div>
           </div>
         </div>
-        ${courseInstanceSideNavPageTabs.map((tabInfo) =>
+        ${resLocals.course_instance ? courseInstanceSideNavPageTabs.map((tabInfo) =>
           SideNavLink({
             resLocals,
             navPage: page,
             navSubPage: subPage,
             tabInfo,
           }),
-        )}
+        ) : ''}
       </div>
     </div>
   `;

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -252,9 +252,7 @@ function CourseInstanceNav({
             data-bs-toggle="dropdown"
             data-bs-boundary="window"
             hx-get="/pl/navbar/course/${resLocals.course
-              .id}/course_instance_switcher/${resLocals.course_instance
-              ? resLocals.course_instance.id
-              : ''}"
+              .id}/course_instance_switcher/${resLocals.course_instance?.id ?? ''}"
             hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
             hx-target="#sideNavCourseInstancesDropdownContent"
           >

--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -259,9 +259,7 @@ function CourseInstanceNav({
             hx-target="#sideNavCourseInstancesDropdownContent"
           >
             <span>
-              ${resLocals.course_instance
-                ? resLocals.course_instance.short_name
-                : 'Select a course instance...'}
+              ${resLocals.course_instance?.short_name ?? 'Select a course instance...'}
             </span>
           </button>
           <div class="dropdown-menu py-0 overflow-hidden">

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
@@ -12,6 +12,7 @@ import { config } from '../lib/config.js';
 import { clearCookie } from '../lib/cookie.js';
 import { features } from '../lib/features/index.js';
 import { idsEqual } from '../lib/id.js';
+import { selectCourseHasCourseInstances } from '../models/course-instances.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:authzCourseOrInstance');
@@ -93,6 +94,10 @@ export async function authzCourseOrInstance(req: Request, res: Response) {
     has_course_permission_own: permissions_course.has_course_permission_own,
   };
   res.locals.user = res.locals.authz_data.user;
+  res.locals.course_has_course_instances = await selectCourseHasCourseInstances({
+    course_id: res.locals.course.id,
+  });
+
   if (isCourseInstance) {
     res.locals.course_instance = result.rows[0].course_instance;
     const permissions_course_instance = result.rows[0].permissions_course_instance;


### PR DESCRIPTION
Related to https://github.com/PrairieLearn/PrairieLearn/discussions/11550#discussioncomment-12480352.

Currently, when enhanced navigation is enabled, if a user is on a course page, they must navigate to the course instances page to select a course instance. They cannot do so directly through the side nav. 

This PR enables users to navigate to course instances directly from the side nav on course pages:

![image](https://github.com/user-attachments/assets/cd1c19bc-36a4-40ba-95a5-f01eb99871ba)

![image](https://github.com/user-attachments/assets/173088fa-36a7-44a3-9c4f-4ab7ee065c4e)

![image](https://github.com/user-attachments/assets/c654b78e-8610-46c7-a4c9-f950ba5c0b60)

If a course has no course instances, the course instances switcher is hidden:

![image](https://github.com/user-attachments/assets/2b8e51c9-d1a0-4e43-a059-51095d83cd7a)


