### PR TITLE
Institution admin page access for global admins with admin access disabled

### DIFF
--- a/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
+++ b/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
@@ -26,13 +26,9 @@ export async function selectAndAuthzInstitutionAsAdmin({
     }),
   );
 
-  if (
-    result == null ||
-    (!result.administrator && !result.institution_administrator) ||
-    (result.administrator && !access_as_administrator && !result.institution_administrator)
-  ) {
-    throw new HttpStatusError(403, 'Not authorized');
+  if (result && (result.institution_administrator || (result.administrator && access_as_administrator))) {
+    return result.institution;
   }
-
-  return result.institution;
+  
+  throw new HttpStatusError(403, 'Not authorized');
 }

--- a/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
+++ b/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
@@ -26,9 +26,12 @@ export async function selectAndAuthzInstitutionAsAdmin({
     }),
   );
 
-  if (result && (result.institution_administrator || (result.administrator && access_as_administrator))) {
+  if (
+    result &&
+    (result.institution_administrator || (result.administrator && access_as_administrator))
+  ) {
     return result.institution;
   }
-  
+
   throw new HttpStatusError(403, 'Not authorized');
 }

--- a/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
+++ b/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
@@ -33,5 +33,5 @@ export async function selectAndAuthzInstitutionAsAdmin({
     return result.institution;
   }
 
-  throw new HttpStatusError(403, 'Not authorized');
+  throw new HttpStatusError(403, 'Not authorized');//
 }

--- a/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
+++ b/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
@@ -33,5 +33,5 @@ export async function selectAndAuthzInstitutionAsAdmin({
     return result.institution;
   }
 
-  throw new HttpStatusError(403, 'Not authorized');//
+  throw new HttpStatusError(403, 'Not authorized');
 }

--- a/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
+++ b/apps/prairielearn/src/ee/lib/selectAndAuthz.ts
@@ -29,7 +29,7 @@ export async function selectAndAuthzInstitutionAsAdmin({
   if (
     result == null ||
     (!result.administrator && !result.institution_administrator) ||
-    (result.administrator && !access_as_administrator)
+    (result.administrator && !access_as_administrator && !result.institution_administrator)
   ) {
     throw new HttpStatusError(403, 'Not authorized');
   }


### PR DESCRIPTION
Related to https://github.com/PrairieLearn/PrairieLearn/pull/11583#discussion_r2001781822. 

When a global admin has admin access turned off but is explicitly listed as an institution admin independent of global admin access, they cannot access institution admin pages:

![Screenshot 2025-03-18 at 4 17 48 PM](https://github.com/user-attachments/assets/39f52077-66c5-40b3-8dc1-9e58a818dc1b)
![Screenshot 2025-03-18 at 4 18 12 PM](https://github.com/user-attachments/assets/db15f79e-04a5-434e-8308-0e45025ff554)

However, "turn on admin access" should only control global admin access, so institution admin pages should still be accessible in this case. 

This PR ensures that global admins with admin access turned off that are explicitly listed as institution admins have access to institution admin pages. 