### PR TITLE
Use replaceAll instead of replace where appropriate

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -299,7 +299,7 @@ class PLDrawingAnswerState {
 
   _updateAnswerInput() {
     // Correctly escape double back-slashes... (\\)
-    let temp = JSON.stringify(_.values(this._answerData)).replace('\\\\', '\\\\\\\\');
+    let temp = JSON.stringify(_.values(this._answerData)).replaceAll('\\\\', '\\\\\\\\');
     this._htmlInput.val(temp);
   }
 

--- a/apps/prairielearn/src/components/CourseRequestsTable.html.ts
+++ b/apps/prairielearn/src/components/CourseRequestsTable.html.ts
@@ -209,7 +209,7 @@ function CourseRequestApproveForm({
   coursesRoot: string;
   csrfToken: string;
 }) {
-  const repo_name = 'pl-' + request.short_name.replace(' ', '').toLowerCase();
+  const repo_name = 'pl-' + request.short_name.replaceAll(' ', '').toLowerCase();
   return html`
     <form name="create-course-from-request-form-${request.id}" method="POST">
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -320,7 +320,7 @@ export async function createCourseRepoJob(
  * @param short_name Course shortname
  */
 export function reponameFromShortname(short_name: string) {
-  return 'pl-' + short_name.replace(' ', '').toLowerCase();
+  return 'pl-' + short_name.replaceAll(' ', '').toLowerCase();
 }
 
 /**

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -235,7 +235,10 @@ async function pipeCursorToArchive<T>(
   extractFiles: (row: T) => ArchiveFile[] | null,
 ) {
   const archive = archiver('zip');
-  const dirname = (res.locals.assessment_set.name + res.locals.assessment.number).replace(' ', '');
+  const dirname = (res.locals.assessment_set.name + res.locals.assessment.number).replaceAll(
+    ' ',
+    '',
+  );
   const prefix = `${dirname}/`;
   archive.append('', { name: prefix });
   archive.pipe(res);

--- a/packages/sanitize/src/index.test.ts
+++ b/packages/sanitize/src/index.test.ts
@@ -15,6 +15,12 @@ describe('sanitizeObject', () => {
     assert.deepEqual(expected, sanitizeObject(input));
   });
 
+  it('handles multiple null bytes in top-level string', () => {
+    const input = { test: 'test\u0000ing\u0000' };
+    const expected = { test: 'test\\u0000ing\\u0000' };
+    assert.deepEqual(expected, sanitizeObject(input));
+  });
+
   it('handles null byte in nested string', () => {
     const input = {
       test: {

--- a/packages/sanitize/src/index.ts
+++ b/packages/sanitize/src/index.ts
@@ -12,7 +12,7 @@ export function sanitizeObject<T>(value: T): T {
   } else if (Array.isArray(value)) {
     return value.map(sanitizeObject) as T;
   } else if (typeof value === 'string') {
-    return value.replace('\u0000', '\\u0000') as T;
+    return value.replaceAll('\u0000', '\\u0000') as T;
   } else if (typeof value === 'object') {
     const sanitized = Object.entries(value).map(([key, value]) => {
       return [key, sanitizeObject(value)];


### PR DESCRIPTION
@jonatanschroeder called out in https://github.com/PrairieLearn/PrairieLearn/pull/11541#discussion_r1999095447 that I had used `String.prototype.replace` when I should have used `String.prototype.replaceAll`. I decided to check the rest of the codebase and found a few more places where I believe we were using the wrong one.