### PR TITLE
Docs: warn about the use of boolean attributes

### DIFF
--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -171,6 +171,25 @@ def get_string_attrib(
     return str_val
 
 
+LIBXML_BOOLEAN_ATTRIBUTES = frozenset(
+    {
+        "checked",
+        "compact",
+        "declare",
+        "defer",
+        "disabled",
+        "ismap",
+        "multiple",
+        "nohref",
+        "noresize",
+        "noshade",
+        "nowrap",
+        "readonly",
+        "selected",
+    }
+)
+
+
 # Order here matters, as we want to override the case where the args is omitted
 @overload
 def get_boolean_attrib(element: lxml.html.HtmlElement, name: str) -> bool: ...
@@ -203,6 +222,15 @@ def get_boolean_attrib(
     Raises:
         ValueError: If the attribute is not a valid boolean value.
     """
+
+    # If the attribute is a boolean attribute, then its value is determined by its presence
+    if name in LIBXML_BOOLEAN_ATTRIBUTES:
+        if args[0] is not False:
+            raise ValueError(
+                f'Attribute "{name}" is treated as a boolean attribute, with a default value False.'
+            )
+        return has_attrib(element, name)
+
     (val, is_default) = _get_attrib(element, name, *args)
     if is_default:
         return val

--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -224,7 +224,7 @@ def get_boolean_attrib(
     """
 
     # If the attribute is a boolean attribute, then its value is determined by its presence
-    if name in LIBXML_BOOLEAN_ATTRIBUTES:
+    if name.lower() in LIBXML_BOOLEAN_ATTRIBUTES:
         if args[0] is not False:
             raise ValueError(
                 f'Attribute "{name}" is treated as a boolean attribute, with a default value False.'

--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -17,6 +17,22 @@ from prairielearn.misc_utils import escape_unicode_string
 
 EnumT = TypeVar("EnumT", bound=Enum)
 
+LIBXML_BOOLEAN_ATTRIBUTES = frozenset({
+    "checked",
+    "compact",
+    "declare",
+    "defer",
+    "disabled",
+    "ismap",
+    "multiple",
+    "nohref",
+    "noresize",
+    "noshade",
+    "nowrap",
+    "readonly",
+    "selected",
+})
+
 
 def get_enum_attrib(
     element: lxml.html.HtmlElement,
@@ -116,6 +132,16 @@ def _get_attrib(
     if len(args) > 1:
         raise ValueError("Only one additional argument is allowed")
 
+    # libxml2 sometimes changes the content of boolean attributes, so their
+    # value is not reliable. To avoid problems, we raise an error if the value
+    # is used for anything other than a boolean check. The boolean function has
+    # a test before this point with an early return, so this point should only
+    # be reached if this is being handled with a non-boolean value.
+    if name.lower() in LIBXML_BOOLEAN_ATTRIBUTES:
+        raise ValueError(
+            f"The attribute '{name}' is an HTML boolean attribute, and should not be used."
+        )
+
     if name in element.attrib:
         return (element.attrib[name], False)
 
@@ -171,25 +197,6 @@ def get_string_attrib(
     return str_val
 
 
-LIBXML_BOOLEAN_ATTRIBUTES = frozenset(
-    {
-        "checked",
-        "compact",
-        "declare",
-        "defer",
-        "disabled",
-        "ismap",
-        "multiple",
-        "nohref",
-        "noresize",
-        "noshade",
-        "nowrap",
-        "readonly",
-        "selected",
-    }
-)
-
-
 # Order here matters, as we want to override the case where the args is omitted
 @overload
 def get_boolean_attrib(element: lxml.html.HtmlElement, name: str) -> bool: ...
@@ -222,12 +229,12 @@ def get_boolean_attrib(
     Raises:
         ValueError: If the attribute is not a valid boolean value.
     """
-
     # If the attribute is a boolean attribute, then its value is determined by its presence
     if name.lower() in LIBXML_BOOLEAN_ATTRIBUTES:
-        if args[0] is not False:
+        default_value = None if len(args) == 0 else args[0]
+        if default_value is not False:
             raise ValueError(
-                f'Attribute "{name}" is treated as a boolean attribute, with a default value False.'
+                f'Attribute "{name}" is an HTML boolean attribute, and cannot be used with a default value of {default_value}.'
             )
         return has_attrib(element, name)
 

--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -234,11 +234,11 @@ def get_boolean_attrib(
     # If the attribute is a boolean attribute, then its value is determined by its presence
     if name.lower() in LIBXML_BOOLEAN_ATTRIBUTES:
         default_value = None if len(args) == 0 else args[0]
-        if default_value is not False:
+        if default_value:
             raise ValueError(
                 f'Attribute "{name}" is an HTML boolean attribute, and cannot be used with a default value of {default_value}.'
             )
-        return has_attrib(element, name)
+        return has_attrib(element, name) or default_value
 
     (val, is_default) = _get_attrib(element, name, *args)
     if is_default:

--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -133,11 +133,12 @@ def _get_attrib(
     if len(args) > 1:
         raise ValueError("Only one additional argument is allowed")
 
-    # libxml2 sometimes changes the content of boolean attributes, so their
-    # value is not reliable. To avoid problems, we raise an error if the value
-    # is used for anything other than a boolean check. The boolean function has
-    # a test before this point with an early return, so this point should only
-    # be reached if this is being handled with a non-boolean value.
+    # libxml2 omits the content of certain boolean attributes during
+    # serialization, so their value is not reliable. To avoid problems, we raise
+    # an error if the value is used for anything other than a boolean check. The
+    # boolean function has a test before this point with an early return, so
+    # this point should only be reached if this is being handled with a
+    # non-boolean value.
     if name.lower() in LIBXML_BOOLEAN_ATTRIBUTES:
         raise ValueError(
             f"The attribute '{name}' is an HTML boolean attribute, and should not be used."

--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -17,6 +17,7 @@ from prairielearn.misc_utils import escape_unicode_string
 
 EnumT = TypeVar("EnumT", bound=Enum)
 
+# From https://gitlab.gnome.org/GNOME/libxml2/-/blob/4aa08c80b711ab296f6e6ecab24df8cf6d0be5fc/HTMLtree.c#L305-309
 LIBXML_BOOLEAN_ATTRIBUTES = frozenset({
     "checked",
     "compact",

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -777,13 +777,15 @@ def test_get_boolean_attrib_invalid(html_str: str) -> None:
         ("<pl-thing></pl-thing>", False),
     ],
 )
-def test_get_boolean_attrib_libxml(html_str: str, expected_result: bool) -> None:  # noqa: FBT001
+def test_get_boolean_attrib_libxml(html_str: str, expected_result: bool | None) -> None:  # noqa: FBT001
     """Test that using HTML boolean attributes is only valid when reading as boolean with default False."""
     element = lxml.html.fragment_fromstring(html_str)
     result = pl.get_boolean_attrib(element, "checked", False)  # noqa: FBT003
     assert result == expected_result
-    with pytest.raises(ValueError, match="boolean attribute"):
-        pl.get_boolean_attrib(element, "checked")
+    if not expected_result:
+        expected_result = None
+    result = pl.get_boolean_attrib(element, "checked")
+    assert result == expected_result
     with pytest.raises(ValueError, match="boolean attribute"):
         pl.get_boolean_attrib(element, "checked", True)  # noqa: FBT003
     with pytest.raises(ValueError, match="boolean attribute"):

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -767,6 +767,38 @@ def test_get_boolean_attrib_invalid(html_str: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("html_str", "expected_result"),
+    [
+        ('<pl-thing checked="true"></pl-thing>', True),
+        ('<pl-thing checked="false"></pl-thing>', True),
+        ('<pl-thing checked="checked"></pl-thing>', True),
+        ('<pl-thing checked=""></pl-thing>', True),
+        ("<pl-thing checked></pl-thing>", True),
+        ("<pl-thing></pl-thing>", False),
+    ],
+)
+def test_get_boolean_attrib_libxml(html_str: str, expected_result: bool) -> None:  # noqa: FBT001
+    """Test that using HTML boolean attributes is only valid when reading as boolean with default False."""
+    element = lxml.html.fragment_fromstring(html_str)
+    result = pl.get_boolean_attrib(element, "checked", False)  # noqa: FBT003
+    assert result == expected_result
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_boolean_attrib(element, "checked")
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_boolean_attrib(element, "checked", True)  # noqa: FBT003
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_string_attrib(element, "checked", "")
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_integer_attrib(element, "checked", 0)
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_float_attrib(element, "checked", 0)
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_color_attrib(element, "checked", "red1")
+    with pytest.raises(ValueError, match="boolean attribute"):
+        pl.get_enum_attrib(element, "checked", DummyEnum)
+
+
+@pytest.mark.parametrize(
     ("html_str", "expected_result", "default"),
     [
         # Basic integer parsing

--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -6,7 +6,7 @@ Element code uses the [`prairielearn` module](https://prairielearn.readthedocs.i
 
 !!! info
 
-    When deciding on the attributes used by your element, avoid using attribute names that are generally interpreted as Boolean attributes in HTML elements. These attribute names may be incorrectly interpreted and their values converted to mean something different than your original intent. In particular, you should avoid these attributes: `checked`, `compact`, `declare`, `defer`, `disabled`, `ismap`, `multiple`, `nohref`, `noresize`, `noshade`, `nowrap`, `readonly`, `selected`.
+    When deciding on the attributes used by your element, avoid using attribute names that are generally interpreted as boolean attributes in HTML elements. These attribute names may be incorrectly interpreted and their values converted to mean something different than your original intent. In particular, you should avoid these attributes: `checked`, `compact`, `declare`, `defer`, `disabled`, `ismap`, `multiple`, `nohref`, `noresize`, `noshade`, `nowrap`, `readonly`, `selected`.
 
     Additionally, you are encouraged to avoid attribute names that have special meaning in HTML (e.g., `onclick` or `style`), as they may be misinterpreted by IDEs.
 

--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -4,6 +4,12 @@ See [`elements/`](https://github.com/PrairieLearn/PrairieLearn/tree/master/apps/
 
 Element code uses the [`prairielearn` module](https://prairielearn.readthedocs.io/en/latest/python-reference/) for common functionality like parsing attributes and computing scores.
 
+!!! info
+
+    When deciding on the attributes used by your element, avoid using attribute names that are generally interpreted as Boolean attributes in HTML elements. These attribute names may be incorrectly interpreted and their values converted to mean something different than your original intent. In particular, you should avoid these attributes: `checked`, `compact`, `declare`, `defer`, `disabled`, `ismap`, `multiple`, `nohref`, `noresize`, `noshade`, `nowrap`, `readonly`, `selected`.
+
+    Additionally, you are encouraged to avoid attribute names that have special meaning in HTML (e.g., `onclick` or `style`), as they may be misinterpreted by IDEs.
+
 ## Anatomy of an element
 
 The system-wide elements available in the current build of the PrairieLearn server


### PR DESCRIPTION
As discussed on Slack. Attributes treated by libxml as boolean attributes can cause weird behaviour, such as changing the value during processing. This PR ensures that:

* [x] these attributes are listed in the documentation as discouraged;
* [x] the boolean processing of these attributes treats any value as true, and absence as false, while raising an exception if the default is not false;
* [x] other attribute processing functions raise an error if the name is in use.

Still testing to ensure this won't break any regular elements. 