### PR TITLE
Configure Dependabot to ignore React dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       # https://github.com/getsentry/sentry-javascript/issues/15737
       # https://github.com/getsentry/sentry-javascript/issues/15213
       - dependency-name: '@opentelemetry/*'
+      # We use Yarn `resolutions` to point these to our Preact compat packages.
+      # We don't ever care about which version is actually listed in `package.json` files.
+      - dependency-name: 'react'
+      - dependency-name: 'react-dom'
 
     groups:
       # Many OpenTelemetry packages are still pre-v1, so updates frequently won't


### PR DESCRIPTION
See inline comment for details. This will prevent PRs like #12330 in the future.