### PR TITLE
Use cryptographically secure keys/secrets for LTI 1.1

### DIFF
--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import z from 'zod';
@@ -113,9 +115,11 @@ router.post(
 
 export default router;
 
-function randomString() {
-  const len = 10;
-  return (
-    Math.random().toString(36).substring(2, len) + Math.random().toString(36).substring(2, len)
-  );
+/** Generates a cryptographically secure random alphanumeric string. */
+function randomString(length = 32) {
+  // Each byte is two hex characters, so we need Math.ceil(length / 2)
+  return crypto
+    .randomBytes(Math.ceil(length / 2))
+    .toString('hex')
+    .slice(0, length);
 }


### PR DESCRIPTION
Lifting out of https://github.com/PrairieLearn/PrairieLearn/pull/12546#discussion_r2252223969. With hexadecimal characters, a length of 32 gives us 128 bits of entropy, which should be sufficient.