### PR TITLE
Install jupyter-collaboration with conda in JupyterLab workspace

### DIFF
--- a/workspaces/jupyterlab-python/install.sh
+++ b/workspaces/jupyterlab-python/install.sh
@@ -13,8 +13,8 @@ NEW_GID=1001
 groupmod -g $NEW_GID $GROUP_NAME
 usermod -u $NEW_UID -g $NEW_GID $USER_NAME
 for d in /home /tmp; do
-  find $d -user $OLD_UID -execdir chown -h $NEW_UID {} +
-  find $d -group $OLD_GID -execdir chgrp -h $NEW_GID {} +
+    find $d -user $OLD_UID -execdir chown -h $NEW_UID {} +
+    find $d -group $OLD_GID -execdir chgrp -h $NEW_GID {} +
 done
 
 # Install dependencies and various libraries.

--- a/workspaces/jupyterlab-python/install.sh
+++ b/workspaces/jupyterlab-python/install.sh
@@ -13,8 +13,8 @@ NEW_GID=1001
 groupmod -g $NEW_GID $GROUP_NAME
 usermod -u $NEW_UID -g $NEW_GID $USER_NAME
 for d in /home /tmp; do
-    find $d -user $OLD_UID -execdir chown -h $NEW_UID {} +
-    find $d -group $OLD_GID -execdir chgrp -h $NEW_GID {} +
+  find $d -user $OLD_UID -execdir chown -h $NEW_UID {} +
+  find $d -group $OLD_GID -execdir chgrp -h $NEW_GID {} +
 done
 
 # Install dependencies and various libraries.
@@ -29,9 +29,15 @@ chmod 0755 /usr/local/bin/pl-gosu-helper.sh
 # Install all Python dependencies.
 pip3 install -r /requirements.txt
 
+# This extension must be installed with `conda` and not `pip`. We don't know
+# exactly why that is. See the following GitHub issue for more background:
+# https://github.com/jupyterlab/jupyter-collaboration/issues/462
+conda install --yes jupyter-collaboration==3.1.0
+
 # Clear various caches to minimize the final image size.
 apt-get clean
 pip3 cache purge
+conda clean --all
 
 # Suppress the opt-in dialog for announcements.
 # https://stackoverflow.com/questions/75511508/how-to-stop-this-message-would-you-like-to-receive-official-jupyter-news

--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -5,7 +5,6 @@ defusedxml==0.7.1
 Faker==37.1.0
 folium==0.19.5
 ipython==8.33.0
-jupyter-collaboration==3.1.0
 matplotlib==3.10.1
 nbconvert==7.16.6
 nbformat==5.10.4


### PR DESCRIPTION
This is a fix for the issue described here: https://github.com/jupyterlab/jupyter-collaboration/issues/462

For posterity: `prairielearn/workspace-jupyterlab-python:90d9e5bef1c0950457a60a78d224f99e32339cee` and on were broken, whereas `prairielearn/workspace-jupyterlab-python:5cd46e341504107d342b6f95ad33515b8fee0b50` (built just a few days before that) worked fine. Neither the base image tag nor any dependencies were changed between those builds, so we really don't know what caused this to start happening.