### PR TITLE
Put sharing tab in alphabetical order

### DIFF
--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -134,6 +134,14 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
           },
 
           {
+            activeSubPage: 'sharing',
+            urlSuffix: '/course_admin/sharing',
+            iconClasses: 'fas fa-share-nodes',
+            tabLabel: 'Sharing',
+            renderCondition: (resLocals) => resLocals.question_sharing_enabled,
+          },
+
+          {
             activeSubPage: 'tags',
             urlSuffix: '/course_admin/tags',
             iconClasses: 'fas fa-hashtag',
@@ -145,14 +153,6 @@ export function getNavPageTabs(hasEnhancedNavigation: boolean) {
             urlSuffix: '/course_admin/topics',
             iconClasses: 'fas fa-quote-right',
             tabLabel: 'Topics',
-          },
-
-          {
-            activeSubPage: 'sharing',
-            urlSuffix: '/course_admin/sharing',
-            iconClasses: 'fas fa-share-nodes',
-            tabLabel: 'Sharing',
-            renderCondition: (resLocals) => resLocals.question_sharing_enabled,
           },
         ]
       : [


### PR DESCRIPTION
I saw a note about this on slack recently, I figured now is a good time to fix since sharing still isn't enabled by default anyway.

