### PR TITLE
Add required `namespace` option to `node-metrics`

### DIFF
--- a/.changeset/clean-planets-know.md
+++ b/.changeset/clean-planets-know.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/node-metrics': major
+---
+
+Add required `namespace` option

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -2385,6 +2385,7 @@ if (esMain(import.meta) && config.startServer) {
       nodeMetrics.start({
         awsConfig: makeAwsClientConfig(),
         intervalSeconds: config.nodeMetricsIntervalSec,
+        namespace: 'PrairieLearn',
         dimensions: [
           { Name: 'Server Group', Value: config.groupName },
           { Name: 'InstanceId', Value: `${config.instanceId}:${config.serverPort}` },

--- a/packages/node-metrics/src/index.ts
+++ b/packages/node-metrics/src/index.ts
@@ -16,6 +16,7 @@ let time = process.hrtime.bigint();
 interface NodeMetricsOptions {
   awsConfig: CloudWatchClientConfig;
   intervalSeconds: number;
+  namespace: string;
   dimensions: Dimension[];
   onError: (err: Error) => void;
 }
@@ -85,7 +86,7 @@ async function emit(options: NodeMetricsOptions) {
     // eslint-disable-next-line @prairielearn/aws-client-shared-config
     const cloudwatch = new CloudWatch(options.awsConfig);
     await cloudwatch.putMetricData({
-      Namespace: 'PrairieLearn',
+      Namespace: options.namespace,
       MetricData: metrics.map((m) => ({
         ...m,
         StorageResolution: 1,


### PR DESCRIPTION
Previously the `node-metrics` CloudWatch logger was hardcoding `Namespace: 'PrairieLearn'`. This PR adds a `namespace` option so that we can use `node-metrics` in non-PL projects.

See https://github.com/PrairieLearnInc/PrairieTest/pull/2249#discussion_r2067730520 for the issue that triggered this PR.