### PR TITLE
Fix flaky sync tests

### DIFF
--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1804,17 +1804,7 @@ describe('Assessment syncing', () => {
   });
 
   describe('Test validating shared questions on sync', () => {
-    beforeAll(() => {
-      // Temporarily enable validation of shared questions
-      config.checkSharingOnSync = true;
-    });
-    afterAll(() => {
-      // Disable again for other tests
-      config.checkSharingOnSync = false;
-    });
-
     it('records an error if a zone references a QID from another course that does not exist or we do not have permissions for', async () => {
-      features.enable('question-sharing');
       const courseData = util.getCourseData();
       const assessment = makeAssessment(courseData);
       assessment.zones?.push({
@@ -1827,7 +1817,11 @@ describe('Assessment syncing', () => {
         ],
       });
       courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
-      await util.writeAndSyncCourseData(courseData);
+
+      await withConfig({ checkSharingOnSync: true }, async () => {
+        await util.writeAndSyncCourseData(courseData);
+      });
+
       const syncedAssessment = await findSyncedAssessment('fail');
       assert.match(
         syncedAssessment?.sync_errors,

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -17,7 +17,6 @@ import {
   QuestionSchema,
   ZoneSchema,
 } from '../../lib/db-types.js';
-import { features } from '../../lib/features/index.js';
 import { idsEqual } from '../../lib/id.js';
 import type {
   AssessmentJsonInput,


### PR DESCRIPTION
I witnessed some flaky tests on #12475 that I'm pretty sure were due to the un-awaited `features.enable('question-sharing');` call here. As it turns out, `question-sharing` doesn't even have to be enabled for this test to pass!