### PR TITLE
Reduce `pl-image-capture` font sizes

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -381,7 +381,7 @@ const MAX_ZOOM_SCALE = 5;
       });
 
       imagePlaceholderDiv.innerHTML = `
-        <span class="text-muted text-center">
+        <span class="small text-muted text-center ">
           No image captured yet.
           <br/>
           Use a clean sheet of paper.

--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.mustache
@@ -88,14 +88,14 @@ $(function() {
     <div class="d-flex gap-2 flex-wrap p-2 justify-content-end border-top">
       <button
         type="button"
-        class="js-crop-rotate-button btn btn-secondary d-none"
+        class="js-crop-rotate-button btn btn-secondary btn-sm d-none"
       >
         <i class="bi bi-crop me-1"></i>
         Crop/rotate
       </button>
       <button
         type="button"
-        class="js-capture-with-local-camera-button btn btn-info"
+        class="js-capture-with-local-camera-button btn btn-info btn-sm"
       >
         <i class="bi bi-camera-fill me-1"></i>
         <span>Use webcam</span>
@@ -103,7 +103,7 @@ $(function() {
       {{#mobile_capture_enabled}}
         <button 
           type="button" 
-          class="js-capture-with-mobile-device-button btn btn-info"
+          class="js-capture-with-mobile-device-button btn btn-info btn-sm"
           data-bs-toggle="popover"
           data-bs-container="body"
           data-bs-html="true"
@@ -117,18 +117,18 @@ $(function() {
                   <span class="visually-hidden">Loading...</span>
                 </div>
               </div>
-              <p class="text-muted mb-0">
+              <p class="small text-muted mb-0">
                 Scan the QR code with your mobile device to capture an image of your work. 
               </p>
             {{/external_image_capture_available}}
             {{^external_image_capture_available}}
-              <p class="text-muted mb-0">
+              <p class="small text-muted mb-0">
                 Mobile device capture is not available in this environment.
               </p>
-              <p class="text-muted mb-0 mt-3">
+              <p class="small text-muted mb-0 mt-3">
                 It will be available once the question is deployed to production.
               </p>
-              <p class="text-muted mb-0 mt-3">
+              <p class="small text-muted mb-0 mt-3">
                 For setup instructions to enable mobile capture locally, refer to the <a href="https://prairielearn.readthedocs.io/en/latest/dev-guide/configJson/#setting-up-external-image-capture-locally" target="_blank">the server configuration guide</a>.
               </p>
             {{/external_image_capture_available}}
@@ -157,7 +157,7 @@ $(function() {
       </div>
     </div>
     <div class="d-flex p-2 gap-2 justify-content-end align-items-center flex-wrap">
-      <p class="js-local-camera-instructions text-muted my-0 me-auto">
+      <p class="js-local-camera-instructions text-muted my-0 me-auto small">
         Make sure your photo is clear, well-lit, and shows all your work legibly. 
         <br/>
         Later, you can crop or rotate the image as needed.
@@ -165,13 +165,13 @@ $(function() {
       <div class="d-flex align-items-center gap-2">
         <button 
           type="button"
-          class="js-cancel-local-camera-button btn btn-secondary"
+          class="js-cancel-local-camera-button btn btn-secondary btn-sm"
         >
           Cancel
         </button>
         <button 
           type="button"
-          class="js-capture-local-camera-image-button btn btn-info" 
+          class="js-capture-local-camera-image-button btn btn-info btn-sm" 
           disabled
         >
           <i class="bi bi-camera-fill me-1"></i>
@@ -189,7 +189,7 @@ $(function() {
     </div>
     <div class="d-flex align-items-center gap-2 p-2 flex-wrap justify-content-end">
       <div class="d-flex align-items-center gap-2">
-        <label for="rotation-slider-{{uuid}}" class="text-muted text-nowrap mb-0 me-1">
+        <label for="rotation-slider-{{uuid}}" class="text-muted text-nowrap mb-0 me-1 small">
           Rotation: 
         </label>
         <input 
@@ -206,7 +206,7 @@ $(function() {
       <div class="d-flex align-items-center gap-2">
         <button 
           type="button"
-          class="js-rotate-clockwise-button btn btn-light border"
+          class="js-rotate-clockwise-button btn btn-light border btn-sm"
           title="Rotate clockwise"
           data-toggle="tooltip"
           data-placement="top" 
@@ -216,7 +216,7 @@ $(function() {
         </button>
         <button 
           type="button"
-          class="js-rotate-counterclockwise-button btn btn-light border"
+          class="js-rotate-counterclockwise-button btn btn-light border btn-sm"
           title="Rotate counterclockwise"
           data-toggle="tooltip"
           data-placement="top"
@@ -249,13 +249,13 @@ $(function() {
       <div class="d-flex align-items-center gap-2 justify-content-end flex-wrap">
         <button 
           type="button"
-          class="js-cancel-crop-rotate-button btn btn-secondary"
+          class="js-cancel-crop-rotate-button btn btn-secondary btn-sm"
         >
           Cancel
         </button>
         <button 
           type="button" 
-          class="js-apply-changes-button btn btn-info"
+          class="js-apply-changes-button btn btn-info btn-sm"
         >
           <i class="bi bi-check2 me-1"></i>
           Apply changes


### PR DESCRIPTION
- Reduced `pl-image-capture` button and font sizes to `small`/`btn-sm` to make space in the bottom bar for the "delete uploaded image" button in #12549 and "use entire image" button in #12548 

<img width="798" height="522" alt="Screenshot 2025-08-06 at 10 54 41 AM" src="https://github.com/user-attachments/assets/5c870d80-822a-4069-ab7b-a2e47302f502" />

<img width="807" height="843" alt="Screenshot 2025-08-06 at 10 55 08 AM" src="https://github.com/user-attachments/assets/a587021e-ee8b-421b-a5c6-bc10b0d9008c" />

<img width="816" height="910" alt="Screenshot 2025-08-06 at 10 55 19 AM" src="https://github.com/user-attachments/assets/d091018b-27ba-4a3c-b6b0-7dcbc4d503e7" />

<img width="855" height="830" alt="Screenshot 2025-08-06 at 10 55 39 AM" src="https://github.com/user-attachments/assets/2ed1fbb4-a1cc-4d8b-b8e7-c661ba601008" />

