### PR TITLE
Enable better type checking

### DIFF
--- a/apps/prairielearn/assets/scripts/behaviors/bootstrap-compat.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/bootstrap-compat.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { makeMigrator } from '../lib/bootstrap-compat-utils.js';
 
 // eslint-disable-next-line no-console

--- a/apps/prairielearn/assets/scripts/behaviors/react-fragments/index.tsx
+++ b/apps/prairielearn/assets/scripts/behaviors/react-fragments/index.tsx
@@ -34,7 +34,7 @@ onDocumentReady(() => {
       const dataElement = el.querySelector('script[data-component-props]');
       if (!dataElement) throw new Error('No data element found');
       if (!dataElement.textContent) throw new Error('Data element has no content');
-      const data = superjson.parse(dataElement.textContent) as object;
+      const data: object = superjson.parse(dataElement.textContent);
 
       const rootElement = el.querySelector('div[data-component-root]');
       if (!rootElement) throw new Error('No root element found');

--- a/apps/prairielearn/assets/scripts/instructorAssessmentsClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentsClient.ts
@@ -18,7 +18,7 @@ onDocumentReady(() => {
   const { assessmentIdsNeedingStatsUpdate, urlPrefix } =
     decodeData<StatsUpdateData>('stats-update-data');
   // Fetch new statistics in parallel, but with a limit to avoid saturating the server.
-  async.eachLimit(assessmentIdsNeedingStatsUpdate, 3, async (assessment_id) => {
+  void async.eachLimit(assessmentIdsNeedingStatsUpdate, 3, async (assessment_id) => {
     try {
       const response = await fetch(
         `${urlPrefix}/instance_admin/assessments/stats/${assessment_id}`,

--- a/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradebookClient.ts
@@ -249,9 +249,9 @@ function setupEditScorePopovers(csrfToken: string) {
           $(popoverButton).popover('hide');
         });
 
-        form.addEventListener('submit', function (event) {
+        form.addEventListener('submit', async function (event) {
           event.preventDefault();
-          fetch(form.action, {
+          await fetch(form.action, {
             method: 'POST',
             body: new URLSearchParams(new FormData(form, event.submitter) as any),
           }).then(async (response) => {

--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -45,7 +45,7 @@ const mathjaxPromise = new Promise<void>((resolve, reject) => {
     },
     // Kept for compatibility reasons.
     onReady: (cb: any) => {
-      mathjaxPromise.then(cb);
+      void mathjaxPromise.then(cb);
     },
     // Adds a custom function so that, regardless if Mathjax.typesetPromise() is accessed before or
     // after the page is loaded, it will be resolved when the page is ready.

--- a/apps/prairielearn/assets/scripts/lib/questionsTable.tsx
+++ b/apps/prairielearn/assets/scripts/lib/questionsTable.tsx
@@ -79,12 +79,12 @@ onDocumentReady(() => {
       text += SyncProblemButtonHtml({
         type: 'error',
         output: question.sync_errors,
-      });
+      }).toString();
     } else if (question.sync_warnings) {
       text += SyncProblemButtonHtml({
         type: 'warning',
         output: question.sync_warnings,
-      });
+      }).toString();
     }
 
     // We only want to show the sharing name prefix for publicly-shared questions.
@@ -96,7 +96,7 @@ onDocumentReady(() => {
       <a class="formatter-data" href="${urlPrefix}/question/${question.id}/preview">
         ${prefix}${question.qid}
       </a>
-    `;
+    `.toString();
     if (question.open_issue_count > 0) {
       text += html`<a
         class="badge rounded-pill text-bg-danger ms-1"
@@ -104,7 +104,7 @@ onDocumentReady(() => {
           question.qid ?? '',
         )}"
         >${question.open_issue_count}</a
-      >`;
+      >`.toString();
     }
     return text.toString();
   };

--- a/apps/prairielearn/assets/scripts/pageLayoutClient.ts
+++ b/apps/prairielearn/assets/scripts/pageLayoutClient.ts
@@ -1,7 +1,7 @@
 import { onDocumentReady } from '@prairielearn/browser-utils';
 
 // Handle when the user expands or collapses the side nav
-onDocumentReady(async () => {
+onDocumentReady(() => {
   // Visible on wider viewports (768px and up)
   const sideNavTogglerButton = document.querySelector<HTMLButtonElement>('#side-nav-toggler');
 
@@ -89,7 +89,7 @@ onDocumentReady(async () => {
     });
   });
 
-  sideNavMobileButton.addEventListener('click', async () => {
+  sideNavMobileButton.addEventListener('click', () => {
     // Animate the side nav
     appContainerDiv.classList.add('animate');
     const sideNavExpanded = !appContainerDiv.classList.contains('mobile-collapsed');
@@ -133,7 +133,7 @@ onDocumentReady(async () => {
     }
   });
 
-  courseNavToggler.addEventListener('click', async () => {
+  courseNavToggler.addEventListener('click', () => {
     const courseNavExpanded = !courseNavDiv.classList.contains('mobile-collapsed');
 
     // Animate the course nav

--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -219,7 +219,7 @@ function updateDynamicPanels(msg: SubmissionPanels, submissionId: string) {
       // must be executed. Typical vanilla JS alternatives don't support
       // this kind of script.
       $(answerContainer).html(msg.answerPanel);
-      mathjaxTypeset([answerContainer]);
+      void mathjaxTypeset([answerContainer]);
       answerContainer.closest('.grading-block')?.classList.remove('d-none');
     }
   }
@@ -230,7 +230,7 @@ function updateDynamicPanels(msg: SubmissionPanels, submissionId: string) {
     // that must be executed. Typical vanilla JS alternatives don't support
     // this kind of script.
     $(submissionPanelSelector).replaceWith(msg.submissionPanel);
-    mathjaxTypeset([document.querySelector(submissionPanelSelector) as HTMLElement]);
+    void mathjaxTypeset([document.querySelector(submissionPanelSelector) as HTMLElement]);
   }
 
   if (msg.questionScorePanel) {

--- a/apps/prairielearn/src/api/trpc/trpc.ts
+++ b/apps/prairielearn/src/api/trpc/trpc.ts
@@ -19,7 +19,7 @@ function getJWT(req: Request) {
   return token || null;
 }
 
-export async function createContext({ req }: CreateExpressContextOptions) {
+export function createContext({ req }: CreateExpressContextOptions) {
   return {
     jwt: getJWT(req),
     bypassJwt: false,

--- a/apps/prairielearn/src/api/v1/index.ts
+++ b/apps/prairielearn/src/api/v1/index.ts
@@ -1,5 +1,4 @@
 import { type NextFunction, type Request, type Response, Router } from 'express';
-import asyncHandler from 'express-async-handler';
 
 import * as error from '@prairielearn/error';
 import * as Sentry from '@prairielearn/sentry';
@@ -11,12 +10,12 @@ const router = Router();
  * viewing permissions. This should be added to any routes that provide student
  * data.
  */
-const authzHasCourseInstanceView = asyncHandler(async (req, res, next) => {
+const authzHasCourseInstanceView = (req: Request, res: Response, next: NextFunction) => {
   if (!res.locals.authz_data.has_course_instance_permission_view) {
     throw new error.HttpStatusError(403, 'Requires student data view access');
   }
   next();
-});
+};
 
 /**
  * We'll forbid API access to the example course unless the user is a global
@@ -32,12 +31,12 @@ function assertNotExampleCourse(req: Request, res: Response, next: NextFunction)
 /**
  * Used to block access to course sync unless has course editor permissions
  */
-const authzHasCourseEditor = asyncHandler(async (req, res, next) => {
+const authzHasCourseEditor = (req: Request, res: Response, next: NextFunction) => {
   if (!res.locals.authz_data.has_course_permission_edit) {
     throw new error.HttpStatusError(403, 'Access denied (must be course editor)');
   }
   next();
-});
+};
 
 // Pretty-print all JSON responses.
 router.use((await import('./prettyPrintJson.js')).default);

--- a/apps/prairielearn/src/components/JobStatus.tsx
+++ b/apps/prairielearn/src/components/JobStatus.tsx
@@ -1,8 +1,8 @@
 import { html } from '@prairielearn/html';
 
-import type { Job, JobSequence } from '../lib/db-types.js';
+import type { Job } from '../lib/db-types.js';
 
-export function JobStatus({ status }: { status: Job['status'] | JobSequence['status'] }) {
+export function JobStatus({ status }: { status: Job['status'] }) {
   if (status === 'Running') {
     return html`<span class="badge text-bg-primary">Running</span>`;
   } else if (status === 'Success') {

--- a/apps/prairielearn/src/components/Navbar.tsx
+++ b/apps/prairielearn/src/components/Navbar.tsx
@@ -1,8 +1,9 @@
 import { type FlashMessageType, flash } from '@prairielearn/flash';
-import { type HtmlValue, html, unsafeHtml } from '@prairielearn/html';
+import { html, unsafeHtml } from '@prairielearn/html';
 import { run } from '@prairielearn/run';
 
 import { config } from '../lib/config.js';
+import { assertNever } from '../lib/types.js';
 
 import { IssueBadgeHtml } from './IssueBadge.js';
 import type { NavPage, NavSubPage, NavbarType } from './Navbar.types.js';
@@ -187,7 +188,7 @@ function NavbarByType({
       } else if (navbarType === 'institution') {
         return NavbarInstitution({ resLocals });
       } else {
-        throw new Error(`Unknown navbarType: ${navbarType}`);
+        assertNever(navbarType, 'Unknown navbarType');
       }
     }
   }
@@ -213,7 +214,7 @@ function UserDropdownMenu({
     authn_is_administrator,
   } = resLocals;
 
-  let displayedName: HtmlValue;
+  let displayedName = '';
   if (authz_data) {
     displayedName = authz_data.user.name || authz_data.user.uid;
 
@@ -232,11 +233,14 @@ function UserDropdownMenu({
     (authz_data.authn_has_course_permission_preview ||
       authz_data.authn_has_course_instance_permission_view)
   ) {
-    displayedName = html`${displayedName} <span class="badge text-bg-warning">student</span>`;
+    displayedName = html`${displayedName}
+      <span class="badge text-bg-warning">student</span>`.toString();
   } else if (authz_data?.overrides) {
-    displayedName = html`${displayedName} <span class="badge text-bg-warning">modified</span>`;
+    displayedName = html`${displayedName}
+      <span class="badge text-bg-warning">modified</span>`.toString();
   } else if (navbarType === 'instructor') {
-    displayedName = html`${displayedName} <span class="badge text-bg-success">staff</span>`;
+    displayedName = html`${displayedName}
+      <span class="badge text-bg-success">staff</span>`.toString();
   }
 
   return html`

--- a/apps/prairielearn/src/cron/sendExternalGraderDeadLetters.ts
+++ b/apps/prairielearn/src/cron/sendExternalGraderDeadLetters.ts
@@ -90,6 +90,7 @@ async function drainQueue(sqs: SQSClient, queueName: string) {
       // keep getting messages if we got some this time
       return true;
     },
+    // eslint-disable-next-line @typescript-eslint/require-await
     async (keepGoing) => keepGoing,
   );
   return messages;

--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
@@ -348,7 +348,7 @@ async function verify(req: Request, tokenSet: TokenSet) {
   if (cacheResult) {
     throw new HttpStatusError(500, 'Cannot reuse LTI 1.3 nonce, try login again');
   }
-  await cache.set(nonceKey, true, 60 * 60 * 1000); // 60 minutes
+  cache.set(nonceKey, true, 60 * 60 * 1000); // 60 minutes
   // Canvas OIDC logins expire after 3600 seconds
 
   // Save parameters about the platform back to the lti13_instance

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-render.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-render.ts
@@ -1,4 +1,5 @@
 import * as cheerio from 'cheerio';
+import { ElementType } from 'domelementtype';
 
 import { formatHtmlWithPrettier } from '../../../lib/prettier.js';
 
@@ -19,7 +20,7 @@ export async function stripHtmlForAiGrading(html: string) {
 
   // Filter out more irrelevant elements/attributes.
   $('*').each((_, el) => {
-    if (el.type !== 'tag') return;
+    if (el.type !== ElementType.Tag) return;
 
     // Remove elements that are hidden from screen readers.
     if ($(el).attr('aria-hidden') === 'true') {
@@ -39,7 +40,7 @@ export async function stripHtmlForAiGrading(html: string) {
 
   // Remove all elements that have no text content.
   $('*').each((_, el) => {
-    if (el.type !== 'tag') return;
+    if (el.type !== ElementType.Tag) return;
     if ($(el).text().trim() === '') {
       $(el).remove();
     }

--- a/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
+++ b/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
@@ -208,11 +208,11 @@ function extractFromCompletion(
  * Returns the AI question generation cache used for rate limiting.
  */
 let aiQuestionGenerationCache: Cache | undefined;
-export function getAiQuestionGenerationCache() {
+export async function getAiQuestionGenerationCache() {
   // The cache variable is outside the function to avoid creating multiple instances of the same cache in the same process.
   if (aiQuestionGenerationCache) return aiQuestionGenerationCache;
   aiQuestionGenerationCache = new Cache();
-  aiQuestionGenerationCache.init({
+  await aiQuestionGenerationCache.init({
     type: config.nonVolatileCacheType,
     keyPrefix: config.cacheKeyPrefix,
     redisUrl: config.nonVolatileRedisUrl,
@@ -264,7 +264,7 @@ export async function getIntervalUsage({
 /**
  * Add the cost of a completion to the usage of the user for the current interval.
  */
-export async function addCompletionCostToIntervalUsage({
+export function addCompletionCostToIntervalUsage({
   aiQuestionGenerationCache,
   userId,
   promptTokens,

--- a/apps/prairielearn/src/ee/lib/context-parsers/documentation.ts
+++ b/apps/prairielearn/src/ee/lib/context-parsers/documentation.ts
@@ -190,7 +190,7 @@ function writeOutTables(elementSections: ElementSection[]) {
   return elementSections;
 }
 
-export async function buildContextForElementDocs(rawMarkdown: string): Promise<DocumentChunk[]> {
+export function buildContextForElementDocs(rawMarkdown: string): DocumentChunk[] {
   const file = unified().use(remarkParse).use(remarkGfm).parse(rawMarkdown);
 
   const elementSections = writeOutTables(cleanElementSections(extractElementSections(file)));

--- a/apps/prairielearn/src/ee/lib/contextEmbeddings.ts
+++ b/apps/prairielearn/src/ee/lib/contextEmbeddings.ts
@@ -132,7 +132,7 @@ export async function syncContextDocuments(client: OpenAI, authnUserId: string) 
     const elementDocsPath = path.join(REPOSITORY_ROOT_PATH, 'docs/elements.md');
     allowedFilepaths.push(path.relative(REPOSITORY_ROOT_PATH, elementDocsPath));
     const fileText = await fs.readFile(elementDocsPath, { encoding: 'utf-8' });
-    const files = await buildContextForElementDocs(fileText);
+    const files = buildContextForElementDocs(fileText);
     for (const doc of files) {
       await insertDocumentChunk(
         client,

--- a/apps/prairielearn/src/ee/lib/lti13.test.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.test.ts
@@ -77,11 +77,11 @@ describe('fetchRetry()', () => {
     next();
   });
 
-  app.get('/403all', async (req, res) => {
+  app.get('/403all', (req, res) => {
     res.status(403).json([]);
   });
 
-  app.get('/403oddAttempt', async (req, res) => {
+  app.get('/403oddAttempt', (req, res) => {
     if (apiCount % 2 === 1) {
       res.status(403).json([]);
     } else {

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -591,7 +591,7 @@ export function findValueByKey(obj: unknown, targetKey: string): unknown {
  */
 export async function fetchRetry(
   input: RequestInfo | URL,
-  opts?: RequestInit | undefined,
+  opts?: RequestInit,
   incomingfetchRetryOpts?: {
     retryLeft?: number;
     sleepMs?: number;
@@ -666,7 +666,7 @@ export async function fetchRetry(
  */
 export async function fetchRetryPaginated(
   input: RequestInfo | URL,
-  opts?: RequestInit | undefined,
+  opts?: RequestInit,
   incomingfetchRetryOpts?: {
     retryLeft?: number;
     sleepMs?: number;

--- a/apps/prairielearn/src/ee/lib/validateHTML.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.ts
@@ -121,7 +121,7 @@ function assertInChoices(
 ) {
   if (!(choices.includes(val) || mustacheTemplateRegex.test(val))) {
     errors.push(
-      `${tag}: value for attribute ${key} must be in ${choices}, but value provided is ${val}`,
+      `${tag}: value for attribute ${key} must be in ${choices.join(', ')}, but value provided is ${val}`,
     );
   }
 }

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -6,7 +6,13 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
-import { loadSqlEquiv, queryAsync, queryOptionalRow, queryRows } from '@prairielearn/postgres';
+import {
+  loadSqlEquiv,
+  queryAsync,
+  queryOptionalRow,
+  queryRow,
+  queryRows,
+} from '@prairielearn/postgres';
 
 import { config } from '../../../lib/config.js';
 import { type Lti13Instance, Lti13InstanceSchema } from '../../../lib/db-types.js';
@@ -187,7 +193,7 @@ router.post(
       flash('success', 'Platform updated.');
       return res.redirect(req.originalUrl);
     } else if (req.body.__action === 'add_instance') {
-      const new_li = await queryRows(
+      const new_li = await queryRow(
         sql.insert_instance,
         {
           ...lti13_instance_defaults,

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -40,7 +40,7 @@ import { InstructorAiGenerateDraftEditor } from './instructorAiGenerateDraftEdit
 const router = Router({ mergeParams: true });
 const sql = loadSqlEquiv(import.meta.url);
 
-const aiQuestionGenerationCache = getAiQuestionGenerationCache();
+const aiQuestionGenerationCache = await getAiQuestionGenerationCache();
 
 async function saveGeneratedQuestion(
   res: Response,

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/SampleQuestionDemo.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/SampleQuestionDemo.tsx
@@ -73,7 +73,7 @@ export function SampleQuestionDemo({
   useLayoutEffect(() => {
     if (cardRef.current) {
       // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent
-      onMathjaxTypeset([cardRef.current]);
+      void onMathjaxTypeset([cardRef.current]);
     }
   }, [variant?.question, onMathjaxTypeset]);
 
@@ -310,7 +310,7 @@ function CheckboxOrRadioInput({
         <FormCheck
           key={option.value}
           id={`check-${option.value}`}
-          type={answerType as 'checkbox' | 'radio'}
+          type={answerType}
           label={variantOptionToString(option)}
           value={option.value}
           checked={selectedOptions.has(option.value)}

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.ts
@@ -27,7 +27,7 @@ import {
 const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
 
-const aiQuestionGenerationCache = getAiQuestionGenerationCache();
+const aiQuestionGenerationCache = await getAiQuestionGenerationCache();
 
 function assertCanCreateQuestion(resLocals: Record<string, any>) {
   // Do not allow users to edit without permission

--- a/apps/prairielearn/src/ee/pages/terms/terms.ts
+++ b/apps/prairielearn/src/ee/pages/terms/terms.ts
@@ -11,12 +11,9 @@ import { Terms } from './terms.html.js';
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });
 
-router.get(
-  '/',
-  asyncHandler(async (req, res) => {
-    res.send(Terms({ user: res.locals.authn_user, resLocals: res.locals }));
-  }),
-);
+router.get('/', (req, res) => {
+  res.send(Terms({ user: res.locals.authn_user, resLocals: res.locals }));
+});
 
 router.post(
   '/',

--- a/apps/prairielearn/src/ee/webhooks/stripe/index.ts
+++ b/apps/prairielearn/src/ee/webhooks/stripe/index.ts
@@ -98,14 +98,14 @@ router.post(
       event.type === 'checkout.session.completed' ||
       event.type === 'checkout.session.async_payment_succeeded'
     ) {
-      const session = event.data.object as Stripe.Checkout.Session;
+      const session = event.data.object;
       await handleSessionUpdate(session);
     } else if (event.type === 'product.updated') {
-      const product = event.data.object as Stripe.Product;
+      const product = event.data.object;
       const productId = product.id;
       await clearStripeProductCache(productId);
     } else if (event.type === 'price.updated') {
-      const price = event.data.object as Stripe.Price;
+      const price = event.data.object;
       const productId = typeof price.product === 'string' ? price.product : price.product.id;
       await clearStripeProductCache(productId);
     }

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
@@ -349,7 +349,7 @@ export class CodeCallerContainer implements CodeCaller {
     if (this.state === CREATED) {
       this.state = EXITED;
     } else if (this.state === WAITING) {
-      this._cleanup();
+      void this._cleanup();
       this.state = EXITING;
     }
     this._checkState();
@@ -480,7 +480,7 @@ export class CodeCallerContainer implements CodeCaller {
     this.debug('enter _timeout()');
     this._checkState([IN_CALL]);
     this.timeoutID = null;
-    this._cleanup();
+    void this._cleanup();
     this.state = EXITING;
     this._callCallback(new Error('timeout exceeded, killing CodeCallerContainer container'));
     this.debug('exit _timeout()');
@@ -499,7 +499,7 @@ export class CodeCallerContainer implements CodeCaller {
    * @param err An error that occurred while waiting for the container to exit.
    * @param code The status code that the container exited with
    */
-  async _handleContainerExit(err: Error | null | undefined, code?: number) {
+  _handleContainerExit(err: Error | null | undefined, code?: number) {
     this.debug('enter _handleContainerExit()');
     this._checkState([WAITING, IN_CALL, EXITING]);
     if (this.state === WAITING) {

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.ts
@@ -12,6 +12,7 @@ import { run } from '@prairielearn/run';
 
 import { deferredPromise } from '../deferred.js';
 import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from '../paths.js';
+import { assertNever } from '../types.js';
 
 import {
   type CallType,
@@ -179,6 +180,7 @@ export class CodeCallerNative implements CodeCaller {
     debug(`[${this.uuid} ${paddedState}] ${message}`);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async prepareForCourse({ coursePath, forbiddenModules }: PrepareForCourseOptions) {
     this.debug('enter prepareForCourse()');
     this.coursePath = coursePath;
@@ -227,7 +229,7 @@ export class CodeCallerNative implements CodeCaller {
     } else if (type === 'restart' || type === 'ping') {
       // Doesn't need a working directory
     } else {
-      throw new Error(`Unknown function call type: ${type}`);
+      assertNever(type, 'Unknown function call type');
     }
 
     const callData = { file, fcn, args, cwd, paths, forbidden_modules: this.forbiddenModules };

--- a/apps/prairielearn/src/lib/code-caller/index.ts
+++ b/apps/prairielearn/src/lib/code-caller/index.ts
@@ -12,6 +12,7 @@ import * as chunks from '../chunks.js';
 import { config } from '../config.js';
 import { type Course } from '../db-types.js';
 import * as load from '../load.js';
+import { assertNever } from '../types.js';
 
 import { CodeCallerContainer, init as initCodeCallerDocker } from './code-caller-container.js';
 import { CodeCallerNative } from './code-caller-native.js';
@@ -77,13 +78,14 @@ export async function init({ lazyWorkers = false }: CodeCallerInitOptions = {}) 
               dropPrivileges: false,
             });
           } else {
-            throw new Error(`Unexpected workersExecutionMode: ${workersExecutionMode}`);
+            assertNever(workersExecutionMode, 'Unexpected workersExecutionMode');
           }
         });
 
         load.startJob('python_worker_idle', codeCaller.uuid);
         return codeCaller;
       },
+      // eslint-disable-next-line @typescript-eslint/require-await
       destroy: async (codeCaller) => {
         logger.verbose(
           `Destroying Python worker ${codeCaller.uuid} (last course path: ${codeCaller.getCoursePath()})`,

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -641,7 +641,7 @@ export async function loadConfig(paths: string[]) {
   }
 }
 
-export async function resetConfig() {
+export function resetConfig() {
   loader.reset();
 }
 

--- a/apps/prairielearn/src/lib/course-files-api.ts
+++ b/apps/prairielearn/src/lib/course-files-api.ts
@@ -13,6 +13,7 @@ function getCourseFilesLink() {
   if (config.courseFilesApiTransport === 'process') {
     return unstable_localLink({
       router: courseFilesRouter,
+      // eslint-disable-next-line @typescript-eslint/require-await
       createContext: async () => ({ jwt: null, bypassJwt: true }),
     });
   }

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -988,7 +988,7 @@ export const QuestionSchema = z.object({
   external_grading_enable_networking: z.boolean().nullable(),
   external_grading_enabled: z.boolean().nullable(),
   external_grading_entrypoint: z.string().nullable(),
-  external_grading_environment: z.any(),
+  external_grading_environment: z.record(z.string(), z.string().nullable()),
   external_grading_files: z.any().nullable(),
   external_grading_image: z.string().nullable(),
   external_grading_timeout: z.number().nullable(),

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -2323,7 +2323,7 @@ export class FileModifyEditor extends Editor {
     return sha256(contents).toString();
   }
 
-  async shouldEdit() {
+  shouldEdit() {
     debug('get hash of edit contents');
     const editHash = this.getHash(this.editContents);
     debug('editHash: ' + editHash);
@@ -2375,7 +2375,7 @@ export class FileModifyEditor extends Editor {
   async write() {
     debug('FileModifyEditor: write()');
 
-    if (!(await this.shouldEdit())) return null;
+    if (!this.shouldEdit()) return null;
 
     debug('ensure path exists');
     await fs.ensureDir(path.dirname(this.filePath));

--- a/apps/prairielearn/src/lib/externalGraderResults.ts
+++ b/apps/prairielearn/src/lib/externalGraderResults.ts
@@ -35,7 +35,7 @@ export async function init() {
 
   // Start work in an IIFE so we can keep going asynchronously
   // after we return to the caller.
-  (async () => {
+  void (async () => {
     while (true) {
       // Spin until we can get at least one message from the queue.
       let messages: ReceiveMessageResult['Messages'];

--- a/apps/prairielearn/src/lib/externalGraderSqs.ts
+++ b/apps/prairielearn/src/lib/externalGraderSqs.ts
@@ -74,7 +74,7 @@ export class ExternalGraderSqs implements Grader {
         async () => sendJobToQueue(grading_job.id, question, config),
       ],
       (err) => {
-        fs.remove(dir);
+        void fs.remove(dir);
         if (err) {
           emitter.emit('error', err);
         } else {

--- a/apps/prairielearn/src/lib/externalGradingSocket.ts
+++ b/apps/prairielearn/src/lib/externalGradingSocket.ts
@@ -42,7 +42,7 @@ export function connection(socket: Socket) {
       return callback(null);
     }
 
-    socket.join(`variant-${msg.variant_id}`);
+    void socket.join(`variant-${msg.variant_id}`);
 
     getVariantSubmissionsStatus(msg.variant_id).then(
       (submissions) => {

--- a/apps/prairielearn/src/lib/externalImageCaptureSocket.ts
+++ b/apps/prairielearn/src/lib/externalImageCaptureSocket.ts
@@ -18,7 +18,7 @@ export function init() {
 }
 
 export function connection(socket: Socket) {
-  socket.on('joinExternalImageCapture', async (msg, callback) => {
+  socket.on('joinExternalImageCapture', (msg, callback) => {
     if (!ensureProps(msg, ['variant_id', 'variant_token', 'file_name'])) {
       return callback(null);
     }
@@ -29,7 +29,7 @@ export function connection(socket: Socket) {
       return callback(null);
     }
 
-    socket.join(`variant-${msg.variant_id}-file-${msg.file_name}`);
+    void socket.join(`variant-${msg.variant_id}-file-${msg.file_name}`);
 
     socket.on('externalImageCaptureAck', (msg, callback) => {
       if (!ensureProps(msg, ['variant_id', 'variant_token', 'file_name'])) {

--- a/apps/prairielearn/src/lib/file-store.ts
+++ b/apps/prairielearn/src/lib/file-store.ts
@@ -11,6 +11,7 @@ import * as sqldb from '@prairielearn/postgres';
 import { getFromS3, uploadToS3 } from './aws.js';
 import { config } from './config.js';
 import { type File, FileSchema, IdSchema } from './db-types.js';
+import { assertNever } from './types.js';
 
 const debug = debugfn('prairielearn:socket-server');
 const sql = sqldb.loadSqlEquiv(import.meta.url);
@@ -216,6 +217,6 @@ export async function getFile(
       file,
     };
   } else {
-    throw new Error(`Unknown storage type: ${file.storage_type}`);
+    assertNever(file.storage_type, 'Unknown storage type');
   }
 }

--- a/apps/prairielearn/src/lib/github.test.ts
+++ b/apps/prairielearn/src/lib/github.test.ts
@@ -4,7 +4,7 @@ import { courseRepoContentUrl, httpPrefixForCourseRepo } from './github.js';
 
 describe('Github library', () => {
   describe('httpPrefixforCourseRepo', () => {
-    it('Converts to HTTPS prefix when repo has proper format', async () => {
+    it('Converts to HTTPS prefix when repo has proper format', () => {
       assert.equal(
         httpPrefixForCourseRepo('git@github.com:username/repo.git'),
         'https://github.com/username/repo',
@@ -23,20 +23,20 @@ describe('Github library', () => {
       );
     });
 
-    it('Returns null if repo uses a different format', async () => {
+    it('Returns null if repo uses a different format', () => {
       assert.isNull(httpPrefixForCourseRepo('https://github.com/username/repo.git'));
       assert.isNull(httpPrefixForCourseRepo('https://www.github.com/username/repo.git'));
       assert.isNull(httpPrefixForCourseRepo('git@gitlab.com:username/repo.git'));
     });
 
-    it('Returns null if repo is not provided', async () => {
+    it('Returns null if repo is not provided', () => {
       assert.isNull(httpPrefixForCourseRepo(''));
       assert.isNull(httpPrefixForCourseRepo(null));
     });
   });
 
   describe('courseRepoContentUrl', () => {
-    it('Computes a URL for the example course', async () => {
+    it('Computes a URL for the example course', () => {
       const course = { repository: 'IRRELEVANT', branch: 'IRRELEVANT', example_course: true };
       assert.equal(
         courseRepoContentUrl(course),
@@ -52,7 +52,7 @@ describe('Github library', () => {
       );
     });
 
-    it('Computes a URL for a non-example course when repo has proper format', async () => {
+    it('Computes a URL for a non-example course when repo has proper format', () => {
       const course = {
         repository: 'git@github.com:username/repo.git',
         branch: 'master',
@@ -69,7 +69,7 @@ describe('Github library', () => {
       );
     });
 
-    it('Returns null if repo is not provided', async () => {
+    it('Returns null if repo is not provided', () => {
       const course = { repository: null, branch: 'master', example_course: false };
       assert.isNull(courseRepoContentUrl(course));
       assert.isNull(courseRepoContentUrl(course, 'questions/addNumbers'));

--- a/apps/prairielearn/src/lib/markdown.test.ts
+++ b/apps/prairielearn/src/lib/markdown.test.ts
@@ -8,43 +8,43 @@ function testMarkdownQuestion(question: string, expected: string) {
 }
 
 describe('Markdown processing', () => {
-  it('renders basic markdown correctly', async () => {
+  it('renders basic markdown correctly', () => {
     const question = '<markdown>\n# Hello, world!\nThis **works**.\n</markdown>';
     const expected = '<h1>Hello, world!</h1>\n<p>This <strong>works</strong>.</p>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles multiple <markdown> tags', async () => {
+  it('handles multiple <markdown> tags', () => {
     const question = '<markdown>`nice`</markdown><markdown>`also nice`</markdown>';
     const expected = '<p><code>nice</code></p>\n<p><code>also nice</code></p>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks', async () => {
+  it('handles code blocks', () => {
     const question = '<markdown>\n```\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code >int a = 12;</pl-code>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks with language', async () => {
+  it('handles code blocks with language', () => {
     const question = '<markdown>\n```cpp\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code language="cpp">int a = 12;</pl-code>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks with highlighted lines', async () => {
+  it('handles code blocks with highlighted lines', () => {
     const question = '<markdown>\n```{1,2-3}\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code highlight-lines="1,2-3">int a = 12;</pl-code>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles code blocks with language and highlighted lines', async () => {
+  it('handles code blocks with language and highlighted lines', () => {
     const question = '<markdown>\n```cpp{1,2-3}\nint a = 12;\n```\n</markdown>';
     const expected = '<pl-code language="cpp" highlight-lines="1,2-3">int a = 12;</pl-code>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles escaped dollar-sign symbols', async () => {
+  it('handles escaped dollar-sign symbols', () => {
     const question =
       '<markdown>You need \\$2.00 for a muffin, \\\\$1.50 for a coffee, and \\\\\\$5.00 for a sandwich.</markdown>';
     const expected =
@@ -52,19 +52,19 @@ describe('Markdown processing', () => {
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles escaped <markdown> tags', async () => {
+  it('handles escaped <markdown> tags', () => {
     const question = '<markdown>```html\n<markdown#></markdown#>\n```</markdown>';
     const expected = '<pl-code language="html">&lt;markdown&gt;&lt;/markdown&gt;</pl-code>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles weird escaped <markdown> tags', async () => {
+  it('handles weird escaped <markdown> tags', () => {
     const question = '<markdown>```html\n<markdown###></markdown###>\n```</markdown>';
     const expected = '<pl-code language="html">&lt;markdown##&gt;&lt;/markdown##&gt;</pl-code>';
     testMarkdownQuestion(question, expected);
   });
 
-  it('handles empty <markdown> tags', async () => {
+  it('handles empty <markdown> tags', () => {
     const question = 'before\n<markdown></markdown>\n*between*\n<markdown>`second`</markdown>';
     const expected = 'before\n\n*between*\n<p><code>second</code></p>';
     testMarkdownQuestion(question, expected);

--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -770,7 +770,7 @@ export async function renderPanelsForSubmission({
         urlPrefix,
       }).toString();
     },
-    async () => {
+    () => {
       // Render the question score panel
       if (!renderScorePanels) return;
 
@@ -796,7 +796,7 @@ export async function renderPanelsForSubmission({
         instance_question_info: { question_number, previous_variants },
       }).toString();
     },
-    async () => {
+    () => {
       // Render the assessment score panel
       if (!renderScorePanels) return;
 

--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -181,7 +181,7 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
    */
   executeInBackground(fn: ServerJobExecutionFunction): void {
     this.checkAndMarkStarted();
-    this.executeInternal(fn, false);
+    void this.executeInternal(fn, false);
   }
 
   private checkAndMarkStarted() {

--- a/apps/prairielearn/src/lib/socket-server.ts
+++ b/apps/prairielearn/src/lib/socket-server.ts
@@ -46,7 +46,7 @@ export let io: Server;
 let pub: Redis;
 let sub: Redis;
 
-export async function init(server: http.Server) {
+export function init(server: http.Server) {
   debug('init(): creating socket server');
   io = new Server(server);
   if (config.redisUrl) {

--- a/apps/prairielearn/src/lib/types.ts
+++ b/apps/prairielearn/src/lib/types.ts
@@ -48,6 +48,7 @@ export type ExpandRecursively<T> = T extends object
     : never
   : T;
 
-export function assertNever(value: never): never {
-  throw new Error(`Unexpected value: ${value}`);
+export function assertNever(value: never, message = 'Unexpected value'): never {
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  throw new Error(`${message}: ${value}`);
 }

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -94,7 +94,7 @@ export class SubmissionFormatError extends Error {
   }
 }
 
-export async function init(): Promise<void> {
+export function init(): void {
   workspaceUtils.init(socketServer.io);
   socketServer.io
     .of(workspaceUtils.WORKSPACE_SOCKET_NAMESPACE)
@@ -130,7 +130,7 @@ function connection(socket: Socket) {
   const workspace_id = socket.handshake.auth.workspace_id;
 
   socket.on('joinWorkspace', (callback: (result: any) => void) => {
-    socket.join(`workspace-${workspace_id}`);
+    void socket.join(`workspace-${workspace_id}`);
 
     sqldb.queryRow(sql.select_workspace, { workspace_id }, WorkspaceSchema).then(
       (workspace) => callback({ workspace_id, state: workspace.state }),
@@ -444,6 +444,7 @@ export async function generateWorkspaceFiles({
 
   const staticFiles: WorkspaceFile[] = (
     await async
+      // eslint-disable-next-line @typescript-eslint/require-await
       .mapSeries(klaw(localPath), async (file: klaw.Item): Promise<WorkspaceFile | null> => {
         return file.stats.isFile()
           ? { name: path.relative(localPath, file.path), localPath: file.path }

--- a/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx
@@ -1,5 +1,4 @@
-import { type Request, type Response } from 'express';
-import asyncHandler from 'express-async-handler';
+import { type NextFunction, type Request, type Response } from 'express';
 
 import * as error from '@prairielearn/error';
 
@@ -9,7 +8,7 @@ import { Hydrate } from '../lib/preact.js';
 
 import { AuthzAccessMismatch } from './AuthzAccessMismatch.js';
 
-export async function authzHasCoursePreviewOrInstanceView(req: Request, res: Response) {
+export function authzHasCoursePreviewOrInstanceView(req: Request, res: Response) {
   const effectiveAccess =
     res.locals.authz_data.has_course_permission_preview ||
     res.locals.authz_data.has_course_instance_permission_view;
@@ -51,11 +50,11 @@ export async function authzHasCoursePreviewOrInstanceView(req: Request, res: Res
   }
 }
 
-export default asyncHandler(async (req, res, next) => {
-  const body = await authzHasCoursePreviewOrInstanceView(req, res);
+export default (req: Request, res: Response, next: NextFunction): void => {
+  const body = authzHasCoursePreviewOrInstanceView(req, res);
   if (body) {
     res.status(403).send(body);
   } else {
     next();
   }
-});
+};

--- a/apps/prairielearn/src/middlewares/authzWorkspace.ts
+++ b/apps/prairielearn/src/middlewares/authzWorkspace.ts
@@ -86,7 +86,7 @@ export default function ({ publicQuestionEndpoint } = { publicQuestionEndpoint: 
       // from the instructor question preview and we should authorize for that.
       req.params.question_id = result.question_id;
       // TODO: This is a little hacky. Further context: https://github.com/PrairieLearn/PrairieLearn/pull/12496#discussion_r2240249138
-      const body = await authzHasCoursePreviewOrInstanceView(req, res);
+      const body = authzHasCoursePreviewOrInstanceView(req, res);
       if (body) {
         res.status(403).send(body);
         return;

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieCheck.ts
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieCheck.ts
@@ -1,11 +1,11 @@
-import asyncHandler from 'express-async-handler';
+import type { NextFunction, Request, Response } from 'express';
 
 import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
 import { idsEqual } from '../lib/id.js';
 
-export default asyncHandler(async (req, res, next) => {
+export default (req: Request, res: Response, next: NextFunction): void => {
   // This middleware looks for a workspace_id-specific cookie and,
   // if found, skips the rest of authn/authz. The special cookie is
   // set by middlewares/authzWorkspaceCookieSet.js
@@ -26,4 +26,4 @@ export default asyncHandler(async (req, res, next) => {
 
   // otherwise we fall through and proceed to the full authn/authz stack
   next();
-});
+};

--- a/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.ts
+++ b/apps/prairielearn/src/middlewares/authzWorkspaceCookieSet.ts
@@ -1,11 +1,11 @@
-import asyncHandler from 'express-async-handler';
+import type { NextFunction, Request, Response } from 'express';
 
 import { generateSignedToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
 import { setCookie, shouldSecureCookie } from '../lib/cookie.js';
 
-export default asyncHandler(async (req, res, next) => {
+export default (req: Request, res: Response, next: NextFunction): void => {
   // We should only have arrived here if we passed authn/authz and
   // are authorized to access res.locals.workspace_id. We will set a
   // short-lived cookie specific to this workspace_id that will let
@@ -25,4 +25,4 @@ export default asyncHandler(async (req, res, next) => {
     secure: shouldSecureCookie(req),
   });
   next();
-});
+};

--- a/apps/prairielearn/src/middlewares/csrfToken.ts
+++ b/apps/prairielearn/src/middlewares/csrfToken.ts
@@ -1,11 +1,11 @@
-import asyncHandler from 'express-async-handler';
+import type { NextFunction, Request, Response } from 'express';
 
 import { HttpStatusError } from '@prairielearn/error';
 import { checkSignedToken, generateSignedToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
 
-export default asyncHandler(async (req, res, next) => {
+export default (req: Request, res: Response, next: NextFunction): void => {
   const tokenData = {
     url: req.originalUrl,
     authn_user_id: res.locals.authn_user?.user_id,
@@ -24,4 +24,4 @@ export default asyncHandler(async (req, res, next) => {
     }
   }
   next();
-});
+};

--- a/apps/prairielearn/src/models/assessment-question.ts
+++ b/apps/prairielearn/src/models/assessment-question.ts
@@ -87,5 +87,5 @@ export async function selectAssessmentQuestions({
     prevZoneId = row.zone.id;
     prevAltGroupId = row.alternative_group.id;
   }
-  return result as StaffAssessmentQuestionRow[];
+  return result;
 }

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -33,17 +33,14 @@ function validateFeature(feature: string): FeatureName {
   return feature;
 }
 
-router.get(
-  '/',
-  asyncHandler(async (req, res) => {
-    res.send(
-      AdministratorFeatures({
-        features: features.allFeatures().sort(),
-        resLocals: res.locals,
-      }),
-    );
-  }),
-);
+router.get('/', (req, res) => {
+  res.send(
+    AdministratorFeatures({
+      features: features.allFeatures().sort(),
+      resLocals: res.locals,
+    }),
+  );
+});
 
 router.get(
   '/:feature',

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.ts
@@ -87,7 +87,7 @@ router.post(
     let error: string | null = null;
     let result: AdministratorQueryResult | null = null;
     try {
-      result = (await module.default(queryParams)) as AdministratorQueryResult;
+      result = await module.default(queryParams);
     } catch (err) {
       logger.error(err);
       error = err.toString();

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.ts
@@ -14,12 +14,9 @@ import { AdministratorSettings } from './administratorSettings.html.js';
 
 const router = Router();
 
-router.get(
-  '/',
-  asyncHandler(async (req, res) => {
-    res.send(AdministratorSettings({ resLocals: res.locals }));
-  }),
-);
+router.get('/', (req, res) => {
+  res.send(AdministratorSettings({ resLocals: res.locals }));
+});
 
 router.post(
   '/',

--- a/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.ts
+++ b/apps/prairielearn/src/pages/authCallbackOAuth2/authCallbackOAuth2.ts
@@ -27,6 +27,7 @@ router.get(
     if (code == null) {
       throw new Error('No "code" query parameter for authCallbackOAuth2');
     } else if (typeof code !== 'string') {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`Invalid 'code' query parameter for authCallbackOAuth2: ${code}`);
     }
     // FIXME: should check req.query.state to avoid CSRF

--- a/apps/prairielearn/src/pages/authLogin/authLogin.test.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.test.ts
@@ -11,7 +11,7 @@ describe('authLogin', () => {
   afterAll(() => assets.close());
 
   describe('service-specific login', () => {
-    it('renders login page with service query parameter', async () => {
+    it('renders login page with service query parameter', () => {
       const html = AuthLoginInstitution({
         showUnsupportedMessage: false,
         supportedProviders: [{ name: 'SAML', is_default: true }],
@@ -45,7 +45,7 @@ describe('authLogin', () => {
       assert.include(html, 'Sign in with Microsoft');
     });
 
-    it('handles supported non-LTI providers with only default', async () => {
+    it('handles supported non-LTI providers with only default', () => {
       const html = AuthLoginInstitution({
         showUnsupportedMessage: false,
         supportedProviders: [{ name: 'SAML', is_default: true }],
@@ -130,7 +130,7 @@ describe('authLogin', () => {
   });
 
   describe('unsupported provider message', () => {
-    it('handles no supported providers', async () => {
+    it('handles no supported providers', () => {
       const html = AuthLoginInstitution({
         showUnsupportedMessage: true,
         supportedProviders: [],
@@ -146,7 +146,7 @@ describe('authLogin', () => {
       assert.include(html, 'Contact your institution for more information.');
     });
 
-    it('handles LTI providers', async () => {
+    it('handles LTI providers', () => {
       const html = AuthLoginInstitution({
         showUnsupportedMessage: true,
         supportedProviders: [
@@ -169,7 +169,7 @@ describe('authLogin', () => {
       );
     });
 
-    it('does not render unsupported provider message if not shown', async () => {
+    it('does not render unsupported provider message if not shown', () => {
       const html = AuthLoginInstitution({
         showUnsupportedMessage: false,
         supportedProviders: [{ name: 'SAML', is_default: true }],

--- a/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.ts
+++ b/apps/prairielearn/src/pages/authLoginOAuth2/authLoginOAuth2.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-import asyncHandler from 'express-async-handler';
 import { OAuth2Client } from 'google-auth-library';
 
 import { HttpStatusError } from '@prairielearn/error';
@@ -8,31 +7,28 @@ import { config } from '../../lib/config.js';
 
 const router = Router();
 
-router.get(
-  '/',
-  asyncHandler(async (req, res) => {
-    if (
-      !config.hasOauth ||
-      !config.googleClientId ||
-      !config.googleClientSecret ||
-      !config.googleRedirectUrl
-    ) {
-      throw new HttpStatusError(404, 'Google login is not enabled');
-    }
+router.get('/', (req, res) => {
+  if (
+    !config.hasOauth ||
+    !config.googleClientId ||
+    !config.googleClientSecret ||
+    !config.googleRedirectUrl
+  ) {
+    throw new HttpStatusError(404, 'Google login is not enabled');
+  }
 
-    const oauth2Client = new OAuth2Client(
-      config.googleClientId,
-      config.googleClientSecret,
-      config.googleRedirectUrl,
-    );
-    const url = oauth2Client.generateAuthUrl({
-      access_type: 'online',
-      scope: ['openid', 'profile', 'email'],
-      prompt: 'select_account',
-      // FIXME: should add some state here to avoid CSRF
-    });
-    res.redirect(url);
-  }),
-);
+  const oauth2Client = new OAuth2Client(
+    config.googleClientId,
+    config.googleClientSecret,
+    config.googleRedirectUrl,
+  );
+  const url = oauth2Client.generateAuthUrl({
+    access_type: 'online',
+    scope: ['openid', 'profile', 'email'],
+    prompt: 'select_account',
+    // FIXME: should add some state here to avoid CSRF
+  });
+  res.redirect(url);
+});
 
 export default router;

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -263,20 +263,17 @@ async function pipeCursorToArchive<T>(
       }
     }
   }
-  archive.finalize();
+  await archive.finalize();
 }
 
-router.get(
-  '/',
-  asyncHandler(async (req, res) => {
-    if (!res.locals.authz_data.has_course_instance_permission_view) {
-      throw new error.HttpStatusError(403, 'Access denied (must be a student data viewer)');
-    }
-    res.send(
-      InstructorAssessmentDownloads({ resLocals: res.locals, filenames: getFilenames(res.locals) }),
-    );
-  }),
-);
+router.get('/', (req, res) => {
+  if (!res.locals.authz_data.has_course_instance_permission_view) {
+    throw new error.HttpStatusError(403, 'Access denied (must be a student data viewer)');
+  }
+  res.send(
+    InstructorAssessmentDownloads({ resLocals: res.locals, filenames: getFilenames(res.locals) }),
+  );
+});
 
 /**
  * Local abstraction to adapt our internal notion of columns to the columns

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -42,9 +42,9 @@ router.get(
     oneOfPermissions: ['has_course_instance_permission_view'],
     unauthorizedUsers: 'block',
   }),
-  asyncHandler(async (req, res) => {
+  (req, res) => {
     res.send(InstructorAssessmentInstances({ resLocals: res.locals }));
-  }),
+  },
 );
 
 router.post(

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.ts
@@ -188,9 +188,9 @@ router.post(
         const given_cp_and_cip = result.given_cp.filter(
           (uid) => !result.not_given_cip.includes(uid),
         );
-        debug(`given_cp: ${result.given_cp}`);
-        debug(`not_given_cip: ${result.not_given_cip}`);
-        debug(`given_cp_and_cip: ${given_cp_and_cip}`);
+        debug(`given_cp: ${result.given_cp.join(', ')}`);
+        debug(`not_given_cip: ${result.not_given_cip.join(', ')}`);
+        debug(`given_cp_and_cip: ${given_cp_and_cip.join(', ')}`);
         if (given_cp_and_cip.length > 0) {
           if (course_instance) {
             info.push(html`

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -42,66 +42,63 @@ router.get(
   }),
 );
 
-router.post(
-  '/',
-  asyncHandler(async (req, res) => {
-    if (
-      !(
-        res.locals.authz_data.authn_has_course_permission_preview ||
-        res.locals.authz_data.authn_has_course_instance_permission_view
-      )
-    ) {
-      throw new HttpStatusError(
-        403,
-        'Access denied (must be course previewer or student data viewer)',
-      );
-    }
+router.post('/', (req, res) => {
+  if (
+    !(
+      res.locals.authz_data.authn_has_course_permission_preview ||
+      res.locals.authz_data.authn_has_course_instance_permission_view
+    )
+  ) {
+    throw new HttpStatusError(
+      403,
+      'Access denied (must be course previewer or student data viewer)',
+    );
+  }
 
-    if (req.body.__action === 'reset') {
-      clearCookie(res, ['pl_requested_uid', 'pl2_requested_uid']);
-      clearCookie(res, ['pl_requested_course_role', 'pl2_requested_course_role']);
-      clearCookie(res, ['pl_requested_course_instance_role', 'pl2_requested_course_instance_role']);
-      clearCookie(res, ['pl_requested_date', 'pl2_requested_date']);
-      setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'changeUid') {
-      setCookie(res, ['pl_requested_uid', 'pl2_requested_uid'], req.body.pl_requested_uid, {
-        maxAge: 60 * 60 * 1000,
-      });
-      setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'changeCourseRole') {
-      setCookie(
-        res,
-        ['pl_requested_course_role', 'pl2_requested_course_role'],
-        req.body.pl_requested_course_role,
-        { maxAge: 60 * 60 * 1000 },
-      );
-      setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'changeCourseInstanceRole') {
-      setCookie(
-        res,
-        ['pl_requested_course_instance_role', 'pl2_requested_course_instance_role'],
-        req.body.pl_requested_course_instance_role,
-        { maxAge: 60 * 60 * 1000 },
-      );
-      setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'changeDate') {
-      const date = parseISO(req.body.pl_requested_date);
-      if (!isValid(date)) {
-        throw new HttpStatusError(400, `invalid requested date: ${req.body.pl_requested_date}`);
-      }
-      setCookie(res, ['pl_requested_date', 'pl2_requested_date'], date.toISOString(), {
-        maxAge: 60 * 60 * 1000,
-      });
-      setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
-      res.redirect(req.originalUrl);
-    } else {
-      throw new HttpStatusError(400, 'unknown action: ' + res.locals.__action);
+  if (req.body.__action === 'reset') {
+    clearCookie(res, ['pl_requested_uid', 'pl2_requested_uid']);
+    clearCookie(res, ['pl_requested_course_role', 'pl2_requested_course_role']);
+    clearCookie(res, ['pl_requested_course_instance_role', 'pl2_requested_course_instance_role']);
+    clearCookie(res, ['pl_requested_date', 'pl2_requested_date']);
+    setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
+    res.redirect(req.originalUrl);
+  } else if (req.body.__action === 'changeUid') {
+    setCookie(res, ['pl_requested_uid', 'pl2_requested_uid'], req.body.pl_requested_uid, {
+      maxAge: 60 * 60 * 1000,
+    });
+    setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
+    res.redirect(req.originalUrl);
+  } else if (req.body.__action === 'changeCourseRole') {
+    setCookie(
+      res,
+      ['pl_requested_course_role', 'pl2_requested_course_role'],
+      req.body.pl_requested_course_role,
+      { maxAge: 60 * 60 * 1000 },
+    );
+    setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
+    res.redirect(req.originalUrl);
+  } else if (req.body.__action === 'changeCourseInstanceRole') {
+    setCookie(
+      res,
+      ['pl_requested_course_instance_role', 'pl2_requested_course_instance_role'],
+      req.body.pl_requested_course_instance_role,
+      { maxAge: 60 * 60 * 1000 },
+    );
+    setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
+    res.redirect(req.originalUrl);
+  } else if (req.body.__action === 'changeDate') {
+    const date = parseISO(req.body.pl_requested_date);
+    if (!isValid(date)) {
+      throw new HttpStatusError(400, `invalid requested date: ${req.body.pl_requested_date}`);
     }
-  }),
-);
+    setCookie(res, ['pl_requested_date', 'pl2_requested_date'], date.toISOString(), {
+      maxAge: 60 * 60 * 1000,
+    });
+    setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
+    res.redirect(req.originalUrl);
+  } else {
+    throw new HttpStatusError(400, 'unknown action: ' + res.locals.__action);
+  }
+});
 
 export default router;

--- a/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
+++ b/apps/prairielearn/src/pages/instructorFileBrowser/instructorFileBrowser.ts
@@ -87,7 +87,7 @@ router.post(
         throw new Error(`Invalid file path: ${req.body.file_path}`);
       }
       const editor = new FileDeleteEditor({
-        locals: res.locals as any as any,
+        locals: res.locals as any,
         container,
         deletePath,
       });

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
@@ -1,20 +1,16 @@
 import { Router } from 'express';
-import asyncHandler from 'express-async-handler';
 
 import { HttpStatusError } from '@prairielearn/error';
 
 const router = Router();
 
-router.get(
-  '/*',
-  asyncHandler(async (req, res) => {
-    if (!res.locals.authz_data.has_course_permission_view) {
-      throw new HttpStatusError(403, 'Access denied (must be course viewer)');
-    }
-    if (req.query.type) res.type(req.query.type.toString());
-    if (req.query.attachment) res.attachment(req.query.attachment.toString());
-    res.sendFile(req.params[0], { root: res.locals.course.path });
-  }),
-);
+router.get('/*', (req, res) => {
+  if (!res.locals.authz_data.has_course_permission_view) {
+    throw new HttpStatusError(403, 'Access denied (must be course viewer)');
+  }
+  if (req.query.type) res.type(req.query.type.toString());
+  if (req.query.attachment) res.attachment(req.query.attachment.toString());
+  res.sendFile(req.params[0], { root: res.locals.course.path });
+});
 
 export default router;

--- a/apps/prairielearn/src/pages/instructorStudents/components/ColumnManager.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/components/ColumnManager.tsx
@@ -134,11 +134,7 @@ export function ColumnManager({ table }: { table: Table<StudentRow> }) {
 
     // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (activeElementId) {
-      const element = document.getElementById(activeElementId);
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
-      if (element) {
-        (element as HTMLElement).focus();
-      }
+      document.getElementById(activeElementId)?.focus();
     }
   }, [activeElementId]);
 

--- a/apps/prairielearn/src/pages/instructorStudents/components/StudentsTable.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/components/StudentsTable.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-table';
 import { notUndefined, useVirtualizer } from '@tanstack/react-virtual';
 import clsx from 'clsx';
-import { type JSX, type ThHTMLAttributes, useEffect, useRef, useState } from 'preact/compat';
+import { type JSX, useEffect, useRef, useState } from 'preact/compat';
 
 import type { StudentRow } from '../instructorStudents.shared.js';
 
@@ -180,9 +180,7 @@ export function StudentsTable({ table }: { table: Table<StudentRow> }) {
   }, [isTableResizing]);
 
   // Helper function to get aria-sort value
-  const getAriaSort = (
-    sortDirection: false | SortDirection,
-  ): ThHTMLAttributes<HTMLTableCellElement>['aria-sort'] => {
+  const getAriaSort = (sortDirection: false | SortDirection) => {
     switch (sortDirection) {
       case 'asc':
         return 'ascending';

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
@@ -194,9 +194,9 @@ function StudentsCard({
                 aria-label="Search by UID, name or email."
                 placeholder="Search by UID, name, email..."
                 value={globalFilter}
-                onInput={(e) => {
+                onInput={async (e) => {
                   if (!(e.target instanceof HTMLInputElement)) return;
-                  setGlobalFilter(e.target.value);
+                  await setGlobalFilter(e.target.value);
                 }}
               />
               <button
@@ -205,7 +205,7 @@ function StudentsCard({
                 aria-label="Clear search"
                 title="Clear search"
                 data-bs-toggle="tooltip"
-                onClick={() => setGlobalFilter('')}
+                onClick={async () => await setGlobalFilter('')}
               >
                 <i class="bi bi-x-circle" aria-hidden="true" />
               </button>

--- a/apps/prairielearn/src/pages/sideNavSettings/sideNavSettings.ts
+++ b/apps/prairielearn/src/pages/sideNavSettings/sideNavSettings.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 
 const router = Router();
 
-router.put('/', async (req, res) => {
+router.put('/', (req, res) => {
   req.session.side_nav_expanded = Boolean(req.body.side_nav_expanded);
   res.sendStatus(204);
 });

--- a/apps/prairielearn/src/pages/studentAssessmentInstanceTimeRemaining/studentAssessmentInstanceTimeRemaining.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstanceTimeRemaining/studentAssessmentInstanceTimeRemaining.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-import asyncHandler from 'express-async-handler';
 
 import selectAndAuthzAssessmentInstance from '../../middlewares/selectAndAuthzAssessmentInstance.js';
 import studentAssessmentAccess from '../../middlewares/studentAssessmentAccess.js';
@@ -9,18 +8,15 @@ const router = Router({ mergeParams: true });
 router.use(selectAndAuthzAssessmentInstance);
 router.use(studentAssessmentAccess);
 
-router.get(
-  '/',
-  asyncHandler(async (req, res, next) => {
-    if (res.locals.assessment.type !== 'Exam') return next();
+router.get('/', (req, res, next) => {
+  if (res.locals.assessment.type !== 'Exam') return next();
 
-    res.send(
-      JSON.stringify({
-        serverRemainingMS: res.locals.assessment_instance_remaining_ms,
-        serverTimeLimitMS: res.locals.assessment_instance_time_limit_ms,
-      }),
-    );
-  }),
-);
+  res.send(
+    JSON.stringify({
+      serverRemainingMS: res.locals.assessment_instance_remaining_ms,
+      serverTimeLimitMS: res.locals.assessment_instance_time_limit_ms,
+    }),
+  );
+});
 
 export default router;

--- a/apps/prairielearn/src/question-servers/calculation-subprocess.ts
+++ b/apps/prairielearn/src/question-servers/calculation-subprocess.ts
@@ -145,6 +145,7 @@ export async function grade(
 // The following functions don't do anything for v2 questions; they're just
 // here to satisfy the question server interface.
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function render(
   _renderSelection: RenderSelection,
   _variant: Variant,
@@ -163,6 +164,7 @@ export async function render(
   return { courseIssues: [], data };
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function prepare(
   _question: Question,
   _course: Course,
@@ -176,6 +178,7 @@ export async function prepare(
   return { courseIssues: [], data };
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function parse(
   submission: ParseSubmission,
   variant: Variant,

--- a/apps/prairielearn/src/question-servers/freeform.ts
+++ b/apps/prairielearn/src/question-servers/freeform.ts
@@ -24,6 +24,7 @@ import { idsEqual } from '../lib/id.js';
 import { isEnterprise } from '../lib/license.js';
 import * as markdown from '../lib/markdown.js';
 import { APP_ROOT_PATH } from '../lib/paths.js';
+import { assertNever } from '../lib/types.js';
 import { getOrUpdateCourseCommitHash } from '../models/course.js';
 import {
   type ElementCoreJson,
@@ -125,7 +126,7 @@ async function loadElements(sourceDir: string, elementType: 'core' | 'course') {
   const elementSchema = run(() => {
     if (elementType === 'core') return ElementCoreJsonSchema;
     if (elementType === 'course') return ElementCourseJsonSchema;
-    throw new Error(`Unknown element type ${elementType}`);
+    assertNever(elementType, 'Unknown element type');
   });
 
   let files: string[];
@@ -489,7 +490,7 @@ async function processQuestionPhase<T>(
     course_path: config.workersExecutionMode === 'container' ? '/course' : context.course_dir_host,
   };
   const courseIssues: CourseIssueError[] = [];
-  let result: any | null = null;
+  let result: any = null;
   let output: string | null = null;
 
   try {
@@ -1126,27 +1127,27 @@ export async function render(
 
       const extensions = context.course_element_extensions;
       const dependencies = {
-        coreStyles: [],
-        coreScripts: [],
-        nodeModulesStyles: [],
-        nodeModulesScripts: [],
-        coreElementStyles: [],
-        coreElementScripts: [],
-        courseElementStyles: [],
-        courseElementScripts: [],
-        extensionStyles: [],
-        extensionScripts: [],
-        clientFilesCourseStyles: [],
-        clientFilesCourseScripts: [],
-        clientFilesQuestionStyles: [],
-        clientFilesQuestionScripts: [],
+        coreStyles: [] as string[],
+        coreScripts: [] as string[],
+        nodeModulesStyles: [] as string[],
+        nodeModulesScripts: [] as string[],
+        coreElementStyles: [] as string[],
+        coreElementScripts: [] as string[],
+        courseElementStyles: [] as string[],
+        courseElementScripts: [] as string[],
+        extensionStyles: [] as string[],
+        extensionScripts: [] as string[],
+        clientFilesCourseStyles: [] as string[],
+        clientFilesCourseScripts: [] as string[],
+        clientFilesQuestionStyles: [] as string[],
+        clientFilesQuestionScripts: [] as string[],
       };
       const dynamicDependencies = {
         nodeModulesScripts: {},
         coreElementScripts: {},
         courseElementScripts: {},
         extensionScripts: {},
-        clientFilesCourseScripts: {},
+        clientFilesCourseScripts: {} as Record<string, string>,
       };
 
       for (const type in question.dependencies) {

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -73,6 +73,7 @@ import * as serverJobs from './lib/server-jobs.js';
 import { PostgresSessionStore } from './lib/session-store.js';
 import * as socketServer from './lib/socket-server.js';
 import { SocketActivityMetrics } from './lib/telemetry/socket-activity-metrics.js';
+import { assertNever } from './lib/types.js';
 import { getSearchParams } from './lib/url.js';
 import * as workspace from './lib/workspace.js';
 import { markAllWorkspaceHostsUnhealthy } from './lib/workspaceHost.js';
@@ -2042,7 +2043,7 @@ export async function startServer(app: express.Express) {
     server = http.createServer(app);
     logger.verbose('server listening to HTTP on port ' + config.serverPort);
   } else {
-    throw new Error('unknown serverType: ' + config.serverType);
+    assertNever(config.serverType, 'unknown serverType');
   }
 
   // Capture metrics about the server, including the number of active connections
@@ -2151,7 +2152,7 @@ function idleErrorHandler(err: Error) {
       last_query: (err as any)?.data?.lastQuery ?? undefined,
     },
   });
-  Sentry.close().finally(() => process.exit(1));
+  void Sentry.close().finally(() => process.exit(1));
 }
 
 const isHMR = DEV_EXECUTION_MODE === 'hmr';
@@ -2462,7 +2463,7 @@ if ((esMain(import.meta) || (isHMR && !isServerInitialized())) && config.startSe
     if (config.initNewsItems) {
       // We initialize news items asynchronously so that servers can boot up
       // in production as quickly as possible.
-      news_items.initInBackground({
+      await news_items.initInBackground({
         // Always notify in production environments.
         notifyIfPreviouslyEmpty: !config.devMode,
       });
@@ -2494,13 +2495,13 @@ if ((esMain(import.meta) || (isHMR && !isServerInitialized())) && config.startSe
     app = await initExpress();
     const httpServer = await startServer(app);
 
-    await socketServer.init(httpServer);
+    socketServer.init(httpServer);
 
     externalGradingSocket.init();
     externalGrader.init();
     externalImageCaptureSocket.init();
 
-    await workspace.init();
+    workspace.init();
     serverJobs.init();
 
     if (config.runningInEc2 && config.nodeMetricsIntervalSec) {
@@ -2596,7 +2597,7 @@ if ((esMain(import.meta) || (isHMR && !isServerInitialized())) && config.startSe
   await socketServer.close();
   app = await initExpress();
   const httpServer = await startServer(app);
-  await socketServer.init(httpServer);
+  socketServer.init(httpServer);
 }
 
 /**

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -541,9 +541,9 @@ export async function loadCourseInfo({
    */
   function getFieldWithoutDuplicates<
     K extends 'tags' | 'topics' | 'assessmentSets' | 'assessmentModules' | 'sharingSets',
-  >(fieldName: K, entryIdentifier: string, defaults?: CourseJson[K] | undefined): CourseJson[K] {
+  >(fieldName: K, entryIdentifier: string, defaults?: CourseJson[K]): CourseJson[K] {
     const known = new Map();
-    const duplicateEntryIds = new Set();
+    const duplicateEntryIds = new Set<string>();
 
     (info[fieldName] || []).forEach((entry) => {
       const entryId = entry[entryIdentifier];
@@ -687,7 +687,7 @@ async function loadAndValidateJson<T extends { uuid: string }>({
   schema: any;
   /** Whether or not a missing file constitutes an error */
   tolerateMissing?: boolean;
-  validate: (info: T) => Promise<{ warnings: string[]; errors: string[] }>;
+  validate: (info: T) => { warnings: string[]; errors: string[] };
 }): Promise<InfoFile<T> | null> {
   const loadedJson: InfoFile<T> | null = await loadInfoFile({
     coursePath,
@@ -705,7 +705,7 @@ async function loadAndValidateJson<T extends { uuid: string }>({
     return loadedJson;
   }
 
-  const validationResult = await validate(loadedJson.data);
+  const validationResult = validate(loadedJson.data);
   if (validationResult.errors.length > 0) {
     infofile.addErrors(loadedJson, validationResult.errors);
     return loadedJson;
@@ -735,7 +735,7 @@ async function loadInfoForDirectory<T extends { uuid: string }>({
   infoFilename: string;
   defaultInfo: any;
   schema: any;
-  validate: (info: T) => Promise<{ warnings: string[]; errors: string[] }>;
+  validate: (info: T) => { warnings: string[]; errors: string[] };
   /** Whether or not info files should be searched for recursively */
   recursive?: boolean;
 }): Promise<Record<string, InfoFile<T>>> {
@@ -938,13 +938,13 @@ function checkAllowAccessUids(rule: { uids?: string[] }): string[] {
   return warnings;
 }
 
-async function validateQuestion({
+function validateQuestion({
   question,
   sharingEnabled,
 }: {
   question: QuestionJson;
   sharingEnabled: boolean;
-}): Promise<{ warnings: string[]; errors: string[] }> {
+}): { warnings: string[]; errors: string[] } {
   const warnings: string[] = [];
   const errors: string[] = [];
 
@@ -996,7 +996,7 @@ function formatValues(qids: Set<string> | string[]) {
     .join(', ');
 }
 
-async function validateAssessment({
+function validateAssessment({
   assessment,
   questions,
   sharingEnabled,
@@ -1006,7 +1006,7 @@ async function validateAssessment({
   questions: Record<string, InfoFile<QuestionJson>>;
   sharingEnabled: boolean;
   courseInstanceExpired: boolean;
-}): Promise<{ warnings: string[]; errors: string[] }> {
+}): { warnings: string[]; errors: string[] } {
   const warnings: string[] = [];
   const errors: string[] = [];
 
@@ -1318,13 +1318,13 @@ async function validateAssessment({
   return { warnings, errors };
 }
 
-async function validateCourseInstance({
+function validateCourseInstance({
   courseInstance,
   sharingEnabled,
 }: {
   courseInstance: CourseInstanceJson;
   sharingEnabled: boolean;
-}): Promise<{ warnings: string[]; errors: string[] }> {
+}): { warnings: string[]; errors: string[] } {
   const warnings: string[] = [];
   const errors: string[] = [];
 

--- a/apps/prairielearn/src/sync/fromDisk/assessments.ts
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.ts
@@ -6,6 +6,7 @@ import { run } from '@prairielearn/run';
 import { config } from '../../lib/config.js';
 import { IdSchema } from '../../lib/db-types.js';
 import { features } from '../../lib/features/index.js';
+import { assertNever } from '../../lib/types.js';
 import { type AssessmentJson, type CommentJson } from '../../schemas/index.js';
 import { type CourseInstanceData } from '../course-db.js';
 import { isAccessRuleAccessibleInFuture } from '../dates.js';
@@ -204,7 +205,7 @@ function getParamsForAssessment(
             pointsList: undefined,
           };
         } else {
-          throw new Error(`Unknown assessment type: ${assessment.type}`);
+          assertNever(assessment.type, 'Unknown assessment type');
         }
       });
 

--- a/apps/prairielearn/src/sync/fromDisk/entity-list.test.ts
+++ b/apps/prairielearn/src/sync/fromDisk/entity-list.test.ts
@@ -323,7 +323,7 @@ describe('determineOperationsForEntities', () => {
     assert.deepEqual(result.entitiesToDelete, ['A', 'B']);
   });
 
-  it('does not delete if it should not', async () => {
+  it('does not delete if it should not', () => {
     const result = determineOperationsForEntities<TestEntityWithHeading>({
       courseEntities: [],
       existingEntities: [

--- a/apps/prairielearn/src/tests/access.test.ts
+++ b/apps/prairielearn/src/tests/access.test.ts
@@ -46,39 +46,39 @@ describe('Access control', { timeout: 20000 }, function () {
       2450 after course_instance
      */
 
-  function cookiesStudent() {
+  async function cookiesStudent() {
     const cookies = new fetchCookie.toughCookie.CookieJar();
-    cookies.setCookie('pl_test_user=test_student', siteUrl);
+    await cookies.setCookie('pl_test_user=test_student', siteUrl);
     return cookies;
   }
 
-  function cookiesStudentExam() {
-    const cookies = cookiesStudent();
-    cookies.setCookie('pl_test_mode=Exam', siteUrl);
+  async function cookiesStudentExam() {
+    const cookies = await cookiesStudent();
+    await cookies.setCookie('pl_test_mode=Exam', siteUrl);
     return cookies;
   }
 
-  function cookiesStudentExamBeforeCourseInstance() {
-    const cookies = cookiesStudentExam();
-    cookies.setCookie('pl_test_date=1750-06-13T13:12:00Z', siteUrl);
+  async function cookiesStudentExamBeforeCourseInstance() {
+    const cookies = await cookiesStudentExam();
+    await cookies.setCookie('pl_test_date=1750-06-13T13:12:00Z', siteUrl);
     return cookies;
   }
 
-  function cookiesStudentExamBeforeAssessment() {
-    const cookies = cookiesStudentExam();
-    cookies.setCookie('pl_test_date=1850-06-13T13:12:00Z', siteUrl);
+  async function cookiesStudentExamBeforeAssessment() {
+    const cookies = await cookiesStudentExam();
+    await cookies.setCookie('pl_test_date=1850-06-13T13:12:00Z', siteUrl);
     return cookies;
   }
 
-  function cookiesStudentExamAfterAssessment() {
-    const cookies = cookiesStudentExam();
-    cookies.setCookie('pl_test_date=2350-06-13T13:12:00Z', siteUrl);
+  async function cookiesStudentExamAfterAssessment() {
+    const cookies = await cookiesStudentExam();
+    await cookies.setCookie('pl_test_date=2350-06-13T13:12:00Z', siteUrl);
     return cookies;
   }
 
-  function cookiesStudentExamAfterCourseInstance() {
-    const cookies = cookiesStudentExam();
-    cookies.setCookie('pl_test_date=2450-06-13T13:12:00Z', siteUrl);
+  async function cookiesStudentExamAfterCourseInstance() {
+    const cookies = await cookiesStudentExam();
+    await cookies.setCookie('pl_test_date=2450-06-13T13:12:00Z', siteUrl);
     return cookies;
   }
 
@@ -89,7 +89,7 @@ describe('Access control', { timeout: 20000 }, function () {
 
   /**********************************************************************/
 
-  async function getPl(cookies, shouldContainQA101) {
+  async function getPl(cookies: Parameters<typeof fetchCookie>[1], shouldContainQA101: boolean) {
     const res = await fetchCookie(fetch, cookies)(siteUrl);
     assert.equal(res.status, 200);
     const page = await res.text();
@@ -100,7 +100,7 @@ describe('Access control', { timeout: 20000 }, function () {
 
   describe('1. GET /pl', function () {
     it('as student should not contain QA 101', async () => {
-      await getPl(cookiesStudent(), false);
+      await getPl(await cookiesStudent(), false);
     });
   });
 
@@ -118,13 +118,13 @@ describe('Access control', { timeout: 20000 }, function () {
 
   describe('4. GET /pl', function () {
     it('as student should contain QA 101', async () => {
-      await getPl(cookiesStudent(), true);
+      await getPl(await cookiesStudent(), true);
     });
     it('as student in Exam mode before course instance time period should not contain QA 101', async () => {
-      await getPl(cookiesStudentExamBeforeCourseInstance(), false);
+      await getPl(await cookiesStudentExamBeforeCourseInstance(), false);
     });
     it('as student in Exam mode after course instance time period should not contain QA 101', async () => {
-      await getPl(cookiesStudentExamAfterCourseInstance(), false);
+      await getPl(await cookiesStudentExamAfterCourseInstance(), false);
     });
   });
 

--- a/apps/prairielearn/src/tests/accessibility/index.test.ts
+++ b/apps/prairielearn/src/tests/accessibility/index.test.ts
@@ -13,6 +13,7 @@ import { IdSchema } from '@prairielearn/zod';
 import { config } from '../../lib/config.js';
 import { features } from '../../lib/features/index.js';
 import { TEST_COURSE_PATH } from '../../lib/paths.js';
+import { assertNever } from '../../lib/types.js';
 import * as news_items from '../../news_items/index.js';
 import * as server from '../../server.js';
 import * as helperServer from '../helperServer.js';
@@ -374,7 +375,7 @@ function shouldSkipPath(path) {
     } else if (r instanceof RegExp) {
       return r.test(path);
     } else {
-      throw new Error(`Invalid route: ${r}`);
+      assertNever(r, 'Invalid route');
     }
   });
 }

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -428,7 +428,7 @@ describe('test course editor', { timeout: 20_000 }, function () {
       await updateCourseSharingName({ course_id: 2, sharing_name: 'test-course' });
     });
 
-    describe('verify edits', async function () {
+    describe('verify edits', function () {
       publicCopyTestData.forEach((element) => {
         testEdit(element);
       });

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -36,8 +36,8 @@ describe('Enroll page (enterprise)', function () {
   afterAll(helperServer.after);
 
   const originalIsEnterprise = config.isEnterprise;
-  beforeAll(async () => (config.isEnterprise = true));
-  afterAll(async () => (config.isEnterprise = originalIsEnterprise));
+  beforeAll(() => (config.isEnterprise = true));
+  afterAll(() => (config.isEnterprise = originalIsEnterprise));
 
   test.sequential('enroll a single student', async () => {
     const res = await enrollUser('1', USER_1);

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -132,7 +132,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), '100%');
         });
         it('should result in 1 "grading-block" component being displayed', () => {
@@ -165,7 +165,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), 'saved, not graded');
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -199,7 +199,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
           assert.lengthOf(grading_jobs, 0);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
             'manual grading: waiting for grading',
@@ -231,7 +231,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
           assert.lengthOf(grading_jobs, 0);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
             'manual grading: waiting for grading',
@@ -295,7 +295,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), '100%');
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -327,7 +327,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), 'saved, not graded');
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -385,7 +385,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), '100%');
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -428,7 +428,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), '100%');
         });
         it('should result in 1 "grading-block" component being displayed', () => {
@@ -464,7 +464,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), 'saved, not graded');
         });
         it('should NOT result in "grading-block" component being displayed', () => {
@@ -504,7 +504,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
           assert.lengthOf(grading_jobs, 0);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
             'manual grading: waiting for grading',
@@ -542,7 +542,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
           assert.lengthOf(grading_jobs, 0);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(
             getLatestSubmissionStatus($questionsPage),
             'manual grading: waiting for grading',
@@ -584,7 +584,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), '100%');
         });
         it('should result in 1 "grading-block" component being displayed', () => {
@@ -616,7 +616,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
         });
-        it('should display submission status', async () => {
+        it('should display submission status', () => {
           assert.equal(getLatestSubmissionStatus($questionsPage), 'saved, not graded');
         });
         it('should NOT result in "grading-block" component being displayed', () => {

--- a/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
+++ b/apps/prairielearn/src/tests/groupExamRolePermissions.test.ts
@@ -383,7 +383,7 @@ describe('Assessment instance with group roles & permissions - Exam', function (
         body: new URLSearchParams({
           __action: 'grade',
           __csrf_token: questionOneFirstUserCsrfToken,
-          __variant_id: variantId as string,
+          __variant_id: variantId,
         }),
       });
       assert.equal(
@@ -403,7 +403,7 @@ describe('Assessment instance with group roles & permissions - Exam', function (
         body: new URLSearchParams({
           __action: 'grade',
           __csrf_token: questionOneSecondtUserCsrfToken,
-          __variant_id: variantId as string,
+          __variant_id: variantId,
         }),
       });
       assert.isOk(questionSubmissionWithPermissionResponse.ok);

--- a/apps/prairielearn/src/tests/groupRole.test.ts
+++ b/apps/prairielearn/src/tests/groupRole.test.ts
@@ -1776,7 +1776,7 @@ describe('Test group role reassignment logic when user leaves', { timeout: 20_00
     assert.lengthOf(locals.studentUsers, 5);
   });
 
-  test.sequential('should setup group info', async function () {
+  test.sequential('should setup group info', function () {
     locals.groupId = '1';
     locals.groupName = '1';
     locals.groupMembers = locals.studentUsers.map((user) => ({

--- a/apps/prairielearn/src/tests/groupRolePermissions.test.ts
+++ b/apps/prairielearn/src/tests/groupRolePermissions.test.ts
@@ -389,7 +389,7 @@ describe('Assessment instance with group roles & permissions - Homework', functi
         body: new URLSearchParams({
           __action: 'grade',
           __csrf_token: questionOneFirstUserCsrfToken,
-          __variant_id: variantId as string,
+          __variant_id: variantId,
         }),
       });
       assert.equal(
@@ -409,7 +409,7 @@ describe('Assessment instance with group roles & permissions - Homework', functi
         body: new URLSearchParams({
           __action: 'grade',
           __csrf_token: questionOneSecondtUserCsrfToken,
-          __variant_id: variantId as string,
+          __variant_id: variantId,
         }),
       });
       assert.isOk(questionSubmissionWithPermissionResponse.ok);

--- a/apps/prairielearn/src/tests/groupStudent.test.ts
+++ b/apps/prairielearn/src/tests/groupStudent.test.ts
@@ -25,7 +25,7 @@ locals.assessmentsUrl = locals.courseInstanceUrl + '/assessments';
 const storedConfig: Record<string, any> = {};
 
 describe('Group based homework assess control on student side', { timeout: 20_000 }, function () {
-  beforeAll(async () => {
+  beforeAll(() => {
     storedConfig.authUid = config.authUid;
     storedConfig.authName = config.authName;
     storedConfig.authUin = config.authUin;
@@ -35,7 +35,7 @@ describe('Group based homework assess control on student side', { timeout: 20_00
 
   afterAll(helperServer.after);
 
-  afterAll(async () => {
+  afterAll(() => {
     Object.assign(config, storedConfig);
   });
 

--- a/apps/prairielearn/src/tests/helperClient.ts
+++ b/apps/prairielearn/src/tests/helperClient.ts
@@ -40,7 +40,7 @@ export function getCSRFToken($: cheerio.CheerioAPI): string {
   assert.lengthOf(csrfTokenSpan, 1);
   const csrfToken = csrfTokenSpan.text();
   assert.isString(csrfToken);
-  return csrfToken as string;
+  return csrfToken;
 }
 
 /**

--- a/apps/prairielearn/src/tests/lti13.test.ts
+++ b/apps/prairielearn/src/tests/lti13.test.ts
@@ -284,7 +284,7 @@ describe('LTI 1.3', () => {
   });
 
   afterAll(async () => {
-    helperServer.after();
+    await helperServer.after();
     config.isEnterprise = false;
     config.features = {};
   });
@@ -445,7 +445,7 @@ describe('LTI 1.3', () => {
     const app = express();
     app.use(express.urlencoded({ extended: true }));
 
-    app.post('/token', async (req, res) => {
+    app.post('/token', (req, res) => {
       assert.equal(req.body.grant_type, 'client_credentials');
       assert.equal(req.body.client_id, CLIENT_ID);
       assert.equal(

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -459,23 +459,17 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
         assertAlert($manualGradingPage, 'has one open instance');
       });
 
-      test.sequential(
-        'manual grading page should list one question requiring grading',
-        async () => {
-          const row = $manualGradingPage(`tr:contains("${manualGradingQuestionTitle}")`);
-          assert.equal(row.length, 1);
-          const count = row
-            .find('td[data-testid="iq-to-grade-count"]')
-            .text()
-            .replaceAll(/\s/g, '');
-          assert.equal(count, '1/1');
-          const nextButton = row.find('.btn:contains("next submission")');
-          assert.equal(nextButton.length, 1);
-          manualGradingAssessmentQuestionUrl =
-            siteUrl + row.find(`a:contains("${manualGradingQuestionTitle}")`).attr('href');
-          manualGradingNextUngradedUrl = manualGradingAssessmentQuestionUrl + '/next_ungraded';
-        },
-      );
+      test.sequential('manual grading page should list one question requiring grading', () => {
+        const row = $manualGradingPage(`tr:contains("${manualGradingQuestionTitle}")`);
+        assert.equal(row.length, 1);
+        const count = row.find('td[data-testid="iq-to-grade-count"]').text().replaceAll(/\s/g, '');
+        assert.equal(count, '1/1');
+        const nextButton = row.find('.btn:contains("next submission")');
+        assert.equal(nextButton.length, 1);
+        manualGradingAssessmentQuestionUrl =
+          siteUrl + row.find(`a:contains("${manualGradingQuestionTitle}")`).attr('href');
+        manualGradingNextUngradedUrl = manualGradingAssessmentQuestionUrl + '/next_ungraded';
+      });
 
       test.sequential(
         'manual grading page for assessment question should warn about an open instance',
@@ -1115,21 +1109,15 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
         assertAlert($manualGradingPage, 'has one open instance');
       });
 
-      test.sequential(
-        'manual grading page should list one question requiring grading',
-        async () => {
-          const row = $manualGradingPage(`tr:contains("${manualGradingQuestionTitle}")`);
-          assert.equal(row.length, 1);
-          const count = row
-            .find('td[data-testid="iq-to-grade-count"]')
-            .text()
-            .replaceAll(/\s/g, '');
-          assert.equal(count, '1/1');
-          manualGradingAssessmentQuestionUrl =
-            siteUrl + row.find(`a:contains("${manualGradingQuestionTitle}")`).attr('href');
-          manualGradingNextUngradedUrl = manualGradingAssessmentQuestionUrl + '/next_ungraded';
-        },
-      );
+      test.sequential('manual grading page should list one question requiring grading', () => {
+        const row = $manualGradingPage(`tr:contains("${manualGradingQuestionTitle}")`);
+        assert.equal(row.length, 1);
+        const count = row.find('td[data-testid="iq-to-grade-count"]').text().replaceAll(/\s/g, '');
+        assert.equal(count, '1/1');
+        manualGradingAssessmentQuestionUrl =
+          siteUrl + row.find(`a:contains("${manualGradingQuestionTitle}")`).attr('href');
+        manualGradingNextUngradedUrl = manualGradingAssessmentQuestionUrl + '/next_ungraded';
+      });
 
       test.sequential(
         'manual grading page for assessment question should warn about an open instance',

--- a/apps/prairielearn/src/tests/permissions/effectiveUser.test.ts
+++ b/apps/prairielearn/src/tests/permissions/effectiveUser.test.ts
@@ -403,7 +403,7 @@ describe('effective user', { timeout: 60_000 }, function () {
   });
 
   test.sequential('instructor cannot request higher course instance role', async () => {
-    updateCourseInstancePermissionsRole({
+    await updateCourseInstancePermissionsRole({
       course_id: '1',
       user_id: instructorId,
       course_instance_id: '1',

--- a/apps/prairielearn/src/tests/serverJobs.test.ts
+++ b/apps/prairielearn/src/tests/serverJobs.test.ts
@@ -31,6 +31,7 @@ describe('server-jobs', () => {
         description: 'test server job',
       });
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       await serverJob.execute(async (job) => {
         job.info('testing info');
         job.error('testing error');
@@ -59,6 +60,7 @@ describe('server-jobs', () => {
       });
 
       await expect(
+        // eslint-disable-next-line @typescript-eslint/require-await
         serverJob.execute(async (job) => {
           job.info('testing info');
           throw new Error('failing job');
@@ -82,6 +84,7 @@ describe('server-jobs', () => {
       });
 
       await expect(
+        // eslint-disable-next-line @typescript-eslint/require-await
         serverJob.execute(async (job) => {
           job.fail('failing job');
         }),
@@ -109,6 +112,7 @@ describe('server-jobs', () => {
       });
 
       await expect(
+        // eslint-disable-next-line @typescript-eslint/require-await
         serverJob.executeUnsafe(async (job) => {
           job.info('testing info');
           throw new Error('failing job');

--- a/apps/prairielearn/src/tests/testSequentialQuestions.test.ts
+++ b/apps/prairielearn/src/tests/testSequentialQuestions.test.ts
@@ -207,7 +207,7 @@ describe(
       assert.isFalse(context.instanceQuestions[4].locked);
     });
 
-    test.sequential('Unlocking question 4 does NOT cascade to question 6', async function () {
+    test.sequential('Unlocking question 4 does NOT cascade to question 6', function () {
       assert.isTrue(context.instanceQuestions[5].locked);
     });
   },

--- a/apps/prairielearn/src/tests/workspaceAccess.test.ts
+++ b/apps/prairielearn/src/tests/workspaceAccess.test.ts
@@ -32,10 +32,10 @@ const studentNotEnrolled: AuthUser = {
 };
 
 describe('Test workspace authorization access', { timeout: 20_000 }, function () {
-  beforeAll(async function () {
+  beforeAll(function () {
     config.workspaceEnable = false;
   });
-  afterAll(async function () {
+  afterAll(function () {
     config.workspaceEnable = true;
   });
 

--- a/apps/prairielearn/src/webhooks/terminate.ts
+++ b/apps/prairielearn/src/webhooks/terminate.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 
 import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
 import * as jose from 'jose';
 
 import { logger } from '@prairielearn/logger';
@@ -20,52 +21,55 @@ const router = Router();
  * recommended that this endpoint be blocked at your load balancer or firewall
  * for extra security.
  */
-router.post('/', async (req, res) => {
-  try {
-    const jwt = req.headers['prairielearn-signature'];
-    if (!jwt) {
-      res.status(403).send('Missing PrairieLearn-Signature header');
-      return;
-    }
-    if (Array.isArray(jwt)) {
-      res.status(403).send('Multiple PrairieLearn-Signature headers');
-      return;
-    }
-
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
     try {
-      const key = crypto.createSecretKey(config.secretKey, 'utf-8');
-      await jose.jwtVerify(jwt, key, {
-        issuer: 'PrairieLearn',
-        subject: 'terminate',
+      const jwt = req.headers['prairielearn-signature'];
+      if (!jwt) {
+        res.status(403).send('Missing PrairieLearn-Signature header');
+        return;
+      }
+      if (Array.isArray(jwt)) {
+        res.status(403).send('Multiple PrairieLearn-Signature headers');
+        return;
+      }
+
+      try {
+        const key = crypto.createSecretKey(config.secretKey, 'utf-8');
+        await jose.jwtVerify(jwt, key, {
+          issuer: 'PrairieLearn',
+          subject: 'terminate',
+        });
+      } catch (err) {
+        logger.error('Error decoding PrairieLearn-Signature header', err);
+        res.status(403).send(`Invalid PrairieLearn-Signature header: ${err.message}`);
+        return;
+      }
+
+      // If a client uses a keepalive connection, we'd be temporarily deadlocked
+      // if we waited for the client to close the connection, as `server.close()`
+      // in `server.js` won't finish until all connections have closed. To work
+      // around this, we'll explicitly close the underlying socket once we've sent
+      // the response.
+      //
+      // TODO: Once we have a minimum Node version of 18.2, we should use
+      // `server.closeIdleConnections` in `server.js` instead of this.
+      const socket = res.socket;
+      res.on('close', () => {
+        socket?.end(() => {
+          socket.destroy();
+          logger.info('Terminating server due to webhook request');
+          process.kill(process.pid, 'SIGTERM');
+        });
       });
+
+      res.status(200).send('Terminating');
     } catch (err) {
-      logger.error('Error decoding PrairieLearn-Signature header', err);
-      res.status(403).send(`Invalid PrairieLearn-Signature header: ${err.message}`);
-      return;
+      logger.error('Error in terminate webhook', err);
+      res.status(500).send(err.message);
     }
-
-    // If a client uses a keepalive connection, we'd be temporarily deadlocked
-    // if we waited for the client to close the connection, as `server.close()`
-    // in `server.js` won't finish until all connections have closed. To work
-    // around this, we'll explicitly close the underlying socket once we've sent
-    // the response.
-    //
-    // TODO: Once we have a minimum Node version of 18.2, we should use
-    // `server.closeIdleConnections` in `server.js` instead of this.
-    const socket = res.socket;
-    res.on('close', () => {
-      socket?.end(() => {
-        socket.destroy();
-        logger.info('Terminating server due to webhook request');
-        process.kill(process.pid, 'SIGTERM');
-      });
-    });
-
-    res.status(200).send('Terminating');
-  } catch (err) {
-    logger.error('Error in terminate webhook', err);
-    res.status(500).send(err.message);
-  }
-});
+  }),
+);
 
 export default router;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,6 @@
 // @ts-check
+import path from 'path';
+
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import eslintReact from '@eslint-react/eslint-plugin';
@@ -194,6 +196,7 @@ export default tseslint.config([
       'no-useless-concat': 'off', // TODO: Consider enabling this
       'no-useless-constructor': 'off',
       'no-useless-return': 'off', // TODO: Consider enabling this
+      'no-void': 'off', // https://typescript-eslint.io/rules/no-floating-promises/#ignorevoid
       'object-shorthand': 'error',
       'one-var': ['off', 'never'], // TODO: Consider enabling this
       'prefer-arrow-callback': 'off',
@@ -529,6 +532,73 @@ export default tseslint.config([
       'jsdoc/require-returns': 'off',
       'jsdoc/require-param': 'off',
       'jsdoc/tag-lines': 'off',
+    },
+  },
+  {
+    // We only include apps/prairielearn for performance reasons.
+    files: ['apps/prairielearn/**/*.{ts,tsx}'],
+    extends: [tseslint.configs.recommendedTypeCheckedOnly],
+    rules: {
+      '@typescript-eslint/no-base-to-string': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      // We don't always check that we got a error when a promise is rejected.
+      '@typescript-eslint/prefer-promise-reject-errors': 'off',
+      '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        {
+          allow: [{ name: ['Error', 'URL', 'URLSearchParams'], from: 'lib' }],
+          allowAny: true,
+          allowBoolean: true,
+          allowNullish: true,
+          allowNumber: true,
+          allowRegExp: true,
+        },
+      ],
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+
+        {
+          checksConditionals: true,
+          checksSpreads: true,
+          checksVoidReturn: {
+            // Common usage with `async` functions
+            arguments: false,
+            // Common usage with `async` onClick handlers
+            attributes: false,
+            inheritedMethods: true,
+            // Common usage with e.g. setState
+            properties: false,
+            returns: true,
+            variables: true,
+          },
+        },
+      ],
+      '@typescript-eslint/only-throw-error': [
+        'error',
+        {
+          allow: [
+            {
+              name: 'HttpRedirect',
+              from: 'file',
+            },
+          ],
+          allowRethrowing: true,
+          allowThrowingAny: true,
+          allowThrowingUnknown: true,
+        },
+      ],
+    },
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ['vite.config.ts', 'vitest.config.ts'],
+        },
+        tsconfigRootDir: path.join(import.meta.dirname, 'apps', 'prairielearn'),
+      },
     },
   },
   {


### PR DESCRIPTION
- Enables the recommended typechecked settings for code in `apps/prairielearn`
- Most violations are about the usage of `async` -- we can either disable this rule, or deal with obvious mistakes (i.e. an async method is required even though no async features are in use)

I think the rule about dangling promises seems very useful 👍 