### PR TITLE
Fix spacing in zone headings

### DIFF
--- a/apps/prairielearn/src/components/AssessmentQuestions.tsx
+++ b/apps/prairielearn/src/components/AssessmentQuestions.tsx
@@ -19,10 +19,10 @@ export function AssessmentQuestionHeaders({
           <th colspan={nTableCols}>
             Zone {question.zone.number}. {question.zone.title}{' '}
             {question.zone.number_choose == null
-              ? ' (Choose all questions)'
+              ? '(Choose all questions)'
               : question.zone.number_choose === 1
-                ? ' (Choose 1 question)'
-                : ` (Choose ${question.zone.number_choose} questions)`}
+                ? '(Choose 1 question)'
+                : `(Choose ${question.zone.number_choose} questions)`}
             {question.zone.max_points != null
               ? ` (maximum ${question.zone.max_points} points)`
               : ''}


### PR DESCRIPTION
Fixing a minor regression from #12249. There is a space missing between the question title and `(Choose ...)`.

Before the fix:
<img width="826" height="318" alt="Screenshot 2025-08-12 at 10 46 25 AM" src="https://github.com/user-attachments/assets/f40b6e64-9ea1-4539-b82e-c34af566889e" />

After: 
<img width="884" height="320" alt="Screenshot 2025-08-12 at 10 45 54 AM" src="https://github.com/user-attachments/assets/b7b73e9d-7288-45fe-b572-3522b9c2e06f" />
