### PR TITLE
Add network config to Docker compose file

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -13,6 +13,10 @@ services:
     environment:
       - HOST_JOBS_DIR=${HOME}/pl_ag_jobs
       - NODE_ENV=production
+    # This must be changed if you've changed Docker's address pools.
+    # i.e., "default-address-pools" in /etc/docker/daemon.json
+    extra_hosts:
+      - "host.docker.internal:172.17.0.1"
 
 volumes:
   postgres:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -16,7 +16,7 @@ services:
     # This must be changed if you've changed Docker's address pools.
     # i.e., "default-address-pools" in /etc/docker/daemon.json
     extra_hosts:
-      - "host.docker.internal:172.17.0.1"
+      - 'host.docker.internal:172.17.0.1'
 
 volumes:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
     # This must be changed if you've changed Docker's address pools.
     # i.e., "default-address-pools" in /etc/docker/daemon.json
     extra_hosts:
-      - "host.docker.internal:172.17.0.1"
+      - 'host.docker.internal:172.17.0.1'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,7 @@ services:
     environment:
       - HOST_JOBS_DIR=${HOME}/pl_ag_jobs
       - DEV=true
+    # This must be changed if you've changed Docker's address pools.
+    # i.e., "default-address-pools" in /etc/docker/daemon.json
+    extra_hosts:
+      - "host.docker.internal:172.17.0.1"


### PR DESCRIPTION
Network config is missing in current docker compose file for development.  Consequently, one cannot launch workspace.

Ref: https://github.com/PrairieLearn/PrairieLearn/issues/9805