### PR TITLE
Warn if `pl-image-capture` isn't saved on unload

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -322,6 +322,7 @@
           data: msg.file_content,
           type: 'image/jpeg',
         });
+        this.setHiddenCaptureChangedFlag(true);
 
         // Acknowledge that the external image capture was received.
         socket.emit(

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -30,6 +30,13 @@ $(function() {
       data-skip-unload-check="true"
       disabled
     />
+    <input 
+      class="js-hidden-capture-changed-flag"
+      type="hidden"
+      name="{{file_name}}_changed"
+      value="false"
+      disabled
+    />
     {{/editable}}
     <div class="js-uploaded-image-container">
       <div


### PR DESCRIPTION
Closes #12482. 

If the user captures an image without saving it or crops/rotates the image, they'll receive an alert that they have unsaved changes:

