### PR TITLE
Add in-term ratios for course instance usages

### DIFF
--- a/apps/prairielearn/src/admin_queries/course_instances_usage.json
+++ b/apps/prairielearn/src/admin_queries/course_instances_usage.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "minimum_term_ratio",
-      "description": "Minimum ratio of in-term vs out-of-term submissions for a course instance to count as active.",
+      "description": "Minimum ratio of in-term to total submissions for a course instance to count as active.",
       "default": "0.5"
     },
     {

--- a/apps/prairielearn/src/admin_queries/course_instances_usage.json
+++ b/apps/prairielearn/src/admin_queries/course_instances_usage.json
@@ -7,14 +7,39 @@
       "default": ""
     },
     {
-      "name": "start_date",
-      "description": "Start of the date range (e.g., the drop deadline near the start of the term).",
+      "name": "total_start",
+      "description": "Start of the total time period (should be at least 6 months before the term start).",
       "default": "2021-01-01T00:00:00"
     },
     {
-      "name": "end_date",
-      "description": "End of the date range (e.g., last day of the term).",
+      "name": "term_start",
+      "description": "Start of the term.",
+      "default": "2021-01-01T00:00:00"
+    },
+    {
+      "name": "active_start",
+      "description": "Start of the active date range (the drop deadline in the term).",
+      "default": "2021-01-01T00:00:00"
+    },
+    {
+      "name": "term_end",
+      "description": "End of the term.",
       "default": "2022-01-01T00:00:00"
+    },
+    {
+      "name": "total_end",
+      "description": "End of the total time period (should be at least 6 months past the term end, even if that's in the future).",
+      "default": "2022-01-01T00:00:00"
+    },
+    {
+      "name": "minimum_term_ratio",
+      "description": "Minimum ratio of in-term vs out-of-term submissions for a course instance to count as active.",
+      "default": "0.5"
+    },
+    {
+      "name": "minimum_student_count",
+      "description": "Minimum number of students for a course instance to count as active.",
+      "default": "5"
     }
   ]
 }

--- a/apps/prairielearn/src/admin_queries/course_instances_usage.sql
+++ b/apps/prairielearn/src/admin_queries/course_instances_usage.sql
@@ -215,7 +215,7 @@ SELECT
   CASE
     WHEN ci.id IS NOT NULL
     AND cd.submission_term_ratio >= $minimum_term_ratio
-    AND cd.total_students > $minimum_student_count THEN 1
+    AND cd.total_students >= $minimum_student_count THEN 1
     ELSE NULL
   END AS active_instance,
   -- number of course staff

--- a/apps/prairielearn/src/admin_queries/course_instances_usage.sql
+++ b/apps/prairielearn/src/admin_queries/course_instances_usage.sql
@@ -1,6 +1,10 @@
+-- There are three time ranges:
+-- 1. "active": $active_start to $term_end (this is the time range when we count active enrollments)
+-- 2. "term": $term_start to $term_end (this is the true term time range, for determining term ratios)
+-- 3. "total": $total_start to $total_end (this is the time range for detecting usage outside of the term)
 WITH
-  -- First we select all usage data for the given institution(s) and time range.
-  selected_course_instance_usages AS (
+  -- Select all usage data for the given institution(s) and the active time range.
+  active_course_instance_usages AS (
     SELECT
       ciu.*
     FROM
@@ -12,46 +16,137 @@ WITH
         OR $institution_short_name::text = ''
         OR $institution_short_name::text IS NULL
       )
-      AND ciu.date BETWEEN $start_date AND $end_date
+      AND ciu.date BETWEEN $active_start AND $term_end
   ),
-  -- Now we'll select out the student usage data. This is all data with
-  -- `include_in_statistics` set to true. We also set the `total_staff` to NULL
-  -- for the later UNION. This student data must have a `course_instance_id`.
-  student_course_instances_usage_data AS (
+  -- Select all usage data for the given institution(s) and the term time range.
+  term_course_instance_usages AS (
     SELECT
-      sciu.course_id,
-      sciu.course_instance_id,
-      NULL::bigint AS total_staff,
+      ciu.*
+    FROM
+      institutions AS i
+      JOIN course_instance_usages AS ciu ON (ciu.institution_id = i.id)
+    WHERE
+      (
+        i.short_name = $institution_short_name::text
+        OR $institution_short_name::text = ''
+        OR $institution_short_name::text IS NULL
+      )
+      AND ciu.date BETWEEN $term_start AND $term_end
+  ),
+  -- Select all usage data for the given institution(s) and the total time range.
+  total_course_instance_usages AS (
+    SELECT
+      ciu.*
+    FROM
+      institutions AS i
+      JOIN course_instance_usages AS ciu ON (ciu.institution_id = i.id)
+    WHERE
+      (
+        i.short_name = $institution_short_name::text
+        OR $institution_short_name::text = ''
+        OR $institution_short_name::text IS NULL
+      )
+      AND ciu.date BETWEEN $total_start AND $total_end
+  ),
+  -- Calculate the student usage data in the active time range.
+  student_active_data AS (
+    SELECT
+      ciu.course_id,
+      ciu.course_instance_id,
       count(DISTINCT u.user_id) AS total_students,
       count(DISTINCT u.user_id) FILTER (
         WHERE
           u.institution_id != i.id
-      ) AS outside_students,
+      ) AS outside_students
+    FROM
+      active_course_instance_usages AS ciu
+      JOIN institutions AS i ON (i.id = ciu.institution_id)
+      JOIN users AS u ON (u.user_id = ciu.user_id)
+    WHERE
+      ciu.include_in_statistics
+    GROUP BY
+      ciu.course_id,
+      ciu.course_instance_id
+  ),
+  -- Calculate the student usage data in the term time range.
+  student_term_data AS (
+    SELECT
+      ciu.course_id,
+      ciu.course_instance_id,
+      count(*) FILTER (
+        WHERE
+          ciu.type = 'Submission'
+      ) AS term_submissions,
       EXTRACT(
         EPOCH
         FROM
-          sum(sciu.duration) FILTER (
+          sum(ciu.duration) FILTER (
             WHERE
-              sciu.type = 'External grading'
+              ciu.type = 'External grading'
           )
       ) / 3600 AS external_grading_hours,
       EXTRACT(
         EPOCH
         FROM
-          sum(sciu.duration) FILTER (
+          sum(ciu.duration) FILTER (
             WHERE
-              sciu.type = 'Workspace'
+              ciu.type = 'Workspace'
           )
       ) / 3600 AS workspace_hours
     FROM
-      selected_course_instance_usages AS sciu
-      JOIN institutions AS i ON (i.id = sciu.institution_id)
-      JOIN users AS u ON (u.user_id = sciu.user_id)
+      term_course_instance_usages AS ciu
+      JOIN institutions AS i ON (i.id = ciu.institution_id)
+      JOIN users AS u ON (u.user_id = ciu.user_id)
     WHERE
-      sciu.include_in_statistics
+      ciu.include_in_statistics
     GROUP BY
-      sciu.course_id,
-      sciu.course_instance_id
+      ciu.course_id,
+      ciu.course_instance_id
+  ),
+  -- Calculate the student usage data in the total time range.
+  student_total_data AS (
+    SELECT
+      ciu.course_id,
+      ciu.course_instance_id,
+      count(*) FILTER (
+        WHERE
+          ciu.type = 'Submission'
+      ) AS total_submissions
+    FROM
+      total_course_instance_usages AS ciu
+      JOIN institutions AS i ON (i.id = ciu.institution_id)
+      JOIN users AS u ON (u.user_id = ciu.user_id)
+    WHERE
+      ciu.include_in_statistics
+    GROUP BY
+      ciu.course_id,
+      ciu.course_instance_id
+  ),
+  -- Aggregate the student data usage and compute the "submission term ratio"
+  -- for each course instance. This is the ratio of submissions that occured
+  -- within the term to the total submissions over all time.
+  student_course_instances_usage_data AS (
+    SELECT
+      active.course_id,
+      active.course_instance_id,
+      NULL::bigint AS total_staff,
+      active.total_students,
+      active.outside_students,
+      term.term_submissions,
+      total.total_submissions,
+      term.term_submissions::float / greatest(1, total.total_submissions::float) AS submission_term_ratio,
+      term.external_grading_hours,
+      term.workspace_hours
+    FROM
+      student_active_data AS active
+      JOIN student_term_data AS term ON (
+        term.course_id = active.course_id
+        AND term.course_instance_id = active.course_instance_id
+      )
+      JOIN student_total_data AS total ON (
+        total.course_id = active.course_id
+        AND total.course_instance_id = active.course_instance_id
+      )
   ),
   -- Now we get the staff usage data. This is all data with
   -- `include_in_statistics` set to false. We also set the `total_students` and
@@ -61,34 +156,36 @@ WITH
   -- the course level, so we set the `course_instance_id` to NULL.
   staff_courses_usage_data AS (
     SELECT
-      sciu.course_id,
+      ciu.course_id,
       NULL::bigint AS course_instance_id,
-      count(DISTINCT sciu.user_id) AS total_staff,
+      count(DISTINCT ciu.user_id) AS total_staff,
       NULL::bigint AS total_students,
       NULL::bigint AS outside_students,
+      NULL::bigint AS term_submissions,
+      NULL::bigint AS total_submissions,
+      NULL::float AS submission_term_ratio,
       EXTRACT(
         EPOCH
         FROM
-          sum(sciu.duration) FILTER (
+          sum(ciu.duration) FILTER (
             WHERE
-              sciu.type = 'External grading'
+              ciu.type = 'External grading'
           )
       ) / 3600 AS external_grading_hours,
       EXTRACT(
         EPOCH
         FROM
-          sum(sciu.duration) FILTER (
+          sum(ciu.duration) FILTER (
             WHERE
-              sciu.type = 'Workspace'
+              ciu.type = 'Workspace'
           )
       ) / 3600 AS workspace_hours
     FROM
-      selected_course_instance_usages AS sciu
+      term_course_instance_usages AS ciu
     WHERE
-      sciu.type = 'Submission'
-      AND NOT sciu.include_in_statistics
+      NOT ciu.include_in_statistics
     GROUP BY
-      sciu.course_id
+      ciu.course_id
   ),
   -- As the final step, we combine the student and staff usage data into a single
   -- table. The above queries are designed to have the same columns, so we can
@@ -114,12 +211,25 @@ SELECT
   c.id AS course_id,
   ci.short_name AS course_instance,
   ci.id AS course_instance_id,
+  -- is this course instance active?
+  CASE
+    WHEN ci.id IS NOT NULL
+    AND cd.submission_term_ratio >= $minimum_term_ratio
+    AND cd.total_students > $minimum_student_count THEN 1
+    ELSE NULL
+  END AS active_instance,
   -- number of course staff
   cd.total_staff,
   -- total number of students
   cd.total_students,
   -- number of students from a different institution
   cd.outside_students,
+  -- number of submissions in the active date range
+  cd.term_submissions,
+  -- number of submissions in the total date range
+  cd.total_submissions,
+  -- ratio of submissions in the term date range to total submissions
+  cd.submission_term_ratio,
   -- running duration of external grading jobs (in hours)
   cd.external_grading_hours,
   -- running duration of workspaces (in hours)


### PR DESCRIPTION
This adds the ratio of in-term to total activity for course instance usages. It also adds cutoffs for the minimum such ratio (default: 0.5) and the minimum number of students (default: 5) for a course instance to count as "active" in the current term. The minimum number of students is hard to tune perfectly. With 5 we get zero false positives, but we do get a couple of false negatives (tested on UIUC Fa24).