### PR TITLE
update pl-order-blocks for bootstrap 5.3

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
@@ -239,7 +239,7 @@ window.PLOrderBlocks = function (uuid, options) {
     if (!indicator) {
       indicator = document.createElement('li');
       indicator.classList.add('pl-order-blocks-pairing-indicator');
-      indicator.classList.add('list-group-item-info');
+      indicator.classList.add('bg-info-subtle');
       indicator.setAttribute('data-distractor-bin', uuid);
       indicator.id = 'indicator-' + uuid;
       indicator.innerHTML += '<span style="font-size:13px;">Pick one:</span>';

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.mustache
@@ -14,7 +14,7 @@ $(function() {
 
     <div class="d-flex flex-wrap pl-order-blocks-question-{{uuid}}">
         <div class="pl-order-blocks-container {{block_layout}} {{dropzone_layout}} ">
-            <div class="card-header pl-order-blocks-header list-group-item-primary">
+            <div class="card-header pl-order-blocks-header bg-primary-subtle">
                 <span class="me-2">{{source-header}}</span>
                 <button type="button" style="vertical-align:middle;" class="btn btn-light btn-sm" data-bs-toggle="popover" data-bs-html="true" title="Order Blocks" data-bs-content="{{help_text}}">
                     <i class="fa fa-question-circle" aria-hidden="true"></i>
@@ -33,7 +33,7 @@ $(function() {
             </ul>
         </div>
         <div class="pl-order-blocks-container {{block_layout}} {{dropzone_layout}} ">
-            <div class="card-header pl-order-blocks-header list-group-item-primary">
+            <div class="card-header pl-order-blocks-header bg-primary-subtle">
                 <span class="me-2">{{solution-header}}</span>
             </div>
             <ul id="order-blocks-dropzone-{{uuid}}" name="{{answer_name}}" class="card-body list-group pl-order-blocks-connected-sortable dropzone">
@@ -72,7 +72,7 @@ $(function() {
         <ul class="card-body list-group list-unstyled">
             {{#student_submission}}
                 {{#distractor_feedback}}
-                <li class="pl-order-blocks-pairing-indicator list-group-item-warning">
+                <li class="pl-order-blocks-pairing-indicator bg-warning-subtle">
                     <ul class="list-unstyled">
                         <li>
                             <div class="pl-order-blocks-correctness-badge-container">
@@ -91,7 +91,7 @@ $(function() {
                 {{/distractor_feedback}}
                 {{^distractor_feedback}}
                     {{#ordering_feedback}}
-                    <li class="pl-order-blocks-pairing-indicator list-group-item-warning">
+                    <li class="pl-order-blocks-pairing-indicator bg-warning-subtle">
                         <ul class="list-unstyled">
                             <li>
                                 <div class="pl-order-blocks-correctness-badge-container">
@@ -136,7 +136,7 @@ $(function() {
 
 {{#true_answer}}
     <div class="pl-order-blocks-answer-container {{block_layout}} {{dropzone_layout}}">
-        <div class="card-header list-group-item-success">Correct answer ({{ordering_message}}{{indentation_message}}):</div>
+        <div class="card-header bg-success-subtle">Correct answer ({{ordering_message}}{{indentation_message}}):</div>
         <ul class="card-body list-group">
         {{#question_solution}}
             <li class="{{block_formatting}} pl-order-block" style="margin-left: {{indent}}px">{{{inner_html}}}</li>
@@ -147,11 +147,11 @@ $(function() {
     {{#show_distractors}}
     <br><br>
     <div class="pl-order-blocks-answer-container  {{block_layout}} {{dropzone_layout}}">
-        <div class="card-header list-group-item-danger">Incorrect Blocks (these blocks should not be included in your solution):</div>
+        <div class="card-header bg-danger-subtle">Incorrect Blocks (these blocks should not be included in your solution):</div>
         <ul class="card-body list-group list-unstyled">
         {{#distractors}}
             {{#distractor_feedback}}
-            <li class="pl-order-blocks-pairing-indicator list-group-item-warning">
+            <li class="pl-order-blocks-pairing-indicator bg-warning-subtle">
                 <ul class="p-0">
                     <li class="{{block_formatting}} pl-order-block">{{{inner_html}}}</li>
                 </ul>


### PR DESCRIPTION
We were previously abusing the list-group-item styles for color, but that doesn't work anymore with new bootstrap. Thankfully they have styles for background color now, easy drop in fix.

