### PR TITLE
Bump requests to 2.32.4 in jupyterlab-python workspace

### DIFF
--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -19,7 +19,7 @@ PuLP==3.2.1
 Pygments==2.19.1
 pyarrow==20.0.0
 pygraphviz==1.14
-requests==2.32.3
+requests==2.32.4
 scikit-image==0.25.2
 scikit-learn==1.6.1
 scipy==1.15.2


### PR DESCRIPTION
Matches the changes in #12151 and #12147, but in the jupyterlab-python workspace, which for some reason dependabot wasn't able to create yet.