### PR TITLE
Make user info available to render() in server.py

### DIFF
--- a/apps/prairielearn/src/question-servers/freeform.ts
+++ b/apps/prairielearn/src/question-servers/freeform.ts
@@ -459,6 +459,7 @@ function checkData(data: Record<string, any>, origData: Record<string, any>, pha
              || checkProp('ai_grading',            'boolean', ['render'],                           [])
              || checkProp('panel',                 'string',  ['render'],                           [])
              || checkProp('num_valid_submissions', 'integer', ['render'],                           [])
+             || checkProp('user',                  'object',  ['render'],                           [])
              || checkProp('gradable',              'boolean', ['parse', 'grade', 'test'],           [])
              || checkProp('filename',              'string',  ['file'],                             [])
              || checkProp('test_type',             'string',  ['test'],                             [])
@@ -965,6 +966,7 @@ async function renderPanel(
     ai_grading: locals.questionRenderContext === 'ai_grading',
     panel,
     num_valid_submissions: variant.num_tries ?? null,
+    user: locals.user,
   } satisfies ExecutionData;
 
   const { data: cachedData, cacheHit } = await getCachedDataOrCompute(

--- a/apps/prairielearn/src/question-servers/types.ts
+++ b/apps/prairielearn/src/question-servers/types.ts
@@ -149,4 +149,5 @@ export interface ExecutionData {
   filename?: string;
   gradable?: boolean;
   extensions?: Record<string, ElementExtensionJsonExtension>;
+  user?: Record<string, unknown>;
 }


### PR DESCRIPTION
My research team is planning to convert a ML-powered metacognitive calibration intervention that we've been developing as a browser extension into something that directly integrates into PrairieLearn instead. Ideally, this will greatly reduce the burden for students to participate and try out the intervention. But, as we found and discussed in Slack, currently PL doesn't have a way to get the a student's ID in server.py for a question, which is essential for this type of use case because machine learning is used to personalize the intervention. After embarrassingly many hours of grep and vim, I found that the most straightforward way to get this information to server.py was in the `render()` function, as part of the `data` parameter that gets passed in.

The approach in this PR works great for our purposes. We can make a simple modification to the `html` string and return it from there. Also, as the PL docs say regarding `render()`, "[This is rarely used except for very advanced questions](https://prairielearn.readthedocs.io/en/latest/question/server/#step-3-render)", so I think it minimizes the chances of somehow accidentally breaking something (e.g., a question that puts a `user` key into `data` during `generate()` -- if that's even possible).

It is easy to try out. For example, you can add a `server.py` to the *testCourse/questions/orderBlocks* question with these contents to see it in the test course:
```python
import json

def render(data, html):
    userjson = json.dumps(data["user"])
    return html.replace(
        "these different configurations.",
        "these different configurations.<br /><pre>" + userjson + "</pre>",
    )
```