### PR TITLE
Skip reinitialization of assets in tests

### DIFF
--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -134,6 +134,8 @@ function assertAssetsPrefix(): string {
   return assetsPrefix;
 }
 
+let initialized = false;
+
 /**
  * Computes the hashes of directories from which we serve cacheable assets.
  * Should be run at server startup before any responses are served.
@@ -141,6 +143,11 @@ function assertAssetsPrefix(): string {
  * Also initializes the assets compiler.
  */
 export async function init() {
+  // Specifically for tests, we avoid re-initializing things. The hashes typically
+  // won't change during tests, and if they do, we won't actually care about them
+  // since we won't try to load the assets from the tests.
+  if (initialized) return;
+
   await Promise.all([computeElementsHash(), computePublicHash()]);
   assetsPrefix = config.assetsPrefix;
 
@@ -150,6 +157,8 @@ export async function init() {
     buildDirectory: path.resolve(APP_ROOT_PATH, 'public/build'),
     publicPath: `${assetsPrefix}/build`,
   });
+
+  initialized = true;
 }
 
 /**

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -146,6 +146,9 @@ export async function init() {
   // Specifically for tests, we avoid re-initializing things. The hashes typically
   // won't change during tests, and if they do, we won't actually care about them
   // since we won't try to load the assets from the tests.
+  //
+  // In production use cases, this should only be called once per process, so this
+  // guard won't have any effect.
   if (initialized) return;
 
   await Promise.all([computeElementsHash(), computePublicHash()]);

--- a/apps/prairielearn/src/tests/helperServer.ts
+++ b/apps/prairielearn/src/tests/helperServer.ts
@@ -68,6 +68,8 @@ export function before(courseDir: string | string[] = TEST_COURSE_PATH): () => P
 
       debug('before(): initialize code callers');
       await codeCaller.init({ lazyWorkers: true });
+
+      debug('before(): initialize assets');
       await assets.init();
 
       debug('before(): start server');


### PR DESCRIPTION
This yields a small performance increase (~100ms/test) for suites like `src/ee/pages/instructorInstanceAdminBilling/instructorInstanceAdminBilling.test.ts` that repeatedly set up and tear down the testing server.