### PR TITLE
Enable no-duplicate-imports eslint rule

### DIFF
--- a/apps/prairielearn/src/lib/externalGraderLocal.ts
+++ b/apps/prairielearn/src/lib/externalGraderLocal.ts
@@ -14,8 +14,7 @@ import * as sqldb from '@prairielearn/postgres';
 
 import { config } from './config.js';
 import type { Course, GradingJob, Question, Submission, Variant } from './db-types.js';
-import { type Grader } from './externalGraderCommon.js';
-import { buildDirectory, makeGradingResult } from './externalGraderCommon.js';
+import { type Grader, buildDirectory, makeGradingResult } from './externalGraderCommon.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/externalGraderSqs.ts
+++ b/apps/prairielearn/src/lib/externalGraderSqs.ts
@@ -20,8 +20,7 @@ import {
   type Submission,
   type Variant,
 } from './db-types.js';
-import { type Grader } from './externalGraderCommon.js';
-import { buildDirectory, getJobDirectory } from './externalGraderCommon.js';
+import { type Grader, buildDirectory, getJobDirectory } from './externalGraderCommon.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/pages/publicAssessments/publicAssessments.ts
+++ b/apps/prairielearn/src/pages/publicAssessments/publicAssessments.ts
@@ -6,8 +6,10 @@ import * as error from '@prairielearn/error';
 import { getCourseInstanceCopyTargets } from '../../lib/copy-content.js';
 import { UserSchema } from '../../lib/db-types.js';
 import { selectAssessments } from '../../models/assessment.js';
-import { selectCourseInstanceIsPublic } from '../../models/course-instances.js';
-import { selectOptionalCourseInstanceById } from '../../models/course-instances.js';
+import {
+  selectCourseInstanceIsPublic,
+  selectOptionalCourseInstanceById,
+} from '../../models/course-instances.js';
 import { selectCourseById } from '../../models/course.js';
 import { selectQuestionsForCourseInstanceCopy } from '../../models/question.js';
 

--- a/apps/prairielearn/src/schemas/jsonSchemas.ts
+++ b/apps/prairielearn/src/schemas/jsonSchemas.ts
@@ -35,8 +35,10 @@ import {
   type QuestionCalculationOptionsJson,
   QuestionCalculationOptionsJsonSchema,
 } from './questionOptionsCalculation.js';
-import { QuestionCheckboxOptionsJsonSchema } from './questionOptionsCheckbox.js';
-import type { QuestionCheckboxOptionsJson } from './questionOptionsCheckbox.js';
+import {
+  type QuestionCheckboxOptionsJson,
+  QuestionCheckboxOptionsJsonSchema,
+} from './questionOptionsCheckbox.js';
 import {
   type QuestionFileOptionsJson,
   QuestionFileOptionsJsonSchema,

--- a/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
+++ b/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
@@ -11,8 +11,7 @@ import {
 } from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import type { User } from '../lib/db-types.js';
-import { GroupRoleSchema, QuestionSchema } from '../lib/db-types.js';
+import { GroupRoleSchema, QuestionSchema, type User } from '../lib/db-types.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
 import { generateAndEnrollUsers } from '../models/enrollment.js';
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,7 @@ export default tseslint.config([
       'no-restricted-syntax': ['error', ...NO_RESTRICTED_SYNTAX],
       'object-shorthand': 'error',
       'prefer-const': ['error', { destructuring: 'all' }],
+      'no-duplicate-imports': 'error',
 
       // Blocks double-quote strings (unless a single quote is present in the
       // string) and backticks (unless there is a tag or substitution in place).


### PR DESCRIPTION
Most cases of duplicate imports are done by mistake, and we don't have any case of legitimate duplicate imports on purpose.

The rule also has an option for no duplicate exports. It would catch this case:
https://github.com/PrairieLearn/PrairieLearn/blob/365920394d8ac7d1e0e63439804b7e1ce9607ac3/packages/sentry/src/index.ts#L87-L136
If you're ok with either joining these or using an eslint-ignore comment I can enable this option.

This rule does not have autofix, but vscode is usually pretty good at reusing existing imports when possible, so autofix should not be a big deal. If autofix is required we can consider using [`import/no-duplicates` from the eslint-plugin-import plugin](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md) (which would require a new dev dependency), however the plugin itself [discourages its use if not necessary](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md#when-not-to-use-it).