### PR TITLE
Add modified_at column to variants and submissions tables

### DIFF
--- a/apps/prairielearn/src/lib/grading.sql
+++ b/apps/prairielearn/src/lib/grading.sql
@@ -51,7 +51,8 @@ WITH
     UPDATE variants
     SET
       params = $params,
-      true_answer = $true_answer
+      true_answer = $true_answer,
+      modified_at = now()
     WHERE
       id = $variant_id
     RETURNING
@@ -112,7 +113,8 @@ WITH
     UPDATE variants
     SET
       duration = duration + ($delta * interval '1 ms'),
-      first_duration = coalesce(first_duration, $delta * interval '1 ms')
+      first_duration = coalesce(first_duration, $delta * interval '1 ms'),
+      -- TODO: update `modified_at` here?
     WHERE
       id = $variant_id
   )
@@ -132,6 +134,8 @@ INSERT INTO
     gradable,
     broken,
     client_fingerprint_id
+    -- TODO: remove once this column has a default
+    modified_at
   )
 VALUES
   (
@@ -148,7 +152,8 @@ VALUES
     $feedback,
     $gradable,
     $broken,
-    $client_fingerprint_id
+    $client_fingerprint_id,
+    NOW()
   )
 RETURNING
   id;

--- a/apps/prairielearn/src/lib/grading.sql
+++ b/apps/prairielearn/src/lib/grading.sql
@@ -114,7 +114,7 @@ WITH
     SET
       duration = duration + ($delta * interval '1 ms'),
       first_duration = coalesce(first_duration, $delta * interval '1 ms'),
-      -- TODO: update `modified_at` here?
+      modified_at = now()
     WHERE
       id = $variant_id
   )

--- a/apps/prairielearn/src/lib/grading.sql
+++ b/apps/prairielearn/src/lib/grading.sql
@@ -133,7 +133,7 @@ INSERT INTO
     feedback,
     gradable,
     broken,
-    client_fingerprint_id
+    client_fingerprint_id,
     -- TODO: remove once this column has a default
     modified_at
   )

--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -449,6 +449,7 @@ SET
   partial_scores = COALESCE($partial_scores::JSONB, partial_scores),
   manual_rubric_grading_id = $manual_rubric_grading_id,
   graded_at = now(),
+  modified_at = now(),
   override_score = COALESCE($score, override_score),
   score = COALESCE($score, score),
   correct = COALESCE($correct, correct),

--- a/apps/prairielearn/src/lib/question-variant.sql
+++ b/apps/prairielearn/src/lib/question-variant.sql
@@ -50,7 +50,9 @@ WITH
         authn_user_id,
         workspace_id,
         course_id,
-        client_fingerprint_id
+        client_fingerprint_id,
+        -- TODO: remove once this column has a default
+        modified_at
       )
     VALUES
       (
@@ -72,7 +74,8 @@ WITH
         $authn_user_id,
         $workspace_id,
         $course_id,
-        $client_fingerprint_id
+        $client_fingerprint_id,
+        NOW()
       )
     RETURNING
       *

--- a/apps/prairielearn/src/lib/submissions-upload.sql
+++ b/apps/prairielearn/src/lib/submissions-upload.sql
@@ -50,7 +50,9 @@ INSERT INTO
     params,
     true_answer,
     options,
-    number
+    number,
+    -- TODO: remove once this column has a default
+    modified_at
   )
 VALUES
   (
@@ -63,7 +65,8 @@ VALUES
     $params,
     $true_answer,
     $options,
-    $number
+    $number,
+    NOW()
   )
 RETURNING
   id AS variant_id;
@@ -78,6 +81,8 @@ INSERT INTO
     params,
     true_answer,
     date
+    -- TODO: remove once this column has a default
+    modified_at
   )
 VALUES
   (
@@ -87,7 +92,8 @@ VALUES
     '{}'::jsonb, -- We don't have any useful value for `raw_submitted_answer` here.
     $params,
     $true_answer,
-    $submission_date
+    $submission_date,
+    NOW()
   )
 RETURNING
   id AS submission_id;

--- a/apps/prairielearn/src/migrations/20250513234929_variants__modified_at__add.sql
+++ b/apps/prairielearn/src/migrations/20250513234929_variants__modified_at__add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE variants
+ADD COLUMN modified_at TIMESTAMPTZ;

--- a/apps/prairielearn/src/migrations/20250513235033_submissions__modified_at__add.sql
+++ b/apps/prairielearn/src/migrations/20250513235033_submissions__modified_at__add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE submissions
+ADD COLUMN modified_at TIMESTAMPTZ;

--- a/apps/prairielearn/src/models/grading-job.sql
+++ b/apps/prairielearn/src/models/grading-job.sql
@@ -48,6 +48,7 @@ WITH
   canceled_job_submissions AS (
     UPDATE submissions AS s
     SET
+      -- TODO: update `modified_at` here?
       grading_requested_at = NULL
     FROM
       canceled_jobs
@@ -58,6 +59,7 @@ WITH
   updated_submission AS (
     UPDATE submissions AS s
     SET
+      -- TODO: update `modified_at` here?
       grading_requested_at = now()
     FROM
       grading_job_data AS gjd

--- a/apps/prairielearn/src/models/grading-job.sql
+++ b/apps/prairielearn/src/models/grading-job.sql
@@ -48,8 +48,8 @@ WITH
   canceled_job_submissions AS (
     UPDATE submissions AS s
     SET
-      -- TODO: update `modified_at` here?
-      grading_requested_at = NULL
+      grading_requested_at = NULL,
+      modified_at = now()
     FROM
       canceled_jobs
     WHERE
@@ -59,8 +59,8 @@ WITH
   updated_submission AS (
     UPDATE submissions AS s
     SET
-      -- TODO: update `modified_at` here?
-      grading_requested_at = now()
+      grading_requested_at = now(),
+      modified_at = now()
     FROM
       grading_job_data AS gjd
     WHERE

--- a/apps/prairielearn/src/models/variant.sql
+++ b/apps/prairielearn/src/models/variant.sql
@@ -11,7 +11,7 @@ UPDATE variants AS v
 SET
   broken_at = CURRENT_TIMESTAMP,
   broken_by = $authn_user_id,
-  -- TODO: update `modified_at` here?
+  modified_at = CURRENT_TIMESTAMP
 FROM
   instance_questions AS iq
   JOIN assessment_questions AS aq ON (iq.assessment_question_id = aq.id)
@@ -26,8 +26,8 @@ WHERE
 UPDATE variants AS v
 SET
   broken_at = CURRENT_TIMESTAMP,
-  broken_by = $authn_user_id
-  -- TODO: update `modified_at` here?
+  broken_by = $authn_user_id,
+  modified_at = CURRENT_TIMESTAMP
 FROM
   instance_questions AS iq
 WHERE

--- a/apps/prairielearn/src/models/variant.sql
+++ b/apps/prairielearn/src/models/variant.sql
@@ -10,7 +10,8 @@ WHERE
 UPDATE variants AS v
 SET
   broken_at = CURRENT_TIMESTAMP,
-  broken_by = $authn_user_id
+  broken_by = $authn_user_id,
+  -- TODO: update `modified_at` here?
 FROM
   instance_questions AS iq
   JOIN assessment_questions AS aq ON (iq.assessment_question_id = aq.id)
@@ -26,6 +27,7 @@ UPDATE variants AS v
 SET
   broken_at = CURRENT_TIMESTAMP,
   broken_by = $authn_user_id
+  -- TODO: update `modified_at` here?
 FROM
   instance_questions AS iq
 WHERE

--- a/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql
+++ b/apps/prairielearn/src/sprocs/grading_jobs_update_after_grading.sql
@@ -112,6 +112,7 @@ BEGIN
     UPDATE submissions
     SET
         graded_at = now(),
+        modified_at = now(),
         gradable = new_gradable,
         broken = new_broken,
         params = COALESCE(new_params, params),
@@ -128,7 +129,8 @@ BEGIN
     UPDATE variants AS v
     SET
         params = COALESCE(new_params, params),
-        true_answer = COALESCE(new_true_answer, true_answer)
+        true_answer = COALESCE(new_true_answer, true_answer),
+        modified_at = now()
     WHERE v.id = variant_id;
 
     UPDATE grading_jobs

--- a/apps/prairielearn/src/sprocs/variants_update_after_grading.sql
+++ b/apps/prairielearn/src/sprocs/variants_update_after_grading.sql
@@ -12,8 +12,7 @@ BEGIN
     PERFORM variants_lock(variant_id);
 
     -- Increment num_tries
-    -- TODO: update `modified_at` here?
-    UPDATE variants AS v SET num_tries = v.num_tries + 1 WHERE v.id = variant_id;
+    UPDATE variants AS v SET num_tries = v.num_tries + 1, modified_at = NOW() WHERE v.id = variant_id;
 
     -- Get (1) flag that says whether or not the question has only a single variant,
     --     (2) type of assessment
@@ -33,8 +32,7 @@ BEGIN
     -- Close the variant if it's on a homework assessment, if it's not of a
     -- question with only one variant, and if the max num tries has been reached
     IF assessment_type = 'Homework' AND NOT single_variant AND (used_all_tries OR correct) THEN
-        -- TODO: update `modified_at` here?
-        UPDATE variants SET open = false WHERE id = variant_id;
+        UPDATE variants SET open = false, modified_at = NOW() WHERE id = variant_id;
     END IF;
 END;
 $$ LANGUAGE plpgsql VOLATILE;

--- a/apps/prairielearn/src/sprocs/variants_update_after_grading.sql
+++ b/apps/prairielearn/src/sprocs/variants_update_after_grading.sql
@@ -12,6 +12,7 @@ BEGIN
     PERFORM variants_lock(variant_id);
 
     -- Increment num_tries
+    -- TODO: update `modified_at` here?
     UPDATE variants AS v SET num_tries = v.num_tries + 1 WHERE v.id = variant_id;
 
     -- Get (1) flag that says whether or not the question has only a single variant,
@@ -32,6 +33,7 @@ BEGIN
     -- Close the variant if it's on a homework assessment, if it's not of a
     -- question with only one variant, and if the max num tries has been reached
     IF assessment_type = 'Homework' AND NOT single_variant AND (used_all_tries OR correct) THEN
+        -- TODO: update `modified_at` here?
         UPDATE variants SET open = false WHERE id = variant_id;
     END IF;
 END;

--- a/database/tables/submissions.pg
+++ b/database/tables/submissions.pg
@@ -16,6 +16,7 @@ columns
     is_ai_graded: boolean not null default false
     manual_rubric_grading_id: bigint
     mode: enum_mode
+    modified_at: timestamp with time zone
     override_score: double precision
     params: jsonb
     partial_scores: jsonb

--- a/database/tables/variants.pg
+++ b/database/tables/variants.pg
@@ -12,6 +12,7 @@ columns
     group_id: bigint
     id: bigint not null default nextval('variants_id_seq'::regclass)
     instance_question_id: bigint
+    modified_at: timestamp with time zone
     num_tries: integer not null default 0
     number: integer
     open: boolean default true

--- a/docs/dev-guide/guide.md
+++ b/docs/dev-guide/guide.md
@@ -136,7 +136,7 @@ In general, we prefer simplicity. We standardize on JavaScript/TypeScript (Node.
   
   -- BLOCK insert_user
   INSERT INTO
-    submissions (uid)
+    users (uid)
   VALUES
     ($uid)
   RETURNING

--- a/docs/dev-guide/guide.md
+++ b/docs/dev-guide/guide.md
@@ -134,11 +134,11 @@ In general, we prefer simplicity. We standardize on JavaScript/TypeScript (Node.
   WHERE
     id = $question_id;
   
-  -- BLOCK insert_submission
+  -- BLOCK insert_user
   INSERT INTO
-    submissions (submitted_answer)
+    submissions (uid)
   VALUES
-    ($submitted_answer)
+    ($uid)
   RETURNING
     *;
   ```

--- a/packages/postgres-tools/src/bin/pg-describe.ts
+++ b/packages/postgres-tools/src/bin/pg-describe.ts
@@ -98,9 +98,10 @@ function printDescription(description: DatabaseDescription) {
 
 async function writeDescriptionToDisk(description: DatabaseDescription, dir: string) {
   const formattedDescription = formatDatabaseDescription(description, { coloredOutput: false });
-  await fs.emptyDir(dir);
-  await fs.mkdir(path.join(dir, 'tables'));
-  await fs.mkdir(path.join(dir, 'enums'));
+  await fs.ensureDir(path.join(dir, 'tables'));
+  await fs.ensureDir(path.join(dir, 'enums'));
+  await fs.emptyDir(path.join(dir, 'tables'));
+  await fs.emptyDir(path.join(dir, 'enums'));
   await async.eachOf(formattedDescription.tables, async (value, key) => {
     await fs.writeFile(path.join(dir, 'tables', `${key}.pg`), value);
   });


### PR DESCRIPTION
This is the first part of #11974. In future PRs, we'll backfill these columns, add a `NOT NULL` constraint, and then add a default of `NOW()`.

@mwest1066 while working on this change, I wasn't sure exactly when we should update `modified_at`. Should it be literally any time we have an `UPDATE` statement with these tables? That's simple but I wasn't sure exactly how we wanted this value to behave. For now, I just added `TODO` comments to the relevant locations in this PR to help with discussion.