### PR TITLE
Add option to hide verbose messages in job outputs

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/jobSequenceResults.ts
+++ b/apps/prairielearn/assets/scripts/lib/jobSequenceResults.ts
@@ -51,4 +51,13 @@ onDocumentReady(() => {
       },
     );
   });
+
+  document.querySelectorAll<HTMLInputElement>('.js-toggle-verbose').forEach((checkbox) => {
+    checkbox.addEventListener('change', () => {
+      const targetOutput = document.getElementById(checkbox.getAttribute('data-target-id') ?? '');
+      if (targetOutput) {
+        targetOutput.style.setProperty('--verbose-display', checkbox.checked ? '' : 'none');
+      }
+    });
+  });
 });

--- a/apps/prairielearn/src/components/JobSequenceResults.html.ts
+++ b/apps/prairielearn/src/components/JobSequenceResults.html.ts
@@ -67,16 +67,18 @@ export function JobSequenceResults({
                       : ''}
                   `
                 : ''}
-              <div class="float-end form-check">
-                <input
-                  type="checkbox"
-                  class="js-toggle-verbose form-check-input"
-                  id="toggle-verbose-${job.id}"
-                  data-target-id="output-${job.id}"
-                />
-                <label class="form-check-label" for="toggle-verbose-${job.id}">
-                  Show verbose messages
-                </label>
+              <div class="d-flex justify-content-end float-md-end">
+                <div class="form-check form-switch">
+                  <input
+                    type="checkbox"
+                    class="js-toggle-verbose form-check-input"
+                    id="toggle-verbose-${job.id}"
+                    data-target-id="output-${job.id}"
+                  />
+                  <label class="form-check-label" for="toggle-verbose-${job.id}">
+                    Show verbose messages
+                  </label>
+                </div>
               </div>
               <p class="mb-1">
                 Started ${job.start_date ? `at ${formatDate(job.start_date, timeZone)}` : ''}

--- a/apps/prairielearn/src/components/JobSequenceResults.html.ts
+++ b/apps/prairielearn/src/components/JobSequenceResults.html.ts
@@ -1,9 +1,8 @@
-import { AnsiUp } from 'ansi_up';
-
 import { EncodedData } from '@prairielearn/browser-utils';
 import { formatDate } from '@prairielearn/formatter';
 import { html, unsafeHtml } from '@prairielearn/html';
 
+import { ansiToHtml } from '../lib/chalk.js';
 import type { Course } from '../lib/db-types.js';
 import type { JobSequenceWithTokens, JobWithToken } from '../lib/server-jobs.types.js';
 
@@ -24,7 +23,6 @@ export function JobSequenceResults({
   course: Course | undefined;
   jobSequence: JobSequenceWithTokens;
 }) {
-  const ansiup = new AnsiUp();
   const timeZone = course?.display_timezone || 'UTC';
 
   return html`
@@ -69,6 +67,17 @@ export function JobSequenceResults({
                       : ''}
                   `
                 : ''}
+              <div class="float-end form-check">
+                <input
+                  type="checkbox"
+                  class="js-toggle-verbose form-check-input"
+                  id="toggle-verbose-${job.id}"
+                  data-target-id="output-${job.id}"
+                />
+                <label class="form-check-label" for="toggle-verbose-${job.id}">
+                  Show verbose messages
+                </label>
+              </div>
               <p class="mb-1">
                 Started ${job.start_date ? `at ${formatDate(job.start_date, timeZone)}` : ''}
                 ${jobSequence.user_uid ? `by ${jobSequence.user_uid}` : ''}
@@ -99,9 +108,9 @@ export function JobSequenceResults({
               <pre
                 id="output-${job.id}"
                 class="text-white rounded p-3 mb-0 mt-3"
-                style="background-color: black;"
+                style="background-color: black; --verbose-display: none;"
               >
-${unsafeHtml(job.output ? ansiup.ansi_to_html(job.output) : '')}</pre
+${unsafeHtml(ansiToHtml(job.output))}</pre
               >
             </li>
           </div>

--- a/apps/prairielearn/src/components/SyncErrorsAndWarnings.html.ts
+++ b/apps/prairielearn/src/components/SyncErrorsAndWarnings.html.ts
@@ -1,15 +1,12 @@
-import { AnsiUp } from 'ansi_up';
-
 import { html, unsafeHtml } from '@prairielearn/html';
 
+import { ansiToHtml } from '../lib/chalk.js';
 import {
   type Assessment,
   type Course,
   type CourseInstance,
   type Question,
 } from '../lib/db-types.js';
-
-const ansiUp = new AnsiUp();
 
 export function CourseSyncErrorsAndWarnings({
   authz_data,
@@ -117,8 +114,8 @@ function SyncErrorsAndWarnings({
     return '';
   }
 
-  const syncErrorsAnsified = syncErrors ? unsafeHtml(ansiUp.ansi_to_html(syncErrors)) : null;
-  const syncWarningsAnsified = syncWarnings ? unsafeHtml(ansiUp.ansi_to_html(syncWarnings)) : null;
+  const syncErrorsAnsified = syncErrors ? unsafeHtml(ansiToHtml(syncErrors)) : null;
+  const syncWarningsAnsified = syncWarnings ? unsafeHtml(ansiToHtml(syncWarnings)) : null;
   const infoFileName = fileEditUrl.split('/').pop();
 
   return html`

--- a/apps/prairielearn/src/components/SyncProblemButton.html.ts
+++ b/apps/prairielearn/src/components/SyncProblemButton.html.ts
@@ -1,8 +1,6 @@
-import { AnsiUp } from 'ansi_up';
-
 import { escapeHtml, html, unsafeHtml } from '@prairielearn/html';
 
-const ansiUp = new AnsiUp();
+import { ansiToHtml } from '../lib/chalk.js';
 
 export function SyncProblemButton({ output, type }: { output: string; type: 'error' | 'warning' }) {
   const title = type === 'error' ? 'Sync Errors' : 'Sync Warnings';
@@ -13,7 +11,7 @@ export function SyncProblemButton({ output, type }: { output: string; type: 'err
     class="text-white rounded p-3 mb-0"
     style="background-color: black;"
   >
-${unsafeHtml(ansiUp.ansi_to_html(output))}</pre
+${unsafeHtml(ansiToHtml(output))}</pre
   >`;
 
   return html`

--- a/apps/prairielearn/src/lib/chalk.ts
+++ b/apps/prairielearn/src/lib/chalk.ts
@@ -3,7 +3,10 @@ import { Chalk } from 'chalk';
 export const chalk = new Chalk({ level: 3 });
 
 const ansiUp = new AnsiUp();
-// Set a custom style for faint text that allows it to be hidden
+// Set a custom style for faint text that allows it to be hidden. This only
+// affects pages that set `--verbose-display` to a specific value, pages that
+// don't set this variable will not be affected and will use the default CSS
+// display value.
 ansiUp.faintStyle = 'opacity: 0.7; display: var(--verbose-display);';
 
 export function ansiToHtml(ansiString: string | null): string {

--- a/apps/prairielearn/src/lib/chalk.ts
+++ b/apps/prairielearn/src/lib/chalk.ts
@@ -1,2 +1,13 @@
+import { AnsiUp } from 'ansi_up';
 import { Chalk } from 'chalk';
 export const chalk = new Chalk({ level: 3 });
+
+const ansiUp = new AnsiUp();
+// Set a custom style for faint text that allows it to be hidden
+ansiUp.faintStyle = 'opacity: 0.7; display: var(--verbose-display);';
+
+export function ansiToHtml(ansiString: string | null): string {
+  const htmlString = ansiUp.ansi_to_html(ansiString ?? '');
+  // We want to be able to hide whole lines of output, so we need to ensure the line breaks are inside spans.
+  return htmlString.replaceAll('</span>\n', '\n</span>');
+}

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.html.ts
@@ -1,10 +1,9 @@
-import { AnsiUp } from 'ansi_up';
-
 import { html, joinHtml, unsafeHtml } from '@prairielearn/html';
 
 import { JobSequenceResults } from '../../components/JobSequenceResults.html.js';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
+import { ansiToHtml } from '../../lib/chalk.js';
 import { config } from '../../lib/config.js';
 import type { FileEdit } from '../../lib/db-types.js';
 import type { InstructorFilePaths } from '../../lib/instructorFiles.js';
@@ -43,7 +42,6 @@ export function InstructorFileEditor({
   draftEdit: DraftEdit | null;
 }) {
   const { course, __csrf_token } = resLocals;
-  const ansiUp = new AnsiUp();
 
   return PageLayout({
     resLocals,
@@ -76,7 +74,7 @@ export function InstructorFileEditor({
               <pre
                 class="text-white rounded p-3 mb-0"
                 style="background-color: black;"
-              ><code>${unsafeHtml(ansiUp.ansi_to_html(editorData.sync_errors))}</code></pre>
+              ><code>${unsafeHtml(ansiToHtml(editorData.sync_errors))}</code></pre>
             </div>
           `
         : ''}
@@ -92,7 +90,7 @@ export function InstructorFileEditor({
               <pre
                 class="text-white rounded p-3 mb-0"
                 style="background-color: black;"
-              ><code>${unsafeHtml(ansiUp.ansi_to_html(editorData.sync_warnings))}</code></pre>
+              ><code>${unsafeHtml(ansiToHtml(editorData.sync_warnings))}</code></pre>
             </div>
           `
         : ''}


### PR DESCRIPTION
Resolves #11613.

Adds a checkbox to the job sequence page that hides/shows verbose messages in the output. Verbose messages are determined by the use of `chalk.dim` based output. Hiding is done with the use of a custom CSS variable that is updated based on the checked status of the checkbox, and is used in the style for "faint" output.

To ensure consistency of formats, all references to AnsiUp have been moved to a library function, so that the same format is used in all cases (e.g., sync errors/warnings). This should also allow future changes to the style of individual message types to be consistent across pages (e.g., if we decide to use a different color/style for different errors/warnings). The checkbox was not added to other pages (though I should note that sync errors/warnings don't currently have verbose messages that I could identify), but if necessary it should be easy to add.

![chrome-capture-2025-4-11](https://github.com/user-attachments/assets/3cd960e5-e5cc-4a2a-9dd4-b185701b9495)