### PR TITLE
Add breadcrumb to manual grading instance question page

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
@@ -153,3 +153,10 @@ FROM
   submission_grading_context_embeddings AS emb
 WHERE
   emb.submission_id = $submission_id;
+
+-- BLOCK toggle_ai_grading_mode
+UPDATE assessment_questions
+SET
+  ai_grading_mode = NOT ai_grading_mode
+WHERE
+  id = $assessment_question_id;

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -448,3 +448,8 @@ export async function selectEmbeddingForSubmission(
     SubmissionGradingContextEmbeddingSchema,
   );
 }
+
+export async function toggleAiGradingMode(assessment_question_id: string): Promise<void> {
+  await queryAsync(sql.toggle_ai_grading_mode, { assessment_question_id });
+  return;
+}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.html.tsx
@@ -102,7 +102,7 @@ export function AssessmentQuestion({
         assessmentId: assessment.id,
         urlPrefix,
       })}
-      <div class="d-flex flex-row justify-content-between align-items-center mb-3">
+      <div class="d-flex flex-row justify-content-between align-items-center mb-3 gap-2">
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb mb-0">
             <li class="breadcrumb-item">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.sql
@@ -96,13 +96,6 @@ WHERE
   iq.assessment_question_id = $assessment_question_id
   AND iq.id = ANY ($instance_question_ids::BIGINT[]);
 
--- BLOCK toggle_ai_grading_mode
-UPDATE assessment_questions
-SET
-  ai_grading_mode = NOT ai_grading_mode
-WHERE
-  id = $assessment_question_id;
-
 -- BLOCK delete_ai_grading_jobs
 WITH
   deleted_grading_jobs AS (

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.ts
@@ -18,6 +18,7 @@ import {
   calculateAiGradingStats,
   fillInstanceQuestionColumns,
 } from '../../../ee/lib/ai-grading/ai-grading-stats.js';
+import { toggleAiGradingMode } from '../../../ee/lib/ai-grading/ai-grading-util.js';
 import { aiGrade } from '../../../ee/lib/ai-grading/ai-grading.js';
 import {
   AssessmentQuestionSchema,
@@ -195,9 +196,7 @@ router.post(
         res.send({});
       }
     } else if (req.body.__action === 'toggle_ai_grading_mode') {
-      await queryAsync(sql.toggle_ai_grading_mode, {
-        assessment_question_id: res.locals.assessment_question.id,
-      });
+      await toggleAiGradingMode(res.locals.assessment_question.id);
       res.redirect(req.originalUrl);
     } else if (
       ['ai_grade_assessment', 'ai_grade_assessment_graded', 'ai_grade_assessment_all'].includes(

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -27,13 +27,18 @@ export function InstanceQuestion({
   graders,
   assignedGrader,
   lastGrader,
+  aiGradingEnabled,
+  aiGradingMode,
 }: {
   resLocals: Record<string, any>;
   conflict_grading_job: GradingJobData | null;
   graders: User[] | null;
   assignedGrader: User | null;
   lastGrader: User | null;
+  aiGradingEnabled: boolean;
+  aiGradingMode: boolean;
 }) {
+  const { urlPrefix, assessment, question, assessment_question, __csrf_token } = resLocals;
   return PageLayout({
     resLocals: {
       ...resLocals,
@@ -89,6 +94,45 @@ export function InstanceQuestion({
             </div>
           `
         : ''}
+      <div class="d-flex flex-row justify-content-between align-items-center mb-3">
+        <nav aria-label="breadcrumb">
+          <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item">
+              <a href="${urlPrefix}/assessment/${assessment.id}/manual_grading"> Manual grading </a>
+            </li>
+            <li class="breadcrumb-item">
+              <a
+                href="${urlPrefix}/assessment/${assessment.id}/manual_grading/assessment_question/${assessment_question.id}"
+                >Question ${assessment_question.number_in_alternative_group}. ${question.title}</a
+              >
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">Question panel</li>
+          </ol>
+        </nav>
+
+        ${aiGradingEnabled
+          ? html`
+              <form method="POST" class="card px-3 py-2 mb-0">
+                <input type="hidden" name="__action" value="toggle_ai_grading_mode" />
+                <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                <div class="form-check form-switch mb-0">
+                  <input
+                    class="form-check-input"
+                    type="checkbox"
+                    role="switch"
+                    id="switchCheckDefault"
+                    ${aiGradingMode ? 'checked' : ''}
+                    onchange="setTimeout(() => this.form.submit(), 150)"
+                  />
+                  <label class="form-check-label" for="switchCheckDefault">
+                    <i class="bi bi-stars"></i>
+                    AI grading mode
+                  </label>
+                </div>
+              </form>
+            `
+          : ''}
+      </div>
       ${conflict_grading_job
         ? ConflictGradingJobModal({ resLocals, conflict_grading_job, graders, lastGrader })
         : ''}


### PR DESCRIPTION
<img width="1889" height="815" alt="image" src="https://github.com/user-attachments/assets/f2fbf45e-5663-4a0a-8b4f-3d0591827e04" />
Similar update has been applied to manual grading assessment question page as well. We are adding breadcrumb for easy navigation in instance question page. 