### PR TITLE
Remove empty names_for_user values from Python grader examples

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1288,17 +1288,10 @@ data["params"]["names_from_user"] = [
 
 <p>Your code snippet should define the following variables:</p>
 <pl-external-grader-variables params-name="names_from_user">
-  <pl-variable name="x" type="numpy array (length $n$)"
-    >Solution to $\mathbf{Ax}=\mathbf{b}$.</pl-variable
-  >
+  <pl-variable name="x" type="numpy array (length $n$)">
+    Solution to $\mathbf{Ax}=\mathbf{b}$.
+  </pl-variable>
 </pl-external-grader-variables>
-
-<!--
-  The following tag defines an empty list for the given params-name.
-  This is useful for some cases where a parameter must be set to empty to run the external grader.
-  Nothing will be displayed from this tag.
--->
-<pl-external-grader-variables params-name="names_empty" empty="true"></pl-external-grader-variables>
 ```
 
 ```python title="server.py"

--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -98,7 +98,7 @@ The question should contain a way for students to submit files, such as `<pl-fil
 
 By default, the grader will look for a gradable file named `user_code.py`, but this can be changed in the test suite.
 
-Expected variables can also be displayed to the user with the `<pl-external-grader-variables>` element. By setting the `variables-name` attribute to either `names_for_user` or `names_from_user`, both sets of variables can be shown.
+Provided and/or expected variables can also be displayed to the user with the `<pl-external-grader-variables>` element. By setting the `params-name` attribute to either `names_for_user` or `names_from_user`, either set of variables can be shown.
 
 ### `tests/setup_code.py`
 

--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -26,31 +26,68 @@ A full `info.json` file should look something like:
 }
 ```
 
-### `server.py`
+### Variables for and from the user
 
-The server code in the `generate()` function must define the list of variables or functions that will be passed to the autograded student code as `names_for_user`, and also those that will be passed from the student code to the test code as `names_from_user`. Only variables or functions listed in `names_for_user` will be accessible by the user from the setup code; only names listed in `names_from_user` will be accessible by the test cases from the user code.
+The question must specify the variables that will be read from student code for grading (`names_from_user`). Optionally, the question may also specify variables that will be made available to student code from the question's setup code (`names_for_user`). Only variables or functions listed in `names_for_user` will be accessible by the user from the setup code; only names listed in `names_from_user` will be accessible by the test cases from the user code.
 
-These are stored as a list of dictionary objects in the `data["params"]` dict. The above `names_for_user` and `names_from_user` lists are stored as separate keys in `params`. For example:
+Each variable must have the following:
+
+- `name`: The name of the variable in the student code.
+- `description`: A human-readable description of the variable.
+- `type`: A human-readable description of the type of the variable. This is used for display purposes only, and does not affect the grading.
+
+There are two ways to do specify these variables.
+
+#### `question.html`
+
+The `<pl-external-grader-variables>` element can be used to both specify and display a table of variables.
+
+```html title="question.html"
+<pl-external-grader-variables params-name="names_for_user">
+  <pl-variable name="n" type="integer">
+    Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.
+  </pl-variable>
+  <pl-variable name="A" type="numpy array (shape $n \times n$)"> Matrix $\mathbf{A}$. </pl-variable>
+  <pl-variable name="b" type="numpy array (length $n$)"> Vector $\mathbf{b}$. </pl-variable>
+</pl-external-grader-variables>
+
+<pl-external-grader-variables params-name="names_from_user">
+  <pl-variable name="x" type="numpy array (length $n$)">
+    Solution to $\mathbf{Ax}=\mathbf{b}$.
+  </pl-variable>
+</pl-external-grader-variables>
+```
+
+#### `server.py`
+
+If you need to dynamically generate the lists of variables, you can also do so directly in `server.py` by assigning to `data["params"]["names_for_user"]` and `data["params"]["names_from_user"]`. The below example is equivalent to the `question.html` example above:
 
 ```python title="server.py"
 def generate(data):
     data["params"]["names_for_user"] = [
-        {"name": "x", "description": "Description of the variable", "type": "float"},
+        {"name": "n", "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.", "type": "integer"},
+        {"name": "A", "description": r"Matrix $\mathbf{A}$.", "type": "numpy array"},
+        {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"}
     ]
     data["params"]["names_from_user"] = [
-        {"name": "x_sq", "description": "The square of $x$", "type": "float"},
+        {"name": "x", "description": r"Solution to $\mathbf{Ax}=\mathbf{b}$.", "type": "numpy array"}
     ]
 ```
 
-Each variable dictionary has entries `name` (the Python variable name in the code), `description` (human-readable), and `type` (human-readable). These variable lists are used for two purposes: (1) showing students which variables are used, and (2) making variables available to the student code and autograder code.
+You can still use `<pl-external-grader-variables>` to display the variables to students; just omit the nested `<pl-variable>` elements.
+
+```html title="question.html"
+<pl-external-grader-variables params-name="names_for_user"></pl-external-grader-variables>
+<pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
+```
 
 ### `question.html`
 
-At a minimum, the question markup should contain a `pl-file-editor` element (or `pl-file-upload`) and a `pl-external-grader-results` to show the status of grading jobs. These are placed in the question panel and submission panel, respectively. It is also recommended to place a `pl-file-preview` element in the submission panel so that students may see their previous code submissions. An example question markup is given below:
+The question should contain a way for students to submit files, such as `<pl-file-editor>`, `<pl-file-upload>`, or a workspace. The question should also contain a `<pl-external-grader-results>` element to show the grading results. These are placed in the question panel and submission panel, respectively. It is also recommended to place a `<pl-file-preview>` element in the submission panel so that students may see their previous code submissions. An example question markup is given below:
 
 ```html title="question.html"
 <pl-question-panel>
-  <pl-file-editor file-name="user_code.py"></pl-file-editor>
+  <pl-file-editor file-name="user_code.py" ace-mode="ace/mode/python"></pl-file-editor>
 </pl-question-panel>
 
 <pl-submission-panel>
@@ -62,35 +99,6 @@ At a minimum, the question markup should contain a `pl-file-editor` element (or 
 By default, the grader will look for a gradable file named `user_code.py`, but this can be changed in the test suite.
 
 Expected variables can also be displayed to the user with the `<pl-external-grader-variables>` element. By setting the `variables-name` attribute to either `names_for_user` or `names_from_user`, both sets of variables can be shown.
-
-Full example:
-
-```html title="question.html"
-<pl-question-panel>
-  <p>... Question prompt ...</p>
-
-  <p>The setup code gives the following variables:</p>
-  <p>
-    <pl-external-grader-variables
-      variables-category="names_for_user"
-    ></pl-external-grader-variables>
-  </p>
-
-  <p>Your code snippet should define the following variables:</p>
-  <pl-external-grader-variables variables-category="names_from_user"></pl-external-grader-variables>
-  <pl-file-editor
-    file_name="user_code.py"
-    ace_mode="ace/mode/python"
-    source-file-name="tests/initial_code.py"
-  ></pl-file-editor>
-</pl-question-panel>
-
-<pl-submission-panel>
-  <pl-external-grader-results></pl-external-grader-results>
-</pl-submission-panel>
-```
-
-Note that the `<pl-external-grader-variables>` element is for purely decorative purposes only, `names_for_user` or `names_from_user` or both can be omitted without any negative results.
 
 ### `tests/setup_code.py`
 

--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -26,7 +26,7 @@ A full `info.json` file should look something like:
 }
 ```
 
-### Variables for and from the user
+### User variables
 
 The question must specify the variables that will be read from student code for grading (`names_from_user`). Optionally, the question may also specify variables that will be made available to student code from the question's setup code (`names_for_user`). Only variables or functions listed in `names_for_user` will be accessible by the user from the setup code; only names listed in `names_from_user` will be accessible by the test cases from the user code.
 
@@ -38,48 +38,48 @@ Each variable must have the following:
 
 There are two ways to do specify these variables.
 
-#### `question.html`
+=== "`question.html`"
 
-The `<pl-external-grader-variables>` element can be used to both specify and display a table of variables.
+    The `<pl-external-grader-variables>` element can be used to both specify and display a table of variables.
 
-```html title="question.html"
-<pl-external-grader-variables params-name="names_for_user">
-  <pl-variable name="n" type="integer">
-    Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.
-  </pl-variable>
-  <pl-variable name="A" type="numpy array (shape $n \times n$)"> Matrix $\mathbf{A}$. </pl-variable>
-  <pl-variable name="b" type="numpy array (length $n$)"> Vector $\mathbf{b}$. </pl-variable>
-</pl-external-grader-variables>
+    ```html title="question.html"
+    <pl-external-grader-variables params-name="names_for_user">
+      <pl-variable name="n" type="integer">
+        Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.
+      </pl-variable>
+      <pl-variable name="A" type="numpy array (shape $n \times n$)"> Matrix $\mathbf{A}$. </pl-variable>
+      <pl-variable name="b" type="numpy array (length $n$)"> Vector $\mathbf{b}$. </pl-variable>
+    </pl-external-grader-variables>
 
-<pl-external-grader-variables params-name="names_from_user">
-  <pl-variable name="x" type="numpy array (length $n$)">
-    Solution to $\mathbf{Ax}=\mathbf{b}$.
-  </pl-variable>
-</pl-external-grader-variables>
-```
+    <pl-external-grader-variables params-name="names_from_user">
+      <pl-variable name="x" type="numpy array (length $n$)">
+        Solution to $\mathbf{Ax}=\mathbf{b}$.
+      </pl-variable>
+    </pl-external-grader-variables>
+    ```
 
-#### `server.py`
+=== "`server.py`"
 
-If you need to dynamically generate the lists of variables, you can also do so directly in `server.py` by assigning to `data["params"]["names_for_user"]` and `data["params"]["names_from_user"]`. The below example is equivalent to the `question.html` example above:
+    Using `<pl-external-grader-variables>` in `question.html` is the recommended way to specify user variables. However, if you need to dynamically generate the lists of variables or have more advanced needs, you can also do so directly in `server.py` by assigning to `data["params"]["names_for_user"]` and `data["params"]["names_from_user"]`. The following example is equivalent to the previous `question.html` example:
 
-```python title="server.py"
-def generate(data):
-    data["params"]["names_for_user"] = [
-        {"name": "n", "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.", "type": "integer"},
-        {"name": "A", "description": r"Matrix $\mathbf{A}$.", "type": "numpy array"},
-        {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"}
-    ]
-    data["params"]["names_from_user"] = [
-        {"name": "x", "description": r"Solution to $\mathbf{Ax}=\mathbf{b}$.", "type": "numpy array"}
-    ]
-```
+    ```python title="server.py"
+    def generate(data):
+        data["params"]["names_for_user"] = [
+            {"name": "n", "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.", "type": "integer"},
+            {"name": "A", "description": r"Matrix $\mathbf{A}$.", "type": "numpy array"},
+            {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"}
+        ]
+        data["params"]["names_from_user"] = [
+            {"name": "x", "description": r"Solution to $\mathbf{Ax}=\mathbf{b}$.", "type": "numpy array"}
+        ]
+    ```
 
-You can still use `<pl-external-grader-variables>` to display the variables to students; just omit the nested `<pl-variable>` elements.
+    You can still use `<pl-external-grader-variables>` to display the variables to students; just omit the nested `<pl-variable>` elements.
 
-```html title="question.html"
-<pl-external-grader-variables params-name="names_for_user"></pl-external-grader-variables>
-<pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
-```
+    ```html title="question.html"
+    <pl-external-grader-variables params-name="names_for_user"></pl-external-grader-variables>
+    <pl-external-grader-variables params-name="names_from_user"></pl-external-grader-variables>
+    ```
 
 ### `question.html`
 

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/question.html
@@ -16,7 +16,6 @@
     <pl-variable name="G" type="2d numpy array">markov matrix G</pl-variable>
     <pl-variable name="xstar2" type="1d numpy array">probability of winning and losing</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
 </pl-question-panel>
 

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/question.html
@@ -15,7 +15,6 @@
   <pl-external-grader-variables params-name="names_from_user">
     <pl-variable name="power_iteration" type="function">function that performs power iteration</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
 </pl-question-panel>
 

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/question.html
@@ -14,7 +14,6 @@
     <pl-variable name="M2" type="2d numpy array">markov matrix M2</pl-variable>
     <pl-variable name="M3" type="2d numpy array">markov matrix M3</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 </pl-question-panel>
 
 <pl-submission-panel>

--- a/exampleCourse/questions/demo/annotated/engMarkovBrewing/server.py
+++ b/exampleCourse/questions/demo/annotated/engMarkovBrewing/server.py
@@ -22,7 +22,6 @@ def generate(data):
     data["params"]["initial_culture"] = 100 - data["params"]["initial_sw"]
     data["params"]["percent_composition"] = random.randint(10, 25)
 
-    data["params"]["names_for_user"] = []
     data["params"]["names_from_user"] = [
         {
             "name": "hours",

--- a/exampleCourse/questions/demo/autograder/codeEditor/question.html
+++ b/exampleCourse/questions/demo/autograder/codeEditor/question.html
@@ -15,7 +15,6 @@
   <pl-external-grader-variables params-name="names_from_user">
     <pl-variable name="fib" type="python function">Function to compute the $n^\text{th}$ Fibonacci number</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
   <pl-file-editor file-name="user_code.py" ace-mode="ace/mode/python" source-file-name="initial_code.py">
   </pl-file-editor>

--- a/exampleCourse/questions/demo/autograder/codeUpload/question.html
+++ b/exampleCourse/questions/demo/autograder/codeUpload/question.html
@@ -18,7 +18,6 @@
   <pl-external-grader-variables params-name="names_from_user">
     <pl-variable name="fib" type="python function">Function to compute the $n^\text{th}$ Fibonacci number</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
   <pl-file-upload file-names="fib.py"></pl-file-upload>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/autograder/python/leadingTrailing/server.py
+++ b/exampleCourse/questions/demo/autograder/python/leadingTrailing/server.py
@@ -2,7 +2,6 @@ import base64
 
 
 def generate(data):
-    data["params"]["names_for_user"] = []
     data["params"]["names_from_user"] = [{"name": "gradient_descent"}]
 
 

--- a/exampleCourse/questions/demo/autograder/python/orderBlocksAddNumpy/server.py
+++ b/exampleCourse/questions/demo/autograder/python/orderBlocksAddNumpy/server.py
@@ -1,5 +1,4 @@
 def generate(data):
-    data["params"]["names_for_user"] = []
     data["params"]["names_from_user"] = [
         {
             "name": "my_dot_product",

--- a/exampleCourse/questions/demo/autograder/python/orderBlocksRandomParams/server.py
+++ b/exampleCourse/questions/demo/autograder/python/orderBlocksRandomParams/server.py
@@ -11,7 +11,6 @@ def generate(data):
     data["params"]["option3"] = "a = " + str(2 * a + 1)
     data["params"]["option4"] = "a = " + str(4 * a)
 
-    data["params"]["names_for_user"] = []
     data["params"]["names_from_user"] = [
         {
             "name": "return_number",

--- a/exampleCourse/questions/demo/autograder/python/pandas/question.html
+++ b/exampleCourse/questions/demo/autograder/python/pandas/question.html
@@ -8,7 +8,6 @@
         Create a Pandas DataFrame, <code>df</code>, that matches the following format:
         <pl-dataframe params-name="df" show-python="false"></pl-dataframe>
     </p>
-    <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
     <p>Your code snippet should define the following variables:</p>
     <pl-external-grader-variables params-name="names_from_user">
         <pl-variable name="df" type="Pandas DataFrame"></pl-variable>

--- a/exampleCourse/questions/demo/autograder/python/plots/question.html
+++ b/exampleCourse/questions/demo/autograder/python/plots/question.html
@@ -11,7 +11,6 @@
     </p>
 
     <p>The setup code does not provide any variables.</p>
-    <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
     <p>Your code snippet should define the following variables:</p>
     <pl-external-grader-variables params-name="names_from_user">

--- a/exampleCourse/questions/demo/autograder/python/random/question.html
+++ b/exampleCourse/questions/demo/autograder/python/random/question.html
@@ -13,7 +13,6 @@
     <pl-external-grader-variables params-name="names_from_user">
         <pl-variable name="area" type="Number">Approximate area of the circle.</pl-variable>
     </pl-external-grader-variables>
-    <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
     <pl-file-editor
         file-name="user_code.py"
         ace-mode="ace/mode/python"

--- a/exampleCourse/questions/demo/autograder/python/randomFunctionName/server.py
+++ b/exampleCourse/questions/demo/autograder/python/randomFunctionName/server.py
@@ -37,7 +37,6 @@ def generate(data):
     # Pick the function name
     function_name = random.choice(FUN_CHOICES)
 
-    data["params"]["names_for_user"] = []
     data["params"]["names_from_user"] = [
         {
             "name": function_name,

--- a/exampleCourse/questions/demo/workspace/jupyterlab/question.html
+++ b/exampleCourse/questions/demo/workspace/jupyterlab/question.html
@@ -18,7 +18,6 @@
   <pl-external-grader-variables params-name="names_from_user">
     <pl-variable name="fib" type="python function">Function to compute the $n^\text{th}$ Fibonacci number</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
   <pl-workspace></pl-workspace>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/workspace/vscode-python/question.html
+++ b/exampleCourse/questions/demo/workspace/vscode-python/question.html
@@ -18,7 +18,6 @@
   <pl-external-grader-variables params-name="names_from_user">
     <pl-variable name="fib" type="python function">Function to compute the $n^\text{th}$ Fibonacci number</pl-variable>
   </pl-external-grader-variables>
-  <pl-external-grader-variables params-name="names_for_user" empty="true"></pl-external-grader-variables>
 
   <pl-workspace></pl-workspace>
 </pl-question-panel>


### PR DESCRIPTION
As of https://github.com/PrairieLearn/PrairieLearn/pull/11808, `names_for_user` is now optional. This updates our example questions to reflect that.

I also reworked the documentation around this to reflect the fact that `names_for_user` is optional, and the fact that `<pl-external-grader-variables>` can actually be used to set `names_for_user` and `names_from_user`.

Closes #11689.