### PR TITLE
Use cache for image builds in test pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,8 +70,7 @@ jobs:
         run: docker tag prairielearn/plbase:${{ env.COMMIT_SHA }} prairielearn/plbase:latest
 
       - name: Build the prairielearn docker image
-        run: |
-          docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .
+        run: docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} --cache-from type=registry,ref=prairielearn/prairielearn:buildcache-linux-amd64 .
 
       # This ensures that the `prairielearn/executor` image is built with the
       # correct version of `prairielearn/prairielearn`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,18 +69,10 @@ jobs:
         if: ${{ env.images_plbase_modified }}
         run: docker tag prairielearn/plbase:${{ env.COMMIT_SHA }} prairielearn/plbase:latest
 
-      - name: Set up Turborepo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo/cache
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
+        s
       - name: Build the prairielearn docker image
         run: |
-          docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} \
-          --mount=type=bind,src=.turbo/cache dst=/PrairieLearn/.turbo \
-          --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .
+          docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .
 
       # This ensures that the `prairielearn/executor` image is built with the
       # correct version of `prairielearn/prairielearn`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,6 @@ jobs:
         if: ${{ env.images_plbase_modified }}
         run: docker tag prairielearn/plbase:${{ env.COMMIT_SHA }} prairielearn/plbase:latest
 
-        s
       - name: Build the prairielearn docker image
         run: |
           docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,8 @@ jobs:
         with:
           context: images/plbase
           platforms: linux/amd64
-          no-cache: true
+          pull: true
+          cache-from: type=registry,ref=prairielearn/plbase:buildcache-linux-amd64
           tags: prairielearn/plbase:${{ env.COMMIT_SHA }}
 
       # This ensures that the `prairielearn/prairielearn` image is built with the
@@ -69,7 +70,7 @@ jobs:
         run: docker tag prairielearn/plbase:${{ env.COMMIT_SHA }} prairielearn/plbase:latest
 
       - name: Build the prairielearn docker image
-        run: docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} .
+        run: docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .
 
       # This ensures that the `prairielearn/executor` image is built with the
       # correct version of `prairielearn/prairielearn`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,18 @@ jobs:
         if: ${{ env.images_plbase_modified }}
         run: docker tag prairielearn/plbase:${{ env.COMMIT_SHA }} prairielearn/plbase:latest
 
+      - name: Set up Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo/cache
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
       - name: Build the prairielearn docker image
-        run: docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .
+        run: |
+          docker build -t prairielearn/prairielearn:${{ env.COMMIT_SHA }} \
+          --mount=type=bind,src=.turbo/cache dst=/PrairieLearn/.turbo \
+          --cache-from prairielearn/prairielearn:buildcache-linux-amd64 .
 
       # This ensures that the `prairielearn/executor` image is built with the
       # correct version of `prairielearn/prairielearn`.


### PR DESCRIPTION
Not sure if this is worth doing, but this should save about half the docker rebuild time.