### PR TITLE
Tweak filtering for 'Older instances'

### DIFF
--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -73,6 +73,9 @@ WITH
           'id',
           ci.id,
           'expired',
+          -- If no access rules exist, it is typically either a sandbox or a
+          -- future CI that has not yet been configured. In both cases it should
+          -- not be considered expired.
           coalesce(d.expired, FALSE)
         )
         ORDER BY

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -73,7 +73,7 @@ WITH
           'id',
           ci.id,
           'expired',
-          coalesce(d.expired, TRUE)
+          coalesce(d.expired, FALSE)
         )
         ORDER BY
           d.start_date DESC NULLS LAST,


### PR DESCRIPTION
As discussed on Slack

<details>
<summary>Slack Quotes</summary>
Zac:

> Given that a course instance could be created for the future with no access role, is it worth changing Older instances to be Inactive instances or is it just expected that future instances should have an access role with dates from the future and then would not be filtered under the older criteria?

Jonatan:

>only the end date is considered in this filtering, so a future course instance will not be "older" even if it's not yet active.

Nathan:

> What if we just don't put something in "older instances" if it doesn't have any access rules at all?

> untested, but it might be as simple as changing the coalesced value here to FALSE

</details>

Makes it so that course instances without an access role still show up as opposed to being collapsed in the 'Older instances' dropdown

![image](https://github.com/user-attachments/assets/339382d4-a093-498e-8a25-2f87770adcef)
