### PR TITLE
Hide explanation of local external grader and workspace setup

### DIFF
--- a/docs/PrairieDraw.md
+++ b/docs/PrairieDraw.md
@@ -211,7 +211,7 @@ These files should be committed to the `git` repository and pushed to the live s
 
 ## Advanced: Running without Docker
 
-If you want to generate LaTeX label images without docker then you will need to install [Python](https://www.python.org), [ImageMagick](http://www.imagemagick.org/), and [LaTeX](http://tug.org/texlive/) and then run the following command in the root of the PrairieLearn repository:
+If you want to generate LaTeX label images without Docker then you will need to install [Python](https://www.python.org), [ImageMagick](http://www.imagemagick.org/), and [LaTeX](http://tug.org/texlive/) and then run the following command in the root of the PrairieLearn repository:
 
 ```sh
 python contrib/generate_text.py --subdir /path/to/course

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,7 +30,7 @@ brackets being optional.
 
 ## Useful commands
 
-In all of these commands, `IMAGE` refers to a docker image; if you built the
+In all of these commands, `IMAGE` refers to a Docker image; if you built the
 image manually (with `docker build`), then you should use `prairielearn`. If
 you downloaded it (following the installation guide), use
 `prairielearn/prairielearn`.
@@ -79,11 +79,11 @@ This section describes common applications for [Docker Compose](https://github.c
 
 ### Basics
 
-A docker-compose file describes the services an application needs to run. In our case, we use `docker-compose` to configure and run the PrairieLearn docker container locally.
+A docker-compose file describes the services an application needs to run. In our case, we use `docker-compose` to configure and run the PrairieLearn Docker container locally.
 
 To run PrairieLearn with `docker-compose`, run `docker-compose up pl`. This will, in order:
 
-- Build the PL docker image, and tag it as `prairielearn/prairielearn:local`
+- Build the PrairieLearn Docker image, and tag it as `prairielearn/prairielearn:local`
 - Mount `./testCourse` as a volume for a test course
 - Set up the container to run [external grading jobs](externalGrading.md)
 - Mount the current directory as `/PrairieLearn`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -312,10 +312,10 @@ See [The Grading Process section in Externally graded questions](externalGrading
 ## Why can't I launch PrairieLearn with docker?
 
 When previewing content within a local copy of PrairieLearn, the web version
-is powered by a docker container. At the end of a session, closing out of
-either the web browser or the terminal that launched the docker container
+is powered by a Docker container. At the end of a session, closing out of
+either the web browser or the terminal that launched the Docker container
 will **not** stop PrairieLearn from running. Therefore, when relaunching the
-docker version of PrairieLearn, the existing port may already be taken.
+Docker version of PrairieLearn, the existing port may already be taken.
 For example, we would have:
 
 ```bash

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -80,7 +80,7 @@ If Docker's Rosetta option isn't enabled, first check Apple's instructions to [i
 
 There are a few extra steps needed to run PrairieLearn locally with support for external graders and workspaces.
 
-First, create an empty directory to use to share job data between containers. This directory can live anywhere, but needs to be created first and referenced in the docker launch command. This directory only needs to be created once. If you are running Windows, the directory should be created inside the WSL 2 instance. You can create this directory using a command like:
+First, create an empty directory to use to share job data between containers. This directory can live anywhere, but needs to be created first and referenced in the Docker launch command. This directory only needs to be created once. If you are running Windows, the directory should be created inside the WSL 2 instance. You can create this directory using a command like:
 
 ```bash
 mkdir "$HOME/pl_ag_jobs"
@@ -93,7 +93,7 @@ docker run -it --rm -p 3000:3000 \
   -v "$HOME/pl-tam212:/course" `# Replace the path with your course directory` \
   -v "$HOME/pl_ag_jobs:/jobs" `# Map the jobs directory into /jobs` \
   -e HOST_JOBS_DIR="$HOME/pl_ag_jobs" \
-  -v /var/run/docker.sock:/var/run/docker.sock `# Mount docker into itself so container can spawn others` \
+  -v /var/run/docker.sock:/var/run/docker.sock `# Mount Docker into container so it can spawn others` \
   --platform linux/amd64 `# Ensure the emulated amd64 version is used on ARM chips` \
   --add-host=host.docker.internal:172.17.0.1 `# Ensure network connectivity` \
   prairielearn/prairielearn
@@ -101,16 +101,10 @@ docker run -it --rm -p 3000:3000 \
 
 ??? question "Why is this necessary?"
 
-    In production, PrairieLearn runs external grading jobs and workspaces on a distributed system that uses a variety of AWS services to efficiently run many jobs in parallel. When developing questions locally, you won't have access to this infrastructure, but PrairieLearn allows you to still run external grading jobs and workspaces locally with a few workarounds.
+    In production, PrairieLearn runs external grading jobs and workspaces on a distributed system that can efficiently run many jobs in parallel. When developing questions locally, you won't have access to this infrastructure, but PrairieLearn allows you to still run external grading jobs and workspaces locally. To do this, it needs extra Docker command line arguments to provide two key capabilities:
 
-    - Instead of running jobs on an EC2 instance, they will be run locally and directly with Docker on the host machine.
-    - Instead of sending jobs to the grading containers with S3, we write them to a directory on the host machine and then mount that directory directly into the grading container as `/grade`.
-    - Instead of receiving an SQS message to indicate that results are available, PrairieLearn will simply wait for the grading container to die, and then attempt to read `results/results.json` from the folder that was mounted in as `/grade`.
-
-    In order to run external grading jobs when PrairieLearn is running locally inside Docker, there are a few additional preparation steps that are necessary:
-
-    - We need a way of starting up Docker containers on the host machine from within another Docker container. We achieve this by mounting the Docker socket from the host into the Docker container running PrairieLearn; this allows us to run "sibling" containers.
-    - We need to get job files from inside the Docker container running PrairieLearn to the host machine so that Docker can mount them to `/grade` on the grading machine. We achieve this by mounting a directory on the host machine to `/jobs` on the grading machine, and setting an environment variable `HOST_JOBS_DIR` containing the absolute path of that directory on the host machine.
+    - PrairieLearn needs a way of starting up Docker containers on the host machine from within another Docker container. This is achieved by mounting the Docker socket from the host into the Docker container running PrairieLearn; this allows it to run "sibling" containers.
+    - PrairieLearn needs to get job files from inside the Docker container running PrairieLearn to the host machine so that Docker can mount them to either `/grade` in the grading container or the home directory in the workspace container. This is achieved by mounting a directory on the host machine to `/jobs` in the PrairieLearn container, and setting an environment variable `HOST_JOBS_DIR` containing the absolute path of that directory on the host machine.
 
 #### Troubleshooting the --add-host option and network timeouts
 
@@ -142,6 +136,6 @@ docker run -it --rm -p 3000:3000 --pull=always [other args] prairielearn/prairie
 
 !!! tip
 
-    The command above uses the `--pull=always` option, which will update the local version of the image every time the docker command is restarted. If you keep a long-running container locally, make sure to restart the container when updates in the production servers are announced in the [PrairieLearn GitHub Discussions page](https://github.com/PrairieLearn/PrairieLearn/discussions/categories/announcements).
+    The command above uses the `--pull=always` option, which will update the local version of the image every time the Docker command is restarted. If you keep a long-running container locally, make sure to restart the container when updates in the production servers are announced in the [PrairieLearn GitHub Discussions page](https://github.com/PrairieLearn/PrairieLearn/discussions/categories/announcements).
 
 Additional tags are available for older versions. The list of available versions is viewable on the [Docker Hub build page](https://hub.docker.com/r/prairielearn/prairielearn/builds/).

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -244,7 +244,7 @@ In order to run workspaces in a local Docker environment, the `docker` command m
 
 ## Developing with workspaces (in Docker)
 
-For development, run the docker container as described in [Installing with local source code](../installingLocal.md) but also add the workspace-specific arguments described above to the docker command line. Inside the container, run:
+For development, run the Docker container as described in [Installing with local source code](../installingLocal.md) but also add the workspace-specific arguments described above to the Docker command line. Inside the container, run:
 
 ```sh
 make dev-all


### PR DESCRIPTION
Most people won't care about this; this explanation just gets in the way of the command they're looking for. This PR hides it in a collapsible section.