### PR TITLE
Patch Python Autograder linecaching for ipynb files

### DIFF
--- a/graders/python/python_autograder/pl_execute.py
+++ b/graders/python/python_autograder/pl_execute.py
@@ -89,8 +89,10 @@ def execute_code(
         _, extension = path.splitext(fname_student)
         if extension == ".ipynb":
             str_student = extract_ipynb_contents(f, ipynb_key)
+            fake_student_filename = "submission.py"
         else:
             str_student = f.read()
+            fake_student_filename = fname_student
     str_student = "\n".join(filter(bool, (str_leading, str_student, str_trailing)))
 
     with open(path.join(filenames_dir, "test.py"), encoding="utf-8") as f:
@@ -189,10 +191,10 @@ def execute_code(
     # code that we're going to execute, since it doesn't include the leading
     # and trailing code. We'll manually construct a `linecache` entry for it
     # so that the traceback will show the correct code for each line.
-    populate_linecache(fname_student, str_student)
+    populate_linecache(fake_student_filename, str_student)
 
     try:
-        code_student = compile(str_student, fname_student, "exec")
+        code_student = compile(str_student, fake_student_filename, "exec")
         exec(code_student, student_globals)
         err = None
     except Exception:


### PR DESCRIPTION
In the Python autograder, the linecache tracebacks for syntax errors/issues that arise when compiling codes does not work properly for ipynb files, since it reports the raw JSON lines instead of the code blocks where it was extracted from. This makes debugging for the students more difficult than it needs to be.
For example, if I create a syntax error on this line 16
```python
X, Y a= probabilities
```
Then the autograder prints this:
```
Traceback (most recent call last):
  File "/grade/run/pl_execute.py", line 195, in execute_code
    code_student = compile(str_student, fname_student, "exec")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/grade/run/SA2_assessment.ipynb", line 16
    "**Grading**:\n",
         ^^^^^^^^^^^^^
SyntaxError: invalid syntax. Maybe you meant '==' or ':=' instead of '='?
```
Where the line 16 in the ipynb is a mismatched JSON entry which does not say `X, Y a= probabilities`, where the syntax error is actually located. By changing the filename from where the linecache is based on this mismatch will no longer occur.