### PR TITLE
Upgrade workspace-jupyterlab-python base image and collaboration dep

### DIFF
--- a/workspaces/jupyterlab-python/Dockerfile
+++ b/workspaces/jupyterlab-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/minimal-notebook:2025-03-31
+FROM quay.io/jupyter/minimal-notebook:2025-04-10
 ARG CACHEBUST=2025-04-04-17-34-59
 
 ENV XDG_DATA_HOME=/tmp/local/share

--- a/workspaces/jupyterlab-python/install.sh
+++ b/workspaces/jupyterlab-python/install.sh
@@ -29,15 +29,9 @@ chmod 0755 /usr/local/bin/pl-gosu-helper.sh
 # Install all Python dependencies.
 pip3 install -r /requirements.txt
 
-# This extension must be installed with `conda` and not `pip`. We don't know
-# exactly why that is. See the following GitHub issue for more background:
-# https://github.com/jupyterlab/jupyter-collaboration/issues/462
-conda install --yes jupyter-collaboration==3.1.0
-
 # Clear various caches to minimize the final image size.
 apt-get clean
 pip3 cache purge
-conda clean --all
 
 # Suppress the opt-in dialog for announcements.
 # https://stackoverflow.com/questions/75511508/how-to-stop-this-message-would-you-like-to-receive-official-jupyter-news

--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -4,6 +4,7 @@ colormath==3.0.0
 defusedxml==0.7.1
 Faker==37.1.0
 folium==0.19.5
+jupyter-collaboration==4.0.1
 ipython==8.33.0
 matplotlib==3.10.1
 nbconvert==7.16.6


### PR DESCRIPTION
Now that the dependency has been fixed and `jupyter/minimal-notebook` uses `jupyterlab==4.4.0`, we should be able to undo the hacky fix from #11726.