### PR TITLE
Update icon for AI question generation

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.ts
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.ts
@@ -236,7 +236,7 @@ onDocumentReady(() => {
 
   if (showAddQuestionButton) {
     tableSettings.buttons.addQuestion = {
-      text: 'Add Question',
+      text: 'Add question',
       icon: 'fa-plus',
       attributes: { title: 'Create a new question' },
       event: () => {
@@ -250,7 +250,7 @@ onDocumentReady(() => {
       html: html`
         <a class="btn btn-secondary" href="${urlPrefix}/ai_generate_question_drafts">
           <i class="bi bi-stars" aria-hidden="true"></i>
-          Generate Question with AI
+          Generate question with AI
         </a>
       `.toString(),
     };

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.ts
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.ts
@@ -249,7 +249,7 @@ onDocumentReady(() => {
     tableSettings.buttons.aiGenerateQuestion = {
       html: html`
         <a class="btn btn-secondary" href="${urlPrefix}/ai_generate_question_drafts">
-          <i class="fa fa-wand-magic-sparkles" aria-hidden="true"></i>
+          <i class="bi bi-stars" aria-hidden="true"></i>
           Generate Question with AI
         </a>
       `.toString(),


### PR DESCRIPTION
As discussed in https://github.com/PrairieLearn/PrairieLearn/pull/11989#discussion_r2103169901, we want to standardize on this new icon for AI functionality.

I also took the opportunity to standardize on sentence case for these button labels.

Before:

<img width="682" alt="Screenshot 2025-06-03 at 12 21 20" src="https://github.com/user-attachments/assets/cbf2da2d-ba7a-4918-871d-a75208091676" />

After:

<img width="674" alt="Screenshot 2025-06-03 at 12 20 41" src="https://github.com/user-attachments/assets/8726a8b5-ce14-48b0-b738-4b306cb2e981" />

