### PR TITLE
Add host argument to dev:vite command

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon --exec \"yarn dev:no-watch\" --",
     "dev:bun": "bun --watch src/server.ts",
     "dev:no-watch": "tsx --tsconfig src/tsconfig.json src/server.js",
-    "dev:vite": "vite --port 3000",
+    "dev:vite": "vite --port 3000 --host",
     "start": "node dist/server.js",
     "start-executor": "node dist/executor.js",
     "test": "vitest run --coverage",


### PR DESCRIPTION
In local tests using a container, the `--host` argument was required to expose the port outside of the container.

If a better approach exists please feel free to reject or modify the PR.