### PR TITLE
Disable shareable link copying in JupyterLab workspace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,9 @@ jobs:
         uses: docker/build-push-action@v6 # https://github.com/marketplace/actions/build-and-push-docker-images
         with:
           context: workspaces/jupyterlab-python
-          platforms: linux/amd64,linux/arm64
+          # Temp to speed up testing builds.
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
           no-cache: true
           tags: prairielearn/workspace-jupyterlab-python:${{ env.COMMIT_SHA }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,9 +113,7 @@ jobs:
         uses: docker/build-push-action@v6 # https://github.com/marketplace/actions/build-and-push-docker-images
         with:
           context: workspaces/jupyterlab-python
-          # Temp to speed up testing builds.
-          # platforms: linux/amd64,linux/arm64
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
           no-cache: true
           tags: prairielearn/workspace-jupyterlab-python:${{ env.COMMIT_SHA }}

--- a/workspaces/jupyterlab-python/install.sh
+++ b/workspaces/jupyterlab-python/install.sh
@@ -37,10 +37,11 @@ pip3 cache purge
 # https://stackoverflow.com/questions/75511508/how-to-stop-this-message-would-you-like-to-receive-official-jupyter-news
 jupyter labextension disable @jupyterlab/apputils-extension:announcements
 
-# Suppress the "Copy shareable link" context menu item.
-# This confuses instructors by misleading them into thinking that a student
-# would be able to access random workspaces.
+# Remove buttons and menu options that show a "shareable link".
+# These confuse instructors by misleading them into thinking that a student
+# would be able to access random workspaces by these links.
 jupyter labextension disable @jupyterlab/filebrowser-extension:share-file
+jupyter labextension disable @jupyter/collaboration-extension:shared-link
 
 # Delete ourself.
 rm /requirements.txt /install.sh

--- a/workspaces/jupyterlab-python/install.sh
+++ b/workspaces/jupyterlab-python/install.sh
@@ -37,5 +37,10 @@ pip3 cache purge
 # https://stackoverflow.com/questions/75511508/how-to-stop-this-message-would-you-like-to-receive-official-jupyter-news
 jupyter labextension disable @jupyterlab/apputils-extension:announcements
 
+# Suppress the "Copy shareable link" context menu item.
+# This confuses instructors by misleading them into thinking that a student
+# would be able to access random workspaces.
+jupyter labextension disable @jupyterlab/filebrowser-extension:share-file
+
 # Delete ourself.
 rm /requirements.txt /install.sh


### PR DESCRIPTION
We heard from an instructor recently that the presence of this link caused them to worry that students could access any workspace if they knew the link. They tested this with a colleague (who was on course staff) and it "worked". This is of course by design: anyone with staff permissions can access any other staff workspace in the course. Nevertheless, this worried them a lot. Hiding the link doesn't change our (already safe) behavior, but it should hopefully help avoid additional confusion in the future.

"Copy shareable link" on the context menu for files:

<img width="460" alt="Screenshot 2025-03-18 at 10 04 46" src="https://github.com/user-attachments/assets/a29ffce3-5ecd-4eb6-8cad-8c7588e50428" />

Share button in the upper-right:

<img width="127" alt="Screenshot 2025-03-18 at 10 04 51" src="https://github.com/user-attachments/assets/1d24cd70-4bc5-46f1-9aab-a8f5a37b6b4c" />