### PR TITLE
Permanently disabled revise question button patch

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts
+++ b/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts
@@ -6,7 +6,7 @@ export function saveButtonEnabling(form: HTMLFormElement, saveButton: HTMLButton
   // This is important so we don't have to read all values for each input on every
   // change event when we check if there are differences.
   const valueHasChanged: Record<string, boolean> = {};
-  form.querySelectorAll('input, select').forEach((element) => {
+  form.querySelectorAll('input, select, textarea').forEach((element) => {
     valueHasChanged[element.id] = false;
   });
 
@@ -25,11 +25,15 @@ export function saveButtonEnabling(form: HTMLFormElement, saveButton: HTMLButton
   // set valueHasChanged{} to false. Then call checkDifferences() to see if the save
   // button should be enabled.
   form.addEventListener('input', (e) => {
-    if (!(e.target instanceof HTMLInputElement)) return;
+    if (!(e.target instanceof HTMLInputElement) && !(e.target instanceof HTMLTextAreaElement)) {
+      return;
+    }
 
     if (
-      (e.target.type === 'checkbox' && e.target.checked === e.target.defaultChecked) ||
-      (e.target.type !== 'checkbox' && e.target.value === e.target.defaultValue)
+      (e.target instanceof HTMLInputElement &&
+        ((e.target.type === 'checkbox' && e.target.checked === e.target.defaultChecked) ||
+          (e.target.type !== 'checkbox' && e.target.value === e.target.defaultValue))) ||
+      (e.target instanceof HTMLTextAreaElement && e.target.value === e.target.defaultValue)
     ) {
       valueHasChanged[(e.target as HTMLElement).id] = false;
     } else {

--- a/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts
+++ b/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts
@@ -32,7 +32,7 @@ export function saveButtonEnabling(form: HTMLFormElement, saveButton: HTMLButton
     if (
       (e.target instanceof HTMLInputElement &&
         ((e.target.type === 'checkbox' && e.target.checked === e.target.defaultChecked) ||
-          (e.target.type !== 'checkbox' && e.target.value === e.target.defaultValue))) ||
+        (e.target.type !== 'checkbox' && e.target.value === e.target.defaultValue))) ||
       (e.target instanceof HTMLTextAreaElement && e.target.value === e.target.defaultValue)
     ) {
       valueHasChanged[(e.target as HTMLElement).id] = false;

--- a/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts
+++ b/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts
@@ -32,7 +32,7 @@ export function saveButtonEnabling(form: HTMLFormElement, saveButton: HTMLButton
     if (
       (e.target instanceof HTMLInputElement &&
         ((e.target.type === 'checkbox' && e.target.checked === e.target.defaultChecked) ||
-        (e.target.type !== 'checkbox' && e.target.value === e.target.defaultValue))) ||
+          (e.target.type !== 'checkbox' && e.target.value === e.target.defaultValue))) ||
       (e.target instanceof HTMLTextAreaElement && e.target.value === e.target.defaultValue)
     ) {
       valueHasChanged[(e.target as HTMLElement).id] = false;


### PR DESCRIPTION
In the AI question generation draft editor, even after a user would type in a revision prompt, the revise question button remained disabled, preventing the user from submitting question revisions. 

This PR resolves that issue:

https://github.com/user-attachments/assets/62e5580c-1c5d-4a93-ac98-e5237749fb1c

The problem was that the question revision input was a `textarea`, but `saveButtonEnabling` checked that text inputs were `input` elements:

https://github.com/PrairieLearn/PrairieLearn/blob/f8f93a5caea6d49d72752062a5d119aa55df05f4/apps/prairielearn/assets/scripts/lib/saveButtonEnabling.ts#L27-L40

This is now fixed.