### PR TITLE
Show selected course instance in navbar

### DIFF
--- a/apps/prairielearn/src/components/Navbar.html.ts
+++ b/apps/prairielearn/src/components/Navbar.html.ts
@@ -766,6 +766,13 @@ function NavbarButtons({
     });
   }
 
+  if (resLocals.course_instance) {
+    allNavbarButtons.push({
+      text: resLocals.course_instance.short_name,
+      href: `/pl/course_instance/${resLocals.course_instance.id}/instructor/instance_admin/assessments`,
+    });
+  }
+
   return html`
     ${allNavbarButtons.map((navbarButton, index) =>
       NavbarButton({


### PR DESCRIPTION
As noted in feedback about the new nav experience (https://github.com/PrairieLearn/PrairieLearn/discussions/12230#discussioncomment-13565161), it's impossible to tell what course instance you're looking at if the sidebar is collapsed. This PR adds a link to the navbar with the selected course instance ("SectionA" in the following screenshot):

<img width="471" alt="navbar" src="https://github.com/user-attachments/assets/6a989236-2884-4347-8b4e-9c2fd93a906b" />
