### PR TITLE
Disable Biome in CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,6 +36,9 @@ reviews:
     # The version of ruff (0.8.2) used by coderabbit is not modern enough to support our config.
     ruff:
       enabled: false
+    # coderabbit is flagging lint issues in our test suite that aren't relevant (lint/suspicious/noDuplicateTestHooks)
+    biome:
+      enabled: false
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,7 +36,7 @@ reviews:
     # The version of ruff (0.8.2) used by coderabbit is not modern enough to support our config.
     ruff:
       enabled: false
-    # coderabbit is flagging lint issues in our test suite that aren't relevant (lint/suspicious/noDuplicateTestHooks)
+    # Biome is flagging issues in our test suite that aren't relevant (lint/suspicious/noDuplicateTestHooks)
     biome:
       enabled: false
 


### PR DESCRIPTION
See https://github.com/PrairieLearn/PrairieLearn/pull/11943#discussion_r2087767974 and similar comments in that PR. We use ESLint; we don't need input from Biome.