### PR TITLE
Reject question data that fails validation

### DIFF
--- a/apps/prairielearn/src/question-servers/freeform.ts
+++ b/apps/prairielearn/src/question-servers/freeform.ts
@@ -694,7 +694,12 @@ async function processQuestionServer<T extends ExecutionData>(
         fatal: true,
       }),
     );
-    return { courseIssues, data };
+    return {
+      courseIssues,
+      // The new `data` failed validation, so we can't safely return it. Return
+      // the original data instead.
+      data: origData,
+    };
   }
 
   return { courseIssues, data, html, fileData };


### PR DESCRIPTION
To reproduce the original error on `master`, edit `testCourse/questions/addNumbers/server.py` as follows:

```diff
-    data["correct_answers"] = c
+    data["correct_answers"] = c
```

Load the question; observe you see an HTTP 500 error page.

On this branch, you'll instead see an issue was filed and the variant was marked as broken.