### PR TITLE
Ignore pyright errors in test files in example course

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,9 +183,9 @@ extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
 executionEnvironments = [
   # TODO: after https://github.com/tamasfe/taplo/issues/332, split with newlines
-  { root = "./graders/python", pythonVersion = "3.12", reportUntypedNamedTuple = "none", reportUntypedFunctionDecorator = "none", reportUnnecessaryComparison = "none", reportUnnecessaryIsInstance = "none", reportMissingTypeArgument = "none" },
-  { root = "./graders/c", pythonVersion = "3.12", reportArgumentType = "none", reportOperatorIssue = "none", reportAttributeAccessIssue = "none", reportIndexIssue = "none", reportCallIssue = "none", reportMissingTypeArgument = "none" },
-  { root = "./exampleCourse/questions", pythonVersion = "3.10", reportArgumentType = "none", reportUnknownParameterType = "none", reportMissingParameterType = "none", reportOperatorIssue = "none", reportCallIssue = "none", reportConstantRedefinition = "none" },
+  { root = "./graders/python", pythonVersion = "3.12", reportUntypedNamedTuple = "none", reportUntypedFunctionDecorator = "none", reportUnnecessaryComparison = "none", reportUnnecessaryIsInstance = "none", reportMissingTypeArgument = "none", extraPaths = [] },
+  { root = "./graders/c", pythonVersion = "3.12", reportArgumentType = "none", reportOperatorIssue = "none", reportAttributeAccessIssue = "none", reportIndexIssue = "none", reportCallIssue = "none", reportMissingTypeArgument = "none", extraPaths = [] },
+  { root = "./exampleCourse/questions", pythonVersion = "3.10", reportArgumentType = "none", reportUnknownParameterType = "none", reportMissingParameterType = "none", reportOperatorIssue = "none", reportCallIssue = "none", reportConstantRedefinition = "none", extraPaths = ["./apps/prairielearn/python", "./graders/python/python_autograder"] },
 ]
 reportUnnecessaryTypeIgnoreComment = "error"
 # These rules would require significant changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ ignore = [
   "./apps/prairielearn/elements/pl-checkbox",           # requires refactor
   "./apps/prairielearn/elements/pl-prairiedraw-figure", # deprecated
   "./apps/prairielearn/elements/pl-threejs",            # deprecated
-  "./exampleCourse/questions/**/tests",                 # test files
+  "./exampleCourse/questions/**/tests",                 # autograder tests, use different dependencies
 ]
 extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
@@ -186,7 +186,7 @@ executionEnvironments = [
   # TODO: after https://github.com/tamasfe/taplo/issues/332, split with newlines
   { root = "./graders/python", pythonVersion = "3.12", reportUntypedNamedTuple = "none", reportUntypedFunctionDecorator = "none", reportUnnecessaryComparison = "none", reportUnnecessaryIsInstance = "none", reportMissingTypeArgument = "none", extraPaths = [] },
   { root = "./graders/c", pythonVersion = "3.12", reportArgumentType = "none", reportOperatorIssue = "none", reportAttributeAccessIssue = "none", reportIndexIssue = "none", reportCallIssue = "none", reportMissingTypeArgument = "none", extraPaths = [] },
-  { root = "./exampleCourse/questions", pythonVersion = "3.10", reportArgumentType = "none", reportUnknownParameterType = "none", reportMissingParameterType = "none", reportOperatorIssue = "none", reportCallIssue = "none", reportConstantRedefinition = "none" }
+  { root = "./exampleCourse/questions", pythonVersion = "3.10", reportArgumentType = "none", reportUnknownParameterType = "none", reportMissingParameterType = "none", reportOperatorIssue = "none", reportCallIssue = "none", reportConstantRedefinition = "none" },
 ]
 reportUnnecessaryTypeIgnoreComment = "error"
 # These rules would require significant changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,11 +173,12 @@ include = [
   "./graders",
   "./scripts",
 ]
-exclude = [
+ignore = [
   "./apps/prairielearn/elements/pl-drawing",            # requires refactor
   "./apps/prairielearn/elements/pl-checkbox",           # requires refactor
   "./apps/prairielearn/elements/pl-prairiedraw-figure", # deprecated
   "./apps/prairielearn/elements/pl-threejs",            # deprecated
+  "./exampleCourse/questions/**/tests",                 # test files
 ]
 extraPaths = ["./apps/prairielearn/python"]
 pythonVersion = "3.10"
@@ -185,7 +186,7 @@ executionEnvironments = [
   # TODO: after https://github.com/tamasfe/taplo/issues/332, split with newlines
   { root = "./graders/python", pythonVersion = "3.12", reportUntypedNamedTuple = "none", reportUntypedFunctionDecorator = "none", reportUnnecessaryComparison = "none", reportUnnecessaryIsInstance = "none", reportMissingTypeArgument = "none", extraPaths = [] },
   { root = "./graders/c", pythonVersion = "3.12", reportArgumentType = "none", reportOperatorIssue = "none", reportAttributeAccessIssue = "none", reportIndexIssue = "none", reportCallIssue = "none", reportMissingTypeArgument = "none", extraPaths = [] },
-  { root = "./exampleCourse/questions", pythonVersion = "3.10", reportArgumentType = "none", reportUnknownParameterType = "none", reportMissingParameterType = "none", reportOperatorIssue = "none", reportCallIssue = "none", reportConstantRedefinition = "none", extraPaths = ["./apps/prairielearn/python", "./graders/python/python_autograder"] },
+  { root = "./exampleCourse/questions", pythonVersion = "3.10", reportArgumentType = "none", reportUnknownParameterType = "none", reportMissingParameterType = "none", reportOperatorIssue = "none", reportCallIssue = "none", reportConstantRedefinition = "none" }
 ]
 reportUnnecessaryTypeIgnoreComment = "error"
 # These rules would require significant changes


### PR DESCRIPTION
Without this setting, editing a test.py file for a question in example course in VSCode would cause Pylance to complain about missing imports for autograder files.

I also removed the extra paths in the graders/* files since they don't get access to the prairielearn.py content, so using the default extra paths would not give a proper type check.

I know this is an imperfect solution, since it would not distinguish Python files for server.py and tests/ directory, or files used in other graders, but this is the most common autograder language in the example course. If you don't agree with this change please feel free to reject it.