### PR TITLE
List only canonical timezones in timezone dropdowns

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
@@ -6,7 +6,7 @@ import { flash } from '@prairielearn/flash';
 import { loadSqlEquiv, queryRow, runInTransactionAsync } from '@prairielearn/postgres';
 
 import { InstitutionSchema } from '../../../lib/db-types.js';
-import { getAvailableTimezones } from '../../../lib/timezones.js';
+import { getCanonicalTimezones } from '../../../lib/timezones.js';
 import { insertAuditLog } from '../../../models/audit-log.js';
 import { parseDesiredPlanGrants } from '../../lib/billing/components/PlanGrantsEditor.html.js';
 import {
@@ -27,7 +27,7 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     const institution = await getInstitution(req.params.institution_id);
-    const availableTimezones = await getAvailableTimezones();
+    const availableTimezones = await getCanonicalTimezones([institution.display_timezone]);
     const statistics = await queryRow(
       sql.select_institution_statistics,
       { institution_id: req.params.institution_id },

--- a/apps/prairielearn/src/lib/timezones.ts
+++ b/apps/prairielearn/src/lib/timezones.ts
@@ -18,6 +18,11 @@ async function getAvailableTimezonesFromDB(): Promise<Timezone[]> {
   return availableTimezones;
 }
 
+/**
+ * Returns a list of all timezones supported by the database. The list is
+ * memoized so that, if it is needed more than once in the same session, the
+ * same list is returned.
+ */
 export async function getAvailableTimezones(): Promise<Timezone[]> {
   if (memoizedAvailableTimezones == null) {
     memoizedAvailableTimezones = await getAvailableTimezonesFromDB();
@@ -25,6 +30,16 @@ export async function getAvailableTimezones(): Promise<Timezone[]> {
   return memoizedAvailableTimezones;
 }
 
+/**
+ * Returns a filtered list of canonical timezones that are supported by both
+ * Postgres and the JavaScript Intl API. As per the specification of
+ * Intl.supportedValuesOf('timeZone'), the list includes only canonical timezone
+ * names, and does not include aliases or deprecated names.
+ *
+ * @param alwaysInclude - Optional array of timezone names to always include in
+ * the result, even if they're not canonical. These timezones are only included
+ * if they're supported by Postgres.
+ */
 export async function getCanonicalTimezones(alwaysInclude?: string[]): Promise<Timezone[]> {
   const availableTimezones = await getAvailableTimezones();
   const canonicalTimezones = Intl.supportedValuesOf('timeZone');

--- a/apps/prairielearn/src/lib/timezones.ts
+++ b/apps/prairielearn/src/lib/timezones.ts
@@ -42,9 +42,13 @@ export async function getAvailableTimezones(): Promise<Timezone[]> {
  */
 export async function getCanonicalTimezones(alwaysInclude?: string[]): Promise<Timezone[]> {
   const availableTimezones = await getAvailableTimezones();
-  const canonicalTimezones = Intl.supportedValuesOf('timeZone');
+  const canonicalTimezones = new Set(Intl.supportedValuesOf('timeZone'));
+  // Intl.supportedValuesOf('timeZone') returns the list of canonical timezones,
+  // but it skips UTC and a few other entries
+  // (https://github.com/tc39/ecma402/issues/778). We include UTC manually.
+  canonicalTimezones.add('UTC');
   return availableTimezones.filter(
-    ({ name }) => canonicalTimezones.includes(name) || alwaysInclude?.includes(name),
+    ({ name }) => canonicalTimezones.has(name) || alwaysInclude?.includes(name),
   );
 }
 

--- a/apps/prairielearn/src/lib/timezones.ts
+++ b/apps/prairielearn/src/lib/timezones.ts
@@ -20,25 +20,17 @@ async function getAvailableTimezonesFromDB(): Promise<Timezone[]> {
 
 export async function getAvailableTimezones(): Promise<Timezone[]> {
   if (memoizedAvailableTimezones == null) {
-    // Different portions of the code use the timezone in either PostgreSQL or
-    // Intl, so we return only those timezones that are supported by both. While
-    // Intl provides a list of supported timezones via Intl.supportedValuesOf(),
-    // the list is not exhaustive and may not include some timezones supported
-    // by JS as aliases. Instead, we attempt to create a new DateTimeFormat
-    // element and filter out timezones for which this process returns and
-    // error.
-    const pgSupportedTimezones = await getAvailableTimezonesFromDB();
-    memoizedAvailableTimezones = pgSupportedTimezones.filter(({ name }) => {
-      try {
-        new Intl.DateTimeFormat('en-US', { timeZone: name });
-        return true;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (e) {
-        return false;
-      }
-    });
+    memoizedAvailableTimezones = await getAvailableTimezonesFromDB();
   }
   return memoizedAvailableTimezones;
+}
+
+export async function getCanonicalTimezones(alwaysInclude?: string[]): Promise<Timezone[]> {
+  const availableTimezones = await getAvailableTimezones();
+  const canonicalTimezones = Intl.supportedValuesOf('timeZone');
+  return availableTimezones.filter(
+    ({ name }) => canonicalTimezones.includes(name) || alwaysInclude?.includes(name),
+  );
 }
 
 export async function getAvailableTimezonesByName(): Promise<Map<string, Timezone>> {

--- a/apps/prairielearn/src/lib/timezones.ts
+++ b/apps/prairielearn/src/lib/timezones.ts
@@ -20,7 +20,12 @@ async function getAvailableTimezonesFromDB(): Promise<Timezone[]> {
 
 export async function getAvailableTimezones(): Promise<Timezone[]> {
   if (memoizedAvailableTimezones == null) {
-    memoizedAvailableTimezones = await getAvailableTimezonesFromDB();
+    // Different portions of the code use the timezone in either PostgreSQL or
+    // Intl, so we return only those timezones that are supported by both.
+    const jsSupportedTimezones = Intl.supportedValuesOf('timeZone');
+    memoizedAvailableTimezones = (await getAvailableTimezonesFromDB()).filter(({ name }) =>
+      jsSupportedTimezones.includes(name),
+    );
   }
   return memoizedAvailableTimezones;
 }

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
@@ -4,7 +4,7 @@ import asyncHandler from 'express-async-handler';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
-import { getAvailableTimezones } from '../../lib/timezones.js';
+import { getCanonicalTimezones } from '../../lib/timezones.js';
 
 import {
   AdministratorInstitutions,
@@ -18,7 +18,7 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     const institutions = await sqldb.queryRows(sql.select_institutions, InstitutionRowSchema);
-    const availableTimezones = await getAvailableTimezones();
+    const availableTimezones = await getCanonicalTimezones();
     res.send(
       AdministratorInstitutions({ institutions, availableTimezones, resLocals: res.locals }),
     );

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -12,7 +12,7 @@ import { flash } from '@prairielearn/flash';
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { CourseInfoCreateEditor, FileModifyEditor } from '../../lib/editors.js';
 import { getPaths } from '../../lib/instructorFiles.js';
-import { getAvailableTimezones } from '../../lib/timezones.js';
+import { getCanonicalTimezones } from '../../lib/timezones.js';
 import { updateCourseShowGettingStarted } from '../../models/course.js';
 
 import { InstructorCourseAdminSettings } from './instructorCourseAdminSettings.html.js';
@@ -26,7 +26,7 @@ router.get(
     const courseInfoExists = await fs.pathExists(
       path.join(res.locals.course.path, 'infoCourse.json'),
     );
-    const availableTimezones = await getAvailableTimezones();
+    const availableTimezones = await getCanonicalTimezones([res.locals.course.display_timezone]);
 
     let origHash = '';
     if (courseInfoExists) {

--- a/apps/prairielearn/src/schemas/schemas/infoCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourse.json
@@ -24,9 +24,8 @@
       "type": "string"
     },
     "timezone": {
-      "description": "The timezone for all date input and display (e.g., \"America/Chicago\", from the TZ column at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).",
-      "type": "string",
-      "default": "America/Chicago"
+      "description": "The timezone for all date input and display (e.g., \"America/Chicago\"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred.",
+      "type": "string"
     },
     "options": {
       "description": "Options for this course.",

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -24,9 +24,8 @@
       "type": "string"
     },
     "timezone": {
-      "description": "The timezone for all date input and display (e.g., \"America/Chicago\", from the TZ column at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).",
-      "type": "string",
-      "default": "America/Chicago"
+      "description": "The timezone for all date input and display (e.g., \"America/Chicago\"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred. If not specified, the timezone of the course will be used.",
+      "type": "string"
     },
     "allowIssueReporting": {
       "description": "DEPRECATED -- do not use.",


### PR DESCRIPTION
The institution/course/course instance timezone is used in different parts of the code, sometimes in conversions done via sprocs/queries (i.e., using Postgres), sometimes via the formatter package (i.e., using JS Intl). Postgres supports some timezones that are not supported by Intl. If a user selects one of these timezones, this can cause an issue in pages that use the formatter package (which will gradually be used more often, so this may happen more often for these timezones).

This PR changes the lib function that populates dropdowns for timezones to filter only those timezones supported by both Postgres and Intl.

AFAIK there is no restriction in sync currently that checks if the timezone is valid, and this PR does not attempt to add this restriction in sync. So this PR attempts to avoid the issue when the UI is used to update the timezone, but not for JSON updates. It also does not address server-side validation of UI values.

I did a bit of checking locally to check which timezones are not supported, and other than a timezone named "Factory", all other unsupported timezones have the `posix/` prefix.

I should point out that the production server (at least the CA one) does not currently have the `posix/*` or `Factory` timezones, I'm not sure why. What this tells me is that this is unlikely to be a problem in production at this point.

Fixes #11619.