### PR TITLE
Fix alert when enabling student billing

### DIFF
--- a/apps/prairielearn/src/ee/lib/billing/components/InstructorInstanceAdminBillingForm.html.ts
+++ b/apps/prairielearn/src/ee/lib/billing/components/InstructorInstanceAdminBillingForm.html.ts
@@ -110,11 +110,16 @@ export function InstructorInstanceAdminBillingForm(props: InstructorInstanceAdmi
   const {
     studentBillingEnabled,
     studentBillingCanChange,
+    studentBillingDidChange,
     studentBillingAlert,
     computeEnabled,
     computeCanChange,
+    computeDidChange,
     computeAlert,
   } = instructorInstanceAdminBillingState(props);
+
+  const showEnableAlert =
+    (studentBillingEnabled && studentBillingDidChange) || (computeEnabled && computeDidChange);
 
   const enrollmentLimitPercentage = Math.min(100, (enrollmentCount / enrollmentLimit) * 100);
   const enrollmentLimitExceeded = enrollmentCount > enrollmentLimit;
@@ -210,19 +215,16 @@ export function InstructorInstanceAdminBillingForm(props: InstructorInstanceAdmi
         ${MaybeAlert(computeAlert)}
       </div>
 
-      <div
-        class="alert alert-warning js-student-billing-warning"
-        data-student-billing-enabled="${studentBillingEnabled}"
-        data-compute-enabled="${computeEnabled}"
-        data-enrollment-count="${enrollmentCount}"
-        data-enrollment-limit="${enrollmentLimit}"
-        hidden
-      >
-        Any students currently enrolled in your course will lose access until they have paid for the
-        above features. If your course is currently in session, you should carefully consider the
-        impact of enabling student billing. Before proceeding, you should communicate this change to
-        your students.
-      </div>
+      ${showEnableAlert
+        ? html`
+            <div class="alert alert-warning" role="alert">
+              Any students currently enrolled in your course will lose access until they have paid
+              for the above features. If your course is currently in session, you should carefully
+              consider the impact of enabling student billing. Before proceeding, you should
+              communicate this change to your students.
+            </div>
+          `
+        : ''}
 
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
       <button type="submit" class="btn btn-primary" ${!editable ? 'disabled' : null}>Save</button>


### PR DESCRIPTION
I'm pulling this out of #12173, which is where we discovered that this alert wasn't actually wired up to anything and thus wouldn't be shown.