### PR TITLE
Add ARIA label to matching options

### DIFF
--- a/apps/prairielearn/elements/pl-matching/pl-matching.mustache
+++ b/apps/prairielearn/elements/pl-matching/pl-matching.mustache
@@ -6,7 +6,14 @@
         <div class="pl-matching-statement-select">
             <select name="{{name}}" class="form-select" {{^editable}}disabled{{/editable}} aria-labelledby="statement-label-{{statement_id}}">
                 {{#options}}
-                    <option {{selected}} value="{{index}}">{{value}}</option>
+                    <option 
+                       {{selected}}
+                       value="{{index}}"
+                       {{#blank}}aria-label="Blank"{{/blank}}
+                       {{^no_counters}}{{^blank}}aria-labelledby="pl-matching-{{uuid}}-option-{{value}}-content"{{/blank}}{{/no_counters}}
+                    >
+                      {{value}}
+                    </option>
                 {{/options}}
             </select>
         </div>
@@ -30,7 +37,9 @@
 <div class="pl-matching-options">
 <ol>
 {{#options}}
-    <li class="pl-matching-option" style="--pl-matching-counter-type: {{counter_type}}">{{{html}}}</li>
+    <li class="pl-matching-option" style="--pl-matching-counter-type: {{counter_type}}">
+        <span id="pl-matching-{{uuid}}-option-{{counter}}-content">{{{html}}}</span>
+    </li>
 {{/options}}
 </ol>
 </div>

--- a/apps/prairielearn/elements/pl-matching/pl-matching.py
+++ b/apps/prairielearn/elements/pl-matching/pl-matching.py
@@ -61,6 +61,7 @@ def get_select_options(
         return {
             "index": index,
             "value": opt,
+            "blank": index == -1,
             "selected": "selected" if index == selected_value else "",
         }
 
@@ -359,8 +360,12 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             statement_set.append(statement_html)
 
         option_set = []
-        for option in display_options:
-            option_html = {"key": option["key"], "html": option["html"].strip()}
+        for index, option in enumerate(display_options):
+            option_html = {
+                "key": option["key"],
+                "counter": get_counter(index + 1, counter_type),
+                "html": option["html"].strip(),
+            }
             option_set.append(option_html)
 
         html_params: dict[str, str | bool | float | list[Any]] = {
@@ -372,6 +377,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             "no_counters": no_counters,
             "options_placement": options_placement.value,
             "editable": data["editable"],
+            "uuid": pl.get_uuid(),
         }
 
         if score is not None:

--- a/apps/prairielearn/elements/pl-matching/pl-matching.py
+++ b/apps/prairielearn/elements/pl-matching/pl-matching.py
@@ -360,10 +360,10 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             statement_set.append(statement_html)
 
         option_set = []
-        for index, option in enumerate(display_options):
+        for index, option in enumerate(display_options, start=1):
             option_html = {
                 "key": option["key"],
-                "counter": get_counter(index + 1, counter_type),
+                "counter": get_counter(index, counter_type),
                 "html": option["html"].strip(),
             }
             option_set.append(option_html)

--- a/exampleCourse/questions/element/matching/question.html
+++ b/exampleCourse/questions/element/matching/question.html
@@ -143,7 +143,7 @@
 <pl-card>
     <pl-question-panel>
         <p>
-            Example 8: This example uses the `options-placement="bottom"` argument. This is useful for questions with long statements and options, which may wrap over multiple lines or cause formatting issues in the default "right" placement.
+            Example 8: This example uses the <code>options-placement="bottom"</code> argument. This is useful for questions with long statements and options, which may wrap over multiple lines or cause formatting issues in the default "right" placement.
         </p>
     </pl-question-panel>
         


### PR DESCRIPTION
Resolves #11990. Adds a screen reader label to options, so that the screen reader announces the meaning of each option instead of its letter.