### PR TITLE
Use unique tooltips on the collapsed sidebar

### DIFF
--- a/apps/prairielearn/src/components/SideNav.html.ts
+++ b/apps/prairielearn/src/components/SideNav.html.ts
@@ -23,6 +23,7 @@ interface SideNavTabInfo {
   urlSuffix: string | ((resLocals: Record<string, any>) => string);
   iconClasses: string;
   tabLabel: string;
+  tabTooltip?: string;
   htmlSuffix?: (resLocals: Record<string, any>) => HtmlValue;
   renderCondition?: (resLocals: Record<string, any>) => boolean;
 }
@@ -52,7 +53,7 @@ const sideNavPagesTabs = {
       activeSubPages: ['instances'],
       urlSuffix: '/course_admin/instances',
       iconClasses: 'fas fa-chalkboard-teacher fa-fw',
-      tabLabel: 'Course Instances',
+      tabLabel: 'Course instances',
     },
     {
       activePages: ['course_admin', 'question'],
@@ -95,6 +96,7 @@ const sideNavPagesTabs = {
       urlSuffix: '/course_admin/file_view',
       iconClasses: 'fa fa-edit fa-fw',
       tabLabel: 'Files',
+      tabTooltip: 'Course files',
       renderCondition: ({ authz_data }) => authz_data.has_course_permission_view,
     },
     {
@@ -103,6 +105,7 @@ const sideNavPagesTabs = {
       urlSuffix: '/course_admin/settings',
       iconClasses: 'fas fa-cog fa-fw',
       tabLabel: 'Settings',
+      tabTooltip: 'Course settings',
     },
   ],
   instance_admin: [
@@ -128,6 +131,7 @@ const sideNavPagesTabs = {
       urlSuffix: '/instance_admin/file_view',
       iconClasses: 'fa fa-edit fa-fw',
       tabLabel: 'Files',
+      tabTooltip: 'Course instance files',
     },
     {
       activePages: ['instance_admin'],
@@ -143,6 +147,7 @@ const sideNavPagesTabs = {
       urlSuffix: '/instance_admin/settings',
       iconClasses: 'fas fa-cog fa-fw',
       tabLabel: 'Settings',
+      tabTooltip: 'Course instance settings',
     },
   ],
 } satisfies Partial<Record<Exclude<NavPage, undefined>, SideNavTabInfo[]>>;
@@ -324,6 +329,7 @@ function SideNavLink({
     activeSubPages,
     iconClasses,
     tabLabel,
+    tabTooltip,
     htmlSuffix,
     renderCondition,
   } = tabInfo;
@@ -347,7 +353,7 @@ function SideNavLink({
       aria-current="${isActive ? 'page' : ''}"
       data-bs-toggle="${!sideNavExpanded ? 'tooltip' : ''}"
       data-bs-placement="right"
-      data-bs-title="${tabLabel}"
+      data-bs-title="${tabTooltip ?? tabLabel}"
     >
       <i class="icon flex-shrink-0 ${iconClasses}"></i>
       <span class="side-nav-link-text">${tabLabel}</span>


### PR DESCRIPTION
We received feedback that it was difficult to differentiate the course and course instance files/settings items in the sidebar when it's collapsed. This PR adds a "course" or "course instance" prefix to 

<img width="791" alt="Screenshot 2025-06-24 at 12 45 09" src="https://github.com/user-attachments/assets/ad501b0c-334c-4f83-8717-cd31ad0d5a4d" />

There may be more we can do here to make the distinction clearer without hovering/focusing the buttons, but this is a low-effort step in the right direction while we consider other changes here.