### PR TITLE
Add support for course-specific question templates

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/questionsTable.ts
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.ts
@@ -258,15 +258,16 @@ onDocumentReady(() => {
 
   $('#questionsTable').bootstrapTable(tableSettings);
 
-  // The startFromInput either has value 'Template' or 'Empty question'
+  // The startFromInput either has value 'empty', 'example' or 'course'
   const startFromInput = document.querySelector<HTMLInputElement>('#start_from');
 
-  // The templateQuestionInput lets the user select the template question to start from, and is only
-  // enabled when the startFromInput is set to 'Template'
+  // The templateQuestionInput lets the user select the template question to
+  // start from, and is only enabled when the startFromInput is set to 'example'
+  // or 'course'
   const templateQuestionInput = document.querySelector<HTMLInputElement>('#template_qid');
 
-  // The templateContainerDiv is hidden when the startFromInput is set to 'Empty question',
-  // otherwise it is shown.
+  // The templateContainerDiv is hidden when the startFromInput is set to
+  // 'empty', otherwise it is shown.
   const templateContainerDiv = document.querySelector<HTMLDivElement>('#templateContainer');
 
   if (!startFromInput || !templateQuestionInput || !templateContainerDiv) {
@@ -274,10 +275,23 @@ onDocumentReady(() => {
   }
 
   startFromInput.addEventListener('change', () => {
-    // If the startFromInput is set to 'Template', the templateQuestionInput should be visible and enabled
-    // Otherwise, it should be hidden and disabled.
-    templateQuestionInput.disabled = startFromInput.value !== 'Template';
-    templateContainerDiv.hidden = startFromInput.value !== 'Template';
+    // If the startFromInput is set to 'example' or 'course', the
+    // templateQuestionInput should be visible and enabled Otherwise, it should
+    // be hidden and disabled.
+    const isTemplateSelected = ['example', 'course'].includes(startFromInput.value);
+    templateQuestionInput.disabled = !isTemplateSelected;
+    templateContainerDiv.hidden = !isTemplateSelected;
+    // Only show template options that match the selected template type.
+    templateQuestionInput.querySelectorAll('option').forEach((option) => {
+      option.hidden = startFromInput.value !== option.dataset.templateSource;
+    });
+    // If the current selection is hidden, change selection to first non-hidden template
+    const selectedOption = templateQuestionInput.querySelector<HTMLOptionElement>('option:checked');
+    if (selectedOption?.hidden) {
+      const visibleOption =
+        templateQuestionInput.querySelector<HTMLOptionElement>('option:not([hidden])');
+      if (visibleOption) templateQuestionInput.value = visibleOption.value;
+    }
   });
 
   $(document).keydown((event) => {

--- a/apps/prairielearn/src/api/trpc/routers/course-files/createQuestion.ts
+++ b/apps/prairielearn/src/api/trpc/routers/course-files/createQuestion.ts
@@ -18,6 +18,7 @@ export const createQuestion = privateProcedure
       // Question data.
       qid: z.string().optional(),
       title: z.string().optional(),
+      template_start_from: z.enum(['empty', 'example', 'course']).optional(),
       template_qid: z.string().optional(),
       files: z.record(z.string()).optional(),
       is_draft: z.boolean().optional(),
@@ -56,6 +57,7 @@ export const createQuestion = privateProcedure
       files: opts.input.files,
       qid: opts.input.qid,
       title: opts.input.title,
+      template_start_from: opts.input.template_start_from,
       template_qid: opts.input.template_qid,
       isDraft: opts.input.is_draft,
     });

--- a/apps/prairielearn/src/components/QuestionsTable.html.ts
+++ b/apps/prairielearn/src/components/QuestionsTable.html.ts
@@ -41,7 +41,7 @@ export function QuestionsTable({
   /**
    * The template questions the user can select as a starting point when creating a new question.
    */
-  templateQuestions?: { qid: string; title: string }[];
+  templateQuestions?: { example_course: boolean; qid: string; title: string }[];
   showAddQuestionButton?: boolean;
   showAiGenerateQuestionButton?: boolean;
   showSharingSets?: boolean;
@@ -270,7 +270,7 @@ function CreateQuestionModal({
   templateQuestions,
 }: {
   csrfToken: string;
-  templateQuestions: { qid: string; title: string }[];
+  templateQuestions: { example_course: boolean; qid: string; title: string }[];
 }) {
   return Modal({
     id: 'createQuestionModal',
@@ -316,8 +316,11 @@ function CreateQuestionModal({
           required
           aria-describedby="start_from_help"
         >
-          <option value="Empty question">Empty question</option>
-          <option value="Template">Template</option>
+          <option value="empty">Empty question</option>
+          <option value="example">Default Template</option>
+          ${templateQuestions.some(({ example_course }) => !example_course)
+            ? html`<option value="course">Course-specific Template</option>`
+            : ''}
         </select>
         <small id="start_from_help" class="form-text text-muted">
           Begin with an empty question or a pre-made question template.
@@ -335,11 +338,18 @@ function CreateQuestionModal({
           disabled
         >
           ${templateQuestions.map(
-            (question) => html`<option value="${question.qid}">${question.title}</option>`,
+            (question) =>
+              html`<option
+                data-template-source="${question.example_course ? 'example' : 'course'}"
+                value="${question.qid}"
+              >
+                ${question.title}
+              </option>`,
           )}
         </select>
         <small id="template_help" class="form-text text-muted">
-          The question will be created from this template.
+          The question will be created from this template. To create your own template, create a
+          question with a QID starting with "<code>template/</code>".
         </small>
       </div>
     `,

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1375,6 +1375,7 @@ export class QuestionAddEditor extends Editor {
 
   private qid?: string;
   private title?: string;
+  private template_start_from?: 'empty' | 'example' | 'course';
   private template_qid?: string;
   private files?: Record<string, string>;
   private isDraft?: boolean;
@@ -1383,6 +1384,7 @@ export class QuestionAddEditor extends Editor {
     params: BaseEditorOptions & {
       qid?: string;
       title?: string;
+      template_start_from?: 'empty' | 'example' | 'course';
       template_qid?: string;
       files?: Record<string, string>;
       isDraft?: boolean;
@@ -1396,6 +1398,7 @@ export class QuestionAddEditor extends Editor {
     this.uuid = uuidv4();
     this.qid = params.qid;
     this.title = params.title;
+    this.template_start_from = params.template_start_from;
     this.template_qid = params.template_qid;
     this.files = params.files;
     this.isDraft = params.isDraft;
@@ -1461,12 +1464,15 @@ export class QuestionAddEditor extends Editor {
       });
     }
 
-    if (this.template_qid) {
-      const exampleCourseQuestionsPath = path.join(EXAMPLE_COURSE_PATH, 'questions');
-      const fromPath = path.join(exampleCourseQuestionsPath, this.template_qid);
+    if (this.template_start_from !== 'empty' && this.template_qid) {
+      const sourceQuestionsPath =
+        this.template_start_from === 'course'
+          ? questionsPath
+          : path.join(EXAMPLE_COURSE_PATH, 'questions');
+      const fromPath = path.join(sourceQuestionsPath, this.template_qid);
 
-      // Ensure that the template_qid folder path is fully contained in the example course questions directory
-      if (!contains(exampleCourseQuestionsPath, fromPath)) {
+      // Ensure that the template_qid folder path is fully contained in the source course questions directory
+      if (!contains(sourceQuestionsPath, fromPath)) {
         throw new AugmentedError('Invalid folder path', {
           info: html`
             <p>The path of the template question folder</p>
@@ -1475,7 +1481,7 @@ export class QuestionAddEditor extends Editor {
             </div>
             <p>must be inside the root directory</p>
             <div class="container">
-              <pre class="bg-dark text-white rounded p-2">${exampleCourseQuestionsPath}</pre>
+              <pre class="bg-dark text-white rounded p-2">${sourceQuestionsPath}</pre>
             </div>
           `,
         });

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.html.tsx
@@ -16,7 +16,7 @@ export const QuestionsPage = ({
   resLocals,
 }: {
   questions: QuestionsPageData[];
-  templateQuestions?: { qid: string; title: string }[];
+  templateQuestions?: { example_course: boolean; qid: string; title: string }[];
   course_instances: CourseInstance[];
   showAddQuestionButton: boolean;
   showAiGenerateQuestionButton: boolean;

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.sql
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.sql
@@ -1,0 +1,31 @@
+-- BLOCK select_template_questions
+WITH
+  source_courses AS (
+    SELECT
+      *
+    FROM
+      pl_courses
+    WHERE
+      example_course IS TRUE
+    UNION
+    SELECT
+      *
+    FROM
+      pl_courses
+    WHERE
+      id = $course_id
+  )
+SELECT
+  c.example_course,
+  q.qid,
+  q.title
+FROM
+  questions AS q
+  JOIN source_courses AS c ON (c.id = q.course_id)
+WHERE
+  q.qid LIKE 'template/%'
+  AND q.title IS NOT NULL
+  AND q.deleted_at IS NULL
+ORDER BY
+  c.example_course,
+  q.title;

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -68,7 +68,7 @@ const testEditData: EditData[] = [
     data: {
       qid: 'New',
       title: 'New',
-      start_from: 'Empty question',
+      start_from: 'empty',
     },
     files: new Set([
       'README.md',
@@ -92,7 +92,7 @@ const testEditData: EditData[] = [
     data: {
       qid: 'custom_id',
       title: 'Custom Question',
-      start_from: 'Empty question',
+      start_from: 'empty',
       template_qid: 'template/string-input/random',
     },
     files: new Set([

--- a/apps/prairielearn/src/tests/instructorQuestionsCreation.test.ts
+++ b/apps/prairielearn/src/tests/instructorQuestionsCreation.test.ts
@@ -73,7 +73,7 @@ describe('Creating a question', () => {
           orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
           title: 'Test Question',
           qid: 'test-question',
-          start_from: 'Empty question',
+          start_from: 'empty',
         }),
       },
     );
@@ -99,7 +99,7 @@ describe('Creating a question', () => {
     assert.isUndefined(questionInfo.shareSourcePublicly);
   });
 
-  test.sequential('create a new template question', async () => {
+  test.sequential('create a new question from the example course templates', async () => {
     // Fetch the questions page for the course instance
     const questionsResponse = await fetchCheerio(
       `${siteUrl}/pl/course_instance/1/instructor/course_admin/questions`,
@@ -118,7 +118,7 @@ describe('Creating a question', () => {
           orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
           title: 'Test Random Graph',
           qid: 'test-random-graph',
-          start_from: 'Template',
+          start_from: 'example',
           template_qid: 'template/matrix-component-input/random-graph',
         }),
       },
@@ -132,7 +132,7 @@ describe('Creating a question', () => {
     );
   });
 
-  test.sequential('verify that the new template question has the correct info', async () => {
+  test.sequential('verify that the new question has the correct info', async () => {
     const questionLivePath = path.join(questionsLiveDir, 'test-random-graph');
     const questionLiveInfoPath = path.join(questionLivePath, 'info.json');
     const questionInfo = JSON.parse(await fs.readFile(questionLiveInfoPath, 'utf8'));
@@ -195,7 +195,7 @@ describe('Creating a question', () => {
           orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
           title: 'Test Question',
           qid: 'test-question',
-          start_from: 'Empty question',
+          start_from: 'empty',
         }),
       },
     );
@@ -234,7 +234,7 @@ describe('Creating a question', () => {
           __action: 'add_question',
           __csrf_token: questionsResponse.$('input[name=__csrf_token]').val() as string,
           orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
-          start_from: 'Empty question',
+          start_from: 'empty',
         }),
       },
     );
@@ -288,7 +288,7 @@ describe('Creating a question', () => {
             orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
             title: 'New Test Question',
             qid: '../new-test-question',
-            start_from: 'Empty question',
+            start_from: 'empty',
           }),
         },
       );
@@ -317,7 +317,7 @@ describe('Creating a question', () => {
             orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
             title: 'New Test Question',
             qid: 'new-test-question',
-            start_from: 'Template',
+            start_from: 'example',
             template_qid: 'template/non-existent-template',
           }),
         },
@@ -351,7 +351,7 @@ describe('Creating a question', () => {
             orig_hash: questionsResponse.$('input[name=orig_hash]').val() as string,
             title: 'New Test Question',
             qid: 'new-test-question',
-            start_from: 'Template',
+            start_from: 'example',
             template_qid: '../template/matrix-component-input/random-graph',
           }),
         },


### PR DESCRIPTION
Allows course-owners to create templates that can be used for the creation of new questions. These can be useful when courses use a specific question style, or to create templates for custom elements, or similar patterns.

As discussed on Slack, the selection of available templates is moved from a sync process to a simpler DB query. I don't think there is a strong rationale for assuming there will be significant differences between these values, particularly since we don't make those assumptions anywhere else in the codebase.

Pending: CI tests.

Resolves #6103.