### PR TITLE
Backfill usage data v3

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
@@ -77,6 +77,8 @@ FROM
 WHERE
   s.id >= $start
   AND s.id <= $end
+  AND s.date >= $START_DATE
+  AND s.date < $END_DATE
 ON CONFLICT (
   type,
   course_id,

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
@@ -1,0 +1,60 @@
+-- BLOCK delete_old_usages
+DELETE FROM course_instance_usages
+WHERE
+  type = 'Submission'
+  AND date >= $START_DATE
+  AND date < $END_DATE;
+
+-- BLOCK select_bounds
+SELECT
+  min(id),
+  max(id)
+FROM
+  submissions
+WHERE
+  date >= $START_DATE
+  AND date < $END_DATE;
+
+-- BLOCK update_course_instance_usages_for_submissions
+INSERT INTO
+  course_instance_usages (
+    type,
+    institution_id,
+    course_id,
+    course_instance_id,
+    date,
+    user_id,
+    include_in_statistics
+  )
+SELECT
+  'Submission',
+  i.id,
+  c.id,
+  ci.id,
+  date_trunc('day', s.date, 'UTC'),
+  -- We use `v.authn_user_id` for backfill, because this is guaranteed to be
+  -- non-null and should virtually always be the same as `ai.user_id` for
+  -- students (we want to match the user_id for student submissions, to avoid
+  -- counting course staff as students).
+  v.authn_user_id,
+  coalesce(ai.include_in_statistics, false)
+FROM
+  submissions AS s
+  JOIN variants AS v ON (v.id = s.variant_id)
+  JOIN questions AS q ON (q.id = v.question_id)
+  JOIN pl_courses AS c ON (c.id = q.course_id)
+  JOIN institutions AS i ON (i.id = c.institution_id)
+  LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+  LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+  LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+  s.id >= $start
+  AND s.id <= $end
+ON CONFLICT (
+  type,
+  course_id,
+  course_instance_id,
+  date,
+  user_id
+) DO NOTHING;

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
@@ -67,6 +67,9 @@ FROM
 WHERE
   s.id >= $start
   AND s.id <= $end
+  -- The ID range we are backfilling is deliberately a superset of the rows in
+  -- the exact date range, because date and ID are not strictly correlated.
+  -- Because of this we additionally filter on the date range.
   AND s.date >= $START_DATE
   AND s.date < $END_DATE
 ON CONFLICT (

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
@@ -5,6 +5,32 @@ WHERE
   AND date >= $START_DATE
   AND date < $END_DATE;
 
+-- BLOCK select_min_bound
+SELECT
+  id
+FROM
+  submissions
+WHERE
+  date >= $START_DATE::timestamptz - interval '1 day'
+ORDER BY
+  date ASC,
+  id ASC
+LIMIT
+  1;
+
+-- BLOCK select_max_bound
+SELECT
+  id
+FROM
+  submissions
+WHERE
+  date < $END_DATE::timestamptz + interval '1 day'
+ORDER BY
+  date DESC,
+  id DESC
+LIMIT
+  1;
+
 -- BLOCK select_bounds
 SELECT
   min(id),

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.sql
@@ -31,16 +31,6 @@ ORDER BY
 LIMIT
   1;
 
--- BLOCK select_bounds
-SELECT
-  min(id),
-  max(id)
-FROM
-  submissions
-WHERE
-  date >= $START_DATE
-  AND date < $END_DATE;
-
 -- BLOCK update_course_instance_usages_for_submissions
 INSERT INTO
   course_instance_usages (

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
@@ -6,7 +6,7 @@ import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 const sql = loadSqlEquiv(import.meta.url);
 
 const START_DATE = '2025-02-15T00:00:00Z';
-const END_DATE = '2025-03-18T00:00:00Z';
+const END_DATE = '2025-03-21T00:00:00Z';
 
 export default makeBatchedMigration({
   async getParameters() {

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
@@ -27,6 +27,11 @@ export default makeBatchedMigration({
     return { min, max, batchSize: 100_000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {
-    await queryAsync(sql.update_course_instance_usages_for_submissions, { start, end });
+    await queryAsync(sql.update_course_instance_usages_for_submissions, {
+      start,
+      end,
+      START_DATE,
+      END_DATE,
+    });
   },
 });

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const START_DATE = '2025-02-15T00:00:00Z';
+const END_DATE = '2025-03-18T00:00:00Z';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    // First delete old usage data
+    await queryAsync(sql.delete_old_usages, { START_DATE, END_DATE });
+
+    // Only backfill from submissions within the date range
+    const { min, max } = await queryRow(
+      sql.select_bounds,
+      { START_DATE, END_DATE },
+      z.object({
+        min: z.bigint({ coerce: true }).nullable(),
+        max: z.bigint({ coerce: true }).nullable(),
+      }),
+    );
+    return { min, max, batchSize: 100_000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.update_course_instance_usages_for_submissions, { start, end });
+  },
+});

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
@@ -14,13 +14,15 @@ export default makeBatchedMigration({
     await queryAsync(sql.delete_old_usages, { START_DATE, END_DATE });
 
     // Only backfill from submissions within the date range
-    const { min, max } = await queryRow(
-      sql.select_bounds,
-      { START_DATE, END_DATE },
-      z.object({
-        min: z.bigint({ coerce: true }).nullable(),
-        max: z.bigint({ coerce: true }).nullable(),
-      }),
+    const min = await queryRow(
+      sql.select_min_bound,
+      { START_DATE },
+      z.bigint({ coerce: true }).nullable(),
+    );
+    const max = await queryRow(
+      sql.select_max_bound,
+      { END_DATE },
+      z.bigint({ coerce: true }).nullable(),
     );
     return { min, max, batchSize: 100_000 };
   },

--- a/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
@@ -14,18 +14,16 @@ export default makeBatchedMigration({
     await queryAsync(sql.delete_old_usages, { START_DATE, END_DATE });
 
     // Only backfill from submissions within the date range
-    const min =
-      (await queryOptionalRow(
-        sql.select_min_bound,
-        { START_DATE },
-        z.bigint({ coerce: true }).nullable(),
-      )) ?? 1n;
-    const max =
-      (await queryOptionalRow(
-        sql.select_max_bound,
-        { END_DATE },
-        z.bigint({ coerce: true }).nullable(),
-      )) ?? 1n;
+    const min = await queryOptionalRow(
+      sql.select_min_bound,
+      { START_DATE },
+      z.bigint({ coerce: true }).nullable(),
+    );
+    const max = await queryOptionalRow(
+      sql.select_max_bound,
+      { END_DATE },
+      z.bigint({ coerce: true }).nullable(),
+    );
     return { min, max, batchSize: 100_000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {

--- a/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.sql
@@ -69,6 +69,8 @@ WHERE
   AND gj.grading_finished_at > gj.grading_received_at
   AND gj.id >= $start
   AND gj.id <= $end
+  AND gj.grading_finished_at >= $START_DATE
+  AND gj.grading_finished_at < $END_DATE
 GROUP BY
   -- We need to aggregate by all columns in the unique constraint because INSERT
   -- ... ON CONFLICT DO UPDATE can't update a row multiple times.

--- a/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.sql
@@ -69,6 +69,9 @@ WHERE
   AND gj.grading_finished_at > gj.grading_received_at
   AND gj.id >= $start
   AND gj.id <= $end
+  -- The ID range we are backfilling is deliberately a superset of the rows in
+  -- the exact date range, because date and ID are not strictly correlated.
+  -- Because of this we additionally filter on the date range.
   AND gj.grading_finished_at >= $START_DATE
   AND gj.grading_finished_at < $END_DATE
 GROUP BY

--- a/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.sql
@@ -1,0 +1,89 @@
+-- BLOCK delete_old_usages
+DELETE FROM course_instance_usages
+WHERE
+  type = 'External grading'
+  AND date >= $START_DATE
+  AND date < $END_DATE;
+
+-- BLOCK select_bounds
+SELECT
+  min(id),
+  max(id)
+FROM
+  grading_jobs
+WHERE
+  grading_method = 'External'
+  -- Use `date` for the index. We start earlier than $START_DATE because we
+  -- really care about `grading_finished_at` and we don't want to miss any rows
+  -- that have `date` just before $START_DATE.
+  AND date >= $START_DATE::timestamptz - interval '1 day'
+  AND date < $END_DATE
+  -- also check `grading_finished_at` so we don't double-count
+  AND grading_finished_at >= $START_DATE
+  AND grading_finished_at < $END_DATE;
+
+-- BLOCK update_course_instance_usages_for_external_gradings
+INSERT INTO
+  course_instance_usages (
+    type,
+    institution_id,
+    course_id,
+    course_instance_id,
+    date,
+    user_id,
+    include_in_statistics,
+    duration
+  )
+SELECT
+  'External grading',
+  -- There will only be one institution, so we can use `any_value()`
+  any_value (i.id),
+  c.id,
+  ci.id,
+  date_trunc('day', gj.grading_finished_at, 'UTC'),
+  -- Use v.authn_user_id because we don't care about really tracking the
+  -- effective user, we are only using this to avoid contention when there are
+  -- many users updating simultaneously.
+  v.authn_user_id,
+  -- It's possible that there are different values of `include_in_statistics` bu
+  -- we aren't worried about tracking this accurately.
+  any_value (coalesce(ai.include_in_statistics, false)),
+  sum(gj.grading_finished_at - gj.grading_received_at)
+FROM
+  grading_jobs AS gj
+  JOIN submissions AS s ON (s.id = gj.submission_id)
+  JOIN variants AS v ON (v.id = s.variant_id)
+  JOIN questions AS q ON (q.id = v.question_id)
+  JOIN pl_courses AS c ON (c.id = q.course_id)
+  JOIN institutions AS i ON (i.id = c.institution_id)
+  LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+  LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+  LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+  gj.grading_method = 'External'
+  -- Avoid inserting anything if we'd compute a NULL duration.
+  AND gj.grading_received_at IS NOT NULL
+  AND gj.grading_finished_at IS NOT NULL
+  -- Avoid inserting negative durations.
+  AND gj.grading_finished_at > gj.grading_received_at
+  AND gj.id >= $start
+  AND gj.id <= $end
+GROUP BY
+  -- We need to aggregate by all columns in the unique constraint because INSERT
+  -- ... ON CONFLICT DO UPDATE can't update a row multiple times.
+  c.id,
+  ci.id,
+  date_trunc('day', gj.grading_finished_at, 'UTC'),
+  v.authn_user_id
+ON CONFLICT (
+  -- Conflicts will only occur with pre-existing rows, not from rows inserted by
+  -- the current execution of this query.
+  type,
+  course_id,
+  course_instance_id,
+  date,
+  user_id
+) DO UPDATE
+SET
+  duration = course_instance_usages.duration + EXCLUDED.duration;

--- a/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
@@ -6,7 +6,7 @@ import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 const sql = loadSqlEquiv(import.meta.url);
 
 const START_DATE = '2025-02-15T00:00:00Z';
-const END_DATE = '2025-03-18T00:00:00Z';
+const END_DATE = '2025-03-21T00:00:00Z';
 
 export default makeBatchedMigration({
   async getParameters() {

--- a/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const START_DATE = '2025-02-15T00:00:00Z';
+const END_DATE = '2025-03-18T00:00:00Z';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    // First delete old usage data
+    await queryAsync(sql.delete_old_usages, { START_DATE, END_DATE });
+
+    // Only backfill from grading jobs within the date range
+    const { min, max } = await queryRow(
+      sql.select_bounds,
+      { START_DATE, END_DATE },
+      z.object({
+        min: z.bigint({ coerce: true }).nullable(),
+        max: z.bigint({ coerce: true }).nullable(),
+      }),
+    );
+    return { min, max, batchSize: 100_000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.update_course_instance_usages_for_external_gradings, { start, end });
+  },
+});

--- a/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
@@ -25,6 +25,11 @@ export default makeBatchedMigration({
     return { min, max, batchSize: 100_000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {
-    await queryAsync(sql.update_course_instance_usages_for_external_gradings, { start, end });
+    await queryAsync(sql.update_course_instance_usages_for_external_gradings, {
+      start,
+      end,
+      START_DATE,
+      END_DATE,
+    });
   },
 });

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
@@ -5,21 +5,12 @@ WHERE
   AND date >= $START_DATE
   AND date < $END_DATE;
 
--- BLOCK select_bounds
+-- BLOCK select_max_bound
 SELECT
-  min(id),
   max(id)
 FROM
   workspaces
 WHERE
-  -- Use `launched_at` for the index. We start earlier than $START_DATE because
-  -- we really care about `state_updated_at` and we don't want to miss any rows
-  -- that have `launched_at` just before $START_DATE. We'll cap it at 1 week, so
-  -- we shouldn't miss too many rows.
-  launched_at >= $START_DATE::timestamptz - interval '1 week'
-  AND launched_at < $END_DATE
-  -- also check `state_updated_at` so we don't double-count
-  AND state_updated_at >= $START_DATE
   AND state_updated_at < $END_DATE;
 
 -- BLOCK update_course_instance_usages_for_workspaces

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
@@ -10,7 +10,7 @@ SELECT
 FROM
   workspaces
 WHERE
-  AND state_updated_at < $END_DATE;
+  state_updated_at < $END_DATE;
 
 -- BLOCK update_course_instance_usages_for_workspaces
 INSERT INTO

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
@@ -1,0 +1,82 @@
+-- BLOCK delete_old_usages
+DELETE FROM course_instance_usages
+WHERE
+  type = 'Workspace'
+  AND date >= $START_DATE
+  AND date < $END_DATE;
+
+-- BLOCK select_bounds
+SELECT
+  min(id),
+  max(id)
+FROM
+  workspaces
+WHERE
+  -- Use `launched_at` for the index. We start earlier than $START_DATE because
+  -- we really care about `state_updated_at` and we don't want to miss any rows
+  -- that have `launched_at` just before $START_DATE. We'll cap it at 1 week, so
+  -- we shouldn't miss too many rows.
+  launched_at >= $START_DATE::timestamptz - interval '1 week'
+  AND launched_at < $END_DATE
+  -- also check `state_updated_at` so we don't double-count
+  AND state_updated_at >= $START_DATE
+  AND state_updated_at < $END_DATE;
+
+-- BLOCK update_course_instance_usages_for_workspaces
+INSERT INTO
+  course_instance_usages (
+    type,
+    institution_id,
+    course_id,
+    course_instance_id,
+    date,
+    user_id,
+    include_in_statistics,
+    duration
+  )
+SELECT
+  'Workspace',
+  -- There will only be one institution, so we can use `any_value()`
+  any_value (i.id),
+  c.id,
+  ci.id,
+  date_trunc('day', w.state_updated_at, 'UTC'),
+  -- Use v.authn_user_id because we don't care about really tracking the
+  -- effective user, we are only using this to avoid contention when there are
+  -- many users updating simultaneously.
+  v.authn_user_id,
+  -- It's possible that there are different values of `include_in_statistics`
+  -- but we aren't worried about tracking this accurately.
+  any_value (coalesce(ai.include_in_statistics, false)),
+  sum(w.launching_duration + w.running_duration)
+FROM
+  workspaces AS w
+  JOIN variants AS v ON (v.workspace_id = w.id)
+  JOIN questions AS q ON (q.id = v.question_id)
+  JOIN pl_courses AS c ON (c.id = q.course_id)
+  JOIN institutions AS i ON (i.id = c.institution_id)
+  LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+  LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
+  LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
+  LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+  w.id >= $start
+  AND w.id <= $end
+GROUP BY
+  -- We need to aggregate by all columns in the unique constraint because INSERT
+  -- ... ON CONFLICT DO UPDATE can't update a row multiple times.
+  c.id,
+  ci.id,
+  date_trunc('day', w.state_updated_at, 'UTC'),
+  v.authn_user_id
+ON CONFLICT (
+  -- Conflicts will only occur with pre-existing rows, not from rows inserted by
+  -- the current execution of this query.
+  type,
+  course_id,
+  course_instance_id,
+  date,
+  user_id
+) DO UPDATE
+SET
+  duration = course_instance_usages.duration + EXCLUDED.duration;

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
@@ -52,6 +52,9 @@ FROM
 WHERE
   w.id >= $start
   AND w.id <= $end
+  -- The ID range we are backfilling is deliberately a superset of the rows in
+  -- the exact date range, because date and ID are not strictly correlated.
+  -- Because of this we additionally filter on the date range.
   AND w.state_updated_at < $END_DATE
 GROUP BY
   -- We need to aggregate by all columns in the unique constraint because INSERT

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
@@ -2,7 +2,6 @@
 DELETE FROM course_instance_usages
 WHERE
   type = 'Workspace'
-  AND date >= $START_DATE
   AND date < $END_DATE;
 
 -- BLOCK select_max_bound
@@ -53,7 +52,6 @@ FROM
 WHERE
   w.id >= $start
   AND w.id <= $end
-  AND w.state_updated_at >= $START_DATE
   AND w.state_updated_at < $END_DATE
 GROUP BY
   -- We need to aggregate by all columns in the unique constraint because INSERT

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.sql
@@ -62,6 +62,8 @@ FROM
 WHERE
   w.id >= $start
   AND w.id <= $end
+  AND w.state_updated_at >= $START_DATE
+  AND w.state_updated_at < $END_DATE
 GROUP BY
   -- We need to aggregate by all columns in the unique constraint because INSERT
   -- ... ON CONFLICT DO UPDATE can't update a row multiple times.

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
@@ -25,7 +25,6 @@ export default makeBatchedMigration({
     await queryAsync(sql.update_course_instance_usages_for_workspaces, {
       start,
       end,
-
       END_DATE,
     });
   },

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
@@ -6,7 +6,7 @@ import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 const sql = loadSqlEquiv(import.meta.url);
 
 const START_DATE = '2025-02-15T00:00:00Z';
-const END_DATE = '2025-03-18T00:00:00Z';
+const END_DATE = '2025-03-21T00:00:00Z';
 
 export default makeBatchedMigration({
   async getParameters() {

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const START_DATE = '2025-02-15T00:00:00Z';
+const END_DATE = '2025-03-18T00:00:00Z';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    // First delete old usage data
+    await queryAsync(sql.delete_old_usages, { START_DATE, END_DATE });
+
+    // Only backfill from workspaces within the date range
+    const { min, max } = await queryRow(
+      sql.select_bounds,
+      { START_DATE, END_DATE },
+      z.object({
+        min: z.bigint({ coerce: true }).nullable(),
+        max: z.bigint({ coerce: true }).nullable(),
+      }),
+    );
+    return { min, max, batchSize: 10_000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.update_course_instance_usages_for_workspaces, { start, end });
+  },
+});

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
@@ -5,22 +5,19 @@ import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
 
 const sql = loadSqlEquiv(import.meta.url);
 
-const START_DATE = '2025-02-15T00:00:00Z';
 const END_DATE = '2025-03-21T00:00:00Z';
 
 export default makeBatchedMigration({
   async getParameters() {
     // First delete old usage data
-    await queryAsync(sql.delete_old_usages, { START_DATE, END_DATE });
+    await queryAsync(sql.delete_old_usages, { END_DATE });
 
     // Only backfill from workspaces within the date range
-    const { min, max } = await queryRow(
-      sql.select_bounds,
-      { START_DATE, END_DATE },
-      z.object({
-        min: z.bigint({ coerce: true }).nullable(),
-        max: z.bigint({ coerce: true }).nullable(),
-      }),
+    const min = 1n;
+    const max = await queryRow(
+      sql.select_max_bound,
+      { END_DATE },
+      z.bigint({ coerce: true }).nullable(),
     );
     return { min, max, batchSize: 10_000 };
   },
@@ -28,7 +25,7 @@ export default makeBatchedMigration({
     await queryAsync(sql.update_course_instance_usages_for_workspaces, {
       start,
       end,
-      START_DATE,
+
       END_DATE,
     });
   },

--- a/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
+++ b/apps/prairielearn/src/batched-migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
@@ -25,6 +25,11 @@ export default makeBatchedMigration({
     return { min, max, batchSize: 10_000 };
   },
   async execute(start: bigint, end: bigint): Promise<void> {
-    await queryAsync(sql.update_course_instance_usages_for_workspaces, { start, end });
+    await queryAsync(sql.update_course_instance_usages_for_workspaces, {
+      start,
+      end,
+      START_DATE,
+      END_DATE,
+    });
   },
 });

--- a/apps/prairielearn/src/migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
+++ b/apps/prairielearn/src/migrations/20250318174636_course_instance_usages__submissions__backfill_v3.ts
@@ -1,0 +1,8 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  // This is similar to the previous batched migration, but for a different time
+  // range. This is to backfill data that was incorrectly generated due to the
+  // bug fixed by #11590.
+  await enqueueBatchedMigration('20250318174636_course_instance_usages__submissions__backfill_v3');
+}

--- a/apps/prairielearn/src/migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
+++ b/apps/prairielearn/src/migrations/20250318175247_course_instance_usages__external_grading_jobs__backfill_v3.ts
@@ -1,0 +1,10 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  // This is similar to the previous batched migration, but for a different time
+  // range. This is to backfill data that was incorrectly generated due to the
+  // bug fixed by #11590.
+  await enqueueBatchedMigration(
+    '20250318175247_course_instance_usages__external_grading_jobs__backfill_v3',
+  );
+}

--- a/apps/prairielearn/src/migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
+++ b/apps/prairielearn/src/migrations/20250318180548_course_instance_usages__workspaces__backfill_v3.ts
@@ -1,0 +1,8 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  // This is similar to the previous batched migration, but for a different time
+  // range. This is to backfill data that was incorrectly generated due to the
+  // bug fixed by #11590.
+  await enqueueBatchedMigration('20250318180548_course_instance_usages__workspaces__backfill_v3');
+}


### PR DESCRIPTION
This PR backfills usage data that was incorrectly generated due to the bug in #11590. These backfills are identical to those in #11366/#11437, #11377, and #11378.