### PR TITLE
Skip weak dependencies when building plbase image

### DIFF
--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -12,7 +12,7 @@ dnf update -y
 # - `libjpeg-devel` is needed by the Pillow package
 # - `procps-ng` is needed for the `pkill` executable, which is used by `zygote.py`
 # - `texlive` and `texlive-dvipng` are needed for matplotlib LaTeX labels
-dnf -y install \
+dnf -y install -setopt=install_weak_deps=False \
     bash-completion \
     gcc \
     gcc-c++ \

--- a/images/plbase/plbase-install.sh
+++ b/images/plbase/plbase-install.sh
@@ -12,7 +12,7 @@ dnf update -y
 # - `libjpeg-devel` is needed by the Pillow package
 # - `procps-ng` is needed for the `pkill` executable, which is used by `zygote.py`
 # - `texlive` and `texlive-dvipng` are needed for matplotlib LaTeX labels
-dnf -y install -setopt=install_weak_deps=False \
+dnf -y install --setopt=install_weak_deps=False \
     bash-completion \
     gcc \
     gcc-c++ \


### PR DESCRIPTION
This should be the equivalent of `--no-install-recommends` that we use with `apt-get` in Ubuntu-based images. I'm hoping this shrinks the resulting image size. If it does, we should probably audit to see which packages were removed and ensure their removal is unlikely to cause problems.