### PR TITLE
Remove invalid string message

### DIFF
--- a/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
+++ b/apps/prairielearn/elements/pl-string-input/pl-string-input.mustache
@@ -9,7 +9,7 @@
             type="text"
             inputmode="text"
             class="form-control pl-string-input-input {{#parse_error}}has-validation is-invalid{{/parse_error}}"
-            {{#parse_error}}aria-invalid="true" aria-describedby="pl-string-input-{{uuid}}-error"{{/parse_error}}
+            {{#parse_error}}aria-invalid="true"{{/parse_error}}
             size="{{size}}"
             autocomplete="off"
             autocorrect="off"
@@ -48,9 +48,6 @@
                 <span class="badge text-bg-danger">
                     Invalid 
                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                </span>
-                <span id="pl-string-input-{{uuid}}-error">
-                    You must enter a string.
                 </span>
                 <a 
                     class="link-primary"


### PR DESCRIPTION
This PR addresses a problem related to the recent changes in #11489. That PR displayed a message for an invalid string. However, we have had problems with using a standardized message if there are any parsing errors and displaying this rather than custom feedback. This PR simply removes that messaging so users are more likely to click "More info..." for help.

Here is a screenshot before the change:
<img width="596" alt="Screenshot 2025-03-18 at 1 48 00 PM" src="https://github.com/user-attachments/assets/d757ff0d-0f09-46dd-ba01-8049933b8da2" />

And here is the updated version with the messaging removed:
<img width="557" alt="Screenshot 2025-03-18 at 1 48 20 PM" src="https://github.com/user-attachments/assets/9dc43f0c-bad8-455a-aa65-4068e7118125" />

