### PR TITLE
`pl-image-capture` Submitted image rotation

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.css
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.css
@@ -1,4 +1,5 @@
 .capture-preview {
   object-fit: contain;
   max-height: max(60vh, 600px);
+  transition: transform 0.2s ease-in-out;
 }

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -506,7 +506,7 @@ const MAX_ZOOM_SCALE = 5;
       capturePreview.alt = 'Captured image preview';
 
       const capturePreviewParent = document.createElement('div');
-      capturePreviewParent.className = 'js-capture-preview-div';
+      capturePreviewParent.className = 'js-capture-preview-div bg-body-secondary';
       capturePreviewParent.style.transformOrigin = 'center center';
 
       capturePreviewParent.appendChild(capturePreview);
@@ -518,7 +518,6 @@ const MAX_ZOOM_SCALE = 5;
         capturePreview.addEventListener(
           'load',
           () => {
-            this.capturePreviewWidth = capturePreview.clientWidth;
             this.capturePreviewHeight = capturePreview.clientHeight;
           },
           { once: true },
@@ -574,13 +573,34 @@ const MAX_ZOOM_SCALE = 5;
             // Don't use modulo to ensure that the animated rotation direction is always clockwise.
             rotation += 90;
 
-            // If the image is rotated by 90 or 270 degrees, it must be scaled down to fit within the original dimensions. 
-            // If width > height, the scale factor is height / width (scale down longer width to match the original height)
-            // If width < height, the scale factor is width / height (scale down longer height to match the original width)
-            // Otherwise, reset the scale factor to 1.
-            const rotatedScaleFactor = rotation % 180 === 0 ? 1 : Math.min(this.capturePreviewWidth / this.capturePreviewHeight, this.capturePreviewHeight / this.capturePreviewWidth);
+            // Obtain the dimensions of the image after rotation, in case the user
+            // changed their viewport dimensions.
+            const capturePreview = this.imageCaptureDiv.querySelector('.capture-preview');
 
-            capturePreviewImg.style.transform = `rotate(${rotation}deg) scale(${rotatedScaleFactor})`;
+            const photoHeight = capturePreview.clientHeight;
+
+            /**
+             * Calculate the width of the photo within the capture preview, accounting for
+             * when the maxHeight constraint results in gray bars on the sides of the image.
+             */
+            const photoWidth =
+              photoHeight * (capturePreview.naturalWidth / capturePreview.naturalHeight);
+
+            const clientHeight = capturePreview.clientHeight;
+            const clientWidth = capturePreview.clientWidth;
+
+            /**
+             * Calculate the scale factor based on the rotation and the aspect ratio.
+             *
+             * If the rotation is 0 or 180 degrees, the scale factor is 1.
+             * If the rotation is 90 or 270 degrees, the scale factor is determined by the aspect ratio of the image.
+             */
+            const scaleFactor =
+              rotation % 180 === 0
+                ? 1
+                : Math.min(clientHeight / photoWidth, clientWidth / photoHeight);
+
+            capturePreviewImg.style.transform = `rotate(${rotation}deg) scale(${scaleFactor})`;
             this.imageCapturePreviewPanzoom.reset({ animate: true });
           });
 

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -507,7 +507,6 @@ const MAX_ZOOM_SCALE = 5;
 
       const capturePreviewParent = document.createElement('div');
       capturePreviewParent.className = 'js-capture-preview-div bg-body-secondary';
-      // capturePreviewParent.style.transformOrigin = 'center center';
 
       capturePreviewParent.appendChild(capturePreview);
 

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -544,7 +544,6 @@ const MAX_ZOOM_SCALE = 5;
         zoomButtonsContainer.classList.remove('d-none');
 
         if (!this.imageCapturePreviewPanzoom) {
-          let rotation = 0;
           // Initialize Panzoom on the parent of the captured image element, since
           // the image itself may be rotated.
           this.imageCapturePreviewPanzoom = Panzoom(capturePreviewParent, {
@@ -560,6 +559,7 @@ const MAX_ZOOM_SCALE = 5;
             this.imageCapturePreviewPanzoom.zoomOut();
           });
 
+          let rotation = 0;
           viewerRotateClockwiseButton.addEventListener('click', () => {
             const capturePreviewImg = this.imageCaptureDiv.querySelector(
               '.js-uploaded-image-container .capture-preview',

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -544,12 +544,16 @@ const MAX_ZOOM_SCALE = 5;
         zoomButtonsContainer.classList.remove('d-none');
 
         if (!this.imageCapturePreviewPanzoom) {
+          let rotation = 0;
           // Initialize Panzoom on the parent of the captured image element, since
           // the image itself may be rotated.
           this.imageCapturePreviewPanzoom = Panzoom(capturePreviewParent, {
             contain: 'outside',
             minScale: MIN_ZOOM_SCALE,
             maxScale: MAX_ZOOM_SCALE,
+            setTransform: (_, { scale, x, y }) => {
+              this.imageCapturePreviewPanzoom.setStyle('transform', `rotate(${rotation}deg) scale(${scale}) translate(${x}px, ${y}px)`);    
+            }
           });
 
           zoomInButton.addEventListener('click', () => {
@@ -559,7 +563,6 @@ const MAX_ZOOM_SCALE = 5;
             this.imageCapturePreviewPanzoom.zoomOut();
           });
 
-          let rotation = 0;
           viewerRotateClockwiseButton.addEventListener('click', () => {
             const capturePreviewImg = this.imageCaptureDiv.querySelector(
               '.js-uploaded-image-container .capture-preview',
@@ -571,7 +574,9 @@ const MAX_ZOOM_SCALE = 5;
 
             // Don't use modulo to ensure that the animated rotation direction is always clockwise.
             rotation += 90;
-            capturePreviewImg.style.transform = `rotate(${rotation}deg)`;
+
+            this.imageCapturePreviewPanzoom.reset({ animate: true });
+            // capturePreviewImg.style.transform = `rotate(${rotation}deg)`;
           });
 
           let panEnabled = false;

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -544,7 +544,7 @@ const MAX_ZOOM_SCALE = 5;
         zoomButtonsContainer.classList.remove('d-none');
 
         if (!this.imageCapturePreviewPanzoom) {
-          // Initialize Panzoom on the parent of the image element, since
+          // Initialize Panzoom on the parent of the captured image element, since
           // the image itself may be rotated.
           this.imageCapturePreviewPanzoom = Panzoom(capturePreviewParent, {
             contain: 'outside',

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -570,30 +570,32 @@ const MAX_ZOOM_SCALE = 5;
               capturePreviewImg,
             });
 
-            // Don't use modulo to ensure that the animated rotation direction is always clockwise.
-            rotation += 90;
-
-            // Obtain the dimensions of the image after rotation, in case the user
-            // changed their viewport dimensions.
-            const capturePreview = this.imageCaptureDiv.querySelector('.capture-preview');
-
-            const photoHeight = capturePreview.clientHeight;
+            /**
+             * The image within the capture preview div always fills the height of the div.
+             */
+            const photoHeight = capturePreviewImg.clientHeight;
 
             /**
-             * Calculate the width of the photo within the capture preview, accounting for
-             * when the maxHeight constraint results in gray bars on the sides of the image.
+             * Compute the displayed image width inside the capture preview div, excluding
+             * any whitespace on the side that resulted from the max-height: 600px constraint.
              */
             const photoWidth =
-              photoHeight * (capturePreview.naturalWidth / capturePreview.naturalHeight);
+              photoHeight * (capturePreviewImg.naturalWidth / capturePreviewImg.naturalHeight);
 
-            const clientHeight = capturePreview.clientHeight;
-            const clientWidth = capturePreview.clientWidth;
+            const clientHeight = capturePreviewImg.clientHeight;
+            const clientWidth = capturePreviewImg.clientWidth;
 
             /**
-             * Calculate the scale factor based on the rotation and the aspect ratio.
+             * Rotation is strictly increasing so that the rotation animation is always in the same direction.
+             */
+            rotation += 90;
+
+            /**
+             * Compute the scale factor based on the rotation.
              *
-             * If the rotation is 0 or 180 degrees, the scale factor is 1.
-             * If the rotation is 90 or 270 degrees, the scale factor is determined by the aspect ratio of the image.
+             * - If image is parallel to the capture preview div, reset its scaling to 1.
+             * - If image is perpendicular to the capture preview div, scale it so its longest side
+             *   fits within the preview container without clipping.
              */
             const scaleFactor =
               rotation % 180 === 0

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -507,7 +507,7 @@ const MAX_ZOOM_SCALE = 5;
 
       const capturePreviewParent = document.createElement('div');
       capturePreviewParent.className = 'js-capture-preview-div bg-body-secondary';
-      capturePreviewParent.style.transformOrigin = 'center center';
+      // capturePreviewParent.style.transformOrigin = 'center center';
 
       capturePreviewParent.appendChild(capturePreview);
 
@@ -570,33 +570,24 @@ const MAX_ZOOM_SCALE = 5;
               capturePreviewImg,
             });
 
-            /**
-             * The image within the capture preview div always fills the height of the div.
-             */
+            // The capture preview image always fills the entire height.
             const photoHeight = capturePreviewImg.clientHeight;
 
-            /**
-             * Compute the displayed image width inside the capture preview div, excluding
-             * any whitespace on the side that resulted from the max-height: 600px constraint.
-             */
+            // Compute the width of the capture preview image excluding any side
+            // whitespace coming from the max-height: 600px constraint.
             const photoWidth =
               photoHeight * (capturePreviewImg.naturalWidth / capturePreviewImg.naturalHeight);
 
             const clientHeight = capturePreviewImg.clientHeight;
             const clientWidth = capturePreviewImg.clientWidth;
 
-            /**
-             * Rotation is strictly increasing so that the rotation animation is always in the same direction.
-             */
+            // Rotation is strictly increasing so that the rotation animation is always in the same direction.
             rotation += 90;
 
-            /**
-             * Compute the scale factor based on the rotation.
-             *
-             * - If image is parallel to the capture preview div, reset its scaling to 1.
-             * - If image is perpendicular to the capture preview div, scale it so its longest side
-             *   fits within the preview container without clipping.
-             */
+            // Compute the scale factor based on the rotation.
+            // - If image is parallel to the capture preview div, reset its scaling to 1.
+            // - If image is perpendicular to the capture preview div, scale it so its longest side
+            //   fits within the preview container without clipping.
             const scaleFactor =
               rotation % 180 === 0
                 ? 1

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -500,7 +500,7 @@ const MAX_ZOOM_SCALE = 5;
       });
 
       const capturePreview = document.createElement('img');
-      capturePreview.className = 'capture-preview img-fluid bg-body-secondary w-100 transition-all';
+      capturePreview.className = 'capture-preview img-fluid bg-body-secondary w-100';
 
       capturePreview.src = dataUrl;
       capturePreview.alt = 'Captured image preview';
@@ -544,8 +544,8 @@ const MAX_ZOOM_SCALE = 5;
         zoomButtonsContainer.classList.remove('d-none');
 
         if (!this.imageCapturePreviewPanzoom) {
-          let rotation = 0;
-
+          // Initialize Panzoom on the parent of the image element, since
+          // the image itself may be rotated.
           this.imageCapturePreviewPanzoom = Panzoom(capturePreviewParent, {
             contain: 'outside',
             minScale: MIN_ZOOM_SCALE,
@@ -558,6 +558,8 @@ const MAX_ZOOM_SCALE = 5;
           zoomOutButton.addEventListener('click', () => {
             this.imageCapturePreviewPanzoom.zoomOut();
           });
+
+          let rotation = 0;
           viewerRotateClockwiseButton.addEventListener('click', () => {
             const capturePreviewImg = this.imageCaptureDiv.querySelector(
               '.js-uploaded-image-container .capture-preview',
@@ -567,9 +569,9 @@ const MAX_ZOOM_SCALE = 5;
               capturePreviewImg,
             });
 
+            // Don't use modulo to ensure that the animated rotation direction is always clockwise.
             rotation += 90;
             capturePreviewImg.style.transform = `rotate(${rotation}deg)`;
-            // this.imageCapturePreviewPanzoom.reset({ animate: false });
           });
 
           let panEnabled = false;

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -507,6 +507,7 @@ const MAX_ZOOM_SCALE = 5;
 
       const capturePreviewParent = document.createElement('div');
       capturePreviewParent.className = 'js-capture-preview-div';
+      capturePreviewParent.style.transformOrigin = 'center center';
 
       capturePreviewParent.appendChild(capturePreview);
 
@@ -517,6 +518,7 @@ const MAX_ZOOM_SCALE = 5;
         capturePreview.addEventListener(
           'load',
           () => {
+            this.capturePreviewWidth = capturePreview.clientWidth;
             this.capturePreviewHeight = capturePreview.clientHeight;
           },
           { once: true },
@@ -551,9 +553,6 @@ const MAX_ZOOM_SCALE = 5;
             contain: 'outside',
             minScale: MIN_ZOOM_SCALE,
             maxScale: MAX_ZOOM_SCALE,
-            setTransform: (_, { scale, x, y }) => {
-              this.imageCapturePreviewPanzoom.setStyle('transform', `rotate(${rotation}deg) scale(${scale}) translate(${x}px, ${y}px)`);    
-            }
           });
 
           zoomInButton.addEventListener('click', () => {
@@ -575,8 +574,14 @@ const MAX_ZOOM_SCALE = 5;
             // Don't use modulo to ensure that the animated rotation direction is always clockwise.
             rotation += 90;
 
+            // If the image is rotated by 90 or 270 degrees, it must be scaled down to fit within the original dimensions. 
+            // If width > height, the scale factor is height / width (scale down longer width to match the original height)
+            // If width < height, the scale factor is width / height (scale down longer height to match the original width)
+            // Otherwise, reset the scale factor to 1.
+            const rotatedScaleFactor = rotation % 180 === 0 ? 1 : Math.min(this.capturePreviewWidth / this.capturePreviewHeight, this.capturePreviewHeight / this.capturePreviewWidth);
+
+            capturePreviewImg.style.transform = `rotate(${rotation}deg) scale(${rotatedScaleFactor})`;
             this.imageCapturePreviewPanzoom.reset({ animate: true });
-            // capturePreviewImg.style.transform = `rotate(${rotation}deg)`;
           });
 
           let panEnabled = false;

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -500,13 +500,18 @@ const MAX_ZOOM_SCALE = 5;
       });
 
       const capturePreview = document.createElement('img');
-      capturePreview.className = 'capture-preview img-fluid bg-body-secondary w-100';
+      capturePreview.className = 'capture-preview img-fluid bg-body-secondary w-100 transition-all';
 
       capturePreview.src = dataUrl;
       capturePreview.alt = 'Captured image preview';
 
+      const capturePreviewParent = document.createElement('div');
+      capturePreviewParent.className = 'js-capture-preview-div';
+
+      capturePreviewParent.appendChild(capturePreview);
+
       uploadedImageContainer.innerHTML = '';
-      uploadedImageContainer.appendChild(capturePreview);
+      uploadedImageContainer.appendChild(capturePreviewParent);
 
       if (originalCapture) {
         capturePreview.addEventListener(
@@ -520,11 +525,15 @@ const MAX_ZOOM_SCALE = 5;
 
       if (!this.editable) {
         const zoomButtonsContainer = this.imageCaptureDiv.querySelector('.js-zoom-buttons');
+        const viewerRotateClockwiseButton = this.imageCaptureDiv.querySelector(
+          '.js-viewer-rotate-clockwise-button',
+        );
         const zoomInButton = this.imageCaptureDiv.querySelector('.js-zoom-in-button');
         const zoomOutButton = this.imageCaptureDiv.querySelector('.js-zoom-out-button');
 
         this.ensureElementsExist({
           zoomButtonsContainer,
+          viewerRotateClockwiseButton,
           zoomInButton,
           zoomOutButton,
         });
@@ -535,7 +544,9 @@ const MAX_ZOOM_SCALE = 5;
         zoomButtonsContainer.classList.remove('d-none');
 
         if (!this.imageCapturePreviewPanzoom) {
-          this.imageCapturePreviewPanzoom = Panzoom(capturePreview, {
+          let rotation = 0;
+
+          this.imageCapturePreviewPanzoom = Panzoom(capturePreviewParent, {
             contain: 'outside',
             minScale: MIN_ZOOM_SCALE,
             maxScale: MAX_ZOOM_SCALE,
@@ -546,6 +557,19 @@ const MAX_ZOOM_SCALE = 5;
           });
           zoomOutButton.addEventListener('click', () => {
             this.imageCapturePreviewPanzoom.zoomOut();
+          });
+          viewerRotateClockwiseButton.addEventListener('click', () => {
+            const capturePreviewImg = this.imageCaptureDiv.querySelector(
+              '.js-uploaded-image-container .capture-preview',
+            );
+
+            this.ensureElementsExist({
+              capturePreviewImg,
+            });
+
+            rotation += 90;
+            capturePreviewImg.style.transform = `rotate(${rotation}deg)`;
+            // this.imageCapturePreviewPanzoom.reset({ animate: false });
           });
 
           let panEnabled = false;

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -52,6 +52,16 @@ $(function() {
       <div class="js-zoom-buttons position-absolute top-0 end-0 m-2 d-none">
         <button 
           type="button" 
+          class="js-viewer-rotate-clockwise-button btn btn-light border"
+          title="Rotate clockwise"
+          data-toggle="tooltip"
+          data-placement="top"
+          aria-label="Rotate clockwise"
+        >
+          <i class="bi bi-arrow-clockwise"></i>
+        </button>
+        <button 
+          type="button" 
           class="js-zoom-in-button btn btn-light border"
           title="Zoom in"
           data-toggle="tooltip"

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -54,8 +54,8 @@ $(function() {
           type="button" 
           class="js-viewer-rotate-clockwise-button btn btn-light border"
           title="Rotate clockwise"
-          data-toggle="tooltip"
-          data-placement="top"
+          data-bs-toggle="tooltip"
+          data-bs-placement="top"
           aria-label="Rotate clockwise"
         >
           <i class="bi bi-arrow-clockwise"></i>
@@ -64,8 +64,8 @@ $(function() {
           type="button" 
           class="js-zoom-in-button btn btn-light border"
           title="Zoom in"
-          data-toggle="tooltip"
-          data-placement="top" 
+          data-bs-toggle="tooltip"
+          data-bs-placement="top" 
           aria-label="Zoom in"
         >
           <i class="bi bi-zoom-in"></i>
@@ -74,8 +74,8 @@ $(function() {
           type="button" 
           class="js-zoom-out-button btn btn-light border"
           title="Zoom out"
-          data-toggle="tooltip"
-          data-placement="top" 
+          data-bs-toggle="tooltip"
+          data-bs-placement="top" 
           aria-label="Zoom out"
         >
           <i class="bi bi-zoom-out"></i>


### PR DESCRIPTION
Closes #12560

- Added rotate clockwise button for viewing submitted images captured with `pl-image-capture`

<img width="1198" height="999" alt="Screenshot 2025-08-04 at 2 01 22 PM" src="https://github.com/user-attachments/assets/7fd6228c-2c8b-4d18-add5-bdea5af21966" />
