### PR TITLE
Specialized rendering of pl-rich-text-editor for AI grading

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
@@ -6,6 +6,7 @@ from enum import Enum
 import chevron
 import lxml.html
 import prairielearn as pl
+from typing_extensions import assert_never
 
 
 class Counter(Enum):
@@ -80,6 +81,9 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
 
 
 def render(element_html: str, data: pl.QuestionData) -> str:
+    if data["panel"] == "answer":
+        return ""
+
     element = lxml.html.fragment_fromstring(element_html)
     file_name = pl.get_string_attrib(element, "file-name", "")
     answer_name = get_answer_name(file_name)
@@ -123,12 +127,12 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 span.attrib.clear()
 
         # Reconstruct the HTML content
-        contents = "".join([
+        contents = "".join(
             str(lxml.html.tostring(fragment, encoding="unicode"))
             if not isinstance(fragment, str)
             else str(fragment)
             for fragment in html_doc
-        ])
+        )
 
         return f'<div data-file-name="{file_name}">\n{contents}\n</div>'
 
@@ -186,10 +190,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         with open("pl-rich-text-editor.mustache", encoding="utf-8") as f:
             return chevron.render(f, html_params).strip()
 
-    elif data["panel"] == "answer":
-        return ""
-    else:
-        raise ValueError("Invalid panel type: " + data["panel"])
+    assert_never(data["panel"])
 
 
 def parse(element_html: str, data: pl.QuestionData) -> None:

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
@@ -111,7 +111,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
 
     if data["ai_grading"]:
         if data["panel"] != "submission" or not submitted_file:
-            return ""
+            return f'<div data-file-name="{file_name}"></div>'
 
         contents = submitted_file.get("contents", "")
         contents = base64.b64decode(contents).decode("utf-8")

--- a/apps/prairielearn/python/prairielearn/internal/check_data.py
+++ b/apps/prairielearn/python/prairielearn/internal/check_data.py
@@ -82,6 +82,11 @@ PROPS: dict[str, PropInfo] = {
         "present_phases": frozenset({"render"}),
         "edit_phases": frozenset(),
     },
+    "ai_grading": {
+        "type": "boolean",
+        "present_phases": frozenset({"render"}),
+        "edit_phases": frozenset(),
+    },
     "panel": {
         "type": "string",
         "present_phases": frozenset({"render"}),

--- a/apps/prairielearn/python/prairielearn/question_utils.py
+++ b/apps/prairielearn/python/prairielearn/question_utils.py
@@ -50,6 +50,7 @@ class QuestionData(TypedDict):
     extensions: dict[str, Any]
     num_valid_submissions: int
     manual_grading: bool
+    ai_grading: bool
     answers_names: dict[str, bool]
 
 

--- a/apps/prairielearn/python/test/conftest.py
+++ b/apps/prairielearn/python/test/conftest.py
@@ -20,5 +20,6 @@ def question_data() -> QuestionData:
         "extensions": {},
         "num_valid_submissions": 0,
         "manual_grading": False,
+        "ai_grading": False,
         "answers_names": {},
     }

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -1113,6 +1113,7 @@ def test_load_extension() -> None:
         "panel": "question",
         "num_valid_submissions": 0,
         "manual_grading": False,
+        "ai_grading": False,
         "answers_names": {},
     }
 

--- a/apps/prairielearn/src/question-servers/freeform.ts
+++ b/apps/prairielearn/src/question-servers/freeform.ts
@@ -547,6 +547,7 @@ function checkData(data: Record<string, any>, origData: Record<string, any>, pha
              || checkProp('feedback',              'object',  ['render', 'parse', 'grade', 'test'], ['grade', 'parse', 'test'])
              || checkProp('editable',              'boolean', ['render'],                           [])
              || checkProp('manual_grading',        'boolean', ['render'],                           [])
+             || checkProp('ai_grading',            'boolean', ['render'],                           [])
              || checkProp('panel',                 'string',  ['render'],                           [])
              || checkProp('num_valid_submissions','integer',  ['render'],                           [])
              || checkProp('gradable',              'boolean', ['parse', 'grade', 'test'],           [])
@@ -1353,6 +1354,7 @@ async function renderPanel(
       }
       return false;
     }),
+    ai_grading: locals.questionRenderContext === 'ai_grading',
     panel,
     num_valid_submissions: variant.num_tries ?? null,
   } satisfies ExecutionData;

--- a/apps/prairielearn/src/question-servers/types.ts
+++ b/apps/prairielearn/src/question-servers/types.ts
@@ -139,6 +139,7 @@ export interface ExecutionData {
   raw_submitted_answers?: Record<string, unknown>;
   editable?: boolean;
   manual_grading?: boolean;
+  ai_grading?: boolean;
   panel?: 'question' | 'answer' | 'submission';
   num_valid_submissions?: number;
   filename?: string;


### PR DESCRIPTION
Closes #11558. Part of #11559.

This PR adds a new `ai_grading` key to the `data` object received by questions and elements during rendering. Its value is `True` when the question is being rendered for AI grading, either because it's actually being rendered or because the instructor is previewing how it'll look (see #11582).

As a test that this actually works, I updated `<pl-rich-text-editor>` to have specialized rendering for AI grading. Previously, it would render a script and a base64-encoded hidden input, neither of which mean anything to the AI. Now, it renders like this (taken from `element/richTextEditor` in the example course):

```html
<div data-file-name="meaning.html">
  <p><span>$1+1=2$</span></p>
</div>

<div data-file-name="woodchuck.html">If a woodchuck could chuck wood,</div>

<div data-file-name="character-count-demo.html">If a woodchuck could chuck wood,</div>

<div data-file-name="disabled-clipboard.html">
  <p>asdf</p>
</div>

<div data-file-name="recipe.html">
  <ul>
    <li>&nbsp;here</li>
  </ul>
</div>

<div data-file-name="pbj.html">
  <ul>
    <li>Open the bread package;</li>
    <li>[continue] asdf</li>
  </ul>
</div>
```

I'll discuss some of the choices I made in inline comments.