### PR TITLE
Mark variant as broken when prepare phase errors

### DIFF
--- a/apps/prairielearn/src/question-servers/freeform.js
+++ b/apps/prairielearn/src/question-servers/freeform.js
@@ -549,7 +549,13 @@ async function experimentalProcess(phase, codeCaller, data, context, html) {
     result = res.result;
     output = res.output;
   } catch (err) {
-    courseIssues.push(err);
+    courseIssues.push(
+      new CourseIssueError(err.message, {
+        data: err.data,
+        cause: err,
+        fatal: true,
+      }),
+    );
   }
 
   if ((output?.length ?? 0) > 0) {

--- a/testCourse/questions/brokenGeneration/info.json
+++ b/testCourse/questions/brokenGeneration/info.json
@@ -2,6 +2,5 @@
   "uuid": "a2f12dbe-e030-4782-87aa-713d61728539",
   "title": "Broken generation function",
   "topic": "Algebra",
-  "tags": ["mwest", "fa18", "tpl101", "v3"],
   "type": "v3"
 }

--- a/testCourse/questions/brokenPrepare/info.json
+++ b/testCourse/questions/brokenPrepare/info.json
@@ -1,0 +1,6 @@
+{
+  "uuid": "938405f1-6b40-4beb-b1cb-6f8225f9a4d2",
+  "title": "Broken prepare phase",
+  "topic": "Algebra",
+  "type": "v3"
+}

--- a/testCourse/questions/brokenPrepare/question.html
+++ b/testCourse/questions/brokenPrepare/question.html
@@ -1,0 +1,2 @@
+<!-- Deliberately broken; missing answers-name attribute -->
+<pl-string-input></pl-string-input>


### PR DESCRIPTION
I noticed this behavior difference when working on some automated comparisons between the `legacy` and `experimental` question processors. `legacy` and `new` treat any failure of Python code as a fatal error; this PR updates the `experimental` processor to do the same.

You can test this with the new question introduced in this PR. Before this change, the variant would not be marked as broken; now it is.