### PR TITLE
Fix spacing between courses in load from disk log

### DIFF
--- a/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
+++ b/apps/prairielearn/src/pages/instructorLoadFromDisk/instructorLoadFromDisk.ts
@@ -46,7 +46,7 @@ async function update(locals: Record<string, any>) {
       const hasInfoCourseFile = await fs.pathExists(infoCourseFile);
       if (!hasInfoCourseFile) {
         job.verbose('infoCourse.json not found, skipping');
-        if (index !== config.courseDirs.length - 1) job.info('');
+        if (index !== courseDirs.size - 1) job.info('');
         return;
       }
       const syncResult = await syncFromDisk.syncOrCreateDiskToSql(courseDir, job);
@@ -54,7 +54,7 @@ async function update(locals: Record<string, any>) {
         job.fail('Sync completely failed due to invalid question sharing edit.');
         return;
       }
-      if (index !== config.courseDirs.length - 1) job.info('');
+      if (index !== courseDirs.size - 1) job.info('');
       if (syncResult.hadJsonErrors) anyCourseHadJsonErrors = true;
       if (config.chunksGenerator) {
         const chunkChanges = await updateChunksForCourse({


### PR DESCRIPTION
When using the "Load from disk" button in dev mode, the log displays the results of all course syncs, separated by blank lines. To make the log slightly cleaner the last course is not followed by a blank line. However, when this process was updated to also sync courses in the DB that are not in the config file in #11200 and #11311, the identification of the "last course" was not properly updated, causing the blank line to be missing between the config courses and the DB-only courses.