### PR TITLE
API endpoints to manage staff permissions

### DIFF
--- a/apps/prairielearn/src/api/v1/endpoints/courseStaffPermissions/index.ts
+++ b/apps/prairielearn/src/api/v1/endpoints/courseStaffPermissions/index.ts
@@ -1,0 +1,140 @@
+import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+
+import * as error from '@prairielearn/error';
+
+import {
+  deleteCourseInstancePermissions,
+  deleteCoursePermissions,
+  insertCourseInstancePermissions,
+  insertCoursePermissionsByUserUid,
+  updateCourseInstancePermissionsRole,
+  updateCoursePermissionsRole,
+} from '../../../../models/course-permissions.js';
+import { selectOptionalUserByUid } from '../../../../models/user.js';
+
+const router = Router({ mergeParams: true });
+
+// Grant user access to course
+router.post(
+  '/insert',
+  asyncHandler(async (req, res) => {
+    const { uid, course_role } = req.body;
+
+    const job = await insertCoursePermissionsByUserUid({
+      course_id: req.params.course_id,
+      uid,
+      course_role,
+      authn_user_id: res.locals.authz_data.authn_user.user_id,
+    });
+    res.status(200).json({ user: job });
+  }),
+);
+
+// Update user access to course
+router.post(
+  '/update',
+  asyncHandler(async (req, res) => {
+    const { uid, course_role } = req.body;
+
+    const user = await selectOptionalUserByUid(uid);
+    if (!user) {
+      throw new error.HttpStatusError(404, 'User not found');
+    }
+
+    await updateCoursePermissionsRole({
+      course_id: req.params.course_id,
+      user_id: user.user_id,
+      course_role,
+      authn_user_id: res.locals.authz_data.authn_user.user_id,
+    });
+    res.status(200).json({ output: 'updated: ' + uid });
+  }),
+);
+
+// Remove user access from course
+router.post(
+  '/delete',
+  asyncHandler(async (req, res) => {
+    const { uid } = req.body;
+
+    const user = await selectOptionalUserByUid(uid);
+    if (!user) {
+      throw new error.HttpStatusError(404, 'User not found');
+    }
+
+    await deleteCoursePermissions({
+      course_id: req.params.course_id,
+      user_id: user.user_id,
+      authn_user_id: res.locals.authz_data.authn_user.user_id,
+    });
+    res.status(200).json({ status: 'complete' });
+  }),
+);
+
+// Grant user access to student data
+router.post(
+  '/insert/:course_instance(\\d+)',
+  asyncHandler(async (req, res) => {
+    const { uid, course_instance_role } = req.body;
+
+    const user = await selectOptionalUserByUid(uid);
+    if (!user) {
+      throw new error.HttpStatusError(404, 'User not found');
+    }
+
+    await insertCourseInstancePermissions({
+      course_id: req.params.course_id,
+      course_instance_id: req.params.course_instance,
+      user_id: user.user_id,
+      course_instance_role,
+      authn_user_id: res.locals.authz_data.authn_user.user_id,
+    });
+    res.status(200).json({ output: 'updated: ' + uid });
+  }),
+);
+
+// Update user access to student data
+router.post(
+  '/update/:course_instance(\\d+)',
+  asyncHandler(async (req, res) => {
+    const { uid, course_instance_role } = req.body;
+
+    const user = await selectOptionalUserByUid(uid);
+    if (!user) {
+      throw new error.HttpStatusError(404, 'User not found');
+    }
+
+    await updateCourseInstancePermissionsRole({
+      course_id: req.params.course_id,
+      course_instance_id: req.params.course_instance,
+      user_id: user.user_id,
+      course_instance_role,
+      authn_user_id: res.locals.authz_data.authn_user.user_id,
+    });
+    res.status(200).json({ output: 'updated: ' + uid });
+  }),
+);
+
+// Remove user access from student data
+router.post(
+  '/delete/:course_instance(\\d+)',
+  asyncHandler(async (req, res) => {
+    const { uid } = req.body;
+
+    const user = await selectOptionalUserByUid(uid);
+    if (!user) {
+      throw new error.HttpStatusError(404, 'User not found');
+    }
+
+    await deleteCourseInstancePermissions({
+      course_id: req.params.course_id,
+      course_instance_id: req.params.course_instance,
+      user_id: user.user_id,
+      authn_user_id: res.locals.authz_data.authn_user.user_id,
+    });
+    res.status(200).json({ status: 'complete' });
+  }),
+);
+
+export default router;

--- a/apps/prairielearn/src/api/v1/index.ts
+++ b/apps/prairielearn/src/api/v1/index.ts
@@ -91,6 +91,10 @@ router.use(
   (await import('./endpoints/courseInstanceAccessRules/index.js')).default,
 );
 router.use(
+  '/course/:course_id(\\d+)/staff',
+  (await import('./endpoints/courseStaffPermissions/index.js')).default,
+);
+router.use(
   '/course/:course_id(\\d+)/sync',
   (await import('./endpoints/courseSync/index.js')).default,
 );


### PR DESCRIPTION
Adds `/insert`, `/update`, and `/delete` API endpoints to give the ability to manage staff permissions in a course instance.

<details>
<summary>Example usage</summary>

```bash
curl -X POST -H "Content-Type: application/json" -H "Private-Token: TOKEN" -d '{"uid": "[viewer@example.com](mailto:viewer@example.com)", "course_role": "Previewer"}' http://localhost:3000/pl/api/v1/course/1/staff/insert 

curl -X POST -H "Content-Type: application/json" -H "Private-Token: TOKEN" -d '{"uid": "[viewer@example.com](mailto:viewer@example.com)", "course_role": "Editor"}' http://localhost:3000/pl/api/v1/course/1/staff/update/

curl -X POST -H "Content-Type: application/json" -H "Private-Token: TOKEN" -d '{"uid": "[viewer@example.com](mailto:viewer@example.com)", "course_instance_role": "Student Data Viewer"}' http://localhost:3000/pl/api/v1/course/1/staff/insert/3

curl -X POST -H "Content-Type: application/json" -H "Private-Token: TOKEN" -d '{"uid": "[viewer@example.com](mailto:viewer@example.com)", "course_instance_role": "Student Data Editor"}' http://localhost:3000/pl/api/v1/course/1/staff/update/3

curl -X POST -H "Content-Type: application/json" -H "Private-Token: TOKEN" -d '{"uid": "[viewer@example.com](mailto:viewer@example.com)"}' http://localhost:3000/pl/api/v1/course/1/staff/delete/3 

curl -X POST -H "Content-Type: application/json" -H "Private-Token: TOKEN" -d '{"uid": "[viewer@example.com](mailto:viewer@example.com)"}' http://localhost:3000/pl/api/v1/course/1/staff/delete
```

</details>

Couple todo items but would be helpful for feedback first (both here or for the questions in the linked issue) to avoid duplicating the work effort
- documentation
- test cases

Closes #12444 
