### PR TITLE
Fix CodeCallerContainer stdin handling

### DIFF
--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
@@ -437,6 +437,7 @@ export class CodeCallerContainer implements CodeCaller {
       stdin: true,
       stdout: true,
       stderr: true,
+      hijack: true,
     });
     this.stdinStream = new MemoryStream();
     this.stdoutStream = new MemoryStream();


### PR DESCRIPTION
On a recent attempted deploy of revision `2578ecc57a91e8e5b0c7087d48cd5626a6f2360b`, I observed that the code callers were failing to start properly. After some investigation, it appeared that the Node process running inside the executor container wasn't receiving data over stdin. Adding `hijack: true` fixed that locally; I'm going to try to deploy from this branch to see if it works in production environments too. I don't know why this changed anything, and I also don't know why this ever worked in the first place.

See here for more details on connection hijacking: https://docs.docker.com/reference/api/engine/version/v1.45/#tag/Container/operation/ContainerAttach