### PR TITLE
`pl-image-capture` Clean sheet instruction

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -381,7 +381,11 @@ const MAX_ZOOM_SCALE = 5;
       });
 
       imagePlaceholderDiv.innerHTML = `
-        <span class="text-muted">No image captured yet.</span>
+        <span class="text-muted text-center">
+          No image captured yet.
+          <br/>
+          Use a clean sheet of paper for each capture.
+        </span>
       `;
     }
 

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -384,7 +384,7 @@ const MAX_ZOOM_SCALE = 5;
         <span class="text-muted text-center">
           No image captured yet.
           <br/>
-          Use a clean sheet of paper for each capture.
+          Use a clean sheet of paper.
         </span>
       `;
     }


### PR DESCRIPTION
Based on feedback from testing, instructed students to use a clean sheet of paper for every capture. 

I placed this below "No image captured yet" so that students see the message before they start writing. 

<img width="661" height="328" alt="Screenshot 2025-08-04 at 12 03 41 PM" src="https://github.com/user-attachments/assets/fa586d83-9583-4114-88ba-ac488de9389e" />
