### PR TITLE
Fix Integrations page button overflow

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -123,13 +123,16 @@ export function InstructorInstanceAdminLti13({
               <div class="dropdown mb-2">
                 <button
                   type="button"
-                  class="btn dropdown-toggle border border-gray"
+                  class="btn dropdown-toggle border border-gray w-100 text-start pe-4"
                   data-bs-toggle="dropdown"
                   aria-haspopup="true"
                   aria-expanded="false"
                   data-bs-boundary="window"
                 >
-                  ${instance.lti13_instance.name}: ${instance.lti13_course_instance.context_label}
+                  <span class="d-inline-block text-truncate w-100">
+                    ${instance.lti13_instance.name}: <br />
+                    ${instance.lti13_course_instance.context_label}
+                  </span>
                 </button>
                 <div class="dropdown-menu">
                   ${instances.map((i) => {


### PR DESCRIPTION
Fixes the LTI 1.3 instructor admin page instance picker dropbox button to not overflow it's column.

Before:
![image](https://github.com/user-attachments/assets/59b9b516-f63a-4cfc-add1-73926d904207)

After:
![image](https://github.com/user-attachments/assets/5f13199c-865f-48f4-9f55-4b49e72abc9d)

It's mostly a bootstrap class change, but making the button multiline gives more space for the course label.