### PR TITLE
Add buildcache for docker images

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -63,7 +63,8 @@ jobs:
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }}
-          cache-to: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max
+          # Only export the cache on the default branch
+          cache-to: ${{ github.ref_name == github.event.repository.default_branch && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max' || '' }}
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -165,7 +166,8 @@ jobs:
           tags: '${{ inputs.image-prefix }}${{ matrix.image }}:${{ github.sha }}-${{ runner.arch }}'
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }}
-          cache-to: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max
+          # Only export the cache on the default branch
+          cache-to: ${{ github.ref_name == github.event.repository.default_branch && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max' || '' }}
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -64,7 +64,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
+          cache-to: ${{ github.ref_name == github.event.repository.default_branch && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -167,7 +167,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
+          cache-to: ${{ github.ref_name == github.event.repository.default_branch && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -64,7 +64,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-${2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
+          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -167,7 +167,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-${2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
+          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -64,7 +64,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }},mode=max' || '' }}
+          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-${2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -167,7 +167,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }},mode=max' || '' }}
+          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && format('type=registry,ref={0}-{1}:buildcache-${2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -64,7 +64,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ github.ref_name == github.event.repository.default_branch && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
+          cache-to: ${{ (true || github.ref_name == github.event.repository.default_branch) && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -167,7 +167,7 @@ jobs:
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
           cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ github.ref_name == github.event.repository.default_branch && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
+          cache-to: ${{ (true || github.ref_name == github.event.repository.default_branch) && format('type=registry,ref={0}-{1}:buildcache-{2},mode=max', inputs.image-prefix, matrix.image, runner.arch) || '' }}
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -61,6 +61,9 @@ jobs:
           context: ${{ inputs.directory }}/${{ matrix.image }}
           tags: '${{ inputs.image-prefix }}${{ matrix.image }}:${{ github.sha }}-${{ runner.arch }}'
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
+          # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
+          cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }}
+          cache-to: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -160,6 +163,9 @@ jobs:
           # We will tag using a platform-specific image instead of doing a push-by-digest (https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners).
           # We want to use the default docker builder, as buildx uses `docker-container`, which has additional overhead to load local images (https://docs.docker.com/build/ci/github-actions/named-contexts/#using-with-a-container-builder).
           tags: '${{ inputs.image-prefix }}${{ matrix.image }}:${{ github.sha }}-${{ runner.arch }}'
+          # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
+          cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }}
+          cache-to: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -62,9 +62,9 @@ jobs:
           tags: '${{ inputs.image-prefix }}${{ matrix.image }}:${{ github.sha }}-${{ runner.arch }}'
           push: ${{ env.CAN_PUSH_IMAGE == 'true' }}
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
-          cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }}
+          cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ github.ref_name == github.event.repository.default_branch && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max' || '' }}
+          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }},mode=max' || '' }}
 
       # Export the base image as a tarball (See https://docs.docker.com/build/ci/github-actions/share-image-jobs/)
       - name: Export tarball
@@ -165,9 +165,9 @@ jobs:
           # We want to use the default docker builder, as buildx uses `docker-container`, which has additional overhead to load local images (https://docs.docker.com/build/ci/github-actions/named-contexts/#using-with-a-container-builder).
           tags: '${{ inputs.image-prefix }}${{ matrix.image }}:${{ github.sha }}-${{ runner.arch }}'
           # These need to be os-specific caches (https://github.com/docker/buildx/discussions/1382)
-          cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }}
+          cache-from: type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }}
           # Only export the cache on the default branch
-          cache-to: ${{ github.ref_name == github.event.repository.default_branch && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.os }},mode=max' || '' }}
+          cache-to: ${{ (github.ref_name == github.event.repository.default_branch || true) && 'type=registry,ref=${{ inputs.image-prefix }}-${{ matrix.image }}:buildcache-${{ runner.arch }},mode=max' || '' }}
 
       - name: Export metadata
         if: ${{ steps.check-modified.outputs.was-modified == 'true' }}

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -52,6 +52,7 @@ def execute_code(
     - include_plt: If true, plots will be included in grading results.
     - console_output_fname: Filename to redirect console output to.
     - test_iter_num: The iteration number of this test, when test cases are run multiple times.
+    - ipynb_key: The key to use for extracting the student code from an ipynb file
 
     Returns:
     - ref_result: A named tuple with reference variables


### PR DESCRIPTION
Resolves #11597

Pushes a buildcache for arm and x86 on default branches. This should avoid rebuilding some steps from the Dockerfile. When pulling images, it downloads from `tag:buildcache-AMD64` or `tag:buildcache-X64`. This should in theory provide another practical speedup for building images in CI (i.e. the c image, saving 10/12 minutes of the build time if it has changed).