### PR TITLE
Consistently render linebreaks in issue student message

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.html.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.html.ts
@@ -204,7 +204,7 @@ export function IssuePanel({
                 </tr>
                 <tr>
                   <th>Student message:</th>
-                  <td>${issue.student_message}</td>
+                  <td style="white-space: pre-wrap;">${issue.student_message}</td>
                 </tr>
                 <tr>
                   <th>Instructor message:</th>
@@ -215,7 +215,7 @@ export function IssuePanel({
               ? html`
                   <tr>
                     <th>Student message:</th>
-                    <td>${issue.student_message}</td>
+                    <td style="white-space: pre-wrap;">${issue.student_message}</td>
                   </tr>
                   <tr>
                     <th>Instructor message:</th>
@@ -225,7 +225,7 @@ export function IssuePanel({
               : html`
                   <tr>
                     <th>Message:</th>
-                    <td>${issue.student_message}</td>
+                    <td style="white-space: pre-wrap;">${issue.student_message}</td>
                   </tr>
                 `}
           <tr>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -2,7 +2,7 @@ import { formatDistance } from 'date-fns';
 import { z } from 'zod';
 
 import { formatDate } from '@prairielearn/formatter';
-import { html, joinHtml } from '@prairielearn/html';
+import { html } from '@prairielearn/html';
 
 import { AssessmentBadge } from '../../components/AssessmentBadge.html.js';
 import { Modal } from '../../components/Modal.html.js';

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.ts
@@ -276,7 +276,7 @@ function IssueRow({
                   </button>
                 `}
         </div>
-        <p class="mb-0">${getFormattedMessage(issue)}</p>
+        <p class="mb-0" style="white-space: pre-wrap;">${getFormattedMessage(issue)}</p>
         <small class="text-muted me-2">
           #${issue.id} reported
           ${issue.date
@@ -319,9 +319,8 @@ function IssueRow({
 
 function getFormattedMessage(issue: Issue) {
   if (!issue.student_message) return html`&mdash;`;
-
-  const message = joinHtml(issue.student_message.split(/\r?\n|\r/), html`<br />`);
-  return issue.manually_reported ? html`"${message}"` : message;
+  if (issue.manually_reported) return `"${issue.student_message}"`;
+  return issue.student_message;
 }
 
 function CloseMatchingIssuesModal({


### PR DESCRIPTION
Students will sometimes use line breaks, e.g. in long regrade requests. We were correctly formatting this on the issues list page, but not when rendering issues on specific variants. This PR fixes that by adding `white-space: pre-wrap;` to the relevant containers.

Before:

<img width="788" alt="Screenshot 2025-05-19 at 10 06 17" src="https://github.com/user-attachments/assets/2cd3a2f2-f8c8-41a2-b9e0-1e9bffd74378" />

After:

<img width="788" alt="Screenshot 2025-05-19 at 10 06 33" src="https://github.com/user-attachments/assets/9e3c198a-b69f-4072-a959-d683a2c5a1c2" />
