### PR TITLE
Refactor LTI 1.3 grade push to support multiple-instance assessments

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.sql
+++ b/apps/prairielearn/src/ee/lib/lti13.sql
@@ -118,7 +118,10 @@ WITH
   -- For each user, select the instance with the highest score for each assessment
   -- Similar to the gradebook code
 SELECT DISTINCT
-  ON (cai.user_id, cai.assessment_id) cai.*,
+  ON (cai.user_id, cai.assessment_id) cai.id,
+  cai.score_perc,
+  cai.date,
+  cai.open,
   to_jsonb(u) || jsonb_build_object('lti13_sub', lu.sub) AS user
 FROM
   course_assessment_instances AS cai

--- a/apps/prairielearn/src/ee/lib/lti13.sql
+++ b/apps/prairielearn/src/ee/lib/lti13.sql
@@ -110,7 +110,7 @@ WITH
       LEFT JOIN groups AS g ON (g.id = ai.group_id)
       LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
     WHERE
-      a.id = $assessment_id
+      ai.assessment_id = $assessment_id
       AND g.deleted_at IS NULL
       AND ai.score_perc IS NOT NULL
       AND ai.date IS NOT NULL

--- a/apps/prairielearn/src/ee/lib/lti13.sql
+++ b/apps/prairielearn/src/ee/lib/lti13.sql
@@ -131,7 +131,7 @@ ORDER BY
   cai.user_id,
   cai.assessment_id,
   cai.score_perc DESC,
-  cai.id;
+  cai.id DESC;
 
 -- BLOCK select_assessment_in_lti13_course_instance
 SELECT

--- a/apps/prairielearn/src/ee/lib/lti13.sql
+++ b/apps/prairielearn/src/ee/lib/lti13.sql
@@ -95,40 +95,40 @@ WHERE
   AND assessment_id = $assessment_id;
 
 -- BLOCK select_assessment_instances_for_scores
-SELECT
-  ai.*,
-  CASE
-    WHEN a.group_work
-    AND ai.group_id IS NOT NULL THEN (
-      SELECT
-        COALESCE(
-          jsonb_agg(
-            to_jsonb(users) || jsonb_build_object('lti13_sub', lti13_users.sub)
-          ),
-          '[]'::jsonb
-        )
-      FROM
-        group_users
-        JOIN users ON (group_users.user_id = users.user_id)
-        LEFT JOIN lti13_users ON (lti13_users.user_id = group_users.user_id)
-      WHERE
-        group_users.group_id = ai.group_id
-    )
-    ELSE jsonb_build_array(
-      to_jsonb(u) || jsonb_build_object('lti13_sub', lu.sub)
-    )
-  END AS users
+WITH
+  course_assessment_instances AS (
+    SELECT
+      COALESCE(ai.user_id, gu.user_id) AS user_id,
+      ai.id,
+      ai.assessment_id,
+      ai.score_perc,
+      ai.date,
+      ai.open
+    FROM
+      assessment_instances AS ai
+      JOIN assessments AS a ON (a.id = ai.assessment_id)
+      LEFT JOIN groups AS g ON (g.id = ai.group_id)
+      LEFT JOIN group_users AS gu ON (gu.group_id = g.id)
+    WHERE
+      a.id = $assessment_id
+      AND g.deleted_at IS NULL
+      AND ai.score_perc IS NOT NULL
+      AND ai.date IS NOT NULL
+  )
+  -- For each user, select the instance with the highest score for each assessment
+  -- Similar to the gradebook code
+SELECT DISTINCT
+  ON (cai.user_id, cai.assessment_id) cai.*,
+  to_jsonb(u) || jsonb_build_object('lti13_sub', lu.sub) AS user
 FROM
-  assessment_instances AS ai
-  JOIN assessments AS a ON (a.id = ai.assessment_id)
-  LEFT JOIN users AS u ON (u.user_id = ai.user_id)
-  LEFT JOIN lti13_users AS lu ON (lu.user_id = ai.user_id)
-WHERE
-  ai.assessment_id = $assessment_id
-  AND ai.score_perc IS NOT NULL
-  AND ai.date IS NOT NULL
+  course_assessment_instances AS cai
+  JOIN users AS u ON (u.user_id = cai.user_id)
+  LEFT JOIN lti13_users AS lu ON (lu.user_id = cai.user_id)
 ORDER BY
-  ai.id;
+  cai.user_id,
+  cai.assessment_id,
+  cai.score_perc DESC,
+  cai.id;
 
 -- BLOCK select_assessment_in_lti13_course_instance
 SELECT

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -18,9 +18,9 @@ import {
 
 import { selectAssessmentInstanceLastSubmissionDate } from '../../lib/assessment.js';
 import {
-  AssessmentInstanceSchema,
   AssessmentSchema,
   DateFromISOString,
+  IdSchema,
   Lti13CourseInstanceSchema,
   Lti13InstanceSchema,
   UserSchema,
@@ -838,10 +838,14 @@ export async function updateLti13Scores(
   const assessment_instances = await queryRows(
     sql.select_assessment_instances_for_scores,
     { assessment_id: assessment.id },
-    AssessmentInstanceSchema.extend({
-      score_perc: z.number(), // not .nullable() from SQL query
-      date: DateFromISOString, // not .nullable() from SQL query
-      users: UserWithLti13SubSchema.array(),
+    z.object({
+      id: IdSchema,
+      user_id: IdSchema,
+      assessment_id: IdSchema,
+      score_perc: z.number(),
+      date: DateFromISOString,
+      open: z.boolean(),
+      user: UserWithLti13SubSchema,
     }),
   );
 
@@ -861,73 +865,72 @@ export async function updateLti13Scores(
   };
 
   for (const assessment_instance of assessment_instances) {
-    for (const user of assessment_instance.users) {
-      // Get/Refresh the token in the main loop in case it expires during the run.
-      const token = await getAccessToken(instance.lti13_instance.id);
+    // Get/Refresh the token in the main loop in case it expires during the run.
+    const token = await getAccessToken(instance.lti13_instance.id);
 
-      const ltiUser = memberships.lookup(user);
-      const isCourseStaff = courseStaffUids.has(user.uid);
+    const user = assessment_instance.user;
+    const ltiUser = memberships.lookup(user);
+    const isCourseStaff = courseStaffUids.has(user.uid);
 
-      // User not found in LTI, reporting only
-      if (ltiUser === null) {
-        job.info(
-          `Not sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.` +
-            ` Could not find ${isCourseStaff ? 'course staff' : 'student'} ${user.uid}` +
-            ` in ${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
-        );
-        counts.not_sent++;
-        continue;
-      }
+    // User not found in LTI, reporting only
+    if (ltiUser === null) {
+      job.info(
+        `Not sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.` +
+          ` Could not find ${isCourseStaff ? 'course staff' : 'student'} ${user.uid}` +
+          ` in ${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
+      );
+      counts.not_sent++;
+      continue;
+    }
 
-      // User is not a student in LTI, reporting only
-      if (!ltiUser.roles.includes(STUDENT_ROLE)) {
-        job.info(
-          `Not sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.` +
-            ` ${isCourseStaff ? 'Course staff' : 'Student'} ${user.uid} is not a student` +
-            ` in ${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
-        );
-        counts.not_sent++;
-        continue;
-      }
+    // User is not a student in LTI, reporting only
+    if (!ltiUser.roles.includes(STUDENT_ROLE)) {
+      job.info(
+        `Not sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.` +
+          ` ${isCourseStaff ? 'Course staff' : 'Student'} ${user.uid} is not a student` +
+          ` in ${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
+      );
+      counts.not_sent++;
+      continue;
+    }
 
-      job.info(`Sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.`);
+    job.info(`Sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.`);
 
-      const submittedAt = await selectAssessmentInstanceLastSubmissionDate(assessment_instance.id);
+    const submittedAt = await selectAssessmentInstanceLastSubmissionDate(assessment_instance.id);
 
-      /*
+    /*
        https://www.imsglobal.org/spec/lti-ags/v2p0#score-service-media-type-and-schema
        Canvas has extensions we could use described at
        https://canvas.instructure.com/doc/api/score.html#method.lti/ims/scores.create
       */
-      const score: Lti13Score = {
-        timestamp,
-        scoreGiven: assessment_instance.score_perc,
-        scoreMaximum: 100,
-        activityProgress: assessment_instance.open ? 'Submitted' : 'Completed',
-        gradingProgress: 'FullyGraded',
-        userId: ltiUser.user_id,
-        submission: {
-          startedAt: assessment_instance.date,
-          submittedAt: submittedAt ?? undefined,
-        },
-      };
+    const score: Lti13Score = {
+      timestamp,
+      scoreGiven: assessment_instance.score_perc,
+      scoreMaximum: 100,
+      activityProgress: assessment_instance.open ? 'Submitted' : 'Completed',
+      gradingProgress: 'FullyGraded',
+      userId: ltiUser.user_id,
+      submission: {
+        startedAt: assessment_instance.date,
+        submittedAt: submittedAt ?? undefined,
+      },
+    };
 
-      try {
-        await fetchRetry(assessment.lti13_lineitem_id_url + '/scores', {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-type': 'application/vnd.ims.lis.v1.score+json',
-          },
-          body: JSON.stringify(score),
-        });
-        counts.success++;
-      } catch (error) {
-        counts.error++;
-        job.warn(`\t${error.message}`);
-        if (error instanceof AugmentedError && error.data.body) {
-          job.verbose(error.data.body);
-        }
+    try {
+      await fetchRetry(assessment.lti13_lineitem_id_url + '/scores', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/vnd.ims.lis.v1.score+json',
+        },
+        body: JSON.stringify(score),
+      });
+      counts.success++;
+    } catch (error) {
+      counts.error++;
+      job.warn(`\t${error.message}`);
+      if (error instanceof AugmentedError && error.data.body) {
+        job.verbose(error.data.body);
       }
     }
   }

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -840,8 +840,6 @@ export async function updateLti13Scores(
     { assessment_id: assessment.id },
     z.object({
       id: IdSchema,
-      user_id: IdSchema,
-      assessment_id: IdSchema,
       score_perc: z.number(),
       date: DateFromISOString,
       open: z.boolean(),

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.sql
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.sql
@@ -47,7 +47,7 @@ WITH
       cai.user_id,
       cai.assessment_id,
       cai.score_perc DESC,
-      cai.id
+      cai.id DESC
   ),
   user_ids AS (
     -- Select all users that:


### PR DESCRIPTION
Refactors the LTI 1.3 SQL to send the highest score of multiple-instance assessments, similar to code from the gradebook.

Refactored to return a row for each group-assessment-instance instead of looping inside of it like the previous version did. This removed a loop in the typescript, so it might be better reviewed with whitespace ignored.

The review discussion identified we could fix the SQL to choose the latest assessment instance with the highest score, so that change was pushed to the gradebook too.

Closes #12520 