### PR TITLE
Correctly upgrade pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-sequential:
 venv-setup:
 	@[ -f .venv/bin/python3 ] || \
 		uv venv --python-preference only-system --python 3.10 --seed .venv || \
-		python3 -m venv .venv
+		python3 -m venv --upgrade-deps .venv
 
 # Note the `--compile-bytecode` flag, which is needed to ensure fast
 # performance the first time things run:

--- a/scripts/pl-install.sh
+++ b/scripts/pl-install.sh
@@ -77,7 +77,6 @@ arch="$(uname -m)"
 # Pinning the Conda version so the default Python version is 3.10. Later conda versions use 3.12 as the default.
 curl -LO https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Miniforge3-Linux-${arch}.sh
 bash Miniforge3-Linux-${arch}.sh -b -p /usr/local -f
-pip install -U pip
 
 # Clear various caches to minimize the final image size.
 dnf clean all


### PR DESCRIPTION
In #12634 , I made a last second change to how pip was upgraded that upgraded the system pip, but not the version of pip used in the virtual environment. I assumed that the version of pip would be shared between the two, but it seems it is not. This PR correctly upgrades pip in the venv.