### PR TITLE
Increase timeout for tests that take longer to run

### DIFF
--- a/apps/prairielearn/src/tests/issues.test.ts
+++ b/apps/prairielearn/src/tests/issues.test.ts
@@ -17,7 +17,7 @@ const courseInstanceIssuesUrl = baseUrl + '/course_instance/1/instructor/course_
 const courseIssuesUrl = baseUrl + '/course/1/course_admin/issues';
 
 describe('Issues', function () {
-  this.timeout(10000);
+  this.timeout(15000);
 
   before('set up testing server', helperServer.before());
   after('shut down testing server', helperServer.after);

--- a/apps/prairielearn/src/tests/newsItems.test.ts
+++ b/apps/prairielearn/src/tests/newsItems.test.ts
@@ -18,7 +18,7 @@ locals.baseUrl = locals.siteUrl + '/pl';
 locals.newsItemsUrl = locals.baseUrl + '/news_items';
 
 describe('News items', function () {
-  this.timeout(10000);
+  this.timeout(15000);
 
   before('set up testing server', helperServer.before());
   after('shut down testing server', helperServer.after);


### PR DESCRIPTION
We've seen several cases recently of CI failing due to timeout in these two tests. I'm not sure why they are failing so frequently (maybe slower hardware), but rerunning the test often causes it to pass, so the issue is volatile. This PR attempts to increase the timeout so that these errors happen less often.