### PR TITLE
Disable coderabbit review status comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ reviews:
   profile: chill
   request_changes_workflow: false # Do not approve after comments resolved
   high_level_summary: false
-  review_status: true
+  review_status: false # Do not make comments on PRs that are not ready for review
   collapse_walkthrough: true
   changed_files_summary: true
   sequence_diagrams: false


### PR DESCRIPTION
Having coderabbit add a comment saying "I won't review because (it's draft | base is not master | it's a bot | etc.)" is noise that doesn't actually help.