### PR TITLE
LTI 1.3 schema extended to support deep linking

### DIFF
--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
@@ -309,7 +309,7 @@ async function setupPassport(lti13_instance_id: string) {
 }
 
 async function verify(req: Request, tokenSet: TokenSet) {
-  const lti13_claims = Lti13ClaimSchema.passthrough().parse(tokenSet.claims());
+  const lti13_claims = Lti13ClaimSchema.parse(tokenSet.claims());
 
   // Check nonce to protect against reuse
   const nonceKey = `lti13auth-nonce:${req.params.lti13_instance_id}:${lti13_claims['nonce']}`;

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -170,7 +170,7 @@ export const Lti13DeepLinkingRequestSchema = Lti13ClaimBaseSchema.merge(
     'https://purl.imsglobal.org/spec/lti/claim/message_type': z.literal('LtiDeepLinkingRequest'),
     'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings': z.object({
       deep_link_return_url: z.string(),
-      accept_types: z.enum(['link', 'file', 'html', 'ltiResourceLink', 'image']).array(),
+      accept_types: z.string().array(),
       accept_presentation_document_targets: z.enum(['embed', 'iframe', 'window']).array(),
       accept_media_types: z.string().optional(),
       accept_multiple: z.boolean().optional(),

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -162,7 +162,7 @@ export const Lti13ResourceLinkRequestSchema = Lti13ClaimBaseSchema.merge(
       title: z.string().nullish(),
     }),
   }),
-).passthrough();
+);
 
 // https://www.imsglobal.org/spec/lti-dl/v2p0#message-claims
 export const Lti13DeepLinkingRequestSchema = Lti13ClaimBaseSchema.merge(
@@ -170,9 +170,9 @@ export const Lti13DeepLinkingRequestSchema = Lti13ClaimBaseSchema.merge(
     'https://purl.imsglobal.org/spec/lti/claim/message_type': z.literal('LtiDeepLinkingRequest'),
     'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings': z.object({
       deep_link_return_url: z.string(),
-      accept_types: z.string().array(),
-      accept_presentation_document_targets: z.string().array(),
-      accept_media_types: z.string().array().optional(),
+      accept_types: z.enum(['link', 'file', 'html', 'ltiResourceLink', 'image']).array(),
+      accept_presentation_document_targets: z.enum(['embed', 'iframe', 'window']).array(),
+      accept_media_types: z.string().optional(),
       accept_multiple: z.boolean().optional(),
       accept_lineitem: z.boolean().optional(),
       auto_create: z.boolean().optional(),
@@ -181,7 +181,7 @@ export const Lti13DeepLinkingRequestSchema = Lti13ClaimBaseSchema.merge(
       data: z.any().optional(),
     }),
   }),
-).passthrough();
+);
 
 export const Lti13ClaimSchema = z.discriminatedUnion(
   'https://purl.imsglobal.org/spec/lti/claim/message_type',

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -205,7 +205,6 @@ export class Lti13Claim {
         status: 403,
       });
     }
-    console.log(this.claims);
     this.valid = true;
     this.req = req;
 

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -71,16 +71,11 @@ export type Lineitems = z.infer<typeof LineitemsSchema>;
 
 // Validate LTI 1.3
 // https://www.imsglobal.org/spec/lti/v1p3#required-message-claims
-export const Lti13ClaimSchema = z.object({
-  'https://purl.imsglobal.org/spec/lti/claim/message_type': z.literal('LtiResourceLinkRequest'),
+export const Lti13ClaimBaseSchema = z.object({
   'https://purl.imsglobal.org/spec/lti/claim/version': z.literal('1.3.0'),
   'https://purl.imsglobal.org/spec/lti/claim/deployment_id': z.string(),
   'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': z.string(),
-  'https://purl.imsglobal.org/spec/lti/claim/resource_link': z.object({
-    id: z.string(),
-    description: z.string().nullish(),
-    title: z.string().nullish(),
-  }),
+
   // https://www.imsglobal.org/spec/security/v1p0/#tool-jwt
   // https://www.imsglobal.org/spec/security/v1p0/#id-token
   iss: z.string(),
@@ -138,7 +133,60 @@ export const Lti13ClaimSchema = z.object({
   // https://www.imsglobal.org/spec/lti/v1p3#vendor-specific-extension-claims
   // My development Canvas sends their own named extension as a top level property
   // "https://www.instructure.com/placement": "course_navigation"
+
+  // https://www.imsglobal.org/spec/lti-ags/v2p0#assignment-and-grade-service-claim
+  'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint': z
+    .object({
+      lineitems: z.string().optional(),
+      lineitem: z.string().optional(),
+      scope: z.string().array(),
+    })
+    .optional(),
+
+  // https://www.imsglobal.org/spec/lti-nrps/v2p0/#resource-link-membership-service
+  'https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice': z
+    .object({
+      context_memberships_url: z.string(),
+      service_versions: z.literal('2.0').array(),
+    })
+    .optional(),
 });
+
+// https://www.imsglobal.org/spec/lti/v1p3#required-message-claims
+export const Lti13ResourceLinkRequestSchema = Lti13ClaimBaseSchema.merge(
+  z.object({
+    'https://purl.imsglobal.org/spec/lti/claim/message_type': z.literal('LtiResourceLinkRequest'),
+    'https://purl.imsglobal.org/spec/lti/claim/resource_link': z.object({
+      id: z.string(),
+      description: z.string().nullish(),
+      title: z.string().nullish(),
+    }),
+  }),
+).passthrough();
+
+// https://www.imsglobal.org/spec/lti-dl/v2p0#message-claims
+export const Lti13DeepLinkingRequestSchema = Lti13ClaimBaseSchema.merge(
+  z.object({
+    'https://purl.imsglobal.org/spec/lti/claim/message_type': z.literal('LtiDeepLinkingRequest'),
+    'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings': z.object({
+      deep_link_return_url: z.string(),
+      accept_types: z.string().array(),
+      accept_presentation_document_targets: z.string().array(),
+      accept_media_types: z.string().array().optional(),
+      accept_multiple: z.boolean().optional(),
+      accept_lineitem: z.boolean().optional(),
+      auto_create: z.boolean().optional(),
+      title: z.string().optional(),
+      text: z.string().optional(),
+      data: z.any().optional(),
+    }),
+  }),
+).passthrough();
+
+export const Lti13ClaimSchema = z.discriminatedUnion(
+  'https://purl.imsglobal.org/spec/lti/claim/message_type',
+  [Lti13ResourceLinkRequestSchema, Lti13DeepLinkingRequestSchema],
+);
 export type Lti13ClaimType = z.infer<typeof Lti13ClaimSchema>;
 
 export const STUDENT_ROLE = 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner';
@@ -150,13 +198,14 @@ export class Lti13Claim {
 
   constructor(req: Request) {
     try {
-      this.claims = Lti13ClaimSchema.passthrough().parse(req.session.lti13_claims);
+      this.claims = Lti13ClaimSchema.parse(req.session.lti13_claims);
     } catch (err) {
       throw new AugmentedError('LTI session invalid or timed out, please try logging in again.', {
         cause: err,
         status: 403,
       });
     }
+    console.log(this.claims);
     this.valid = true;
     this.req = req;
 


### PR DESCRIPTION
Ahead of LTI 1.3 placements in assignment selection, we needed to support a new LTI 1.3 message type. This PR changes the `LTI13ClaimSchema` to a `discriminatedUnion()` that combines a base LTI claim with specific objects for types `LtiResourceLinkRequest` and `LtiDeepLinkingRequest`.

~~Discriminated unions do not have `passthrough()` function so that was moved from `parse()` to their schema definitions.~~ `passthrough()` was removed in this PR so we `strip()` claims not validated.