### PR TITLE
Add hidden link to accessibility guide

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -46,7 +46,10 @@ export function Navbar({
         `
       : ''}
 
-    <div class="container-fluid bg-primary visually-hidden-focusable">
+    <nav
+      class="container-fluid bg-primary visually-hidden-focusable"
+      aria-label="Skip link and accessibility guide"
+    >
       <a href="#content" class="d-inline-flex p-2 m-2 text-white">Skip to main content</a>
       <a
         href="https://prairielearn.readthedocs.io/en/latest/student-guide/accessibility/"
@@ -54,7 +57,7 @@ export function Navbar({
       >
         Accessibility guide
       </a>
-    </div>
+    </nav>
 
     ${config.announcementHtml
       ? html`

--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -46,9 +46,13 @@ export function Navbar({
         `
       : ''}
 
-    <div class="container-fluid bg-primary">
-      <a href="#content" class="visually-hidden-focusable d-inline-flex p-2 m-2 text-white">
-        Skip to main content
+    <div class="container-fluid bg-primary visually-hidden-focusable">
+      <a href="#content" class="d-inline-flex p-2 m-2 text-white">Skip to main content</a>
+      <a
+        href="https://prairielearn.readthedocs.io/en/latest/student-guide/accessibility/"
+        class="d-inline-flex p-2 m-2 text-white"
+      >
+        Accessibility guide
       </a>
     </div>
 


### PR DESCRIPTION
This came out of discussion with UMich, who were concerned that it wasn't easy for students to discover the accessibility documentation. Adding it as a hidden link that becomes visible on keyboard focus seems like a good, unobtrusive way to make this link readily available.