### PR TITLE
Use canonical timezones in course instance settings

### DIFF
--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -22,7 +22,7 @@ import {
 } from '../../lib/editors.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
-import { getAvailableTimezones } from '../../lib/timezones.js';
+import { getCanonicalTimezones } from '../../lib/timezones.js';
 import { getCanonicalHost } from '../../lib/url.js';
 
 import { InstructorInstanceAdminSettings } from './instructorInstanceAdminSettings.html.js';
@@ -43,7 +43,9 @@ router.get(
       `${res.locals.plainUrlPrefix}/course_instance/${res.locals.course_instance.id}`,
       host,
     ).href;
-    const availableTimezones = await getAvailableTimezones();
+    const availableTimezones = await getCanonicalTimezones([
+      res.locals.course_instance.display_timezone,
+    ]);
 
     const infoCourseInstancePath = path.join(
       'courseInstances',


### PR DESCRIPTION
The changes in #11609 were created before canonical timezones, introduced in #11625, were in place. This PR updates the course instance settings page to use the same list as course settings and institution settings, i.e., only canonical timezones as well as the current one if it's not canonical.