### PR TITLE
Improve handling of escaped characters in rich text editor options

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -67,7 +67,10 @@
 
   Quill.register('modules/clipboard', PotentiallyDisabledClipboard, true);
 
-  window.PLRTE = function (uuid, options) {
+  window.PLRTE = function (uuid) {
+    const baseElement = document.getElementById(`rte-${uuid}`);
+    const options = JSON.parse(baseElement.dataset.options);
+
     if (!options.modules) options.modules = {};
     if (!options.modules.clipboard) options.modules.clipboard = {};
     options.modules.clipboard.toast_id = 'rte-clipboard-toast-' + uuid;
@@ -105,10 +108,10 @@
     // Set the bounds for UI elements (e.g., the tooltip for the formula editor)
     // to the question container.
     // https://quilljs.com/docs/configuration#bounds
-    options.bounds = document.getElementById(`rte-${uuid}`).closest('.question-container');
+    options.bounds = baseElement.closest('.question-container');
 
     let inputElement = $('#rte-input-' + uuid);
-    let quill = new Quill('#rte-' + uuid, options);
+    let quill = new Quill(baseElement, options);
     let renderer = null;
     if (options.format === 'markdown') {
       renderer = new showdown.Converter({

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.mustache
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.mustache
@@ -1,6 +1,6 @@
 <script>
 $(function() {
-    var rte = window.PLRTE('{{editor_uuid}}', {{{quill_options_json}}});
+    var rte = window.PLRTE('{{editor_uuid}}');
 });
 </script>
 <input type="hidden" id="rte-input-{{editor_uuid}}"
@@ -18,7 +18,7 @@ $(function() {
       </div>
     </div>
     {{/clipboard_enabled}}
-    <div id="rte-{{editor_uuid}}" class="border mathjax_ignore"></div>
+    <div id="rte-{{editor_uuid}}" class="border mathjax_ignore" data-options="{{quill_options_json}}"></div>
     {{#counter_enabled}}
         <div class="pl-rich-text-editor-counter-container">
             <div id="rte-counter-{{editor_uuid}}" class="text-secondary"></div>

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.mustache
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.mustache
@@ -1,16 +1,6 @@
 <script>
 $(function() {
-    var rte = window.PLRTE('{{editor_uuid}}', {
-        readOnly: {{read_only}},
-        placeholder: '{{placeholder}}',
-        format: '{{format}}',
-        markdownShortcuts: {{markdown_shortcuts}},
-        counter: '{{counter}}',
-        modules: { clipboard: { {{^clipboard_enabled}}enabled: false{{/clipboard_enabled}} } },
-        {{#quill_theme}}
-        theme: '{{.}}',
-        {{/quill_theme}}
-    });
+    var rte = window.PLRTE('{{editor_uuid}}', {{{quill_options_json}}});
 });
 </script>
 <input type="hidden" id="rte-input-{{editor_uuid}}"

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import json
 import os
 from enum import Enum
 
@@ -137,22 +138,20 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         return f'<div data-file-name="{file_name}">\n{contents}\n</div>'
 
     if data["panel"] == "question" or data["panel"] == "submission":
+        quill_options = {
+            "readOnly": data["panel"] == "submission" or not data["editable"],
+            "placeholder": placeholder,
+            "format": input_format.value,
+            "markdownShortcuts": markdown_shortcuts,
+            "counter": counter.value,
+            "modules": {"clipboard": {} if clipboard_enabled else {"enabled": False}},
+            "theme": quill_theme or None,
+        }
         html_params = {
             "name": answer_name,
             "file_name": file_name,
-            "quill_theme": quill_theme,
-            "placeholder": placeholder,
             "editor_uuid": uuid,
-            "question": data["panel"] == "question",
-            "submission": data["panel"] == "submission",
-            "read_only": (
-                "true"
-                if (data["panel"] == "submission" or not data["editable"])
-                else "false"
-            ),
-            "format": input_format.value,
-            "markdown_shortcuts": "true" if markdown_shortcuts else "false",
-            "counter": counter.value,
+            "quill_options_json": json.dumps(quill_options),
             "counter_enabled": counter != Counter.NONE,
             "clipboard_enabled": clipboard_enabled,
         }


### PR DESCRIPTION
Fixes #11904. Mustache escape does not consider single quotes (apostrophe) as needing escaping. This PR changes the setting of quill options to be handled using JSON in a data attribute, which takes care of any necessary escaping.