### PR TITLE
Fix Vitest deprecation warnings

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -128,23 +128,16 @@ export const sharedConfig = defineConfig({
   },
 });
 
-export default defineConfig(async ({ mode, command }) => {
-  // We need to deliberately forward the mode to the PrairieLearn config.
-  // If we just referenced the project by the path, `mode` would not be passed correctly.
-  const prairielearnConfigModule = await import('./apps/prairielearn/vitest.config');
-  const prairielearnConfig = prairielearnConfigModule.default({ mode, command });
-
-  return mergeConfig(
-    sharedConfig,
-    defineConfig({
-      test: {
-        projects: ['packages/*', 'apps/grader-host', 'apps/workspace-host', prairielearnConfig],
-        coverage: {
-          all: true,
-          reporter: ['html', 'text-summary', 'cobertura'],
-          include: ['{apps,packages}/*/src/**'],
-        },
+export default mergeConfig(
+  sharedConfig,
+  defineConfig({
+    test: {
+      projects: ['apps/grader-host', 'apps/prairielearn', 'apps/workspace-host', 'packages/*'],
+      coverage: {
+        all: true,
+        reporter: ['html', 'text-summary', 'cobertura'],
+        include: ['{apps,packages}/*/src/**'],
       },
-    }),
-  );
-});
+    },
+  }),
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import { resolve } from 'pathe';
 import { slash } from 'vite-node/utils';
 import { defineConfig, mergeConfig } from 'vitest/config';
-import { BaseSequencer, type TestSpecification, resolveConfig } from 'vitest/node';
+import { BaseSequencer, type TestSpecification } from 'vitest/node';
 
 // Vitest will try to intelligently sequence the test suite based on which ones
 // are slowest. However, this depends on cached data from previous runs, which
@@ -128,26 +128,17 @@ export const sharedConfig = defineConfig({
   },
 });
 
-export default defineConfig(async ({ mode }) => {
-  // Resolve the Vitest configuration for PrairieLearn with the given mode.
-  // By default, the configuration is not resolved with the mode.
-  const { vitestConfig: prairielearnTestConfig } = await resolveConfig({
-    mode,
-    config: 'vitest.config.ts',
-    root: 'apps/prairielearn',
-  });
+export default defineConfig(async ({ mode, command }) => {
+  // We need to deliberately forward the mode to the PrairieLearn config.
+  // If we just referenced the project by the path, `mode` would not be passed correctly.
+  const prairielearnConfigModule = await import('./apps/prairielearn/vitest.config');
+  const prairielearnConfig = prairielearnConfigModule.default({ mode, command });
+
   return mergeConfig(
     sharedConfig,
     defineConfig({
       test: {
-        projects: [
-          'packages/*',
-          'apps/grader-host',
-          'apps/workspace-host',
-          {
-            test: prairielearnTestConfig,
-          },
-        ],
+        projects: ['packages/*', 'apps/grader-host', 'apps/workspace-host', prairielearnConfig],
         coverage: {
           all: true,
           reporter: ['html', 'text-summary', 'cobertura'],


### PR DESCRIPTION
When running `yarn test` in the root of the repository, the following warnings were printed:

```
 DEPRECATED  `poolMatchGlobs` is deprecated. Use `test.projects` to define different configurations instead.
 DEPRECATED  "cache.dir" is deprecated, use Vite's "cacheDir" instead if you want to change the cache director. Note caches will be written to "cacheDir/vitest"
 DEPRECATED  "environmentMatchGlobs" is deprecated. Use `test.projects` to define different configurations instead.
```

This is because `resolveConfig()` produced configs with those values.

~This PR changes things to directly import the config and instantiate it. This uses the raw config, which doesn't contain any deprecated properties.~

As @reteps pointed out, we no longer rely on `mode` being propagated down from the root config, so we can just use a path to `apps/prairielearn` directly instead of trying to independently resolve the config.