### PR TITLE
`pl-image-capture` Use entire image button

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -150,6 +150,8 @@ const MAX_ZOOM_SCALE = 5;
       const flipHorizontalButton = this.imageCaptureDiv.querySelector('.js-flip-horizontal-button');
       const flipVerticalButton = this.imageCaptureDiv.querySelector('.js-flip-vertical-button');
 
+      const useFullImageButton = this.imageCaptureDiv.querySelector('.js-use-full-image-button');
+
       this.ensureElementsExist({
         cropRotateButton,
         rotationSlider,
@@ -158,6 +160,7 @@ const MAX_ZOOM_SCALE = 5;
         rotateCounterclockwiseButton,
         flipHorizontalButton,
         flipVerticalButton,
+        useFullImageButton
       });
 
       cropRotateButton.addEventListener('click', () => {
@@ -191,6 +194,10 @@ const MAX_ZOOM_SCALE = 5;
       cancelCropRotateButton.addEventListener('click', () => {
         this.cancelCropRotate();
       });
+
+      useFullImageButton.addEventListener('click', () => {
+        this.selectFullImage();
+      }); 
     }
 
     /**
@@ -1183,6 +1190,40 @@ const MAX_ZOOM_SCALE = 5;
       // Restore the previous hidden capture changed flag value.
       // Needed for the case that the user had no changes before starting crop/rotate.
       this.setCaptureChangedFlag(this.previousCaptureChangedFlag);
+    }
+
+    async selectFullImage() {
+      this.ensureCropperExists();
+
+      const cropperImage = this.cropper.getCropperImage();
+      const cropperSelection = this.cropper.getCropperSelection();
+
+      this.ensureElementsExist({
+        cropperImage,
+        cropperSelection,
+      });
+
+
+      cropperImage.$resetTransform();  
+      cropperSelection.$reset();     
+
+      // Reset the selection to the full image.
+
+      console.log('natural width', cropperImage.width);
+      console.log('natural height', cropperImage.height);
+
+      cropperSelection.$change(
+        0,
+        0,
+        cropperImage.width,
+        cropperImage.height,
+      ).$render();
+
+      // Center the image in the cropper.
+      cropperImage.$center('contain');
+
+      // Save the selection to the hidden input field.
+      await this.saveCropperSelectionToHiddenInput();
     }
   }
 

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -160,7 +160,7 @@ const MAX_ZOOM_SCALE = 5;
         rotateCounterclockwiseButton,
         flipHorizontalButton,
         flipVerticalButton,
-        useFullImageButton
+        useFullImageButton,
       });
 
       cropRotateButton.addEventListener('click', () => {
@@ -197,7 +197,7 @@ const MAX_ZOOM_SCALE = 5;
 
       useFullImageButton.addEventListener('click', () => {
         this.selectFullImage();
-      }); 
+      });
     }
 
     /**
@@ -1197,27 +1197,20 @@ const MAX_ZOOM_SCALE = 5;
 
       const cropperImage = this.cropper.getCropperImage();
       const cropperSelection = this.cropper.getCropperSelection();
+      const cropperCanvas = this.cropper.getCropperCanvas();
 
       this.ensureElementsExist({
         cropperImage,
         cropperSelection,
+        cropperCanvas,
       });
 
+      cropperImage.$resetTransform();
 
-      cropperImage.$resetTransform();  
-      cropperSelection.$reset();     
-
-      // Reset the selection to the full image.
-
-      console.log('natural width', cropperImage.width);
-      console.log('natural height', cropperImage.height);
-
-      cropperSelection.$change(
-        0,
-        0,
-        cropperImage.width,
-        cropperImage.height,
-      ).$render();
+      // Select the entire image in the cropper.
+      cropperSelection
+        .$change(0, 0, cropperCanvas.clientWidth, cropperCanvas.clientHeight)
+        .$render();
 
       // Center the image in the cropper.
       cropperImage.$center('contain');

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -173,84 +173,98 @@ $(function() {
       >
     </div>
   </div>
-  <div class="js-crop-rotate-container d-none">
-    <div class="js-cropper-container">
-      <img class="js-cropper-base-image w-100" alt="Captured image" />
-    </div>
-    <div class="d-flex align-items-center gap-2 p-2 flex-wrap justify-content-end">
-      <div class="d-flex align-items-center gap-2">
-        <label for="rotation-slider-{{uuid}}" class="text-muted text-nowrap mb-0 me-1">
-          Rotation: 
-        </label>
-        <input 
-          id="rotation-slider-{{uuid}}"
-          type="range" 
-          class="js-rotation-slider form-range mx-2" 
-          style="max-width: 200px; min-width: 100px;" 
-          min="-45" 
-          max="45" 
-          step="1" 
-          value="0"
-        />  
+  <div class="js-crop-rotate-container d-none position-relative">
+    <div class="position-relative">
+      <div class="js-cropper-container">
+        <img class="js-cropper-base-image w-100" alt="Captured image" />
       </div>
-      <div class="d-flex align-items-center gap-2">
-        <button 
-          type="button"
-          class="js-rotate-clockwise-button btn btn-light border"
-          title="Rotate clockwise"
-          data-toggle="tooltip"
-          data-placement="top" 
-          aria-label="Rotate clockwise"
-        >
-          <i class="bi bi-arrow-clockwise"></i>
-        </button>
-        <button 
-          type="button"
-          class="js-rotate-counterclockwise-button btn btn-light border"
-          title="Rotate counterclockwise"
-          data-toggle="tooltip"
-          data-placement="top"
-          aria-label="Rotate counterclockwise"
-        >
-          <i class="bi bi-arrow-counterclockwise"></i>
-        </button>
+      <div class="d-flex align-items-center gap-2 p-2 flex-wrap justify-content-end">
+        <div class="d-flex align-items-center gap-2">
+          <label for="rotation-slider-{{uuid}}" class="text-muted text-nowrap mb-0 me-1">
+            Rotation: 
+          </label>
+          <input 
+            id="rotation-slider-{{uuid}}"
+            type="range" 
+            class="js-rotation-slider form-range mx-2" 
+            style="max-width: 200px; min-width: 100px;" 
+            min="-45" 
+            max="45" 
+            step="1" 
+            value="0"
+          />  
+        </div>
+        <div class="d-flex align-items-center gap-2">
+          <button 
+            type="button"
+            class="js-rotate-clockwise-button btn btn-light border"
+            title="Rotate clockwise"
+            data-toggle="tooltip"
+            data-placement="top" 
+            aria-label="Rotate clockwise"
+          >
+            <i class="bi bi-arrow-clockwise"></i>
+          </button>
+          <button 
+            type="button"
+            class="js-rotate-counterclockwise-button btn btn-light border"
+            title="Rotate counterclockwise"
+            data-toggle="tooltip"
+            data-placement="top"
+            aria-label="Rotate counterclockwise"
+          >
+            <i class="bi bi-arrow-counterclockwise"></i>
+          </button>
 
-        <button 
-          type="button"
-          class="js-flip-horizontal-button btn btn-light border"
-          title="Flip horizontally"
-          data-toggle="tooltip"
-          data-placement="top"
-          aria-label="Flip horizontally"
-        >
-          <i class="bi bi-symmetry-vertical"></i>
-        </button>
-        <button 
-          type="button"
-          class="js-flip-vertical-button btn btn-light border"
-          title="Flip vertically"
-          data-toggle="tooltip"
-          data-placement="top"
-          aria-label="Flip vertically"
-        >
-          <i class="bi bi-symmetry-horizontal"></i>
-        </button>
+          <button 
+            type="button"
+            class="js-flip-horizontal-button btn btn-light border"
+            title="Flip horizontally"
+            data-toggle="tooltip"
+            data-placement="top"
+            aria-label="Flip horizontally"
+          >
+            <i class="bi bi-symmetry-vertical"></i>
+          </button>
+          <button 
+            type="button"
+            class="js-flip-vertical-button btn btn-light border"
+            title="Flip vertically"
+            data-toggle="tooltip"
+            data-placement="top"
+            aria-label="Flip vertically"
+          >
+            <i class="bi bi-symmetry-horizontal"></i>
+          </button>
+        </div>
+        <div class="d-flex align-items-center gap-2 justify-content-end flex-wrap">
+          <button 
+            type="button"
+            class="js-cancel-crop-rotate-button btn btn-secondary"
+          >
+            Cancel
+          </button>
+          <button 
+            type="button" 
+            class="js-apply-changes-button btn btn-info"
+          >
+            <i class="bi bi-check2 me-1"></i>
+            Apply changes
+          </button>
+        </div>
       </div>
-      <div class="d-flex align-items-center gap-2 justify-content-end flex-wrap">
-        <button 
-          type="button"
-          class="js-cancel-crop-rotate-button btn btn-secondary"
-        >
-          Cancel
-        </button>
-        <button 
-          type="button" 
-          class="js-apply-changes-button btn btn-info"
-        >
-          <i class="bi bi-check2 me-1"></i>
-          Apply changes
-        </button>
-      </div>
+    </div>
+    <div class="js-top-buttons position-absolute top-0 end-0 m-2">
+      <button 
+        type="button" 
+        class="js-use-full-image-button btn btn-primary"
+        title="Crop to the full, original image"
+        data-toggle="tooltip"
+        data-placement="top" 
+        aria-label="Crop to the full, original image"
+      >
+        Use full image
+      </button>
     </div>
   </div>
   

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -261,9 +261,10 @@ $(function() {
         title="Crop to the full, original image"
         data-toggle="tooltip"
         data-placement="top" 
+        trigger="hover"
         aria-label="Crop to the full, original image"
       >
-        Use full image
+        Use entire image
       </button>
     </div>
   </div>


### PR DESCRIPTION
To undo crop and rotation changes, users currently must manually undo changes or retake their image. This can be particularly frustrating in exam environments, where pressure is high and time is very valuable. 

This PR adds a button to select the entire image in the crop/rotate interface:

<img width="729" height="715" alt="Screenshot 2025-08-04 at 10 00 00 AM" src="https://github.com/user-attachments/assets/6c750684-1720-48a4-8cb6-ac99d91d2180" />

On click:

<img width="711" height="705" alt="Screenshot 2025-08-04 at 10 00 36 AM" src="https://github.com/user-attachments/assets/65e10c19-d0e5-453f-87fc-6de6051d8dc0" />

On hover: 
<img width="282" height="151" alt="Screenshot 2025-08-04 at 10 00 43 AM" src="https://github.com/user-attachments/assets/af97f970-37f2-41d6-b180-e62638ddd0d5" />
