### PR TITLE
Include element assets on AI question generation preview

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.html.ts
@@ -1,4 +1,4 @@
-import { html } from '@prairielearn/html';
+import { html, unsafeHtml } from '@prairielearn/html';
 import { run } from '@prairielearn/run';
 
 import { HeadContents } from '../../../components/HeadContents.html.js';
@@ -42,6 +42,7 @@ export function InstructorAiGenerateDraftEditor({
           compiledStylesheetTag('instructorAiGenerateDraftEditor.css'),
         ]}
         <script defer src="${nodeModulesAssetPath('mathjax/es5/startup.js')}"></script>
+        ${unsafeHtml(resLocals.extraHeadersHtml)}
       </head>
       <body hx-ext="loading-states">
         <div class="app-container">


### PR DESCRIPTION
Without this, element scripts and styles weren't being included, which resulted in elements that required them rendering and behaving strangely.