### PR TITLE
Rename column for human-AI agreement when displaying AI grading stats

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
@@ -376,7 +376,7 @@ onDocumentReady(() => {
         aiGradingEnabled
           ? {
               field: 'rubric_difference',
-              title: 'AI accuracy',
+              title: 'AI agreement',
               visible: aiGradingMode,
               filterControl: 'select',
               formatter: (value: boolean, row: InstanceQuestionRow) =>


### PR DESCRIPTION
As suggested in the dev meeting, disagreements between AI and human might not necessarily mean inaccurate AI grading. We are now renaming the `AI accuracy` column to `AI agreement` to reflect this. 