### PR TITLE
Use coverage report from native execution of Python tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,9 +101,6 @@ jobs:
         # spinning until it eventually times out. This shorter timeout helps
         # ensure that the tests fail more quickly so that people can fix them.
         timeout-minutes: 30
-      - name: Run the Python tests
-        run: docker exec test_container sh -c "make -s -C /PrairieLearn test-python"
-        timeout-minutes: 5
 
       # Since tests run in the context of the container, we need to copy all
       # the coverage reports out of the container and into the host filesystem.
@@ -113,15 +110,7 @@ jobs:
         uses: codecov/codecov-action@v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          exclude: apps/prairielearn/python
           flags: javascript
-
-      - name: Upload Python coverage report to Codecov
-        uses: codecov/codecov-action@v5.4.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: apps/prairielearn/python
-          flags: python
 
   native-checks:
     runs-on: ubuntu-latest
@@ -233,3 +222,10 @@ jobs:
       # in those cases.
       - name: Check for duplicate Node dependencies
         run: yarn dedupe --check
+
+      - name: Upload Python coverage report to Codecov
+        uses: codecov/codecov-action@v5.4.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: apps/prairielearn/python
+          flags: python

--- a/scripts/copy_docker_coverage_reports.sh
+++ b/scripts/copy_docker_coverage_reports.sh
@@ -13,7 +13,6 @@ CONTAINER_NAME=$1
 # Construct a list of all coverage reports in the container.
 docker container exec $CONTAINER_NAME bash -c "find /PrairieLearn/apps -name cobertura-coverage.xml" >> /tmp/coverage_reports.txt
 docker container exec $CONTAINER_NAME bash -c "find /PrairieLearn/packages -name cobertura-coverage.xml" >> /tmp/coverage_reports.txt
-docker container exec $CONTAINER_NAME bash -c "find /PrairieLearn/apps/prairielearn/python -name coverage.xml" >> /tmp/coverage_reports.txt
 
 # Print the list for debugging.
 echo "Coverage reports in container:"


### PR DESCRIPTION
We were already running the Python tests in the (faster) `native-checks` job, we might as well use the coverage reports generated there. This should shave about a minute off the `test-prairielearn` job in the best case.