### PR TITLE
Fix MathJax when it's loaded multiple times on the same page

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -12,7 +12,7 @@ const mathjaxPromise = new Promise<void>((resolve, reject) => {
   if (window.MathJax) {
     // Something else already loaded MathJax on this page. Just resolve the promise
     // once MathJax reports that it is ready.
-    window.MathJax.startup.promise.then(() => resolve());
+    window.MathJax.startup.promise.then(resolve, reject);
     return;
   }
 

--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -9,6 +9,13 @@ declare global {
 }
 
 const mathjaxPromise = new Promise<void>((resolve, reject) => {
+  if (window.MathJax) {
+    // Something else already loaded MathJax on this page. Just resolve the promise
+    // once MathJax reports that it is ready.
+    window.MathJax.startup.promise.then(() => resolve());
+    return;
+  }
+
   window.MathJax = {
     options: {
       // We previously documented the `tex2jax_ignore` class, so we'll keep
@@ -84,9 +91,9 @@ const mathjaxPromise = new Promise<void>((resolve, reject) => {
   });
 });
 
-export async function mathjaxTypeset() {
+export async function mathjaxTypeset(elements?: Element[]) {
   await mathjaxPromise;
-  return window.MathJax.typesetPromise();
+  return window.MathJax.typesetPromise(elements);
 }
 
 export async function mathjaxConvert(value: string) {

--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -189,18 +189,20 @@ function updateDynamicPanels(msg: SubmissionPanels, submissionId: string) {
       // must be executed. Typical vanilla JS alternatives don't support
       // this kind of script.
       $(answerContainer).html(msg.answerPanel);
-      mathjaxTypeset();
+      mathjaxTypeset([answerContainer]);
       answerContainer.closest('.grading-block')?.classList.remove('d-none');
     }
   }
 
   if (msg.submissionPanel) {
+    const submissionPanelSelector = `#submission-${submissionId}`;
     // Using jQuery here because msg.submissionPanel may contain scripts
     // that must be executed. Typical vanilla JS alternatives don't support
     // this kind of script.
-    $('#submission-' + submissionId).replaceWith(msg.submissionPanel);
-    mathjaxTypeset();
+    $(submissionPanelSelector).replaceWith(msg.submissionPanel);
+    mathjaxTypeset([document.querySelector(submissionPanelSelector) as HTMLElement]);
   }
+
   if (msg.questionScorePanel) {
     const parsedHTML = parseHTMLElement(document, msg.questionScorePanel);
 
@@ -212,12 +214,14 @@ function updateDynamicPanels(msg: SubmissionPanels, submissionId: string) {
     const targetElement = document.getElementById(parsedHTML.id);
     targetElement?.replaceWith(parsedHTML);
   }
+
   if (msg.assessmentScorePanel) {
     const assessmentScorePanel = document.getElementById('assessment-score-panel');
     if (assessmentScorePanel) {
       assessmentScorePanel.outerHTML = msg.assessmentScorePanel;
     }
   }
+
   if (msg.questionPanelFooter) {
     const parsedHTML = parseHTMLElement(document, msg.questionPanelFooter);
 
@@ -229,12 +233,14 @@ function updateDynamicPanels(msg: SubmissionPanels, submissionId: string) {
     const targetElement = document.getElementById(parsedHTML.id);
     targetElement?.replaceWith(parsedHTML);
   }
+
   if (msg.questionNavNextButton) {
     const questionNavNextButton = document.getElementById('question-nav-next');
     if (questionNavNextButton) {
       questionNavNextButton.outerHTML = msg.questionNavNextButton;
     }
   }
+
   setupDynamicObjects();
 }
 


### PR DESCRIPTION
This is specifically relevant to `apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.ts`, which loads `lib/mathjax.ts` twice on the same page: once from `apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js`, and once from `apps/prairielearn/assets/scripts/question.ts`. They'd both try to write `window.MathJax`, but only the last one to run before MathJax loaded would win, and thus only that one would ever have `mathjaxPromise` resolve.

The actual issue this caused could be reproduced by making a bunch of submissions to a question that rendered math in its submission panel. When asynchronously loading a submission on the instructor manual grading page, that math wasn't typeset. Now, it is.

While I was here, I also updated `typesetPromise` to take an optional array of elements to typeset. This is more efficient when we can reason about which content on the page actually changed.