### PR TITLE
Simplify creation of submitted files in parse function

### DIFF
--- a/apps/prairielearn/python/prairielearn/question_utils.py
+++ b/apps/prairielearn/python/prairielearn/question_utils.py
@@ -211,6 +211,9 @@ def add_submitted_file(
 ) -> None:
     """Add a submitted file to the data dictionary.
 
+    Raises:
+        ValueError: If neither `base64_contents` nor `raw_contents` is provided.
+
     Examples:
         >>> add_submitted_file(data, "foo.txt", "base64-contents", mimetype="text/plain")
         >>> data["submitted_answers"]
@@ -221,9 +224,11 @@ def add_submitted_file(
                     {"name": "bar.txt", "contents": "cmF3IGNvbnRlbnRz"}]}
     """
     if base64_contents is None:
-        # If raw_contents is None, use an empty string as the contents
+        # If raw_contents is None, raise an error
         if raw_contents is None:
-            raw_contents = b""
+            raise ValueError(
+                "No content provided for file. Either base64_contents or raw_contents must be provided."
+            )
         # If raw_contents is provided, encode it to base64
         if isinstance(raw_contents, str):
             raw_contents = raw_contents.encode("utf-8")

--- a/apps/prairielearn/python/prairielearn/question_utils.py
+++ b/apps/prairielearn/python/prairielearn/question_utils.py
@@ -5,6 +5,7 @@ from prairielearn import ...
 ```
 """
 
+import base64
 import math
 from typing import Any, Literal, TypedDict
 
@@ -203,8 +204,9 @@ def add_files_format_error(data: QuestionData, error: str) -> None:
 def add_submitted_file(
     data: QuestionData,
     file_name: str,
-    base64_contents: str,
+    base64_contents: str | None = None,
     *,
+    raw_contents: str | bytes | bytearray | None = None,
     mimetype: str | None = None,
 ) -> None:
     """Add a submitted file to the data dictionary.
@@ -213,7 +215,19 @@ def add_submitted_file(
         >>> add_submitted_file(data, "foo.txt", "base64-contents", mimetype="text/plain")
         >>> data["submitted_answers"]
         {"_files": [{"name": "foo.txt", "contents": "base64-contents", "mimetype": "text/plain"}]}
+        >>> add_submitted_file(data, "bar.txt", raw_contents="raw contents")
+        >>> data["submitted_answers"]
+        {"_files": [{"name": "foo.txt", "contents": "base64-contents", "mimetype": "text/plain"},
+                    {"name": "bar.txt", "contents": "cmF3IGNvbnRlbnRz"}]}
     """
+    if base64_contents is None:
+        # If raw_contents is None, use an empty string as the contents
+        if raw_contents is None:
+            raw_contents = b""
+        # If raw_contents is provided, encode it to base64
+        if isinstance(raw_contents, str):
+            raw_contents = raw_contents.encode("utf-8")
+        base64_contents = base64.b64encode(raw_contents).decode("utf-8")
     if data["submitted_answers"].get("_files") is None:
         data["submitted_answers"]["_files"] = []
     if isinstance(data["submitted_answers"]["_files"], list):

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -1258,6 +1258,7 @@ def test_add_submitted_file(question_data: pl.QuestionData) -> None:
     # Test adding first file
     base64_msg1 = base64.b64encode(b"msg1").decode("utf-8")
     base64_msg2 = base64.b64encode(b"msg2").decode("utf-8")
+    base64_msg3 = base64.b64encode(b"msg3").decode("utf-8")
     pl.add_submitted_file(question_data, "test1.txt", base64_msg1)
     assert question_data["submitted_answers"]["_files"] == [
         {"name": "test1.txt", "contents": base64_msg1}
@@ -1268,6 +1269,23 @@ def test_add_submitted_file(question_data: pl.QuestionData) -> None:
     assert question_data["submitted_answers"]["_files"] == [
         {"name": "test1.txt", "contents": base64_msg1},
         {"name": "test2.txt", "contents": base64_msg2},
+    ]
+
+    # Test adding third file with raw content
+    pl.add_submitted_file(question_data, "test3.txt", raw_contents="msg3")
+    assert question_data["submitted_answers"]["_files"] == [
+        {"name": "test1.txt", "contents": base64_msg1},
+        {"name": "test2.txt", "contents": base64_msg2},
+        {"name": "test3.txt", "contents": base64_msg3},
+    ]
+
+    # Test adding fourth file with no content
+    pl.add_submitted_file(question_data, "test4.txt")
+    assert question_data["submitted_answers"]["_files"] == [
+        {"name": "test1.txt", "contents": base64_msg1},
+        {"name": "test2.txt", "contents": base64_msg2},
+        {"name": "test3.txt", "contents": base64_msg3},
+        {"name": "test4.txt", "contents": ""},
     ]
 
 

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -1280,12 +1280,12 @@ def test_add_submitted_file(question_data: pl.QuestionData) -> None:
     ]
 
     # Test adding fourth file with no content
-    pl.add_submitted_file(question_data, "test4.txt")
+    with pytest.raises(ValueError, match="No content provided for file"):
+        pl.add_submitted_file(question_data, "test4.txt")
     assert question_data["submitted_answers"]["_files"] == [
         {"name": "test1.txt", "contents": base64_msg1},
         {"name": "test2.txt", "contents": base64_msg2},
         {"name": "test3.txt", "contents": base64_msg3},
-        {"name": "test4.txt", "contents": ""},
     ]
 
 

--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -140,6 +140,16 @@ Although questions with custom grading may not rely on the full grading function
     code in this case is to always cast the data to the desired type, for example `int(data["submitted_answers"][name])`. See the
     [PrairieLearn elements documentation](../elements.md) for more detailed discussion related to specific elements.
 
+The `parse()` function can also be used to create custom files to be sent to an external grader. This can be done with the `pl.add_submitted_file()` function, as in the example below:
+
+```python title="server.py"
+import prairielearn as pl
+
+def parse(data):
+    code = f"x = {data["submitted_answers"]["expression"]}"
+    pl.add_submitted_file(data, "user_code.py", raw_contents=code)
+```
+
 ## Step 5: `grade`
 
 Finally, the `grade(data)` function is called to grade the question. The grade function is responsible for:

--- a/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/info.json
+++ b/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/info.json
@@ -1,0 +1,14 @@
+{
+  "uuid": "07b694dd-dccd-4c95-84fb-149abf98e6b3",
+  "title": "Autograder demo: Fill-in-the-blank last element",
+  "topic": "Autograder",
+  "tags": ["jonatan", "code"],
+  "type": "v3",
+  "singleVariant": true,
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "enabled": true,
+    "image": "prairielearn/grader-python",
+    "timeout": 60
+  }
+}

--- a/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/question.html
+++ b/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/question.html
@@ -1,0 +1,41 @@
+<pl-question-panel>
+    <p>
+        <i>
+            This question demonstrates the creation of a file from other elements in the question. It uses a "fill-in-the-blank" model to allow students to write code elements that will be combined into a single file.
+        </i>
+    </p>
+
+    <p>
+        Complete the following function that finds the last element of a list and returns it. The function should be named <code>last_element</code> and should take a single argument, which is the list from which to extract the last element.
+    </p>
+
+    <pl-external-grader-variables params-name="names_for_user" empty="true">
+    </pl-external-grader-variables>
+
+    <p>Your code snippet should define the following functions:</p>
+    <pl-external-grader-variables params-name="names_from_user">
+        <pl-variable name="last_element" type="function">Returns the last element of a list</pl-variable>
+    </pl-external-grader-variables>
+    <pl-overlay width="600" height="200" clip="false">
+      <pl-background>
+<pl-code language="python">
+def last_element(lst: list):
+    """    Returns the last element of a list.
+    Args:
+        lst (list): The list from which to extract the last element.
+    Returns:
+        The last element of the list.
+    """
+
+    return lst[                                      ]
+</pl-code></pl-background>
+      <pl-location left="270" top="155">
+        <pl-string-input answers-name="index" display="inline" size="30" show-help-text="false"></pl-string-input>
+      </pl-location>
+    </pl-overlay>
+</pl-question-panel>
+
+<pl-submission-panel>
+    <pl-external-grader-results></pl-external-grader-results>
+    <pl-file-preview></pl-file-preview>
+</pl-submission-panel>

--- a/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/server.py
+++ b/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/server.py
@@ -1,0 +1,9 @@
+import prairielearn as pl
+
+
+def parse(data):
+    code = f"""
+def last_element(lst: list):
+    return lst[{data["submitted_answers"]["index"]}]
+    """.strip()
+    pl.add_submitted_file(data, "user_code.py", raw_contents=code)

--- a/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/tests/ans.py
+++ b/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/tests/ans.py
@@ -1,0 +1,2 @@
+def last_element(lst: list):
+    return lst[-1]

--- a/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/tests/test.py
+++ b/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/tests/test.py
@@ -1,0 +1,30 @@
+import random
+
+from code_feedback import Feedback
+from pl_helpers import name, points
+from pl_unit_test import PLTestCase
+
+
+class Test(PLTestCase):
+    @points(10)
+    @name("last_element")
+    def test_0(self):
+        num_tests = 10
+        score = 0
+        for _ in range(num_tests):
+            # Generate a random list of integers
+            lst = random.sample(range(1000), k=random.randint(1, 20))
+            check = lst.copy()
+            correct_answer = lst[-1]
+            student_answer = Feedback.call_user(self.st.last_element, lst)
+            if not Feedback.check_scalar(
+                f"last_element({check})", correct_answer, student_answer
+            ):
+                continue
+            if lst != check:
+                Feedback.add_feedback(
+                    f"Your function modified the input list {lst} to {check}. It should not modify the input list."
+                )
+                continue
+            score += 1
+        Feedback.set_score(score / num_tests)

--- a/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/tests/test.py
+++ b/exampleCourse/questions/demo/autograder/python/fillBlankLastElement/tests/test.py
@@ -23,7 +23,7 @@ class Test(PLTestCase):
                 continue
             if lst != check:
                 Feedback.add_feedback(
-                    f"Your function modified the input list {lst} to {check}. It should not modify the input list."
+                    f"Your function modified the input list {check} to {lst}. It should not modify the input list."
                 )
                 continue
             score += 1


### PR DESCRIPTION
Includes a simplified interface for instructors to create files in the `parse()` function of a question. Also creates an example question using this method, as well as basic documentation for this use. Based on discussion in #12279.