### PR TITLE
Select distinct LTI 1.3 instances

### DIFF
--- a/apps/prairielearn/src/ee/models/lti13-user.sql
+++ b/apps/prairielearn/src/ee/models/lti13-user.sql
@@ -8,8 +8,8 @@ SET
   sub = $sub;
 
 -- BLOCK select_lti13_instance_identities_for_course_instance
-SELECT
-  to_jsonb(lti13_instances.*) AS lti13_instance,
+SELECT DISTINCT
+  ON (lti13_instances.id) to_jsonb(lti13_instances.*) AS lti13_instance,
   lti13_users.id AS lti13_user_id
 FROM
   lti13_course_instances


### PR DESCRIPTION
Closes #12641. I tested this on the production data from that issue and it correctly returns one row.