### PR TITLE
Fix instance question status logic for homeworks

### DIFF
--- a/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
+++ b/apps/prairielearn/src/sprocs/instance_questions_points_homework.sql
@@ -73,17 +73,17 @@ BEGIN
     END LOOP;
     auto_points := least(auto_points, aq.max_auto_points);
 
-    -- status
     IF auto_points >= aq.max_auto_points AND aq.max_manual_points = 0 THEN
+        -- If the student has achieved the maximum possible points, and there
+        -- are no manual points: status is complete.
         status := 'complete';
-    ELSIF correct AND iq.status != 'complete' THEN
+    ELSIF highest_submission_score >= 1.0 AND iq.status != 'complete' THEN
+        -- Current variant, or some previous variant, got 100%, and the
+        -- question is not yet complete: status is correct.
         status := 'correct';
     ELSE
-        -- use current status unless it's 'unanswered' or 'saved'
-        status := iq.status;
-        IF iq.status IN ('unanswered', 'saved') THEN
-            status := 'incorrect';
-        END IF;
+        -- Student has not yet achieved 100% in any variant: status is incorrect.
+        status := 'incorrect';
     END IF;
 END;
 $$ LANGUAGE plpgsql STABLE;


### PR DESCRIPTION
[As discussed on Slack](https://prairielearn.slack.com/archives/C266KEH9A/p1755700073734889). At some point in the past, the logic for the status was to retain it if the current variant did not achieve 100% score. This was mainly to ensure that, if an instance question was tagged as correct or complete, that an incorrect answer afterwards did not replace that status. However, in #12339 the grading status was re-introduced, causing the logic to check for previous status to fail.

This PR changes the logic to perform the full evaluation of what constitutes each status, instead of relying on the previous status. All relevant information was already precomputed anyway, so this has the secondary advantage of making the status logic easier to understand.