### PR TITLE
Refactor partial scores calculations in v3 questions

### DIFF
--- a/apps/prairielearn/src/question-servers/calculation-subprocess.js
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.js
@@ -175,7 +175,7 @@ export async function prepare(_question, _course, variant) {
   const data = {
     params: variant.params ?? {},
     true_answer: variant.true_answer ?? {},
-    options: variant.options,
+    options: variant.options ?? {},
   };
   return { courseIssues: [], data };
 }

--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -916,12 +916,10 @@ async function processQuestionHtml(phase, codeCaller, data, context) {
   });
 
   if (phase === 'grade' || phase === 'test') {
-    const partial_scores = /** @type {Record<string, unknown>} */ (resultData.partial_scores ?? {});
-
     if (context.question.partial_credit) {
       let total_weight = 0;
       let total_weight_score = 0;
-      for (const value of Object.values(partial_scores)) {
+      for (const value of Object.values(resultData.partial_scores ?? {})) {
         const { score, weight } = getPartialScoreValues(value);
         total_weight += weight;
         total_weight_score += weight * score;
@@ -930,8 +928,10 @@ async function processQuestionHtml(phase, codeCaller, data, context) {
     } else {
       let score = 0;
       if (
-        Object.keys(partial_scores).length > 0 &&
-        Object.values(partial_scores).every((value) => getPartialScoreValues(value).score >= 1)
+        Object.keys(resultData.partial_scores ?? {}).length > 0 &&
+        Object.values(resultData.partial_scores ?? {}).every(
+          (value) => getPartialScoreValues(value).score >= 1,
+        )
       ) {
         score = 1;
       }

--- a/apps/prairielearn/src/question-servers/types.ts
+++ b/apps/prairielearn/src/question-servers/types.ts
@@ -16,9 +16,9 @@ export type QuestionServerReturnValue<T> = Promise<{
 }>;
 
 export interface GenerateResultData {
-  params: Record<string, any>;
-  true_answer: Record<string, any>;
-  options?: Record<string, any> | null;
+  params: Record<string, unknown>;
+  true_answer: Record<string, unknown>;
+  options?: Record<string, unknown>;
 }
 
 export type PrepareResultData = GenerateResultData;
@@ -31,34 +31,34 @@ export interface RenderResultData {
 }
 
 export interface ParseResultData {
-  params: Record<string, any>;
-  true_answer: Record<string, any>;
-  submitted_answer: Record<string, any>;
-  feedback: Record<string, any>;
-  raw_submitted_answer: Record<string, any>;
-  format_errors: Record<string, any>;
+  params: Record<string, unknown>;
+  true_answer: Record<string, unknown>;
+  submitted_answer: Record<string, unknown>;
+  feedback: Record<string, unknown>;
+  raw_submitted_answer: Record<string, unknown>;
+  format_errors: Record<string, unknown>;
   gradable: boolean;
 }
 
 export interface GradeResultData {
-  params: Record<string, any>;
-  true_answer: Record<string, any>;
-  submitted_answer: Record<string, any>;
-  format_errors: Record<string, any>;
-  raw_submitted_answer: Record<string, any>;
-  partial_scores: Record<string, any>;
+  params: Record<string, unknown>;
+  true_answer: Record<string, unknown>;
+  submitted_answer: Record<string, unknown>;
+  format_errors: Record<string, unknown>;
+  raw_submitted_answer: Record<string, unknown>;
+  partial_scores: Record<string, unknown>;
   score: number;
-  feedback: Record<string, any>;
+  feedback: Record<string, unknown>;
   gradable: boolean;
   v2_score?: number;
 }
 
 export interface TestResultData {
   params: Record<string, any>;
-  true_answer: Record<string, any>;
-  format_errors: Record<string, any>;
-  raw_submitted_answer: Record<string, any>;
-  partial_scores: Record<string, any>;
+  true_answer: Record<string, unknown>;
+  format_errors: Record<string, unknown>;
+  raw_submitted_answer: Record<string, unknown>;
+  partial_scores: Record<string, unknown>;
   score: number;
   gradable: boolean;
 }
@@ -121,9 +121,9 @@ export type ElementExtensionJsonExtension = ElementExtensionJson & {
 // That is why many fields are optional, as they are only present in later phases.
 export interface ExecutionData {
   params: Record<string, any>;
-  correct_answers: Record<string, any>;
+  correct_answers: Record<string, unknown>;
   variant_seed: number;
-  options: Record<string, any> & {
+  options: Record<string, unknown> & {
     question_path: string;
     client_files_question_path: string;
     client_files_course_path: string;
@@ -131,17 +131,17 @@ export interface ExecutionData {
     course_extensions_path: string;
   };
   answers_names?: Record<string, string>;
-  submitted_answers?: Record<string, any>;
-  format_errors?: Record<string, any>;
-  partial_scores?: Record<string, any>;
+  submitted_answers?: Record<string, unknown>;
+  format_errors?: Record<string, unknown>;
+  partial_scores?: Record<string, unknown>;
   score?: number;
-  feedback?: Record<string, any>;
-  raw_submitted_answers?: Record<string, any>;
+  feedback?: Record<string, unknown>;
+  raw_submitted_answers?: Record<string, unknown>;
   editable?: boolean;
   manual_grading?: boolean;
   panel?: 'question' | 'answer' | 'submission';
   num_valid_submissions?: number;
   filename?: string;
   gradable?: boolean;
-  extensions?: Record<string, ElementExtensionJsonExtension> | [];
+  extensions?: Record<string, ElementExtensionJsonExtension>;
 }


### PR DESCRIPTION
Lifting this out of #11053.

Our validation on data coming back from workers only ensures that `partial_scores` is an object. It doesn't say anything about what type the object's values have. To improve the safety here, we're now representing `partial_scores` (and all other `data` dictionaries) as `Record<string, unknown>` to force ourselves to validate the values we're reading from it.