### PR TITLE
Use specific course instance in tests

### DIFF
--- a/apps/prairielearn/src/models/assessment.sql
+++ b/apps/prairielearn/src/models/assessment.sql
@@ -1,11 +1,3 @@
--- BLOCK check_assessment_is_public
-SELECT
-  a.share_source_publicly
-FROM
-  assessments AS a
-WHERE
-  a.id = $assessment_id;
-
 -- BLOCK select_assessment_by_id
 SELECT
   *
@@ -13,6 +5,24 @@ FROM
   assessments
 WHERE
   id = $assessment_id;
+
+-- BLOCK select_assessment_by_tid
+SELECT
+  *
+FROM
+  assessments
+WHERE
+  tid = $tid
+  AND course_instance_id = $course_instance_id
+  AND deleted_at IS NULL;
+
+-- BLOCK check_assessment_is_public
+SELECT
+  a.share_source_publicly
+FROM
+  assessments AS a
+WHERE
+  a.id = $assessment_id;
 
 -- BLOCK select_assessment_info_for_job
 SELECT

--- a/apps/prairielearn/src/models/assessment.ts
+++ b/apps/prairielearn/src/models/assessment.ts
@@ -19,11 +19,6 @@ import {
 
 const sql = loadSqlEquiv(import.meta.url);
 
-export async function selectAssessmentIsPublic(assessment_id: string): Promise<boolean> {
-  const isPublic = await queryRow(sql.check_assessment_is_public, { assessment_id }, z.boolean());
-  return isPublic;
-}
-
 export async function selectAssessmentById(assessment_id: string): Promise<Assessment> {
   return await queryRow(sql.select_assessment_by_id, { assessment_id }, AssessmentSchema);
 }
@@ -32,6 +27,25 @@ export async function selectOptionalAssessmentById(
   assessment_id: string,
 ): Promise<Assessment | null> {
   return await queryOptionalRow(sql.select_assessment_by_id, { assessment_id }, AssessmentSchema);
+}
+
+export async function selectAssessmentByTid({
+  course_instance_id,
+  tid,
+}: {
+  course_instance_id: string;
+  tid: string;
+}) {
+  return await queryRow(
+    sql.select_assessment_by_tid,
+    { course_instance_id, tid },
+    AssessmentSchema,
+  );
+}
+
+export async function selectAssessmentIsPublic(assessment_id: string): Promise<boolean> {
+  const isPublic = await queryRow(sql.check_assessment_is_public, { assessment_id }, z.boolean());
+  return isPublic;
 }
 
 export async function selectAssessmentInfoForJob(assessment_id: string) {

--- a/apps/prairielearn/src/models/course-instances.sql
+++ b/apps/prairielearn/src/models/course-instances.sql
@@ -6,6 +6,16 @@ FROM
 WHERE
   ci.id = $course_instance_id;
 
+-- BLOCK select_course_instance_by_short_name
+SELECT
+  ci.*
+FROM
+  course_instances AS ci
+WHERE
+  ci.course_id = $course_id
+  AND ci.short_name = $short_name
+  AND ci.deleted_at IS NULL;
+
 -- BLOCK select_course_instances_with_staff_access
 SELECT
   ci.*,

--- a/apps/prairielearn/src/models/course-instances.ts
+++ b/apps/prairielearn/src/models/course-instances.ts
@@ -30,6 +30,20 @@ export async function selectCourseInstanceById(
   );
 }
 
+export async function selectCourseInstanceByShortName({
+  course_id,
+  short_name,
+}: {
+  course_id: string;
+  short_name: string;
+}): Promise<CourseInstance> {
+  return queryRow(
+    sql.select_course_instance_by_short_name,
+    { course_id, short_name },
+    CourseInstanceSchema,
+  );
+}
+
 /**
  * Returns all course instances to which the given user has staff access.
  *

--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -2,6 +2,8 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
+import type { CourseInstance } from '../lib/db-types.js';
+import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 
 import * as helperExam from './helperExam.js';
 import * as helperServer from './helperServer.js';
@@ -20,6 +22,11 @@ describe('Client files endpoints', () => {
   before(helperServer.before());
   after(helperServer.after);
 
+  let courseInstance: CourseInstance;
+  before(async () => {
+    courseInstance = await selectCourseInstanceByShortName({ course_id: '1', short_name: 'Sp15' });
+  });
+
   // TODO: refactor this to be a function that we can call in a `before` hook.
   // Right now, this actually creates a bunch of `describe()` blocks and tests.
   helperExam.startExam({});
@@ -27,14 +34,14 @@ describe('Client files endpoints', () => {
   describe('clientFilesCourse', () => {
     it('works for instructor course instance URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instructor/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
 
     it('works for instructor assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instructor/assessment/1/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/assessment/1/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
@@ -48,14 +55,14 @@ describe('Client files endpoints', () => {
 
     it('works for instructor course instance question URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instructor/question/1/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/question/1/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
 
     it('works for instructor instance question URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instructor/instance_question/1/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/instance_question/1/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
@@ -92,14 +99,14 @@ describe('Client files endpoints', () => {
   describe('clientFilesCourseInstance', () => {
     it('works for instructor course instance URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instructor/clientFilesCourseInstance/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/clientFilesCourseInstance/data.txt`,
         'This data is specific to the course instance.',
       );
     });
 
     it('works for instructor assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instructor/assessment/1/clientFilesCourseInstance/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/assessment/1/clientFilesCourseInstance/data.txt`,
         'This data is specific to the course instance.',
       );
     });

--- a/apps/prairielearn/src/tests/manualGrading.test.sql
+++ b/apps/prairielearn/src/tests/manualGrading.test.sql
@@ -1,14 +1,3 @@
--- BLOCK get_assessment
-SELECT
-  a.*
-FROM
-  assessments AS a
-  JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
-WHERE
-  a.course_instance_id = 1
-  AND aset.abbreviation = 'HW'
-  AND a.number = '9';
-
 -- BLOCK get_instance_question
 SELECT
   *

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -7,6 +7,8 @@ import fetch from 'node-fetch';
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
+import { selectAssessmentByTid } from '../models/assessment.js';
+import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 import {
   insertCourseInstancePermissions,
   insertCoursePermissionsByUserUid,
@@ -380,10 +382,16 @@ describe('Manual Grading', function () {
   after('shut down testing server', helperServer.after);
 
   before('build assessment manual grading page URL', async () => {
-    const assessments = (await sqldb.queryAsync(sql.get_assessment, {})).rows;
-    assert.lengthOf(assessments, 1);
-    manualGradingAssessmentUrl = `${baseUrl}/course_instance/1/instructor/assessment/${assessments[0].id}/manual_grading`;
-    instancesAssessmentUrl = `${baseUrl}/course_instance/1/instructor/assessment/${assessments[0].id}/instances`;
+    const courseInstance = await selectCourseInstanceByShortName({
+      course_id: '1',
+      short_name: 'Sp15',
+    });
+    const assessment = await selectAssessmentByTid({
+      course_instance_id: courseInstance.id,
+      tid: 'hw9-internalExternalManual',
+    });
+    manualGradingAssessmentUrl = `${baseUrl}/course_instance/${assessment.course_instance_id}/instructor/assessment/${assessment.id}/manual_grading`;
+    instancesAssessmentUrl = `${baseUrl}/course_instance/${assessment.course_instance_id}/instructor/assessment/${assessment.id}/instances`;
   });
 
   before('add staff users', async () => {

--- a/apps/prairielearn/src/tests/permissions/institutionAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/institutionAdminAccess.test.ts
@@ -6,7 +6,9 @@ import { queryAsync, queryRow } from '@prairielearn/postgres';
 
 import { ensureInstitutionAdministrator } from '../../ee/models/institution-administrator.js';
 import { config } from '../../lib/config.js';
-import { UserSchema } from '../../lib/db-types.js';
+import { type Assessment, type CourseInstance, UserSchema } from '../../lib/db-types.js';
+import { selectAssessmentByTid } from '../../models/assessment.js';
+import { selectCourseInstanceByShortName } from '../../models/course-instances.js';
 import { selectOptionalUserByUid } from '../../models/user.js';
 import * as helperServer from '../helperServer.js';
 import { withUser } from '../utils/auth.js';
@@ -14,8 +16,14 @@ import { withUser } from '../utils/auth.js';
 const SITE_URL = `http://localhost:${config.serverPort}`;
 const INSTITUTION_ADMIN_COURSES = `${SITE_URL}/pl/institution/1/admin/courses`;
 const COURSE_URL = `${SITE_URL}/pl/course/1/course_admin/instances`;
-const COURSE_INSTANCE_URL = `${SITE_URL}/pl/course_instance/1/instructor/instance_admin/assessments`;
-const ASSESSMENT_INSTANCES_URL = `${SITE_URL}/pl/course_instance/1/instructor/assessment/1/instances`;
+
+function getCourseInstanceUrl(courseInstance: CourseInstance) {
+  return `${SITE_URL}/pl/course_instance/${courseInstance.id}/instructor/course_admin/instances`;
+}
+
+function getAssessmentInstancesUrl(courseInstance: CourseInstance, assessment: Assessment) {
+  return `${SITE_URL}/pl/course_instance/${courseInstance.id}/instructor/assessment/${assessment.id}/instances`;
+}
 
 interface AuthUser {
   name: string;
@@ -63,9 +71,16 @@ describe('institution administrators', () => {
   before('set up testing server', helperServer.before());
   after('shut down testing server', helperServer.after);
 
+  let courseInstance: CourseInstance;
+  let assessment: Assessment;
   before(async () => {
     await insertUser(ADMIN_USER);
     await insertUser(INSTITUTION_ADMIN_USER);
+    courseInstance = await selectCourseInstanceByShortName({ course_id: '1', short_name: 'Sp15' });
+    assessment = await selectAssessmentByTid({
+      course_instance_id: courseInstance.id,
+      tid: 'hw1-automaticTestSuite',
+    });
   });
 
   step('global admin can access institution admin courses', async () => {
@@ -79,7 +94,8 @@ describe('institution administrators', () => {
   });
 
   step('global admin can access course instance', async () => {
-    const res = await withUser(ADMIN_USER, () => fetch(COURSE_INSTANCE_URL));
+    const url = getCourseInstanceUrl(courseInstance);
+    const res = await withUser(ADMIN_USER, () => fetch(url));
     assert.equal(res.status, 200);
   });
 
@@ -94,12 +110,14 @@ describe('institution administrators', () => {
   });
 
   step('institution admin (no permissions) cannot access course instance', async () => {
-    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(COURSE_INSTANCE_URL));
+    const url = getCourseInstanceUrl(courseInstance);
+    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(url));
     assert.equal(res.status, 403);
   });
 
   step('institution admin (no permissions) can access assessment instances', async () => {
-    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(ASSESSMENT_INSTANCES_URL));
+    const url = getAssessmentInstancesUrl(courseInstance, assessment);
+    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(url));
     assert.equal(res.status, 403);
   });
 
@@ -124,12 +142,14 @@ describe('institution administrators', () => {
   });
 
   step('institution admin can access course instance', async () => {
-    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(COURSE_INSTANCE_URL));
+    const url = getCourseInstanceUrl(courseInstance);
+    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(url));
     assert.equal(res.status, 200);
   });
 
   step('institution admin can access assessment instances', async () => {
-    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(ASSESSMENT_INSTANCES_URL));
+    const url = getAssessmentInstancesUrl(courseInstance, assessment);
+    const res = await withUser(INSTITUTION_ADMIN_USER, () => fetch(url));
     assert.equal(res.status, 200);
   });
 });


### PR DESCRIPTION
#11770 introduced a new `public` course instance to `testCourse`. This broke the assumption in a number of tests that only a single course instance (`Sp15`) would be present in the test course. This PR updates tests that rely on that specific course instance to always query for it explicitly instead of hardcoding `course_instance/1`.

Note that there are still some tests that hardcode `course_instance/1`. Many of them use their own manually-constructed fixture, and others access subroutes that don't care which course instance is in use.