### PR TITLE
Handle SIGINT and SIGTERM in executor image

### DIFF
--- a/apps/prairielearn/src/executor.ts
+++ b/apps/prairielearn/src/executor.ts
@@ -122,6 +122,9 @@ async function prepareCodeCaller() {
   });
 }
 
+process.once('SIGINT', () => process.exit(0));
+process.once('SIGTERM', () => process.exit(0));
+
 (async () => {
   let codeCaller = await prepareCodeCaller();
 


### PR DESCRIPTION
This makes testing the `prairielearn/executor` image easier by actually making it possible to kill the process when running it as follows:

```
docker run --rm -it prairielearn/executor
```