### PR TITLE
Disable logs in the code caller containers

### DIFF
--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
@@ -413,6 +413,12 @@ export class CodeCallerContainer implements CodeCaller {
         AutoRemove: true,
         // Prevent forkbombs
         PidsLimit: 64,
+        // We use stdout to communicate from the container to the host, so the logs
+        // would rapidly fill up the host's disk space if we didn't disable logging.
+        LogConfig: {
+          Type: 'none',
+          Config: {},
+        },
       },
       Env: [
         // Proxy the `DEBUG` environment variable to the container so we can


### PR DESCRIPTION
We were running out of disk space in production because of these logs 😬 