### PR TITLE
Fix malformed HTML in Python test

### DIFF
--- a/apps/prairielearn/python/test/traverse_test.py
+++ b/apps/prairielearn/python/test/traverse_test.py
@@ -319,7 +319,7 @@ def test_traverse_and_replace_void_elements() -> None:
     def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
         return e
 
-    html = traverse_and_replace('<div><br><input name="input"</div>', replace)
+    html = traverse_and_replace('<div><br><input name="input"></div>', replace)
     assert html == '<div><br><input name="input"></div>'
 
 


### PR DESCRIPTION
This is relevant for #12304, where this is causing a test failure.