### PR TITLE
Improve contrast on custom button/badge colors

### DIFF
--- a/apps/prairielearn/public/stylesheets/colors.css
+++ b/apps/prairielearn/public/stylesheets/colors.css
@@ -420,23 +420,23 @@
 }
 
 .color-turquoise3 {
-  color: #000;
+  color: #fff;
   background-color: #008b80;
 }
 
 .btn.color-turquoise3 {
-  --bs-btn-color: #000;
+  --bs-btn-color: #fff;
   --bs-btn-bg: #008b80;
   --bs-btn-border-color: #008b80;
-  --bs-btn-hover-color: #000;
+  --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #269c93;
   --bs-btn-hover-border-color: #1a978d;
   --bs-btn-focus-shadow-rgb: 0, 118, 109;
-  --bs-btn-active-color: #000;
+  --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #33a299;
   --bs-btn-active-border-color: #1a978d;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
+  --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #008b80;
   --bs-btn-disabled-border-color: #008b80;
 }
@@ -507,23 +507,23 @@
 }
 
 .color-green3 {
-  color: #000;
+  color: #fff;
   background-color: #008c31;
 }
 
 .btn.color-green3 {
-  --bs-btn-color: #000;
+  --bs-btn-color: #fff;
   --bs-btn-bg: #008c31;
   --bs-btn-border-color: #008c31;
-  --bs-btn-hover-color: #000;
+  --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #269d50;
   --bs-btn-hover-border-color: #1a9846;
   --bs-btn-focus-shadow-rgb: 0, 119, 42;
-  --bs-btn-active-color: #000;
+  --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #33a35a;
   --bs-btn-active-border-color: #1a9846;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
+  --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #008c31;
   --bs-btn-disabled-border-color: #008c31;
 }
@@ -594,23 +594,23 @@
 }
 
 .color-yellow3 {
-  color: #000;
+  color: #fff;
   background-color: #d87400;
 }
 
 .btn.color-yellow3 {
-  --bs-btn-color: #000;
+  --bs-btn-color: #fff;
   --bs-btn-bg: #d87400;
   --bs-btn-border-color: #d87400;
-  --bs-btn-hover-color: #000;
+  --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: #de8926;
   --bs-btn-hover-border-color: #dc821a;
   --bs-btn-focus-shadow-rgb: 184, 99, 0;
-  --bs-btn-active-color: #000;
+  --bs-btn-active-color: #fff;
   --bs-btn-active-bg: #e09033;
   --bs-btn-active-border-color: #dc821a;
   --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-  --bs-btn-disabled-color: #000;
+  --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #d87400;
   --bs-btn-disabled-border-color: #d87400;
 }


### PR DESCRIPTION
I recently read this article: https://webkit.org/blog/16929/contrast-color/. It explains something that I think a lot of us have felt intuitively: even things that technically pass the WCAG 2.1 AA contrast requirements can _appear_ to have insufficient contrast. Long story short, human vision is weird, and the simple algorithm used in WCAG 2 doesn't match how we actually perceive things. WCAG 3 is proposing to use a new contrast algorithm, a calculator for which is available here: https://apcacontrast.com/.

I ran some of our most suspect color combinations and confirmed that yes, swapping the text color does provide more _perceptual_ contrast.

Before:

<img width="839" alt="Screenshot 2025-05-19 at 10 45 32" src="https://github.com/user-attachments/assets/eea008fa-41b6-4931-b0ed-0e36caeb8332" />

After:

<img width="840" alt="Screenshot 2025-05-19 at 10 45 46" src="https://github.com/user-attachments/assets/65c24e17-63e8-4c25-b75e-1bb5299eb995" />
