### PR TITLE
Restore "grading" status in instance questions

### DIFF
--- a/apps/prairielearn/src/models/grading-job.sql
+++ b/apps/prairielearn/src/models/grading-job.sql
@@ -96,6 +96,19 @@ WITH
       grading_job_data AS gjd
     RETURNING
       gj.*
+  ),
+  updated_instance_question AS (
+    -- If the variant is associated with an instance question, update its
+    -- status. This is a no-op for instructor and public variants.
+    UPDATE instance_questions AS iq
+    SET
+      status = 'grading'
+    FROM
+      new_grading_job AS gj
+      JOIN submissions AS s ON (s.id = gj.submission_id)
+      JOIN variants AS v ON (v.id = s.variant_id)
+    WHERE
+      iq.id = v.instance_question_id
   )
 SELECT
   gj.*,


### PR DESCRIPTION
Resolves #12338. Sets the instance question status to "grading" between the creation of a grading job and its completion. This status used to be in place in the past, but a slightly-related change has removed this status.

Probably a good idea to wait until #12272 is merged, since the current styles don't show a proper view for the status in the corresponding badge.

No migration is created to update existing records since I expect any previous instance questions with this kind of status are likely to be updated in the near future anyway once their corresponding grading jobs complete or are cancelled.