### PR TITLE
Improve consistency when importing Express

### DIFF
--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAccessRules/index.ts
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAccessRules/index.ts
@@ -1,12 +1,12 @@
 import * as path from 'node:path';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
 
 const sql = sqldb.loadSql(path.join(import.meta.dirname, '..', 'queries.sql'));
-const router = express.Router({ mergeParams: true });
+const router = Router({ mergeParams: true });
 
 router.get(
   '/',

--- a/apps/prairielearn/src/ee/lib/lti13.test.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.test.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type Request, type Response } from 'express';
 import { assert, describe, expect, test } from 'vitest';
 import { z } from 'zod';
 
@@ -35,7 +35,7 @@ const PRODUCTS = [
   'Zucchini',
 ];
 
-function productApi(req: express.Request, res: express.Response) {
+function productApi(req: Request, res: Response) {
   const page = parseInt(req.query.page as string) || 1;
   const limit = parseInt(req.query.limit as string) || 10;
 

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { type Response, Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import OpenAI from 'openai';
 
@@ -28,11 +28,11 @@ import { GenerationFailure } from '../instructorAiGenerateDrafts/instructorAiGen
 
 import { InstructorAiGenerateDraftEditor } from './instructorAiGenerateDraftEditor.html.js';
 
-const router = express.Router({ mergeParams: true });
+const router = Router({ mergeParams: true });
 const sql = loadSqlEquiv(import.meta.url);
 
 async function saveGeneratedQuestion(
-  res: express.Response,
+  res: Response,
   htmlFileContents: string | undefined,
   pythonFileContents: string | undefined,
   title?: string,

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import OpenAI from 'openai';
 
@@ -16,7 +16,7 @@ import {
   InstructorAIGenerateDrafts,
 } from './instructorAiGenerateDrafts.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 function assertCanCreateQuestion(resLocals: Record<string, any>) {

--- a/apps/prairielearn/src/ee/webhooks/stripe/index.ts
+++ b/apps/prairielearn/src/ee/webhooks/stripe/index.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type Request, Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import type Stripe from 'stripe';
 
@@ -15,9 +15,9 @@ import {
   updateStripeCheckoutSessionData,
 } from '../../models/stripe-checkout-sessions.js';
 
-const router = express.Router({ mergeParams: true });
+const router = Router({ mergeParams: true });
 
-function constructEvent(req: express.Request) {
+function constructEvent(req: Request) {
   if (!config.stripeWebhookSigningSecret) {
     throw new Error('Stripe is not configured.');
   }

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 
-import express from 'express';
+import express, { Router } from 'express';
 import { type HashElementNode, hashElement } from 'folder-hash';
 import { v4 as uuid } from 'uuid';
 
@@ -176,7 +176,7 @@ export async function close() {
  */
 export function applyMiddleware(app: express.Application) {
   const assetsPrefix = assertAssetsPrefix();
-  const router = express.Router();
+  const router = Router();
 
   // Compiled assets have a digest/hash embedded in their filenames, so they
   // don't require a separate cachebuster.

--- a/apps/prairielearn/src/middlewares/staticNodeModules.ts
+++ b/apps/prairielearn/src/middlewares/staticNodeModules.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import * as express from 'express';
+import express, { Router } from 'express';
 import { type ServeStaticOptions } from 'serve-static';
 
 import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from '../lib/paths.js';
@@ -19,7 +19,7 @@ const NODE_MODULES_PATHS = [
  * to serve all files, or a subdirectory like `mathjax/es5`.
  */
 export default function (servePath: string, options?: ServeStaticOptions) {
-  const router = express.Router();
+  const router = Router();
 
   NODE_MODULES_PATHS.forEach((p) => {
     const resolvedServePath = path.resolve(p, servePath);

--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -1,7 +1,7 @@
 import type http from 'http';
 import type { Socket } from 'net';
 
-import type express from 'express';
+import { type Request, type Response } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import type * as httpProxyMiddleware from 'http-proxy-middleware';
 
@@ -73,7 +73,7 @@ export function getStatusCode(err: any): number {
   }
 }
 
-function getRequestPath(req: express.Request): string {
+function getRequestPath(req: Request): string {
   // `req.originalUrl` won't be defined for websocket requests, but for
   // non-websocket requests, `req.url` won't contain the full path. So we
   // need to handle both.
@@ -82,7 +82,7 @@ function getRequestPath(req: express.Request): string {
 
 export function makeWorkspaceProxyMiddleware() {
   const workspaceUrlRewriteCache = new LocalCache(config.workspaceUrlRewriteCacheMaxAgeSec);
-  const workspaceProxyOptions: httpProxyMiddleware.Options<express.Request, express.Response> = {
+  const workspaceProxyOptions: httpProxyMiddleware.Options<Request, Response> = {
     target: 'invalid',
     ws: true,
     pathFilter: (_path, req) => {

--- a/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
+++ b/apps/prairielearn/src/pages/administratorAdmins/administratorAdmins.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -8,7 +8,7 @@ import { UserSchema } from '../../lib/db-types.js';
 
 import { AdministratorAdmins } from './administratorAdmins.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.ts
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -13,7 +13,7 @@ import { selectAllInstitutions } from '../../models/institution.js';
 
 import { AdministratorCourseRequests } from './administratorCourseRequests.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.ts
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -15,7 +15,7 @@ import { selectAllInstitutions } from '../../models/institution.js';
 
 import { AdministratorCourses, CourseWithInstitutionSchema } from './administratorCourses.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
+++ b/apps/prairielearn/src/pages/administratorInstitutions/administratorInstitutions.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -11,7 +11,7 @@ import {
   InstitutionRowSchema,
 } from './administratorInstitutions.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.ts
@@ -1,7 +1,7 @@
 import * as fsPromises from 'node:fs/promises';
 import * as path from 'path';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as jsonLoad from '../../lib/json-load.js';
@@ -12,7 +12,7 @@ import {
   AdministratorQueryJsonSchema,
 } from './administratorQueries.html.js';
 
-const router = express.Router();
+const router = Router();
 const queriesDir = path.resolve(import.meta.dirname, '..', '..', 'admin_queries');
 
 router.get(

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
@@ -1,6 +1,6 @@
 import * as path from 'node:path';
 
-import express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { stringify } from '@prairielearn/csv';
@@ -17,7 +17,7 @@ import {
   QueryRunRowSchema,
 } from './administratorQuery.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const queriesDir = path.resolve(import.meta.dirname, '..', '..', 'admin_queries');

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import OpenAI from 'openai';
 
@@ -12,7 +12,7 @@ import { isEnterprise } from '../../lib/license.js';
 
 import { AdministratorSettings } from './administratorSettings.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
@@ -7,7 +7,7 @@ import { config } from '../../lib/config.js';
 
 import { AdministratorWorkspaces, WorkspaceHostRowSchema } from './administratorWorkspaces.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/enroll/enroll.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
@@ -24,7 +24,7 @@ import {
   EnrollmentLimitExceededMessage,
 } from './enroll.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 router.get('/', [

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
@@ -8,7 +8,7 @@ import {
   InstructorAssessmentAccess,
 } from './instructorAssessmentAccess.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -1,7 +1,7 @@
 import { pipeline } from 'node:stream/promises';
 
 import archiver from 'archiver';
-import * as express from 'express';
+import { type Response, Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
@@ -31,7 +31,7 @@ import {
   InstructorAssessmentDownloads,
 } from './instructorAssessmentDownloads.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 type Columns = [string, string][];
@@ -230,7 +230,7 @@ interface ArchiveFile {
 }
 
 async function pipeCursorToArchive<T>(
-  res: express.Response,
+  res: Response,
   cursor: sqldb.CursorIterator<T>,
   extractFiles: (row: T) => ArchiveFile[] | null,
 ) {

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
@@ -24,7 +24,7 @@ import {
   InstructorAssessmentGroups,
 } from './instructorAssessmentGroups.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 /**

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -1,6 +1,6 @@
 import { pipeline } from 'node:stream/promises';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
@@ -25,7 +25,7 @@ import {
   InstructorAssessmentInstance,
 } from './instructorAssessmentInstance.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const DateDurationResultSchema = z.object({

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -1,5 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -17,7 +17,7 @@ import { regradeAssessmentInstance } from '../../lib/regrading.js';
 import { InstructorAssessmentInstances } from './instructorAssessmentInstances.html.js';
 import { AssessmentInstanceRowSchema } from './instructorAssessmentInstances.types.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -15,7 +15,7 @@ import { selectCourseInstanceGraderStaff } from '../../../models/course-instance
 import { AssessmentQuestion } from './assessmentQuestion.html.js';
 import { InstanceQuestionRowSchema } from './assessmentQuestion.types.js';
 
-const router = express.Router();
+const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import qs from 'qs';
 import { z } from 'zod';
@@ -23,7 +23,7 @@ import {
 } from './instanceQuestion.html.js';
 import { RubricSettingsModal } from './rubricSettingsModal.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 async function prepareLocalsForRender(query: Record<string, any>, resLocals: Record<string, any>) {

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.ts
@@ -1,6 +1,6 @@
 import { pipeline } from 'node:stream/promises';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
@@ -20,7 +20,7 @@ import {
   InstructorAssessmentQuestionStatistics,
 } from './instructorAssessmentQuestionStatistics.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 function makeStatsCsvFilename(locals) {

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -8,7 +8,7 @@ import { resetVariantsForAssessmentQuestion } from '../../models/variant.js';
 
 import { InstructorAssessmentQuestions } from './instructorAssessmentQuestions.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -11,7 +11,7 @@ import {
   RegradingJobSequenceSchema,
 } from './instructorAssessmentRegrading.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import sha256 from 'crypto-js/sha256.js';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 import { z } from 'zod';
@@ -29,7 +29,7 @@ import { getCanonicalHost } from '../../lib/url.js';
 
 import { InstructorAssessmentSettings } from './instructorAssessmentSettings.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { stringify } from '@prairielearn/csv';
@@ -17,7 +17,7 @@ import {
   UserScoreSchema,
 } from './instructorAssessmentStatistics.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 function getFilenames(locals: Record<string, any>): Filenames {

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -16,7 +16,7 @@ import {
   UploadJobSequenceSchema,
 } from './instructorAssessmentUploads.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorCourseAdminGettingStarted/instructorCourseAdminGettingStarted.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminGettingStarted/instructorCourseAdminGettingStarted.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { HttpStatusError } from '@prairielearn/error';
@@ -9,7 +9,7 @@ import { updateCourseShowGettingStarted } from '../../models/course.js';
 
 import { InstructorCourseAdminGettingStarted } from './instructorCourseAdminGettingStarted.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.ts
@@ -1,5 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 import { z } from 'zod';
@@ -21,7 +21,7 @@ import {
   InstructorCourseAdminInstances,
 } from './instructorCourseAdminInstances.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
@@ -7,7 +7,7 @@ import { AssessmentModuleSchema } from '../../lib/db-types.js';
 
 import { InstructorCourseAdminModules } from './instructorCourseAdminModules.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as sqldb from '@prairielearn/postgres';
@@ -7,7 +7,7 @@ import { AssessmentSetSchema } from '../../lib/db-types.js';
 
 import { InstructorCourseAdminSets } from './instructorCourseAdminSets.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import sha256 from 'crypto-js/sha256.js';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 import { v4 as uuidv4 } from 'uuid';
@@ -18,7 +18,7 @@ import { updateCourseShowGettingStarted } from '../../models/course.js';
 
 import { InstructorCourseAdminSettings } from './instructorCourseAdminSettings.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
@@ -1,6 +1,6 @@
 import * as async from 'async';
 import debugfn from 'debug';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -36,7 +36,7 @@ import {
 const debug = debugfn('prairielearn:instructorCourseAdminStaff');
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
-const router = express.Router();
+const router = Router();
 
 /**
  * The maximum number of UIDs that can be provided in a single request.

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.ts
@@ -1,11 +1,11 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { selectTagsByCourseId } from '../../models/tags.js';
 
 import { InstructorCourseAdminTags } from './instructorCourseAdminTags.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.ts
@@ -1,11 +1,11 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { selectTopicsByCourseId } from '../../models/topics.js';
 
 import { InstructorCourseAdminTopics } from './instructorCourseAdminTopics.html.js';
 
-const router = express.Router();
+const router = Router();
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import debugfn from 'debug';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { flash } from '@prairielearn/flash';
@@ -14,7 +14,7 @@ import { idsEqual } from '../../lib/id.js';
 import { selectCourseById } from '../../models/course.js';
 import { selectQuestionByUuid } from '../../models/question.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:instructorFileTransfer');
 

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
@@ -2,7 +2,7 @@ import type * as stream from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 import { NoSuchKey, S3 } from '@aws-sdk/client-s3';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -12,7 +12,7 @@ import { makeS3ClientConfig } from '../../lib/aws.js';
 
 import { GradingJobRowSchema, InstructorGradingJob } from './instructorGradingJob.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -8,7 +8,7 @@ import { getCourseOwners } from '../../lib/course.js';
 
 import { InstructorInstanceAdminLti } from './instructorInstanceAdminLti.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import sha256 from 'crypto-js/sha256.js';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 import { z } from 'zod';
@@ -27,7 +27,7 @@ import { selectCourseInstanceByUuid } from '../../models/course-instances.js';
 
 import { InstructorInstanceAdminSettings } from './instructorInstanceAdminSettings.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import sha256 from 'crypto-js/sha256.js';
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
 import * as shlex from 'shlex';
@@ -49,7 +49,7 @@ import {
   SharingSetRowSchema,
 } from './instructorQuestionSettings.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.post(

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.ts
@@ -1,6 +1,6 @@
 import { pipeline } from 'node:stream/promises';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { stringifyStream } from '@prairielearn/csv';
@@ -15,7 +15,7 @@ import {
   InstructorQuestionStatistics,
 } from './instructorQuestionStatistics.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 function makeStatsCsvFilename(locals) {

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
@@ -22,7 +22,7 @@ import {
   RequestCourse,
 } from './instructorRequestCourse.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/publicAssessmentQuestions/publicAssessmentQuestions.ts
+++ b/apps/prairielearn/src/pages/publicAssessmentQuestions/publicAssessmentQuestions.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -12,7 +12,7 @@ import { selectCourseByCourseInstanceId } from '../../models/course.js';
 
 import { PublicAssessmentQuestions } from './publicAssessmentQuestions.html.js';
 
-const router = express.Router({ mergeParams: true });
+const router = Router({ mergeParams: true });
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/publicAssessments/publicAssessments.ts
+++ b/apps/prairielearn/src/pages/publicAssessments/publicAssessments.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -10,7 +10,7 @@ import { selectCourseById } from '../../models/course.js';
 
 import { PublicAssessments } from './publicAssessments.html.js';
 
-const router = express.Router({ mergeParams: true });
+const router = Router({ mergeParams: true });
 
 router.get(
   '/',

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 
-import express from 'express';
+import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -16,7 +16,7 @@ import { isEnterprise } from '../../lib/license.js';
 
 import { AccessTokenSchema, UserSettings } from './userSettings.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 router.get(

--- a/apps/prairielearn/src/pages/workspace/workspace.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import { type Response, Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
@@ -11,10 +11,10 @@ import { selectVariantIdForWorkspace } from '../../models/workspace.js';
 
 import { Workspace } from './workspace.html.js';
 
-const router = express.Router();
+const router = Router();
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
-async function getNavTitleHref(res: express.Response): Promise<string> {
+async function getNavTitleHref(res: Response): Promise<string> {
   const variant_id = await selectVariantIdForWorkspace(res.locals.workspace_id);
 
   if (res.locals.assessment == null) {

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -23,6 +23,7 @@ import express, {
   type Request,
   type RequestHandler,
   type Response,
+  Router,
 } from 'express';
 import asyncHandler from 'express-async-handler';
 import multer from 'multer';
@@ -151,7 +152,7 @@ export async function initExpress(): Promise<Express> {
     },
   });
 
-  const sessionRouter = express.Router();
+  const sessionRouter = Router();
   sessionRouter.use(sessionMiddleware);
   sessionRouter.use(flashMiddleware());
   sessionRouter.use((req, res, next) => {
@@ -270,7 +271,7 @@ export async function initExpress(): Promise<Express> {
   const workspaceProxySocketActivityMetrics = new SocketActivityMetrics(meter, 'workspace-proxy');
   workspaceProxySocketActivityMetrics.start();
 
-  const workspaceAuthRouter = express.Router();
+  const workspaceAuthRouter = Router();
   workspaceAuthRouter.use([
     // We use a short-lived cookie to cache a successful
     // authn/authz for a specific workspace. We run the following


### PR DESCRIPTION
@ZacWarham pointed out in https://github.com/PrairieLearn/PrairieLearn/pull/12133#discussion_r2134820512 that we weren't being consistent with how Express was being imported. To make it easier and more reliably for new contributors to pattern-match against existing code, this PR updates the codebase to be more consistent with how Express is imported:

- `Router` is always imported with a named import.
- Type like `Request` and `Response` are always imported with a named import.
- The default `express` export is still used in a few situations:
  - For things like `.static(...)`
  - For types like `Application` that don't have sufficient meaning on their own.