### PR TITLE
Backfill modified_at column for variants and submissions

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20250514232243_variants__modified_at__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250514232243_variants__modified_at__backfill.sql
@@ -1,0 +1,25 @@
+-- BLOCK select_bounds
+SELECT
+  MAX(id)
+FROM
+  variants;
+
+-- BLOCK update_variants_modified_at
+UPDATE variants
+SET
+  modified_at = COALESCE(
+    (
+      SELECT
+        MAX(COALESCE(s.graded_at, s.date))
+      FROM
+        submissions AS s
+      WHERE
+        variant_id = variants.id
+    ),
+    -- If the variant doesn't have any submissions, we'll use its creation date.
+    variants.date
+  )
+WHERE
+  modified_at IS NULL
+  AND id >= $start
+  AND id <= $end;

--- a/apps/prairielearn/src/batched-migrations/20250514232243_variants__modified_at__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250514232243_variants__modified_at__backfill.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const result = await queryRow(sql.select_bounds, z.bigint({ coerce: true }).nullable());
+    return { min: 1n, max: result, batchSize: 1000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.update_variants_modified_at, { start, end });
+  },
+});

--- a/apps/prairielearn/src/batched-migrations/20250514233007_submissions__modified_at__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20250514233007_submissions__modified_at__backfill.sql
@@ -1,0 +1,14 @@
+-- BLOCK select_bounds
+SELECT
+  MAX(id)
+FROM
+  submissions;
+
+-- BLOCK update_submissions_modified_at
+UPDATE submissions
+SET
+  modified_at = COALESCE(graded_at, date)
+WHERE
+  modified_at IS NULL
+  AND id >= $start
+  AND id <= $end;

--- a/apps/prairielearn/src/batched-migrations/20250514233007_submissions__modified_at__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20250514233007_submissions__modified_at__backfill.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { loadSqlEquiv, queryAsync, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const result = await queryRow(sql.select_bounds, z.bigint({ coerce: true }).nullable());
+    return { min: 1n, max: result, batchSize: 1000 };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await queryAsync(sql.update_submissions_modified_at, { start, end });
+  },
+});

--- a/apps/prairielearn/src/migrations/20250514232243_variants__modified_at__backfill.ts
+++ b/apps/prairielearn/src/migrations/20250514232243_variants__modified_at__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20250514232243_variants__modified_at__backfill');
+}

--- a/apps/prairielearn/src/migrations/20250514233007_submissions__modified_at__backfill.ts
+++ b/apps/prairielearn/src/migrations/20250514233007_submissions__modified_at__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20250514233007_submissions__modified_at__backfill');
+}


### PR DESCRIPTION
Part of the fix for #11974.

Must not be merged until #11982 has been deployed.