### PR TITLE
Backfill JSON columns

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20250502181707_json_columns__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250502181707_json_columns__backfill.ts
@@ -1,0 +1,64 @@
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import * as namedLocks from '@prairielearn/named-locks';
+import { queryOneRowAsync, queryRows } from '@prairielearn/postgres';
+
+import { type Course, CourseSchema } from '../lib/db-types.js';
+import { createServerJob } from '../lib/server-jobs.js';
+import { getLockNameForCoursePath } from '../models/course.js';
+import { syncDiskToSqlWithLock } from '../sync/syncFromDisk.js';
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const result = await queryOneRowAsync('SELECT MAX(id) as max from pl_courses;', {});
+    return {
+      min: 1n,
+      max: result.rows[0].max,
+      batchSize: 10,
+    };
+  },
+
+  async execute(min: bigint, max: bigint): Promise<void> {
+    const courses = await queryRows(
+      'SELECT * FROM pl_courses WHERE id >= $min AND id <= $max AND deleted_at IS NULL',
+      { min, max },
+      CourseSchema,
+    );
+
+    for (const course of courses) {
+      await syncCourse(course);
+    }
+  },
+});
+
+/**
+ * Re-syncs an existing course. Does NOT pull new changes from the remote repository.
+ */
+export async function syncCourse(course: Course) {
+  const serverJob = await createServerJob({
+    courseId: course.id,
+    type: 'sync',
+    description: 'Sync from disk',
+    // Since this is a sync performed by the system, don't associate any user
+    // with it.
+    userId: undefined,
+    authnUserId: undefined,
+  });
+
+  // We use `executeUnsafe` to ensure that any errors bubble up and mark the
+  // batched migration job as failed.
+  await serverJob.executeUnsafe(async (job) => {
+    const lockName = getLockNameForCoursePath(course.path);
+    await namedLocks.doWithLock(
+      lockName,
+      {
+        // Set a long timeout to try to ensure that the lock is acquired.
+        timeout: 60_000,
+        onNotAcquired: () => job.fail('Another user is already syncing or modifying this course.'),
+      },
+      async () => {
+        job.info('Sync git repository to database');
+        await syncDiskToSqlWithLock(course.id, course.path, job);
+      },
+    );
+  });
+}

--- a/apps/prairielearn/src/migrations/20250502181707_json_columns__backfill.ts
+++ b/apps/prairielearn/src/migrations/20250502181707_json_columns__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20250502181707_json_columns__backfill');
+}


### PR DESCRIPTION
Closes #11640. This is step two of the two-step plan to ensure that all JSON fields have corresponding columns in the database. In step one, we created the columns and updated sync code to reflect the new storing of data. Step two is the backfilling of these columns for existing courses. Most of the batch migration code here is similar to `20240523183853_sync_courses_for_implicit_flag` as we are essentially accomplishing the same goal of forcing a sync for all of active courses. 

I tested this migration successfully locally by using the following steps:
- Drop my local db. 
- Checkout a commit from immediately before any of the new columns were add. 
- Create the db. 
- Verify that the new columns are not there.
- Sync local courses.
- Checkout the new branch (`backfill-json-columns`)
- Migrate (`make migrate-dev`)
- Verify that the new columns are there and that they are populated with the data from the local courses 