### PR TITLE
Fix public preview URL for shared question

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.html.ts
@@ -166,7 +166,7 @@ function QuestionInfo({
       ? `course_instance/${course_instance.id}/instructor`
       : `course/${course.id}`
   }/question/${question.id}?variant_seed=${variant.variant_seed}`;
-  const publicPreviewUrl = `${config.urlPrefix}/public/course/${course.id}/question/${question.id}/preview`;
+  const publicPreviewUrl = `${config.urlPrefix}/public/course/${question.course_id}/question/${question.id}/preview`;
 
   // We don't show the sharing name in the QID if the question is not shared
   // publicly for importing, such as if only `share_source_publicly` is set.


### PR DESCRIPTION
This panel is used both in the sharing course and in any consuming course. When a question is previewed in the context of a consuming course, we must use the course ID of the question, not the course that's currently being viewed.