### PR TITLE
Fix course instance usage queries

### DIFF
--- a/apps/prairielearn/src/models/course-instance-usages.sql
+++ b/apps/prairielearn/src/models/course-instance-usages.sql
@@ -26,7 +26,7 @@ FROM
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
   LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
   LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
-  LEFT JOIN course_instances AS ci ON (ci.course_id = a.course_instance_id)
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
 WHERE
   s.id = $submission_id
 ON CONFLICT (
@@ -71,7 +71,7 @@ FROM
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
   LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
   LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
-  LEFT JOIN course_instances AS ci ON (ci.course_id = a.course_instance_id)
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
 WHERE
   gj.id = $grading_job_id
   -- Avoid inserting anything if we'd compute a NULL duration.

--- a/packages/workspace-utils/src/index.sql
+++ b/packages/workspace-utils/src/index.sql
@@ -161,7 +161,7 @@ FROM
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
   LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
   LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
-  LEFT JOIN course_instances AS ci ON (ci.course_id = a.course_instance_id)
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
 WHERE
   w.id = $workspace_id
 ON CONFLICT (


### PR DESCRIPTION
This was the same bug that was fixed in https://github.com/PrairieLearn/PrairieLearn/pull/11437 for the backfill queries. Copy-paste meant that the bug was also in the real-time usage queries.

I'll follow up shortly with new backfill queries.