### PR TITLE
Remove recommonmark

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ pytest-cov==6.2.1
 pytest-repeat==0.9.4
 pytest-github-actions-annotate-failures==0.3.0
 pytest==8.4.1
-recommonmark==0.7.1
 regex==2025.7.34
 ruff==0.12.7
 schemdraw==0.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ pytest-repeat==0.9.4
 pytest-github-actions-annotate-failures==0.3.0
 pytest==8.4.1
 regex==2025.7.34
+requests==2.32.4
 ruff==0.12.7
 schemdraw==0.21
 scikit-learn==1.7.1


### PR DESCRIPTION
Follow up to #12572 . This would _actually_ remove Sphinx as a dep.

In addition to the analysis done there, I also did the same for `recommonmark` with `rg 'import recommonmark' -g '*.py'`. There were no mentions.