### PR TITLE
Add quotes to QIDs in sync errors to highlight whitespace

### DIFF
--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1124,6 +1124,16 @@ async function validateQuestion(
   return { warnings, errors };
 }
 
+/**
+ * Surrounds each qid with quotation marks
+ * @returns A set of qids
+ */
+function formatQids( qids: Set<string> ) {
+  return Array.from(qids)
+    .map((qid) => `"${qid}"`)
+    .join(', ');
+}
+
 async function validateAssessment(
   assessment: Assessment,
   questions: Record<string, InfoFile<Question>>,
@@ -1172,10 +1182,10 @@ async function validateAssessment(
     });
   }
 
-  const foundQids = new Set();
-  const duplicateQids = new Set();
-  const missingQids = new Set();
-  const draftQids = new Set();
+  const foundQids = new Set<string>();
+  const duplicateQids = new Set<string>();
+  const missingQids = new Set<string>();
+  const draftQids = new Set<string>();
   const checkAndRecordQid = (qid: string): void => {
     if (qid[0] === '@') {
       // Question is being imported from another course. We hold off on validating this until
@@ -1318,19 +1328,19 @@ async function validateAssessment(
 
   if (duplicateQids.size > 0) {
     errors.push(
-      `The following questions are used more than once: ${formatQids({ qids: duplicateQids })}`,
+      `The following questions are used more than once: ${formatQids( duplicateQids )}`,
     );
   }
 
   if (missingQids.size > 0) {
     errors.push(
-      `The following questions do not exist in this course: ${formatQids({ qids: missingQids })}`,
+      `The following questions do not exist in this course: ${formatQids( missingQids )}`,
     );
   }
 
   if (draftQids.size > 0) {
     errors.push(
-      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatQids({ qids: draftQids })}`,
+      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatQids( draftQids )}`,
     );
   }
 
@@ -1414,11 +1424,6 @@ async function validateAssessment(
   return { warnings, errors };
 }
 
-function formatQids({ qids }: { qids: Set<unknown> }) {
-  return Array.from(qids)
-    .map((qid) => `"${qid}"`)
-    .join(', ');
-}
 
 async function validateCourseInstance(
   courseInstance: CourseInstance,

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1318,19 +1318,19 @@ async function validateAssessment(
 
   if (duplicateQids.size > 0) {
     errors.push(
-      `The following questions are used more than once: ${[...duplicateQids].join(', ')}`,
+      `The following questions are used more than once: ${formatQids({ qids: duplicateQids })}`,
     );
   }
 
   if (missingQids.size > 0) {
     errors.push(
-      `The following questions do not exist in this course: "${[...missingQids].join('", "')}"`,
+      `The following questions do not exist in this course: ${formatQids({ qids: missingQids })}`,
     );
   }
 
   if (draftQids.size > 0) {
     errors.push(
-      `The following questions are marked as draft and therefore cannot be used in assessments: ${[...draftQids].join(', ')}`,
+      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatQids({ qids: draftQids })}`,
     );
   }
 
@@ -1412,6 +1412,12 @@ async function validateAssessment(
   }
 
   return { warnings, errors };
+}
+
+function formatQids({ qids }: { qids: Set<unknown> }) {
+  return Array.from(qids)
+    .map((qid) => `"${qid}"`)
+    .join(', ');
 }
 
 async function validateCourseInstance(

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1125,8 +1125,8 @@ async function validateQuestion(
 }
 
 /**
- * Surrounds each qid with quotation marks
- * @returns A set of qids
+ * Formats a set of QIDs into a string for use in error messages.
+ * @returns A comma-separated list of double-quoted QIDs.
  */
 function formatQids(qids: Set<string>) {
   return Array.from(qids)

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1324,7 +1324,7 @@ async function validateAssessment(
 
   if (missingQids.size > 0) {
     errors.push(
-      `The following questions do not exist in this course: ${[...missingQids].join(', ')}`,
+      `The following questions do not exist in this course: "${[...missingQids].join('", "')}"`,
     );
   }
 

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1128,7 +1128,7 @@ async function validateQuestion(
  * Surrounds each qid with quotation marks
  * @returns A set of qids
  */
-function formatQids( qids: Set<string> ) {
+function formatQids(qids: Set<string>) {
   return Array.from(qids)
     .map((qid) => `"${qid}"`)
     .join(', ');
@@ -1327,20 +1327,16 @@ async function validateAssessment(
   });
 
   if (duplicateQids.size > 0) {
-    errors.push(
-      `The following questions are used more than once: ${formatQids( duplicateQids )}`,
-    );
+    errors.push(`The following questions are used more than once: ${formatQids(duplicateQids)}`);
   }
 
   if (missingQids.size > 0) {
-    errors.push(
-      `The following questions do not exist in this course: ${formatQids( missingQids )}`,
-    );
+    errors.push(`The following questions do not exist in this course: ${formatQids(missingQids)}`);
   }
 
   if (draftQids.size > 0) {
     errors.push(
-      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatQids( draftQids )}`,
+      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatQids(draftQids)}`,
     );
   }
 
@@ -1423,7 +1419,6 @@ async function validateAssessment(
 
   return { warnings, errors };
 }
-
 
 async function validateCourseInstance(
   courseInstance: CourseInstance,

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1849,7 +1849,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /The following questions are used more than once: test/,
+      /The following questions are used more than once: "test"/,
     );
   });
 

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1783,7 +1783,7 @@ describe('Assessment syncing', () => {
       title: 'test zone',
       questions: [
         {
-          id: 'i do not exist',
+          id: 'i do not exist ',
           points: [1, 2, 3],
         },
       ],
@@ -1793,7 +1793,7 @@ describe('Assessment syncing', () => {
     const syncedAssessment = await findSyncedAssessment('fail');
     assert.match(
       syncedAssessment?.sync_errors,
-      /The following questions do not exist in this course: i do not exist/,
+      /The following questions do not exist in this course: "i do not exist "/,
     );
   });
 

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -2301,7 +2301,7 @@ describe('Assessment syncing', () => {
     console.log(syncedData.assessment.sync_errors);
     assert.match(
       syncedData.assessment?.sync_errors,
-      /The following questions are marked as draft and therefore cannot be used in assessments: __drafts__\/draft_1/,
+      /The following questions are marked as draft and therefore cannot be used in assessments: "__drafts__\/draft_1"/,
     );
   });
 


### PR DESCRIPTION
Updates the sync error for missing questions to include quotes to make whitespaces more obvious. Also updated test to match.

![sync log](https://github.com/user-attachments/assets/cf00c0cc-9dcd-4a4d-a585-fb6f51102299)

Closes #2933 