### PR TITLE
Remove apt caching in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,11 +123,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install OS packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.0
-        with:
-          packages: git-restore-mtime
-          version: 1.0
-          execute_install_scripts: true
+        run: sudo apt-get install -y git-restore-mtime
 
       - name: Install additional dependencies
         run: |-
@@ -193,11 +189,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install OS packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.5.0
-        with:
-          packages: graphviz libgraphviz-dev
-          version: 1.0
-          execute_install_scripts: true
+        run: sudo apt-get install -y graphviz libgraphviz-dev
 
       - name: Install additional dependencies
         run: |-


### PR DESCRIPTION
We recently had two CI failures that traced back to this action:

- https://github.com/PrairieLearn/PrairieLearn/actions/runs/15126128873/job/42518423527
- https://github.com/PrairieLearn/PrairieLearn/actions/runs/15126128873/job/42518423520

This issue is described here: https://github.com/awalsh128/cache-apt-pkgs-action/issues/82. It was closed as fixed, but clearly it's still happening.