### PR TITLE
Add feature to enable public question consuming only

### DIFF
--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -6,6 +6,7 @@ const featureNames = [
   // Should only be applied to courses/institutions.
   'process-questions-in-server',
   'question-sharing',
+  'consume-public-questions',
   'ai-grading',
   'disable-public-workspaces',
   'ai-question-generation',

--- a/apps/prairielearn/src/sync/fromDisk/assessments.ts
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.ts
@@ -419,7 +419,12 @@ export async function sync(
       course_instance_id: courseInstanceId,
       institution_id: institutionId,
     });
-    if (!questionSharingEnabled && config.checkSharingOnSync) {
+    const consumePublicQuestionsEnabled = await features.enabled('consume-public-questions', {
+      course_id: courseId,
+      course_instance_id: courseInstanceId,
+      institution_id: institutionId,
+    });
+    if (!(questionSharingEnabled || consumePublicQuestionsEnabled) && config.checkSharingOnSync) {
       for (const [tid, qids] of assessmentImportedQids.entries()) {
         if (qids.length > 0) {
           infofile.addError(


### PR DESCRIPTION
From discussions with @nwalters512 and @mfsilva22, it would be nice if any course could consume public questions, without them necessarily needing to have sharing enabled for their course. This will allow us to enable consuming public question for everyone right away.

Currently, anyone can view publicly shared questions, but they will get an error if they actually try to import them, which is a bit odd. This will solve that problem as well.

Letting people consume questions by sharing set is a bit messier, because they need access to the Sharing settings page to do that. So, we can just launch that the same time we make all the sharing features public access.