### PR TITLE
Ensure new assessments with sharing errors have associated assessment set

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/assessments.ts
+++ b/apps/prairielearn/src/sync/fromDisk/assessments.ts
@@ -307,7 +307,7 @@ function getParamsForAssessment(
   };
 }
 
-function parseSharedQuestionReference(qid) {
+function parseSharedQuestionReference(qid: string) {
   const firstSlash = qid.indexOf('/');
   if (firstSlash === -1) {
     // No QID, invalid question reference. An error will be recorded when trying to locate this question
@@ -397,6 +397,29 @@ export async function sync(
     });
   }
 
+  const assessmentParams = Object.entries(assessments).map(([tid, assessment]) => {
+    return JSON.stringify([
+      tid,
+      assessment.uuid,
+      infofile.stringifyErrors(assessment),
+      infofile.stringifyWarnings(assessment),
+      getParamsForAssessment(assessment, questionIds),
+    ]);
+  });
+
+  await sqldb.callAsync('sync_assessments', [
+    assessmentParams,
+    courseId,
+    courseInstanceId,
+    config.checkSharingOnSync,
+  ]);
+}
+
+export async function validateAssessmentSharedQuestions(
+  courseId: string,
+  assessments: CourseInstanceData['assessments'],
+  questionIds: Record<string, string>,
+) {
   // A set of all imported question IDs.
   const importedQids = new Set<string>();
 
@@ -433,14 +456,12 @@ export async function sync(
       z.string(),
     );
     const questionSharingEnabled = await features.enabled('question-sharing', {
-      course_id: courseId,
-      course_instance_id: courseInstanceId,
       institution_id: institutionId,
+      course_id: courseId,
     });
     const consumePublicQuestionsEnabled = await features.enabled('consume-public-questions', {
-      course_id: courseId,
-      course_instance_id: courseInstanceId,
       institution_id: institutionId,
+      course_id: courseId,
     });
     if (!(questionSharingEnabled || consumePublicQuestionsEnabled) && config.checkSharingOnSync) {
       for (const [tid, qids] of assessmentImportedQids.entries()) {
@@ -452,50 +473,33 @@ export async function sync(
         }
       }
     }
-  }
 
-  const importedQuestions = await sqldb.queryRows(
-    sql.get_imported_questions,
-    {
-      course_id: courseId,
-      imported_question_info: JSON.stringify(
-        Array.from(importedQids, parseSharedQuestionReference),
-      ),
-    },
-    z.object({ sharing_name: z.string(), qid: z.string(), id: IdSchema }),
-  );
-  for (const row of importedQuestions) {
-    questionIds['@' + row.sharing_name + '/' + row.qid] = row.id;
-  }
-  const missingQids = new Set(Array.from(importedQids).filter((qid) => !(qid in questionIds)));
-  if (config.checkSharingOnSync) {
-    for (const [tid, qids] of assessmentImportedQids.entries()) {
-      const assessmentMissingQids = qids.filter((qid) => missingQids.has(qid));
-      if (assessmentMissingQids.length > 0) {
-        infofile.addError(
-          assessments[tid],
-          `For each of the following, either the course you are referencing does not exist, or the question does not exist within that course: ${[
-            ...assessmentMissingQids,
-          ].join(', ')}`,
-        );
+    const importedQuestions = await sqldb.queryRows(
+      sql.get_imported_questions,
+      {
+        course_id: courseId,
+        imported_question_info: JSON.stringify(
+          Array.from(importedQids, parseSharedQuestionReference),
+        ),
+      },
+      z.object({ sharing_name: z.string(), qid: z.string(), id: IdSchema }),
+    );
+    for (const row of importedQuestions) {
+      questionIds['@' + row.sharing_name + '/' + row.qid] = row.id;
+    }
+    const missingQids = new Set(Array.from(importedQids).filter((qid) => !(qid in questionIds)));
+    if (config.checkSharingOnSync) {
+      for (const [tid, qids] of assessmentImportedQids.entries()) {
+        const assessmentMissingQids = qids.filter((qid) => missingQids.has(qid));
+        if (assessmentMissingQids.length > 0) {
+          infofile.addError(
+            assessments[tid],
+            `For each of the following, either the course you are referencing does not exist, or the question does not exist within that course: ${[
+              ...assessmentMissingQids,
+            ].join(', ')}`,
+          );
+        }
       }
     }
   }
-
-  const assessmentParams = Object.entries(assessments).map(([tid, assessment]) => {
-    return JSON.stringify([
-      tid,
-      assessment.uuid,
-      infofile.stringifyErrors(assessment),
-      infofile.stringifyWarnings(assessment),
-      getParamsForAssessment(assessment, questionIds),
-    ]);
-  });
-
-  await sqldb.callAsync('sync_assessments', [
-    assessmentParams,
-    courseId,
-    courseInstanceId,
-    config.checkSharingOnSync,
-  ]);
 }

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1837,7 +1837,7 @@ describe('Assessment syncing', () => {
         questions: [
           {
             id: '@example-course/i do not exist',
-            points: [1, 2, 3],
+            points: [3, 2, 1],
           },
         ],
       });


### PR DESCRIPTION
This showed up in production while trying to transfer an existing course to a new server. The course referenced shared questions that didn't exist there, but instead of failing with a nice error message, this assertion was failing:

https://github.com/PrairieLearn/PrairieLearn/blob/69d2169eb57ef8242e40076c4fbfa22a7fdda954/apps/prairielearn/src/sprocs/sync_assessments.sql#L654

This is because the assessment set syncing code inspects the assessments for errors to determine if the "Unknown" assessment set should be created:

https://github.com/PrairieLearn/PrairieLearn/blob/69d2169eb57ef8242e40076c4fbfa22a7fdda954/apps/prairielearn/src/sync/fromDisk/assessmentSets.ts#L52-L67

But because assessment syncing (necessarily) happens after assessment set syncing, the old code wasn't running in time to fix sync issues: 

https://github.com/PrairieLearn/PrairieLearn/blob/69d2169eb57ef8242e40076c4fbfa22a7fdda954/apps/prairielearn/src/sync/syncFromDisk.ts#L153-L170

By changing the execution order, we ensure that things work as expected.