### PR TITLE
Prevent zombie zygote processes

### DIFF
--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -187,12 +187,13 @@ def worker_loop() -> None:
             json_inp = sys.stdin.readline()
 
             # Sometimes we seem to get an empty line, so we'll just ignore it.
-            # On the other hand if the input is empty, the parent process has died
-            # and we should exit to avoid becoming a zombie
             if json_inp == "\n":
                 continue
+
+            # If the input is empty, the server has died and we should exit to avoid
+            # becoming a zombie. Exit non-zero to ensure the parent process also exits
             if json_inp == "":
-                sys.exit()
+                sys.exit(1)
 
             # Unpack the input line as JSON. If that fails, log the line for debugging.
             try:

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -187,12 +187,12 @@ def worker_loop() -> None:
             json_inp = sys.stdin.readline()
 
             # Sometimes we seem to get an empty line, so we'll just ignore it.
+            # On the other hand if the input is empty, the parent process has died
+            # and we should exit to avoid becoming a zombie
             if json_inp == "\n":
                 continue
             if json_inp == "":
                 sys.exit()
-            # if not json_inp.strip():
-            # continue
 
             # Unpack the input line as JSON. If that fails, log the line for debugging.
             try:

--- a/apps/prairielearn/python/zygote.py
+++ b/apps/prairielearn/python/zygote.py
@@ -187,8 +187,12 @@ def worker_loop() -> None:
             json_inp = sys.stdin.readline()
 
             # Sometimes we seem to get an empty line, so we'll just ignore it.
-            if not json_inp.strip():
+            if json_inp == "\n":
                 continue
+            if json_inp == "":
+                sys.exit()
+            # if not json_inp.strip():
+            # continue
 
             # Unpack the input line as JSON. If that fails, log the line for debugging.
             try:


### PR DESCRIPTION
If the prairielearn server crashes during startup, but after creating the zygote child processes, some zombie zygote process can be left behind. Examining them with strace showed they were stuck in a loop repeatedly reading the empty string. This should solve the problem.