### PR TITLE
Remove unnecessary workspace directory creation

### DIFF
--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -805,12 +805,6 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
     throw Error('Could not access workspace files.', { cause: err });
   }
 
-  debug(`Creating directory ${workspaceJobPath}`);
-  await fs.mkdir(workspaceJobPath, { recursive: true }).catch((err) => {
-    // Ignore the directory if it already exists. Otherwise, rethrow the error.
-    if (err && err.code !== 'EEXIST') throw err;
-  });
-
   await fs.chown(
     workspaceJobPath,
     config.workspaceJobsDirectoryOwnerUid,


### PR DESCRIPTION
The workspace host code relies on the workspace job directory existing before the container is created, however it also tries to create the directory after checking for access. This latter process is unnecessary, as the code would have already thrown an exception if the directory did not exist. In other words: if the directory exists, it doesn't need to be created; if it doesn't, the previous call to `fs.access` would have caused an exception.

This seems to be a remnant from #6983, where the directory had to be created if the file content was stored in S3 format, which is no longer supported (in that case the directory would contain a local version of the data, if I understand the code correctly).

With that in mind: the use of `fs.access` before other file system operations is usually not a good idea, as it is prone to race conditions. Since there is a call to `fs.chown` right after this point, we could always change the code to move the try/catch from `fs.access` to `fs.chown` to achieve the same result and remove the need for `fs.access` itself. While `fs.chown` may fail for other reasons besides the file not existing, this would still provide a more user-friendly message to `fs.chown` while keeping the functionality mostly the same.