### PR TITLE
Bump dockerode to 4.0.5

### DIFF
--- a/apps/grader-host/package.json
+++ b/apps/grader-host/package.json
@@ -27,7 +27,7 @@
     "@prairielearn/sentry": "workspace:^",
     "async": "^3.2.6",
     "byline": "^5.0.0",
-    "dockerode": "^4.0.4",
+    "dockerode": "^4.0.5",
     "execa": "^9.5.2",
     "fs-extra": "^11.3.0",
     "logform": "^2.7.0",

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -90,7 +90,7 @@
     "date-fns-tz": "^3.2.0",
     "debug": "^4.4.0",
     "delegated-events": "^1.1.2",
-    "dockerode": "^4.0.4",
+    "dockerode": "^4.0.5",
     "dompurify": "^3.2.4",
     "dropzone": "^5.9.3",
     "ejs": "^3.1.10",

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -32,7 +32,7 @@
     "async-mutex": "^0.5.0",
     "body-parser": "^1.20.3",
     "debug": "^4.4.0",
-    "dockerode": "^4.0.4",
+    "dockerode": "^4.0.5",
     "express": "^4.21.2",
     "express-async-handler": "^1.2.0",
     "ioredis": "^5.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3462,7 +3462,7 @@ __metadata:
     c8: "npm:^10.1.3"
     chai: "npm:^5.2.0"
     chai-as-promised: "npm:^8.0.1"
-    dockerode: "npm:^4.0.4"
+    dockerode: "npm:^4.0.5"
     execa: "npm:^9.5.2"
     fs-extra: "npm:^11.3.0"
     logform: "npm:^2.7.0"
@@ -3848,7 +3848,7 @@ __metadata:
     date-fns-tz: "npm:^3.2.0"
     debug: "npm:^4.4.0"
     delegated-events: "npm:^1.1.2"
-    dockerode: "npm:^4.0.4"
+    dockerode: "npm:^4.0.5"
     dompurify: "npm:^3.2.4"
     dropzone: "npm:^5.9.3"
     ejs: "npm:^3.1.10"
@@ -4095,7 +4095,7 @@ __metadata:
     c8: "npm:^10.1.3"
     chai: "npm:^5.2.0"
     debug: "npm:^4.4.0"
-    dockerode: "npm:^4.0.4"
+    dockerode: "npm:^4.0.5"
     express: "npm:^4.21.2"
     express-async-handler: "npm:^1.2.0"
     fast-glob: "npm:^3.3.3"
@@ -8478,18 +8478,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dockerode@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "dockerode@npm:4.0.4"
+"dockerode@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "dockerode@npm:4.0.5"
   dependencies:
     "@balena/dockerignore": "npm:^1.0.2"
     "@grpc/grpc-js": "npm:^1.11.1"
     "@grpc/proto-loader": "npm:^0.7.13"
     docker-modem: "npm:^5.0.6"
     protobufjs: "npm:^7.3.2"
-    tar-fs: "npm:~2.0.1"
+    tar-fs: "npm:~2.1.2"
     uuid: "npm:^10.0.0"
-  checksum: 10c0/02394f2bfd68eb74381488b3294b09439e2ec8506ea5c50aa78a3e419e787598ff3b1c60e3233a7dc4e503577ba94c3b1cfe6c8d05d8427b684f4c5930330ec8
+  checksum: 10c0/a9b9024d8afc40788a195740bf9cf60e92def44ee3e046c3497b0c6a0f49c46ea07e6e89d248daf3c391c66cb260aaf1111badb73f85db54e0d106b1e760aa19
   languageName: node
   linkType: hard
 
@@ -15487,19 +15487,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "tar-fs@npm:2.0.1"
+"tar-fs@npm:~2.1.2":
+  version: 2.1.2
+  resolution: "tar-fs@npm:2.1.2"
   dependencies:
     chownr: "npm:^1.1.1"
     mkdirp-classic: "npm:^0.5.2"
     pump: "npm:^3.0.0"
-    tar-stream: "npm:^2.0.0"
-  checksum: 10c0/0128e888b61c7c4e8e7997d66ceccc3c79d73c01e87cfcc3d9f6b8555b0c88b8d67d91ff167f00b067f726dde497b2d1fb2bba0cfcb3ccb95ae413cb86c715bc
+    tar-stream: "npm:^2.1.4"
+  checksum: 10c0/9c704bd4a53be7565caf34ed001d1428532457fe3546d8fc1233f0f0882c3d2403f8602e8046e0b0adeb31fe95336572a69fb28851a391523126b697537670fc
   languageName: node
   linkType: hard
 
-"tar-stream@npm:^2.0.0":
+"tar-stream@npm:^2.1.4":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
Resolves a dependabot alert on an indirect dependency.