### PR TITLE
Switch to class instead of className

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAiGenerateDraftsSampleQuestions.tsx
+++ b/apps/prairielearn/assets/scripts/instructorAiGenerateDraftsSampleQuestions.tsx
@@ -90,7 +90,7 @@ function SampleQuestionSelector({
   onClickNext: () => void;
 }) {
   return (
-    <div style={{ width: '100%' }} className="d-flex align-items-center gap-2 mb-3 flex-wrap">
+    <div style={{ width: '100%' }} class="d-flex align-items-center gap-2 mb-3 flex-wrap">
       <Dropdown
         style={{ flex: 1 }}
         onSelect={(eventKey) => onSelectQuestionIndex(Number(eventKey))}
@@ -99,7 +99,7 @@ function SampleQuestionSelector({
           as="button"
           type="button"
           style={{ width: '100%' }}
-          className="btn dropdown-toggle border border-gray d-flex justify-content-between align-items-center bg-white"
+          class="btn dropdown-toggle border border-gray d-flex justify-content-between align-items-center bg-white"
         >
           {selectedQuestionName}
         </DropdownToggle>
@@ -115,7 +115,7 @@ function SampleQuestionSelector({
           ))}
         </DropdownMenu>
       </Dropdown>
-      <div className="d-flex align-items-center gap-2">
+      <div class="d-flex align-items-center gap-2">
         <Button onClick={onClickPrevious} disabled={selectedQuestionIndex === 0}>
           Previous
         </Button>
@@ -138,7 +138,7 @@ function SampleQuestionPrompt({ prompt }: { prompt: string }) {
 
   return (
     <>
-      <p className="fw-bold mb-1 mt-3">Prompt</p>
+      <p class="fw-bold mb-1 mt-3">Prompt</p>
       <p>{prompt}</p>
       <OverlayTrigger
         placement="top"

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/SampleQuestionDemo.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/SampleQuestionDemo.tsx
@@ -188,11 +188,11 @@ export function SampleQuestionDemo({
     : '';
 
   return (
-    <Card className="shadow">
+    <Card class="shadow">
       <CardHeader>
-        <div className="d-flex align-items-center gap-2">
-          <p className="mb-0">{prompt.name}</p>
-          <span className="badge rounded-pill bg-success me-3">Try me!</span>
+        <div class="d-flex align-items-center gap-2">
+          <p class="mb-0">{prompt.name}</p>
+          <span class="badge rounded-pill bg-success me-3">Try me!</span>
         </div>
       </CardHeader>
       <CardBody>
@@ -238,12 +238,12 @@ export function SampleQuestionDemo({
         )}
       </CardBody>
       <CardFooter>
-        <div className="d-flex flex-wrap justify-content-end align-items-center gap-2">
+        <div class="d-flex flex-wrap justify-content-end align-items-center gap-2">
           <i>Answer: {answerText}</i>
-          <div className="flex-grow-1"></div>
-          <div className="d-flex align-items-center gap-2">
+          <div class="flex-grow-1"></div>
+          <div class="d-flex align-items-center gap-2">
             <Button onClick={handleGenerateNewVariant}>
-              <span className="text-nowrap">New variant</span>
+              <span class="text-nowrap">New variant</span>
             </Button>
 
             <Button onClick={handleGrade}>Grade</Button>
@@ -265,7 +265,7 @@ function FeedbackBadge({ grade }: { grade: number }) {
     }
   });
   return (
-    <span className={`badge ${badgeType}`}>
+    <span class={`badge ${badgeType}`}>
       {Math.floor(grade)}
       {'%'}
     </span>
@@ -288,7 +288,7 @@ function NumericOrStringInput({
   onChange: (text: string) => void;
 }) {
   return (
-    <InputGroup className="mt-2">
+    <InputGroup class="mt-2">
       <InputGroupText key={answerLabel} as="label" for="sample-question-response" id="answer-label">
         {answerLabel}
       </InputGroupText>
@@ -301,7 +301,7 @@ function NumericOrStringInput({
       />
       {(answerUnits || grade !== null) && (
         <InputGroupText>
-          {answerUnits && <span className={grade !== null ? 'me-2' : ''}>{answerUnits}</span>}
+          {answerUnits && <span class={grade !== null ? 'me-2' : ''}>{answerUnits}</span>}
           {grade !== null && <FeedbackBadge grade={grade} />}
         </InputGroupText>
       )}
@@ -323,7 +323,7 @@ function CheckboxOrRadioInput({
   onSelectOption: (option: string) => void;
 }) {
   return (
-    <div className="mt-2">
+    <div class="mt-2">
       {options.map((option) => (
         <FormCheck
           id={`check-${option.value}`}
@@ -336,7 +336,7 @@ function CheckboxOrRadioInput({
         />
       ))}
       {grade !== null && (
-        <div className="mt-2">
+        <div class="mt-2">
           <FeedbackBadge grade={grade} />
         </div>
       )}


### PR DESCRIPTION
- Since Preact doesn't need to abide by the `React` className rules, I would prefer to use class instead.