### PR TITLE
LTI 1.3: Document Canvas requirements for grade sync

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -908,7 +908,9 @@ export async function updateLti13Scores(
   job.info(`${counts.error} score${counts.error === 1 ? '' : 's'} not sent due to errors.`);
   if (counts.error > 0 && counts.success === 0) {
     job.warn('\tNo scores successfully sent and errors are present.');
-    job.warn(`\tIs the ${instance.lti13_instance.name} course published?`);
+    job.warn(
+      `\tIs the ${instance.lti13_instance.name} ${instance.lti13_course_instance.context_label} course published?`,
+    );
   }
   job.info(`${counts.not_sent} score${counts.not_sent === 1 ? '' : 's'} skipped (not sent).`);
 }

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -907,7 +907,7 @@ export async function updateLti13Scores(
   job.info(`${counts.success} score${counts.success === 1 ? '' : 's'} successfully sent.`);
   job.info(`${counts.error} score${counts.error === 1 ? '' : 's'} not sent due to errors.`);
   if (counts.error > 0 && counts.success === 0) {
-    job.warn('\tNo successful scores sent and errors are present.');
+    job.warn('\tNo scores successfully sent and errors are present.');
     job.warn(`\tIs the ${instance.lti13_instance.name} course published?`);
   }
   job.info(`${counts.not_sent} score${counts.not_sent === 1 ? '' : 's'} skipped (not sent).`);

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -907,7 +907,7 @@ export async function updateLti13Scores(
   job.info(`${counts.success} score${counts.success === 1 ? '' : 's'} successfully sent.`);
   job.info(`${counts.error} score${counts.error === 1 ? '' : 's'} not sent due to errors.`);
   if (counts.error > 0 && counts.success === 0) {
-    job.warn(`\tNo successful scores sent and errors are present.`);
+    job.warn('\tNo successful scores sent and errors are present.');
     job.warn(`\tIs the ${instance.lti13_instance.name} course published?`);
   }
   job.info(`${counts.not_sent} score${counts.not_sent === 1 ? '' : 's'} skipped (not sent).`);

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -906,5 +906,9 @@ export async function updateLti13Scores(
   job.info('Done.\n\nSummary:');
   job.info(`${counts.success} score${counts.success === 1 ? '' : 's'} successfully sent.`);
   job.info(`${counts.error} score${counts.error === 1 ? '' : 's'} not sent due to errors.`);
+  if (counts.error > 0 && counts.success === 0) {
+    job.warn(`\tNo successful scores sent and errors are present.`);
+    job.warn(`\tIs the ${instance.lti13_instance.name} course published?`);
+  }
   job.info(`${counts.not_sent} score${counts.not_sent === 1 ? '' : 's'} skipped (not sent).`);
 }

--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -34,6 +34,8 @@ If students click the left menu PrairieLearn link before you have connected a co
 they will see a 'come back later' message. After a course instance is connected, the link will
 take them into your course instance.
 
+Canvas courses must be "Published" for certain integration functionality, like grade reporting, to work.
+
 ## "LTI 1.3" tab in your PrairieLearn course instance
 
 Once a Canvas course is linked with your PrairieLearn course instance, you will see an
@@ -55,6 +57,8 @@ assessment with a Canvas assignment. There are two ways to do this:
 ### Sending grades from PrairieLearn to Canvas
 
 To send grades you first need to link the PrairieLearn assessment with a Canvas assignment, as described above. After doing this, go to your PrairieLearn assessment, select the "LTI 1.3" tab, and then click "Send grades". Grades are always sent as percentage scores out of 100. These are the percentage "Score" values that PrairieLearn shows on the "Gradebook" page and the "Students" tab inside each assessment. Canvas will scale those percentages to the total points configured in the Canvas assignment.
+
+If you receive errors about students not being found in the course, check that your Canvas course is published before sending grades.
 
 ### Unlinking assessments
 


### PR DESCRIPTION
- Adds documentation about Canvas courses being published for grade sending to work.
- Adds in-page troubleshooting to the grade sending page if results appear as though the Canvas page isn't published.

Closes #11292.
