### PR TITLE
Ignore vars that start with an underscore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -157,6 +157,7 @@ export default tseslint.config([
         {
           args: 'after-used',
           argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
         },
       ],
 


### PR DESCRIPTION
I commonly do this to omit a field from an object.

```ts
const foo = { a: 1, b: 2, c: 3, d: 4 }
const { a: _a, ...bar } = foo
```