### PR TITLE
Fix highlighted line in serverFilesCourse example for Python grader

### DIFF
--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -290,7 +290,7 @@ The Python autograder is able to retrieve information from `serverFilesCourse`. 
 
 To access `serverFilesCourse` from the autograder, specify the file or its containing directory in the question `info.json`. For example, to copy the `compounds` directory to the autograder, use:
 
-```json title="info.json" hl_lines="6"
+```json title="info.json" hl_lines="5"
 {
   "externalGradingOptions": {
     "enabled": true,


### PR DESCRIPTION
The wrong line was highlighted:

<img width="1415" height="416" alt="image" src="https://github.com/user-attachments/assets/8783e8c2-0163-43c8-aef2-d0c0cedabf98" />

After:
<img width="1398" height="412" alt="image" src="https://github.com/user-attachments/assets/6e5ad691-b9cb-40f4-bf5b-fe65f6e6c08c" />
