### PR TITLE
Fix handling of delete assessment instance modals

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.tsx
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.tsx
@@ -1,6 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { on } from 'delegated-events';
-import { h, render, Fragment } from 'preact';
+import { Fragment, h, render } from 'preact';
 import React, { useState } from 'preact/hooks';
 
 import { onDocumentReady, templateFromAttributes } from '@prairielearn/browser-utils';
@@ -149,7 +149,7 @@ onDocumentReady(() => {
   $('#deleteAssessmentInstanceModal').on('show.bs.modal', function (event) {
     const modal = $(this);
 
-    modal.find('form').on('submit', (e) => {
+    modal.parents('form').on('submit', (e) => {
       e.preventDefault();
       $.post(
         $(e.target).attr('action') ?? '',
@@ -182,7 +182,7 @@ onDocumentReady(() => {
   $('#deleteAllAssessmentInstancesModal').on('show.bs.modal', function () {
     const modal = $(this);
 
-    modal.find('form').on('submit', (e) => {
+    modal.parents('form').on('submit', (e) => {
       e.preventDefault();
       $.post(
         $(e.target).attr('action') ?? '',

--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.tsx
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.tsx
@@ -149,18 +149,21 @@ onDocumentReady(() => {
   $('#deleteAssessmentInstanceModal').on('show.bs.modal', function (event) {
     const modal = $(this);
 
-    modal.parents('form').on('submit', (e) => {
-      e.preventDefault();
-      $.post(
-        $(e.target).attr('action') ?? '',
-        $(e.target).serialize(),
-        function () {
-          refreshTable();
-        },
-        'json',
-      );
-      modal.modal('hide');
-    });
+    modal
+      .parents('form')
+      .off('submit')
+      .on('submit', (e) => {
+        e.preventDefault();
+        $.post(
+          $(e.target).attr('action') ?? '',
+          $(e.target).serialize(),
+          function () {
+            refreshTable();
+          },
+          'json',
+        );
+        modal.modal('hide');
+      });
 
     // @ts-expect-error -- The BS5 types don't include the `relatedTarget` property on jQuery events.
     const { relatedTarget } = event;
@@ -182,18 +185,21 @@ onDocumentReady(() => {
   $('#deleteAllAssessmentInstancesModal').on('show.bs.modal', function () {
     const modal = $(this);
 
-    modal.parents('form').on('submit', (e) => {
-      e.preventDefault();
-      $.post(
-        $(e.target).attr('action') ?? '',
-        $(e.target).serialize(),
-        function () {
-          refreshTable();
-        },
-        'json',
-      );
-      modal.modal('hide');
-    });
+    modal
+      .parents('form')
+      .off('submit')
+      .on('submit', (e) => {
+        e.preventDefault();
+        $.post(
+          $(e.target).attr('action') ?? '',
+          $(e.target).serialize(),
+          function () {
+            refreshTable();
+          },
+          'json',
+        );
+        modal.modal('hide');
+      });
   });
 
   $('[data-bs-toggle="modal"]').on('click', function (e) {


### PR DESCRIPTION
Fixes #11755. The process that changed the default behavior for deleting assessment instances (both individual and batch) assumed that the form was inside the modal, but recent changes moved that form to contain the modal instead.