### PR TITLE
Display access rule comments

### DIFF
--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -1,16 +1,10 @@
 import { escapeHtml, html } from '@prairielearn/html';
+import { isRenderableComment } from '../lib/comments.js';
 
 export function CommentPopover(comment: string | string[] | Record<string, any> | null) {
-  let content = '';
-  if (
-    !comment ||
-    (typeof comment === 'string' && comment.trim() === '') ||
-    (Array.isArray(comment) && comment.toString() === '[]') ||
-    (typeof comment === 'object' && Object.keys(comment).length === 0)
-  ) {
+  if (!isRenderableComment(comment)) {
     return '';
   }
-  
   const content = typeof comment === 'string' ? comment : JSON.stringify(comment, null, 2);
 
   return html`

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -1,0 +1,16 @@
+import { html } from '@prairielearn/html';
+
+export function CommentPopover(comment: string | null) {
+  return html`
+    <button
+      type="button"
+      class="btn btn-xs btn-ghost"
+      data-bs-toggle="popover"
+      data-bs-container="body"
+      data-bs-placement="auto"
+      data-bs-content="${comment}"
+    >
+      <i class="fa fa-comment"></i>
+    </button>
+  `;
+}

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -4,6 +4,7 @@ export function CommentPopover(comment: string | string[] | Record<string, any> 
   let content = '';
   if (
     !comment ||
+    (typeof comment === 'string' && comment.trim() === '') ||
     (Array.isArray(comment) && comment.toString() === '[]') ||
     (typeof comment === 'object' && Object.keys(comment).length === 0)
   ) {

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -1,4 +1,5 @@
 import { escapeHtml, html } from '@prairielearn/html';
+
 import { isRenderableComment } from '../lib/comments.js';
 
 export function CommentPopover(comment: string | string[] | Record<string, any> | null) {

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -1,6 +1,15 @@
-import { html } from '@prairielearn/html';
+import { escapeHtml, html, HtmlSafeString, unsafeHtml } from '@prairielearn/html';
 
-export function CommentPopover(comment: string | null) {
+export function CommentPopover(comment: string | string[] | Record<string, any> | null) {
+  let content = '';
+  if (comment === null) {
+    return '';
+  } else if (typeof comment === 'string') {
+    content = comment;
+  } else {
+    content = JSON.stringify(comment, null, 2);
+  }
+
   return html`
     <button
       type="button"
@@ -8,7 +17,8 @@ export function CommentPopover(comment: string | null) {
       data-bs-toggle="popover"
       data-bs-container="body"
       data-bs-placement="auto"
-      data-bs-content="${comment}"
+      data-bs-html="true"
+      data-bs-content="${escapeHtml(html`${content}`)}"
     >
       <i class="fa fa-comment"></i>
     </button>

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -9,11 +9,9 @@ export function CommentPopover(comment: string | string[] | Record<string, any> 
     (typeof comment === 'object' && Object.keys(comment).length === 0)
   ) {
     return '';
-  } else if (typeof comment === 'string') {
-    content = comment;
-  } else {
-    content = JSON.stringify(comment, null, 2);
   }
+  
+  const content = typeof comment === 'string' ? comment : JSON.stringify(comment, null, 2);
 
   return html`
     <button

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -2,7 +2,11 @@ import { escapeHtml, html } from '@prairielearn/html';
 
 export function CommentPopover(comment: string | string[] | Record<string, any> | null) {
   let content = '';
-  if (comment === null) {
+  if (
+    !comment ||
+    (Array.isArray(comment) && comment.toString() === '[]') ||
+    (typeof comment === 'object' && Object.keys(comment).length === 0)
+  ) {
     return '';
   } else if (typeof comment === 'string') {
     content = comment;
@@ -14,6 +18,7 @@ export function CommentPopover(comment: string | string[] | Record<string, any> 
     <button
       type="button"
       class="btn btn-xs btn-ghost"
+      aria-label="Access rule comment"
       data-bs-toggle="popover"
       data-bs-container="body"
       data-bs-placement="auto"

--- a/apps/prairielearn/src/components/CommentPopover.html.ts
+++ b/apps/prairielearn/src/components/CommentPopover.html.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, html, HtmlSafeString, unsafeHtml } from '@prairielearn/html';
+import { escapeHtml, html } from '@prairielearn/html';
 
 export function CommentPopover(comment: string | string[] | Record<string, any> | null) {
   let content = '';

--- a/apps/prairielearn/src/lib/comments.test.ts
+++ b/apps/prairielearn/src/lib/comments.test.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 
 import { isRenderableComment } from '../lib/comments.js';
 
-describe('isRenderable should determine non-empty comments', function () {
+describe('isRenderableComment', function () {
   it('should return true for non-empty string', () => {
     assert.isTrue(isRenderableComment('Test comment'));
   });

--- a/apps/prairielearn/src/lib/comments.ts
+++ b/apps/prairielearn/src/lib/comments.ts
@@ -3,7 +3,6 @@
  *
  * @param comment - the comment being assessed
  */
-
 export function isRenderableComment(comment: string | string[] | Record<string, any> | null) {
   if (
     !comment ||

--- a/apps/prairielearn/src/lib/comments.ts
+++ b/apps/prairielearn/src/lib/comments.ts
@@ -1,0 +1,11 @@
+export function isRenderableComment(comment) {
+  if (
+    !comment ||
+    (typeof comment === 'string' && comment.trim() === '') ||
+    (Array.isArray(comment) && comment.length === 0) ||
+    (typeof comment === 'object' && Object.keys(comment).length === 0)
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/apps/prairielearn/src/lib/comments.ts
+++ b/apps/prairielearn/src/lib/comments.ts
@@ -1,4 +1,10 @@
-export function isRenderableComment(comment) {
+/**
+ * Returns a boolean indicating that the comment is not null or empty and should be rendered.
+ *
+ * @param comment - the comment being assessed
+ */
+
+export function isRenderableComment(comment: string | string[] | Record<string, any> | null) {
   if (
     !comment ||
     (typeof comment === 'string' && comment.trim() === '') ||

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -20,7 +20,7 @@ export const AssessmentsFormatForQuestionSchema = z.array(
   }),
 );
 
-const JsonCommentSchema = z.union([z.string(), z.array(z.any()), z.record(z.any())]);
+export const JsonCommentSchema = z.union([z.string(), z.array(z.any()), z.record(z.any())]);
 
 // *******************************************************************************
 // Enum schemas. These should be alphabetized by their corresponding enum name.

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -2,9 +2,11 @@ import { z } from 'zod';
 
 import { html } from '@prairielearn/html';
 
+import { CommentPopover } from '../../components/CommentPopover.html.js';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { AssessmentSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
 import { config } from '../../lib/config.js';
+import { JsonCommentSchema } from '../../lib/db-types.js';
 
 export const AssessmentAccessRulesSchema = z.object({
   mode: z.string(),
@@ -20,6 +22,7 @@ export const AssessmentAccessRulesSchema = z.object({
   pt_exam_id: z.string().nullable(),
   pt_exam_name: z.string().nullable(),
   active: z.string(),
+  comment: JsonCommentSchema.nullable(),
 });
 type AssessmentAccessRules = z.infer<typeof AssessmentAccessRulesSchema>;
 
@@ -59,6 +62,7 @@ export function InstructorAssessmentAccess({
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
+                <th></th>
                 <th>Mode</th>
                 <th>UIDs</th>
                 <th>Start date</th>
@@ -81,6 +85,9 @@ export function InstructorAssessmentAccess({
                 // student data. See https://github.com/PrairieLearn/PrairieLearn/issues/3342
                 return html`
                   <tr>
+                    <td>
+                      ${access_rule.comment ? CommentPopover(access_rule.comment.toString()) : ''}
+                    </td>
                     <td>${access_rule.mode}</td>
                     <td>
                       ${access_rule.uids === '—' ||

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -34,8 +34,7 @@ export function InstructorAssessmentAccess({
   resLocals: Record<string, any>;
   accessRules: AssessmentAccessRules[];
 }) {
-  const showComments =
-    accessRules.filter((access_rule) => isRenderableComment(access_rule.comment)).length > 0;
+  const showComments = accessRules.some((access_rule) => isRenderableComment(access_rule.comment));
   return PageLayout({
     resLocals,
     pageTitle: 'Access',

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -5,6 +5,7 @@ import { html } from '@prairielearn/html';
 import { CommentPopover } from '../../components/CommentPopover.html.js';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { AssessmentSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
+import { isRenderableComment } from '../../lib/comments.js';
 import { config } from '../../lib/config.js';
 import { JsonCommentSchema } from '../../lib/db-types.js';
 
@@ -34,9 +35,7 @@ export function InstructorAssessmentAccess({
   accessRules: AssessmentAccessRules[];
 }) {
   const showComments =
-    accessRules.filter(
-      (access_rule) => access_rule.comment && Object.keys(access_rule.comment).length > 0,
-    ).length > 0;
+    accessRules.filter((access_rule) => isRenderableComment(access_rule.comment)).length > 0;
   return PageLayout({
     resLocals,
     pageTitle: 'Access',

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -85,9 +85,7 @@ export function InstructorAssessmentAccess({
                 // student data. See https://github.com/PrairieLearn/PrairieLearn/issues/3342
                 return html`
                   <tr>
-                    <td>
-                      ${access_rule.comment ? CommentPopover(access_rule.comment.toString()) : ''}
-                    </td>
+                    <td>${CommentPopover(access_rule.comment)}</td>
                     <td>${access_rule.mode}</td>
                     <td>
                       ${access_rule.uids === '—' ||

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -33,6 +33,10 @@ export function InstructorAssessmentAccess({
   resLocals: Record<string, any>;
   accessRules: AssessmentAccessRules[];
 }) {
+  const showComments =
+    accessRules.filter(
+      (access_rule) => access_rule.comment && Object.keys(access_rule.comment).length > 0,
+    ).length > 0;
   return PageLayout({
     resLocals,
     pageTitle: 'Access',
@@ -62,7 +66,9 @@ export function InstructorAssessmentAccess({
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
-                <th><span class="visually-hidden">Comments</span></th>
+                ${showComments
+                  ? html`<th style="width: 1%"><span class="visually-hidden">Comments</span></th>`
+                  : ''}
                 <th>Mode</th>
                 <th>UIDs</th>
                 <th>Start date</th>
@@ -85,7 +91,7 @@ export function InstructorAssessmentAccess({
                 // student data. See https://github.com/PrairieLearn/PrairieLearn/issues/3342
                 return html`
                   <tr>
-                    <td>${CommentPopover(access_rule.comment)}</td>
+                    ${showComments ? html`<td>${CommentPopover(access_rule.comment)}</td>` : ''}
                     <td>${access_rule.mode}</td>
                     <td>
                       ${access_rule.uids === '—' ||

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.ts
@@ -62,7 +62,7 @@ export function InstructorAssessmentAccess({
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
-                <th></th>
+                <th><span class="visually-hidden">Comments</span></th>
                 <th>Mode</th>
                 <th>UIDs</th>
                 <th>Start date</th>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.sql
@@ -33,6 +33,7 @@ SELECT
   pt_c.name AS pt_course_name,
   pt_x.id AS pt_exam_id,
   pt_x.name AS pt_exam_name,
+  aar.json_comment AS comment,
   CASE
     WHEN aar.active THEN 'True'
     ELSE 'False'

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -1,10 +1,10 @@
 import { formatDate } from '@prairielearn/formatter';
 import { html } from '@prairielearn/html';
 
+import { CommentPopover } from '../../components/CommentPopover.html.js';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { CourseInstanceSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
 import { type CourseInstanceAccessRule } from '../../lib/db-types.js';
-import { CommentPopover } from '../../components/CommentPopover.html.js';
 
 export function InstructorInstanceAdminAccess({
   resLocals,
@@ -42,7 +42,7 @@ export function InstructorInstanceAdminAccess({
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
-                <th></th>
+                <th><span class="visually-hidden">Comments</span></th>
                 <th>UIDs</th>
                 <th>Start date</th>
                 <th>End date</th>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -14,6 +14,10 @@ export function InstructorInstanceAdminAccess({
   accessRules: CourseInstanceAccessRule[];
 }) {
   const { authz_data, course_instance } = resLocals;
+  const showComments =
+    accessRules.filter(
+      (access_rule) => access_rule.json_comment && Object.keys(access_rule.json_comment).length > 0,
+    ).length > 0;
 
   return PageLayout({
     resLocals,
@@ -42,7 +46,9 @@ export function InstructorInstanceAdminAccess({
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
-                <th><span class="visually-hidden">Comments</span></th>
+                ${showComments
+                  ? html`<th style="width: 1%"><span class="visually-hidden">Comments</span></th>`
+                  : ''}
                 <th>UIDs</th>
                 <th>Start date</th>
                 <th>End date</th>
@@ -55,6 +61,7 @@ export function InstructorInstanceAdminAccess({
                   accessRule,
                   timeZone: course_instance.display_timezone,
                   hasCourseInstancePermissionView: authz_data.has_course_instance_permission_view,
+                  showComments,
                 }),
               )}
             </tbody>
@@ -69,14 +76,16 @@ function AccessRuleRow({
   accessRule,
   timeZone,
   hasCourseInstancePermissionView,
+  showComments,
 }: {
   accessRule: CourseInstanceAccessRule;
   timeZone: string;
   hasCourseInstancePermissionView: boolean;
+  showComments: boolean;
 }) {
   return html`
     <tr>
-      <td>${CommentPopover(accessRule.json_comment)}</td>
+      ${showComments ? html`<td>${CommentPopover(accessRule.json_comment)}</td>` : ''}
       <td>
         ${accessRule.uids == null
           ? html`&mdash;`

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -5,6 +5,7 @@ import { CommentPopover } from '../../components/CommentPopover.html.js';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { CourseInstanceSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
 import { type CourseInstanceAccessRule } from '../../lib/db-types.js';
+import { isRenderableComment } from '../../lib/comments.js';
 
 export function InstructorInstanceAdminAccess({
   resLocals,
@@ -15,9 +16,7 @@ export function InstructorInstanceAdminAccess({
 }) {
   const { authz_data, course_instance } = resLocals;
   const showComments =
-    accessRules.filter(
-      (access_rule) => access_rule.json_comment && Object.keys(access_rule.json_comment).length > 0,
-    ).length > 0;
+    accessRules.filter((access_rule) => isRenderableComment(access_rule.json_comment)).length > 0;
 
   return PageLayout({
     resLocals,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -76,7 +76,7 @@ function AccessRuleRow({
 }) {
   return html`
     <tr>
-      <td>${accessRule.json_comment ? CommentPopover(accessRule.json_comment.toString()) : ''}</td>
+      <td>${CommentPopover(accessRule.json_comment)}</td>
       <td>
         ${accessRule.uids == null
           ? html`&mdash;`

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -15,8 +15,9 @@ export function InstructorInstanceAdminAccess({
   accessRules: CourseInstanceAccessRule[];
 }) {
   const { authz_data, course_instance } = resLocals;
-  const showComments =
-    accessRules.filter((access_rule) => isRenderableComment(access_rule.json_comment)).length > 0;
+  const showComments = accessRules.some((access_rule) =>
+    isRenderableComment(access_rule.json_comment),
+  );
 
   return PageLayout({
     resLocals,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -4,6 +4,7 @@ import { html } from '@prairielearn/html';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { CourseInstanceSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
 import { type CourseInstanceAccessRule } from '../../lib/db-types.js';
+import { CommentPopover } from '../../components/CommentPopover.html.js';
 
 export function InstructorInstanceAdminAccess({
   resLocals,
@@ -41,6 +42,7 @@ export function InstructorInstanceAdminAccess({
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
+                <th></th>
                 <th>UIDs</th>
                 <th>Start date</th>
                 <th>End date</th>
@@ -74,6 +76,7 @@ function AccessRuleRow({
 }) {
   return html`
     <tr>
+      <td>${accessRule.json_comment ? CommentPopover(accessRule.json_comment.toString()) : ''}</td>
       <td>
         ${accessRule.uids == null
           ? html`&mdash;`

--- a/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminAccess/instructorInstanceAdminAccess.html.ts
@@ -4,8 +4,8 @@ import { html } from '@prairielearn/html';
 import { CommentPopover } from '../../components/CommentPopover.html.js';
 import { PageLayout } from '../../components/PageLayout.html.js';
 import { CourseInstanceSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.html.js';
-import { type CourseInstanceAccessRule } from '../../lib/db-types.js';
 import { isRenderableComment } from '../../lib/comments.js';
+import { type CourseInstanceAccessRule } from '../../lib/db-types.js';
 
 export function InstructorInstanceAdminAccess({
   resLocals,

--- a/apps/prairielearn/src/tests/comments.test.ts
+++ b/apps/prairielearn/src/tests/comments.test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+
 import { isRenderableComment } from '../lib/comments.js';
 
 describe('isRenderable should determine non-empty comments', function () {

--- a/apps/prairielearn/src/tests/comments.test.ts
+++ b/apps/prairielearn/src/tests/comments.test.ts
@@ -1,0 +1,36 @@
+import { assert } from 'chai';
+import { isRenderableComment } from '../lib/comments.js';
+
+describe('isRenderable should determine non-empty comments', function () {
+  it('should return true for non-empty string', () => {
+    assert.isTrue(isRenderableComment('Test comment'));
+  });
+
+  it('should return true for non-empty array', () => {
+    assert.isTrue(isRenderableComment(['test', 'comment']));
+  });
+
+  it('should return true for non-empty object', () => {
+    assert.isTrue(isRenderableComment({ comment: 'test' }));
+  });
+
+  it('should return false for null', () => {
+    assert.isFalse(isRenderableComment(null));
+  });
+
+  it('should return false for empty string', () => {
+    assert.isFalse(isRenderableComment(''));
+  });
+
+  it('should return false for empty array', () => {
+    assert.isFalse(isRenderableComment([]));
+  });
+
+  it('should return false for empty object', () => {
+    assert.isFalse(isRenderableComment({}));
+  });
+
+  it('should return false for whitespace string', () => {
+    assert.isFalse(isRenderableComment('   '));
+  });
+});


### PR DESCRIPTION
This will allow instructors to see comments on access rules from their JSON files. This uses the newly added JSON comment columns to render the access rules for course instances and assessments in the access rules tables.

![Screenshot 2025-05-09 at 9 23 22 AM](https://github.com/user-attachments/assets/a0346687-5fe2-4862-9360-c6348d637b30)
![Screenshot 2025-05-09 at 9 25 16 AM](https://github.com/user-attachments/assets/04784c86-d04f-42b9-b908-834e637b4108)
![Screenshot 2025-05-09 at 9 24 57 AM](https://github.com/user-attachments/assets/1f4b38a1-feda-4885-acca-22f0333fc05d)
