### PR TITLE
Improve tracebacks in the Python grader

### DIFF
--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -91,7 +91,7 @@ def execute_code(
             str_student = extract_ipynb_contents(f, ipynb_key)
         else:
             str_student = f.read()
-    str_student = "\n".join(filter(bool, [str_leading, str_student, str_trailing]))
+    str_student = "\n".join(filter(bool, (str_leading, str_student, str_trailing)))
 
     with open(path.join(filenames_dir, "test.py"), encoding="utf-8") as f:
         str_test = f.read()
@@ -235,12 +235,12 @@ def execute_code(
 
     plot_value = None
     if include_plt:
-        for key in list(student_globals):
+        for val in student_globals.values():
             if (
-                isinstance(student_globals[key], ModuleType)
-                and student_globals[key].__dict__["__name__"] == "matplotlib.pyplot"
+                isinstance(val, ModuleType)
+                and val.__dict__["__name__"] == "matplotlib.pyplot"
             ):
-                plot_value = student_globals[key]
+                plot_value = val
 
         if not plot_value:
             import matplotlib as mpl

--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import linecache
 import os
 import random
 import sys
@@ -32,6 +33,15 @@ def try_read(fname: str) -> str:
     except Exception:
         contents = ""
     return contents
+
+
+def populate_linecache(fname: str, contents: str) -> None:
+    linecache.cache[fname] = (
+        len(contents),
+        None,
+        [line + "\n" for line in contents.splitlines()],
+        fname,
+    )
 
 
 def execute_code(
@@ -81,7 +91,7 @@ def execute_code(
             str_student = extract_ipynb_contents(f, ipynb_key)
         else:
             str_student = f.read()
-    str_student = str_leading + "\n" + str_student + "\n" + str_trailing
+    str_student = "\n".join(filter(bool, [str_leading, str_student, str_trailing]))
 
     with open(path.join(filenames_dir, "test.py"), encoding="utf-8") as f:
         str_test = f.read()
@@ -96,23 +106,30 @@ def execute_code(
         os.remove(path.join(filenames_dir, "trailing_code.py"))
     os.remove(path.join(filenames_dir, "test.py"))
 
-    repeated_setup_name = "repeated_setup()"
-    if repeated_setup_name not in str_setup:
-        repeated_setup_name = "pass"
+    # Since we've deleted some files, we need to manually populate
+    # the linecache so that `traceback` can find the correct contents when
+    # printing any exceptions.
+    populate_linecache(path.join(filenames_dir, "setup_code.py"), str_setup)
+    populate_linecache(fname_ref, str_ref)
 
     # Seed student code and answer code with same seed
     seed = random.randint(0, (2**32) - 1)
 
-    setup_code = {"test_iter_num": test_iter_num, "data": data}
+    setup_globals = {"test_iter_num": test_iter_num, "data": data}
     # make all the variables in setup_code.py available to ans.py
-    exec(str_setup, setup_code)
-    exec(repeated_setup_name, setup_code)
+    code_setup = compile(str_setup, path.join(filenames_dir, "setup_code.py"), "exec")
+    exec(code_setup, setup_globals)
+
+    # If the setup code has a repeated_setup function, run it.
+    repeated_setup = setup_globals.get("repeated_setup")
+    if repeated_setup is not None and callable(repeated_setup):
+        repeated_setup()
 
     names_for_user = [v["name"] for v in data["params"].get("names_for_user", [])]
 
     # Make copies of variables that go to the user so we do not clobber them
     ref_code = {}
-    for i, j in setup_code.items():
+    for i, j in setup_globals.items():
         if (not (i == "__builtins__" or isinstance(j, ModuleType))) and (
             i in names_for_user
         ):
@@ -120,13 +137,14 @@ def execute_code(
     ref_code = deepcopy(ref_code)
 
     # Add any other variables to reference namespace and do not copy
-    for i, j in setup_code.items():
+    for i, j in setup_globals.items():
         if not (
             i == "__builtins__" or isinstance(j, ModuleType) or i in names_for_user
         ):
             ref_code[i] = j
     set_random_seed(seed)
-    exec(str_ref, ref_code)
+    code_ref = compile(str_ref, fname_ref, "exec")
+    exec(code_ref, ref_code)
     # ref_code contains the correct answers
 
     if include_plt:
@@ -142,15 +160,23 @@ def execute_code(
         variable["name"] for variable in data["params"]["names_from_user"]
     ]
 
-    exec(repeated_setup_name, setup_code)
+    # If the setup code has a repeated_setup function, run it.
+    repeated_setup = setup_globals.get("repeated_setup")
+    if repeated_setup is not None and callable(repeated_setup):
+        repeated_setup()
 
-    student_code = {}
-    for i, j in setup_code.items():
+    # Remove the setup and answer code from the linecache to make it slightly
+    # harder for students to read it.
+    linecache.cache.pop(path.join(filenames_dir, "setup_code.py"), None)
+    linecache.cache.pop(fname_ref, None)
+
+    student_globals = {}
+    for i, j in setup_globals.items():
         if (not (i == "__builtins__" or isinstance(j, ModuleType))) and (
             i in names_for_user
         ):
-            student_code[i] = j  # noqa: PERF403 (too complex)
-    student_code = deepcopy(student_code)
+            student_globals[i] = j  # noqa: PERF403 (too complex)
+    student_globals = deepcopy(student_globals)
 
     # Execute student code
     previous_stdout = sys.stdout
@@ -159,8 +185,15 @@ def execute_code(
 
     set_random_seed(seed)
 
+    # The file at path `fname_student` doesn't actually correspond to the
+    # code that we're going to execute, since it doesn't include the leading
+    # and trailing code. We'll manually construct a `linecache` entry for it
+    # so that the traceback will show the correct code for each line.
+    populate_linecache(fname_student, str_student)
+
     try:
-        exec(str_student, student_code)
+        code_student = compile(str_student, fname_student, "exec")
+        exec(code_student, student_globals)
         err = None
     except Exception:
         err = sys.exc_info()
@@ -198,16 +231,16 @@ def execute_code(
 
     student_result = {}
     for name in names_from_user:
-        student_result[name] = student_code.get(name, None)
+        student_result[name] = student_globals.get(name, None)
 
     plot_value = None
     if include_plt:
-        for key in list(student_code):
+        for key in list(student_globals):
             if (
-                isinstance(student_code[key], ModuleType)
-                and student_code[key].__dict__["__name__"] == "matplotlib.pyplot"
+                isinstance(student_globals[key], ModuleType)
+                and student_globals[key].__dict__["__name__"] == "matplotlib.pyplot"
             ):
-                plot_value = student_code[key]
+                plot_value = student_globals[key]
 
         if not plot_value:
             import matplotlib as mpl


### PR DESCRIPTION
This makes three improvements to tracebacks in the Python grader:

- We avoid adding extra newlines if `leading_code` and/or `trailing_code` aren't present. This keeps the line numbers more faithful in the case where `leading_code` isn't specified.
  - This PR doesn't do anything to fix line numbers in situations where `leading_code` _is_ present. That's possible in theory, but is a lot of work for only marginal gain.
- We now use `compile(...)` before `exec(...)` to associate filenames with the executed code (see https://github.com/PrairieLearn/PrairieLearn/pull/1409).
- We now manually populate the `linecache` so that `traceback` can show the lines of code involved in the stack trace.

This is in response to a report from the student that line numbers in tracebacks were always off by one. That's the first bullet above; the other changes are just nice-to-haves that were easy to do while fixing the first one.

## Error in student code, before/after

<img width="916" alt="Screenshot 2025-04-30 at 16 19 00" src="https://github.com/user-attachments/assets/1fa193f0-a210-417d-81d3-052ccf86b054" />
<img width="918" alt="Screenshot 2025-04-30 at 16 25 39" src="https://github.com/user-attachments/assets/f7a95722-74ec-48dc-a381-ffe00fbfcb9d" />

## Error in setup code, before/after

<img width="919" alt="Screenshot 2025-04-30 at 16 24 28" src="https://github.com/user-attachments/assets/c7067899-c9fe-4e67-811c-015b7ab6000c" />
<img width="919" alt="Screenshot 2025-04-30 at 16 19 31" src="https://github.com/user-attachments/assets/a89cb13a-b57d-4313-816e-f0a8806da492" />

## Error in `repeated_setup()`, before/after

<img width="921" alt="Screenshot 2025-04-30 at 16 23 58" src="https://github.com/user-attachments/assets/14f6273f-7209-4e14-ba3a-fdcbf43f8832" />
<img width="921" alt="Screenshot 2025-04-30 at 16 23 34" src="https://github.com/user-attachments/assets/01937189-59ef-4a0a-a170-b1f0d174ec40" />

