### PR TITLE
Add CJS Preact packages

### DIFF
--- a/packages/preact-cjs-compat/README.md
+++ b/packages/preact-cjs-compat/README.md
@@ -1,0 +1,3 @@
+# `@prairielearn/preact-cjs-compat`
+
+This package is an alternative to `@preact/compat` that works with `@prairielearn/preact-cjs`.

--- a/packages/preact-cjs-compat/package.json
+++ b/packages/preact-cjs-compat/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@prairielearn/preact-cjs-compat",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PrairieLearn/PrairieLearn.git",
+    "directory": "packages/browser-utils"
+  },
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./server": "./dist/server.js",
+    "./server.browser": "./dist/server.js",
+    "./client": "./dist/client.js",
+    "./jsx-dev-runtime": "./dist/jsx-dev-runtime.js",
+    "./jsx-runtime": "./dist/jsx-runtime.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc && rm -rf dist && mv dist-tmp dist",
+    "dev": "tsc --watch --preserveWatchOutput"
+  },
+  "dependencies": {
+    "@prairielearn/preact-cjs": "workspace:^"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "workspace:^",
+    "typescript": "^5.7.3"
+  },
+  "sideEffects": false
+}

--- a/packages/preact-cjs-compat/package.json
+++ b/packages/preact-cjs-compat/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/PrairieLearn/PrairieLearn.git",
-    "directory": "packages/browser-utils"
+    "directory": "packages/preact-cjs-compat"
   },
   "main": "dist/index.js",
   "exports": {

--- a/packages/preact-cjs-compat/package.json
+++ b/packages/preact-cjs-compat/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.3"
   },
   "sideEffects": false
 }

--- a/packages/preact-cjs-compat/src/index.ts
+++ b/packages/preact-cjs-compat/src/index.ts
@@ -1,0 +1,3 @@
+import React from '@prairielearn/preact-cjs/compat';
+
+export = React;

--- a/packages/preact-cjs-compat/src/jsx-dev-runtime.ts
+++ b/packages/preact-cjs-compat/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from '@prairielearn/preact-cjs/jsx-dev-runtime';

--- a/packages/preact-cjs-compat/src/jsx-runtime.ts
+++ b/packages/preact-cjs-compat/src/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export * from '@prairielearn/preact-cjs/jsx-runtime';

--- a/packages/preact-cjs-compat/tsconfig.json
+++ b/packages/preact-cjs-compat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@prairielearn/tsconfig/tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist-tmp",
+    "rootDir": "./src",
+    "moduleResolution": "Node16",
+    "module": "Node16",
+    "verbatimModuleSyntax": false
+  }
+}

--- a/packages/preact-cjs/README.md
+++ b/packages/preact-cjs/README.md
@@ -1,0 +1,3 @@
+# `@prairielearn/preact-cjs`
+
+This package re-exports all of Preact's exports, but _only_ the CJS versions. We can't rely on the original package, which provides both ESM and CJS exports, because we have a mixed ESM/CJS codebase and the CJS/ESM versions of Preact don't share the necessary singleton state with each other. So, we need to ensure that we always use the CJS version of Preact.

--- a/packages/preact-cjs/package.json
+++ b/packages/preact-cjs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@prairielearn/preact-cjs",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PrairieLearn/PrairieLearn.git",
+    "directory": "packages/browser-utils"
+  },
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./compat": "./dist/compat.js",
+    "./hooks": "./dist/hooks.js",
+    "./jsx-dev-runtime": "./dist/jsx-dev-runtime.js",
+    "./jsx-runtime": "./dist/jsx-runtime.js"
+  },
+  "scripts": {
+    "build": "tsc && rm -rf dist && mv dist-tmp dist",
+    "dev": "tsc --watch --preserveWatchOutput"
+  },
+  "dependencies": {
+    "original-preact": "npm:preact@^10.25.4"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "workspace:^",
+    "typescript": "^5.7.3"
+  },
+  "sideEffects": false
+}

--- a/packages/preact-cjs/package.json
+++ b/packages/preact-cjs/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/PrairieLearn/PrairieLearn.git",
-    "directory": "packages/browser-utils"
+    "directory": "packages/preact-cjs"
   },
   "main": "dist/index.js",
   "exports": {

--- a/packages/preact-cjs/package.json
+++ b/packages/preact-cjs/package.json
@@ -20,11 +20,11 @@
     "dev": "tsc --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "original-preact": "npm:preact@^10.25.4"
+    "original-preact": "npm:preact@^10.26.5"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.3"
   },
   "sideEffects": false
 }

--- a/packages/preact-cjs/src/compat.ts
+++ b/packages/preact-cjs/src/compat.ts
@@ -1,0 +1,3 @@
+import React from 'original-preact/compat';
+
+export = React as typeof React;

--- a/packages/preact-cjs/src/hooks.ts
+++ b/packages/preact-cjs/src/hooks.ts
@@ -1,0 +1,1 @@
+export * from 'original-preact/hooks';

--- a/packages/preact-cjs/src/index.ts
+++ b/packages/preact-cjs/src/index.ts
@@ -1,0 +1,1 @@
+export * from 'original-preact';

--- a/packages/preact-cjs/src/jsx-dev-runtime.ts
+++ b/packages/preact-cjs/src/jsx-dev-runtime.ts
@@ -1,0 +1,1 @@
+export * from 'original-preact/jsx-dev-runtime';

--- a/packages/preact-cjs/src/jsx-runtime.ts
+++ b/packages/preact-cjs/src/jsx-runtime.ts
@@ -1,0 +1,1 @@
+export * from 'original-preact/jsx-runtime';

--- a/packages/preact-cjs/tsconfig.json
+++ b/packages/preact-cjs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@prairielearn/tsconfig/tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist-tmp",
+    "rootDir": "./src",
+    "moduleResolution": "Node16",
+    "module": "Node16",
+    "verbatimModuleSyntax": false,
+    "typeRoots": [],
+    "types": []
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,6 +4002,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@prairielearn/preact-cjs-compat@workspace:packages/preact-cjs-compat":
+  version: 0.0.0-use.local
+  resolution: "@prairielearn/preact-cjs-compat@workspace:packages/preact-cjs-compat"
+  dependencies:
+    "@prairielearn/preact-cjs": "workspace:^"
+    "@prairielearn/tsconfig": "workspace:^"
+    typescript: "npm:^5.8.3"
+  languageName: unknown
+  linkType: soft
+
+"@prairielearn/preact-cjs@workspace:^, @prairielearn/preact-cjs@workspace:packages/preact-cjs":
+  version: 0.0.0-use.local
+  resolution: "@prairielearn/preact-cjs@workspace:packages/preact-cjs"
+  dependencies:
+    "@prairielearn/tsconfig": "workspace:^"
+    original-preact: "npm:preact@^10.26.5"
+    typescript: "npm:^5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "@prairielearn/prettier-plugin-sql@workspace:^, @prairielearn/prettier-plugin-sql@workspace:packages/prettier-plugin-sql":
   version: 0.0.0-use.local
   resolution: "@prairielearn/prettier-plugin-sql@workspace:packages/prettier-plugin-sql"
@@ -13492,6 +13512,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"original-preact@npm:preact@^10.26.5, preact@npm:^10.26.5":
+  version: 10.26.5
+  resolution: "preact@npm:10.26.5"
+  checksum: 10c0/542a924009489c21b24e9588a5580dac03239a60951d10e6ad1207db66c8e719e1d46a38af6577c8f324b238fbe2aa92e0ffc04d3a71dbe182f56426c8abe632
+  languageName: node
+  linkType: hard
+
 "os-tmpdir@npm:^1.0.2, os-tmpdir@npm:~1.0.2":
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
@@ -14122,13 +14149,6 @@ __metadata:
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
-
-"preact@npm:^10.26.5":
-  version: 10.26.5
-  resolution: "preact@npm:10.26.5"
-  checksum: 10c0/542a924009489c21b24e9588a5580dac03239a60951d10e6ad1207db66c8e719e1d46a38af6577c8f324b238fbe2aa92e0ffc04d3a71dbe182f56426c8abe632
-  languageName: node
-  linkType: hard
 
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1


### PR DESCRIPTION
Preact dual-publishes CJS and ESM code, but they're unable or unwilling to fix the resulting bugs when Preact is used in a mixed ESM/CJS codebase: https://github.com/preactjs/preact/issues/4648

To work around this, we wrap `preact` and `@preact/compat` in our own packages, `@prairielearn/preact-cjs` and `@prairielearn/preact-cjs-compat`. These re-export _only_ the CJS versions of the Preact code.

I'm lifting this out of #10944 as these changes are easy to merge independently. Note that the packages are not yet used, nor are the necessary `overrides` in `package.json` set up yet. I'll introduce those in a future PR when we actually start using Preact to render UI.