### PR TITLE
Add gap between elements of manual grading assessment question header

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -691,7 +691,7 @@ function QuestionPanel({
 
   return html`
     <div class="card mb-3 question-block">
-      <div class="card-header bg-primary text-white d-flex align-items-center">
+      <div class="card-header bg-primary text-white d-flex align-items-center gap-2">
         <h1>
           ${QuestionTitle({
             questionContext,

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -93,7 +93,7 @@ export function InstructorAssessmentGroups({
                 `
               : ''}
             <div class="card mb-4">
-              <div class="card-header bg-primary text-white d-flex align-items-center">
+              <div class="card-header bg-primary text-white d-flex align-items-center gap-2">
                 <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Groups</h1>
                 ${resLocals.authz_data.has_course_instance_permission_edit
                   ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.html.tsx
@@ -73,7 +73,7 @@ export function InstructorAssessmentInstances({ resLocals }: { resLocals: Record
         : ''}
 
       <div class="card mb-4">
-        <div class="card-header bg-primary text-white d-flex align-items-center">
+        <div class="card-header bg-primary text-white d-flex align-items-center gap-2">
           <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Students</h1>
           ${resLocals.authz_data.has_course_instance_permission_edit
             ? html`

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
@@ -88,7 +88,7 @@ export function ManualGradingAssessment({
         : ''}
       <div class="card mb-4">
         <div
-          class="card-header bg-primary text-white align-items-center justify-content-between d-flex w-100 gap-2"
+          class="card-header bg-primary text-white align-items-center justify-content-between d-flex gap-2"
         >
           <h1>
             ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Manual Grading Queue

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
@@ -216,7 +216,7 @@ export function AssessmentQuestion({
         <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
         <div class="card mb-4">
           <div
-            class="card-header bg-primary text-white d-flex justify-content-between align-items-center gap-2"
+            class="card-header bg-primary text-white d-flex justify-content-between align-items-center w-100 gap-2"
           >
             <h1>Student instance questions</h1>
             <div class="d-flex flex-row gap-2">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
@@ -216,7 +216,7 @@ export function AssessmentQuestion({
         <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
         <div class="card mb-4">
           <div
-            class="card-header bg-primary text-white d-flex justify-content-between align-items-center w-100 gap-2"
+            class="card-header bg-primary text-white d-flex justify-content-between align-items-center gap-2"
           >
             <h1>Student instance questions</h1>
             <div class="d-flex flex-row gap-2">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
@@ -216,7 +216,7 @@ export function AssessmentQuestion({
         <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
         <div class="card mb-4">
           <div
-            class="card-header bg-primary text-white d-flex justify-content-between align-items-center"
+            class="card-header bg-primary text-white d-flex justify-content-between align-items-center gap-2"
           >
             <h1>Student instance questions</h1>
             <div class="d-flex flex-row gap-2">

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestionStatistics/instructorAssessmentQuestionStatistics.html.tsx
@@ -100,7 +100,7 @@ export function InstructorAssessmentQuestionStatistics({
         : ''}
 
       <div class="card mb-4">
-        <div class="card-header bg-primary text-white d-flex align-items-center">
+        <div class="card-header bg-primary text-white d-flex align-items-center gap-2">
           <h2>
             ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Question difficulty vs
             discrimination
@@ -293,7 +293,7 @@ export function InstructorAssessmentQuestionStatistics({
       </div>
 
       <div class="card mb-4">
-        <div class="card-header bg-primary text-white d-flex align-items-center">
+        <div class="card-header bg-primary text-white d-flex align-items-center gap-2">
           <h2>
             ${resLocals.assessment_set.name} ${resLocals.assessment.number}: Detailed question
             statistics

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
@@ -159,7 +159,7 @@ function StudentsCard({ course, courseInstance, students, timezone }: StudentsCa
   return (
     <div class="card d-flex flex-column h-100">
       <div class="card-header bg-primary text-white">
-        <div class="d-flex align-items-center justify-content-between">
+        <div class="d-flex align-items-center justify-content-between gap-2">
           <div>Students</div>
           <div>
             <DownloadButton


### PR DESCRIPTION
As discussed in https://github.com/PrairieLearn/PrairieLearn/pull/12512#discussion_r2255404763, we are ensuring spacing between elements in the card header in all viewport sizes. 