### PR TITLE
Fix Socket.io graceful shutdown

### DIFF
--- a/apps/prairielearn/src/tests/helperServer.ts
+++ b/apps/prairielearn/src/tests/helperServer.ts
@@ -121,7 +121,8 @@ export async function after(): Promise<void> {
     await serverJobs.stop();
 
     // This should come after anything that will emit socket events, namely
-    // server jobs and cron.
+    // server jobs and cron. We want to try to ensure that nothing is still
+    // emitting events when we close the socket server.
     debug('after(): close socket server');
     await socketServer.close();
 

--- a/apps/prairielearn/src/tests/helperServer.ts
+++ b/apps/prairielearn/src/tests/helperServer.ts
@@ -111,9 +111,6 @@ export async function after(): Promise<void> {
     debug('after(): stop server');
     await server.stopServer();
 
-    debug('after(): close socket server');
-    await socketServer.close();
-
     debug('after(): close load estimators');
     load.close();
 
@@ -122,6 +119,11 @@ export async function after(): Promise<void> {
 
     debug('after(): close server jobs');
     await serverJobs.stop();
+
+    // This should come after anything that will emit socket events, namely
+    // server jobs and cron.
+    debug('after(): close socket server');
+    await socketServer.close();
 
     debug('after(): close cache');
     await cache.close();


### PR DESCRIPTION
This fixes the following errors that we sometimes saw during test execution.

```
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 2 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: Connection is closed.
 ❯ close node_modules/ioredis/built/redis/event_handler.js:189:25
 ❯ Socket.<anonymous> node_modules/ioredis/built/redis/event_handler.js:156:20
 ❯ Object.onceWrapper node:events:639:26
 ❯ Socket.emit node:events:524:28
 ❯ TCP.<anonymous> node:net:343:12
 ❯ TCP.callbackTrampoline node:internal/async_hooks:130:17

This error originated in "apps/prairielearn/src/tests/api.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: Connection is closed.
 ❯ close node_modules/ioredis/built/redis/event_handler.js:189:25
 ❯ Socket.<anonymous> node_modules/ioredis/built/redis/event_handler.js:156:20
 ❯ Object.onceWrapper node:events:639:26
 ❯ Socket.emit node:events:524:28
 ❯ TCP.<anonymous> node:net:343:12
 ❯ TCP.callbackTrampoline node:internal/async_hooks:130:17

This error originated in "apps/prairielearn/src/tests/api.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
```

The above errors are from https://github.com/PrairieLearn/PrairieLearn/actions/runs/15575666046/job/43859973622?pr=12133, but we've seen this randomly failing in other tests too.

I originally attempted to fix this in https://github.com/PrairieLearn/PrairieLearn/pull/12038 and then https://github.com/PrairieLearn/PrairieLearn/pull/12040. I still think those changes are part of a robust solution, but they weren't enough because they didn't swap out the adapter to ensure that anything still trying to emit messages would succeed.