### PR TITLE
Drop unused number column from assessment questions query

### DIFF
--- a/apps/prairielearn/src/models/assessment-question.sql
+++ b/apps/prairielearn/src/models/assessment-question.sql
@@ -20,7 +20,6 @@ SELECT
   q.title,
   row_to_json(top) AS topic,
   q.id AS question_id,
-  admin_assessment_question_number (aq.id) as number,
   tags_for_question (q.id) AS tags,
   ag.number AS alternative_group_number,
   ag.number_choose AS alternative_group_number_choose,

--- a/apps/prairielearn/src/models/assessment-question.ts
+++ b/apps/prairielearn/src/models/assessment-question.ts
@@ -21,7 +21,6 @@ export const AssessmentQuestionRowSchema = AssessmentQuestionSchema.extend({
   assessment_question_advance_score_perc: AlternativeGroupSchema.shape.advance_score_perc,
   course_id: IdSchema,
   course_sharing_name: z.string().nullable(),
-  number: z.string().nullable(),
   open_issue_count: z.coerce.number().nullable(),
   other_assessments: AssessmentsFormatForQuestionSchema.nullable(),
   sync_errors: QuestionSchema.shape.sync_errors,


### PR DESCRIPTION
Pulled out of https://github.com/PrairieLearn/PrairieLearn/pull/12402#discussion_r2223337873.

To test this, I added `.omit({ number: true })` to the schema and verified that things still built (and thus that nothing was relying on that column).

The `number` column will still exist on the resulting type, it just comes directly from the `assessment_questions` table.