### PR TITLE
Extend help text for GitHub username in request course page

### DIFF
--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -224,8 +224,24 @@ function CourseNewRequestCard({ csrfToken }: { csrfToken: string }): HtmlValue {
             <label class="form-label" for="cr-ghuser">GitHub Username (optional)</label>
             <input type="text" class="form-control" name="cr-ghuser" id="cr-ghuser" />
             <small class="form-text text-muted">
-              Providing your GitHub username will allow you to edit course content offline. You do
-              not need to provide this if you would like to use the online web editor.
+              Providing your GitHub username will allow you to edit course content offline or run a
+              local installation of PrairieLearn. You do not need to provide this if you would like
+              to use the online web editor. You are encouraged to provide it if you are planning
+              complex questions such as questions using
+              <a
+                href="https://prairielearn.readthedocs.io/en/latest/externalGrading/"
+                target="_blank"
+                rel="noopener no referrer"
+                >external grading</a
+              >
+              (e.g., programming questions) or
+              <a
+                href="https://prairielearn.readthedocs.io/en/latest/workspaces/"
+                target="_blank"
+                rel="noopener no referrer"
+                >workspaces</a
+              >, even if you don't yet have use for a local installation. You will also be given
+              permission to add other users to the repository, such as other instructors or TAs.
             </small>
           </div>
           <div class="mb-3">

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -224,24 +224,29 @@ function CourseNewRequestCard({ csrfToken }: { csrfToken: string }): HtmlValue {
             <label class="form-label" for="cr-ghuser">GitHub Username (optional)</label>
             <input type="text" class="form-control" name="cr-ghuser" id="cr-ghuser" />
             <small class="form-text text-muted">
-              Providing your GitHub username will allow you to edit course content offline or run a
-              local installation of PrairieLearn. You do not need to provide this if you would like
-              to use the online web editor. You are encouraged to provide it if you are planning
-              complex questions such as questions using
+              Providing your GitHub username will grant you access to your course's GitHub
+              repository. This access allows you to edit your code in a
+              <a
+                href="https://prairielearn.readthedocs.io/en/latest/installing/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >local installation of PrairieLearn</a
+              >, and to grant access to other instructors or TAs to do the same. You do not need to
+              provide this if you would like to exclusively use the online web editor. You are
+              encouraged to provide it if you are planning complex questions such as those using
               <a
                 href="https://prairielearn.readthedocs.io/en/latest/externalGrading/"
                 target="_blank"
-                rel="noopener no referrer"
-                >external grading</a
+                rel="noopener noreferrer"
+                >code autograding</a
               >
-              (e.g., programming questions) or
+              or
               <a
                 href="https://prairielearn.readthedocs.io/en/latest/workspaces/"
                 target="_blank"
-                rel="noopener no referrer"
+                rel="noopener noreferrer"
                 >workspaces</a
-              >, even if you don't yet have use for a local installation. You will also be given
-              permission to add other users to the repository, such as other instructors or TAs.
+              >, even if you don't yet have use for a local installation.
             </small>
           </div>
           <div class="mb-3">

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,7 +4,7 @@ This page describes the procedure to install and run your course locally within 
 
 ## Why run PrairieLearn locally?
 
-PrairieLearn provides an online interface to create and update questions with a browser interface. While this interface is suitable for simpler questions, it is not ideal for complex cases such as:
+PrairieLearn provides the ability to create and update questions with a browser interface. While this interface is suitable for simpler questions, it is not ideal for complex cases such as:
 
 - Questions using [code autograding](externalGrading.md)
 - Questions using [workspaces](workspaces/index.md)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -12,7 +12,7 @@ PrairieLearn provides the ability to create and update questions with a browser 
 - Questions using [custom Python libraries](questionRuntime/index.md#installing-libraries-in-your-course) in the generation and/or grading process
 - Custom [elements](devElements.md) or [element extensions](elementExtensions.md)
 
-Using the course repository with a local installation simplifies the process of updating the course content. This workflow allows instructors to test changes in the question code or assessment configuration without affecting the student experience. It also helps courses with multiple staff members to collaborate and coordinate changes using [Git workflows](https://git-scm.com/book/en/v2/Distributed-Git-Distributed-Workflows) and [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+Using the course repository with a local installation simplifies the process of updating the course content. This workflow allows instructors to test changes in the question code or assessment configuration without affecting the student experience. It also supports collaboration and coordination in courses with multiple staff members using [Git workflows](https://git-scm.com/book/en/v2/Distributed-Git-Distributed-Workflows) and [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
 ## Installation instructions
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,15 +4,15 @@ This page describes the procedure to install and run your course locally within 
 
 ## Why run PrairieLearn locally?
 
-PrairieLearn provides an online interface to create and update questions with a browser interface. While this interface is suitable for simpler questions, it is not designed to properly handle more complex cases such as:
+PrairieLearn provides an online interface to create and update questions with a browser interface. While this interface is suitable for simpler questions, it is not ideal for complex cases such as:
 
-- Questions using [code autograding](externalGrading.md);
-- Questions using [workspaces](workspaces/index.md);
-- Questions that involve a significant number of [images, documents and other files](clientServerFiles.md);
-- Questions using [custom Python libraries](questionRuntime/index.md#installing-libraries-in-your-course) in the generation and/or grading process;
-- Custom [elements](devElements.md) or [element extensions](elementExtensions.md).
+- Questions using [code autograding](externalGrading.md)
+- Questions using [workspaces](workspaces/index.md)
+- Questions that involve a significant number of [images, documents and other files](clientServerFiles.md)
+- Questions using [custom Python libraries](questionRuntime/index.md#installing-libraries-in-your-course) in the generation and/or grading process
+- Custom [elements](devElements.md) or [element extensions](elementExtensions.md)
 
-For such cases, using the course repository and maintaining/testing it in a local installation simplifies the process of updating the course content. Additionally, using this workflow allows instructors to test changes in the question code or assessment configuration without affecting the student experience. It also allows courses with several staff members to more easily collaborate and coordinate changes using [Git workflows](https://git-scm.com/book/en/v2/Distributed-Git-Distributed-Workflows) and [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+Using the course repository with a local installation simplifies the process of updating the course content. This workflow allows instructors to test changes in the question code or assessment configuration without affecting the student experience. It also helps courses with multiple staff members to collaborate and coordinate changes using [Git workflows](https://git-scm.com/book/en/v2/Distributed-Git-Distributed-Workflows) and [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
 ## Installation instructions
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -2,6 +2,18 @@
 
 This page describes the procedure to install and run your course locally within Docker. You can develop course content locally following the instructions below, or using the [in-browser tools](getStarted.md).
 
+## Why run PrairieLearn locally?
+
+PrairieLearn provides an online interface to create and update questions with a browser interface. While this interface is suitable for simpler questions, it is not designed to properly handle more complex cases such as:
+
+- Questions using [code autograding](externalGrading.md);
+- Questions using [workspaces](workspaces/index.md);
+- Questions that involve a significant number of [images, documents and other files](clientServerFiles.md);
+- Questions using [custom Python libraries](questionRuntime/index.md#installing-libraries-in-your-course) in the generation and/or grading process;
+- Custom [elements](devElements.md) or [element extensions](elementExtensions.md).
+
+For such cases, using the course repository and maintaining/testing it in a local installation simplifies the process of updating the course content. Additionally, using this workflow allows instructors to test changes in the question code or assessment configuration without affecting the student experience. It also allows courses with several staff members to more easily collaborate and coordinate changes using [Git workflows](https://git-scm.com/book/en/v2/Distributed-Git-Distributed-Workflows) and [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+
 ## Installation instructions
 
 Regardless of which operating system you are using, you will need to install the appropriate version of [Docker Desktop](https://www.docker.com/products/docker-desktop/).


### PR DESCRIPTION
As discussed on Slack. Adds language that encourages users to provide GitHub username in course requests when complex questions are planned.