### PR TITLE
Add feature-dating functionality to documentation

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -155,3 +155,20 @@ code.doc-symbol-json::after {
 .md-tooltip2__inner.md-typeset > .md-content__button.md-icon {
   display: none;
 }
+
+/* Badge support, modified from https://github.com/squidfunk/mkdocs-material/blob/462c94e88f89331c0484643d33aabdeba95d7394/src/overrides/assets/stylesheets/custom/_typeset.scss */
+.md-typeset .mdx-badge {
+  font-size: 0.85em;
+}
+
+.md-typeset .mdx-badge__text {
+  box-shadow: 0 0 0 1px inset var(--md-accent-fg-color--transparent);
+  padding: 0.2rem 0.3rem;
+}
+
+.md-typeset .mdx-badge__icon {
+  border-top-left-radius: 0.1rem;
+  border-top-right-radius: 0.1rem;
+  background: var(--md-accent-fg-color--transparent);
+  padding: 0.2rem;
+}

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -108,6 +108,8 @@ compatibility, but they should not be used in new questions.
 
 ### `pl-big-o-input` element
 
+<!-- md:pr-date 6641 -->
+
 Fill in the blank field that allows for asymptotic mathematical input (i.e. big O, big Theta, etc.).
 Gives automated feedback in the case of improper asymptotic input.
 
@@ -244,6 +246,8 @@ To compute `max-select`, we use a similar algorithm (note the different default 
 ---
 
 ### `pl-excalidraw` element
+
+<!-- md:pr-date 9900 -->
 
 Draw a vector diagram using [excalidraw](https://github.com/excalidraw/excalidraw). Only manual grading is supported.
 
@@ -521,6 +525,8 @@ A `pl-option` must be specified with these attributes:
 ---
 
 ### `pl-matrix-component-input` element
+
+<!-- md:pr-date 1184 -->
 
 A `pl-matrix-component-input` element displays a grid of input fields with
 the same shape of the variable stored in `answers-name`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ pymdown-extensions==10.15
 # mkdocstrings-python will format the docstrings using ruff
 # https://mkdocstrings.github.io/python/usage/configuration/signatures/#line_length
 ruff==0.11.12
+PyGithub==2.6.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ mkdocs==1.6.1
 mkdocstrings-python==1.16.11
 mkdocstrings==0.29.1
 pymdown-extensions==10.15
+PyGithub==2.6.1
 # mkdocstrings-python will format the docstrings using ruff
 # https://mkdocstrings.github.io/python/usage/configuration/signatures/#line_length
 ruff==0.11.12
-PyGithub==2.6.1

--- a/docs/scripts/shortcodes.py
+++ b/docs/scripts/shortcodes.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# Modified from squidfunk/mkdocs-material/src/overrides/hooks/shortcodes.py
+# If GITHUB_TOKEN is unset, no transformations are done.
+
+from __future__ import annotations
+
+import os
+import pickle
+import re
+from pathlib import Path
+from re import Match
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.structure.files import Files
+    from mkdocs.structure.pages import Page
+
+from github import Auth, Github
+
+CACHE_PATH = Path(".cache") / "shortcodes" / "data.pkl"
+TOKEN = os.getenv("GITHUB_TOKEN")
+
+pl_repo = None
+did_init = False
+cache = {}
+
+
+def _init() -> None:
+    global cache, pl_repo, did_init  # noqa: PLW0603
+    did_init = True
+    if TOKEN:
+        auth = Auth.Token(TOKEN)
+        g = Github(auth=auth)
+        pl_repo = g.get_repo("prairielearn/prairielearn")
+        cache = _get_cache()
+
+
+def on_page_markdown(
+    markdown: str,
+    *,
+    page: Page,
+    config: MkDocsConfig,  # noqa: ARG001
+    files: Files,
+) -> str:
+    """
+    Resolve comments to markdown badges.
+
+    For example, allows you to write `<!-- md:pr 10000 -->`
+    and resolve this to a badge of when the associated PR was merged.
+    """
+    if not did_init:
+        _init()
+
+    def replace(match: Match[str]) -> str:
+        kind, args = match.groups()
+        args = args.strip()
+        if kind == "pr":
+            return _badge_for_pr(args, page, files, with_date=False)
+        if kind == "pr-date":
+            return _badge_for_pr(args, page, files, with_date=True)
+        # Otherwise, raise an error
+        raise RuntimeError(f"Unknown shortcode: {kind}")
+
+    # If no github authentication token, skip this process
+    if not pl_repo:
+        print(pl_repo)
+        return markdown
+
+    # Find and replace all external asset URLs in current page
+    return re.sub(
+        r"<!-- md:([\w-]+)(.*?) -->",
+        replace,
+        markdown,
+        flags=re.IGNORECASE | re.MULTILINE,
+    )
+
+
+# Create badge
+def _badge(icon: str, text: str = "", kind: str = "") -> str:
+    classes = f"mdx-badge mdx-badge--{kind}" if kind else "mdx-badge"
+    return "".join([
+        f'<span class="{classes}">',
+        *([f'<span class="mdx-badge__icon">{icon}</span>'] if icon else []),
+        *([f'<span class="mdx-badge__text">{text}</span>'] if text else []),
+        "</span>",
+    ])
+
+
+def _badge_for_pr(
+    text: str,
+    page: Page,  # noqa: ARG001
+    files: Files,  # noqa: ARG001
+    *,
+    with_date: bool = False,
+) -> str:
+    global cache  # noqa: PLW0602
+    pr_num = int(text)
+
+    meta = cache.get(pr_num)
+    if not pl_repo:
+        raise RuntimeError("API not found")
+    if meta is None:
+        meta = pl_repo.get_pull(pr_num)
+        cache[pr_num] = meta
+        _save_cache(cache)
+
+    icon = "material-progress-clock"
+    badge_text = meta.created_at.strftime("%B %-d, %Y")
+    if meta.merged_at:
+        icon = "material-progress-check"
+        badge_text = meta.merged_at.strftime("%B %-d, %Y")
+    return _badge(
+        icon=f"[:{icon}:]({meta.html_url})",
+        text=f"{badge_text}" if with_date else "",
+    )
+
+
+def _get_cache() -> dict:  # type: ignore
+    try:
+        with open(CACHE_PATH, "rb") as f:
+            return pickle.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def _save_cache(new_cache: dict) -> None:  # type: ignore
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(CACHE_PATH, "wb") as f:
+        pickle.dump(new_cache, f)

--- a/docs/scripts/shortcodes.py
+++ b/docs/scripts/shortcodes.py
@@ -116,7 +116,7 @@ def _badge_for_pr(
     try:
         pr_num = int(text)
     except ValueError:
-        raise RuntimeError(f"Invalid PR number: {text}")
+        raise RuntimeError(f"Invalid PR number: {text}") from None
 
     if not pl_repo:
         raise RuntimeError("API not found")

--- a/docs/scripts/shortcodes.py
+++ b/docs/scripts/shortcodes.py
@@ -83,7 +83,6 @@ def on_page_markdown(
 
     # If no github authentication token, skip this process
     if not pl_repo:
-        print(pl_repo)
         return markdown
 
     # Find and replace all external asset URLs in current page

--- a/docs/scripts/shortcodes.py
+++ b/docs/scripts/shortcodes.py
@@ -118,9 +118,9 @@ def _badge_for_pr(
     except ValueError:
         raise RuntimeError(f"Invalid PR number: {text}")
 
-    meta = cache.get(pr_num)
     if not pl_repo:
         raise RuntimeError("API not found")
+    meta = cache.get(pr_num)
     if meta is None:
         meta = pl_repo.get_pull(pr_num)
         cache[pr_num] = meta

--- a/docs/scripts/shortcodes.py
+++ b/docs/scripts/shortcodes.py
@@ -114,7 +114,10 @@ def _badge_for_pr(
     with_date: bool = False,
 ) -> str:
     global cache  # noqa: PLW0602
-    pr_num = int(text)
+    try:
+        pr_num = int(text)
+    except ValueError:
+        raise RuntimeError(f"Invalid PR number: {text}")
 
     meta = cache.get(pr_num)
     if not pl_repo:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -305,3 +305,4 @@ watch:
 hooks:
   - docs/scripts/d2_svg_file.py
   - docs/scripts/jsonschema_details_fix.py
+  - docs/scripts/shortcodes.py


### PR DESCRIPTION
I have seen a couple mentions on slack where people were unaware of when a feature was added. Given that various options are added at different points at time for our elements, a way to associate those options with when they were added should make it easier for instructors to know how new a feature is. I thought of this addition when looking at #12061 .

Uses the GitHub API with a cache to retrieve date/status associated with each PR. If no token is found (e.g. local development where this isn't set up) this does nothing.

![CleanShot 2025-06-03 at 10 02 31@2x](https://github.com/user-attachments/assets/838b220c-5e0f-424c-9679-0360feeeb093)


TODO:

On read the docs, we need to provide a `GITHUB_TOKEN` environment variable. This should also resolve the transient D2 failures.