### PR TITLE
Configure flaky session test to retry a few times

### DIFF
--- a/packages/session/src/index.test.ts
+++ b/packages/session/src/index.test.ts
@@ -459,7 +459,11 @@ describe('session middleware', () => {
     });
   });
 
-  it('extends the expiration date of the cookie', async () => {
+  // For unknown reasons, this test is flaky in CI. It's likely due to a race
+  // condition with the session store and the way that the middleware hooks
+  // into the response lifecycle. We haven't been able to isolate the specific
+  // cause, so we'll retry the test a few times to try to avoid a failure in CI.
+  it('extends the expiration date of the cookie', { retry: 3 }, async () => {
     const store = new MemoryStore();
 
     const app = express();


### PR DESCRIPTION
I don't love not knowing what's going on here, but I hate inactionable CI failures even more, so hopefully this is a reasonable compromise.