### PR TITLE
Add issue templates that set the issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,11 @@
+name: Bug Report
+description: An unexpected problem or unintended behavior
+body:
+  - type: textarea
+    attributes:
+      label: Details
+      placeholder: |
+        Type your description here...
+    validations:
+      required: true
+type: Bug

--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -4,8 +4,7 @@ body:
   - type: textarea
     attributes:
       label: Details
-      placeholder: |
-        Type your description here...
+      placeholder: Type your description here...
     validations:
       required: true
 type: Bug

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -1,0 +1,11 @@
+name: Feature Request / Enhancement
+description: A request, idea, or new functionality
+body:
+  - type: textarea
+    attributes:
+      label: Details
+      placeholder: |
+        Type your description here...
+    validations:
+      required: true
+type: Enhancement

--- a/.github/ISSUE_TEMPLATE/2-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/2-enhancement.yml
@@ -4,8 +4,7 @@ body:
   - type: textarea
     attributes:
       label: Details
-      placeholder: |
-        Type your description here...
+      placeholder: Type your description here...
     validations:
       required: true
 type: Enhancement


### PR DESCRIPTION
I'm hoping this can help categorize issues as either bug or enhancement when instructors report them.

I am very aware and also dislike those verbose "Bug report" templates. All this template does is set the type field for triaging, and should otherwise look identical to the "Blank Issue" template.

My thinking is that this forces reporters to decide if they are reporting a bug, or requesting a feature, or neither so that we can prioritize. I think without this click, the odds that someone sets the type is low, which puts more burden on the maintainers.