### PR TITLE
Add logs to try to diagnose root cause of flaky test

### DIFF
--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
@@ -35,19 +35,29 @@ describe('sproc ip_to_mode tests', function () {
 
   describe('Center exam with IP restrictions', () => {
     describe('before check-in', () => {
+      // This test is oddly flaky in CI (it times out), but not locally. In an
+      // effort to figure out what's happening, we're temporarily adding some
+      // extra logging here.
       it('should return "Exam" with a correct IP address when session is starting soon', async () => {
+        console.log('before transaction');
         await helperDb.runInTransactionAndRollback(async () => {
+          console.log('before reservation creation');
           await createCenterExamReservation();
 
+          console.log('before ip_to_mode query');
           const result = await sqldb.callAsync('ip_to_mode', [
             '10.0.0.1',
             // 10 minutes ago.
             new Date(Date.now() - 1000 * 60 * 10),
             user_id,
           ]);
+
+          console.log('before assertions');
           assert.equal(result.rows[0].mode, 'Exam');
           assert.equal(result.rows[0].mode_reason, 'PrairieTest');
+          console.log('after assertions');
         });
+        console.log('after transaction');
       });
 
       it('should return "Exam" with a correct IP address when session started recently', async () => {


### PR DESCRIPTION
This test keeps timing out in CI, but we can't figure out why and can't reproduce the issue locally. I'm hoping these logs will give us some kind of indication as to where things are getting stuck.