### PR TITLE
Show equation preview in rich text editor formula input

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -210,15 +210,15 @@ function initializeFormulaPopover(quill, uuid) {
 
   const popoverContent = document.createElement('form');
   popoverContent.innerHTML = `
-      <div class="mb-3">
-        <label for="rte-formula-input-${uuid}">Formula:</label>
-        <input type="text" class="form-control" id="rte-formula-input-${uuid}" placeholder="Enter Formula" />
-      </div>
-      <div class="mb-3" id="rte-formula-input-preview-${uuid}">
-      </div>
-      <button type="button" class="btn btn-secondary" data-bs-dismiss="popover">Cancel</button>
-      <button type="submit" class="btn btn-primary">Confirm</button>
-    `;
+    <div class="mb-3">
+      <label for="rte-formula-input-${uuid}">Formula:</label>
+      <input type="text" class="form-control" id="rte-formula-input-${uuid}" placeholder="Enter Formula" />
+    </div>
+    <div class="mb-3" id="rte-formula-input-preview-${uuid}">
+    </div>
+    <button type="button" class="btn btn-secondary" data-bs-dismiss="popover">Cancel</button>
+    <button type="submit" class="btn btn-primary">Confirm</button>
+  `;
 
   const popover = new bootstrap.Popover(formulaButton, {
     content: popoverContent,


### PR DESCRIPTION
Resolves #11659. Changes the formula input process to use a bootstrap popover that includes a preview feature for the MathJax formula.

![image](https://github.com/user-attachments/assets/fffbb6fd-ec75-4208-8dc9-4f52996e74c0)
---
![image](https://github.com/user-attachments/assets/9bfa4cb1-3e8d-4d83-80a7-340828c8137d)

Also adds some minor improvements, such as using the selected text as starting input for the formula, and replacing it on completion.