### PR TITLE
Handle null enrollment dates in students table

### DIFF
--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
@@ -1,5 +1,4 @@
 import {
-  type AccessorKeyColumnDef,
   type ColumnFiltersState,
   type ColumnPinningState,
   type ColumnSizingState,
@@ -82,24 +81,25 @@ function StudentsCard({ course, courseInstance, students, timezone }: StudentsCa
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 
-  const columns = useMemo<AccessorKeyColumnDef<StudentRow, any>[]>(
+  const columns = useMemo(
     () => [
-      columnHelper.accessor('user.uid', {
+      columnHelper.accessor((row) => row.user.uid, {
         header: 'UID',
         cell: (info) => info.getValue(),
       }),
-      columnHelper.accessor('user.name', {
+      columnHelper.accessor((row) => row.user.name, {
         header: 'Name',
         cell: (info) => info.getValue() || '—',
       }),
-      columnHelper.accessor('user.email', {
+      columnHelper.accessor((row) => row.user.email, {
         header: 'Email',
         cell: (info) => info.getValue() || '—',
       }),
-      columnHelper.accessor('enrollment.created_at', {
+      columnHelper.accessor((row) => row.enrollment.created_at, {
         header: 'Enrolled on',
         cell: (info) => {
-          const date = new Date(info.getValue());
+          const date = info.getValue();
+          if (date == null) return '—';
           return (
             <FriendlyDate date={date} timezone={timezone} options={{ includeTz: false }} tooltip />
           );


### PR DESCRIPTION
This came up during testing of the students table on staging, where a lot of enrollments were created before we started tracking an enrollment date. If the date isn't known, we'll render an em dash, consistent with names and emails.