### PR TITLE
Remove bespoke query from assessment ordering tests

### DIFF
--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.sql
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.sql
@@ -1,8 +1,0 @@
--- BLOCK get_test_course
-SELECT
-  assessments_group_by,
-  id
-FROM
-  course_instances
-WHERE
-  short_name = 'Fa19';

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
@@ -1,9 +1,8 @@
 import { v4 as uuid } from 'uuid';
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
-import * as sqldb from '@prairielearn/postgres';
-
 import { config } from '../lib/config.js';
+import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 
 import * as helperClient from './helperClient.js';
 import * as helperServer from './helperServer.js';
@@ -14,11 +13,9 @@ import {
   writeCourseToTempDirectory,
 } from './sync/util.js';
 
-const sql = sqldb.loadSqlEquiv(import.meta.url);
-
 describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }, function () {
   let courseDir;
-  let courseInstanceId = null;
+  let courseInstanceId: string | null = null;
   let assessmentBadges;
 
   const course = getCourseData();
@@ -108,15 +105,21 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
   beforeAll(async function () {
     courseDir = await writeCourseToTempDirectory(course);
     await helperServer.before(courseDir)();
-    const courseInstanceResult = await sqldb.queryOneRowAsync(sql.get_test_course, {});
-    courseInstanceId = courseInstanceResult.rows[0].id;
+    const courseInstance = await selectCourseInstanceByShortName({
+      course_id: '1',
+      short_name: 'Fa19',
+    });
+    courseInstanceId = courseInstance.id;
   });
 
   afterAll(helperServer.after);
 
   test.sequential('should default to grouping by Set', async function () {
-    const result = await sqldb.queryOneRowAsync(sql.get_test_course, []);
-    assert.equal(result.rows[0].assessments_group_by, 'Set');
+    const courseInstance = await selectCourseInstanceByShortName({
+      course_id: '1',
+      short_name: 'Fa19',
+    });
+    assert.equal(courseInstance.assessments_group_by, 'Set');
   });
 
   test.sequential('should use correct order when grouping by Set', async function () {

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
@@ -15,7 +15,6 @@ import {
 
 describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }, function () {
   let courseDir;
-  let courseInstanceId: string | null = null;
   let assessmentBadges;
 
   const course = getCourseData();
@@ -79,7 +78,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
   };
 
   async function fetchAssessmentsPage() {
-    const assessmentsUrl = `http://localhost:${config.serverPort}/pl/course_instance/${courseInstanceId}/assessments`;
+    const assessmentsUrl = `http://localhost:${config.serverPort}/pl/course_instance/1/assessments`;
     const response = await helperClient.fetchCheerio(assessmentsUrl);
     assert.isTrue(response.ok);
     return response;
@@ -105,11 +104,6 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
   beforeAll(async function () {
     courseDir = await writeCourseToTempDirectory(course);
     await helperServer.before(courseDir)();
-    const courseInstance = await selectCourseInstanceByShortName({
-      course_id: '1',
-      short_name: 'Fa19',
-    });
-    courseInstanceId = courseInstance.id;
   });
 
   afterAll(helperServer.after);


### PR DESCRIPTION
I noticed that we could remove this query (which already was poorly named) while looking at #12500.