### PR TITLE
LTI 1.3: Add submission metadata to grade posting

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -16,6 +16,7 @@ import {
   runInTransactionAsync,
 } from '@prairielearn/postgres';
 
+import { selectAssessmentInstanceLastSubmissionDate } from '../../lib/assessment.js';
 import {
   AssessmentInstanceSchema,
   AssessmentSchema,
@@ -615,9 +616,12 @@ export const Lti13ScoreSchema = z.object({
   activityProgress: z.enum(['Initialized', 'Started', 'InProgress', 'Submitted', 'Completed']),
   gradingProgress: z.enum(['FullyGraded', 'Pending', 'PendingManual', 'Failed', 'NotReady']),
   timestamp: DateFromISOString,
-  submission: z.any().optional(),
-  startedAt: DateFromISOString.optional(),
-  submittedAt: DateFromISOString.optional(),
+  submission: z
+    .object({
+      startedAt: DateFromISOString.optional(),
+      submittedAt: DateFromISOString.optional(),
+    })
+    .optional(),
   comment: z.string().optional(),
 });
 export type Lti13Score = z.infer<typeof Lti13ScoreSchema>;
@@ -777,6 +781,8 @@ export async function updateLti13Scores(
         continue;
       }
 
+      const submittedAt = await selectAssessmentInstanceLastSubmissionDate(assessment_instance.id);
+
       /*
        https://www.imsglobal.org/spec/lti-ags/v2p0#score-service-media-type-and-schema
        Canvas has extensions we could use described at
@@ -784,12 +790,15 @@ export async function updateLti13Scores(
       */
       const score: Lti13Score = {
         timestamp,
-        startedAt: assessment_instance.date,
         scoreGiven: assessment_instance.score_perc,
         scoreMaximum: 100,
         activityProgress: assessment_instance.open ? 'Submitted' : 'Completed',
         gradingProgress: 'FullyGraded',
         userId,
+        submission: {
+          startedAt: assessment_instance.date,
+          ...(submittedAt != null && { submittedAt }),
+        },
       };
 
       const res = await fetchRetry(assessment.lti13_lineitem_id_url + '/scores', {

--- a/apps/prairielearn/src/lib/assessment.sql
+++ b/apps/prairielearn/src/lib/assessment.sql
@@ -1778,3 +1778,13 @@ FROM
   deleted_assessment_instances AS ai
   LEFT JOIN assessments AS a ON (a.id = ai.assessment_id)
   LEFT JOIN course_instances AS ci ON (ci.id = a.course_instance_id);
+
+-- BLOCK select_assessment_instance_last_submission_date
+SELECT
+  max(s.date)
+FROM
+  submissions AS s
+  JOIN variants AS v ON (v.id = s.variant_id)
+  JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
+WHERE
+  iq.assessment_instance_id = $assessment_instance_id;

--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -12,6 +12,7 @@ import {
   AssessmentInstanceSchema,
   ClientFingerprintSchema,
   CourseSchema,
+  DateFromISOString,
   IdSchema,
   QuestionSchema,
   VariantSchema,
@@ -594,5 +595,13 @@ export function canDeleteAssessmentInstance(resLocals): boolean {
     // Check that the assessment instance was created by an instructor; bypass
     // this check if the course is an example course.
     (!resLocals.assessment_instance.include_in_statistics || resLocals.course.example_course)
+  );
+}
+
+export async function selectAssessmentInstanceLastSubmissionDate(assessment_instance_id: string) {
+  return await sqldb.queryRow(
+    sql.select_assessment_instance_last_submission_date,
+    { assessment_instance_id },
+    DateFromISOString.nullable(),
   );
 }


### PR DESCRIPTION
Modifies LTI 1.3 grade posting:

- Fixes a bug with `startedAt` timestamp
- Adds `submittedAt` timestamp to reflect the latest student submission

This should hopefully address the LMS submission date awareness so it doesn't think the timestamp of grade posting was a student submission. 

