### PR TITLE
Fix question link on instructor question preview workspaces

### DIFF
--- a/apps/prairielearn/src/pages/workspace/workspace.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.ts
@@ -37,7 +37,6 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     let navTitle: string, pageTitle: string | undefined, pageNote: string | undefined;
-
     if (res.locals.assessment == null) {
       // instructor preview
       pageTitle = 'Workspace Preview';

--- a/apps/prairielearn/src/pages/workspace/workspace.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.ts
@@ -37,11 +37,12 @@ router.get(
   '/',
   asyncHandler(async (req, res) => {
     let navTitle: string, pageTitle: string | undefined, pageNote: string | undefined;
+
     if (res.locals.assessment == null) {
       // instructor preview
       pageTitle = 'Workspace Preview';
-      pageNote = res.locals.question_qid;
-      navTitle = res.locals.question_qid;
+      pageNote = res.locals.question.qid;
+      navTitle = res.locals.question.qid;
     } else {
       // student assessment
       pageTitle = 'Workspace';


### PR DESCRIPTION
This was a regression from #11630. Turns out that `question_qid` wasn't quite as unused as we thought it was!

Using `question.qid` will be safe because we'll have run `selectAndAuthzInstructorQuestion` by this point:

https://github.com/PrairieLearn/PrairieLearn/blob/984dc62b2bd67868670cd71f8683af3d6c2c40f9/apps/prairielearn/src/middlewares/authzWorkspace.ts#L80