### PR TITLE
Propertly shut down Socket.io to reduce test flakiness

### DIFF
--- a/apps/prairielearn/src/lib/socket-server.ts
+++ b/apps/prairielearn/src/lib/socket-server.ts
@@ -58,8 +58,7 @@ export async function init(server: http.Server) {
     attachEventListeners(sub, 'sub');
 
     debug('init(): initializing redis socket adapter');
-    const adapter = createAdapter(pub, sub);
-    io.adapter(adapter);
+    io.adapter(createAdapter(pub, sub));
   }
 }
 

--- a/apps/prairielearn/src/lib/socket-server.ts
+++ b/apps/prairielearn/src/lib/socket-server.ts
@@ -43,7 +43,6 @@ function attachEventListeners(client: Redis, type: string) {
 export let io: Server;
 
 let pub: Redis;
-
 let sub: Redis;
 
 export async function init(server: http.Server) {
@@ -59,21 +58,25 @@ export async function init(server: http.Server) {
     attachEventListeners(sub, 'sub');
 
     debug('init(): initializing redis socket adapter');
-    io.adapter(createAdapter(pub, sub));
+    const adapter = createAdapter(pub, sub);
+    io.adapter(adapter);
   }
 }
 
 export async function close() {
-  await pub?.quit();
-  await sub?.quit();
-
   // Note that we don't use `io.close()` here, as that actually tries to close
   // the underlying HTTP server. In our desired shutdown sequence, we first
   // close the HTTP server and then later disconnect all sockets. There's some
   // discussion about this behavior here:
   // https://github.com/socketio/socket.io/discussions/4002#discussioncomment-4080748
   //
+  // The following sequence is based on what `io.close()` would do internally.
+  //
   // Note the use of `io.local`, which prevents the server from attempting to
   // broadcast the disconnect to other servers via Redis.
   io.local.disconnectSockets(true);
+  await Promise.all([...io._nsps.values()].map((nsp) => nsp.adapter.close()));
+  io.engine.close();
+
+  await Promise.all([pub?.quit(), sub?.quit()]);
 }

--- a/apps/prairielearn/src/tests/exam.test.ts
+++ b/apps/prairielearn/src/tests/exam.test.ts
@@ -1762,11 +1762,9 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe(`partial credit test #${iPartialCreditTest + 1}`, function () {
       describe('server', function () {
         it('should shut down', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.after();
         });
         it('should start up', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.before()();
         });
       });

--- a/apps/prairielearn/src/tests/homework.test.ts
+++ b/apps/prairielearn/src/tests/homework.test.ts
@@ -1251,11 +1251,9 @@ describe('Homework assessment', { timeout: 60_000 }, function () {
     describe(`partial credit test #${iPartialCreditTest + 1}`, function () {
       describe('server', function () {
         it('should shut down', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.after();
         });
         it('should start up', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.before()();
         });
       });

--- a/apps/prairielearn/src/tests/zoneGradingExam.test.ts
+++ b/apps/prairielearn/src/tests/zoneGradingExam.test.ts
@@ -221,11 +221,9 @@ describe('Zone grading exam assessment', { timeout: 60_000 }, function () {
     describe(`zone grading test #${iZoneGradingTest + 1}`, function () {
       describe('server', function () {
         it('should shut down', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.after();
         });
         it('should start up', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.before()();
         });
       });

--- a/apps/prairielearn/src/tests/zoneGradingHomework.test.ts
+++ b/apps/prairielearn/src/tests/zoneGradingHomework.test.ts
@@ -262,11 +262,9 @@ describe('Zone grading homework assessment', { timeout: 60_000 }, function () {
     describe(`zone grading test #${iZoneGradingTest + 1}`, function () {
       describe('server', function () {
         it('should shut down', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.after();
         });
         it('should start up', async function () {
-          // pass "this" explicitly to enable this.timeout() calls
           await helperServer.before()();
         });
       });


### PR DESCRIPTION
We recently observed some failed tests in https://github.com/PrairieLearn/PrairieLearn/actions/runs/15173871436/job/42670115274?pr=12012:

```
@prairielearn/prairielearn:test: ⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯
@prairielearn/prairielearn:test: 
@prairielearn/prairielearn:test: Vitest caught 2 unhandled errors during the test run.
@prairielearn/prairielearn:test: This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
@prairielearn/prairielearn:test: 
@prairielearn/prairielearn:test: ⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
@prairielearn/prairielearn:test: Error: Connection is closed.
@prairielearn/prairielearn:test:  ❯ close ../../node_modules/ioredis/built/redis/event_handler.js:189:25
@prairielearn/prairielearn:test:  ❯ Socket.<anonymous> ../../node_modules/ioredis/built/redis/event_handler.js:156:20
@prairielearn/prairielearn:test:  ❯ Object.onceWrapper node:events:639:26
@prairielearn/prairielearn:test:  ❯ Socket.emit node:events:524:28
@prairielearn/prairielearn:test:  ❯ TCP.<anonymous> node:net:343:12
@prairielearn/prairielearn:test:  ❯ TCP.callbackTrampoline node:internal/async_hooks:130:17
@prairielearn/prairielearn:test: 
@prairielearn/prairielearn:test: This error originated in "src/tests/zoneGradingHomework.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
@prairielearn/prairielearn:test: The latest test that might've caused the error is "should shut down". It might mean one of the following:
@prairielearn/prairielearn:test: - The error was thrown, while Vitest was running this test.
@prairielearn/prairielearn:test: - If the error occurred after the test had been completed, this was the last documented test before it was thrown.
@prairielearn/prairielearn:test: 
@prairielearn/prairielearn:test: ⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
@prairielearn/prairielearn:test: Error: Connection is closed.
@prairielearn/prairielearn:test:  ❯ close ../../node_modules/ioredis/built/redis/event_handler.js:189:25
@prairielearn/prairielearn:test:  ❯ Socket.<anonymous> ../../node_modules/ioredis/built/redis/event_handler.js:156:20
@prairielearn/prairielearn:test:  ❯ Object.onceWrapper node:events:639:26
@prairielearn/prairielearn:test:  ❯ Socket.emit node:events:524:28
@prairielearn/prairielearn:test:  ❯ TCP.<anonymous> node:net:343:12
@prairielearn/prairielearn:test:  ❯ TCP.callbackTrampoline node:internal/async_hooks:130:17
@prairielearn/prairielearn:test: 
@prairielearn/prairielearn:test: This error originated in "src/tests/zoneGradingHomework.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
@prairielearn/prairielearn:test: The latest test that might've caused the error is "should shut down". It might mean one of the following:
@prairielearn/prairielearn:test: - The error was thrown, while Vitest was running this test.
@prairielearn/prairielearn:test: - If the error occurred after the test had been completed, this was the last documented test before it was thrown.
@prairielearn/prairielearn:test: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

My guess is that this has been happening for a while, but while Mocha would just ignore this, Vitest elevates this to a test failure.

From what I can tell, this is caused by shutting down the pub/sub Redis connections before we tell Socket.io to stop using the connections. This PR moves the Redis connection closing to be the last thing that's done, and adds calls to close the namespace adapters and also the engine first. This mimics what Socket.io's own `close()` method does internally:

https://github.com/socketio/socket.io/blob/e95f6abf93766662cd3b341599ed312f4330213f/packages/socket.io/lib/index.ts#L802-L828