### PR TITLE
Update native install instructions for installing python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ lint-docs: lint-d2 lint-links lint-markdown
 
 prepare-docs-venv:
 	@if uv --version >/dev/null 2>&1; then \
-		uv venv /tmp/pldocs/venv; \
+		uv venv --python-preference only-system /tmp/pldocs/venv; \
 		uv pip install -r docs/requirements.txt --python /tmp/pldocs/venv; \
 	else \
 		python3 -m venv /tmp/pldocs/venv; \

--- a/docs/dev-guide/installingNative.md
+++ b/docs/dev-guide/installingNative.md
@@ -116,7 +116,7 @@ Most of these prerequisites can be installed using the package manager of your O
 
     !!! bug
 
-        See [astral-sh/python-build-standalone/issues/146](https://github.com/astral-sh/python-build-standalone/issues/146#issuecomment-2981797869) for why we use a system Python version.
+        See [astral-sh/python-build-standalone/issues/146](https://github.com/astral-sh/python-build-standalone/issues/146#issuecomment-2981797869) for why we use the system Python version.
 
 - Clone the latest code:
 

--- a/docs/dev-guide/installingNative.md
+++ b/docs/dev-guide/installingNative.md
@@ -95,7 +95,7 @@ Most of these prerequisites can be installed using the package manager of your O
     The main prerequisites can be installed with [Homebrew](http://brew.sh/):
 
     ```sh
-    brew install git graphviz postgresql@16 redis uv d2 node pgvector
+    brew install git graphviz postgresql@16 redis uv d2 node pgvector python@3.10
 
     # Optional; needed only for some example questions that use LaTeX
     brew install texlive
@@ -114,6 +114,10 @@ Most of these prerequisites can be installed using the package manager of your O
     corepack enable
     ```
 
+    !!! bug
+
+        See [astral-sh/python-build-standalone/issues/146](https://github.com/astral-sh/python-build-standalone/issues/146#issuecomment-2981797869) for why we use a system Python version.
+
 - Clone the latest code:
 
   ```sh
@@ -126,7 +130,7 @@ Most of these prerequisites can be installed using the package manager of your O
   === "uv"
 
         ```sh
-        uv venv --python 3.10 --seed
+        uv venv --python-preference only-system --python 3.10 --seed
         source .venv/bin/activate
         ```
 


### PR DESCRIPTION
Closes #12217; I suspect even though the bug itself is different, the root cause is fixed the same way.

Resolves a bug where the zygote cannot call subprocesses in a forked process. See https://github.com/astral-sh/python-build-standalone/issues/146#issuecomment-2981797869 for more context.