### PR TITLE
Update recommendation for version compatibility in Java grader

### DIFF
--- a/docs/java-grader/index.md
+++ b/docs/java-grader/index.md
@@ -165,7 +165,7 @@ The example above disables the `static` warning (use of static fields applied to
 
 - `-Xlint:none` or `-nowarn` to disable all warnings;
 - `-Xdoclint` to enable warnings for javadoc comments;
-- `-source 10` to compile using the Java 10 language version.
+- `--release 11` to compile using the Java 11 language version.
 
 Similarly, you may set specific options to the `java` command line using the `JDK_JAVA_OPTIONS`. A list of valid options can be found in the [`java' documentation page](https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html#standard-options-for-java). Some options of interest may include:
 


### PR DESCRIPTION
The [`-source` option is not enough](https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler/43103038#43103038), as it restricts language features but not library availability. For example, `str.isBlank()` is not available in Java 8, but since the Java 21 library is available in the boot classpath, it would still be available if compiled with `-source 8`. The `--release` option also sets the library version accordingly.

