### PR TITLE
Simplify AI question generation cache

### DIFF
--- a/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
+++ b/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
@@ -208,11 +208,11 @@ function extractFromCompletion(
  * Returns the AI question generation cache used for rate limiting.
  */
 let aiQuestionGenerationCache: Cache | undefined;
-export function getAiQuestionGenerationCache() {
+export async function getAiQuestionGenerationCache() {
   // The cache variable is outside the function to avoid creating multiple instances of the same cache in the same process.
   if (aiQuestionGenerationCache) return aiQuestionGenerationCache;
   aiQuestionGenerationCache = new Cache();
-  aiQuestionGenerationCache.init({
+  await aiQuestionGenerationCache.init({
     type: config.nonVolatileCacheType,
     keyPrefix: config.cacheKeyPrefix,
     redisUrl: config.nonVolatileRedisUrl,
@@ -251,32 +251,27 @@ const intervalLengthMs = 3600 * 1000;
 /**
  * Retrieve the user's AI question generation usage in the last hour interval, in US dollars
  */
-export async function getIntervalUsage({
-  aiQuestionGenerationCache,
-  userId,
-}: {
-  aiQuestionGenerationCache: Cache;
-  userId: number;
-}) {
-  return (await aiQuestionGenerationCache.get(getIntervalUsageKey(userId))) ?? 0;
+export async function getIntervalUsage({ userId }: { userId: number }) {
+  const cache = await getAiQuestionGenerationCache();
+  return (await cache.get(getIntervalUsageKey(userId))) ?? 0;
 }
 
 /**
  * Add the cost of a completion to the usage of the user for the current interval.
  */
 export async function addCompletionCostToIntervalUsage({
-  aiQuestionGenerationCache,
   userId,
   promptTokens,
   completionTokens,
   intervalCost,
 }: {
-  aiQuestionGenerationCache: Cache;
   userId: number;
   promptTokens: number;
   completionTokens: number;
   intervalCost: number;
 }) {
+  const cache = await getAiQuestionGenerationCache();
+
   const completionCost =
     (config.costPerMillionPromptTokens * promptTokens +
       config.costPerMillionCompletionTokens * completionTokens) /
@@ -285,11 +280,7 @@ export async function addCompletionCostToIntervalUsage({
   // Date.now() % intervalLengthMs is the number of milliseconds since the beginning of the interval.
   const timeRemainingInInterval = intervalLengthMs - (Date.now() % intervalLengthMs);
 
-  aiQuestionGenerationCache.set(
-    getIntervalUsageKey(userId),
-    intervalCost + completionCost,
-    timeRemainingInInterval,
-  );
+  cache.set(getIntervalUsageKey(userId), intervalCost + completionCost, timeRemainingInInterval);
 }
 
 /**

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -26,7 +26,6 @@ import { selectQuestionById } from '../../../models/question.js';
 import {
   addCompletionCostToIntervalUsage,
   approximatePromptCost,
-  getAiQuestionGenerationCache,
   getIntervalUsage,
   regenerateQuestion,
 } from '../../lib/aiQuestionGeneration.js';
@@ -39,8 +38,6 @@ import { InstructorAiGenerateDraftEditor } from './instructorAiGenerateDraftEdit
 
 const router = Router({ mergeParams: true });
 const sql = loadSqlEquiv(import.meta.url);
-
-const aiQuestionGenerationCache = getAiQuestionGenerationCache();
 
 async function saveGeneratedQuestion(
   res: Response,
@@ -263,7 +260,6 @@ router.post(
       }
 
       const intervalCost = await getIntervalUsage({
-        aiQuestionGenerationCache,
         userId: res.locals.authn_user.user_id,
       });
 

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.ts
@@ -13,7 +13,6 @@ import {
   addCompletionCostToIntervalUsage,
   approximatePromptCost,
   generateQuestion,
-  getAiQuestionGenerationCache,
   getIntervalUsage,
 } from '../../lib/aiQuestionGeneration.js';
 
@@ -26,8 +25,6 @@ import {
 
 const router = Router();
 const sql = loadSqlEquiv(import.meta.url);
-
-const aiQuestionGenerationCache = getAiQuestionGenerationCache();
 
 function assertCanCreateQuestion(resLocals: Record<string, any>) {
   // Do not allow users to edit without permission


### PR DESCRIPTION
Calling `getAiQuestionGenerationCache` at the module scope is a bit weird, as that relies on config values. While the current loading order means that we'll always have loaded the config by the time we loaded these files, it's safer to defer until later. This also makes the call sites simpler.

I noticed this while reviewing #12653.