### PR TITLE
Mark more slow tests

### DIFF
--- a/apps/prairielearn/vitest.config.ts
+++ b/apps/prairielearn/vitest.config.ts
@@ -7,7 +7,18 @@ import { BaseSequencer, type TestSpecification } from 'vitest/node';
 // are slowest. However, this depends on cached data from previous runs, which
 // isn't available in CI. So, we manually specify the slowest tests here and
 // use a custom sequencer to always run them first.
-const SLOW_TESTS = ['src/tests/exampleCourseQuestions.test.ts', 'src/tests/cron.test.ts'];
+const SLOW_TESTS = [
+  // 120s
+  'src/tests/exampleCourseQuestions.test.ts',
+  // 90s
+  'src/tests/fileEditor.test.ts',
+  // 70s
+  'src/tests/homework.test.ts',
+  // 40s
+  'src/tests/exam.test.ts',
+  // 20s
+  'src/tests/cron.test.ts',
+];
 
 class CustomSequencer extends BaseSequencer {
   async sort(files: TestSpecification[]) {


### PR DESCRIPTION
- Ran with `yarn vitest --ui` and picked the 5 slowest