### PR TITLE
Fix memory leak caused by flash middleware

### DIFF
--- a/.changeset/neat-experts-look.md
+++ b/.changeset/neat-experts-look.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/flash': patch
+---
+
+Fix memory leak caused by holding reference to HTTP request

--- a/packages/flash/src/index.test.ts
+++ b/packages/flash/src/index.test.ts
@@ -7,7 +7,9 @@ import { flashMiddleware, flash } from './index.js';
 describe('flash', () => {
   it('throws an error if no session present', () => {
     assert.throw(() => {
-      flashMiddleware()({} as any, {} as any, () => {});
+      flashMiddleware()({} as any, {} as any, () => {
+        flash('notice', 'Hello world');
+      });
     });
   });
 

--- a/packages/flash/src/index.test.ts
+++ b/packages/flash/src/index.test.ts
@@ -10,16 +10,16 @@ describe('flash', () => {
       flashMiddleware()({} as any, {} as any, () => {
         flash('notice', 'Hello world');
       });
-    });
+    }, 'No session found on request');
   });
 
   it('throws an error when middleware is not used', () => {
     assert.throw(() => {
       flash('notice', 'Hello world');
-    });
+    }, 'flash() must be called within a request');
     assert.throw(() => {
       flash('notice', html`<p>hello ${'&'} world</p>`);
-    });
+    }, 'flash() must be called within a request');
   });
 
   it('adds a flash using string message', () => {

--- a/packages/flash/src/index.ts
+++ b/packages/flash/src/index.ts
@@ -62,28 +62,46 @@ interface FlashStorage {
 }
 
 function makeFlashStorage(req: Request): FlashStorage {
-  const session = (req as any).session;
+  // The "flash storage" object will be stored in `AsyncLocalStorage` for the
+  // request. If we start some async I/O during a request (such as opening a
+  // database connection or a socket connection to Docker), that would by
+  // default keep the async context, and thus the request. This would prevent
+  // the request object (and any data associated with it) from being garbage
+  // collected. We use a `WeakRef` to fix this.
+  //
+  // This should always be safe, as the request object won't be garbage
+  // collected until the response has been sent, and we should never be reading
+  // or writing flash messages after the response has been sent.
+  const reqRef = new WeakRef(req);
 
-  if (!session) {
-    throw new Error('@prairielearn/flash requires session support');
+  function getSession() {
+    const req = reqRef.deref();
+    const session = (req as any).session;
+    if (!session) throw new Error('No session found on request');
+    return session;
   }
 
   return {
     add(type: FlashMessageType, message: string | HtmlSafeString) {
+      const session = getSession();
       session.flash ??= [];
       session.flash.push({ type, message: html`${message}`.toString() });
     },
     get(type: FlashMessageType) {
+      const session = getSession();
       const messages = session.flash ?? [];
       return messages.filter((message: FlashMessage) => message.type === type);
     },
     getAll() {
+      const session = getSession();
       return session.flash ?? [];
     },
     clear(type: FlashMessageType) {
+      const session = getSession();
       session.flash = session.flash?.filter((message: FlashMessage) => message.type !== type) ?? [];
     },
     clearAll() {
+      const session = getSession();
       session.flash = [];
     },
   } satisfies FlashStorage;

--- a/packages/flash/src/index.ts
+++ b/packages/flash/src/index.ts
@@ -76,6 +76,7 @@ function makeFlashStorage(req: Request): FlashStorage {
 
   function getSession() {
     const req = reqRef.deref();
+    if (!req) throw new Error('Request has been garbage collected');
     const session = (req as any).session;
     if (!session) throw new Error('No session found on request');
     return session;


### PR DESCRIPTION
We recently discovered a memory leak that's very similar to the one that we fixed in https://github.com/PrairieLearn/PrairieLearn/pull/7092. In short: if a Docker code caller times out, the code caller pool will create a new one. This technically occurs in the context of the current request. Creating a new code caller creates a new `Socket` to talk to it, and Node's async-context-tracking system will keep a reference to any active `AsyncLocalStorage` instances for that new socket. The flash middleware uses `AsyncLocalStorage`, and indirectly retains a reference to the request object. That, in turn, references the response object, which includes `res.locals`, which can get very big (ironically, it's extra-likely to be big when a code caller times out since we're more likely dealing with huge submissions). Put together, that means we end up hanging on to a potentially-huge `res.locals` object far beyond when we'd actually need it. It'll stay in memory for as long as the Docker code caller lives, which could be arbitrarily long.

To resolve this, we use a [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) in the flash middleware to hold the request object. This allows it to be garbage collected when there are no other remaining references to it.

For posterity, one can reproduce the memory leak (and lack thereof after this fix) with a few small changes.

First, update `zygote.py` to include a `time.sleep(20)` at some point before processing results are written back to `stdout`; this will reliably trigger a timeout.

Next, update `instructorQuestionPreview.ts` to write a large string to `res.locals` in the `GET` handler:

```ts
res.locals.bigString = Array.from({ length: 1e7 }, () =>
  String.fromCharCode(97 + Math.floor(Math.random() * 26)),
).join('');
```

Finally, boot up PL, attach a debugger, make a request to an instructor question preview page, trigger a garbage collection from the debugger, and take a heap snapshot. Before this fix, you'd be able to easily find a 10MB string in the retained data. After this fix, it won't be there 🎉