### PR TITLE
Adding filter for select rubric items in manual grading interface

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.ts
+++ b/apps/prairielearn/src/lib/manualGrading.ts
@@ -30,7 +30,7 @@ const AppliedRubricItemSchema = z.object({
 });
 type AppliedRubricItem = z.infer<typeof AppliedRubricItemSchema>;
 
-const RubricDataSchema = RubricSchema.extend({
+export const RubricDataSchema = RubricSchema.extend({
   rubric_items: z.array(
     RubricItemSchema.extend({
       num_submissions: z.number(),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
@@ -13,6 +13,7 @@ import {
   nodeModulesAssetPath,
 } from '../../../lib/assets.js';
 import type { User } from '../../../lib/db-types.js';
+import type { RubricData } from '../../../lib/manualGrading.js';
 import { renderHtml } from '../../../lib/preact-html.js';
 
 import { type InstanceQuestionTableData } from './assessmentQuestion.types.js';
@@ -23,12 +24,14 @@ export function AssessmentQuestion({
   aiGradingEnabled,
   aiGradingMode,
   aiGradingStats,
+  rubric_data,
 }: {
   resLocals: Record<string, any>;
   courseStaff: User[];
   aiGradingEnabled: boolean;
   aiGradingMode: boolean;
   aiGradingStats: AiGradingGeneralStats | null;
+  rubric_data: RubricData | null
 }) {
   const {
     number_in_alternative_group,
@@ -79,6 +82,7 @@ export function AssessmentQuestion({
           maxAutoPoints: assessment_question.max_auto_points,
           csrfToken: __csrf_token,
           aiGradingMode,
+          rubric_data
         },
         'instance-question-table-data',
       )}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -8,6 +8,7 @@ import {
   callAsync,
   loadSqlEquiv,
   queryAsync,
+  queryOptionalRow,
   queryRows,
   runInTransactionAsync,
 } from '@prairielearn/postgres';
@@ -46,6 +47,14 @@ router.get(
       course_instance_id: res.locals.course_instance.id,
     });
     const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
+    const rubric_data = await queryOptionalRow(
+      sql.select_rubric_data,
+      {
+        assessment_question_id: res.locals.assessment_question.id,
+        rubric_id: res.locals.assessment_question.manual_rubric_id,
+      },
+      manualGrading.RubricDataSchema,
+    );
     res.send(
       AssessmentQuestion({
         resLocals: res.locals,
@@ -56,6 +65,7 @@ router.get(
           aiGradingEnabled && res.locals.assessment_question.ai_grading_mode
             ? await calculateAiGradingStats(res.locals.assessment_question)
             : null,
+        rubric_data,
       }),
     );
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.types.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
 
 import { AIGradingStatsSchema } from '../../../ee/lib/ai-grading/types.js';
-import { AssessmentQuestionSchema, InstanceQuestionSchema } from '../../../lib/db-types.js';
+import {
+  AssessmentQuestionSchema,
+  InstanceQuestionSchema,
+  RubricItemSchema,
+} from '../../../lib/db-types.js';
+import type { RubricData } from '../../../lib/manualGrading.js';
 
 export const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
   assessment_open: z.boolean(),
@@ -11,6 +16,7 @@ export const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
   assessment_question: AssessmentQuestionSchema,
   user_or_group_name: z.string().nullable(),
   open_issue_count: z.number().nullable(),
+  rubric_grading_items: RubricItemSchema.array(),
 });
 export type InstanceQuestionRow = z.infer<typeof InstanceQuestionRowSchema>;
 
@@ -32,4 +38,5 @@ export interface InstanceQuestionTableData {
   maxAutoPoints: number | null;
   aiGradingMode: boolean;
   csrfToken: string;
+  rubric_data: RubricData | null;
 }


### PR DESCRIPTION
Suggested during GATES meetings, it can be helpful to be able to filter instance questions that have a specific rubric item selected. I am adding dropdown checkbox for filtering instance questions based on all selected rubric items. 
<img width="1879" height="739" alt="image" src="https://github.com/user-attachments/assets/73bcb270-4650-43b9-b3fa-91938f8c6497" />
<img width="1882" height="403" alt="image" src="https://github.com/user-attachments/assets/7e805f9d-504b-4119-8886-f257e1f76785" />
