### PR TITLE
Effective user mismatch remove tooltips

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.ts
@@ -48,7 +48,6 @@ router.get(
   '/:unsafe_lti13_course_instance_id?',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_edit'],
-    errorMessage: 'Access denied (must be a student data editor)',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/middlewares/AuthzAccessMismatch.tsx
+++ b/apps/prairielearn/src/middlewares/AuthzAccessMismatch.tsx
@@ -11,12 +11,10 @@ export type CheckablePermissionKeys = Extract<
   | 'has_course_permission_view'
   | 'has_course_permission_edit'
   | 'has_course_permission_own'
-  | 'has_student_access'
-  | 'has_student_access_with_enrollment'
   | 'has_course_instance_permission_view'
   | 'has_course_instance_permission_edit'
-  | 'course_role'
-  | 'course_instance_role',
+  | 'has_student_access'
+  | 'has_student_access_with_enrollment',
   keyof PageContext['authz_data']
 >;
 
@@ -169,7 +167,7 @@ export function AuthzAccessMismatch({
   });
 
   const [oneOfPermissions, allOtherPermissions] = _.partition(permissions, (permission) =>
-    oneOfPermissionKeys.includes(permission.key),
+    (oneOfPermissionKeys as string[]).includes(permission.key),
   );
 
   // Only show the permissions that are different between authn and authz

--- a/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.ts
+++ b/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.ts
@@ -2,6 +2,7 @@ import { createAuthzMiddleware } from './authzHelper.js';
 
 export default createAuthzMiddleware({
   oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
-  errorMessage: 'Requires either course preview access or student data view access',
+  errorMessage: 'Access denied',
+  // errorExplanation: 'This page requires either course preview access or student data view access.',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.ts
+++ b/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.ts
@@ -2,7 +2,5 @@ import { createAuthzMiddleware } from './authzHelper.js';
 
 export default createAuthzMiddleware({
   oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
-  errorMessage: 'Access denied',
-  // errorExplanation: 'This page requires either course preview access or student data view access.',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.tsx
@@ -9,7 +9,6 @@ export default createAuthzMiddleware({
     // Effective user is enrolled in the course instance.
     'has_student_access_with_enrollment',
   ],
-  errorMessage: 'Access denied',
   errorExplanation: 'This page requires course instance access.',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.tsx
@@ -10,5 +10,6 @@ export default createAuthzMiddleware({
     'has_student_access_with_enrollment',
   ],
   errorMessage: 'Access denied',
+  errorExplanation: 'This page requires course instance access.',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreview.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreview.tsx
@@ -2,7 +2,5 @@ import { createAuthzMiddleware } from './authzHelper.js';
 
 export default createAuthzMiddleware({
   oneOfPermissions: ['has_course_permission_preview'],
-  errorMessage: 'Access denied',
-  errorExplanation: 'This page requires course preview access.',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreview.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreview.tsx
@@ -2,6 +2,7 @@ import { createAuthzMiddleware } from './authzHelper.js';
 
 export default createAuthzMiddleware({
   oneOfPermissions: ['has_course_permission_preview'],
-  errorMessage: 'Requires course preview access',
+  errorMessage: 'Access denied',
+  errorExplanation: 'This page requires course preview access.',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx
@@ -32,7 +32,6 @@ export async function authzHasCoursePreviewOrInstanceView(req: Request, res: Res
       content: (
         <Hydrate>
           <AuthzAccessMismatch
-            errorMessage="Requires either course preview access or student data view access"
             oneOfPermissionKeys={[
               'has_course_permission_preview',
               'has_course_instance_permission_view',

--- a/apps/prairielearn/src/middlewares/authzIsAdministrator.tsx
+++ b/apps/prairielearn/src/middlewares/authzIsAdministrator.tsx
@@ -2,6 +2,5 @@ import { createAuthzMiddleware } from './authzHelper.js';
 
 export default createAuthzMiddleware({
   oneOfPermissions: ['is_administrator'],
-  errorMessage: 'Requires administrator privileges',
   unauthorizedUsers: 'block',
 });

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ts
@@ -22,7 +22,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_edit'],
-    errorMessage: 'Access denied (must be course editor)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires course editor access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.ts
@@ -22,8 +22,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_edit'],
-    errorMessage: 'Access denied',
-    errorExplanation: 'This page requires course editor access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -37,7 +37,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -37,7 +37,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.ts
@@ -37,8 +37,9 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
-    unauthorizedUsers: 'block',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
+    unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {
     const prefix = assessmentFilenamePrefix(

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -55,7 +55,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
@@ -105,7 +104,6 @@ router.get(
   '/:filename',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -55,7 +55,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res, _next) => {
@@ -104,7 +105,8 @@ router.get(
   '/:filename',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -55,7 +55,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res, _next) => {
@@ -104,7 +103,6 @@ router.get(
   '/:filename',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -40,7 +40,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -40,8 +40,9 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
-    unauthorizedUsers: 'block',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
+    unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {
     res.send(InstructorAssessmentInstances({ resLocals: res.locals }));

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -40,7 +40,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
@@ -24,7 +24,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
@@ -24,7 +24,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
@@ -24,7 +24,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -41,7 +41,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -41,7 +41,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -41,7 +41,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -70,7 +70,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -70,7 +70,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -70,7 +70,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
@@ -19,7 +19,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
@@ -19,7 +19,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),

--- a/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentRegrading/instructorAssessmentRegrading.ts
@@ -19,7 +19,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
@@ -24,7 +24,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
@@ -24,7 +24,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentUploads/instructorAssessmentUploads.ts
@@ -24,7 +24,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'block',
   }),

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
@@ -32,7 +32,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_own'],
-    errorMessage: 'Access denied (must be course owner)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires course owner access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSharing/instructorCourseAdminSharing.ts
@@ -32,8 +32,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_own'],
-    errorMessage: 'Access denied',
-    errorExplanation: 'This page requires course owner access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
@@ -48,8 +48,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_own'],
-    errorMessage: 'Access denied',
-    errorExplanation: 'This page requires course owner access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
@@ -48,7 +48,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_own'],
-    errorMessage: 'Access denied (must be course owner)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires course owner access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -17,7 +17,9 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be course previewer or student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation:
+      'This page requires either course preview access or student data view access.',
     unauthorizedUsers: 'block',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -17,7 +17,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation:
       'This page requires either course preview access or student data view access.',
     unauthorizedUsers: 'block',

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
@@ -19,7 +19,8 @@ router.get(
   '/*',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_view'],
-    errorMessage: 'Requires "Viewer" permissions',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires course view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
@@ -19,8 +19,6 @@ router.get(
   '/*',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_view'],
-    errorMessage: 'Access denied',
-    errorExplanation: 'This page requires course view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ts
@@ -41,8 +41,6 @@ router.get(
   '/*',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_edit'],
-    errorMessage: 'Access denied',
-    errorExplanation: 'This page requires course editor access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ts
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.ts
@@ -41,7 +41,8 @@ router.get(
   '/*',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_edit'],
-    errorMessage: 'Requires "Editor" permissions',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires course editor access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.ts
@@ -34,7 +34,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.ts
@@ -34,7 +34,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.ts
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.ts
@@ -34,7 +34,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -93,8 +93,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_preview'],
-    errorMessage: 'Requires course preview permissions',
-    // errorExplanation: 'This page requires course preview access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async function (req, res) {
@@ -156,8 +154,6 @@ router.get(
   '/qid/*',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_preview'],
-    errorMessage: 'Requires course preview permissions',
-    errorExplanation: 'This page requires course preview access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
+++ b/apps/prairielearn/src/pages/instructorQuestions/instructorQuestions.ts
@@ -93,7 +93,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_preview'],
-    errorMessage: 'Requires "Previewer" permissions',
+    errorMessage: 'Requires course preview permissions',
+    // errorExplanation: 'This page requires course preview access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async function (req, res) {
@@ -155,7 +156,8 @@ router.get(
   '/qid/*',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_permission_preview'],
-    errorMessage: 'Requires "Previewer" permissions',
+    errorMessage: 'Requires course preview permissions',
+    errorExplanation: 'This page requires course preview access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
@@ -23,7 +23,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
@@ -23,7 +23,6 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied',
     errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
@@ -23,7 +23,8 @@ router.get(
   '/',
   createAuthzMiddleware({
     oneOfPermissions: ['has_course_instance_permission_view'],
-    errorMessage: 'Access denied (must be a student data viewer)',
+    errorMessage: 'Access denied',
+    errorExplanation: 'This page requires student data view access.',
     unauthorizedUsers: 'passthrough',
   }),
   asyncHandler(async (req, res) => {


### PR DESCRIPTION
This reworks #12496 to avoid using tooltips to show user/permission data. As part of this change, I also did some refactoring.

The main change: I removed `errorMessage` in favor of `errorExplanation`. `errorExplanation` is now optional; an explanation will be generated if none is provided. There's now just a single usage of this in `apps/prairielearn/src/middlewares/authzHasCourseInstanceAccess.tsx`, where the permissions list is complicated and wouldn't mean anything to an end user:

```ts
export default createAuthzMiddleware({
  oneOfPermissions: [
    // Effective user is course instructor.
    'has_course_permission_preview',
    // Effective user is course instance instructor.
    'has_course_instance_permission_view',
    // Effective user is enrolled in the course instance.
    'has_student_access_with_enrollment',
  ],
  errorExplanation: 'This page requires course instance access.',
  unauthorizedUsers: 'block',
});
```

I'll call out some smaller changes below.