### PR TITLE
Update sidebar styles

### DIFF
--- a/apps/prairielearn/assets/stylesheets/pageLayout.css
+++ b/apps/prairielearn/assets/stylesheets/pageLayout.css
@@ -20,9 +20,14 @@ body:has(div.app-container) {
   height: 100%;
   width: 100%;
   transition: 300ms;
+  /**
+   * The width of the sidebar is set to 25ch, which is dependent on the font size.
+   * This should ensure that the sidebar is wide enough to accommodate its content,
+   * while also being responsive to changes in font size.
+   */
   grid-template:
     'top-nav top-nav' auto
-    'side-nav content' 1fr / 300px 1fr;
+    'side-nav content' 1fr / 25ch 1fr;
 }
 
 .app-top-nav {
@@ -83,7 +88,7 @@ body:has(div.app-container) {
   width: 4px;
   position: absolute;
   left: -0.5rem;
-  background-color: var(--bs-secondary);
+  background-color: var(--bs-primary);
   border-top-right-radius: 0.25rem;
   border-bottom-right-radius: 0.25rem;
 }
@@ -140,7 +145,7 @@ body:has(div.app-container) {
   .app-container.side-nav-enabled.collapsed {
     grid-template:
       'top-nav top-nav' auto
-      'side-nav content' 1fr / 50px 1fr;
+      'side-nav content' 1fr / 60px 1fr;
   }
 
   .app-container.side-nav-enabled.collapsed #course-dropdown {
@@ -149,11 +154,6 @@ body:has(div.app-container) {
 
   .app-container.side-nav-enabled.collapsed #course-instance-dropdown {
     display: none;
-  }
-
-  .app-container.side-nav-enabled.collapsed .app-side-nav {
-    padding: 0.5rem 0;
-    padding-top: 0.3rem;
   }
 
   .app-container.side-nav-enabled.collapsed .side-nav-group {
@@ -207,7 +207,8 @@ body:has(div.app-container) {
   }
 
   .app-container.side-nav-enabled.collapsed #side-nav-toggler {
-    padding: 0.5rem 1rem;
+    padding: 0.5rem 0rem;
+    width: 100%;
   }
 
   .app-container.side-nav-enabled.mobile-collapsed .app-side-nav {


### PR DESCRIPTION
This PR makes several adjustments to the new navigation sidebar based on feedback we've received.

## Selected indicator

The "selected" indicator is now shown even when the sidebar is collapsed:

<img width="426" alt="Screenshot 2025-06-24 at 12 27 41" src="https://github.com/user-attachments/assets/f443d5c2-12c8-497a-b833-334add8b3f9e" />
<img width="426" alt="Screenshot 2025-06-24 at 12 27 28" src="https://github.com/user-attachments/assets/c81e05c6-b66d-41a8-824e-62455a149823" />

Previously, only the background changed, which was difficult to see and lacked sufficient contrast:

<img width="426" alt="Screenshot 2025-06-24 at 12 33 24" src="https://github.com/user-attachments/assets/52fedf8b-be10-4fd0-9260-63a77cf0e938" />

I also changed it from `secondary` to `primary` color. I liked the pop of color, but I'm happy to change it back if folks prefer the more muted look.

## Adjusted widths

I adjusted both the collapsed and expanded widths.

- The collapsed sidebar is now 10px wider to account for the space needed to add the selected indicator while still maintaining a reasonable click target size.
- The expanded sidebar is now narrower by ~50px, which allows for more of the page to be used for content. The width now depends on the font size, so it'll be responsive to users increasing their font size for accessibility reasons.
