### PR TITLE
Fix empty groups in LTI grade syncing

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.sql
+++ b/apps/prairielearn/src/ee/lib/lti13.sql
@@ -101,8 +101,11 @@ SELECT
     WHEN a.group_work
     AND ai.group_id IS NOT NULL THEN (
       SELECT
-        jsonb_agg(
-          to_jsonb(users) || jsonb_build_object('lti13_sub', lti13_users.sub)
+        COALESCE(
+          jsonb_agg(
+            to_jsonb(users) || jsonb_build_object('lti13_sub', lti13_users.sub)
+          ),
+          '[]'::jsonb
         )
       FROM
         group_users


### PR DESCRIPTION
If all students leave a group, the group will be empty. Previously, this was returned from this query as `users: null`, which would fail to validate with this schema:

https://github.com/PrairieLearn/PrairieLearn/blob/ab5dc288a868c3db3303cefc248479c805a027bc/apps/prairielearn/src/ee/lib/lti13.ts#L848

Now, an empty array will be returned.