### PR TITLE
Fix duplicate feedback with check_numpy_array_allclose

### DIFF
--- a/graders/python/python_autograder/code_feedback.py
+++ b/graders/python/python_autograder/code_feedback.py
@@ -298,7 +298,7 @@ class Feedback:
         import numpy as np
 
         if not cls.check_numpy_array_features(
-            name, ref, data, accuracy_critical, report_failure
+            name, ref, data, accuracy_critical, report_failure, report_success=False
         ):
             return False
 


### PR DESCRIPTION
This was a regression introduced in https://github.com/PrairieLearn/PrairieLearn/pull/9436. When using `check_numpy_array_allclose(...)`, the "looks good" feedback is printed twice:

![image](https://github.com/user-attachments/assets/9f7621ec-395c-412a-8a06-8580120e0a7c)

To fix this, we just tell `check_numpy_array_features(...)` not to print anything in case of success.