### PR TITLE
Fix paths for compiled asset preloads

### DIFF
--- a/.changeset/neat-cougars-grow.md
+++ b/.changeset/neat-cougars-grow.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/compiled-assets': patch
+---
+
+Fix paths for preloads

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -348,8 +348,9 @@ function makeManifest(
     // Recursively walk the `imports` dependency tree
     const visit = (entry: (typeof meta)['imports'][number]) => {
       if (!['import-statement', 'dynamic-import'].includes(entry.kind)) return;
-      if (preloads.has(entry.path)) return;
-      preloads.add(entry.path);
+      const preloadPath = path.relative(buildDirectory, entry.path);
+      if (preloads.has(preloadPath)) return;
+      preloads.add(preloadPath);
       for (const imp of metafile.inputs[entry.path]?.imports ?? []) {
         visit(imp);
       }


### PR DESCRIPTION
While testing #12446 I noticed that preloads were using a bad URL like `http://localhost:3000/assets/build/public/build/chunk-NYHNC5ZV.js`, which would 404. This PR fixes them to use something like `http://localhost:3000/assets/build/chunk-NYHNC5ZV.js`, which is correct.