### PR TITLE
Add default vscode settings file to template course

### DIFF
--- a/templateCourse/.vscode/settings.json
+++ b/templateCourse/.vscode/settings.json
@@ -2,19 +2,19 @@
   "json.schemas": [
     {
       "fileMatch": ["courseInstances/**/assessments/**/infoAssessment.json"],
-      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoAssessment.json"
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/master/apps/prairielearn/src/schemas/schemas/infoAssessment.json"
     },
     {
       "fileMatch": ["courseInstances/**/infoCourseInstance.json"],
-      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json"
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/master/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json"
     },
     {
       "fileMatch": ["infoCourse.json"],
-      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoCourse.json"
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/master/apps/prairielearn/src/schemas/schemas/infoCourse.json"
     },
     {
       "fileMatch": ["questions/**/info.json"],
-      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoQuestion.json"
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/master/apps/prairielearn/src/schemas/schemas/infoQuestion.json"
     }
   ]
 }

--- a/templateCourse/.vscode/settings.json
+++ b/templateCourse/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["courseInstances/**/assessments/**/infoAssessment.json"],
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoAssessment.json"
+    },
+    {
+      "fileMatch": ["courseInstances/**/infoCourseInstance.json"],
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json"
+    },
+    {
+      "fileMatch": ["infoCourse.json"],
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoCourse.json"
+    },
+    {
+      "fileMatch": ["questions/**/info.json"],
+      "url": "https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/refs/heads/master/apps/prairielearn/src/schemas/schemas/infoQuestion.json"
+    }
+  ]
+}


### PR DESCRIPTION
These settings should allow instructors using vscode in new courses created after this point to use vscode auto completion for JSON files. It does not affect existing courses, and it does not block instructors from overriding the settings.

This is a proposal, I welcome discussion.