### PR TITLE
Use "alpha preview" as label on AI question generation toggle

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.ts
@@ -207,9 +207,7 @@ export function InstructorCourseAdminSettings({
                       for="ai_question_generation_toggle"
                     >
                       Enable AI question generation
-                      <span class="badge rounded-pill text-bg-success ms-2" aria-hidden="true">
-                        Beta
-                      </span>
+                      <span class="badge rounded-pill text-bg-success ms-2">Alpha preview</span>
                     </label>
                     <div class="small text-muted">
                       Generate questions with natural language using AI.


### PR DESCRIPTION
Per offline discussion, we want to emphasize that this is a very early preview and doesn't even really meet the bar for "beta".

<img width="381" alt="Screenshot 2025-06-20 at 12 53 36" src="https://github.com/user-attachments/assets/a4a1c03e-a301-4a1f-95d6-f1c7d014dd25" />
