### PR TITLE
Update requirements.txt - add datascience module from UC Berkeley Data 8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ ansi2html==1.9.2
 automata-lib==9.0.0
 chevron==0.14.0
 coloraide==4.7.2
+datascience==0.17.6
 Faker==37.4.0
 lxml==6.0.0
 matplotlib==3.10.3


### PR DESCRIPTION
In this commit, we add the `datascience` module from the Data 8 curriculum at UC Berkeley.  This module is used not only at Berkeley, but in courses at dozens of universities that have adopted the Data 8 curriculum.

We are proposing this PR because we found that the technique outlined here only made it available in server.py for question generation and for question grading.

* <https://prairielearn.readthedocs.io/en/latest/questionRuntime/#installing-libraries-in-your-course> 

But, we are looking for it to be available in student answer code as well, as illustrated in this screenshot:

<img width="720" height="527" alt="image" src="https://github.com/user-attachments/assets/7ff39ab7-7a6a-40ab-88a1-dcc285f77900" />

If there is another way to accomplish this without this PR, we are happy to continue to explore that.  So far, our efforts at following the documentation and suggestions on the slack have not met with success, so we are trying this approach.
