### PR TITLE
Refactor Mustache template extraction for AI question generation

### DIFF
--- a/apps/prairielearn/src/ee/lib/validateHTML.test.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.test.ts
@@ -23,6 +23,10 @@ describe('extractMustacheTemplateNames', () => {
     assertExtractsNames('Hello, {{ name }}!', ['name']);
   });
 
+  it('handles Mustache tags with dots', () => {
+    assertExtractsNames('Hello, {{foo.bar}}!', ['foo.bar']);
+  });
+
   it('handles triple-braced Mustache tags', () => {
     assertExtractsNames('Hello, {{{name}}}!', ['name']);
   });
@@ -41,6 +45,10 @@ describe('extractMustacheTemplateNames', () => {
 
   it('handles inverted Mustache sections with spaces', () => {
     assertExtractsNames('Hello, {{ ^ foo }}{{ name }}{{ / foo }}!', ['foo', 'name']);
+  });
+
+  it('handles Mustache sections with dots', () => {
+    assertExtractsNames('Hello, {{#foo}}{{.}}{{/foo}}!', ['foo']);
   });
 
   it('handles nested Mustache sections', () => {

--- a/apps/prairielearn/src/ee/lib/validateHTML.test.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.test.ts
@@ -1,0 +1,53 @@
+import { assert } from 'chai';
+
+import { extractMustacheTemplateNames } from './validateHTML.js';
+
+function assertExtractsNames(input: string, expectedNames: string[]) {
+  assert.deepEqual(extractMustacheTemplateNames(input), new Set(expectedNames));
+}
+
+describe('extractMustacheTemplateNames', () => {
+  it('handles string without Mustache tags', () => {
+    assertExtractsNames('Hello, world!', []);
+  });
+
+  it('handles string with single Mustache tag', () => {
+    assertExtractsNames('Hello, {{name}}!', ['name']);
+  });
+
+  it('handles string with multiple Mustache tags', () => {
+    assertExtractsNames('Hello, {{name}}! Your score is {{score}}.', ['name', 'score']);
+  });
+
+  it('handles Mustache tags with spaces', () => {
+    assertExtractsNames('Hello, {{ name }}!', ['name']);
+  });
+
+  it('handles triple-braced Mustache tags', () => {
+    assertExtractsNames('Hello, {{{name}}}!', ['name']);
+  });
+
+  it('handles Mustache sections', () => {
+    assertExtractsNames('Hello, {{#foo}}{{name}}{{/foo}}!', ['foo', 'name']);
+  });
+
+  it('handles Mustache sections with spaces', () => {
+    assertExtractsNames('Hello, {{ # foo }}{{ name }}{{ / foo }}!', ['foo', 'name']);
+  });
+
+  it('handles inverted Mustache sections', () => {
+    assertExtractsNames('Hello, {{^foo}}{{name}}{{/foo}}!', ['foo', 'name']);
+  });
+
+  it('handles inverted Mustache sections with spaces', () => {
+    assertExtractsNames('Hello, {{ ^ foo }}{{ name }}{{ / foo }}!', ['foo', 'name']);
+  });
+
+  it('handles nested Mustache sections', () => {
+    assertExtractsNames('Hello, {{#foo}}{{#bar}}{{name}}{{/bar}}{{/foo}}!', ['foo', 'bar', 'name']);
+  });
+
+  it('handles Mustache comments', () => {
+    assertExtractsNames('Hello, {{! This is a comment }}{{name}}!', ['name']);
+  });
+});

--- a/apps/prairielearn/src/ee/lib/validateHTML.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.ts
@@ -29,9 +29,8 @@ export function extractMustacheTemplateNames(str: string): Set<string> {
         names.add(value);
       } else if (type === '#' || type === '^') {
         // Handles {{#section}}...{{/section}} and {{^inverted-section}}...{{/section}}
-
         // Record the section name itself.
-        names.add(value); // The section name itself
+        names.add(value);
 
         // Process any nested tokens.
         const children = token[4];

--- a/apps/prairielearn/src/ee/lib/validateHTML.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.ts
@@ -44,6 +44,11 @@ export function extractMustacheTemplateNames(str: string): Set<string> {
   }
 
   collectNames(tokens);
+
+  // We deliberately ignore `.` (the current context). It's not a useful name
+  // as it doesn't correspond to a variable in the template in isolation.
+  names.delete('.');
+
   return names;
 }
 

--- a/apps/prairielearn/src/ee/lib/validateHTML.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.ts
@@ -648,6 +648,8 @@ function checkCheckbox(ast: DocumentFragment | ChildNode): ValidationResult {
  * @returns A list of human-readable error messages, if any.
  */
 function dfsCheckParseTree(ast: DocumentFragment | ChildNode, optimistic: boolean) {
+  // Will be resolved by https://github.com/PrairieLearn/PrairieLearn/pull/11963
+  // eslint-disable-next-line prefer-const
   let { errors, mandatoryPythonCorrectAnswers = new Set<string>() } = checkTag(ast, optimistic);
 
   if ('childNodes' in ast && ast.childNodes) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,8 +73,8 @@ export default tseslint.config([
     rules: {
       curly: ['error', 'multi-line', 'consistent'],
       eqeqeq: ['error', 'smart'],
-      'no-floating-promise/no-floating-promise': 'error',
       'handle-callback-err': 'error',
+      'no-floating-promise/no-floating-promise': 'error',
       'no-template-curly-in-string': 'error',
       'no-restricted-globals': [
         'error',
@@ -84,6 +84,7 @@ export default tseslint.config([
       ],
       'no-restricted-syntax': ['error', ...NO_RESTRICTED_SYNTAX],
       'object-shorthand': 'error',
+      'prefer-const': ['error', { destructuring: 'all' }],
 
       'import-x/order': [
         'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,6 +73,7 @@ export default tseslint.config([
     rules: {
       curly: ['error', 'multi-line', 'consistent'],
       eqeqeq: ['error', 'smart'],
+      'no-floating-promise/no-floating-promise': 'error',
       'handle-callback-err': 'error',
       'no-template-curly-in-string': 'error',
       'no-restricted-globals': [
@@ -83,22 +84,6 @@ export default tseslint.config([
       ],
       'no-restricted-syntax': ['error', ...NO_RESTRICTED_SYNTAX],
       'object-shorthand': 'error',
-      'prefer-const': ['error', { destructuring: 'all' }],
-
-      // Blocks double-quote strings (unless a single quote is present in the
-      // string) and backticks (unless there is a tag or substitution in place).
-      quotes: ['error', 'single', { avoidEscape: true }],
-
-      // Enforce alphabetical order of import specifiers within each import group.
-      // The import-x/order rule handles the overall sorting of the import groups.
-      'sort-imports': [
-        'error',
-        {
-          ignoreDeclarationSort: true,
-          ignoreMemberSort: false,
-          memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
-        },
-      ],
 
       'import-x/order': [
         'error',
@@ -121,12 +106,21 @@ export default tseslint.config([
         },
       ],
 
+      // Enforce alphabetical order of import specifiers within each import group.
+      // The import-x/order rule handles the overall sorting of the import groups.
+      'sort-imports': [
+        'error',
+        {
+          ignoreDeclarationSort: true,
+          ignoreMemberSort: false,
+          memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
+        },
+      ],
+
       // The recommended Mocha rules are too strict for us; we'll only enable
       // these two rules.
       'mocha/no-exclusive-tests': 'error',
       'mocha/no-pending-tests': 'error',
-
-      'no-floating-promise/no-floating-promise': 'error',
 
       // These rules are implemented in `packages/eslint-plugin-prairielearn`.
       '@prairielearn/aws-client-mandatory-config': 'error',
@@ -134,6 +128,15 @@ export default tseslint.config([
       '@prairielearn/jsx-no-dollar-interpolation': 'error',
 
       '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
+
+      // Replaces the standard `no-unused-vars` rule.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+        },
+      ],
 
       // We use empty functions in quite a few places, so we'll disable this rule.
       '@typescript-eslint/no-empty-function': 'off',
@@ -145,14 +148,9 @@ export default tseslint.config([
       // TODO: fix the violations so we can enable this rule.
       '@typescript-eslint/no-dynamic-delete': 'off',
 
-      // Replaces the standard `no-unused-vars` rule.
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          args: 'after-used',
-          argsIgnorePattern: '^_',
-        },
-      ],
+      // Blocks double-quote strings (unless a single quote is present in the
+      // string) and backticks (unless there is a tag or substitution in place).
+      quotes: ['error', 'single', { avoidEscape: true }],
 
       // The _.omit function is still useful in some contexts.
       'you-dont-need-lodash-underscore/omit': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,7 +74,6 @@ export default tseslint.config([
       curly: ['error', 'multi-line', 'consistent'],
       eqeqeq: ['error', 'smart'],
       'handle-callback-err': 'error',
-      'no-floating-promise/no-floating-promise': 'error',
       'no-template-curly-in-string': 'error',
       'no-restricted-globals': [
         'error',
@@ -85,6 +84,21 @@ export default tseslint.config([
       'no-restricted-syntax': ['error', ...NO_RESTRICTED_SYNTAX],
       'object-shorthand': 'error',
       'prefer-const': ['error', { destructuring: 'all' }],
+
+      // Blocks double-quote strings (unless a single quote is present in the
+      // string) and backticks (unless there is a tag or substitution in place).
+      quotes: ['error', 'single', { avoidEscape: true }],
+
+      // Enforce alphabetical order of import specifiers within each import group.
+      // The import-x/order rule handles the overall sorting of the import groups.
+      'sort-imports': [
+        'error',
+        {
+          ignoreDeclarationSort: true,
+          ignoreMemberSort: false,
+          memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
+        },
+      ],
 
       'import-x/order': [
         'error',
@@ -107,21 +121,12 @@ export default tseslint.config([
         },
       ],
 
-      // Enforce alphabetical order of import specifiers within each import group.
-      // The import-x/order rule handles the overall sorting of the import groups.
-      'sort-imports': [
-        'error',
-        {
-          ignoreDeclarationSort: true,
-          ignoreMemberSort: false,
-          memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
-        },
-      ],
-
       // The recommended Mocha rules are too strict for us; we'll only enable
       // these two rules.
       'mocha/no-exclusive-tests': 'error',
       'mocha/no-pending-tests': 'error',
+
+      'no-floating-promise/no-floating-promise': 'error',
 
       // These rules are implemented in `packages/eslint-plugin-prairielearn`.
       '@prairielearn/aws-client-mandatory-config': 'error',
@@ -129,15 +134,6 @@ export default tseslint.config([
       '@prairielearn/jsx-no-dollar-interpolation': 'error',
 
       '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
-
-      // Replaces the standard `no-unused-vars` rule.
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          args: 'after-used',
-          argsIgnorePattern: '^_',
-        },
-      ],
 
       // We use empty functions in quite a few places, so we'll disable this rule.
       '@typescript-eslint/no-empty-function': 'off',
@@ -149,9 +145,14 @@ export default tseslint.config([
       // TODO: fix the violations so we can enable this rule.
       '@typescript-eslint/no-dynamic-delete': 'off',
 
-      // Blocks double-quote strings (unless a single quote is present in the
-      // string) and backticks (unless there is a tag or substitution in place).
-      quotes: ['error', 'single', { avoidEscape: true }],
+      // Replaces the standard `no-unused-vars` rule.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+        },
+      ],
 
       // The _.omit function is still useful in some contexts.
       'you-dont-need-lodash-underscore/omit': 'off',


### PR DESCRIPTION
Rather than mucking around with regular expressions, it's more reliable to to use Mustache's built-in parser. It produces an AST that we can traverse and gather information from.