### PR TITLE
Fix manual grading table for AI grading

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
@@ -26,7 +26,6 @@ onDocumentReady(() => {
     instancesUrl,
     groupWork,
     maxAutoPoints,
-    aiGradingEnabled,
     aiGradingMode,
     csrfToken,
   } = decodeData<InstanceQuestionTableData>('instance-question-table-data');
@@ -293,35 +292,10 @@ onDocumentReady(() => {
             scorebarFormatter(score, row, hasCourseInstancePermissionEdit, urlPrefix, csrfToken),
           visible: !aiGradingMode,
         },
-        {
-          field: 'last_grader',
-          title: 'Graded by',
-          visible: !aiGradingMode,
-          filterControl: 'select',
-          filterCustomSearch: (text: string, value: string) => {
-            if (text === generateAiGraderName().toLowerCase()) {
-              return value.includes('js-custom-search-ai-grading');
-            }
-            return null;
-          },
-          formatter: (value: string, row: InstanceQuestionRow) =>
-            value
-              ? row.is_ai_graded
-                ? html`
-                    <span
-                      class="badge rounded-pill text-bg-light border js-custom-search-ai-grading"
-                    >
-                      ${generateAiGraderName()}
-                    </span>
-                  `.toString()
-                : row.last_grader_name
-              : '&mdash;',
-        },
-        aiGradingEnabled
+        aiGradingMode
           ? {
               field: 'ai_graded',
               title: 'Graded by',
-              visible: aiGradingMode,
               filterControl: 'select',
               formatter: (value: boolean, row: InstanceQuestionRow) => {
                 const showPlus = row.ai_grading_status !== 'None' && row.last_human_grader;
@@ -354,8 +328,30 @@ onDocumentReady(() => {
                 }
               },
             }
-          : null,
-        aiGradingEnabled
+          : {
+              field: 'last_grader',
+              title: 'Graded by',
+              filterControl: 'select',
+              filterCustomSearch: (text: string, value: string) => {
+                if (text === generateAiGraderName().toLowerCase()) {
+                  return value.includes('js-custom-search-ai-grading');
+                }
+                return null;
+              },
+              formatter: (value: string, row: InstanceQuestionRow) =>
+                value
+                  ? row.is_ai_graded
+                    ? html`
+                        <span
+                          class="badge rounded-pill text-bg-light border js-custom-search-ai-grading"
+                        >
+                          ${generateAiGraderName()}
+                        </span>
+                      `.toString()
+                    : row.last_grader_name
+                  : '&mdash;',
+            },
+        aiGradingMode
           ? {
               field: 'rubric_difference',
               title: 'AI agreement',

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
@@ -77,7 +77,6 @@ export function AssessmentQuestion({
           maxPoints: assessment_question.max_points,
           groupWork: assessment.group_work,
           maxAutoPoints: assessment_question.max_auto_points,
-          aiGradingEnabled,
           csrfToken: __csrf_token,
           aiGradingMode,
         },

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.types.ts
@@ -24,7 +24,6 @@ export interface InstanceQuestionTableData {
   groupWork: boolean;
   maxPoints: number | null;
   maxAutoPoints: number | null;
-  aiGradingEnabled: boolean;
   aiGradingMode: boolean;
   csrfToken: string;
 }


### PR DESCRIPTION
This PR fixes 2 things: 
1. Columns that only make sense in AI grading mode (`Graded by` that shows multiple graders, and `AI agreement`) should only show up in the column list in AI grading mode. I was using `aiGradingEnabled` earlier, instead of `aiGradingMode`
![image](https://github.com/user-attachments/assets/0eda70ae-ac86-44d4-a3d7-5a2b8600805a)

2. Discussion in #12260, we want to also remove the other `Graded by` (`last_grader`) column in AI grading mode to not confuse the users. I'm merging the rendering for this column conditioning on `aiGradingMode`
![image](https://github.com/user-attachments/assets/a29d1ee7-1737-47c1-8258-c2bce0eba1e5)