### PR TITLE
Improve message when file cannot be previewed

### DIFF
--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
@@ -35,7 +35,13 @@
         const escapedFileName = escapePath(file);
         const path = `${submissionFilesUrl}/${escapedFileName}`;
 
-        const errorMessage = item.querySelector('.alert.error');
+        const infoMessage = item.querySelector('.js-info-alert');
+        const errorMessage = item.querySelector('.js-error-alert');
+
+        function showInfoMessage(message) {
+          infoMessage.textContent = message;
+          infoMessage.classList.remove('d-none');
+        }
 
         function showErrorMessage(message) {
           errorMessage.textContent = message;
@@ -114,6 +120,8 @@
               return result.blob();
             })
             .then(async (blob) => {
+              hideErrorMessage();
+
               const type = blob.type;
               if (type === 'text/plain') {
                 const text = await blob.text();
@@ -147,8 +155,6 @@
                   pre.classList.remove('d-none');
                 }
 
-                hideErrorMessage();
-
                 // Only show the expand/collapse button if the content is tall
                 // enough where scrolling is necessary. This must be done before
                 // auto-expansion happens below.
@@ -167,7 +173,6 @@
                   URL.revokeObjectURL(url);
                 };
                 img.classList.remove('d-none');
-                hideErrorMessage();
               } else if (type === 'application/pdf') {
                 const url = URL.createObjectURL(blob);
                 iframe.src = url;
@@ -175,10 +180,9 @@
                   URL.revokeObjectURL(url);
                 };
                 iframe.closest('.embed-responsive').classList.remove('d-none');
-                hideErrorMessage();
               } else {
                 // We can't preview this file.
-                showErrorMessage('Content preview is not available for this type of file.');
+                showInfoMessage('Content preview is not available for this type of file.');
               }
               wasOpened = true;
             })

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
@@ -24,7 +24,8 @@
             </button>
           </div>
         </div>
-        <div class="alert alert-danger mt-2 d-none error" role="alert"></div>
+        <div class="alert alert-danger mt-2 d-none js-error-alert" role="alert"></div>
+        <div class="alert alert-info mt-2 d-none js-info-alert" role="alert"></div>
         <div class="file-preview collapse" id="file-preview-contents-{{uuid}}-{{index}}">
           <img class="d-none mw-100 mt-2">
           <div class="d-none embed-responsive embed-responsive-4by3 mt-2"> 

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -137,11 +137,6 @@
         this.renderFileList();
 
         if (!isFromDownload) {
-          // Show the preview for the newly-uploaded file
-          const container = this.element.find(`li[data-file="${name}"]`);
-          container.find('.file-preview').addClass('show');
-          container.find('.file-preview-button').removeClass('collapsed');
-
           // Ensure that students see a prompt if they try to navigate away
           // from the page without saving the form. This check is initially
           // disabled because we don't want students to see the prompt if they
@@ -261,8 +256,10 @@
               '"></div>',
           );
 
-          var $error = $('<div class="alert alert-danger mt-2 d-none" role="alert"></div>');
-          $preview.append($error);
+          var $previewNotAvailable = $(
+            '<div class="alert alert-info mt-2 d-none" role="alert">Content preview is not available for this type of file.</div>',
+          );
+          $preview.append($previewNotAvailable);
 
           var $imgPreview = $('<img class="mw-100 mt-2 d-none"/>');
           $preview.append($imgPreview);
@@ -290,6 +287,7 @@
                 URL.revokeObjectURL(url);
               });
               $preview.append($objectPreview);
+              this.expandPreviewForFile(fileName);
             } else {
               var fileContents = this.b64DecodeUnicode(fileData);
               if (!this.isBinary(fileContents)) {
@@ -298,18 +296,18 @@
                 $preview.find('code').text('Binary file not previewed.');
               }
               $codePreview.removeClass('d-none');
+              this.expandPreviewForFile(fileName);
             }
           } catch {
             const url = this.b64ToBlobUrl(fileData);
             $imgPreview
               .on('load', () => {
                 $imgPreview.removeClass('d-none');
+                this.expandPreviewForFile(fileName);
                 URL.revokeObjectURL(url);
               })
               .on('error', () => {
-                $error
-                  .text('Content preview is not available for this type of file.')
-                  .removeClass('d-none');
+                $previewNotAvailable.removeClass('d-none');
                 URL.revokeObjectURL(url);
               })
               .attr('src', url);
@@ -335,6 +333,12 @@
       );
       $alert.append(message);
       this.element.find('.messages').append($alert);
+    }
+
+    expandPreviewForFile(name) {
+      const container = this.element.find(`li[data-file="${name}"]`);
+      container.find('.file-preview').addClass('show');
+      container.find('.file-preview-button').removeClass('collapsed');
     }
 
     /**

--- a/exampleCourse/questions/demo/fileDownloadUpload/question.html
+++ b/exampleCourse/questions/demo/fileDownloadUpload/question.html
@@ -9,7 +9,7 @@
   <p>Construct your solution, scan it, save the file as <strong>ProblemSolution.pdf</strong>, and upload the file below.
      Your solution will be later manually graded by a course staff. </p>
 
-  <pl-file-upload file-names="ProblemSolution.o"></pl-file-upload>
+  <pl-file-upload file-names="ProblemSolution.pdf"></pl-file-upload>
 
 
 </pl-question-panel>

--- a/exampleCourse/questions/demo/fileDownloadUpload/question.html
+++ b/exampleCourse/questions/demo/fileDownloadUpload/question.html
@@ -9,7 +9,7 @@
   <p>Construct your solution, scan it, save the file as <strong>ProblemSolution.pdf</strong>, and upload the file below.
      Your solution will be later manually graded by a course staff. </p>
 
-  <pl-file-upload file-names="ProblemSolution.pdf"></pl-file-upload>
+  <pl-file-upload file-names="ProblemSolution.o"></pl-file-upload>
 
 
 </pl-question-panel>


### PR DESCRIPTION
This PR takes the place of #11138. It uses the suggestions from Jonatan: if a preview is not available after uploading, the preview remains collapsed by default, and instead of a red error message, a more neutral blue "info" alert is used instead.