### PR TITLE
improved test-failure reporting in vitest

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -85,6 +85,11 @@ export const ConfigSchema = z.object({
    * normal usage.
    */
   nonVolatileRedisUrl: z.string().nullable().default(null),
+  /**
+   * If true, if an error page is rendered, the error will be logged to the console if in test mode.
+   * You can disable this for tests that expect errors to be logged.
+   */
+  logTestErrors: z.boolean().default(true),
   logFilename: z.string().default('server.log'),
   logErrorFilename: z.string().nullable().default(null),
   /** Sets the default user UID in development. */

--- a/apps/prairielearn/src/pages/error/error.ts
+++ b/apps/prairielearn/src/pages/error/error.ts
@@ -4,7 +4,7 @@ import jsonStringifySafe from 'json-stringify-safe';
 import { AugmentedError, formatErrorStackSafe } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 
-import { config } from '../../lib/config.js';
+import { DEV_EXECUTION_MODE, config } from '../../lib/config.js';
 
 import { ErrorPage } from './error.html.js';
 
@@ -22,18 +22,21 @@ export default (function (err, req, res, _next) {
 
   const referrer = req.get('Referrer') || null;
 
-  logger.log(err.status >= 500 ? 'error' : 'verbose', 'Error page', {
-    msg: err.message,
-    id: errorId,
-    status: err.status,
-    // Use the "safe" version when logging so that we don't error out while
-    // trying to log the actual error.
-    stack: formatErrorStackSafe(err),
-    data: jsonStringifySafe(err.data),
-    url: req.url,
-    referrer,
-    response_id: res.locals.response_id,
-  });
+  const logError = DEV_EXECUTION_MODE !== 'test' || config.logTestErrors;
+  if (logError) {
+    logger.log(err.status >= 500 ? 'error' : 'verbose', 'Error page', {
+      msg: err.message,
+      id: errorId,
+      status: err.status,
+      // Use the "safe" version when logging so that we don't error out while
+      // trying to log the actual error.
+      stack: formatErrorStackSafe(err),
+      data: jsonStringifySafe(err.data),
+      url: req.url,
+      referrer,
+      response_id: res.locals.response_id,
+    });
+  }
 
   res.send(
     ErrorPage({

--- a/apps/prairielearn/src/question-servers/freeform.ts
+++ b/apps/prairielearn/src/question-servers/freeform.ts
@@ -503,6 +503,12 @@ async function processQuestionPhase<T>(
     result = res.result;
     output = res.output;
   } catch (err) {
+    if (config.devMode && config.logTestErrors) {
+      logger.error(
+        `Error in processQuestionPhase(${phase}) for question ${context.question.directory}`,
+        err,
+      );
+    }
     courseIssues.push(
       new CourseIssueError(err.message, {
         data: err.data,
@@ -641,6 +647,12 @@ async function processQuestionServer<T extends ExecutionData>(
   try {
     ({ result, output } = await execPythonServer(codeCaller, phase, data, html, context));
   } catch (err) {
+    if (config.devMode && config.logTestErrors) {
+      logger.error(
+        `Error in processQuestionServer(${phase}) for question ${context.question.directory}`,
+        err,
+      );
+    }
     const serverFile = path.join(context.question_dir, 'server.py');
     courseIssues.push(
       new CourseIssueError(`${serverFile}: Error calling ${phase}(): ${err.toString()}`, {

--- a/apps/prairielearn/src/tests/exam.test.ts
+++ b/apps/prairielearn/src/tests/exam.test.ts
@@ -8,6 +8,7 @@ import * as helperAttachFiles from './helperAttachFiles.js';
 import * as helperExam from './helperExam.js';
 import * as helperQuestion from './helperQuestion.js';
 import * as helperServer from './helperServer.js';
+import { withConfig } from './utils/config.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
@@ -851,7 +852,9 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         assert.lengthOf(result.rows, 0);
       });
     });
-    helperQuestion.getInstanceQuestion(locals);
+    withConfig({ logTestErrors: false }, () => {
+      helperQuestion.getInstanceQuestion(locals);
+    });
     describe('access the question', function () {
       it('should display "Broken question"', function () {
         elemList = locals.$('div.question-body:contains("Broken question")');
@@ -864,7 +867,9 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         assert.lengthOf(result.rows, 1);
       });
     });
-    helperQuestion.getInstanceQuestion(locals);
+    withConfig({ logTestErrors: false }, () => {
+      helperQuestion.getInstanceQuestion(locals);
+    });
     describe('access the question again', function () {
       it('should display "Broken question"', function () {
         elemList = locals.$('div.question-body:contains("Broken question")');

--- a/apps/prairielearn/src/tests/fileEditor.test.ts
+++ b/apps/prairielearn/src/tests/fileEditor.test.ts
@@ -19,6 +19,7 @@ import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { encodePath } from '../lib/uri-util.js';
 
 import * as helperServer from './helperServer.js';
+import { withConfig } from './utils/config.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
@@ -327,44 +328,46 @@ function badGet(url, expected_status, should_parse) {
       // `fetch()` pre-normalizes the URL, which means we can't use it to test
       // path traversal attacks. In this specific case, we'll use `http.request()`
       // directly to avoid this normalization.
-      const res = await new Promise<{ status: number; text: () => Promise<string> }>(
-        (resolve, reject) => {
-          // We deliberately use the deprecated `node:url#parse()` instead of
-          // `new URL()` to avoid path normalization.
-          const parsedUrl = nodeUrl.parse(url);
-          const req = http.request(
-            {
-              hostname: 'localhost',
-              port: config.serverPort,
-              path: parsedUrl.path,
-              method: 'GET',
-            },
-            (res) => {
-              let data = '';
+      await withConfig({ logTestErrors: false }, async () => {
+        const res = await new Promise<{ status: number; text: () => Promise<string> }>(
+          (resolve, reject) => {
+            // We deliberately use the deprecated `node:url#parse()` instead of
+            // `new URL()` to avoid path normalization.
+            const parsedUrl = nodeUrl.parse(url);
+            const req = http.request(
+              {
+                hostname: 'localhost',
+                port: config.serverPort,
+                path: parsedUrl.path,
+                method: 'GET',
+              },
+              (res) => {
+                let data = '';
 
-              res.on('data', (chunk) => {
-                data += chunk;
-              });
-
-              res.on('end', () => {
-                resolve({
-                  status: res.statusCode ?? 500,
-                  text: () => Promise.resolve(data),
+                res.on('data', (chunk) => {
+                  data += chunk;
                 });
-              });
-            },
-          );
 
-          req.on('error', (err) => {
-            reject(err);
-          });
+                res.on('end', () => {
+                  resolve({
+                    status: res.statusCode ?? 500,
+                    text: () => Promise.resolve(data),
+                  });
+                });
+              },
+            );
 
-          req.end();
-        },
-      );
+            req.on('error', (err) => {
+              reject(err);
+            });
 
-      assert.equal(res.status, expected_status);
-      page = await res.text();
+            req.end();
+          },
+        );
+
+        assert.equal(res.status, expected_status);
+        page = await res.text();
+      });
     });
     if (should_parse) {
       it('should parse', function () {

--- a/apps/prairielearn/src/tests/lti13.test.ts
+++ b/apps/prairielearn/src/tests/lti13.test.ts
@@ -14,6 +14,7 @@ import { selectOptionalUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
 import * as helperServer from './helperServer.js';
+import { withConfig } from './utils/config.js';
 
 const CLIENT_ID = 'prairielearn_test_lms';
 const USER_SUB = 'a555090c-8355-4b58-b315-247612cc22f0';
@@ -360,8 +361,10 @@ describe('LTI 1.3', () => {
     // Confirm the redirect passes through to the course
 
     // Logging in again should fail because of nonce reuse.
-    const repeatLoginRes = await executor.login();
-    assert.equal(repeatLoginRes.status, 500);
+    await withConfig({ logTestErrors: false }, async () => {
+      const repeatLoginRes = await executor.login();
+      assert.equal(repeatLoginRes.status, 500);
+    });
   });
 
   test.sequential('validate login', async () => {
@@ -388,20 +391,22 @@ describe('LTI 1.3', () => {
     const fetchWithCookies = fetchCookie(fetchCheerio);
 
     // Malformed login
-    const startBadLoginResponse = await fetchWithCookies(
-      `${siteUrl}/pl/lti13_instance/1/auth/login`,
-      {
-        method: 'POST',
-        body: new URLSearchParams({
-          iss: siteUrl,
-          // Missing required login_hint
-          //login_hint: 'fef15674-ae78-4763-b915-6fe3dbf42c67',
-          target_link_uri: `${siteUrl}/pl/lti13_instance/1/course_navigation`,
-        }),
-        redirect: 'manual',
-      },
-    );
-    assert.equal(startBadLoginResponse.status, 500);
+    await withConfig({ logTestErrors: false }, async () => {
+      const startBadLoginResponse = await fetchWithCookies(
+        `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        {
+          method: 'POST',
+          body: new URLSearchParams({
+            iss: siteUrl,
+            // Missing required login_hint
+            //login_hint: 'fef15674-ae78-4763-b915-6fe3dbf42c67',
+            target_link_uri: `${siteUrl}/pl/lti13_instance/1/course_navigation`,
+          }),
+          redirect: 'manual',
+        },
+      );
+      assert.equal(startBadLoginResponse.status, 500);
+    });
 
     // Successful login to test malformed response
     const startLoginResponse = await fetchWithCookies(`${siteUrl}/pl/lti13_instance/1/auth/login`, {
@@ -424,18 +429,19 @@ describe('LTI 1.3', () => {
 
     // Not a real token, not running a JWKS server, so not a full test
     // Just making sure if state is missing that PL errors
-    const finishBadLoginResponse = await fetchWithCookies(redirectUri, {
-      method: 'POST',
-      body: new URLSearchParams({
-        nonce,
-        // Missing state parameter
-        //state,
-        id_token: 'junkjunkjunk',
-      }),
-      redirect: 'manual',
+    await withConfig({ logTestErrors: false }, async () => {
+      const finishBadLoginResponse = await fetchWithCookies(redirectUri, {
+        method: 'POST',
+        body: new URLSearchParams({
+          nonce,
+          // Missing state parameter
+          //state,
+          id_token: 'junkjunkjunk',
+        }),
+        redirect: 'manual',
+      });
+      assert.equal(finishBadLoginResponse.status, 500);
     });
-
-    assert.equal(finishBadLoginResponse.status, 500);
   });
 
   test.sequential('request access token', async () => {
@@ -720,30 +726,32 @@ describe('LTI 1.3', () => {
     test.sequential('login should fail with misconfiguration error', async () => {
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/4/course_navigation`;
 
-      const executor = await makeLoginExecutor({
-        user: {
-          name: 'Test User',
-          email: 'test-user@example.com',
-          uin: '123456789',
-          sub: USER_SUB,
-        },
-        fetchWithCookies,
-        oidcProviderPort,
-        keystore,
-        loginUrl: `${siteUrl}/pl/lti13_instance/4/auth/login`,
-        callbackUrl: `${siteUrl}/pl/lti13_instance/4/auth/callback`,
-        targetLinkUri,
+      await withConfig({ logTestErrors: false }, async () => {
+        const executor = await makeLoginExecutor({
+          user: {
+            name: 'Test User',
+            email: 'test-user@example.com',
+            uin: '123456789',
+            sub: USER_SUB,
+          },
+          fetchWithCookies,
+          oidcProviderPort,
+          keystore,
+          loginUrl: `${siteUrl}/pl/lti13_instance/4/auth/login`,
+          callbackUrl: `${siteUrl}/pl/lti13_instance/4/auth/callback`,
+          targetLinkUri,
+        });
+
+        const res = await executor.login();
+        assert.equal(res.status, 500);
+
+        // The error response should contain our misconfiguration error message
+        const responseText = await res.text();
+        assert.include(
+          responseText,
+          'LTI 1.3 instance must have at least one of uid_attribute or uin_attribute configured',
+        );
       });
-
-      const res = await executor.login();
-      assert.equal(res.status, 500);
-
-      // The error response should contain our misconfiguration error message
-      const responseText = await res.text();
-      assert.include(
-        responseText,
-        'LTI 1.3 instance must have at least one of uid_attribute or uin_attribute configured',
-      );
     });
   });
 });

--- a/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migration-runner.test.ts
@@ -151,7 +151,7 @@ describe('BatchedMigrationExecutor', () => {
     const migrationImplementation = makeTestBatchMigration();
     migrationImplementation.setFailingIds([1n, 5010n]);
     const runner = new BatchedMigrationRunner(migration, migrationImplementation);
-    await runner.run();
+    await runner.run({ logError: false });
 
     const jobs = await getBatchedMigrationJobs(migration.id);
     const failedJobs = jobs.filter((job) => job.status === 'failed');

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.test.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.test.ts
@@ -99,6 +99,7 @@ describe('BatchedMigrationsRunner', () => {
     await expect(
       runner.finalizeBatchedMigration('20230406184107_failing_migration', {
         logProgress: false,
+        logError: false,
       }),
     ).rejects.toThrow("but it is 'failed'");
     const migrations = await selectAllBatchedMigrations('test');

--- a/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
+++ b/packages/migrations/src/batched-migrations/batched-migrations-runner.ts
@@ -42,6 +42,7 @@ interface BatchedMigrationStartOptions {
 
 interface BatchedMigrationFinalizeOptions {
   logProgress?: boolean;
+  logError?: boolean;
 }
 
 export class BatchedMigrationsRunner extends EventEmitter {
@@ -150,7 +151,7 @@ export class BatchedMigrationsRunner extends EventEmitter {
 
       // Because we don't give any arguments to `run()`, it will run until it
       // has attempted every job.
-      await runner.run();
+      await runner.run({ logError: options?.logError ?? true });
     });
 
     migration = await selectBatchedMigrationForTimestamp(this.options.project, timestamp);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,14 @@ import crypto from 'node:crypto';
 import { resolve } from 'pathe';
 import { slash } from 'vite-node/utils';
 import { defineConfig, mergeConfig } from 'vitest/config';
-import { BaseSequencer, type TestSpecification, resolveConfig } from 'vitest/node';
+import {
+  BaseSequencer,
+  type TestCase,
+  type TestModuleState,
+  type TestSpecification,
+  resolveConfig,
+} from 'vitest/node';
+import { DefaultReporter } from 'vitest/reporters';
 
 // Vitest will try to intelligently sequence the test suite based on which ones
 // are slowest. However, this depends on cached data from previous runs, which
@@ -102,6 +109,28 @@ class CustomSequencer extends BaseSequencer {
   }
 }
 
+/**
+ * This custom reporter is used to override the default reporter
+ * to not print successful tests live. They clutter the output,
+ * making it harder to see slow and failing tests as they occur.
+ */
+export class SlowAndFailingReporter extends DefaultReporter {
+  renderSucceed = false;
+  onTestRunStart(_: readonly TestSpecification[]): void {}
+  printTestCase(moduleState: TestModuleState, test: TestCase) {
+    // The original reporter prints all test case failures in a module if *any* in that
+    // module failed.
+
+    // This custom reporter overrides the default reporter to *only* print the slow
+    // and failing tests.
+    // See https://github.com/vitest-dev/vitest/blob/512ac7f8d6f3ccb242dc14972f1bcda93abfeed2/packages/vitest/src/node/reporters/base.ts#L212-L214
+    if (moduleState === 'failed') {
+      moduleState = 'passed';
+    }
+    super.printTestCase(moduleState, test);
+  }
+}
+
 export const sharedConfig = defineConfig({
   test: {
     isolate: false,
@@ -124,7 +153,7 @@ export const sharedConfig = defineConfig({
             },
           ],
         ]
-      : ['default'],
+      : [new SlowAndFailingReporter()],
   },
 });
 


### PR DESCRIPTION
- No longer shows the names of passing tests when running the tests locally. Given the large number of tests, if logging is added to a test, it can be quickly buried as more tests run. This decreases the amount of live test output shown, making the "time to identify a failure" lower.
- Adds mechanisms to hide `logger.error` output, and uses those mechanisms to avoid expected console output. Previously, console error output was shown in cases where it was expected (e.g. tests for broken/unauthorized users). That behavior was confusing.
- Adds a custom console logger transport that can be used to format failing code callers
- Logs codecaller issues to the terminal if in development mode