### PR TITLE
List instances for manual grading in pseudo-random order

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -1,53 +1,49 @@
 -- BLOCK select_next_ungraded_instance_question
 WITH
-  prior_instance_question AS (
+  instance_questions_to_grade AS (
     SELECT
-      iq.*,
-      COALESCE(g.name, u.name) AS prior_user_or_group_name
+      iq.id,
+      iq.assigned_grader,
+      ((iq.id % 21317) * 45989) % 3767 AS iq_stable_order,
+      (($prior_instance_question_id % 21317) * 45989) % 3767 AS prior_iq_stable_order
     FROM
       instance_questions AS iq
-      LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
-      LEFT JOIN users AS u ON (u.user_id = ai.user_id)
-      LEFT JOIN groups AS g ON (g.id = ai.group_id)
+      JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
     WHERE
-      iq.id = $prior_instance_question_id
+      iq.assessment_question_id = $assessment_question_id
+      AND ai.assessment_id = $assessment_id -- since assessment_question_id is not authz'ed
+      AND (
+        $prior_instance_question_id::BIGINT IS NULL
+        OR iq.id != $prior_instance_question_id
+      )
+      AND iq.requires_manual_grading
+      AND (
+        iq.assigned_grader = $user_id
+        OR iq.assigned_grader IS NULL
+      )
+      AND EXISTS (
+        SELECT
+          1
+        FROM
+          variants AS v
+          JOIN submissions AS s ON (s.variant_id = v.id)
+        WHERE
+          v.instance_question_id = iq.id
+      )
   )
 SELECT
-  iq.id
+  id
 FROM
-  instance_questions AS iq
-  JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
-  LEFT JOIN users AS u ON (u.user_id = ai.user_id)
-  LEFT JOIN groups AS g ON (g.id = ai.group_id)
-  LEFT JOIN prior_instance_question AS piq ON (TRUE)
-WHERE
-  iq.assessment_question_id = $assessment_question_id
-  AND ai.assessment_id = $assessment_id -- since assessment_question_id is not authz'ed
-  AND (
-    $prior_instance_question_id::BIGINT IS NULL
-    OR iq.id != $prior_instance_question_id
-  )
-  AND iq.requires_manual_grading
-  AND (
-    iq.assigned_grader = $user_id
-    OR iq.assigned_grader IS NULL
-  )
-  AND EXISTS (
-    SELECT
-      1
-    FROM
-      variants AS v
-      JOIN submissions AS s ON (s.variant_id = v.id)
-    WHERE
-      v.instance_question_id = iq.id
-  )
+  instance_questions_to_grade
 ORDER BY
   -- Choose one assigned to current user if one exists, unassigned if not
-  iq.assigned_grader NULLS LAST,
-  -- Choose question that list after the prior if one exists (follow the order in the instance list)
-  (COALESCE(g.name, u.name), iq.id) > (piq.prior_user_or_group_name, piq.id) DESC,
-  COALESCE(g.name, u.name),
-  iq.id
+  assigned_grader NULLS LAST,
+  -- Choose question that list after the prior if one exists. Follow the same
+  -- default pseudo-random deterministic stable order used in the instance
+  -- questions page.
+  iq_stable_order > prior_iq_stable_order DESC,
+  iq_stable_order,
+  id
 LIMIT
   1;
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.sql
@@ -25,7 +25,13 @@ SELECT
   COALESCE(lgu.name, lgu.uid) AS last_grader_name,
   to_jsonb(aq.*) AS assessment_question,
   COALESCE(g.name, u.name) AS user_or_group_name,
-  ic.open_issue_count
+  ic.open_issue_count,
+  -- Pseudo-random deterministic stable order of instance questions. This will
+  -- always return the same set of instance questions in the same order, but it
+  -- is designed to reduce the impact of the order of the instance questions on
+  -- individual students, which reduces bias. See
+  -- https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4603146
+  ((iq.id % 21317) * 45989) % 3767 as iq_stable_order
 FROM
   instance_questions AS iq
   JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
@@ -41,7 +47,7 @@ WHERE
   AND iq.assessment_question_id = $assessment_question_id
   AND iq.status != 'unanswered'
 ORDER BY
-  user_or_group_name,
+  iq_stable_order,
   iq.id;
 
 -- BLOCK update_instance_questions


### PR DESCRIPTION
Closes #7551. Changes the order in which instances are listed in the manual grading assessment question page. The new order is a stable pseudo-random order (using the instance question ID as its input), so that the same list of instance questions are always shown in the same order, but the order is not determined by any information that may be a source of bias (name, creation date, submission date, group name, etc.).

The process to choose the next instance question to be graded (used when a grader submits or skips a manual grading) is also updated to use the same order, so that grades are reported in the same order as listed in the assessment question page.

Best reviewed ignoring whitespaces.