### PR TITLE
Fix timeout of Python tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
         timeout-minutes: 30
       - name: Run the Python tests
         run: docker exec test_container sh -c "make -s -C /PrairieLearn test-python"
-        timeout-minutes: 1
+        timeout-minutes: 5
 
       # Since tests run in the context of the container, we need to copy all
       # the coverage reports out of the container and into the host filesystem.


### PR DESCRIPTION
This makes the timeout consistent with the other place we run them:

https://github.com/PrairieLearn/PrairieLearn/blob/bc7bfc2f7ccd3fedba1169889a0621baaf94b631/.github/workflows/main.yml#L204-L206

I think this mismatch was just an oversight in #11393.