### PR TITLE
Remove Mocha configs

### DIFF
--- a/apps/grader-host/.mocharc.cjs
+++ b/apps/grader-host/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  'node-option': ['import=tsx/esm'],
-};

--- a/apps/workspace-host/.mocharc.cjs
+++ b/apps/workspace-host/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/compiled-assets/.mocharc.cjs
+++ b/packages/compiled-assets/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/config/.mocharc.cjs
+++ b/packages/config/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/csv/.mocharc.cjs
+++ b/packages/csv/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/docker-utils/.mocharc.cjs
+++ b/packages/docker-utils/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/error/.mocharc.cjs
+++ b/packages/error/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/eslint-plugin-prairielearn/.mocharc.cjs
+++ b/packages/eslint-plugin-prairielearn/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/express-list-endpoints/.mocharc.cjs
+++ b/packages/express-list-endpoints/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/flash/.mocharc.cjs
+++ b/packages/flash/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/formatter/.mocharc.cjs
+++ b/packages/formatter/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/html-ejs/.mocharc.cjs
+++ b/packages/html-ejs/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/html/.mocharc.cjs
+++ b/packages/html/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/markdown/.mocharc.cjs
+++ b/packages/markdown/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/marked-mathjax/.mocharc.cjs
+++ b/packages/marked-mathjax/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/migrations/.mocharc.cjs
+++ b/packages/migrations/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  'node-option': ['import=tsx/esm'],
-};

--- a/packages/opentelemetry/.mocharc.cjs
+++ b/packages/opentelemetry/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/path-utils/.mocharc.cjs
+++ b/packages/path-utils/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/postgres/.mocharc.cjs
+++ b/packages/postgres/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/run/.mocharc.cjs
+++ b/packages/run/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/sanitize/.mocharc.cjs
+++ b/packages/sanitize/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/session/.mocharc.cjs
+++ b/packages/session/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};

--- a/packages/zod/.mocharc.cjs
+++ b/packages/zod/.mocharc.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  require: ['tsx'],
-};


### PR DESCRIPTION
After the move to Vitest, these are unused. I missed these in the earlier conversion PRs.