### PR TITLE
Fix hx-ext attribute on body

### DIFF
--- a/apps/prairielearn/src/components/PageLayout.html.ts
+++ b/apps/prairielearn/src/components/PageLayout.html.ts
@@ -104,8 +104,8 @@ export function PageLayout({
           ${sideNavEnabled ? compiledScriptTag('pageLayoutClient.ts') : ''}
         </head>
         <body
-          ${options.hxExt ? `hx-ext="${options.hxExt}"` : ''}
           class="${options.fullHeight ? 'd-flex flex-column h-100' : ''}"
+          hx-ext="${options.hxExt ?? ''}"
         >
           <div
             id="app-container"


### PR DESCRIPTION
This previously rendered as something like `hx-ext=&#34;loading-states&#34;`, which isn't valid. The change here mirrors how the attribute is set when enhanced navigation isn't enabled.