### PR TITLE
Load question chunks when externally grading a variant after auto-close

### DIFF
--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -1827,15 +1827,13 @@ export async function test(variant, question, course, test_type) {
  */
 async function getContext(question, course) {
   const coursePath = chunks.getRuntimeDirectoryForCourse(course);
-  /** @type {chunks.Chunk[]} */
-  const chunksToLoad = [
+  await chunks.ensureChunksForCourseAsync(course.id, [
     { type: 'question', questionId: question.id },
     { type: 'clientFilesCourse' },
     { type: 'serverFilesCourse' },
     { type: 'elements' },
     { type: 'elementExtensions' },
-  ];
-  await chunks.ensureChunksForCourseAsync(course.id, chunksToLoad);
+  ]);
 
   // Select which rendering strategy we'll use. This is computed here so that
   // in can factor into the cache key.


### PR DESCRIPTION
Closes #10770.

The reason this worked most of the time is because we typically got lucky and chunks were already present on servers by the time exams auto-closed. It's likely that things really only got bad for either tiny courses (where normal question HTTP requests wouldn't have reached _every_ server via the load balancer) or after deploys. We never would have seen issues from this during synchronous grading because `parse()` would have been run on the same machine before grading occurred, and `parse()` was always correctly loading all chunks.