### PR TITLE
Update needed packages for Latex installation in documentation

### DIFF
--- a/docs/dev-guide/installingNative.md
+++ b/docs/dev-guide/installingNative.md
@@ -18,14 +18,14 @@ This page describes the procedure to install and run PrairieLearn fully natively
 
 Most of these prerequisites can be installed using the package manager of your OS:
 
-=== "Ubuntu (WSL2)"
+=== "Ubuntu (including WSL2)"
 
     On Ubuntu, use `apt` for the main prerequisites:
 
     ```sh
     sudo apt install git gcc libc6-dev graphviz libgraphviz-dev redis postgresql postgresql-contrib postgresql-server-dev-all
     # Optional; needed only for some example questions that use LaTeX
-    sudo apt install texlive
+    sudo apt install texlive texlive-latex-extra texlive-fonts-extra dvipng
     ```
 
     Make sure you start Postgres:


### PR DESCRIPTION
Running question `demo/annotated/LectureVelocity/1-Introduction` locally in an environment where latex is not installed caused a few issues with dependencies. While installing `texlive` was indeed required, it was not sufficient.