### PR TITLE
Disable fail-fast behavior for sharded tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
     name: Native (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
@@ -190,6 +191,7 @@ jobs:
           path: .vitest-reports/*
           include-hidden-files: true
           retention-days: 1
+
   merge-native-test-reports:
     name: Native (merge test reports)
     if: ${{ !cancelled() }}


### PR DESCRIPTION
We somewhat regularly get transitive test failures. Many times they're simply retriable. One can do that from the GitHub UI, but that doesn't work if the failure of a given test shard causes the others to be canceled mid-execution.

Setting `fail-fast: false` ensures that other shards will continue executing even if one of them fails.

Docs for this option: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast