### PR TITLE
Prevent gradebook assessment badges from triggering sort

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
@@ -71,6 +71,18 @@ onDocumentReady(() => {
         .forEach((el) => (el.style.display = ''));
       $('button.edit-score').popover('hide');
     },
+    onPostHeader() {
+      document.querySelectorAll<HTMLLinkElement>('#gradebook-table thead a').forEach((el) => {
+        el.addEventListener('click', (event) => {
+          // It should still be possible to click any link in the header (e.g.,
+          // the assessment badges) to go to the link target page, but clicking
+          // it should not trigger a sort. While usually the link causes a
+          // different page to load (so sorting would be irrelevant), it still
+          // affects users Ctrl+clicking the link to open it in a new tab.
+          event.stopPropagation();
+        });
+      });
+    },
     onResetView() {
       setupEditScorePopovers(csrfToken);
       document


### PR DESCRIPTION
In the instructor gradebook page, clicking the assessment badge links causes the assessment page to be opened, but also causes the table to be sorted by that column. This is not a big problem if just clicking on the page, since the gradebook page will no longer be available once the page is loaded, but it can be a small nuisance when using Ctrl-click to open the assessment page in a separate tab.

This page handles that issue by triggering `event.stopPropagation()` on click events for any link, which allows the click event to proceed as usual, but does not allow the click to propagate towards the column header itself, which would trigger the sort event.

I considered adding the event to the badge component itself as an `onclick` attribute, but I don't want to make assumptions about where else this badge is being used, and if the behavior is expected in different pages.