### PR TITLE
Restore ability to change effective user in example course

### DIFF
--- a/apps/prairielearn/src/components/Navbar.tsx
+++ b/apps/prairielearn/src/components/Navbar.tsx
@@ -367,8 +367,8 @@ function ViewTypeMenu({ resLocals }: { resLocals: Record<string, any> }) {
   } = resLocals;
 
   // If we're working with an example course, only allow changing the effective
-  // user if the user is an administrator.
-  if (course?.example_course && !authz_data?.is_administrator) {
+  // user if the authenticated user is an administrator.
+  if (course?.example_course && !authz_data?.authn_is_administrator) {
     return '';
   }
 
@@ -559,8 +559,8 @@ function AuthnOverrides({
   const { authz_data, urlPrefix, course, course_instance } = resLocals;
 
   // If we're working with an example course, only allow changing the effective
-  // user if the user is an administrator.
-  if (course?.example_course && !config.devMode && !authz_data?.is_administrator) {
+  // user if the authenticated user is an administrator.
+  if (course?.example_course && !config.devMode && !authz_data?.authn_is_administrator) {
     return '';
   }
 


### PR DESCRIPTION
In #11630, permissions were changed in the example course to block authentication overrides except for administrators. This change is properly implemented server-side, using `res.locals.is_administrator` before the override check. However, in the navbar rendering, that value is computed after the override check, and at that point `res.locals.is_administrator` is used to identify if the effective user is administrator, not the authenticated user. This means that an administrator can switch the effective user to a different (non-administrator) user, but from there cannot easily switch back to staff view, since the effective user is not an administrator. The switch was still possible, but in multiple stages.

Before:
<img width="351" height="422" alt="image" src="https://github.com/user-attachments/assets/85593c5e-549b-46bb-bb9b-e7f5ee087c86" />

After (matching the state before #11630):
<img width="424" height="682" alt="image" src="https://github.com/user-attachments/assets/1895a210-78d8-4ce6-b665-8897a41d28c5" />
