### PR TITLE
Use next available number as default when creating assessments

### DIFF
--- a/apps/prairielearn/src/lib/editors.sql
+++ b/apps/prairielearn/src/lib/editors.sql
@@ -12,16 +12,6 @@ WHERE
   AND a.deleted_at IS NULL
   AND ci.deleted_at IS NULL;
 
--- BLOCK select_assessments_with_course_instance
-SELECT
-  a.title,
-  a.tid AS assessment_directory
-FROM
-  assessments AS a
-WHERE
-  a.course_instance_id = $course_instance_id
-  AND a.deleted_at IS NULL;
-
 -- BLOCK select_course_instances_with_course
 SELECT
   ci.long_name

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -19,6 +19,7 @@ import * as sqldb from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { escapeRegExp } from '@prairielearn/sanitize';
 
+import { selectAssessments } from '../models/assessment.js';
 import {
   getCourseCommitHash,
   getLockNameForCoursePath,
@@ -645,10 +646,8 @@ export class AssessmentCopyEditor extends Editor {
     );
 
     debug('Get all existing long names');
-    const result = await sqldb.queryAsync(sql.select_assessments_with_course_instance, {
-      course_instance_id: this.course_instance.id,
-    });
-    const oldNamesLong = result.rows.map((row) => row.title);
+    const assessments = await selectAssessments({ course_instance_id: this.course_instance.id });
+    const oldNamesLong = assessments.map((row) => row.title).filter((title) => title !== null);
 
     debug('Get all existing short names');
     const oldNamesShort = await this.getExistingShortNames(assessmentsPath, 'infoAssessment.json');
@@ -843,10 +842,10 @@ export class AssessmentAddEditor extends Editor {
     );
 
     debug('Get all existing long names');
-    const result = await sqldb.queryAsync(sql.select_assessments_with_course_instance, {
-      course_instance_id: this.course_instance.id,
-    });
-    const oldNamesLong = result.rows.map((row) => row.title);
+    const assessments = await selectAssessments({ course_instance_id: this.course_instance.id });
+    const oldNamesLong = assessments.map((row) => row.title).filter((title) => title !== null);
+    const nextAssessmentNumber =
+      Math.max(0, ...assessments.map((row) => Number(row.number)).filter(Number.isFinite)) + 1;
 
     debug('Get all existing short names');
     const oldNamesShort = await this.getExistingShortNames(assessmentsPath, 'infoAssessment.json');
@@ -885,7 +884,7 @@ export class AssessmentAddEditor extends Editor {
       title: assessmentTitle,
       set: this.set,
       module: this.module,
-      number: '1',
+      number: nextAssessmentNumber.toString(),
       allowAccess: [],
       zones: [],
     };
@@ -1015,15 +1014,12 @@ async function updateInfoAssessmentFilesForTargetCourse(
   courseInstancePath: string,
   fromCourseSharingName: string,
 ) {
-  const result = await sqldb.queryAsync(sql.select_assessments_with_course_instance, {
-    course_instance_id: courseInstanceId,
-  });
-  const assessments = result.rows;
+  const assessments = await selectAssessments({ course_instance_id: courseInstanceId });
   for (const assessment of assessments) {
     const infoPath = path.join(
       courseInstancePath,
       'assessments',
-      assessment.assessment_directory,
+      assessment.tid ?? '',
       'infoAssessment.json',
     );
 

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1022,10 +1022,12 @@ async function updateInfoAssessmentFilesForTargetCourse(
 ) {
   const assessments = await selectAssessments({ course_instance_id: courseInstanceId });
   for (const assessment of assessments) {
+    // The column is technically nullable, but in practice all assessments have a TID
+    assert(assessment.tid !== null, 'assessment.tid is required');
     const infoPath = path.join(
       courseInstancePath,
       'assessments',
-      assessment.tid ?? '',
+      assessment.tid,
       'infoAssessment.json',
     );
 

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -845,7 +845,13 @@ export class AssessmentAddEditor extends Editor {
     const assessments = await selectAssessments({ course_instance_id: this.course_instance.id });
     const oldNamesLong = assessments.map((row) => row.title).filter((title) => title !== null);
     const nextAssessmentNumber =
-      Math.max(0, ...assessments.map((row) => Number(row.number)).filter(Number.isFinite)) + 1;
+      Math.max(
+        0,
+        ...assessments
+          .filter((assessment) => assessment.assessment_set.name === this.set)
+          .map((assessment) => Number(assessment.number))
+          .filter(Number.isInteger),
+      ) + 1;
 
     debug('Get all existing short names');
     const oldNamesShort = await this.getExistingShortNames(assessmentsPath, 'infoAssessment.json');


### PR DESCRIPTION
Currently, when adding a new assessment using the UI, the assessment number defaults to 1, even if there is an assessment with that number in the set. This PR changes that default to the next numeric value based on assessments on the same set (e.g., if there is an assessment with number 3 in the same set, the default for the new assessment is 4). Assessments with non-integer or non-numeric values are ignored.

This also replaces the query used to retrieve all assessments with a call to the corresponding model function.