### PR TITLE
Hardcode committer and author in container upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-containers.yml
+++ b/.github/workflows/upgrade-containers.yml
@@ -27,8 +27,8 @@ jobs:
           branch: upgrade-containers-${{ steps.get-timestamp.outputs.timestamp }}
           title: 'Upgrade Docker containers'
           commit-message: 'Bump CACHEBUST value of containers'
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           body: |
             This PR updates all Dockerfiles with a new `CACHEBUST` value to rebuild the images.
           labels: chore,dependencies,docker

--- a/.github/workflows/upgrade-containers.yml
+++ b/.github/workflows/upgrade-containers.yml
@@ -27,6 +27,8 @@ jobs:
           branch: upgrade-containers-${{ steps.get-timestamp.outputs.timestamp }}
           title: 'Upgrade Docker containers'
           commit-message: 'Bump CACHEBUST value of containers'
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           body: |
             This PR updates all Dockerfiles with a new `CACHEBUST` value to rebuild the images.
           labels: chore,dependencies,docker


### PR DESCRIPTION
See discussion in https://github.com/PrairieLearn/PrairieLearn/pull/11732. In short: the action that creates the PR will use `github.actor` as the author, and because we use a merge queue, the actor will always be `github-merge-queue`.