### PR TITLE
Remove unneeded auth calls on Instructor Assessment Page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.sql
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.sql
@@ -56,7 +56,6 @@ FROM
   assessments AS a
   JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
   LEFT JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-  LEFT JOIN LATERAL authz_assessment (a.id, $authz_data, $req_date, ci.display_timezone) AS aa ON TRUE
   LEFT JOIN issue_count AS ic ON (ic.assessment_id = a.id)
   LEFT JOIN assessment_modules AS am ON (am.id = a.assessment_module_id)
 WHERE
@@ -84,7 +83,6 @@ SELECT
 FROM
   assessments AS a
   JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-  LEFT JOIN LATERAL authz_assessment (a.id, $authz_data, $req_date, ci.display_timezone) AS aa ON TRUE
 WHERE
   a.id = $assessment_id
   AND ci.id = $course_instance_id

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.sql
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.sql
@@ -61,7 +61,6 @@ FROM
 WHERE
   ci.id = $course_instance_id
   AND a.deleted_at IS NULL
-  AND aa.authorized
 ORDER BY
   (
     CASE
@@ -86,8 +85,7 @@ FROM
 WHERE
   a.id = $assessment_id
   AND ci.id = $course_instance_id
-  AND a.deleted_at IS NULL
-  AND aa.authorized;
+  AND a.deleted_at IS NULL;
 
 -- BLOCK select_assessment_id_from_uuid
 SELECT

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
@@ -50,8 +50,6 @@ router.get(
       sql.select_assessments,
       {
         course_instance_id: res.locals.course_instance.id,
-        authz_data: res.locals.authz_data,
-        req_date: res.locals.req_date,
         assessments_group_by: res.locals.course_instance.assessments_group_by,
       },
       AssessmentRowSchema,

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.ts
@@ -107,8 +107,6 @@ router.get(
       {
         course_instance_id: res.locals.course_instance.id, // for authz checking
         assessment_id: req.params.assessment_id,
-        authz_data: res.locals.authz_data,
-        req_date: res.locals.req_date,
       },
       AssessmentSchema,
     );
@@ -132,8 +130,6 @@ router.get(
 
       const cursor = await queryCursor(sql.select_assessments, {
         course_instance_id: res.locals.course_instance.id,
-        authz_data: res.locals.authz_data,
-        req_date: res.locals.req_date,
         assessments_group_by: res.locals.course_instance.assessments_group_by,
       });
 


### PR DESCRIPTION
These calls were needed back when access rules could be used to restrict TA access to certain assessments.

Now, everyone who can see the instructor assessments page at all should be able to see all the assessments that are on it.