### PR TITLE
Set `body` `overflow-y` to `hidden` using enhanced nav

### DIFF
--- a/apps/prairielearn/assets/stylesheets/pageLayout.css
+++ b/apps/prairielearn/assets/stylesheets/pageLayout.css
@@ -3,7 +3,11 @@
   height: 100%;
 }
 
-body:has(div.app-container) {
+/**
+ * When the app’s main container exists, delegate all scrolling to it.
+ * Disable body scrolling to avoid overflow when tooltips or popovers are opened.
+ */
+body:has(div.app-main-container) {
   overflow-y: hidden !important;
 }
 


### PR DESCRIPTION
On #12496, if the user has a sidebar, a jitter occurs when the user hovers over a Bootstrap-React tooltip:

https://github.com/user-attachments/assets/9b84dbc4-28e1-41c4-9bb9-a8ac36bd81c2

This is because the `body` overflow is unset. This PR fixes that issue:

https://github.com/user-attachments/assets/2e686aac-3a5c-470d-bdfa-81e6ff0ec8ff

