### PR TITLE
Fix handling of workspace URL rewrite checkbox

### DIFF
--- a/.changeset/three-carrots-hide.md
+++ b/.changeset/three-carrots-hide.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/zod': minor
+---
+
+Forbid calling `.optional()` on `BooleanFromCheckboxSchema`

--- a/apps/prairielearn/assets/scripts/instructorQuestionSettingsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorQuestionSettingsClient.ts
@@ -25,28 +25,13 @@ onDocumentReady(() => {
   const workspaceImageInput = document.querySelector<HTMLInputElement>('#workspace_image');
   const workspacePortInput = document.querySelector<HTMLInputElement>('#workspace_port');
   const workspaceHomeInput = document.querySelector<HTMLInputElement>('#workspace_home');
-  const workspaceGradedFilesInput =
-    document.querySelector<HTMLInputElement>('#workspace_graded_files');
-  const workspaceArgsInput = document.querySelector<HTMLInputElement>('#workspace_args');
   const workspaceEnvironmentInput =
     document.querySelector<HTMLInputElement>('#workspace_environment');
-  const workspaceEnableNetworkingCheckbox = document.querySelector<HTMLInputElement>(
-    '#workspace_enable_networking',
-  );
-  const workspaceRewriteUrlCheckbox =
-    document.querySelector<HTMLInputElement>('#workspace_rewrite_url');
 
-  function validateWorkspaceOptions() {
-    if (
-      workspaceImageInput?.value ||
-      workspacePortInput?.value ||
-      workspaceHomeInput?.value ||
-      workspaceGradedFilesInput?.value ||
-      workspaceArgsInput?.value ||
-      (workspaceEnvironmentInput?.value !== '{}' && workspaceEnvironmentInput?.value !== '') ||
-      workspaceEnableNetworkingCheckbox?.checked ||
-      workspaceRewriteUrlCheckbox?.checked
-    ) {
+  let workspaceOptionsShown = showWorkspaceOptionsButton?.getAttribute('hidden') === 'true';
+
+  function updateWorkspaceOptionsValidation() {
+    if (workspaceOptionsShown) {
       workspaceImageInput?.setAttribute('required', 'true');
       workspacePortInput?.setAttribute('required', 'true');
       workspaceHomeInput?.setAttribute('required', 'true');
@@ -126,16 +111,19 @@ onDocumentReady(() => {
     }
   });
 
-  if (!questionSettingsForm || !saveButton) return;
-  saveButtonEnabling(questionSettingsForm, saveButton);
+  if (questionSettingsForm && saveButton) {
+    saveButtonEnabling(questionSettingsForm, saveButton);
+  }
 
+  updateWorkspaceOptionsValidation();
   showWorkspaceOptionsButton?.addEventListener('click', () => {
     workspaceOptions?.removeAttribute('hidden');
     showWorkspaceOptionsButton.setAttribute('hidden', 'true');
+    workspaceOptionsShown = true;
+    updateWorkspaceOptionsValidation();
   });
 
-  questionSettingsForm.addEventListener('submit', (e) => {
-    validateWorkspaceOptions();
+  questionSettingsForm?.addEventListener('submit', (e) => {
     if (!questionSettingsForm.checkValidity()) {
       e.preventDefault();
       questionSettingsForm.reportValidity();

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -138,10 +138,10 @@ router.post(
             .string()
             .transform((s) => shlex.split(s || ''))
             .optional(),
-          workspace_rewrite_url: BooleanFromCheckboxSchema.optional(),
+          workspace_rewrite_url: BooleanFromCheckboxSchema,
           // This will not correctly handle any filenames that have a comma in them.
           // Currently, we do not have any such filenames in prod so we don't think that
-          // escaping commas in indiviudal filenames is necessary.
+          // escaping commas in individual filenames is necessary.
           workspace_graded_files: z
             .string()
             .transform((s) =>
@@ -151,7 +151,7 @@ router.post(
                 .filter((s) => s !== ''),
             )
             .optional(),
-          workspace_enable_networking: BooleanFromCheckboxSchema.optional(),
+          workspace_enable_networking: BooleanFromCheckboxSchema,
           workspace_environment: z.string().optional(),
         })
         .parse(req.body);

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -198,7 +198,7 @@ router.post(
         comment: questionInfo.workspaceOptions?.comment ?? undefined,
         image: propertyValueWithDefault(
           questionInfo.workspaceOptions?.image,
-          body.workspace_image,
+          body.workspace_image?.trim(),
           '',
         ),
         port: propertyValueWithDefault(
@@ -208,7 +208,7 @@ router.post(
         ),
         home: propertyValueWithDefault(
           questionInfo.workspaceOptions?.home,
-          body.workspace_home,
+          body.workspace_home?.trim(),
           '',
         ),
         args: propertyValueWithDefault(
@@ -238,19 +238,26 @@ router.post(
         ),
       };
 
-      const filteredOptions = Object.fromEntries(
-        Object.entries(
-          propertyValueWithDefault(
-            questionInfo.workspaceOptions,
-            workspaceOptions,
-            (val) => !val || Object.keys(val).length === 0,
-          ),
-        ).filter(([_, value]) => value !== undefined),
-      );
-      questionInfo.workspaceOptions =
-        Object.keys(filteredOptions).length > 0
-          ? applyKeyOrder(questionInfo.workspaceOptions, filteredOptions)
-          : undefined;
+      // We'll only write the workspace options if the request contains the
+      // required fields. Client-side validation will ensure that these are
+      // present if a workspace is configured.
+      if (workspaceOptions.image && workspaceOptions.port && workspaceOptions.home) {
+        const filteredOptions = Object.fromEntries(
+          Object.entries(
+            propertyValueWithDefault(
+              questionInfo.workspaceOptions,
+              workspaceOptions,
+              (val) => !val || Object.keys(val).length === 0,
+            ),
+          ).filter(([_, value]) => value !== undefined),
+        );
+        questionInfo.workspaceOptions =
+          Object.keys(filteredOptions).length > 0
+            ? applyKeyOrder(questionInfo.workspaceOptions, filteredOptions)
+            : undefined;
+      } else {
+        questionInfo.workspaceOptions = undefined;
+      }
 
       const formattedJson = await formatJsonWithPrettier(JSON.stringify(questionInfo));
 

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -3,10 +3,30 @@ import { assert, describe, it } from 'vitest';
 
 import {
   ArrayFromStringOrArraySchema,
+  BooleanFromCheckboxSchema,
   IdSchema,
   IntegerFromStringOrEmptySchema,
   IntervalSchema,
 } from './index.js';
+
+describe('BooleanFromCheckboxSchema', () => {
+  it('parses a checked checkbox', () => {
+    const result = BooleanFromCheckboxSchema.parse('on');
+    assert.isTrue(result);
+  });
+  it('parses an unchecked checkbox', () => {
+    const result = BooleanFromCheckboxSchema.parse(undefined);
+    assert.isFalse(result);
+  });
+  it('parses a checkbox with an empty string', () => {
+    const result = BooleanFromCheckboxSchema.parse('');
+    assert.isFalse(result);
+  });
+  it('parses a checkbox with a non-empty string', () => {
+    const result = BooleanFromCheckboxSchema.parse('checked');
+    assert.isTrue(result);
+  });
+});
 
 describe('IdSchema', () => {
   it('parses a valid id', () => {


### PR DESCRIPTION
#12096 still didn't completely fix the handling of this. After that, it was actually impossible to disable URL rewriting from the GUI settings editor. This was caused by us calling `.optional()` on `BooleanFromCheckboxSchema`, which caused it to treat a missing value as `undefined` instead of `false`.

There are a few changes to help address this in this PR:

- I wrapped the `BooleanFromCheckboxSchema` schema in a TypeScript helper that forbids calling `.optional()`. IMO it makes sense to bake in this behavior.
- I updated the form validation for workspace settings to be simpler: if workspace settings are shown, image/port/home will all be required. This is a change from the old behavior, where they'd only be marked as required if any of the workspace settings inputs had a value. This was actually necessary to work with the fact that `workspace_rewrite_url` defaults to true. Since it defaults to being checked, we'd erroneously always start in a state where workspace options were required, even when the form was hidden.
  - The upshot here is that if you click "Configure workspace" by mistake, there's no easy way to undo it short of hitting "Cancel" or reloading the page. IMO this is acceptable for now. We can improve this if this proves to be confusing.