### PR TITLE
Replace hidden text with aria labels in buttons

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -562,12 +562,12 @@ function AuthnOverrides({
     <h6 class="dropdown-header">Effective user</h6>
 
     <form class="dropdown-item-text d-flex flex-nowrap js-effective-uid-form">
-      <label class="visually-hidden" for="effective-uid">UID</label>
       <input
         id="effective-uid"
         type="email"
         placeholder="student@example.com"
         class="form-control form-control-sm me-2 flex-grow-1 js-effective-uid-input"
+        aria-label="UID"
       />
       <button
         type="submit"

--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -532,9 +532,9 @@ function RubricItem({
                 data-bs-content="${item.explanation_rendered}"
                 data-bs-html="true"
                 data-testid="rubric-item-explanation"
+                aria-label="Details"
               >
                 <i class="fas fa-circle-info"></i>
-                <span class="visually-hidden">Details</span>
               </button>
             `
           : ''}

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -341,7 +341,7 @@ function LinkedAssessments({
                               class="btn btn-info dropdown-toggle dropdown-toggle-split"
                               data-bs-toggle="dropdown"
                               aria-expanded="false"
-                              aria-label="Toggle Dropdown"
+                              aria-label="Toggle dropdown"
                             ></button>
                             <ul class="dropdown-menu">
                               <li>

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -341,9 +341,8 @@ function LinkedAssessments({
                               class="btn btn-info dropdown-toggle dropdown-toggle-split"
                               data-bs-toggle="dropdown"
                               aria-expanded="false"
-                            >
-                              <span class="visually-hidden">Toggle Dropdown</span>
-                            </button>
+                              aria-label="Toggle Dropdown"
+                            ></button>
                             <ul class="dropdown-menu">
                               <li>
                                 <button

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.ts
@@ -147,7 +147,7 @@ function AssessmentQuestionRow({
                 data-bs-toggle="tooltip"
                 data-bs-title="This question uses a rubric"
               >
-                <i class="fas fa-list-check"></i><span class="visually-hidden">(uses rubric)</span>
+                <i class="fas fa-list-check"></i>
               </a>
             `}
       </td>
@@ -183,9 +183,9 @@ function AssessmentQuestionRow({
                       data-bs-toggle="modal"
                       data-bs-target="#grader-assignment-modal"
                       data-assessment-question-id="${question.id}"
+                      aria-label="Assign to graders"
                     >
-                      <i class="fas fa-pencil"></i
-                      ><span class="visually-hidden">Assign to&hellip;</span>
+                      <i class="fas fa-pencil"></i>
                     </button>
                   `
                 : ''}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -177,9 +177,8 @@ ${submission.feedback?.manual}</textarea
                       data-bs-toggle="dropdown"
                       aria-haspopup="true"
                       aria-expanded="false"
-                    >
-                      <span class="visually-hidden">Change assigned grader</span>
-                    </button>
+                      aria-label="Change assigned grader"
+                    ></button>
                     <div class="dropdown-menu dropdown-menu-end">
                       ${(graders || []).map(
                         (grader) => html`


### PR DESCRIPTION
This PR replaces some uses of visually hidden text inside buttons, intended to be used for screen readers and accessibility tools, with `aria-label` properties. It also replaces a hidden label for an input box.