### PR TITLE
Adjust how API routes are excluded from certain middlewares

### DIFF
--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -173,7 +173,7 @@ export async function initExpress(): Promise<Express> {
   });
 
   // API routes don't utilize sessions; don't run the session/flash middleware for them.
-  app.use(excludeRoutes(['/pl/api'], sessionRouter));
+  app.use(excludeRoutes(['/pl/api/'], sessionRouter));
 
   // special parsing of file upload paths -- this is inelegant having it
   // separate from the route handlers but it seems to be necessary
@@ -432,7 +432,7 @@ export async function initExpress(): Promise<Express> {
 
   // Set and check `res.locals.__csrf_token`. We exclude API routes as those
   // don't require CSRF protection (and in fact can't have it at all).
-  app.use(excludeRoutes(['/pl/api'], (await import('./middlewares/csrfToken.js')).default));
+  app.use(excludeRoutes(['/pl/api/'], (await import('./middlewares/csrfToken.js')).default));
 
   app.use((await import('./middlewares/logRequest.js')).default);
 


### PR DESCRIPTION
We got an error in production recently when a bot tried to hit `/pl/apidocs/swagger.json`. That failed here when trying to access a property on `req.session`, which was `undefined`:

https://github.com/PrairieLearn/PrairieLearn/blob/b912320f40dda69601d8f0184cc9e3ba77514ec5/apps/prairielearn/src/middlewares/authn.ts#L113

This happened because the regex that we use to skip the authentication middleware for certain routes included a trailing slash:

https://github.com/PrairieLearn/PrairieLearn/blob/b912320f40dda69601d8f0184cc9e3ba77514ec5/apps/prairielearn/src/middlewares/authn.ts#L31

But the paths that we used to exclude the session/CSRF middleware did not include a trailing slash.