### PR TITLE
Remove image capture confirmation phase

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -188,7 +188,7 @@
     /**
      * When the user clicks Enter or Space, apply any pending changes based on the current container.
      * - If in crop-rotate, confirm the crop/rotate changes.
-     * - If in capture-preview, capture the current image.
+     * - If in local-camera-capture, capture the current image.
      */
     createApplyChangesListeners() {
       document.addEventListener('keypress', (event) => {
@@ -207,7 +207,7 @@
      * Show the specified container within the image capture element and hide all others.
      *
      * @param {string} containerName The name of the container to open. Valid values are:
-     * 'capture-preview', 'local-camera-capture'
+     * 'capture-preview', 'local-camera-capture', 'crop-rotate'
      */
     openContainer(containerName) {
       if (!['capture-preview', 'local-camera-capture', 'crop-rotate'].includes(containerName)) {
@@ -449,7 +449,7 @@
       const captureWithLocalCameraButton = this.imageCaptureDiv.querySelector(
         '.js-capture-with-local-camera-button',
       );
-      const captureWithLocalCameraButtonSpan = captureWithLocalCameraButton?.querySelector('span');
+      const captureWithLocalCameraButtonSpan = captureWithLocalCameraButton.querySelector('span');
       this.ensureElementsExist({
         captureWithLocalCameraButtonSpan,
       });

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -442,8 +442,42 @@
         hiddenCaptureInput,
       });
 
+      if (!hiddenCaptureInput.value) {
+        // If no image has been captured yet, update the button text to indicate that the user can retake the image.
+        this.updateCaptureText();
+      }
       hiddenCaptureInput.value = dataUrl;
     }
+
+    updateCaptureText() {
+      const captureWithLocalCameraButton = this.imageCaptureDiv.querySelector(
+        '.js-capture-with-local-camera-button',
+      );
+      const captureWithMobileDeviceButton = this.imageCaptureDiv.querySelector(
+        '.js-capture-with-mobile-device-button',
+      );
+
+      this.ensureElementsExist({
+        captureWithLocalCameraButton,
+        captureWithMobileDeviceButton,
+      });
+
+      const captureWithLocalCameraButtonSpan = captureWithLocalCameraButton.querySelector(
+        'span'
+      );
+      const captureWithMobileDeviceButtonSpan = captureWithMobileDeviceButton.querySelector(
+        'span'
+      );
+
+      this.ensureElementsExist({
+        captureWithLocalCameraButtonSpan,
+        captureWithMobileDeviceButtonSpan,
+      });
+
+      captureWithLocalCameraButtonSpan.innerHTML = 'Retake with webcam';
+      captureWithMobileDeviceButtonSpan.innerHTML = 'Retake with phone';
+    }
+
 
     /**
      * Sets the hidden capture input value to the capture preview, which is the last
@@ -609,12 +643,19 @@
         '.js-local-camera-image-preview',
       );
       const localCameraVideo = localCameraCaptureContainer.querySelector('.js-local-camera-video');
+      const hiddenCaptureInput = this.imageCaptureDiv.querySelector('.js-hidden-capture-input');
 
       this.ensureElementsExist({
         localCameraCaptureContainer,
         localCameraImagePreviewCanvas,
         localCameraVideo,
+        hiddenCaptureInput
       });
+
+      // No image was captured previously
+      if (!hiddenCaptureInput.value) {
+        this.updateCaptureText();
+      }
 
       localCameraImagePreviewCanvas.width = localCameraVideo.videoWidth;
       localCameraImagePreviewCanvas.height = localCameraVideo.videoHeight;

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -55,7 +55,7 @@ $(function() {
         class="js-capture-with-local-camera-button btn btn-info"
       >
         <i class="bi bi-camera-fill me-1"></i>
-        Use webcam
+        <span>Use webcam</span>
       </button>
       {{#mobile_capture_enabled}}
         <button 
@@ -93,7 +93,7 @@ $(function() {
           '
         >
           <i class="bi bi-qr-code-scan me-1"></i>
-          Use phone
+          <span>Use phone</span>
         </button>
       {{/mobile_capture_enabled}}
     </div>

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -135,43 +135,11 @@ $(function() {
           Capture image
         </button>
       </div>
-    </div>
-  </div>
-  <div class="js-local-camera-confirmation-container d-none d-flex flex-column">
-    <canvas
-      class="js-local-camera-image-preview w-100 bg-body-secondary border-bottom"
-      autoplay
-      playsinline
-    >
-    </canvas>
-    <div class="d-flex gap-2 p-2 justify-content-end align-items-center flex-wrap">
-      <p class="text-muted my-0 me-auto">
-        Make sure your photo is clear, well-lit, and shows all your work legibly. 
-        <br/>
-        Later, you can crop or rotate the image as needed.
-      </p>
-      <div class="d-flex align-items-center gap-2">
-        <button 
-          type="button"
-          class="js-cancel-local-camera-confirmation-button btn btn-secondary"
-        >
-          Cancel
-        </button>
-        <button 
-          type="button"
-          class="js-retake-local-camera-image-button btn btn-secondary"
-        >
-          <i class="bi bi-arrow-counterclockwise me-1"></i>
-          Retake
-        </button>
-        <button 
-          type="button" 
-          class="js-confirm-local-camera-image-button btn btn-info"
-        >
-          <i class="bi bi-check2 me-1"></i>
-          Use image
-        </button>
-      </div>
+      <canvas
+        class="js-local-camera-image-preview w-100 bg-body-secondary border-bottom d-none"
+        autoplay
+        playsinline
+      >
     </div>
   </div>
   <div class="js-crop-rotate-container d-none">

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -137,8 +137,6 @@ $(function() {
       </div>
       <canvas
         class="js-local-camera-image-preview w-100 bg-body-secondary border-bottom d-none"
-        autoplay
-        playsinline
       >
     </div>
   </div>


### PR DESCRIPTION
Closes #12481. 

- When the user captures an image, they are no longer prompted to use or retake their image:

<img width="726" height="561" alt="Screenshot 2025-07-25 at 12 37 47 PM" src="https://github.com/user-attachments/assets/68acc9ba-2a9a-40f5-9368-2d56fa78fe46" />

<img width="745" height="666" alt="Screenshot 2025-07-25 at 12 39 18 PM" src="https://github.com/user-attachments/assets/12315e11-0d6c-4147-b2f9-b474ec5a7bc6" />

<img width="685" height="616" alt="Screenshot 2025-07-25 at 12 39 34 PM" src="https://github.com/user-attachments/assets/2b380101-13f9-4ea0-87f0-5cc125b0b62a" />

- The "Use webcam" and "Use phone" text updates to "Retake with webcam" and "Retake with phone" once an image is captured or if an image was previously captured.