### PR TITLE
Ignore OpenTelemetry package upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,10 @@ updates:
       # https://github.com/faisalman/ua-parser-js/issues/680
       - dependency-name: 'ua-parser-js'
         versions: ['>=2']
+      # These upgrades are blocked on Sentry:
+      # https://github.com/getsentry/sentry-javascript/issues/15737
+      # https://github.com/getsentry/sentry-javascript/issues/15213
+      - dependency-name: '@opentelemetry/*'
 
     groups:
       # Many OpenTelemetry packages are still pre-v1, so updates frequently won't
@@ -47,6 +51,8 @@ updates:
       # together, so we'll include a special group for them. Dependabot evaluates
       # groups in the order that they're listed, so this will take precedence over
       # the catch-all patch/minor group below.
+      #
+      # These upgrades are currently ignored, see the note above.
       opentelemetry:
         patterns:
           - '@opentelemetry/*'


### PR DESCRIPTION
See the note, these changes are blocked on Sentry: https://github.com/getsentry/sentry-javascript/issues/15737 and https://github.com/getsentry/sentry-javascript/issues/15213