### PR TITLE
Convert question creation modal to Preact; improve UX

### DIFF
--- a/apps/prairielearn/assets/scripts/esm-bundles/react-fragments/CreateQuestionModalContents.ts
+++ b/apps/prairielearn/assets/scripts/esm-bundles/react-fragments/CreateQuestionModalContents.ts
@@ -1,0 +1,4 @@
+import { CreateQuestionModalContents } from '../../../../src/components/CreateQuestionModalContents.js';
+import { registerReactFragment } from '../../behaviors/react-fragments/index.js';
+
+registerReactFragment(CreateQuestionModalContents);

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.ts
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.ts
@@ -258,42 +258,6 @@ onDocumentReady(() => {
 
   $('#questionsTable').bootstrapTable(tableSettings);
 
-  // The startFromInput either has value 'empty', 'example' or 'course'
-  const startFromInput = document.querySelector<HTMLInputElement>('#start_from');
-
-  // The templateQuestionInput lets the user select the template question to
-  // start from, and is only enabled when the startFromInput is set to 'example'
-  // or 'course'
-  const templateQuestionInput = document.querySelector<HTMLInputElement>('#template_qid');
-
-  // The templateContainerDiv is hidden when the startFromInput is set to
-  // 'empty', otherwise it is shown.
-  const templateContainerDiv = document.querySelector<HTMLDivElement>('#templateContainer');
-
-  if (!startFromInput || !templateQuestionInput || !templateContainerDiv) {
-    return;
-  }
-
-  startFromInput.addEventListener('change', () => {
-    // If the startFromInput is set to 'example' or 'course', the
-    // templateQuestionInput should be visible and enabled; otherwise, it should
-    // be hidden and disabled.
-    const isTemplateSelected = ['example', 'course'].includes(startFromInput.value);
-    templateQuestionInput.disabled = !isTemplateSelected;
-    templateContainerDiv.hidden = !isTemplateSelected;
-    // Only show template options that match the selected template type.
-    templateQuestionInput.querySelectorAll('option').forEach((option) => {
-      option.hidden = startFromInput.value !== option.dataset.templateSource;
-    });
-    // If the current selection is hidden, change selection to first non-hidden template
-    const selectedOption = templateQuestionInput.querySelector<HTMLOptionElement>('option:checked');
-    if (selectedOption?.hidden) {
-      const visibleOption =
-        templateQuestionInput.querySelector<HTMLOptionElement>('option:not([hidden])');
-      if (visibleOption) templateQuestionInput.value = visibleOption.value;
-    }
-  });
-
   $(document).keydown((event) => {
     if (
       (event.ctrlKey || event.metaKey) &&

--- a/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
+++ b/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
@@ -1,0 +1,94 @@
+export function CreateQuestionModalContents({
+  templateQuestions,
+}: {
+  templateQuestions: { example_course: boolean; qid: string; title: string }[];
+}) {
+  return (
+    <>
+      <div class="mb-3">
+        <label class="form-label" for="title">
+          Title
+        </label>
+        <input
+          type="text"
+          class="form-control"
+          id="title"
+          name="title"
+          required
+          aria-describedby="title_help"
+        />
+        <small id="title_help" class="form-text text-muted">
+          The full name of the question, visible to users.
+        </small>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="qid">
+          Question identifier (QID)
+        </label>
+        <input
+          type="text"
+          class="form-control"
+          id="qid"
+          name="qid"
+          required
+          pattern="[\\-A-Za-z0-9_\\/]+"
+          aria-describedby="qid_help"
+        />
+        <small id="qid_help" class="form-text text-muted">
+          A short unique identifier for this question, such as "add-vectors" or "find-derivative".
+          Use only letters, numbers, dashes, and underscores, with no spaces.
+        </small>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="start_from">
+          Start from
+        </label>
+        <select
+          class="form-select"
+          id="start_from"
+          name="start_from"
+          required
+          aria-describedby="start_from_help"
+        >
+          <option value="empty">Empty question</option>
+          <option value="example">PrairieLearn template</option>
+          {templateQuestions.some(({ example_course }) => !example_course) ? (
+            <option value="course">Course-specific template</option>
+          ) : null}
+        </select>
+        <small id="start_from_help" class="form-text text-muted">
+          Begin with an empty question or a pre-made question template.
+        </small>
+      </div>
+
+      <div id="templateContainer" class="mb-3" hidden>
+        <label class="form-label" for="template_qid">
+          Template
+        </label>
+        <select
+          class="form-select"
+          id="template_qid"
+          name="template_qid"
+          required
+          aria-describedby="template_help"
+          disabled
+        >
+          {templateQuestions.map((question) => (
+            <option
+              data-template-source={question.example_course ? 'example' : 'course'}
+              value={question.qid}
+            >
+              {question.title}
+            </option>
+          ))}
+        </select>
+        <small id="template_help" class="form-text text-muted">
+          The question will be created from this template. To create your own template, create a
+          question with a QID starting with "<code>template/</code>".
+        </small>
+      </div>
+    </>
+  );
+}
+
+CreateQuestionModalContents.displayName = 'CreateQuestionModalContents';

--- a/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
+++ b/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
@@ -39,9 +39,9 @@ function SelectableCard({
       onClick={onClick}
       onKeyDown={handleKeyDown}
     >
-      <div class="card-body text-center">
+      <div class="card-body text-center d-flex flex-column justify-content-center">
         <h5 class={`card-title ${selected ? 'text-primary' : ''}`}>{title}</h5>
-        <p id={`${id}_description`} class="card-text text-muted small">
+        <p id={`${id}_description`} class="card-text text-muted small mb-0">
           {description}
         </p>
       </div>
@@ -59,10 +59,9 @@ interface RadioCardGroupProps {
   value: string;
   options: Array<{ id: string; title: string; description: string }>;
   onChange: (value: string) => void;
-  columnClass: string;
 }
 
-function RadioCardGroup({ label, value, options, onChange, columnClass }: RadioCardGroupProps) {
+function RadioCardGroup({ label, value, options, onChange }: RadioCardGroupProps) {
   const cardRefs = useRef<(HTMLElement | null)[]>([]);
 
   const handleKeyDown = (e: KeyboardEvent, currentIndex: number) => {
@@ -101,22 +100,30 @@ function RadioCardGroup({ label, value, options, onChange, columnClass }: RadioC
 
   return (
     <fieldset class="mb-3">
-      <legend class="col-form-label">{label}</legend>
-      <div class="row gx-3" role="radiogroup" aria-label={label}>
+      <legend class="form-label">{label}</legend>
+      <div
+        role="radiogroup"
+        aria-label={label}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+          gap: '1rem',
+          gridAutoRows: '1fr',
+        }}
+      >
         {options.map((option, index) => (
-          <div key={option.id} class={columnClass}>
-            <SelectableCard
-              id={option.id}
-              title={option.title}
-              description={option.description}
-              selected={value === option.id}
-              onClick={() => onChange(option.id)}
-              onKeyDown={(e) => handleKeyDown(e, index)}
-              cardRef={(el) => {
-                cardRefs.current[index] = el;
-              }}
-            />
-          </div>
+          <SelectableCard
+            key={option.id}
+            id={option.id}
+            title={option.title}
+            description={option.description}
+            selected={value === option.id}
+            onClick={() => onChange(option.id)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            cardRef={(el) => {
+              cardRefs.current[index] = el;
+            }}
+          />
         ))}
       </div>
     </fieldset>
@@ -166,7 +173,7 @@ export function CreateQuestionModalContents({
     startFromOptions.push({
       id: 'example',
       title: 'PrairieLearn template',
-      description: 'Start with a pre-built PrairieLearn question template',
+      description: 'Start with a pre-built question template',
     });
   }
 
@@ -222,7 +229,6 @@ export function CreateQuestionModalContents({
           value={startFrom}
           options={startFromOptions}
           onChange={setStartFrom}
-          columnClass={startFromOptions.length === 2 ? 'col-md-6' : 'col-md-4'}
         />
       )}
 

--- a/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
+++ b/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
@@ -1,8 +1,31 @@
+import { useState, useEffect } from 'preact/hooks';
+
 export function CreateQuestionModalContents({
   templateQuestions,
 }: {
   templateQuestions: { example_course: boolean; qid: string; title: string }[];
 }) {
+  const [startFrom, setStartFrom] = useState('empty');
+  const [selectedTemplateQid, setSelectedTemplateQid] = useState('');
+
+  // Filter template questions based on the selected start_from value
+  const filteredTemplateQuestions = templateQuestions.filter((question) => {
+    if (startFrom === 'example') return question.example_course;
+    if (startFrom === 'course') return !question.example_course;
+    return false;
+  });
+
+  // When startFrom changes, auto-select the first available template
+  useEffect(() => {
+    if (filteredTemplateQuestions.length > 0) {
+      setSelectedTemplateQid(filteredTemplateQuestions[0].qid);
+    } else {
+      setSelectedTemplateQid('');
+    }
+  }, [startFrom, filteredTemplateQuestions.length]);
+
+  const isTemplateSelected = ['example', 'course'].includes(startFrom);
+
   return (
     <>
       <div class="mb-3">
@@ -49,6 +72,8 @@ export function CreateQuestionModalContents({
           name="start_from"
           required
           aria-describedby="start_from_help"
+          value={startFrom}
+          onChange={(e) => setStartFrom((e.target as HTMLSelectElement).value)}
         >
           <option value="empty">Empty question</option>
           <option value="example">PrairieLearn template</option>
@@ -61,32 +86,32 @@ export function CreateQuestionModalContents({
         </small>
       </div>
 
-      <div id="templateContainer" class="mb-3" hidden>
-        <label class="form-label" for="template_qid">
-          Template
-        </label>
-        <select
-          class="form-select"
-          id="template_qid"
-          name="template_qid"
-          required
-          aria-describedby="template_help"
-          disabled
-        >
-          {templateQuestions.map((question) => (
-            <option
-              data-template-source={question.example_course ? 'example' : 'course'}
-              value={question.qid}
-            >
-              {question.title}
-            </option>
-          ))}
-        </select>
-        <small id="template_help" class="form-text text-muted">
-          The question will be created from this template. To create your own template, create a
-          question with a QID starting with "<code>template/</code>".
-        </small>
-      </div>
+      {isTemplateSelected && (
+        <div id="templateContainer" class="mb-3">
+          <label class="form-label" for="template_qid">
+            Template
+          </label>
+          <select
+            class="form-select"
+            id="template_qid"
+            name="template_qid"
+            required
+            aria-describedby="template_help"
+            value={selectedTemplateQid}
+            onChange={(e) => setSelectedTemplateQid((e.target as HTMLSelectElement).value)}
+          >
+            {filteredTemplateQuestions.map((question) => (
+              <option key={question.qid} value={question.qid}>
+                {question.title}
+              </option>
+            ))}
+          </select>
+          <small id="template_help" class="form-text text-muted">
+            The question will be created from this template. To create your own template, create a
+            question with a QID starting with "<code>template/</code>".
+          </small>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
+++ b/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
@@ -100,7 +100,8 @@ function RadioCardGroup({ label, value, options, onChange }: RadioCardGroupProps
 
   return (
     <fieldset class="mb-3">
-      <legend class="form-label">{label}</legend>
+      {/* `col-form-label` correctly overrides the default font size for `legend` */}
+      <legend class="col-form-label">{label}</legend>
       <div
         role="radiogroup"
         aria-label={label}

--- a/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
+++ b/apps/prairielearn/src/components/CreateQuestionModalContents.tsx
@@ -1,4 +1,14 @@
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
+
+interface SelectableCardProps {
+  id: string;
+  title: string;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+  onKeyDown?: (e: KeyboardEvent) => void;
+  cardRef?: (el: HTMLElement | null) => void;
+}
 
 function SelectableCard({
   id,
@@ -6,27 +16,25 @@ function SelectableCard({
   description,
   selected,
   onClick,
-}: {
-  id: string;
-  title: string;
-  description: string;
-  selected: boolean;
-  onClick: () => void;
-}) {
+  onKeyDown,
+  cardRef,
+}: SelectableCardProps) {
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       onClick();
     }
+    onKeyDown?.(e);
   };
 
   return (
     <div
-      class={`card h-100 ${selected ? 'border-primary bg-primary bg-opacity-10' : 'border-secondary'} cursor-pointer`}
+      ref={cardRef}
+      class={`card h-100 ${selected ? 'border-primary bg-primary bg-opacity-10' : 'border-secondary'}`}
       style={{ cursor: 'pointer' }}
-      role="button"
-      tabIndex={0}
-      aria-pressed={selected}
+      role="radio"
+      tabIndex={selected ? 0 : -1}
+      aria-checked={selected}
       aria-describedby={`${id}_description`}
       onClick={onClick}
       onKeyDown={handleKeyDown}
@@ -46,11 +54,84 @@ function SelectableCard({
   );
 }
 
+interface RadioCardGroupProps {
+  label: string;
+  value: string;
+  options: Array<{ id: string; title: string; description: string }>;
+  onChange: (value: string) => void;
+  columnClass: string;
+}
+
+function RadioCardGroup({ label, value, options, onChange, columnClass }: RadioCardGroupProps) {
+  const cardRefs = useRef<(HTMLElement | null)[]>([]);
+
+  const handleKeyDown = (e: KeyboardEvent, currentIndex: number) => {
+    let newIndex = currentIndex;
+
+    switch (e.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        e.preventDefault();
+        newIndex = (currentIndex + 1) % options.length;
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        e.preventDefault();
+        newIndex = currentIndex === 0 ? options.length - 1 : currentIndex - 1;
+        break;
+      case 'Home':
+        e.preventDefault();
+        newIndex = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        newIndex = options.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    onChange(options[newIndex].id);
+
+    // Focus the newly selected element, but only after a rerender.
+    setTimeout(() => {
+      cardRefs.current[newIndex]?.focus();
+    }, 0);
+  };
+
+  return (
+    <fieldset class="mb-3">
+      <legend class="col-form-label">{label}</legend>
+      <div class="row gx-3" role="radiogroup" aria-label={label}>
+        {options.map((option, index) => (
+          <div key={option.id} class={columnClass}>
+            <SelectableCard
+              id={option.id}
+              title={option.title}
+              description={option.description}
+              selected={value === option.id}
+              onClick={() => onChange(option.id)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              cardRef={(el) => {
+                cardRefs.current[index] = el;
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
 export function CreateQuestionModalContents({
   templateQuestions,
 }: {
   templateQuestions: { example_course: boolean; qid: string; title: string }[];
 }) {
+  const hasCourseTemplates = templateQuestions.some(({ example_course }) => !example_course);
+  const hasExampleTemplates = templateQuestions.some(({ example_course }) => example_course);
+  const hasAnyTemplates = hasExampleTemplates || hasCourseTemplates;
+
   const [startFrom, setStartFrom] = useState('empty');
   const [selectedTemplateQid, setSelectedTemplateQid] = useState('');
 
@@ -71,7 +152,31 @@ export function CreateQuestionModalContents({
   }, [startFrom, filteredTemplateQuestions.length]);
 
   const isTemplateSelected = ['example', 'course'].includes(startFrom);
-  const hasCourseTemplates = templateQuestions.some(({ example_course }) => !example_course);
+
+  // Build start from options based on available templates
+  const startFromOptions = [
+    {
+      id: 'empty',
+      title: 'Empty question',
+      description: 'Start with a blank question and build from scratch',
+    },
+  ];
+
+  if (hasExampleTemplates) {
+    startFromOptions.push({
+      id: 'example',
+      title: 'PrairieLearn template',
+      description: 'Start with a pre-built PrairieLearn question template',
+    });
+  }
+
+  if (hasCourseTemplates) {
+    startFromOptions.push({
+      id: 'course',
+      title: 'Course template',
+      description: 'Start with a template from your course',
+    });
+  }
 
   return (
     <>
@@ -111,44 +216,20 @@ export function CreateQuestionModalContents({
         </small>
       </div>
 
-      <div class="mb-3">
-        <label class="form-label">Start from</label>
-        <div class="row g-3" role="group" aria-labelledby="start_from_label">
-          <div class={hasCourseTemplates ? 'col-md-4' : 'col-md-6'}>
-            <SelectableCard
-              id="empty"
-              title="Empty question"
-              description="Start with a blank question and build from scratch"
-              selected={startFrom === 'empty'}
-              onClick={() => setStartFrom('empty')}
-            />
-          </div>
-          <div class={hasCourseTemplates ? 'col-md-4' : 'col-md-6'}>
-            <SelectableCard
-              id="example"
-              title="PrairieLearn template"
-              description="Start with a pre-built PrairieLearn question template"
-              selected={startFrom === 'example'}
-              onClick={() => setStartFrom('example')}
-            />
-          </div>
-          {hasCourseTemplates && (
-            <div class="col-md-4">
-              <SelectableCard
-                id="course"
-                title="Course template"
-                description="Start with a template from your course"
-                selected={startFrom === 'course'}
-                onClick={() => setStartFrom('course')}
-              />
-            </div>
-          )}
-        </div>
-        {/* Hidden input for the form submission */}
-        <input type="hidden" name="start_from" value={startFrom} />
-      </div>
+      {hasAnyTemplates && (
+        <RadioCardGroup
+          label="Start from"
+          value={startFrom}
+          options={startFromOptions}
+          onChange={setStartFrom}
+          columnClass={startFromOptions.length === 2 ? 'col-md-6' : 'col-md-4'}
+        />
+      )}
 
-      {isTemplateSelected && (
+      {/* Always include hidden input for form submission */}
+      <input type="hidden" name="start_from" value={startFrom} />
+
+      {isTemplateSelected && filteredTemplateQuestions.length > 0 && (
         <div class="mb-3">
           <label class="form-label" for="template_qid">
             Template

--- a/apps/prairielearn/src/components/QuestionsTable.html.tsx
+++ b/apps/prairielearn/src/components/QuestionsTable.html.tsx
@@ -7,6 +7,9 @@ import { idsEqual } from '../lib/id.js';
 import { type QuestionsPageData } from '../models/questions.js';
 
 import { Modal } from './Modal.html.js';
+import { renderHtml } from '../lib/preact-html.js';
+import { Hydrate } from '../lib/preact.js';
+import { CreateQuestionModalContents } from './CreateQuestionModalContents.js';
 
 export function QuestionsTableHead() {
   // Importing javascript using <script> tags as below is *not* the preferred method, it is better to directly use 'import'
@@ -276,83 +279,11 @@ function CreateQuestionModal({
     id: 'createQuestionModal',
     title: 'Create question',
     formMethod: 'POST',
-    body: html`
-      <div class="mb-3">
-        <label class="form-label" for="title">Title</label>
-        <input
-          type="text"
-          class="form-control"
-          id="title"
-          name="title"
-          required
-          aria-describedby="title_help"
-        />
-        <small id="title_help" class="form-text text-muted">
-          The full name of the question, visible to users.
-        </small>
-      </div>
-      <div class="mb-3">
-        <label class="form-label" for="qid">Question identifier (QID)</label>
-        <input
-          type="text"
-          class="form-control"
-          id="qid"
-          name="qid"
-          required
-          pattern="[\\-A-Za-z0-9_\\/]+"
-          aria-describedby="qid_help"
-        />
-        <small id="qid_help" class="form-text text-muted">
-          A short unique identifier for this question, such as "add-vectors" or "find-derivative".
-          Use only letters, numbers, dashes, and underscores, with no spaces.
-        </small>
-      </div>
-      <div class="mb-3">
-        <label class="form-label" for="start_from">Start from</label>
-        <select
-          class="form-select"
-          id="start_from"
-          name="start_from"
-          required
-          aria-describedby="start_from_help"
-        >
-          <option value="empty">Empty question</option>
-          <option value="example">PrairieLearn template</option>
-          ${templateQuestions.some(({ example_course }) => !example_course)
-            ? html`<option value="course">Course-specific template</option>`
-            : ''}
-        </select>
-        <small id="start_from_help" class="form-text text-muted">
-          Begin with an empty question or a pre-made question template.
-        </small>
-      </div>
-
-      <div id="templateContainer" class="mb-3" hidden>
-        <label class="form-label" for="template_qid">Template</label>
-        <select
-          class="form-select"
-          id="template_qid"
-          name="template_qid"
-          required
-          aria-describedby="template_help"
-          disabled
-        >
-          ${templateQuestions.map(
-            (question) =>
-              html`<option
-                data-template-source="${question.example_course ? 'example' : 'course'}"
-                value="${question.qid}"
-              >
-                ${question.title}
-              </option>`,
-          )}
-        </select>
-        <small id="template_help" class="form-text text-muted">
-          The question will be created from this template. To create your own template, create a
-          question with a QID starting with "<code>template/</code>".
-        </small>
-      </div>
-    `,
+    body: renderHtml(
+      <Hydrate>
+        <CreateQuestionModalContents templateQuestions={templateQuestions} />
+      </Hydrate>,
+    ),
     footer: html`
       <input type="hidden" name="__action" value="add_question" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />

--- a/apps/prairielearn/src/components/QuestionsTable.html.tsx
+++ b/apps/prairielearn/src/components/QuestionsTable.html.tsx
@@ -4,12 +4,12 @@ import { type HtmlSafeString, html } from '@prairielearn/html';
 import { compiledScriptTag, compiledStylesheetTag, nodeModulesAssetPath } from '../lib/assets.js';
 import { type CourseInstance } from '../lib/db-types.js';
 import { idsEqual } from '../lib/id.js';
-import { type QuestionsPageData } from '../models/questions.js';
-
-import { Modal } from './Modal.html.js';
 import { renderHtml } from '../lib/preact-html.js';
 import { Hydrate } from '../lib/preact.js';
+import { type QuestionsPageData } from '../models/questions.js';
+
 import { CreateQuestionModalContents } from './CreateQuestionModalContents.js';
+import { Modal } from './Modal.html.js';
 
 export function QuestionsTableHead() {
   // Importing javascript using <script> tags as below is *not* the preferred method, it is better to directly use 'import'


### PR DESCRIPTION
This PR rewrites the question creation modal in Preact. I did this with the goal of introducing a radio-card kind of selector for the starting point (empty, template, etc), which was much easier to implement with Preact.

On wide viewports:

<img width="822" height="744" alt="Screenshot 2025-07-17 at 23 59 04" src="https://github.com/user-attachments/assets/acb1fde0-6218-4d44-9ce3-313775e47850" />

On narrower viewports:

<img width="523" height="940" alt="Screenshot 2025-07-17 at 23 57 01" src="https://github.com/user-attachments/assets/e44756c7-bfc9-484c-8afa-3a6cefd28ea3" />

Much of this work was done in collaboration with Claude Sonnet 4.