### PR TITLE
Remove unnecessary optional setting in config schema

### DIFF
--- a/apps/workspace-host/src/lib/config.ts
+++ b/apps/workspace-host/src/lib/config.ts
@@ -16,7 +16,7 @@ const ConfigSchema = z.object({
   postgresqlIdleTimeoutMillis: z.number().default(30_000),
   cacheType: z.enum(['none', 'redis', 'memory']).default('none'),
   cacheKeyPrefix: z.string().default('workspace-host-cache:'),
-  redisUrl: z.string().optional().default('redis://localhost:6379/'),
+  redisUrl: z.string().default('redis://localhost:6379/'),
   runningInEc2: z.boolean().default(false),
   cacheImageRegistry: z.string().nullable().default(null),
   awsRegion: z.string().default('us-east-2'),


### PR DESCRIPTION
This config schema is set as `.optional().default(...)`, but the `.default()` implies that the input may be undefined, and the `.optional()` does not affect either input or output. Workspace host [actually expects the redis URL to be a non-null string](https://github.com/PrairieLearn/PrairieLearn/blob/7a1b707f87fce667f49bab7d6e1806a95d44bb45/apps/workspace-host/src/lib/socket-server.ts#L11), so keeping the optional here might be confusing.

Note that `apps/prairielearn` allows `redisUrl` to be null and can work without redis if necessary, so it's unaffected. The corresponding option there is nullable (not optional).

I did a quick check, and this is the only config option set as optional at the root of the config. There are config options corresponding to [objects with optional properties](https://github.com/PrairieLearn/PrairieLearn/blob/7a1b707f87fce667f49bab7d6e1806a95d44bb45/apps/prairielearn/src/lib/config.ts#L316-L317), but those have a different meaning.