### PR TITLE
Automatic serialization/deserialization in zygote.py

### DIFF
--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
@@ -161,13 +161,12 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 if isinstance(a_sub, str):
                     # The representation of the submitted_answer is always
                     # stored in base 10 by the parse function
-                    a_sub_parsed = int(a_sub)
-                else:
-                    a_sub_parsed = pl.from_json(a_sub)
+                    a_sub = int(a_sub)
+
                 a_sub_display = (
-                    np.base_repr(a_sub_parsed, base)
+                    np.base_repr(a_sub, base)
                     if base > 0
-                    else data["raw_submitted_answers"].get(name, str(a_sub_parsed))
+                    else data["raw_submitted_answers"].get(name, str(a_sub))
                 )
             except ValueError:
                 # If the submitted answer is not a valid integer, use the raw

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -31,6 +31,7 @@ from importlib.abc import MetaPathFinder
 from inspect import signature
 from typing import Any
 
+import prairielearn as pl
 import prairielearn.internal.zygote_utils as zu
 from prairielearn.internal import question_phases
 
@@ -157,7 +158,9 @@ class FakerInitializeMetaPathFinder(MetaPathFinder):
 def try_dumps(obj: Any, *, sort_keys: bool = False, allow_nan: bool = False) -> str:
     try:
         zu.assert_all_integers_within_limits(obj)
-        return json.dumps(obj, sort_keys=sort_keys, allow_nan=allow_nan)
+        return json.dumps(
+            obj, sort_keys=sort_keys, allow_nan=allow_nan, default=pl.to_json
+        )
     except Exception:
         print(f"Error converting this object to json:\n{obj}\n", file=sys.stderr)
         raise
@@ -192,7 +195,9 @@ def worker_loop() -> None:
 
             # Unpack the input line as JSON. If that fails, log the line for debugging.
             try:
-                inp = json.loads(json_inp, parse_int=zu.safe_parse_int)
+                inp = json.loads(
+                    json_inp, parse_int=zu.safe_parse_int, object_hook=pl.from_json
+                )
             except json.JSONDecodeError as exc:
                 raise ValueError(f"Error decoding JSON input: {json_inp}") from exc
 


### PR DESCRIPTION
Very draft code for today's meeting showing how it would be do to this transparently, which would almost completely remove all need for instructors to think about serialization. This draft currently doesn't do the `int` work yet, though that feels fairly straightforward.