### PR TITLE
Update use of dim/faint formatting in logs

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -65,7 +65,7 @@
     "ace-builds": "^1.39.1",
     "ace-code": "^1.39.1",
     "ajv": "^8.17.1",
-    "ansi_up": "^6.0.2",
+    "ansi_up": "^6.0.5",
     "archiver": "^7.0.1",
     "async": "^3.2.6",
     "backbone": "^1.6.1",

--- a/apps/prairielearn/src/lib/chalk.ts
+++ b/apps/prairielearn/src/lib/chalk.ts
@@ -1,9 +1,2 @@
 import { Chalk } from 'chalk';
 export const chalk = new Chalk({ level: 3 });
-
-/**
- * This function should be used instead of `chalk.dim`, as `ansi_up` doesn't
- * currently support the ANSI dim modifier:
- * https://github.com/drudru/ansi_up/issues/78.
- */
-export const chalkDim = chalk.rgb(150, 150, 150);

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -19,7 +19,7 @@ import * as courseDB from '../sync/course-db.js';
 import { type CourseData } from '../sync/course-db.js';
 
 import { downloadFromS3, makeS3ClientConfig } from './aws.js';
-import { chalk, chalkDim } from './chalk.js';
+import { chalk } from './chalk.js';
 import { config } from './config.js';
 import { type ServerJob, createServerJob } from './server-jobs.js';
 
@@ -819,19 +819,19 @@ async function _generateAllChunksForCourseWithJob(course_id: string, job: Server
   job.info(chalk.bold('Looking up course directory'));
   const result = await sqldb.queryOneRowAsync(sql.select_course_dir, { course_id });
   let courseDir = result.rows[0].path;
-  job.info(chalkDim(`Found course directory: ${courseDir}`));
+  job.verbose(`Found course directory: ${courseDir}`);
   courseDir = path.resolve(process.cwd(), courseDir);
-  job.info(chalkDim(`Resolved course directory: ${courseDir}`));
+  job.verbose(`Resolved course directory: ${courseDir}`);
 
   const lockName = getLockNameForCoursePath(courseDir);
   job.info(chalk.bold(`Acquiring lock ${lockName}`));
 
   await namedLocks.doWithLock(lockName, {}, async () => {
-    job.info(chalkDim('Acquired lock'));
+    job.verbose('Acquired lock');
 
     job.info(chalk.bold(`Loading course data from ${courseDir}`));
     const courseData = await courseDB.loadFullCourse(course_id, courseDir);
-    job.info(chalkDim('Loaded course data'));
+    job.verbose('Loaded course data');
 
     job.info(chalk.bold('Generating all chunks'));
     const chunkOptions = {
@@ -841,10 +841,10 @@ async function _generateAllChunksForCourseWithJob(course_id: string, job: Server
     };
     const chunkChanges = await updateChunksForCourse(chunkOptions);
     logChunkChangesToJob(chunkChanges, job);
-    job.info(chalkDim('Generated all chunks'));
+    job.verbose('Generated all chunks');
   });
 
-  job.info(chalkDim('Released lock'));
+  job.verbose('Released lock');
 
   job.info(chalk.green(`Successfully generated chunks for course ID = ${course_id}`));
 }

--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -10,7 +10,7 @@ import { loadSqlEquiv, queryAsync, queryRow, queryRows } from '@prairielearn/pos
 import * as Sentry from '@prairielearn/sentry';
 import { checkSignedToken, generateSignedToken } from '@prairielearn/signed-token';
 
-import { chalk, chalkDim } from './chalk.js';
+import { chalk } from './chalk.js';
 import { config } from './config.js';
 import { IdSchema, type Job, JobSchema, JobSequenceSchema } from './db-types.js';
 import { JobSequenceWithJobsSchema, type JobSequenceWithTokens } from './server-jobs.types.js';
@@ -113,7 +113,7 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
   }
 
   verbose(msg: string) {
-    this.addToOutput(chalkDim(msg) + '\n');
+    this.addToOutput(chalk.dim(msg) + '\n');
   }
 
   async exec(
@@ -147,7 +147,7 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
 
       // Record timing information.
       const duration = (performance.now() - start).toFixed(2);
-      this.addToOutput(chalkDim(`Command completed in ${duration}ms`) + '\n\n');
+      this.addToOutput(chalk.dim(`Command completed in ${duration}ms`) + '\n\n');
     }
 
     return { data: this.data };

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -2,7 +2,7 @@ import async from 'async';
 
 import * as namedLocks from '@prairielearn/named-locks';
 
-import { chalk, chalkDim } from '../lib/chalk.js';
+import { chalk } from '../lib/chalk.js';
 import { config } from '../lib/config.js';
 import { type ServerJobLogger } from '../lib/server-jobs.js';
 import { getLockNameForCoursePath, selectOrInsertCourseByPath } from '../models/course.js';
@@ -192,7 +192,7 @@ export async function syncDiskToSql(
   logger: ServerJobLogger,
 ): Promise<SyncResults> {
   const lockName = getLockNameForCoursePath(courseDir);
-  logger.verbose(chalkDim(`Trying lock ${lockName}`));
+  logger.verbose(`Trying lock ${lockName}`);
   const result = await namedLocks.doWithLock(
     lockName,
     {
@@ -203,12 +203,12 @@ export async function syncDiskToSql(
       },
     },
     async () => {
-      logger.verbose(chalkDim(`Acquired lock ${lockName}`));
+      logger.verbose(`Acquired lock ${lockName}`);
       return await syncDiskToSqlWithLock(course_id, courseDir, logger);
     },
   );
 
-  logger.verbose(chalkDim(`Released lock ${lockName}`));
+  logger.verbose(`Released lock ${lockName}`);
   return result;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,7 +3875,7 @@ __metadata:
     ace-builds: "npm:^1.39.1"
     ace-code: "npm:^1.39.1"
     ajv: "npm:^8.17.1"
-    ansi_up: "npm:^6.0.2"
+    ansi_up: "npm:^6.0.5"
     archiver: "npm:^7.0.1"
     async: "npm:^3.2.6"
     axe-core: "npm:^4.10.2"
@@ -6761,6 +6761,13 @@ __metadata:
   version: 6.0.2
   resolution: "ansi_up@npm:6.0.2"
   checksum: 10c0/f39f2d2f2fde2d640d0033c03eb8efbbcbfcb7c01b1ce371c551250213df0546592160768c9b3de8fc2b13fec6dd3ab15bf01ebc6408ec66280fddd94a4ea21e
+  languageName: node
+  linkType: hard
+
+"ansi_up@npm:^6.0.5":
+  version: 6.0.5
+  resolution: "ansi_up@npm:6.0.5"
+  checksum: 10c0/410de314d6f020b9b434150e1982b6622017c4c072685e53f2e5237d9140f366c59ae845800ce272087dc975a837c7224b853e9489f025ff7cd5816d7b5bae28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The previous implementation of ANSI dim/faint formatting was done with a custom color. This was done because ansi_up did not properly support this format. The new 6.0.5 now supports this format, so we can properly use `chalk.dim` instead of a custom color. The default formatting is done with 70% opacity, which looks somewhat similar to the previous choice of color.

**BEFORE**
![image](https://github.com/user-attachments/assets/568201e9-bfed-4280-8cd5-e08cedfee486)

**AFTER**
![image](https://github.com/user-attachments/assets/8e4d79bb-abf5-4177-8e2c-dba276bcf18d)

While this doesn't make a big difference in functionality, this should make a future implementation of a fix for #11613 a bit simpler, by using a combination of a custom `ansiUp.faintStyle` value with appropriate selectors. It also makes the semantic meaning of the output a bit more closely related to the intended meaning (i.e., by using proper faint codes instead of colors).

While reviewing the previous uses of dim formatting, I also replace them with proper calls to `job.verbose` (which already uses dim formatting) to, again, make the output more semantic and less redundant.