### PR TITLE
Unignore Bootstrap in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,6 @@ updates:
       interval: monthly
     rebase-strategy: disabled
     ignore:
-      # We're still waiting for the following PR to be released:
-      # https://github.com/twbs/bootstrap/pull/38725
-      - dependency-name: 'bootstrap'
       # Recent versions of `bootstrap-table` broke behavior we rely on:
       # https://github.com/wenzhixin/bootstrap-table/issues/6745
       - dependency-name: 'bootstrap-table'


### PR DESCRIPTION
As of #11772, we're once again running on the latest version of Bootstrap!