### PR TITLE
Ignore React in VSCode auto-suggestions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
+  "typescript.preferences.autoImportSpecifierExcludeRegexes": ["^react$"],
   "typescript.tsdk": "node_modules/typescript/lib",
   "json.schemas": [
     {


### PR DESCRIPTION
- This ensures that it correctly falls back to preact imports