### PR TITLE
Use shadow DOM in file editor preview box

### DIFF
--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -110,9 +110,23 @@ window.PLFileEditor.prototype.updatePreview = async function (preview_type) {
       `<p>Unknown preview type: <code>${preview_type}</code></p>`)
     : '';
 
+  /** @type HTMLElement */
   const preview = this.element.find('.preview')[0];
-  /** @type ShadowRoot */
-  const shadowRoot = preview.shadowRoot || preview.attachShadow({ mode: 'open' });
+  let shadowRoot = preview.shadowRoot;
+  if (!shadowRoot) {
+    shadowRoot = preview.attachShadow({ mode: 'open' });
+    // MathJax includes assistive content that is not visible by default (i.e.,
+    // only readable by screen readers). The hiding of this content is found in
+    // a style tag in the head, but this tag is not applied to the shadow DOM by
+    // default, so we need to manually adopt the MathJax styles.
+    await MathJax.startup.promise;
+    const mjxStyles = document.getElementById('MJX-SVG-styles');
+    if (mjxStyles) {
+      const style = new CSSStyleSheet();
+      style.replaceSync(mjxStyles.textContent);
+      shadowRoot.adoptedStyleSheets.push(style);
+    }
+  }
   if (html_contents.trim().length === 0) {
     shadowRoot.innerHTML = default_preview_text;
   } else {
@@ -125,13 +139,6 @@ window.PLFileEditor.prototype.updatePreview = async function (preview_type) {
       sanitized_contents.includes('\\[') ||
       sanitized_contents.includes('\\]')
     ) {
-      // MathJax styles need to be applied to the shadow DOM
-      const mjxStyles = document.getElementById('MJX-SVG-styles');
-      if (mjxStyles) {
-        const style = new CSSStyleSheet();
-        style.replaceSync(mjxStyles.textContent);
-        shadowRoot.adoptedStyleSheets.push(style);
-      }
       MathJax.typesetPromise(shadowRoot.children);
     }
   }

--- a/apps/prairielearn/elements/pl-xss-safe/pl-xss-safe.mustache
+++ b/apps/prairielearn/elements/pl-xss-safe/pl-xss-safe.mustache
@@ -1,12 +1,12 @@
 <script>
-  $(async function() {
+  $(async function () {
     const element = document.getElementById('xss-{{uuid}}');
     const language = element.dataset.language;
     let code = element.dataset.code;
     // Uses the same JS library as the pl-file-editor for markdown
     // conversion and xss filter for compatibility and to avoid
     // confusion
-    if (language == "markdown") {
+    if (language === 'markdown') {
       const marked = (await import('marked')).marked;
       await MathJax.startup.promise;
       (await import('@prairielearn/marked-mathjax')).addMathjaxExtension(marked, MathJax);
@@ -15,7 +15,12 @@
     code = DOMPurify.sanitize(code);
     const shadowRoot = element.attachShadow({ mode: 'open' });
     shadowRoot.innerHTML = code;
-    // MathJax styles need to be applied to the shadow DOM
+
+    // MathJax includes assistive content that is not visible by default (i.e.,
+    // only readable by screen readers). The hiding of this content is found in
+    // a style tag in the head, but this tag is not applied to the shadow DOM by
+    // default, so we need to manually adopt the MathJax styles.
+    await MathJax.startup.promise;
     const mjxStyles = document.getElementById('MJX-SVG-styles');
     if (mjxStyles) {
       const style = new CSSStyleSheet();
@@ -25,4 +30,4 @@
     await MathJax.typesetPromise(shadowRoot.children);
   });
 </script>
-<div id="xss-{{uuid}}" data-code="{{contents}}" data-language="{{language}}"></div>
+<div id="xss-{{ uuid }}" data-code="{{ contents }}" data-language="{{ language }}"></div>


### PR DESCRIPTION
Extracted from #12214. The preview content created by some libraries that can be used in preview extensions depends on internal IDs, including in links and SVG styles. The shadow DOM allows us to stop sanitizing IDs, while still ensuring that the IDs don't spill out outside of the preview box without the need to sanitize them, which would require manually updating all references to new ID names. This kind of dependency on SVG IDs has been seen in libraries like mermaid (see #12214) and [smiles-drawer](https://github.com/reymond-group/smilesDrawer).

As an example, using the following input in the HTML or Markdown previewer:

```html
<svg width="120" height="120" viewBox="0 0 120 120">
  <style> #abc { stroke: #000066; fill: #00cc00; } </style>
  <rect id="abc" x="10" y="10" width="100" height="100" />
</svg>
```

The code above does not apply the stroke/fill style to the rectangle in master, but does in the current PR.

~~Pending: figure out how to get MathJax to typeset the content of the shadow DOM.~~ MathJax had to be handled with a small workaround, given the custom styles didn't apply automatically to the shadow DOM. The style object created by MathJax is copied to the shadow DOM to be applied there too.

There are two other parts of the code that sanitize named properties:
* pl-file-preview, for the notebook renderer. I don't expect this to be an issue there, though if someone has a use-case I'm happy to consider.
* pl-rich-text-editor. Given there isn't a lot of typical use-case for a regular user to work with anything that affects named properties, the sanitization here is just an extra layer of protection, so I believe we can keep it as is.