### PR TITLE
Add basic validation of access rule UIDs

### DIFF
--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1285,7 +1285,7 @@ async function validateCourseInstance(
   });
 
   if (accessibleInFuture) {
-    // Only warn about new roles and invalid UIDs for current or future courses.
+    // Only warn about new roles and invalid UIDs for current or future course instances.
     (courseInstance.allowAccess || []).forEach((rule) => {
       warnings.push(...checkAllowAccessRoles(rule));
       warnings.push(...checkAllowAccessUids(rule));

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -891,13 +891,15 @@ function checkAllowAccessDates(rule: { startDate?: string; endDate?: string }): 
   };
 }
 
+/**
+ * It seems to be relatively common for instructors to accidentally put multiple
+ * UIDs in the same string, like "uid1@example.com, uid2@example.com". While we
+ * are pretty loose in what we accept as UIDs, they should never contain commas or
+ * whitespace, so we'll warn about that.
+ */
 function checkAllowAccessUids(rule: { uids?: string[] }): string[] {
   const warnings: string[] = [];
 
-  // It seems to be relatively common for instructors to accidentally put multiple
-  // UIDs in the same string, like "uid1@example.com, uid2@example.com". While we
-  // are pretty loose in what we accept as UIDs, they should never contain commas or
-  // whitespace, so we'll warn about that.
   const uidsWithWhitespace = (rule.uids ?? []).filter((uid) => /\s/.test(uid));
   if (uidsWithWhitespace.length > 0) {
     warnings.push(

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -891,6 +891,30 @@ function checkAllowAccessDates(rule: { startDate?: string; endDate?: string }): 
   };
 }
 
+function checkAllowAccessUids(rule: { uids?: string[] }): string[] {
+  const warnings: string[] = [];
+
+  // It seems to be relatively common for instructors to accidentally put multiple
+  // UIDs in the same string, like "uid1@example.com, uid2@example.com". While we
+  // are pretty loose in what we accept as UIDs, they should never contain commas or
+  // whitespace, so we'll warn about that.
+  const uidsWithWhitespace = (rule.uids ?? []).filter((uid) => /\s/.test(uid));
+  if (uidsWithWhitespace.length > 0) {
+    warnings.push(
+      `The following access rule UIDs contain unexpected whitespace: ${formatValues(uidsWithWhitespace)}`,
+    );
+  }
+
+  const uidsWithCommas = (rule.uids ?? []).filter((uid) => /,/.test(uid));
+  if (uidsWithCommas.length > 0) {
+    warnings.push(
+      `The following access rule UIDs contain unexpected commas: ${formatValues(uidsWithCommas)}`,
+    );
+  }
+
+  return warnings;
+}
+
 async function validateQuestion(
   question: QuestionJson,
 ): Promise<{ warnings: string[]; errors: string[] }> {
@@ -920,10 +944,10 @@ async function validateQuestion(
 }
 
 /**
- * Formats a set of QIDs into a string for use in error messages.
- * @returns A comma-separated list of double-quoted QIDs.
+ * Formats a set or array of strings into a string for use in error messages.
+ * @returns A comma-separated list of double-quoted values.
  */
-function formatQids(qids: Set<string>) {
+function formatValues(qids: Set<string> | string[]) {
   return Array.from(qids)
     .map((qid) => `"${qid}"`)
     .join(', ');
@@ -953,13 +977,13 @@ async function validateAssessment(
 
   // Check assessment access rules.
   (assessment.allowAccess || []).forEach((rule) => {
-    const allowAccessResult = checkAllowAccessDates(rule);
+    const dateErrors = checkAllowAccessDates(rule);
 
     if ('active' in rule && rule.active === false && 'credit' in rule && rule.credit !== 0) {
       errors.push('Invalid allowAccess rule: credit must be 0 if active is false');
     }
 
-    errors.push(...allowAccessResult.errors);
+    errors.push(...dateErrors.errors);
   });
 
   // When additional validation is added, we don't want to warn for past course
@@ -968,8 +992,8 @@ async function validateAssessment(
   // which are accessible either now or any time in the future.
   if (!courseInstanceExpired) {
     (assessment.allowAccess || []).forEach((rule) => {
-      const allowAccessWarnings = checkAllowAccessRoles(rule);
-      warnings.push(...allowAccessWarnings);
+      warnings.push(...checkAllowAccessRoles(rule));
+      warnings.push(...checkAllowAccessUids(rule));
 
       if (rule.examUuid && rule.mode === 'Public') {
         warnings.push('Invalid allowAccess rule: examUuid cannot be used with "mode": "Public"');
@@ -1124,16 +1148,18 @@ async function validateAssessment(
   });
 
   if (duplicateQids.size > 0) {
-    errors.push(`The following questions are used more than once: ${formatQids(duplicateQids)}`);
+    errors.push(`The following questions are used more than once: ${formatValues(duplicateQids)}`);
   }
 
   if (missingQids.size > 0) {
-    errors.push(`The following questions do not exist in this course: ${formatQids(missingQids)}`);
+    errors.push(
+      `The following questions do not exist in this course: ${formatValues(missingQids)}`,
+    );
   }
 
   if (draftQids.size > 0) {
     errors.push(
-      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatQids(draftQids)}`,
+      `The following questions are marked as draft and therefore cannot be used in assessments: ${formatValues(draftQids)}`,
     );
   }
 
@@ -1257,10 +1283,10 @@ async function validateCourseInstance(
   });
 
   if (accessibleInFuture) {
-    // Only warn about new roles for current or future courses.
+    // Only warn about new roles and invalid UIDs for current or future courses.
     (courseInstance.allowAccess || []).forEach((rule) => {
-      const allowAccessWarnings = checkAllowAccessRoles(rule);
-      warnings.push(...allowAccessWarnings);
+      warnings.push(...checkAllowAccessRoles(rule));
+      warnings.push(...checkAllowAccessUids(rule));
     });
 
     if ('userRoles' in courseInstance) {

--- a/apps/prairielearn/src/tests/helperAttachFiles.ts
+++ b/apps/prairielearn/src/tests/helperAttachFiles.ts
@@ -10,7 +10,6 @@ let elemList;
 export function attachFile(locals, textFile) {
   describe('attachFile-1. GET to assessment_instance URL', () => {
     it('should load successfully', async () => {
-      console.log(locals.attachFilesUrl);
       const res = await fetch(locals.attachFilesUrl);
       assert.isOk(res.ok);
       locals.$ = cheerio.load(await res.text());

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -553,7 +553,6 @@ describe('Manual Grading', function () {
         setUser(defaultUser);
         let nextUngraded = await fetch(manualGradingNextUngradedUrl, { redirect: 'manual' });
         assert.equal(nextUngraded.status, 302);
-        console.log(nextUngraded.headers.get('location'), new URL(manualGradingIQUrl).pathname);
         assert.equal(nextUngraded.headers.get('location'), new URL(manualGradingIQUrl).pathname);
         setUser(mockStaff[0]);
         nextUngraded = await fetch(manualGradingNextUngradedUrl, { redirect: 'manual' });

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -475,4 +475,30 @@ describe('Course instance syncing', () => {
       comment2: 'course instance access rule comment 2',
     });
   });
+
+  it('records a warning for UIDs containing commas or spaces', async () => {
+    const courseData = util.getCourseData();
+    courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.allowAccess = [
+      {
+        startDate: '2024-01-01T00:00:00',
+        endDate: '3024-01-31T00:00:00',
+        uids: ['foo@example.com,bar@example.com', 'biz@example.com baz@example.com'],
+      },
+    ];
+    const courseDir = await util.writeCourseToTempDirectory(courseData);
+    await util.syncCourseData(courseDir);
+    const syncedCourseInstances = await util.dumpTable('course_instances');
+    const syncedCourseInstance = syncedCourseInstances.find(
+      (ci) => ci.short_name === util.COURSE_INSTANCE_ID,
+    );
+    assert.isOk(syncedCourseInstance);
+    assert.match(
+      syncedCourseInstance?.sync_warnings,
+      /The following access rule UIDs contain unexpected whitespace: "biz@example.com baz@example.com"/,
+    );
+    assert.match(
+      syncedCourseInstance?.sync_warnings,
+      /The following access rule UIDs contain unexpected commas: "foo@example.com,bar@example.com"/,
+    );
+  });
 });


### PR DESCRIPTION
This was originally brought to our attention by @echuber2. After checking the prod database, it's clear this has impacted many more people (whether or not they realized it).

Relevant queries:

```sql
-- Find all access rules with either whitespace or a comma.
-- This yielded 578 access rules.
SELECT
    COUNT(aar.id)
FROM assessment_access_rules aar
WHERE EXISTS (
    SELECT 1
    FROM unnest(aar.uids) AS uid
    WHERE uid ~ '[\s,]'
);

-- Fine all access rules with either whitespace or a comma, AND an @.
-- This yielded 402 access rule.
SELECT
    COUNT(aar.id)
FROM assessment_access_rules aar
WHERE EXISTS (
    SELECT 1
    FROM unnest(aar.uids) AS uid
    WHERE uid ~ '[\s,]'
    AND uid ~ '@'
);
```

I considered the second case separately because some people seemed to be using UIDs to store comments:

```json
["1.5X people", "foo@example.com", "bar@example.com"]
```

I'm hoping that https://github.com/PrairieLearn/PrairieLearn/pull/11947 will make this unnecessary.