### PR TITLE
Skip cachebuster process for prairielearn packages in local dev

### DIFF
--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 
 import express from 'express';
 import { type HashElementNode, hashElement } from 'folder-hash';
+import { v4 as uuid } from 'uuid';
 
 import * as compiledAssets from '@prairielearn/compiled-assets';
 import { type HtmlSafeString } from '@prairielearn/html';
@@ -106,6 +107,14 @@ function getPackageVersion(packageName: string): string {
  */
 function getNodeModulesAssetHash(assetPath: string): string {
   const packageName = getPackageNameForAssetPath(assetPath);
+
+  if (config.devMode && packageName.startsWith('@prairielearn/')) {
+    // In dev mode, we don't want to cache the hash of our own packages, or use
+    // a repeatable hash that would cause the browser to cache the asset. This
+    // is because we want to be able to change them without changing the package
+    // version number.
+    return uuid();
+  }
 
   // Reading files synchronously and computing cryptographic hashes are both
   // relatively expensive; cache the hashes for each package.


### PR DESCRIPTION
Resolves #11708. This simplifies the development of PL packages used client-side, but ensuring that their assets are never cached by the browser. We still need to `yarn build` the package before its change is seen in the browser, though.

There are currently no cases that I could find where this is used directly, since all PL packages used client-side are used indirectly, via imports in asset scripts. The main potential use case for this is in packages used in elements. The only current element using a PL package is pl-excalibur, and it uses a package outside the monorepo, so testing it becomes a bit tricky. The easiest way to test this code is to merge it with #10570, which uses a custom package in this manner. To test it in that PR, load a page using this package (e.g., demo/markdownEditorLivePreview) in a browser, then make a change in packages/marked-mathjax/src/index.ts and run `yarn build` in that package, then refresh (but not hard refresh) the page on the browser. In master this should not see the update reflected (because the browser will tend to cache the old version of the package asset), but if this PR is merged the update should be reflected (as the URL changes).