### PR TITLE
Use C collation to order course instances during sync

### DIFF
--- a/apps/prairielearn/src/sprocs/sync_course_instances.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_instances.sql
@@ -97,6 +97,8 @@ BEGIN
         -- Mainly, this ensures that the tests are deterministic. So even if we do
         -- add a new course instance, the tests will fail if a new course instance
         -- would be assigned ID 1.
+        --
+        -- We specifically use C collation to ensure that "Sp15" ends up before "public".
         ORDER BY src_short_name COLLATE "C" ASC
         RETURNING dest.short_name AS src_short_name, dest.id AS inserted_dest_id
     )

--- a/apps/prairielearn/src/sprocs/sync_course_instances.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_instances.sql
@@ -97,7 +97,7 @@ BEGIN
         -- Mainly, this ensures that the tests are deterministic. So even if we do
         -- add a new course instance, the tests will fail if a new course instance
         -- would be assigned ID 1.
-        ORDER BY src_short_name ASC
+        ORDER BY src_short_name COLLATE "C" ASC
         RETURNING dest.short_name AS src_short_name, dest.id AS inserted_dest_id
     )
     -- Make a map from CIID to ID to return to the caller


### PR DESCRIPTION
Followup to https://github.com/PrairieLearn/PrairieLearn/pull/12039. Postgres doesn't use a consistent collation by default, so we force it to use `C`.