### PR TITLE
Use consistent colors for sync output

### DIFF
--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -297,13 +297,13 @@ function writeErrorsAndWarningsForInfoFileIfNeeded<T>(
   if (infofile.hasErrors(infoFile)) {
     infoFile.errors.forEach((error) => {
       const indentedError = error.replaceAll('\n', '\n    ');
-      writeLine(chalk.red(`  ✖ ${indentedError}`));
+      writeLine(chalk.redBright(`  ✖ ${indentedError}`));
     });
   }
   if (infofile.hasWarnings(infoFile)) {
     infoFile.warnings.forEach((warning) => {
       const indentedWarning = warning.replaceAll('\n', '\n    ');
-      writeLine(chalk.yellow(`  ⚠ ${indentedWarning}`));
+      writeLine(chalk.yellowBright(`  ⚠ ${indentedWarning}`));
     });
   }
 }

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -177,11 +177,9 @@ export async function syncDiskToSqlWithLock(
   const courseDataHasErrors = courseDB.courseDataHasErrors(courseData);
   const courseDataHasErrorsOrWarnings = courseDB.courseDataHasErrorsOrWarnings(courseData);
   if (courseDataHasErrors) {
-    logger.info(chalk.red('✖ Some JSON files contained errors and were unable to be synced'));
+    logger.error('✖ Some JSON files contained errors and were unable to be synced');
   } else if (courseDataHasErrorsOrWarnings) {
-    logger.info(
-      chalk.yellow('⚠ Some JSON files contained warnings but all were successfully synced'),
-    );
+    logger.info('⚠ Some JSON files contained warnings but all were successfully synced');
   } else {
     logger.info(chalk.green('✓ Course sync successful'));
   }
@@ -215,7 +213,7 @@ export async function syncDiskToSql(
     {
       timeout: 0,
       onNotAcquired: () => {
-        logger.verbose(chalk.red(`Did not acquire lock ${lockName}`));
+        logger.verbose(chalk.redBright(`Did not acquire lock ${lockName}`));
         throw new Error(`Another user is already syncing or modifying the course: ${courseDir}`);
       },
     },

--- a/contrib/verify_course_repo.mjs
+++ b/contrib/verify_course_repo.mjs
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
 
 import * as courseDB from '../apps/prairielearn/dist/sync/course-db.js';
-(async () => {
-  const courseData = await courseDB.loadFullCourse(null, '/course');
-  const errors = [];
-  courseDB.writeErrorsAndWarningsForCourseData(null, courseData, (line) =>
-    line ? errors.push(line) : null,
-  );
-  if (errors.length > 0) {
-    errors.forEach((line) => console.error(line));
-    process.exit(1);
-  }
-})().then(() => {});
+
+const courseData = await courseDB.loadFullCourse(null, '/course');
+const errors = [];
+courseDB.writeErrorsAndWarningsForCourseData(null, courseData, (line) =>
+  line ? errors.push(line) : null,
+);
+if (errors.length > 0) {
+  errors.forEach((line) => console.error(line));
+  process.exit(1);
+}


### PR DESCRIPTION
This makes all the sync output use the same consistent colors (the "bright" variants of red and yellow) that the server job logger is using:

https://github.com/PrairieLearn/PrairieLearn/blob/00b0752bfad75616ce066e375262e7782b7f65e4/apps/prairielearn/src/lib/server-jobs.ts#L102-L108