### PR TITLE
Hide submitter UID in submission panel for manual grading interface

### DIFF
--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -251,12 +251,7 @@ export function SubmissionPanel({
           </div>
         </div>
 
-        ${SubmissionInfoModal({
-          urlPrefix,
-          submission,
-          question,
-          course_instance_id,
-        })}
+        ${SubmissionInfoModal({ urlPrefix, submission, course_instance_id })}
       </div>
     </div>
   `;
@@ -396,12 +391,10 @@ function SubmissionStatusBadge({
 function SubmissionInfoModal({
   urlPrefix,
   submission,
-  question,
   course_instance_id,
 }: {
   urlPrefix: string;
   submission: SubmissionForRender;
-  question: Question;
   course_instance_id?: string | null;
 }) {
   const gradingJobStats = buildGradingJobStats(submission.grading_job);
@@ -426,7 +419,7 @@ function SubmissionInfoModal({
                 </tr>
               `
             : ''}
-          ${gradingJobStats && question.grading_method === 'External'
+          ${gradingJobStats?.grading_method === 'External'
             ? html`
                 <tr>
                   <th><span class="text-dark me-2">&bull;</span>Submit duration</th>
@@ -457,7 +450,7 @@ function SubmissionInfoModal({
         </tbody>
       </table>
       ${gradingJobStats ? '' : html`<p class="mt-2">This submission has not been graded.</p>`}
-      ${gradingJobStats && question.grading_method === 'External'
+      ${gradingJobStats?.grading_method === 'External'
         ? html`
             <div class="d-flex mt-2 mb-2">
               <span
@@ -567,6 +560,7 @@ function buildGradingJobStats(job: GradingJob | null) {
 
   return {
     ...stats,
+    grading_method: job.grading_method,
     phases: durations.map(
       // Round down to avoid width being greater than 100% with floating point errors
       (duration) => Math.floor(((duration ?? 0) * 1000) / totalDuration) / 10,

--- a/apps/prairielearn/src/components/SubmissionPanel.html.ts
+++ b/apps/prairielearn/src/components/SubmissionPanel.html.ts
@@ -189,7 +189,7 @@ export function SubmissionPanel({
               </span>
             </div>
             <span class="small">
-              ${!submission.user_uid
+              ${!submission.user_uid || questionContext === 'manual_grading'
                 ? `Submitted at ${submission.formatted_date} `
                 : `${submission.user_uid} submitted at ${submission.formatted_date}`}
             </span>
@@ -408,96 +408,98 @@ function SubmissionInfoModal({
   return Modal({
     id: `submissionInfoModal-${submission.id}`,
     title: 'Submission info',
-    body: !gradingJobStats
-      ? html`<p>This submission has not been graded.</p>`
-      : html`
-          <table
-            class="table table-sm table-borderless two-column-description mb-0"
-            aria-label="Submission info"
-          >
-            <tbody>
-              <tr>
-                <th>Submission time</th>
-                <td>${submission.formatted_date}</td>
-              </tr>
-              ${question.grading_method === 'External'
-                ? html`
-                    <tr>
-                      <th><span class="text-dark me-2">&bull;</span>Submit duration</th>
-                      <td>${gradingJobStats.submitDuration}</td>
-                    </tr>
-                    <tr>
-                      <th><span class="text-warning me-2">&bull;</span>Queue duration</th>
-                      <td>${gradingJobStats.queueDuration}</td>
-                    </tr>
-                    <tr>
-                      <th><span class="text-primary me-2">&bull;</span>Prepare duration</th>
-                      <td>${gradingJobStats.prepareDuration}</td>
-                    </tr>
-                    <tr>
-                      <th><span class="text-success me-2">&bull;</span>Run duration</th>
-                      <td>${gradingJobStats.runDuration}</td>
-                    </tr>
-                    <tr>
-                      <th><span class="text-danger me-2">&bull;</span>Report duration</th>
-                      <td>${gradingJobStats.reportDuration}</td>
-                    </tr>
-                    <tr>
-                      <th>Total duration</th>
-                      <td>${gradingJobStats.totalDuration}</td>
-                    </tr>
-                  `
-                : ''}
-            </tbody>
-          </table>
-          ${question.grading_method === 'External'
+    body: html`
+      <table
+        class="table table-sm table-borderless two-column-description mb-0"
+        aria-label="Submission info"
+      >
+        <tbody>
+          <tr>
+            <th>Submission time</th>
+            <td>${submission.formatted_date}</td>
+          </tr>
+          ${submission.user_uid
             ? html`
-                <div class="d-flex mt-2 mb-2">
-                  <span
-                    style="display: inline-block; width: ${gradingJobStats
-                      .phases[0]}%; height: 10px;"
-                    class="bg-dark m-0"
-                  ></span>
-                  <span
-                    style="display: inline-block; width: ${gradingJobStats
-                      .phases[1]}%; height: 10px;"
-                    class="bg-warning m-0"
-                  ></span>
-                  <span
-                    style="display: inline-block; width: ${gradingJobStats
-                      .phases[2]}%; height: 10px;"
-                    class="bg-primary m-0"
-                  ></span>
-                  <span
-                    style="display: inline-block; width: ${gradingJobStats
-                      .phases[3]}%; height: 10px;"
-                    class="bg-success m-0"
-                  ></span>
-                  <span
-                    style="display: inline-block; width: ${gradingJobStats
-                      .phases[4]}%; height: 10px;"
-                    class="bg-danger m-0"
-                  ></span>
-                </div>
-                ${course_instance_id != null
-                  ? html`
-                      <a
-                        class="btn btn-primary mt-2"
-                        href="${config.urlPrefix}/course_instance/${course_instance_id}/instructor/grading_job/${submission
-                          .grading_job?.id}"
-                        >View grading job ${submission.grading_job?.id}</a
-                      >
-                    `
-                  : html`
-                      <a
-                        class="btn btn-primary mt-2"
-                        href="${urlPrefix}/grading_job/${submission.grading_job?.id}"
-                        >View grading job ${submission.grading_job?.id}</a
-                      >
-                    `}
+                <tr>
+                  <th>Submitted by</th>
+                  <td>${submission.user_uid}</td>
+                </tr>
               `
             : ''}
-        `,
+          ${gradingJobStats && question.grading_method === 'External'
+            ? html`
+                <tr>
+                  <th><span class="text-dark me-2">&bull;</span>Submit duration</th>
+                  <td>${gradingJobStats.submitDuration}</td>
+                </tr>
+                <tr>
+                  <th><span class="text-warning me-2">&bull;</span>Queue duration</th>
+                  <td>${gradingJobStats.queueDuration}</td>
+                </tr>
+                <tr>
+                  <th><span class="text-primary me-2">&bull;</span>Prepare duration</th>
+                  <td>${gradingJobStats.prepareDuration}</td>
+                </tr>
+                <tr>
+                  <th><span class="text-success me-2">&bull;</span>Run duration</th>
+                  <td>${gradingJobStats.runDuration}</td>
+                </tr>
+                <tr>
+                  <th><span class="text-danger me-2">&bull;</span>Report duration</th>
+                  <td>${gradingJobStats.reportDuration}</td>
+                </tr>
+                <tr>
+                  <th>Total duration</th>
+                  <td>${gradingJobStats.totalDuration}</td>
+                </tr>
+              `
+            : ''}
+        </tbody>
+      </table>
+      ${gradingJobStats ? '' : html`<p class="mt-2">This submission has not been graded.</p>`}
+      ${gradingJobStats && question.grading_method === 'External'
+        ? html`
+            <div class="d-flex mt-2 mb-2">
+              <span
+                style="display: inline-block; width: ${gradingJobStats.phases[0]}%; height: 10px;"
+                class="bg-dark m-0"
+              ></span>
+              <span
+                style="display: inline-block; width: ${gradingJobStats.phases[1]}%; height: 10px;"
+                class="bg-warning m-0"
+              ></span>
+              <span
+                style="display: inline-block; width: ${gradingJobStats.phases[2]}%; height: 10px;"
+                class="bg-primary m-0"
+              ></span>
+              <span
+                style="display: inline-block; width: ${gradingJobStats.phases[3]}%; height: 10px;"
+                class="bg-success m-0"
+              ></span>
+              <span
+                style="display: inline-block; width: ${gradingJobStats.phases[4]}%; height: 10px;"
+                class="bg-danger m-0"
+              ></span>
+            </div>
+            ${course_instance_id != null
+              ? html`
+                  <a
+                    class="btn btn-primary mt-2"
+                    href="${config.urlPrefix}/course_instance/${course_instance_id}/instructor/grading_job/${submission
+                      .grading_job?.id}"
+                    >View grading job ${submission.grading_job?.id}</a
+                  >
+                `
+              : html`
+                  <a
+                    class="btn btn-primary mt-2"
+                    href="${urlPrefix}/grading_job/${submission.grading_job?.id}"
+                    >View grading job ${submission.grading_job?.id}</a
+                  >
+                `}
+          `
+        : ''}
+    `,
     footer: html`
       <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
     `,


### PR DESCRIPTION
Resolves #11883. Hides the UID from the main view of the submission panel. This focuses on reducing grading bias, to allow a grader to make grading decisions that are not affected by the identity of the student.

In order to allow a grader to still see the submitter as necessary, the submission info modal has been modified to include the submitter UID. Since this information was previously only available for graded submissions the modal has also been modified to show useful information for submissions that are not graded (either save-only or ungradable).

This PR has conflicts with #12060. I decided to work on both issues separately to allow more targeted discussion on their merits, but I'm happy to handle any merge conflicts once one of the PRs is merged.

Best reviewed ignoring whitespaces.