### PR TITLE
Add horizontal scroll to assessment instance tables

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -417,10 +417,10 @@ export function InstructorAssessmentInstance({
                           })
                         : ''}
                     </td>
-                    <td class="align-middle text-center text-nowrap">
+                    <td class="text-center text-nowrap" style="padding-top: 0.65rem;">
                       ${Scorebar(instance_question.score_perc)}
                     </td>
-                    <td class="align-middle" style="width: 1em;">
+                    <td style="width: 1em;">
                       ${resLocals.authz_data.has_course_instance_permission_edit
                         ? EditQuestionPointsScoreButton({
                             field: 'score_perc',
@@ -431,7 +431,7 @@ export function InstructorAssessmentInstance({
                           })
                         : ''}
                     </td>
-                    <td class="align-middle text-nowrap" style="width: 1em;">
+                    <td class="text-nowrap" style="width: 1em;">
                       ${resLocals.authz_data.has_course_instance_permission_edit &&
                       instance_question.status !== 'unanswered'
                         ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.ts
@@ -130,177 +130,178 @@ export function InstructorAssessmentInstance({
               : html`${resLocals.instance_user.name} (${resLocals.instance_user.uid})`}
           </h2>
         </div>
+        <div class="table-responsive">
+          <table
+            class="table table-sm table-hover two-column-description"
+            aria-label="Assessment instance summary"
+          >
+            <tbody>
+              ${resLocals.instance_group
+                ? html`
+                    <tr>
+                      <th>Name</th>
+                      <td colspan="2">${resLocals.instance_group.name}</td>
+                    </tr>
+                    <tr>
+                      <th>Group Members</th>
+                      <td colspan="2">${resLocals.instance_group_uid_list.join(', ')}</td>
+                    </tr>
+                  `
+                : html`
+                    <tr>
+                      <th>UID</th>
+                      <td colspan="2">${resLocals.instance_user.uid}</td>
+                    </tr>
+                    <tr>
+                      <th>Name</th>
+                      <td colspan="2">${resLocals.instance_user.name}</td>
+                    </tr>
+                    <tr>
+                      <th>Role</th>
+                      <td colspan="2">${resLocals.instance_role}</td>
+                    </tr>
+                  `}
+              <tr>
+                <th>Instance</th>
+                <td colspan="2">
+                  ${resLocals.assessment_instance.number} (<a
+                    href="${resLocals.plainUrlPrefix}/course_instance/${resLocals.course_instance
+                      .id}/assessment_instance/${resLocals.assessment_instance.id}"
+                    >student view</a
+                  >)
+                </td>
+              </tr>
+              ${resLocals.instance_user
+                ? html`
+                    <tr>
+                      <th>Fingerprint Changes</th>
+                      <td colspan="2">
+                        ${resLocals.assessment_instance.client_fingerprint_id_change_count}
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-ghost"
+                          id="fingerprintDescriptionPopover"
+                          data-bs-toggle="popover"
+                          data-bs-container="body"
+                          data-bs-html="false"
+                          data-bs-title="Client fingerprint changes"
+                          data-bs-content="Client fingerprints are a record of a user's IP address, user agent and session. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
+                        >
+                          <i class="fa fa-question-circle"></i>
+                        </button>
+                      </td>
+                    </tr>
+                  `
+                : ''}
 
-        <table
-          class="table table-sm table-hover two-column-description"
-          aria-label="Assessment instance summary"
-        >
-          <tbody>
-            ${resLocals.instance_group
-              ? html`
-                  <tr>
-                    <th>Name</th>
-                    <td colspan="2">${resLocals.instance_group.name}</td>
-                  </tr>
-                  <tr>
-                    <th>Group Members</th>
-                    <td colspan="2">${resLocals.instance_group_uid_list.join(', ')}</td>
-                  </tr>
-                `
-              : html`
-                  <tr>
-                    <th>UID</th>
-                    <td colspan="2">${resLocals.instance_user.uid}</td>
-                  </tr>
-                  <tr>
-                    <th>Name</th>
-                    <td colspan="2">${resLocals.instance_user.name}</td>
-                  </tr>
-                  <tr>
-                    <th>Role</th>
-                    <td colspan="2">${resLocals.instance_role}</td>
-                  </tr>
-                `}
-            <tr>
-              <th>Instance</th>
-              <td colspan="2">
-                ${resLocals.assessment_instance.number} (<a
-                  href="${resLocals.plainUrlPrefix}/course_instance/${resLocals.course_instance
-                    .id}/assessment_instance/${resLocals.assessment_instance.id}"
-                  >student view</a
-                >)
-              </td>
-            </tr>
-            ${resLocals.instance_user
-              ? html`
-                  <tr>
-                    <th>Fingerprint Changes</th>
-                    <td colspan="2">
-                      ${resLocals.assessment_instance.client_fingerprint_id_change_count}
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-ghost"
-                        id="fingerprintDescriptionPopover"
-                        data-bs-toggle="popover"
-                        data-bs-container="body"
-                        data-bs-html="false"
-                        data-bs-title="Client fingerprint changes"
-                        data-bs-content="Client fingerprints are a record of a user's IP address, user agent and session. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
-                      >
-                        <i class="fa fa-question-circle"></i>
-                      </button>
-                    </td>
-                  </tr>
-                `
-              : ''}
-
-            <tr>
-              <th>Points</th>
-              <td colspan="2">
-                <span id="total-points">
-                  ${formatPoints(resLocals.assessment_instance.points)}
-                </span>
-                <small>
-                  /<span id="total-max-points" class="text-muted"
-                    >${formatPoints(resLocals.assessment_instance.max_points)}
+              <tr>
+                <th>Points</th>
+                <td colspan="2">
+                  <span id="total-points">
+                    ${formatPoints(resLocals.assessment_instance.points)}
                   </span>
-                </small>
-                ${resLocals.authz_data.has_course_instance_permission_edit
-                  ? html`
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-secondary"
-                        id="editTotalPointsButton"
-                        data-bs-toggle="popover"
-                        data-bs-container="body"
-                        data-bs-html="true"
-                        data-bs-placement="auto"
-                        data-bs-title="Change total points"
-                        data-bs-content="${escapeHtml(
-                          EditTotalPointsForm({
-                            resLocals,
-                          }),
-                        )}"
-                      >
-                        <i class="fa fa-edit" aria-hidden="true"></i>
-                      </button>
-                    `
-                  : ''}
-              </td>
-            </tr>
-            <tr>
-              <th>Score</th>
-              <td class="align-middle" style="width: 20%;">
-                ${Scorebar(resLocals.assessment_instance.score_perc)}
-              </td>
-              <td class="align-middle" style="width: 100%;">
-                ${resLocals.authz_data.has_course_instance_permission_edit
-                  ? html`
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-secondary"
-                        id="editTotalScorePercButton"
-                        data-bs-toggle="popover"
-                        data-bs-container="body"
-                        data-bs-html="true"
-                        data-bs-placement="auto"
-                        data-bs-title="Change total percentage score"
-                        data-bs-content="${escapeHtml(
-                          EditTotalScorePercForm({
-                            resLocals,
-                          }),
-                        )}"
-                      >
-                        <i class="fa fa-edit" aria-hidden="true"></i>
-                      </button>
-                    `
-                  : ''}
-              </td>
-            </tr>
-            <tr>
-              <th>Statistics</th>
-              <td colspan="2">
-                ${resLocals.assessment_instance.include_in_statistics
-                  ? html`
-                      Included
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-ghost"
-                        data-bs-toggle="popover"
-                        data-bs-container="body"
-                        data-bs-html="true"
-                        data-bs-title="Included in statistics"
-                        data-bs-content="This assessment is included in the calculation of assessment and question statistics"
-                      >
-                        <i class="fa fa-question-circle"></i>
-                      </button>
-                    `
-                  : html`
-                      Not included
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-ghost"
-                        data-bs-toggle="popover"
-                        data-bs-container="body"
-                        data-bs-html="true"
-                        data-bs-title="Not included in statistics"
-                        data-bs-content="This assessment is not included in the calculation of assessment and question statistics because it was created by a course staff member"
-                      >
-                        <i class="fa fa-question-circle"></i>
-                      </button>
-                    `}
-              </td>
-            </tr>
-            <tr>
-              <th>Date started</th>
-              <td colspan="2">${assessment_instance_date_formatted}</td>
-            </tr>
-            <tr>
-              <th>Duration</th>
-              <td colspan="2">${assessment_instance_duration}</td>
-            </tr>
-          </tbody>
-        </table>
+                  <small>
+                    /<span id="total-max-points" class="text-muted"
+                      >${formatPoints(resLocals.assessment_instance.max_points)}
+                    </span>
+                  </small>
+                  ${resLocals.authz_data.has_course_instance_permission_edit
+                    ? html`
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-secondary"
+                          id="editTotalPointsButton"
+                          data-bs-toggle="popover"
+                          data-bs-container="body"
+                          data-bs-html="true"
+                          data-bs-placement="auto"
+                          data-bs-title="Change total points"
+                          data-bs-content="${escapeHtml(
+                            EditTotalPointsForm({
+                              resLocals,
+                            }),
+                          )}"
+                        >
+                          <i class="fa fa-edit" aria-hidden="true"></i>
+                        </button>
+                      `
+                    : ''}
+                </td>
+              </tr>
+              <tr>
+                <th>Score</th>
+                <td class="align-middle" style="width: 20%;">
+                  ${Scorebar(resLocals.assessment_instance.score_perc)}
+                </td>
+                <td class="align-middle" style="width: 100%;">
+                  ${resLocals.authz_data.has_course_instance_permission_edit
+                    ? html`
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-secondary"
+                          id="editTotalScorePercButton"
+                          data-bs-toggle="popover"
+                          data-bs-container="body"
+                          data-bs-html="true"
+                          data-bs-placement="auto"
+                          data-bs-title="Change total percentage score"
+                          data-bs-content="${escapeHtml(
+                            EditTotalScorePercForm({
+                              resLocals,
+                            }),
+                          )}"
+                        >
+                          <i class="fa fa-edit" aria-hidden="true"></i>
+                        </button>
+                      `
+                    : ''}
+                </td>
+              </tr>
+              <tr>
+                <th>Statistics</th>
+                <td colspan="2">
+                  ${resLocals.assessment_instance.include_in_statistics
+                    ? html`
+                        Included
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-ghost"
+                          data-bs-toggle="popover"
+                          data-bs-container="body"
+                          data-bs-html="true"
+                          data-bs-title="Included in statistics"
+                          data-bs-content="This assessment is included in the calculation of assessment and question statistics"
+                        >
+                          <i class="fa fa-question-circle"></i>
+                        </button>
+                      `
+                    : html`
+                        Not included
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-ghost"
+                          data-bs-toggle="popover"
+                          data-bs-container="body"
+                          data-bs-html="true"
+                          data-bs-title="Not included in statistics"
+                          data-bs-content="This assessment is not included in the calculation of assessment and question statistics because it was created by a course staff member"
+                        >
+                          <i class="fa fa-question-circle"></i>
+                        </button>
+                      `}
+                </td>
+              </tr>
+              <tr>
+                <th>Date started</th>
+                <td colspan="2">${assessment_instance_date_formatted}</td>
+              </tr>
+              <tr>
+                <th>Duration</th>
+                <td colspan="2">${assessment_instance_duration}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div class="card mb-4">
@@ -313,171 +314,173 @@ export function InstructorAssessmentInstance({
           </h2>
         </div>
 
-        <table
-          id="instanceQuestionList"
-          class="table table-sm table-hover"
-          aria-label="Assessment instance questions"
-        >
-          <thead>
-            <tr>
-              <th>Student question</th>
-              <th>Instructor question</th>
-              <th class="text-center">Auto-grading points</th>
-              <th class="text-center">Manual grading points</th>
-              <th class="text-center">Awarded points</th>
-              <th class="text-center" colspan="2">Percentage score</th>
-              <th><!--Manual grading column --></th>
-              <th class="text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${instance_questions.map((instance_question) => {
-              return html`
-                ${instance_question.start_new_zone && instance_question.zone_title
-                  ? html`
-                      <tr>
-                        <th colspan="9">
-                          ${instance_question.zone_title}
-                          ${instance_question.zone_has_max_points
-                            ? html`(maximum ${instance_question.zone_max_points} points)}`
-                            : ''}
-                          ${instance_question.zone_has_best_questions
-                            ? html`(best ${instance_question.zone_best_questions} questions)}`
-                            : ''}
-                        </th>
-                      </tr>
-                    `
-                  : ''}
-                <tr>
-                  <td>
-                    S-${instance_question.question_number}. (<a
-                      href="${resLocals.plainUrlPrefix}/course_instance/${resLocals.course_instance
-                        .id}/instance_question/${instance_question.id}/"
-                      >student view</a
-                    >)
-                  </td>
-                  <td>
-                    I-${instance_question.instructor_question_number}. ${instance_question.qid}
-                    ${resLocals.authz_data.has_course_permission_preview
-                      ? html`
-                          (<a
-                            href="${resLocals.urlPrefix}/question/${instance_question.question_id}/"
-                            >instructor view</a
-                          >)
-                        `
-                      : ''}
-                  </td>
-                  <td class="text-center">
-                    ${InstanceQuestionPoints({
-                      instance_question,
-                      assessment_question: instance_question.assessment_question,
-                      component: 'auto',
-                    })}
-                    ${resLocals.authz_data.has_course_instance_permission_edit
-                      ? EditQuestionPointsScoreButton({
-                          field: 'auto_points',
-                          instance_question,
-                          assessment_question: instance_question.assessment_question,
-                          urlPrefix: resLocals.urlPrefix,
-                          csrfToken: resLocals.__csrf_token,
-                        })
-                      : ''}
-                  </td>
-                  <td class="text-center">
-                    ${InstanceQuestionPoints({
-                      instance_question,
-                      assessment_question: instance_question.assessment_question,
-                      component: 'manual',
-                    })}
-                    ${resLocals.authz_data.has_course_instance_permission_edit
-                      ? EditQuestionPointsScoreButton({
-                          field: 'manual_points',
-                          instance_question,
-                          assessment_question: instance_question.assessment_question,
-                          urlPrefix: resLocals.urlPrefix,
-                          csrfToken: resLocals.__csrf_token,
-                        })
-                      : ''}
-                  </td>
-                  <td class="text-center">
-                    ${InstanceQuestionPoints({
-                      instance_question,
-                      assessment_question: instance_question.assessment_question,
-                      component: 'total',
-                    })}
-                    ${resLocals.authz_data.has_course_instance_permission_edit
-                      ? EditQuestionPointsScoreButton({
-                          field: 'points',
-                          instance_question,
-                          assessment_question: instance_question.assessment_question,
-                          urlPrefix: resLocals.urlPrefix,
-                          csrfToken: resLocals.__csrf_token,
-                        })
-                      : ''}
-                  </td>
-                  <td class="align-middle text-center text-nowrap">
-                    ${Scorebar(instance_question.score_perc)}
-                  </td>
-                  <td class="align-middle" style="width: 1em;">
-                    ${resLocals.authz_data.has_course_instance_permission_edit
-                      ? EditQuestionPointsScoreButton({
-                          field: 'score_perc',
-                          instance_question,
-                          assessment_question: instance_question.assessment_question,
-                          urlPrefix: resLocals.urlPrefix,
-                          csrfToken: resLocals.__csrf_token,
-                        })
-                      : ''}
-                  </td>
-                  <td class="align-middle text-nowrap" style="width: 1em;">
-                    ${resLocals.authz_data.has_course_instance_permission_edit &&
-                    instance_question.status !== 'unanswered'
-                      ? html`
-                          <a
-                            class="btn btn-xs btn-secondary"
-                            href="${resLocals.urlPrefix}/assessment/${resLocals.assessment
-                              .id}/manual_grading/instance_question/${instance_question.id}"
-                            >Manual grading</a
-                          >
-                        `
-                      : ''}
-                  </td>
-                  <td class="text-right">
-                    <div class="dropdown js-question-actions">
-                      <button
-                        type="button"
-                        class="btn btn-secondary btn-xs dropdown-toggle"
-                        data-bs-toggle="dropdown"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                      >
-                        Action <span class="caret"></span>
-                      </button>
-                      <div class="dropdown-menu dropdown-menu-end">
-                        ${resLocals.authz_data.has_course_instance_permission_edit
-                          ? html`
-                              <button
-                                class="dropdown-item"
-                                data-bs-toggle="modal"
-                                data-bs-target="#resetQuestionVariantsModal"
-                                data-instance-question-id="${instance_question.id}"
-                              >
-                                Reset question variants
-                              </button>
-                            `
-                          : html`
-                              <button class="dropdown-item disabled" disabled>
-                                Must have editor permission
-                              </button>
-                            `}
+        <div class="table-responsive">
+          <table
+            id="instanceQuestionList"
+            class="table table-sm table-hover"
+            aria-label="Assessment instance questions"
+          >
+            <thead>
+              <tr>
+                <th>Student question</th>
+                <th>Instructor question</th>
+                <th class="text-center">Auto-grading points</th>
+                <th class="text-center">Manual grading points</th>
+                <th class="text-center">Awarded points</th>
+                <th class="text-center" colspan="2">Percentage score</th>
+                <th><!--Manual grading column --></th>
+                <th class="text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${instance_questions.map((instance_question) => {
+                return html`
+                  ${instance_question.start_new_zone && instance_question.zone_title
+                    ? html`
+                        <tr>
+                          <th colspan="9">
+                            ${instance_question.zone_title}
+                            ${instance_question.zone_has_max_points
+                              ? html`(maximum ${instance_question.zone_max_points} points)}`
+                              : ''}
+                            ${instance_question.zone_has_best_questions
+                              ? html`(best ${instance_question.zone_best_questions} questions)}`
+                              : ''}
+                          </th>
+                        </tr>
+                      `
+                    : ''}
+                  <tr>
+                    <td>
+                      S-${instance_question.question_number}. (<a
+                        href="${resLocals.plainUrlPrefix}/course_instance/${resLocals
+                          .course_instance.id}/instance_question/${instance_question.id}/"
+                        >student view</a
+                      >)
+                    </td>
+                    <td>
+                      I-${instance_question.instructor_question_number}. ${instance_question.qid}
+                      ${resLocals.authz_data.has_course_permission_preview
+                        ? html`
+                            (<a
+                              href="${resLocals.urlPrefix}/question/${instance_question.question_id}/"
+                              >instructor view</a
+                            >)
+                          `
+                        : ''}
+                    </td>
+                    <td class="text-center">
+                      ${InstanceQuestionPoints({
+                        instance_question,
+                        assessment_question: instance_question.assessment_question,
+                        component: 'auto',
+                      })}
+                      ${resLocals.authz_data.has_course_instance_permission_edit
+                        ? EditQuestionPointsScoreButton({
+                            field: 'auto_points',
+                            instance_question,
+                            assessment_question: instance_question.assessment_question,
+                            urlPrefix: resLocals.urlPrefix,
+                            csrfToken: resLocals.__csrf_token,
+                          })
+                        : ''}
+                    </td>
+                    <td class="text-center">
+                      ${InstanceQuestionPoints({
+                        instance_question,
+                        assessment_question: instance_question.assessment_question,
+                        component: 'manual',
+                      })}
+                      ${resLocals.authz_data.has_course_instance_permission_edit
+                        ? EditQuestionPointsScoreButton({
+                            field: 'manual_points',
+                            instance_question,
+                            assessment_question: instance_question.assessment_question,
+                            urlPrefix: resLocals.urlPrefix,
+                            csrfToken: resLocals.__csrf_token,
+                          })
+                        : ''}
+                    </td>
+                    <td class="text-center">
+                      ${InstanceQuestionPoints({
+                        instance_question,
+                        assessment_question: instance_question.assessment_question,
+                        component: 'total',
+                      })}
+                      ${resLocals.authz_data.has_course_instance_permission_edit
+                        ? EditQuestionPointsScoreButton({
+                            field: 'points',
+                            instance_question,
+                            assessment_question: instance_question.assessment_question,
+                            urlPrefix: resLocals.urlPrefix,
+                            csrfToken: resLocals.__csrf_token,
+                          })
+                        : ''}
+                    </td>
+                    <td class="align-middle text-center text-nowrap">
+                      ${Scorebar(instance_question.score_perc)}
+                    </td>
+                    <td class="align-middle" style="width: 1em;">
+                      ${resLocals.authz_data.has_course_instance_permission_edit
+                        ? EditQuestionPointsScoreButton({
+                            field: 'score_perc',
+                            instance_question,
+                            assessment_question: instance_question.assessment_question,
+                            urlPrefix: resLocals.urlPrefix,
+                            csrfToken: resLocals.__csrf_token,
+                          })
+                        : ''}
+                    </td>
+                    <td class="align-middle text-nowrap" style="width: 1em;">
+                      ${resLocals.authz_data.has_course_instance_permission_edit &&
+                      instance_question.status !== 'unanswered'
+                        ? html`
+                            <a
+                              class="btn btn-xs btn-secondary"
+                              href="${resLocals.urlPrefix}/assessment/${resLocals.assessment
+                                .id}/manual_grading/instance_question/${instance_question.id}"
+                              >Manual grading</a
+                            >
+                          `
+                        : ''}
+                    </td>
+                    <td class="text-right">
+                      <div class="dropdown js-question-actions">
+                        <button
+                          type="button"
+                          class="btn btn-secondary btn-xs dropdown-toggle"
+                          data-bs-toggle="dropdown"
+                          aria-haspopup="true"
+                          aria-expanded="false"
+                        >
+                          Action <span class="caret"></span>
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-end">
+                          ${resLocals.authz_data.has_course_instance_permission_edit
+                            ? html`
+                                <button
+                                  class="dropdown-item"
+                                  data-bs-toggle="modal"
+                                  data-bs-target="#resetQuestionVariantsModal"
+                                  data-instance-question-id="${instance_question.id}"
+                                >
+                                  Reset question variants
+                                </button>
+                              `
+                            : html`
+                                <button class="dropdown-item disabled" disabled>
+                                  Must have editor permission
+                                </button>
+                              `}
+                        </div>
                       </div>
-                    </div>
-                  </td>
-                </tr>
-              `;
-            })}
-          </tbody>
-        </table>
+                    </td>
+                  </tr>
+                `;
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div class="card mb-4">
@@ -489,49 +492,51 @@ export function InstructorAssessmentInstance({
               : html`${resLocals.instance_user.name} (${resLocals.instance_user.uid})`}
           </h2>
         </div>
-        <table
-          id="instanceQuestionStatsTable"
-          class="table table-sm table-hover tablesorter"
-          aria-label="Assessment instance statistics"
-        >
-          <thead>
-            <tr>
-              <th>Instructor question</th>
-              <th>Some submission</th>
-              <th>Some perfect submission</th>
-              <th>Some nonzero submission</th>
-              <th>First submission score</th>
-              <th>Last submission score</th>
-              <th>Max submission score</th>
-              <th>Average submission score</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${assessment_instance_stats.map((row) => {
-              return html`
-                <tr>
-                  <td>
-                    I-${row.number}.
-                    ${resLocals.authz_data.has_course_permission_preview
-                      ? html`
-                          <a href="${resLocals.urlPrefix}/question/${row.question_id}/"
-                            >${row.qid}</a
-                          >
-                        `
-                      : row.qid}
-                  </td>
-                  <td>${row.some_submission}</td>
-                  <td>${row.some_perfect_submission}</td>
-                  <td>${row.some_nonzero_submission}</td>
-                  <td>${formatFloat(row.first_submission_score, 2)}</td>
-                  <td>${formatFloat(row.last_submission_score, 2)}</td>
-                  <td>${formatFloat(row.max_submission_score, 2)}</td>
-                  <td>${formatFloat(row.average_submission_score, 2)}</td>
-                </tr>
-              `;
-            })}
-          </tbody>
-        </table>
+        <div class="table-responsive">
+          <table
+            id="instanceQuestionStatsTable"
+            class="table table-sm table-hover tablesorter"
+            aria-label="Assessment instance statistics"
+          >
+            <thead>
+              <tr>
+                <th>Instructor question</th>
+                <th>Some submission</th>
+                <th>Some perfect submission</th>
+                <th>Some nonzero submission</th>
+                <th>First submission score</th>
+                <th>Last submission score</th>
+                <th>Max submission score</th>
+                <th>Average submission score</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${assessment_instance_stats.map((row) => {
+                return html`
+                  <tr>
+                    <td>
+                      I-${row.number}.
+                      ${resLocals.authz_data.has_course_permission_preview
+                        ? html`
+                            <a href="${resLocals.urlPrefix}/question/${row.question_id}/"
+                              >${row.qid}</a
+                            >
+                          `
+                        : row.qid}
+                    </td>
+                    <td>${row.some_submission}</td>
+                    <td>${row.some_perfect_submission}</td>
+                    <td>${row.some_nonzero_submission}</td>
+                    <td>${formatFloat(row.first_submission_score, 2)}</td>
+                    <td>${formatFloat(row.last_submission_score, 2)}</td>
+                    <td>${formatFloat(row.max_submission_score, 2)}</td>
+                    <td>${formatFloat(row.average_submission_score, 2)}</td>
+                  </tr>
+                `;
+              })}
+            </tbody>
+          </table>
+        </div>
         <script>
           $(function () {
             $('#loginstanceQuestionStatsTable').tablesorter({
@@ -569,99 +574,101 @@ export function InstructorAssessmentInstance({
           </small>
         </div>
 
-        <table
-          id="logTable"
-          class="table table-sm table-hover tablesorter"
-          aria-label="Assessment instance log"
-        >
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>User</th>
-              ${resLocals.instance_user ? html`<th>Fingerprint</th>` : ''}
-              <th>Event</th>
-              <th>Instructor question</th>
-              <th>Student question</th>
-              <th>Data</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${assessmentInstanceLog.map((row, index) => {
-              return html`
-                <tr>
-                  <td class="text-nowrap">${row.formatted_date}</td>
-                  <td>${row.auth_user_uid ?? html`&mdash;`}</td>
-                  ${resLocals.instance_user
-                    ? row.client_fingerprint && row.client_fingerprint_number !== null
-                      ? html`
-                          <td>
-                            <button
-                              type="button"
-                              class="btn btn-xs color-${FINGERPRINT_COLORS[
-                                row.client_fingerprint_number % 6
-                              ]}"
-                              id="fingerprintPopover${row.client_fingerprint?.id}-${index}"
-                              data-bs-toggle="popover"
-                              data-bs-container="body"
-                              data-bs-html="true"
-                              data-bs-placement="auto"
-                              data-bs-title="Fingerprint ${row.client_fingerprint_number}"
-                              data-bs-custom-class="popover-wide"
-                              data-bs-content="${escapeHtml(
-                                FingerprintContent({ fingerprint: row.client_fingerprint }),
-                              )}"
-                            >
-                              ${row.client_fingerprint_number}
-                            </button>
-                          </td>
-                        `
-                      : html`<td>&mdash;</td>`
-                    : ''}
-                  <td><span class="badge color-${row.event_color}">${row.event_name}</span></td>
-                  <td>
-                    ${run(() => {
-                      if (!row.qid) return '';
-                      const text = `I-${row.instructor_question_number}. ${row.qid}`;
-                      if (!resLocals.authz_data.has_course_permission_preview) return text;
-                      return html`
-                        <a href="${resLocals.urlPrefix}/question/${row.question_id}/">${text}</a>
-                      `;
-                    })}
-                  </td>
-                  <td>
-                    ${row.student_question_number
-                      ? row.variant_id
+        <div class="table-responsive">
+          <table
+            id="logTable"
+            class="table table-sm table-hover tablesorter"
+            aria-label="Assessment instance log"
+          >
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>User</th>
+                ${resLocals.instance_user ? html`<th>Fingerprint</th>` : ''}
+                <th>Event</th>
+                <th>Instructor question</th>
+                <th>Student question</th>
+                <th>Data</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${assessmentInstanceLog.map((row, index) => {
+                return html`
+                  <tr>
+                    <td class="text-nowrap">${row.formatted_date}</td>
+                    <td>${row.auth_user_uid ?? html`&mdash;`}</td>
+                    ${resLocals.instance_user
+                      ? row.client_fingerprint && row.client_fingerprint_number !== null
                         ? html`
-                            <a
-                              href="${resLocals.plainUrlPrefix}/course_instance/${resLocals
-                                .course_instance
-                                .id}/instance_question/${row.instance_question_id}/?variant_id=${row.variant_id}"
-                            >
-                              S-${row.student_question_number}#${row.variant_number}
-                            </a>
+                            <td>
+                              <button
+                                type="button"
+                                class="btn btn-xs color-${FINGERPRINT_COLORS[
+                                  row.client_fingerprint_number % 6
+                                ]}"
+                                id="fingerprintPopover${row.client_fingerprint?.id}-${index}"
+                                data-bs-toggle="popover"
+                                data-bs-container="body"
+                                data-bs-html="true"
+                                data-bs-placement="auto"
+                                data-bs-title="Fingerprint ${row.client_fingerprint_number}"
+                                data-bs-custom-class="popover-wide"
+                                data-bs-content="${escapeHtml(
+                                  FingerprintContent({ fingerprint: row.client_fingerprint }),
+                                )}"
+                              >
+                                ${row.client_fingerprint_number}
+                              </button>
+                            </td>
                           `
-                        : html`S-${row.student_question_number}`
+                        : html`<td>&mdash;</td>`
                       : ''}
-                  </td>
-                  ${row.event_name !== 'External grading results'
-                    ? html`<td style="word-break: break-all;">
-                        ${row.data != null ? JSON.stringify(row.data) : ''}
-                      </td>`
-                    : html`
-                        <td>
-                          <a
-                            class="btn btn-primary"
-                            href="${resLocals.urlPrefix}/grading_job/${row.data?.id}"
-                          >
-                            View grading job ${row.data?.id}
-                          </a>
-                        </td>
-                      `}
-                </tr>
-              `;
-            })}
-          </tbody>
-        </table>
+                    <td><span class="badge color-${row.event_color}">${row.event_name}</span></td>
+                    <td>
+                      ${run(() => {
+                        if (!row.qid) return '';
+                        const text = `I-${row.instructor_question_number}. ${row.qid}`;
+                        if (!resLocals.authz_data.has_course_permission_preview) return text;
+                        return html`
+                          <a href="${resLocals.urlPrefix}/question/${row.question_id}/">${text}</a>
+                        `;
+                      })}
+                    </td>
+                    <td>
+                      ${row.student_question_number
+                        ? row.variant_id
+                          ? html`
+                              <a
+                                href="${resLocals.plainUrlPrefix}/course_instance/${resLocals
+                                  .course_instance
+                                  .id}/instance_question/${row.instance_question_id}/?variant_id=${row.variant_id}"
+                              >
+                                S-${row.student_question_number}#${row.variant_number}
+                              </a>
+                            `
+                          : html`S-${row.student_question_number}`
+                        : ''}
+                    </td>
+                    ${row.event_name !== 'External grading results'
+                      ? html`<td style="word-break: break-all;">
+                          ${row.data != null ? JSON.stringify(row.data) : ''}
+                        </td>`
+                      : html`
+                          <td>
+                            <a
+                              class="btn btn-primary"
+                              href="${resLocals.urlPrefix}/grading_job/${row.data?.id}"
+                            >
+                              View grading job ${row.data?.id}
+                            </a>
+                          </td>
+                        `}
+                  </tr>
+                `;
+              })}
+            </tbody>
+          </table>
+        </div>
         <script>
           $(function () {
             $('#logTable').tablesorter({


### PR DESCRIPTION
Resolves #12273. 

Added horizontal scrolling to assessment instance tables using the `table-responsive` Bootstrap class. 

![Screenshot 2025-06-25 at 10 54 26 AM](https://github.com/user-attachments/assets/77d8cd76-362e-4174-b2c6-9a9f49d63be0)

Question: On smaller viewports, the percentage score and manual grading cell content is centered, while the other cells' content is not. This is not a regression. Is this okay, or would you like to also have these towards the top of their cells?

![Screenshot 2025-06-25 at 10 54 55 AM](https://github.com/user-attachments/assets/a0085c9c-02eb-4cce-8591-7cd2840b3a46)
