### PR TITLE
Use process.stdout.write in executor

### DIFF
--- a/apps/prairielearn/src/executor.ts
+++ b/apps/prairielearn/src/executor.ts
@@ -143,7 +143,7 @@ process.once('SIGTERM', () => process.exit(0));
   for await (const line of rl) {
     const results = await handleInput(line, codeCaller);
     const { needsFullRestart, ...rest } = results;
-    console.log(JSON.stringify(rest));
+    process.stdout.write(JSON.stringify(rest) + '\n');
     if (needsFullRestart) {
       codeCaller.done();
       codeCaller = await prepareCodeCaller();


### PR DESCRIPTION
#12501 brought this to my attention. IMO using something more low-level like this is more appropriate here.