### PR TITLE
Add links to screen reader suggestions in docs

### DIFF
--- a/docs/question/accessibility.md
+++ b/docs/question/accessibility.md
@@ -78,5 +78,5 @@ Most PrairieLearn elements are designed to meet these requirements by default. H
 While PrairieLearn aims to provide accessible building blocks, it's important to test your questions for accessibility.
 
 - **Keyboard-only navigation**: Can you navigate and answer the question using only the keyboard?
-- **Screen reader**: Use a screen reader (e.g., [NVDA](https://www.nvaccess.org/download/) or [JAWS](https://www.freedomscientific.com/products/software/jaws/) for Windows, [Orca](https://help.gnome.org/users/orca/stable/index.html.en) for Linux, or [VoiceOver](http://www.apple.com/accessibility/voiceover/) for macOS) to experience the question like a student who is blind or has low vision.
+- **Screen reader**: Use a screen reader (e.g., [NVDA](https://www.nvaccess.org/download/) or [JAWS](https://www.freedomscientific.com/products/software/jaws/) for Windows, [Orca](https://help.gnome.org/users/orca/stable/index.html.en) for Linux, or [VoiceOver](https://www.apple.com/accessibility/voiceover/) for macOS) to experience the question like a student who is blind or has low vision.
 - **Accessibility checkers**: Browser extensions and online tools can help identify common accessibility issues. However, they cannot identify all issues, so manual testing is still important.

--- a/docs/question/accessibility.md
+++ b/docs/question/accessibility.md
@@ -78,5 +78,5 @@ Most PrairieLearn elements are designed to meet these requirements by default. H
 While PrairieLearn aims to provide accessible building blocks, it's important to test your questions for accessibility.
 
 - **Keyboard-only navigation**: Can you navigate and answer the question using only the keyboard?
-- **Screen reader**: Use a screen reader (e.g. NVDA, JAWS, or VoiceOver) to experience the question like a student who is blind or has low vision.
+- **Screen reader**: Use a screen reader (e.g., [NVDA](https://www.nvaccess.org/download/) or [JAWS](https://www.freedomscientific.com/products/software/jaws/) for Windows, [Orca](https://help.gnome.org/users/orca/stable/index.html.en) for Linux, or [VoiceOver](http://www.apple.com/accessibility/voiceover/) for macOS) to experience the question like a student who is blind or has low vision.
 - **Accessibility checkers**: Browser extensions and online tools can help identify common accessibility issues. However, they cannot identify all issues, so manual testing is still important.


### PR DESCRIPTION
#11922 added some accessibility suggestions for instructors and question developers, including the suggestion to use screen readers to test a question. However, the provided list did not include links to these tools, which adds an extra burden on instructors searching for these tools (Googling NVDA returns the stock info for NVidia, and JAWS is a movie name). This PR adds links to the tools' official pages, as well as an indication of the OS associated to each tool. For completeness, it also adds a Linux tool.