### PR TITLE
Fix inflated fingerprint change count

### DIFF
--- a/apps/prairielearn/src/middlewares/clientFingerprint.ts
+++ b/apps/prairielearn/src/middlewares/clientFingerprint.ts
@@ -19,13 +19,13 @@ export default asyncHandler(async (req, res, next) => {
     // Only update the client fingerprint if the assessment is open and the
     // access to the assessment is active (i.e., student has permission to
     // submit new answers)
-    res.locals.assessment_instance?.open &&
+    res.locals.assessment_instance.open &&
     res.locals.authz_result?.active &&
-    !idsEqual(res.locals.assessment_instance?.last_client_fingerprint_id, client_fingerprint_id)
+    !idsEqual(res.locals.assessment_instance.last_client_fingerprint_id, client_fingerprint_id)
   ) {
     await sqldb.queryAsync(sql.update_assessment_instance_fingerprint, {
       client_fingerprint_id,
-      assessment_instance_id: res.locals.assessment_instance?.id,
+      assessment_instance_id: res.locals.assessment_instance.id,
       authn_user_id: res.locals.authn_user.user_id,
     });
   }

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts
@@ -34,10 +34,10 @@ const router = Router({ mergeParams: true });
 router.use(selectAndAuthzAssessment);
 router.use(studentAssessmentRedirect);
 router.use(studentAssessmentAccess);
-router.use(logPageView('studentAssessment'));
 
 router.get(
   '/',
+  logPageView('studentAssessmentInstance'),
   asyncHandler(async function (req, res) {
     if (!(res.locals.authz_result?.active ?? true)) {
       // If the student had started the assessment already, they would have been

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
@@ -32,8 +32,6 @@ const sql = loadSqlEquiv(import.meta.url);
 
 router.use(selectAndAuthzAssessmentInstance);
 router.use(studentAssessmentAccess);
-router.use(clientFingerprint);
-router.use(logPageView('studentAssessmentInstance'));
 
 async function ensureUpToDate(locals: Record<string, any>) {
   const updated = await assessment.updateAssessmentInstance(
@@ -218,6 +216,11 @@ router.post(
 
 router.get(
   '/',
+  // We only handle fingerprints on the GET handler. The POST handler won't log
+  // page views, and we only want to track fingerprint changes when we'll also
+  // have a corresponding page view event to show in the logs.
+  clientFingerprint,
+  logPageView('studentAssessmentInstance'),
   asyncHandler(async (req, res, _next) => {
     if (res.locals.assessment.type === 'Homework') {
       await ensureUpToDate(res.locals);

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceFile/studentAssessmentInstanceFile.ts
@@ -14,13 +14,12 @@ import studentAssessmentAccess from '../../middlewares/studentAssessmentAccess.j
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });
 
-router.use(selectAndAuthzAssessmentInstance);
-router.use(studentAssessmentAccess);
-router.use(clientFingerprint);
-router.use(logPageView('studentAssessmentInstanceFile'));
-
 router.get(
   '/:unsafe_file_id(\\d+)/:unsafe_display_filename',
+  selectAndAuthzAssessmentInstance,
+  studentAssessmentAccess,
+  clientFingerprint,
+  logPageView('studentAssessmentInstanceFile'),
   asyncHandler(async (req, res, next) => {
     // Assert that the file belongs to this assessment, that the display
     // filename matches, and that the file is not deleted.

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ts
@@ -10,10 +10,9 @@ import { StudentAssessments, StudentAssessmentsRowSchema } from './studentAssess
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
 
-router.use(logPageView('studentAssessments'));
-
 router.get(
   '/',
+  logPageView('studentAssessments'),
   asyncHandler(async (req, res) => {
     const rows = await queryRows(
       sql.select_assessments,

--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.ts
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.ts
@@ -45,10 +45,9 @@ function mapRow(
   };
 }
 
-router.use(logPageView('studentGradebook'));
-
 router.get(
   '/',
+  logPageView('studentGradebook'),
   asyncHandler(async (req, res) => {
     const rawRows = await getGradebookRows({
       course_instance_id: res.locals.course_instance.id,

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -26,6 +26,7 @@ const sql = loadSqlEquiv(import.meta.url);
 
 const router = Router({ mergeParams: true });
 
+router.use(enterpriseOnly(() => checkPlanGrantsForQuestion));
 router.use((req, res, next) => {
   // Because this router is mounted a general path, its middleware will also
   // be run for sub-routes like `submissions/:submission_id/file/:filename`
@@ -42,7 +43,6 @@ router.use((req, res, next) => {
 
   clientFingerprint(req, res, next);
 });
-router.use(enterpriseOnly(() => checkPlanGrantsForQuestion));
 
 async function processFileUpload(req: Request, res: Response) {
   if (!res.locals.assessment_instance.open) {

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -1453,6 +1453,13 @@ export async function initExpress(): Promise<Express> {
     (await import('./pages/studentAssessmentInstance/studentAssessmentInstance.js')).default,
   );
 
+  // Perform auth for all student-facing instance question routes.
+  app.use(
+    '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)',
+    (await import('./middlewares/selectAndAuthzInstanceQuestion.js')).default,
+    (await import('./middlewares/studentAssessmentAccess.js')).default,
+  );
+
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)',
     (await import('./pages/studentInstanceQuestion/studentInstanceQuestion.js')).default,
@@ -1460,27 +1467,6 @@ export async function initExpress(): Promise<Express> {
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/externalImageCapture/variant/:variant_id(\\d+)',
     (await import('./pages/externalImageCapture/externalImageCapture.js')).default(),
-  );
-
-  if (config.devMode) {
-    app.use(
-      '/pl/course_instance/:course_instance_id(\\d+)/loadFromDisk',
-      (await import('./pages/instructorLoadFromDisk/instructorLoadFromDisk.js')).default,
-    );
-    app.use(
-      '/pl/course_instance/:course_instance_id(\\d+)/jobSequence',
-      (await import('./pages/jobSequence/jobSequence.js')).default,
-    );
-  }
-
-  // Global client files
-  app.use(
-    '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourse',
-    (await import('./pages/clientFilesCourse/clientFilesCourse.js')).default,
-  );
-  app.use(
-    '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourseInstance',
-    (await import('./pages/clientFilesCourseInstance/clientFilesCourseInstance.js')).default,
   );
 
   // Client files for questions
@@ -1513,6 +1499,27 @@ export async function initExpress(): Promise<Express> {
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instance_question/:instance_question_id(\\d+)/text',
     (await import('./pages/legacyQuestionText/legacyQuestionText.js')).default,
+  );
+
+  if (config.devMode) {
+    app.use(
+      '/pl/course_instance/:course_instance_id(\\d+)/loadFromDisk',
+      (await import('./pages/instructorLoadFromDisk/instructorLoadFromDisk.js')).default,
+    );
+    app.use(
+      '/pl/course_instance/:course_instance_id(\\d+)/jobSequence',
+      (await import('./pages/jobSequence/jobSequence.js')).default,
+    );
+  }
+
+  // Global client files
+  app.use(
+    '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourse',
+    (await import('./pages/clientFilesCourse/clientFilesCourse.js')).default,
+  );
+  app.use(
+    '/pl/course_instance/:course_instance_id(\\d+)/clientFilesCourseInstance',
+    (await import('./pages/clientFilesCourseInstance/clientFilesCourseInstance.js')).default,
   );
 
   //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
An instructor recently noticed an assessment instance that had a high fingerprint change count (~35) despite only ever seeing one fingerprint in the logs. There are two related reasons for this:

- We're (accidentally IMO) including the fingerprint change tracking middleware on requests for things like `clientFileQuestion`. If those pages see a different fingerprint, they'd increment the change count and update the latest seen fingerprint ID, but there wouldn't be a corresponding log event. Normally this wouldn't be a problem. However...
- Safari (and possibly other browsers) seem to send reduced user agent strings on subrequests (e.g. loading images from `clientFilesQuestion`. For instance, a request for the main page might have `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15`, but a request for an image would contain `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)`. Because the user agent didn't match, we'd pick that up as a new or changed fingerprint, and the stuff from the above bullet would happen.

This PR solves this by limiting the routes on which the `clientFingerprint` middleware runs.