### PR TITLE
Replace enhanced-navigation feature flag with legacy-navigation

### DIFF
--- a/apps/prairielearn/src/components/AssessmentNavigation.tsx
+++ b/apps/prairielearn/src/components/AssessmentNavigation.tsx
@@ -58,6 +58,7 @@ function AssessmentNavigationModal() {
   return Modal({
     id: 'assessmentNavigationModal',
     title: 'Select assessment',
+    form: false,
     body: html`
       <div id="assessmentNavigationModalContent">
         <div style="width: 100%;" class="d-flex justify-content-center align-items-center">

--- a/apps/prairielearn/src/components/PageLayout.tsx
+++ b/apps/prairielearn/src/components/PageLayout.tsx
@@ -148,13 +148,13 @@ export function PageLayout({
             </div>
             ${sideNavEnabled
               ? html`
-                  <div class="app-side-nav bg-light border-end">
+                  <nav class="app-side-nav bg-light border-end" aria-label="Course navigation">
                     ${SideNav({
                       resLocals,
                       page: navContext.page,
                       subPage: navContext.subPage,
                     })}
-                  </div>
+                  </nav>
                 `
               : ''}
             <div class="${clsx(sideNavEnabled && 'app-main', options.fullHeight && 'h-100')}">

--- a/apps/prairielearn/src/ee/routers/administratorInstitution.ts
+++ b/apps/prairielearn/src/ee/routers/administratorInstitution.ts
@@ -21,11 +21,11 @@ router.use(
     // The navbar relies on this property.
     res.locals.urlPrefix = req.baseUrl;
 
-    const hasEnhancedNavigation = await features.enabled('enhanced-navigation', {
+    const usesLegacyNavigation = await features.enabled('legacy-navigation', {
       institution_id: req.params.institution_id,
       user_id: res.locals.authn_user.user_id,
     });
-    res.locals.has_enhanced_navigation = hasEnhancedNavigation;
+    res.locals.has_enhanced_navigation = !usesLegacyNavigation;
     next();
   }),
 );

--- a/apps/prairielearn/src/ee/routers/institutionAdmin.ts
+++ b/apps/prairielearn/src/ee/routers/institutionAdmin.ts
@@ -10,11 +10,11 @@ router.use(async (req, res, next) => {
   // The navbar relies on this property.
   res.locals.urlPrefix = req.baseUrl;
 
-  const hasEnhancedNavigation = await features.enabled('enhanced-navigation', {
+  const usesLegacyNavigation = await features.enabled('legacy-navigation', {
     institution_id: req.params.institution_id,
     user_id: res.locals.authn_user.user_id,
   });
-  res.locals.has_enhanced_navigation = hasEnhancedNavigation;
+  res.locals.has_enhanced_navigation = !usesLegacyNavigation;
 
   next();
 });

--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -15,9 +15,9 @@ const featureNames = [
   // LTI 1.1. Deprecated so keep scope to course instance, where possible.
   'lti11',
   // Should only be applied globally.
-  'enhanced-navigation-user-toggle',
+  'legacy-navigation-user-toggle',
   // Can be applied to any context.
-  'enhanced-navigation',
+  'legacy-navigation',
 ] as const;
 
 const features = new FeatureManager(featureNames);

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
@@ -154,10 +154,8 @@ export async function authzCourseOrInstance(req: Request, res: Response) {
     res.locals.authz_data.has_student_access = permissions_course_instance.has_student_access;
   }
 
-  res.locals.has_enhanced_navigation = await features.enabledFromLocals(
-    'enhanced-navigation',
-    res.locals,
-  );
+  const usesLegacyNavigation = await features.enabledFromLocals('legacy-navigation', res.locals);
+  res.locals.has_enhanced_navigation = !usesLegacyNavigation;
   res.locals.question_sharing_enabled = await features.enabledFromLocals(
     'question-sharing',
     res.locals,

--- a/apps/prairielearn/src/pages/userSettings/userSettings.html.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.html.ts
@@ -116,9 +116,9 @@ export function UserSettings({
                       <div class="small text-muted">
                         Try a new navigation experience for instructors that makes accessing your
                         course simpler, faster, and more intuitive.
-                        <a href="${ENHANCED_NAV_DISCUSSION_URL}" target="_blank">
-                          Share your feedback
-                        </a>
+                        <a href="${ENHANCED_NAV_DISCUSSION_URL}" target="_blank"
+                          >Share your feedback</a
+                        >
                         to help us improve the new design.
                       </div>
                     </div>

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -55,10 +55,10 @@ router.get(
       authn_user_id: authn_user.user_id,
     });
 
-    const showEnhancedNavigationToggle = await features.enabled('enhanced-navigation-user-toggle', {
+    const showEnhancedNavigationToggle = await features.enabled('legacy-navigation-user-toggle', {
       user_id: authn_user.user_id,
     });
-    const enhancedNavigationEnabled = await features.enabled('enhanced-navigation', {
+    const usesLegacyNavigation = await features.enabled('legacy-navigation', {
       user_id: authn_user.user_id,
     });
 
@@ -72,7 +72,7 @@ router.get(
         purchases,
         isExamMode: mode !== 'Public',
         showEnhancedNavigationToggle,
-        enhancedNavigationEnabled,
+        enhancedNavigationEnabled: !usesLegacyNavigation,
         resLocals: res.locals,
       }),
     );
@@ -85,11 +85,12 @@ router.post(
     if (req.body.__action === 'update_features') {
       const context = { user_id: res.locals.authn_user.user_id };
 
-      if (await features.enabled('enhanced-navigation-user-toggle', context)) {
+      if (await features.enabled('legacy-navigation-user-toggle', context)) {
+        // Checkbox indicates enhanced navigation ON when checked; legacy is inverse
         if (req.body.enhanced_navigation) {
-          await features.enable('enhanced-navigation', context);
+          await features.disable('legacy-navigation', context);
         } else {
-          await features.disable('enhanced-navigation', context);
+          await features.enable('legacy-navigation', context);
         }
       }
 

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -1895,10 +1895,10 @@ export async function initExpress(): Promise<Express> {
   app.use(
     '/pl/administrator',
     asyncHandler(async (req, res, next) => {
-      const hasEnhancedNavigation = await features.enabled('enhanced-navigation', {
+      const usesLegacyNavigation = await features.enabled('legacy-navigation', {
         user_id: res.locals.authn_user.user_id,
       });
-      res.locals.has_enhanced_navigation = hasEnhancedNavigation;
+      res.locals.has_enhanced_navigation = !usesLegacyNavigation;
       next();
     }),
   );


### PR DESCRIPTION
We'd like to turn the new navigation on globally before the semester begins at most universities. We've now been running it for the whole summer and have ironed out all the kinks that we're aware of.

This PR inverts the feature flags: enhanced navigation is now enabled by default but can be turned off for individual users, either by a global admin or if the `legacy-navigation-user-toggle` flag is enabled. We plan to only turn on the user toggle for specific users if it proves to be absolutely necessary (e.g. because there's a bug that's impacting their ability to access their course).

I'm thinking we'll leave these feature flags in place until the end of the year, at which point we can rip out both the old code and the feature flags.

This was written by GPT-5 with Copilot with some minor adjustments by me.