### PR TITLE
Make names_for_user optional in Python grader

### DIFF
--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -108,7 +108,7 @@ def execute_code(
     exec(str_setup, setup_code)
     exec(repeated_setup_name, setup_code)
 
-    names_for_user = [variable["name"] for variable in data["params"]["names_for_user"]]
+    names_for_user = [v["name"] for v in data["params"].get("names_for_user", {})]
 
     # Make copies of variables that go to the user so we do not clobber them
     ref_code = {}


### PR DESCRIPTION
This makes the Python grader slightly more user-friendly by making `names_for_user` optional. I tested this by removing the following line:

https://github.com/PrairieLearn/PrairieLearn/blob/900e986a4e9ad5ae6ec30c6c24945ea15841c96e/exampleCourse/questions/demo/autograder/codeEditor/question.html#L18

Before this change, the entire test suite failed with an error. After this change, it ran as normal.

Once this is deployed, we can remove `<pl-external-grader-variables params-name="names_for_user" empty="true">...` from all example questions.