### PR TITLE
Disable CodeRabbit review on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,7 +21,7 @@ reviews:
     enabled: true
     auto_incremental_review: true
     ignore_title_keywords: []
-    drafts: true
+    drafts: false
     base_branches:
       - master
   finishing_touches:


### PR DESCRIPTION
Let's treat our AI friend the same way we treat human reviewers: drafts shouldn't be reviewed unless specifically requested.