### PR TITLE
Don't store workspace files in raw_submitted_answer

### DIFF
--- a/apps/prairielearn/src/lib/grading.ts
+++ b/apps/prairielearn/src/lib/grading.ts
@@ -187,8 +187,7 @@ export async function saveSubmission(
 ): Promise<{ submission_id: string; variant: Variant }> {
   const submission: Partial<Submission> & SubmissionDataForSaving = {
     ...submissionData,
-    // This is cloned to avoid double-storing workspace files.
-    raw_submitted_answer: structuredClone(submissionData.submitted_answer),
+    raw_submitted_answer: submissionData.submitted_answer,
     gradable: true,
   };
 
@@ -207,6 +206,15 @@ export async function saveSubmission(
         // if we have workspace files, encode them into _files
         if (zipPath != null) {
           const zip = fs.createReadStream(zipPath).pipe(unzipper.Parse({ forceStream: true }));
+
+          // Up until this point, `raw_submitted_answer` was just a reference to
+          // the `submitted_answer` object. If we naively wrote to
+          // `submitted_answer._files`, we'd end up storing the files twice in
+          // the database. To avoid this, we'll create a deep copy of
+          // `raw_submitted_answer` to ensure that we don't end up with
+          // duplicate file entries.
+          submission.raw_submitted_answer = structuredClone(submission.raw_submitted_answer);
+
           if (!('_files' in submission.submitted_answer)) {
             submission.submitted_answer['_files'] = [];
           }

--- a/apps/prairielearn/src/lib/grading.ts
+++ b/apps/prairielearn/src/lib/grading.ts
@@ -187,7 +187,8 @@ export async function saveSubmission(
 ): Promise<{ submission_id: string; variant: Variant }> {
   const submission: Partial<Submission> & SubmissionDataForSaving = {
     ...submissionData,
-    raw_submitted_answer: submissionData.submitted_answer,
+    // This is cloned to avoid double-storing workspace files.
+    raw_submitted_answer: structuredClone(submissionData.submitted_answer),
     gradable: true,
   };
 


### PR DESCRIPTION
Workspace files can be very large; double storing them in both `submitted_answers` and `raw_submitted_answers` is wasteful and should be unnecessary. There's a very small chance that this impacts course code, but I think that's unlikely. I grepped for `raw_submitted_answers.*files` in all courses and there weren't any hits. If this breaks any questions, there's a simple fix: just use `sumbitted_answers` instead.