### PR TITLE
Remove supported browsers list from workspace docs

### DIFF
--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -2,14 +2,6 @@
 
 Workspaces allow students to work in persistent remote containers via in-browser frontends such as VS Code and JupyterLab. The remote containers are configured by instructors to provide custom, uniform environments per question. Workspace questions are integrated with the standard PrairieLearn autograding pipeline.
 
-## Supported browsers
-
-- [x] Chrome is supported
-- [x] Firefox is supported
-- [x] Safari is supported
-- [x] Edge Chromium (version >= 79) is supported
-- [ ] Edge Legacy (version < 79) is untested
-
 ## Directory structure
 
 ```text


### PR DESCRIPTION
This list won't be different from PrairieLearn as a whole; it's not clear why this was added to the workspace docs specifically.

I don't think we need to call out that Edge Legacy is untested, either here or anywhere. It hasn't seen a release in 4 years and per [caniuse.com](https://caniuse.com/usage-table), its usage is 0.09%.