### PR TITLE
`pl-image-capture` Delete uploaded image

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -48,8 +48,42 @@ $(function() {
           </div>
         </div>
       </div>
-      {{^editable}}
-      <div class="js-zoom-buttons position-absolute top-0 end-0 m-2 d-none">
+      <div class="js-uploaded-image-container-top-buttons position-absolute top-0 end-0 m-2 d-none">
+        {{#editable}}
+        <div class="js-uploaded-image-deletion-buttons">
+          <button 
+            type="button" 
+            class="js-delete-uploaded-image-button btn btn-danger"
+            title="Delete uploaded image"
+            data-toggle="tooltip"
+            data-placement="top" 
+            data-trigger="hover"
+            aria-label="Delete uploaded image"
+          >
+            <i class="bi bi-trash-fill"></i>
+          </button>
+        </div>
+        <div class="js-uploaded-image-deletion-confirmation-buttons d-none align-items-center gap-2 p-2 bg-black bg-opacity-75 rounded flex-wrap">
+          <span class="text-white me-2">Are you sure? This is permanent. </span>
+          <div class="d-flex align-items-center gap-2 flex-wrap">
+            <button 
+              type="button" 
+              class="js-confirm-delete-uploaded-image-button btn btn-danger"
+              aria-label="Delete image permanently"
+            >
+              Delete
+            </button>
+            <button 
+              type="button" 
+              class="js-cancel-delete-uploaded-image-button btn btn-secondary"
+              aria-label="Cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+        {{/editable}}
+        {{^editable}}
         <button 
           type="button" 
           class="js-zoom-in-button btn btn-light border"
@@ -70,8 +104,8 @@ $(function() {
         >
           <i class="bi bi-zoom-out"></i>
         </button>
+        {{/editable}}
       </div>
-      {{/editable}}
     </div>
 
     {{#editable}}


### PR DESCRIPTION
Currently users can't delete images captured with `pl-image-capture`, which would be an issue if a user accidentally captures unintended/irrelevant content. 

This PR adds a button that lets users delete their captured image.

<img width="709" height="693" alt="Screenshot 2025-08-04 at 11 03 20 AM" src="https://github.com/user-attachments/assets/54cf8078-1b44-408a-8926-a444350f959d" />

<img width="624" height="595" alt="Screenshot 2025-08-04 at 11 03 38 AM" src="https://github.com/user-attachments/assets/4fd0c34c-1d46-43cc-a96f-9b95a342f5b9" />