### PR TITLE
Shut down subscribe channel before publish channel

### DIFF
--- a/apps/prairielearn/src/lib/socket-server.ts
+++ b/apps/prairielearn/src/lib/socket-server.ts
@@ -77,5 +77,6 @@ export async function close() {
   await Promise.all([...io._nsps.values()].map((nsp) => nsp.adapter.close()));
   io.engine.close();
 
-  await Promise.all([pub?.quit(), sub?.quit()]);
+  await pub?.quit();
+  await sub?.quit();
 }


### PR DESCRIPTION
This _might_ help with the Redis failures that we keep seeing in #12034:

```
error: redis client event for sub: error write EPIPE {"code":"EPIPE","errno":-32,"stack":"Error: write EPIPE\n    at afterWriteDispatched (node:internal/stream_base_commons:161:15)\n    at writeGeneric (node:internal/stream_base_commons:152:3)\n    at Socket._writeGeneric (node:net:958:11)\n    at Socket._write (node:net:970:8)\n    at writeOrBuffer (node:internal/streams/writable:572:12)\n    at _write (node:internal/streams/writable:501:10)\n    at Socket.Writable.write (node:internal/streams/writable:510:10)\n    at EventEmitter.sendCommand (/PrairieLearn/node_modules/ioredis/built/Redis.js:394:29)\n    at EventEmitter.<anonymous> (/PrairieLearn/node_modules/@opentelemetry/instrumentation-ioredis/src/instrumentation.ts:120:25)\n    at /PrairieLearn/node_modules/ioredis/built/redis/event_handler.js:283:22\n    at /PrairieLearn/node_modules/ioredis/built/redis/event_handler.js:69:51\n    at /PrairieLearn/node_modules/ioredis/built/Redis.js:673:17\n    at tryCatcher (/PrairieLearn/node_modules/standard-as-callback/built/utils.js:12:23)\n    at /PrairieLearn/node_modules/standard-as-callback/built/index.js:22:53\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)","syscall":"write"}
```

I've traced this back to what looks like an attempt by `sub` to reconnect and process additional events in the "offline command queue".

I haven't been able to reproduce the error locally so I can't say if this will actually fix anything, this is based strictly on a hunch.