### PR TITLE
Move GitHub path logic to a common function

### DIFF
--- a/apps/prairielearn/src/lib/github.test.ts
+++ b/apps/prairielearn/src/lib/github.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from 'vitest';
 
-import { httpPrefixForCourseRepo } from './github.js';
+import { courseRepoContentUrl, httpPrefixForCourseRepo } from './github.js';
 
 describe('Github library', () => {
   describe('httpPrefixforCourseRepo', () => {
@@ -32,6 +32,48 @@ describe('Github library', () => {
     it('Returns null if repo is not provided', async () => {
       assert.isNull(httpPrefixForCourseRepo(''));
       assert.isNull(httpPrefixForCourseRepo(null));
+    });
+  });
+
+  describe('courseRepoContentUrl', () => {
+    it('Computes a URL for the example course', async () => {
+      const course = { repository: 'IRRELEVANT', branch: 'IRRELEVANT', example_course: true };
+      assert.equal(
+        courseRepoContentUrl(course),
+        'https://github.com/prairielearn/prairielearn/tree/master/exampleCourse',
+      );
+      assert.equal(
+        courseRepoContentUrl(course, 'questions/addNumbers'),
+        'https://github.com/prairielearn/prairielearn/tree/master/exampleCourse/questions/addNumbers',
+      );
+      assert.equal(
+        courseRepoContentUrl(course, '/courseInstances/Sp15'),
+        'https://github.com/prairielearn/prairielearn/tree/master/exampleCourse/courseInstances/Sp15',
+      );
+    });
+
+    it('Computes a URL for a non-example course when repo has proper format', async () => {
+      const course = {
+        repository: 'git@github.com:username/repo.git',
+        branch: 'master',
+        example_course: false,
+      };
+      assert.equal(courseRepoContentUrl(course), 'https://github.com/username/repo/tree/master');
+      assert.equal(
+        courseRepoContentUrl(course, 'questions/addNumbers'),
+        'https://github.com/username/repo/tree/master/questions/addNumbers',
+      );
+      assert.equal(
+        courseRepoContentUrl(course, '/courseInstances/Sp15'),
+        'https://github.com/username/repo/tree/master/courseInstances/Sp15',
+      );
+    });
+
+    it('Returns null if repo is not provided', async () => {
+      const course = { repository: null, branch: 'master', example_course: false };
+      assert.isNull(courseRepoContentUrl(course));
+      assert.isNull(courseRepoContentUrl(course, 'questions/addNumbers'));
+      assert.isNull(courseRepoContentUrl(course, '/courseInstances/Sp15'));
     });
   });
 });

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -13,7 +13,7 @@ import { syncDiskToSql } from '../sync/syncFromDisk.js';
 
 import { logChunkChangesToJob, updateChunksForCourse } from './chunks.js';
 import { config } from './config.js';
-import { type User } from './db-types.js';
+import { type Course, type User } from './db-types.js';
 import { sendCourseRequestMessage } from './opsbot.js';
 import { TEMPLATE_COURSE_PATH } from './paths.js';
 import { formatJsonWithPrettier } from './prettier.js';
@@ -347,4 +347,17 @@ export function httpPrefixForCourseRepo(repository: string | null): string | nul
     }
   }
   return null;
+}
+
+export function courseRepoContentUrl(
+  course: Pick<Course, 'repository' | 'branch' | 'example_course'>,
+  path = '',
+): string | null {
+  if (path && !path.startsWith('/')) path = `/${path}`;
+  if (course.example_course) {
+    // The example course is not found at the root of its repository, so its path is hardcoded
+    return `https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse${path}`;
+  }
+  const repoPrefix = httpPrefixForCourseRepo(course.repository);
+  return repoPrefix ? `${repoPrefix}/tree/${course.branch}${path}` : null;
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -21,7 +21,7 @@ import {
   MultiEditor,
   propertyValueWithDefault,
 } from '../../lib/editors.js';
-import { httpPrefixForCourseRepo } from '../../lib/github.js';
+import { courseRepoContentUrl } from '../../lib/github.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
 import { encodePath } from '../../lib/uri-util.js';
@@ -79,16 +79,10 @@ router.get(
       ).toString();
     }
 
-    let assessmentGHLink: string | null = null;
-    if (res.locals.course.example_course) {
-      // The example course is not found at the root of its repository, so its path is hardcoded
-      assessmentGHLink = `https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/courseInstances/${res.locals.course_instance.short_name}/assessments/${res.locals.assessment.tid}`;
-    } else if (res.locals.course.repository) {
-      const githubPrefix = httpPrefixForCourseRepo(res.locals.course.repository);
-      if (githubPrefix) {
-        assessmentGHLink = `${githubPrefix}/tree/${res.locals.course.branch}/courseInstances/${res.locals.course_instance.short_name}/assessments/${res.locals.assessment.tid}`;
-      }
-    }
+    const assessmentGHLink = courseRepoContentUrl(
+      res.locals.course,
+      `courseInstances/${res.locals.course_instance.short_name}/assessments/${res.locals.assessment.tid}`,
+    );
 
     const canEdit =
       res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -12,7 +12,7 @@ import { flash } from '@prairielearn/flash';
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { CourseInfoCreateEditor, FileModifyEditor } from '../../lib/editors.js';
 import { features } from '../../lib/features/index.js';
-import { httpPrefixForCourseRepo } from '../../lib/github.js';
+import { courseRepoContentUrl } from '../../lib/github.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { getCanonicalTimezones } from '../../lib/timezones.js';
 import { updateCourseShowGettingStarted } from '../../models/course.js';
@@ -30,16 +30,7 @@ router.get(
     );
     const availableTimezones = await getCanonicalTimezones([res.locals.course.display_timezone]);
 
-    let courseGHLink: string | null = null;
-    if (res.locals.course.example_course) {
-      // The example course is not found at the root of its repository, so its path is hardcoded
-      courseGHLink = 'https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/';
-    } else if (res.locals.course.repository) {
-      const githubPrefix = httpPrefixForCourseRepo(res.locals.course.repository);
-      if (githubPrefix) {
-        courseGHLink = `${githubPrefix}/tree/${res.locals.course.branch}`;
-      }
-    }
+    const courseGHLink = courseRepoContentUrl(res.locals.course);
 
     let origHash = '';
     if (courseInfoExists) {

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -19,7 +19,7 @@ import {
   MultiEditor,
   propertyValueWithDefault,
 } from '../../lib/editors.js';
-import { httpPrefixForCourseRepo } from '../../lib/github.js';
+import { courseRepoContentUrl } from '../../lib/github.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
 import { getCanonicalTimezones } from '../../lib/timezones.js';
@@ -66,16 +66,10 @@ router.get(
       ).toString();
     }
 
-    let instanceGHLink: string | null = null;
-    if (res.locals.course.example_course) {
-      // The example course is not found at the root of its repository, so its path is hardcoded
-      instanceGHLink = `https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/courseInstances/${res.locals.course_instance.short_name}`;
-    } else if (res.locals.course.repository) {
-      const githubPrefix = httpPrefixForCourseRepo(res.locals.course.repository);
-      if (githubPrefix) {
-        instanceGHLink = `${githubPrefix}/tree/${res.locals.course.branch}/courseInstances/${res.locals.course_instance.short_name}`;
-      }
-    }
+    const instanceGHLink = courseRepoContentUrl(
+      res.locals.course,
+      `courseInstances/${res.locals.course_instance.short_name}`,
+    );
 
     const canEdit =
       res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -31,7 +31,7 @@ import {
   propertyValueWithDefault,
 } from '../../lib/editors.js';
 import { features } from '../../lib/features/index.js';
-import { httpPrefixForCourseRepo } from '../../lib/github.js';
+import { courseRepoContentUrl } from '../../lib/github.js';
 import { idsEqual } from '../../lib/id.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { applyKeyOrder } from '../../lib/json.js';
@@ -380,16 +380,10 @@ router.get(
       config.secretKey,
     );
 
-    let questionGHLink: string | null = null;
-    if (res.locals.course.example_course) {
-      // The example course is not found at the root of its repository, so its path is hardcoded
-      questionGHLink = `https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/${res.locals.question.qid}`;
-    } else if (res.locals.course.repository) {
-      const githubPrefix = httpPrefixForCourseRepo(res.locals.course.repository);
-      if (githubPrefix) {
-        questionGHLink = `${githubPrefix}/tree/${res.locals.course.branch}/questions/${res.locals.question.qid}`;
-      }
-    }
+    const questionGHLink = courseRepoContentUrl(
+      res.locals.course,
+      `questions/${res.locals.question.qid}`,
+    );
 
     const qids = await sqldb.queryRows(sql.qids, { course_id: res.locals.course.id }, z.string());
 


### PR DESCRIPTION
Something of a follow-up to #12596. Parallel to #12600 but does not touch same files so no conflict involved. The logic to build the path for GitHub repo content is repeated across multiple pages. This PR moves that logic to a common function that builds the URL instead.