### PR TITLE
Deterministically order course instances in the test course

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
+import { run } from '@prairielearn/run';
 
 import { config } from '../../lib/config.js';
 import { IdSchema } from '../../lib/db-types.js';
@@ -83,18 +84,38 @@ export async function sync(
     });
   }
 
-  const courseInstanceParams = Object.entries(courseData.courseInstances).map(
-    ([shortName, courseInstanceData]) => {
-      const { courseInstance } = courseInstanceData;
-      return JSON.stringify([
-        shortName,
-        courseInstance.uuid,
-        infofile.stringifyErrors(courseInstance),
-        infofile.stringifyWarnings(courseInstance),
-        getParamsForCourseInstance(courseInstance.data),
-      ]);
-    },
-  );
+  const entries = run(() => {
+    // This is a total hack, but the test suite hardcoded course instance ID 1
+    // for the test course in a lot of places. To avoid having to change tons
+    // of tests after adding a new course instance to the test course, we'll
+    // alphabetically sort the course instances by name to ensure that `Sp15`
+    // will have ID 1. This assumes that it is in fact that first course instance,
+    // which is currently true.
+    //
+    // Mainly, this ensures that the tests are deterministic. So even if we do
+    // add a new course instance, the tests will fail if a new course instance
+    // would be assigned ID 1.
+    if (
+      courseData.course.uuid === '28760b11-beb1-4507-bb0a-a15bc8eaf091' &&
+      courseData.course.data?.title === 'Test Course' &&
+      courseData.course.data?.name === 'QA 101'
+    ) {
+      return Object.entries(courseData.courseInstances).sort((a, b) => a[0].localeCompare(b[0]));
+    }
+
+    return Object.entries(courseData.courseInstances);
+  });
+
+  const courseInstanceParams = entries.map(([shortName, courseInstanceData]) => {
+    const { courseInstance } = courseInstanceData;
+    return JSON.stringify([
+      shortName,
+      courseInstance.uuid,
+      infofile.stringifyErrors(courseInstance),
+      infofile.stringifyWarnings(courseInstance),
+      getParamsForCourseInstance(courseInstance.data),
+    ]);
+  });
 
   const result = await sqldb.callRow(
     'sync_course_instances',


### PR DESCRIPTION
https://github.com/PrairieLearn/PrairieLearn/pull/11770 introduced a new `public` course instance to `testCourse` that's been causing us trouble ever since, as many tests hardcode course instance IDs to 1 since until recently, there was indeed only a single course instance.

We'd worked a bit to be explicit about which course instance is being used, see e.g. https://github.com/PrairieLearn/PrairieLearn/pull/12008 and https://github.com/PrairieLearn/PrairieLearn/pull/12017. However, @reteps found a bunch more tests that are still hardcoding the specific instance. I figured that fixing all those tests that used to work just fine was a poor use of our time, and that we could get away with this one little stupid hack to make sure they keep passing 😅 