### PR TITLE
Explicit re-exports for Preact

### DIFF
--- a/.changeset/early-hats-thank.md
+++ b/.changeset/early-hats-thank.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/preact-cjs': minor
+---
+
+Explicit re-export for hooks and JSX to fix ESM compatibility

--- a/packages/preact-cjs/src/hooks.ts
+++ b/packages/preact-cjs/src/hooks.ts
@@ -1,1 +1,14 @@
-export * from 'original-preact/hooks';
+export {
+  useState,
+  useReducer,
+  useRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useCallback,
+  useMemo,
+  useContext,
+  useDebugValue,
+  useErrorBoundary,
+  useId,
+} from 'original-preact/hooks';

--- a/packages/preact-cjs/src/jsx-runtime.ts
+++ b/packages/preact-cjs/src/jsx-runtime.ts
@@ -1,1 +1,10 @@
-export * from 'original-preact/jsx-runtime';
+export {
+  Fragment,
+  jsx,
+  jsxs,
+  jsxDEV,
+  jsxTemplate,
+  jsxAttr,
+  jsxEscape,
+  JSX,
+} from 'original-preact/jsx-runtime';


### PR DESCRIPTION
- Imports aren't handled correctly in ESM otherwise