### PR TITLE
Fix copying question from public preview page

### DIFF
--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -31,10 +31,10 @@ onDocumentReady(() => {
     loadPendingSubmissionPanel(e.currentTarget, false);
   });
 
-  const copyQuestionForm = document.querySelector<HTMLFormElement>('#copyQuestionModal form');
+  const copyQuestionForm = document.querySelector<HTMLFormElement>('.js-copy-question-form');
   if (copyQuestionForm) {
     const courseSelect = copyQuestionForm.querySelector<HTMLSelectElement>(
-      '#copyQuestionModal select[name="to_course_id"]',
+      'select[name="to_course_id"]',
     );
     courseSelect?.addEventListener('change', () => {
       const option = courseSelect.selectedOptions[0];

--- a/apps/prairielearn/src/components/Modal.html.ts
+++ b/apps/prairielearn/src/components/Modal.html.ts
@@ -11,7 +11,7 @@ interface ModalProps {
   formEncType?: string;
   formMethod?: string;
   formAction?: string;
-  preventSubmitOnEnter?: boolean;
+  formClass?: string;
 }
 
 export function Modal({
@@ -25,6 +25,7 @@ export function Modal({
   formEncType,
   formMethod = 'POST',
   formAction,
+  formClass,
 }: ModalProps): HtmlSafeString {
   const titleId = `${id}-title`;
   const modal = html`
@@ -49,6 +50,7 @@ export function Modal({
       autocomplete="off"
       ${formEncType ? html`enctype="${formEncType}"` : ''}
       ${formAction ? html`action="${formAction}"` : ''}
+      ${formClass ? html`class="${formClass}"` : ''}
     >
       ${modal}
     </form>

--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -758,6 +758,7 @@ function CopyQuestionModal({ resLocals }: { resLocals: Record<string, any> }) {
     id: 'copyQuestionModal',
     title: 'Copy question',
     formAction: question_copy_targets[0]?.copy_url ?? '',
+    formClass: 'js-copy-question-form',
     body:
       question_copy_targets.length === 0
         ? html`


### PR DESCRIPTION
@echuber2 reported on Slack that when he went to copy a question from the public question preview page, the question was copied to the first course that was selected by default, not the one he changed it to.

This was caused by the changes I made to the `Modal` component in #11522. Because `<form>` now wraps the modal instead of being a child of it, the selector used here didn't work anymore. This PR updates the `Modal` component to allow adding a class to the `<form>`, which should be more robust than relying on element nesting.