### PR TITLE
Add branded types for database objects

### DIFF
--- a/apps/prairielearn/src/components/SyncErrorsAndWarnings.html.ts
+++ b/apps/prairielearn/src/components/SyncErrorsAndWarnings.html.ts
@@ -3,8 +3,8 @@ import { html, unsafeHtml } from '@prairielearn/html';
 import { ansiToHtml } from '../lib/chalk.js';
 import {
   type Assessment,
-  type Course,
-  type CourseInstance,
+  type InstructorCourse,
+  type InstructorCourseInstance,
   type Question,
 } from '../lib/db-types.js';
 
@@ -14,7 +14,7 @@ export function CourseSyncErrorsAndWarnings({
   urlPrefix,
 }: {
   authz_data: { has_course_instance_permission_edit: boolean };
-  course: Course;
+  course: InstructorCourse;
   urlPrefix: string;
 }) {
   return SyncErrorsAndWarnings({
@@ -35,7 +35,7 @@ export function QuestionSyncErrorsAndWarnings({
 }: {
   authz_data: { has_course_instance_permission_edit: boolean };
   question: Question;
-  course: Course;
+  course: InstructorCourse;
   urlPrefix: string;
 }) {
   return SyncErrorsAndWarnings({
@@ -55,8 +55,8 @@ export function CourseInstanceSyncErrorsAndWarnings({
   urlPrefix,
 }: {
   authz_data: { has_course_instance_permission_edit: boolean };
-  courseInstance: CourseInstance;
-  course: Course;
+  courseInstance: InstructorCourseInstance;
+  course: InstructorCourse;
   urlPrefix: string;
 }) {
   return SyncErrorsAndWarnings({
@@ -78,8 +78,8 @@ export function AssessmentSyncErrorsAndWarnings({
 }: {
   authz_data: { has_course_instance_permission_edit: boolean };
   assessment: Assessment;
-  courseInstance: CourseInstance;
-  course: Course;
+  courseInstance: InstructorCourseInstance;
+  course: InstructorCourse;
   urlPrefix: string;
 }) {
   return SyncErrorsAndWarnings({

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -312,7 +312,10 @@ export const ClientFingerprintSchema = z.object({
 });
 export type ClientFingerprint = z.infer<typeof ClientFingerprintSchema>;
 
-export const CourseSchema = z.object({
+/**
+ * Includes fields that are safe to expose to students.
+ */
+export const StudentCourseSchema = z.object({
   announcement_color: z.string().nullable(),
   announcement_html: z.string().nullable(),
   branch: z.string(),
@@ -328,36 +331,71 @@ export const CourseSchema = z.object({
   options: z.any(),
   path: z.string(),
   repository: z.string().nullable(),
-  sharing_name: z.string().nullable(),
-  sharing_token: z.string(),
   short_name: z.string().nullable(),
   show_getting_started: z.boolean(),
+  template_course: z.boolean(),
+  title: z.string().nullable(),
+});
+export type StudentCourse = z.infer<typeof StudentCourseSchema>;
+
+/**
+ * Includes fields that are safe to expose to instructors.
+ */
+export const InstructorCourseSchema = z.object({
+  ...StudentCourseSchema.shape,
+  sharing_name: z.string().nullable(),
+  sharing_token: z.string(),
   sync_errors: z.string().nullable(),
   sync_job_sequence_id: IdSchema.nullable(),
   sync_warnings: z.string().nullable(),
-  template_course: z.boolean(),
-  title: z.string().nullable(),
+});
+export type InstructorCourse = z.infer<typeof InstructorCourseSchema>;
+/**
+ * Includes all fields.
+ */
+export const CourseSchema = z.object({
+  ...InstructorCourseSchema.shape,
   yearly_enrollment_limit: z.number().nullable(),
 });
 export type Course = z.infer<typeof CourseSchema>;
 
-export const CourseInstanceSchema = z.object({
+/**
+ * Includes fields that are safe to expose to students.
+ */
+export const StudentCourseInstanceSchema = z.object({
   assessments_group_by: z.enum(['Set', 'Module']),
   course_id: IdSchema,
   deleted_at: DateFromISOString.nullable(),
   display_timezone: z.string(),
-  enrollment_limit: z.number().nullable(),
   hide_in_enroll_page: z.boolean().nullable(),
   id: IdSchema,
   json_comment: JsonCommentSchema.nullable(),
   long_name: z.string().nullable(),
   share_source_publicly: z.boolean(),
   short_name: z.string().nullable(),
+  uuid: z.string().nullable(),
+});
+export type StudentCourseInstance = z.infer<typeof StudentCourseInstanceSchema>;
+
+/**
+ * Includes fields that are safe to expose to instructors.
+ */
+export const InstructorCourseInstanceSchema = z.object({
+  ...StudentCourseInstanceSchema.shape,
+  enrollment_limit: z.number().nullable(),
   sync_errors: z.string().nullable(),
   sync_job_sequence_id: IdSchema.nullable(),
   sync_warnings: z.string().nullable(),
-  uuid: z.string().nullable(),
 });
+export type InstructorCourseInstance = z.infer<typeof InstructorCourseInstanceSchema>;
+
+/**
+ * Includes all fields.
+ */
+export const CourseInstanceSchema = z.object({
+  ...InstructorCourseInstanceSchema.shape,
+});
+
 export type CourseInstance = z.infer<typeof CourseInstanceSchema>;
 
 export const CourseInstanceAccessRuleSchema = z.object({
@@ -1025,7 +1063,7 @@ export const TopicSchema = z.object({
 });
 export type Topic = z.infer<typeof TopicSchema>;
 
-export const UserSchema = z.object({
+export const StudentUserSchema = z.object({
   deleted_at: DateFromISOString.nullable(),
   email: z.string().nullable(),
   institution_id: IdSchema,
@@ -1033,11 +1071,21 @@ export const UserSchema = z.object({
   lti_course_instance_id: IdSchema.nullable(),
   lti_user_id: z.string().nullable(),
   name: z.string().nullable(),
-  stripe_customer_id: z.string().nullable(),
   terms_accepted_at: DateFromISOString.nullable(),
   uid: z.string(),
-  uin: z.string().nullable(),
   user_id: IdSchema,
+});
+export type StudentUser = z.infer<typeof StudentUserSchema>;
+
+export const InstructorUserSchema = z.object({
+  ...StudentUserSchema.shape,
+  uin: z.string().nullable(),
+});
+export type InstructorUser = z.infer<typeof InstructorUserSchema>;
+
+export const UserSchema = z.object({
+  ...InstructorUserSchema.shape,
+  stripe_customer_id: z.string().nullable(),
 });
 export type User = z.infer<typeof UserSchema>;
 


### PR DESCRIPTION
The motivation for this change is to ensure that we aren't passing context to the frontend accidentally for some common types, we will start using these branded types instead.