### PR TITLE
Patch external capture retake failure

### DIFF
--- a/apps/prairielearn/assets/scripts/externalImageCaptureClient.ts
+++ b/apps/prairielearn/assets/scripts/externalImageCaptureClient.ts
@@ -178,7 +178,6 @@ onDocumentReady(() => {
 
     socket.on('externalImageCaptureAck', (msg: StatusMessage) => {
       clearTimeout(timeout);
-      socket.disconnect();
 
       if (!msg) {
         changeState('failed');


### PR DESCRIPTION
Closes #12640.

Capturing an image then retaking previously resulted in a hang on the "Uploading" screen, then an "Upload failure":

https://github.com/user-attachments/assets/2b8162cf-9d46-4e10-bbd3-f39dbadaa337

This PR fixes that by not disconnecting from the socket after the first capture:

https://github.com/user-attachments/assets/ab3adb7a-82ab-4b62-a1eb-ee78ebaeaf2b