### PR TITLE
UI tweaks to the formula tooltip in rich text editor

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.css
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.css
@@ -5,7 +5,7 @@
 }
 
 .pl-rich-text-editor-container .ql-tooltip {
-  z-index: 1000;
+  z-index: 1;
 }
 
 .pl-rich-text-editor-container:focus-within {

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.css
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.css
@@ -4,6 +4,10 @@
   font-size: inherit;
 }
 
+.pl-rich-text-editor-container .ql-tooltip {
+  z-index: 1000;
+}
+
 .pl-rich-text-editor-container:focus-within {
   outline: 0.2rem solid rgb(0 123 255 / 25%);
   box-shadow: unset;

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -103,6 +103,11 @@
       },
     };
 
+    // Set the bounds for UI elements (e.g., the tooltip for the formula editor)
+    // to the question container.
+    // https://quilljs.com/docs/configuration#bounds
+    options.bounds = document.getElementById(`rte-${uuid}`).closest('.question-container');
+
     let inputElement = $('#rte-input-' + uuid);
     let quill = new Quill('#rte-' + uuid, options);
     let renderer = null;


### PR DESCRIPTION
Fixes #11653. Increases the Z index of the tooltip, and ensures it is always contained within the question container.

Before:

![image](https://github.com/user-attachments/assets/e2d94ca0-9e24-4b06-b1a6-ff1461cbdbb7)

After:

![image](https://github.com/user-attachments/assets/704a46d5-d6c8-408e-b2e9-5d4ac01579cf)
