### PR TITLE
Fix link to issues page in assessment switcher

### DIFF
--- a/apps/prairielearn/src/pages/assessmentsSwitcher/assessmentsSwitcher.html.ts
+++ b/apps/prairielearn/src/pages/assessmentsSwitcher/assessmentsSwitcher.html.ts
@@ -74,7 +74,7 @@ export function AssessmentSwitcher({
               </a>
               ${IssueBadgeHtml({
                 count: row.open_issue_count,
-                urlPrefix: `${plainUrlPrefix}/course_instance/${courseInstanceId}/instructor/`,
+                urlPrefix: `${plainUrlPrefix}/course_instance/${courseInstanceId}/instructor`,
                 issueAid: row.tid,
               })}
             </div>

--- a/apps/prairielearn/src/pages/assessmentsSwitcher/assessmentsSwitcher.html.ts
+++ b/apps/prairielearn/src/pages/assessmentsSwitcher/assessmentsSwitcher.html.ts
@@ -74,7 +74,7 @@ export function AssessmentSwitcher({
               </a>
               ${IssueBadgeHtml({
                 count: row.open_issue_count,
-                urlPrefix: plainUrlPrefix,
+                urlPrefix: `${plainUrlPrefix}/course_instance/${courseInstanceId}/instructor/`,
                 issueAid: row.tid,
               })}
             </div>


### PR DESCRIPTION
The assessment switcher was using `plainUrlPrefix` in place of `urlPrefix`, which in the context of the issue badge component was an incorrect assumption. The issue badge assumes that the `urlPrefix` will have the instructor prefix for either the course or course instance, but the assessment switcher does not have that value in `urlPrefix`, since it does not lie under a route that includes that update. In this context the PR updates the call to the issue badge to include the `urlPrefix` in the format expected by that component.