### PR TITLE
Fix @prairielearn/preact-cjs-compat/jsx-runtime

### DIFF
--- a/packages/preact-cjs-compat/src/jsx-runtime.js
+++ b/packages/preact-cjs-compat/src/jsx-runtime.js
@@ -1,1 +1,9 @@
-export * from '@prairielearn/preact-cjs/jsx-runtime';
+const jsxRuntime = require('@prairielearn/preact-cjs/jsx-runtime');
+
+module.exports.Fragment = jsxRuntime.Fragment;
+module.exports.jsx = jsxRuntime.jsx;
+module.exports.jsxs = jsxRuntime.jsxs;
+module.exports.jsxDEV = jsxRuntime.jsxDEV;
+module.exports.jsxTemplate = jsxRuntime.jsxTemplate;
+module.exports.jsxAttr = jsxRuntime.jsxAttr;
+module.exports.jsxEscape = jsxRuntime.jsxEscape;


### PR DESCRIPTION
As reported by @reteps in https://github.com/PrairieLearn/PrairieLearn/pull/12211#issuecomment-3013862776. This all of course needs to be CJS.