### PR TITLE
Improve indication of active item in tom-select dropdowns

### DIFF
--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -423,3 +423,8 @@ small .user-output-invalid {
 .fixed-table-toolbar div.pagination-detail {
   margin: 0 1em 0 0 !important;
 }
+
+/** Provide a higher-contrast focus indicator for tom-select dropdowns */
+.ts-dropdown .active {
+  outline: 2px solid var(--bs-primary);
+}

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -427,4 +427,5 @@ small .user-output-invalid {
 /** Provide a higher-contrast focus indicator for tom-select dropdowns */
 .ts-dropdown .active {
   outline: 2px solid var(--bs-primary);
+  outline-offset: -2px;
 }


### PR DESCRIPTION
This change improves accessibility for folks who are navigating PL with a keyboard.

<img width="1085" alt="Screenshot 2025-04-18 at 09 04 29" src="https://github.com/user-attachments/assets/97637efb-5d28-4629-b69c-0d33a44ac80e" />
