### PR TITLE
Use consistent assessment in client files tests

### DIFF
--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -119,7 +119,7 @@ describe('Client files endpoints', () => {
 
     it('works for course instance URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/clientFilesCourseInstance/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/clientFilesCourseInstance/data.txt`,
         'This data is specific to the course instance.',
       );
     });

--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -96,7 +96,7 @@ describe('Client files endpoints', () => {
 
     it('works for instance question URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/instance_question/1/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instance_question/1/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });

--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -2,11 +2,12 @@ import { assert } from 'chai';
 import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
-import type { CourseInstance } from '../lib/db-types.js';
+import type { Assessment, CourseInstance } from '../lib/db-types.js';
 import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 
 import * as helperExam from './helperExam.js';
 import * as helperServer from './helperServer.js';
+import { selectAssessmentByTid } from '../models/assessment.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 
@@ -23,8 +24,13 @@ describe('Client files endpoints', () => {
   after(helperServer.after);
 
   let courseInstance: CourseInstance;
+  let assessment: Assessment;
   before(async () => {
     courseInstance = await selectCourseInstanceByShortName({ course_id: '1', short_name: 'Sp15' });
+    assessment = await selectAssessmentByTid({
+      course_instance_id: courseInstance.id,
+      tid: 'hw1-automaticTestSuite',
+    });
   });
 
   // TODO: refactor this to be a function that we can call in a `before` hook.
@@ -41,7 +47,7 @@ describe('Client files endpoints', () => {
 
     it('works for instructor assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/assessment/1/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/assessment/${assessment.id}/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
@@ -83,7 +89,7 @@ describe('Client files endpoints', () => {
 
     it('works for assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/assessment/1/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/1/assessment/${assessment.id}/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
@@ -106,7 +112,7 @@ describe('Client files endpoints', () => {
 
     it('works for instructor assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/assessment/1/clientFilesCourseInstance/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/instructor/assessment/${assessment.id}/clientFilesCourseInstance/data.txt`,
         'This data is specific to the course instance.',
       );
     });
@@ -120,7 +126,7 @@ describe('Client files endpoints', () => {
 
     it('works for assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/assessment/1/clientFilesCourseInstance/data.txt`,
+        `${siteUrl}/pl/course_instance/1/assessment/${assessment.id}/clientFilesCourseInstance/data.txt`,
         'This data is specific to the course instance.',
       );
     });

--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -3,11 +3,11 @@ import fetch from 'node-fetch';
 
 import { config } from '../lib/config.js';
 import type { Assessment, CourseInstance } from '../lib/db-types.js';
+import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 
 import * as helperExam from './helperExam.js';
 import * as helperServer from './helperServer.js';
-import { selectAssessmentByTid } from '../models/assessment.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 
@@ -89,7 +89,7 @@ describe('Client files endpoints', () => {
 
     it('works for assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/assessment/${assessment.id}/clientFilesCourse/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/assessment/${assessment.id}/clientFilesCourse/data.txt`,
         'This data is specific to the course.',
       );
     });
@@ -126,7 +126,7 @@ describe('Client files endpoints', () => {
 
     it('works for assessment URL', async () => {
       await testFile(
-        `${siteUrl}/pl/course_instance/1/assessment/${assessment.id}/clientFilesCourseInstance/data.txt`,
+        `${siteUrl}/pl/course_instance/${courseInstance.id}/assessment/${assessment.id}/clientFilesCourseInstance/data.txt`,
         'This data is specific to the course instance.',
       );
     });


### PR DESCRIPTION
Similar to #12008, just with assessments, not course instances.

The issue here was manifesting as flakey tests, where these would fail when assessment with ID 1 didn't belong to the `Sp15` course instance.