### PR TITLE
Filter issues by assessment

### DIFF
--- a/apps/prairielearn/src/components/IssueBadge.html.ts
+++ b/apps/prairielearn/src/components/IssueBadge.html.ts
@@ -33,16 +33,16 @@ export function IssueBadge({
 
   if (issueAid) {
     return html`
-    <a
-      class="badge rounded-pill text-bg-danger ${className ?? ''}"
-      href="${urlPrefix}/course_admin/issues${issueAid
-        ? `?q=is%3Aopen+assessment%3A${encodeURIComponent(issueAid)}`
-        : ''}"
-      aria-label="${count} open ${count === 1 ? 'issue' : 'issues'}"
-    >
-      ${count}
-    </a>
-  `;
+      <a
+        class="badge rounded-pill text-bg-danger ${className ?? ''}"
+        href="${urlPrefix}/course_admin/issues${issueAid
+          ? `?q=is%3Aopen+assessment%3A${encodeURIComponent(issueAid)}`
+          : ''}"
+        aria-label="${count} open ${count === 1 ? 'issue' : 'issues'}"
+      >
+        ${count}
+      </a>
+    `;
   }
 
   return html`

--- a/apps/prairielearn/src/components/IssueBadge.html.ts
+++ b/apps/prairielearn/src/components/IssueBadge.html.ts
@@ -4,6 +4,7 @@ export function IssueBadge({
   count,
   suppressLink,
   issueQid,
+  issueAid,
   urlPrefix,
   className,
 }: {
@@ -14,11 +15,13 @@ export function IssueBadge({
       suppressLink: true;
       urlPrefix?: undefined;
       issueQid?: undefined;
+      issueAid?: undefined;
     }
   | {
       suppressLink?: false;
       urlPrefix: string;
       issueQid?: string | null;
+      issueAid?: string | null;
     }
 )) {
   // Convert explicitly to a number because some unvalidated queries still return a string (via bigint)
@@ -26,6 +29,20 @@ export function IssueBadge({
 
   if (suppressLink) {
     return html`<span class="badge rounded-pill text-bg-danger ${className ?? ''}">${count}</span>`;
+  }
+
+  if (issueAid) {
+    return html`
+    <a
+      class="badge rounded-pill text-bg-danger ${className ?? ''}"
+      href="${urlPrefix}/course_admin/issues${issueAid
+        ? `?q=is%3Aopen+assessment%3A${encodeURIComponent(issueAid)}`
+        : ''}"
+      aria-label="${count} open ${count === 1 ? 'issue' : 'issues'}"
+    >
+      ${count}
+    </a>
+  `;
   }
 
   return html`

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -154,7 +154,7 @@ export function InstructorAssessments({
                                 ? html` <i class="fas fa-users" aria-hidden="true"></i> `
                                 : ''}
                             </a>
-                            ${IssueBadge({ count: row.open_issue_count, urlPrefix })}
+                            ${IssueBadge({ count: row.open_issue_count, urlPrefix, issueAid: row.tid })}
                           </td>
 
                           <td class="align-middle">${row.tid}</td>

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.ts
@@ -154,7 +154,11 @@ export function InstructorAssessments({
                                 ? html` <i class="fas fa-users" aria-hidden="true"></i> `
                                 : ''}
                             </a>
-                            ${IssueBadge({ count: row.open_issue_count, urlPrefix, issueAid: row.tid })}
+                            ${IssueBadge({
+                              count: row.open_issue_count,
+                              urlPrefix,
+                              issueAid: row.tid,
+                            })}
                           </td>
 
                           <td class="align-middle">${row.tid}</td>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -34,6 +34,7 @@ WITH
       issues AS i
       LEFT JOIN questions AS q ON (q.id = i.question_id)
       LEFT JOIN users AS u ON (u.user_id = i.user_id)
+      LEFT JOIN assessments AS a ON (a.id = i.assessment_id)
     WHERE
       i.course_id = $course_id
       AND (
@@ -67,6 +68,14 @@ WITH
       AND (
         $filter_not_users::text[] IS NULL
         OR u.uid NOT ILIKE ANY ($filter_not_users::text[])
+      )
+      AND (
+        $filter_assessments::text[] IS NULL
+        OR a.tid ILIKE ANY ($filter_assessments::text[])
+      )
+      AND (
+        $filter_not_assessments::text[] IS NULL
+        OR a.tid NOT ILIKE ANY ($filter_not_assessments::text[])
       )
       AND (
         $filter_query_text::text IS NULL

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.ts
@@ -39,6 +39,8 @@ function parseRawQuery(str: string) {
     filter_query_text: null as string | null,
     filter_users: null as string[] | null,
     filter_not_users: null as string[] | null,
+    filter_assessments: null as string[] | null,
+    filter_not_assessments: null as string[] | null,
   };
 
   const queryText = parsedQuery.getAllText();
@@ -80,6 +82,15 @@ function parseRawQuery(str: string) {
         } else {
           filters.filter_not_users = filters.filter_not_users || [];
           filters.filter_not_users.push(formatForLikeClause(option.value));
+        }
+        break;
+      case 'assessment':
+        if (!option.negated) {
+          filters.filter_assessments = filters.filter_assessments || [];
+          filters.filter_assessments.push(formatForLikeClause(option.value));
+        } else {
+          filters.filter_not_assessments = filters.filter_not_assessments || [];
+          filters.filter_not_assessments.push(formatForLikeClause(option.value));
         }
         break;
     }


### PR DESCRIPTION
When viewing issues there have been times where it would be nice to just see issues from a specific assessment. I could not see a way to do this (hopefully I did not miss anything?) so I added a way to do this.

- Adds an assessment option to the filter based on the AID of an assessment

![filter option](https://github.com/user-attachments/assets/71f1e0f7-6410-4e70-abae-926705025e7c)

- Updates the assessments page issue badge to link to the specific assessment through this filter

![updated URL](https://github.com/user-attachments/assets/ae492d71-bb5e-469b-8e71-d0bfba7c8a4d)