### PR TITLE
Move timeouts to Makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,14 +96,9 @@ jobs:
         run: docker run -td -v /var/run/docker.sock:/var/run/docker.sock -v /tmp/prairielearn:/jobs --tmpfs=/var/postgres -e HOST_JOBS_DIR=/tmp/prairielearn --name=test_container prairielearn/prairielearn /bin/bash
       - name: Run the JavaScript tests
         run: docker exec test_container sh -c "make -s -C /PrairieLearn test-js"
-        # The JS tests hang relatively often when someone makes a mistake in a PR,
-        # and the GitHub Actions default timeout is 6 hours, so the CI run keeps
-        # spinning until it eventually times out. This shorter timeout helps
-        # ensure that the tests fail more quickly so that people can fix them.
-        timeout-minutes: 30
+
       - name: Run the Python tests
         run: docker exec test_container sh -c "make -s -C /PrairieLearn test-python"
-        timeout-minutes: 1
 
       # Since tests run in the context of the container, we need to copy all
       # the coverage reports out of the container and into the host filesystem.
@@ -203,7 +198,6 @@ jobs:
         run: make lint-python
       - name: Run the Python tests
         run: make test-python
-        timeout-minutes: 5
       - name: Run the Dockerfile linter
         run: make lint-docker
       - name: Run the Shellcheck linter

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ start-s3rver:
 
 test: test-js test-python
 test-js: start-support
-	@yarn turbo run test
+	@timeout 1800 yarn turbo run test
 test-js-dist: start-support
-	@yarn turbo run test:dist
+	@timeout 1800 yarn turbo run test:dist
 test-python:
-	@python3 -m pytest
-	@python3 -m coverage xml -o ./apps/prairielearn/python/coverage.xml
+	@timeout 60 python3 -m pytest
+	@timeout 60 python3 -m coverage xml -o ./apps/prairielearn/python/coverage.xml
 test-prairielearn: start-support
 	@yarn workspace @prairielearn/prairielearn run test
 


### PR DESCRIPTION
- Lessens difference between CI and Makefile