### PR TITLE
Split test execution into local/docker set

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
           --name=test_container \
           prairielearn/prairielearn /bin/bash
       - name: Run the JavaScript tests
-        run: docker exec --env GITHUB_ACTIONS=true test_container sh -c "make -s -C /PrairieLearn test-js"
+        run: docker exec --env GITHUB_ACTIONS=true test_container sh -c "make -s -C /PrairieLearn test-js-only-docker"
         # The JS tests hang relatively often when someone makes a mistake in a PR,
         # and the GitHub Actions default timeout is 6 hours, so the CI run keeps
         # spinning until it eventually times out. This shorter timeout helps
@@ -203,7 +203,12 @@ jobs:
           git config --global safe.directory '*'
 
       - name: Test JavaScript code
-        run: make test-js
+        run: make test-js-only-local
+      - name: Upload JavaScript coverage report to Codecov
+        uses: codecov/codecov-action@v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: javascript
 
   native-checks-js:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ start-s3rver:
 test: test-js test-python
 test-js: start-support
 	@yarn test
+test-js-only-docker: start-support
+	@yarn test:only-docker
+test-js-only-local: start-support
+	@yarn test:only-local	
 test-js-dist: start-support build
 	@yarn workspace @prairielearn/prairielearn run test:dist
 test-python:

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -11,6 +11,8 @@
     "start": "node dist/server.js",
     "start-executor": "node dist/executor.js",
     "test": "vitest run --coverage",
+    "test:only-docker": "vitest run --coverage --mode=docker-only",
+    "test:only-local": "vitest run --coverage --mode=local-only",
     "test:dist": "vitest run --coverage dist/**/*.test.js"
   },
   "dependencies": {

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -11,8 +11,8 @@
     "start": "node dist/server.js",
     "start-executor": "node dist/executor.js",
     "test": "vitest run --coverage",
-    "test:only-docker": "vitest run --coverage --mode=docker-only",
-    "test:only-local": "vitest run --coverage --mode=local-only",
+    "test:only-docker": "vitest run --coverage --mode=only-docker",
+    "test:only-local": "vitest run --coverage --mode=only-local",
     "test:dist": "vitest run --coverage dist/**/*.test.js"
   },
   "dependencies": {

--- a/apps/prairielearn/vitest.config.ts
+++ b/apps/prairielearn/vitest.config.ts
@@ -19,14 +19,15 @@ const isRunningOnDist = process.argv
   .slice(2)
   .some((arg) => arg.startsWith('dist/') || arg.includes('/dist/'));
 
-// For CI, we want to run a subset of tests natively, and a subset of tests only in Docker.
-// We control this via the `mode` argument passed to the Vitest CLI
 const dockerOnlyTests = ['src/tests/exampleCourseQuestions.test.ts'];
 
 export default defineConfig(({ mode }) => {
   let include: string[] = configDefaults.include;
   let exclude: string[] = configDefaults.exclude;
 
+  // For CI, we want to run a subset of tests natively, and a subset of tests only in Docker.
+  // We control this via the `mode` argument passed to the Vitest CLI
+  // We do this instead of defining separate projects as we want this toggle available in the root project config and this config, and projects aren't inherited by the root config.
   if (mode === 'only-docker') {
     if (isRunningOnDist) throw new Error('Cannot run only-docker tests on dist files.');
     include = dockerOnlyTests;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "start": "yarn workspace @prairielearn/prairielearn start",
     "start-workspace-host": "yarn workspace @prairielearn/workspace-host start",
     "test": "vitest run --coverage",
+    "test:only-docker": "vitest run --coverage --mode=only-docker --project @prairielearn/prairielearn",
+    "test:only-local": "vitest run --coverage --mode=only-local",
     "version": "changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn"
   },
   "dependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,6 +66,7 @@ export const sharedConfig = defineConfig({
 });
 
 export default defineConfig(async ({ mode }) => {
+  // Resolve the Vitest configuration for PrairieLearn with the given mode. By default, the configuration is not resolved with the mode.
   const { vitestConfig: prairielearnTestConfig } = await resolveConfig({
     mode,
     config: 'vitest.config.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from 'vitest/config';
-import { BaseSequencer, type TestSpecification } from 'vitest/node';
+import { BaseSequencer, type TestSpecification, resolveConfig } from 'vitest/node';
 
 // Vitest will try to intelligently sequence the test suite based on which ones
 // are slowest. However, this depends on cached data from previous runs, which
@@ -65,16 +65,30 @@ export const sharedConfig = defineConfig({
   },
 });
 
-export default mergeConfig(
-  sharedConfig,
-  defineConfig({
-    test: {
-      projects: ['packages/*', 'apps/prairielearn', 'apps/grader-host', 'apps/workspace-host'],
-      coverage: {
-        all: true,
-        reporter: ['html', 'text-summary', 'cobertura'],
-        include: ['{apps,packages}/*/src/**'],
+export default defineConfig(async ({ mode }) => {
+  const { vitestConfig: prairielearnTestConfig } = await resolveConfig({
+    mode,
+    config: 'vitest.config.ts',
+    root: 'apps/prairielearn',
+  });
+  return mergeConfig(
+    sharedConfig,
+    defineConfig({
+      test: {
+        projects: [
+          'packages/*',
+          'apps/grader-host',
+          'apps/workspace-host',
+          {
+            test: prairielearnTestConfig,
+          },
+        ],
+        coverage: {
+          all: true,
+          reporter: ['html', 'text-summary', 'cobertura'],
+          include: ['{apps,packages}/*/src/**'],
+        },
       },
-    },
-  }),
-);
+    }),
+  );
+});


### PR DESCRIPTION
- Runs a subset of tests in the local CI job, and another subset in the docker CI job.

I could potentially refactor this into a 'projects' config instead of a 'mode' toggle if needed.