### PR TITLE
Add functionality back to ignore comments in pl-block-groups.

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
+++ b/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
@@ -382,7 +382,7 @@ def collect_answer_options(
             case "pl-block-group":
                 group_tag, group_depends = get_graph_info(inner_element)
                 for answer_element in inner_element:
-                    if isinstance(inner_element, _Comment):
+                    if isinstance(answer_element, _Comment):
                         continue
                     options = AnswerOptions(
                         answer_element,

--- a/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
+++ b/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
@@ -382,6 +382,8 @@ def collect_answer_options(
             case "pl-block-group":
                 group_tag, group_depends = get_graph_info(inner_element)
                 for answer_element in inner_element:
+                    if isinstance(inner_element, _Comment):
+                        continue
                     options = AnswerOptions(
                         answer_element,
                         {"tag": group_tag, "depends": group_depends},

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -62,6 +62,7 @@ has become increasingly complex, with many different possible combinations of op
 <pl-order-blocks answers-name="test-solving-2" source-blocks-order="random" grading-method="dag">
   <pl-answer correct="true" tag="1"> 1</pl-answer>
   <pl-block-group tag="g3" depends="1, g2">
+    <!-- Comments can be inside block group tags -->
     <pl-answer correct="true" tag="10">10</pl-answer>
   </pl-block-group>
   <pl-block-group tag="g1" depends="1">


### PR DESCRIPTION
This is returning functionality lost in the refactor in #12441. 

If anyone has added comments nested inside a pl-block-group tag, those questions will throw an error on the current master, so this should be merged/deployed ASAP.