### PR TITLE
Fix workspace proxy path rewriting

### DIFF
--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -89,7 +89,6 @@ export function makeWorkspaceProxyMiddleware() {
       // The path provided to this function doesn't include the full path with
       // the `/pl/workspace/<workspace_id>/container/` prefix, so we need to
       // reconstruct it from the request.
-      //
       const path = getRequestPath(req);
       return WORKSPACE_CONTAINER_PATH_REGEXP.test(path);
     },


### PR DESCRIPTION
This was a regression introduced by #11664. `pathRewrite` got a path without the `/pl/workspace/...` prefix, which broke workspaces like Jupyterlab that depended on that. I tested the changes in this PR with both the VSCode and Jupyterlab workspaces (the first uses rewriting, the second does not) and things are working well now.