### PR TITLE
Require display name for hydrated Preact components

### DIFF
--- a/apps/prairielearn/src/lib/preact.tsx
+++ b/apps/prairielearn/src/lib/preact.tsx
@@ -53,6 +53,8 @@ export function hydrate<T>(content: VNode<T>, nameOverride?: string): VNode {
   }
 
   if (!nameOverride && !Component.displayName) {
+    // This is only defined in development, not in production when the function name is minified.
+    const componentDevName = Component.name || 'UnknownComponent';
     throw new AugmentedError(
       'Component does not have a displayName or nameOverride, which is required for hydration.',
       {
@@ -60,9 +62,9 @@ export function hydrate<T>(content: VNode<T>, nameOverride?: string): VNode {
           <p>Make sure to add a displayName to the component:</p>
           <pre>
           <code>
-export const ${Component.name} = ...;
+export const ${componentDevName} = ...;
 // Add this line:
-${Component.name}.displayName = '${Component.name}';
+${componentDevName}.displayName = '${componentDevName}';
           </code>
           </pre>
         </div>`,

--- a/apps/prairielearn/src/lib/preact.tsx
+++ b/apps/prairielearn/src/lib/preact.tsx
@@ -52,12 +52,24 @@ export function hydrate<T>(content: VNode<T>, nameOverride?: string): VNode {
     throw new Error('hydrate expects a Preact component');
   }
 
-  if (!nameOverride && !Component.displayName && !Component.name) {
-    throw new Error(
-      'Component does not have a name or displayName -- provide a nameOverride for the component.',
+  if (!nameOverride && !Component.displayName) {
+    throw new AugmentedError(
+      'Component does not have a displayName or nameOverride, which is required for hydration.',
+      {
+        info: html`<div>
+          <p>Make sure to add a displayName to the component:</p>
+          <pre>
+          <code>
+export const ${Component.name} = ...;
+// Add this line:
+${Component.name}.displayName = '${Component.name}';
+          </code>
+          </pre>
+        </div>`,
+      },
     );
   }
-  const componentName = `${nameOverride || Component.name || Component.displayName}`;
+  const componentName = `${nameOverride || Component.displayName}`;
   const scriptPath = `esm-bundles/react-fragments/${componentName}.ts`;
   let compiledScriptSrc = '';
   try {


### PR DESCRIPTION
We can't rely on `Component.name` because for production builds, this is a mangled/minified value that isn't useful to us.