### PR TITLE
Add execute and executeRow helpers, cleanup SQL that isn't using models

### DIFF
--- a/.changeset/twelve-kids-fetch.md
+++ b/.changeset/twelve-kids-fetch.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/postgres': minor
+---
+
+Add `execute` and `executeRow` helpers that don't return the actual values from a query.

--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -108,11 +108,9 @@ export function makeWorkspaceProxyMiddleware(containerPathRegex: RegExp) {
             ' FROM questions AS q' +
             ' JOIN variants AS v ON (v.question_id = q.id)' +
             ' WHERE v.workspace_id = $workspace_id;';
-          workspace_url_rewrite = await queryRow(
-            sql,
-            { workspace_id },
-            QuestionSchema.shape.workspace_url_rewrite,
-          ) ?? true;
+          workspace_url_rewrite =
+            (await queryRow(sql, { workspace_id }, QuestionSchema.shape.workspace_url_rewrite)) ??
+            true;
           workspaceUrlRewriteCache.set(workspace_id, workspace_url_rewrite);
         }
 

--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -108,12 +108,11 @@ export function makeWorkspaceProxyMiddleware(containerPathRegex: RegExp) {
             ' FROM questions AS q' +
             ' JOIN variants AS v ON (v.question_id = q.id)' +
             ' WHERE v.workspace_id = $workspace_id;';
-          const rawWorkspaceUrlRewrite = await queryRow(
+          workspace_url_rewrite = await queryRow(
             sql,
             { workspace_id },
             QuestionSchema.shape.workspace_url_rewrite,
-          );
-          workspace_url_rewrite = rawWorkspaceUrlRewrite ?? true;
+          ) ?? true;
           workspaceUrlRewriteCache.set(workspace_id, workspace_url_rewrite);
         }
 

--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -7,10 +7,10 @@ import type * as httpProxyMiddleware from 'http-proxy-middleware';
 
 import { HttpStatusError } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
-import { queryOneRowAsync, queryOptionalRow } from '@prairielearn/postgres';
+import { queryOptionalRow, queryRow } from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import { WorkspaceSchema } from '../lib/db-types.js';
+import { QuestionSchema, WorkspaceSchema } from '../lib/db-types.js';
 import { LocalCache } from '../lib/local-cache.js';
 
 /**
@@ -108,8 +108,12 @@ export function makeWorkspaceProxyMiddleware(containerPathRegex: RegExp) {
             ' FROM questions AS q' +
             ' JOIN variants AS v ON (v.question_id = q.id)' +
             ' WHERE v.workspace_id = $workspace_id;';
-          const result = await queryOneRowAsync(sql, { workspace_id });
-          workspace_url_rewrite = result.rows[0].workspace_url_rewrite ?? true;
+          const rawWorkspaceUrlRewrite = await queryRow(
+            sql,
+            { workspace_id },
+            QuestionSchema.shape.workspace_url_rewrite,
+          );
+          workspace_url_rewrite = rawWorkspaceUrlRewrite ?? true;
           workspaceUrlRewriteCache.set(workspace_id, workspace_url_rewrite);
         }
 

--- a/apps/prairielearn/src/sync/fromDisk/courseInfo.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInfo.ts
@@ -1,5 +1,6 @@
 import * as sqldb from '@prairielearn/postgres';
 
+import { CourseSchema } from '../../lib/db-types.js';
 import type { CourseJson } from '../../schemas/infoCourse.js';
 import { type CourseData } from '../course-db.js';
 import * as infofile from '../infofile.js';
@@ -16,12 +17,12 @@ function isExampleCourse(courseInfo: CourseJson): boolean {
 
 export async function sync(courseData: CourseData, courseId: string) {
   if (infofile.hasErrors(courseData.course)) {
-    const res = await sqldb.queryZeroOrOneRowAsync(sql.update_course_errors, {
+    const rowCount = await sqldb.execute(sql.update_course_errors, {
       course_id: courseId,
       sync_errors: infofile.stringifyErrors(courseData.course),
       sync_warnings: infofile.stringifyWarnings(courseData.course),
     });
-    if (res.rowCount !== 1) throw new Error(`Unable to find course with ID ${courseId}`);
+    if (rowCount !== 1) throw new Error(`Unable to find course with ID ${courseId}`);
     return;
   }
 
@@ -30,16 +31,20 @@ export async function sync(courseData: CourseData, courseId: string) {
     throw new Error('Course info file is missing data');
   }
 
-  const res = await sqldb.queryZeroOrOneRowAsync(sql.update_course, {
-    course_id: courseId,
-    short_name: courseInfo.name,
-    title: courseInfo.title,
-    display_timezone: courseInfo.timezone || null,
-    example_course: isExampleCourse(courseInfo),
-    options: courseInfo.options || {},
-    comment: JSON.stringify(courseInfo.comment),
-    sync_warnings: infofile.stringifyWarnings(courseData.course),
-  });
-  if (res.rowCount !== 1) throw new Error(`Unable to find course with ID ${courseId}`);
-  courseInfo.timezone = res.rows[0].display_timezone;
+  const course = await sqldb.queryOptionalRow(
+    sql.update_course,
+    {
+      course_id: courseId,
+      short_name: courseInfo.name,
+      title: courseInfo.title,
+      display_timezone: courseInfo.timezone || null,
+      example_course: isExampleCourse(courseInfo),
+      options: courseInfo.options || {},
+      comment: JSON.stringify(courseInfo.comment),
+      sync_warnings: infofile.stringifyWarnings(courseData.course),
+    },
+    CourseSchema,
+  );
+  if (course == null) throw new Error(`Unable to find course with ID ${courseId}`);
+  courseInfo.timezone = course.display_timezone;
 }

--- a/apps/prairielearn/src/tests/accessAsStudent.test.ts
+++ b/apps/prairielearn/src/tests/accessAsStudent.test.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
 import * as sqldb from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import { type Config, config } from '../lib/config.js';
 
@@ -51,8 +52,8 @@ describe('Test student auto-enrollment', { timeout: 20_000 }, function () {
 
   describe('A student user with no access to course instance', function () {
     it('should not have access to assessments page with no access rule', async () => {
-      const result = (await sqldb.queryAsync(sql.insert_course_instance, {})).rows[0];
-      const newAssessmentsUrl = baseUrl + `/course_instance/${result.id}/assessments`;
+      const courseInstanceId = await sqldb.queryRow(sql.insert_course_instance, IdSchema);
+      const newAssessmentsUrl = baseUrl + `/course_instance/${courseInstanceId}/assessments`;
       const response = await fetch(newAssessmentsUrl);
       assert.equal(response.status, 403);
     });

--- a/apps/prairielearn/src/tests/courseElementExtension.test.sql
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.sql
@@ -1,7 +1,0 @@
--- BLOCK select_question_by_qid
-SELECT
-  *
-FROM
-  questions
-WHERE
-  qid = $qid;

--- a/apps/prairielearn/src/tests/courseElementExtension.test.ts
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.ts
@@ -102,9 +102,7 @@ describe('Course element extensions', { timeout: 60_000 }, function () {
     test.sequential('find the example question in the database', async () => {
       locals.question = await sqldb.queryRow(
         sql.select_question_by_qid,
-        {
-          qid: testQid,
-        },
+        { qid: testQid },
         QuestionSchema,
       );
     });

--- a/apps/prairielearn/src/tests/courseElementExtension.test.ts
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.ts
@@ -8,6 +8,7 @@ import { afterAll, assert, beforeAll, describe, it, test } from 'vitest';
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
+import { QuestionSchema } from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths.js';
 import * as freeform from '../question-servers/freeform.js';
 
@@ -99,12 +100,13 @@ describe('Course element extensions', { timeout: 60_000 }, function () {
       'extendable-element/extension-clientfiles/clientFilesExtension/cat-2536662_640.jpg';
 
     test.sequential('find the example question in the database', async () => {
-      const results = await sqldb.queryZeroOrOneRowAsync(sql.select_question_by_qid, {
-        qid: testQid,
-      });
-      assert(results.rowCount === 1, `could not find question ${testQid}`);
-
-      locals.question = results.rows[0];
+      locals.question = await sqldb.queryRow(
+        sql.select_question_by_qid,
+        {
+          qid: testQid,
+        },
+        QuestionSchema,
+      );
     });
     test.sequential('check the question page for extension css and js files', async () => {
       const questionUrl =

--- a/apps/prairielearn/src/tests/courseElementExtension.test.ts
+++ b/apps/prairielearn/src/tests/courseElementExtension.test.ts
@@ -5,17 +5,13 @@ import fs from 'fs-extra';
 import _ from 'lodash';
 import { afterAll, assert, beforeAll, describe, it, test } from 'vitest';
 
-import * as sqldb from '@prairielearn/postgres';
-
 import { config } from '../lib/config.js';
-import { QuestionSchema } from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../lib/paths.js';
+import { selectQuestionByQid } from '../models/question.js';
 import * as freeform from '../question-servers/freeform.js';
 
 import * as helperClient from './helperClient.js';
 import * as helperServer from './helperServer.js';
-
-const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 describe('Course element extensions', { timeout: 60_000 }, function () {
   describe('Extensions can be loaded', function () {
@@ -100,11 +96,7 @@ describe('Course element extensions', { timeout: 60_000 }, function () {
       'extendable-element/extension-clientfiles/clientFilesExtension/cat-2536662_640.jpg';
 
     test.sequential('find the example question in the database', async () => {
-      locals.question = await sqldb.queryRow(
-        sql.select_question_by_qid,
-        { qid: testQid },
-        QuestionSchema,
-      );
+      locals.question = await selectQuestionByQid({ qid: testQid, course_id: '1' });
     });
     test.sequential('check the question page for extension css and js files', async () => {
       const questionUrl =

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -6,6 +6,7 @@ import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
+import { VariantSchema } from '../lib/db-types.js';
 
 import { type User, parseInstanceQuestionId, saveOrGrade, setUser } from './helperClient.js';
 import * as helperServer from './helperServer.js';
@@ -117,7 +118,9 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should submit "grade" action', async () => {
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+
+          assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'grade');
           assert.equal(gradeRes.status, 200);
@@ -126,8 +129,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should result in 1 grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 1);
+          const rowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(rowCount, 1);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
@@ -150,7 +153,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           await fetch(iqUrl);
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'save');
           assert.equal(gradeRes.status, 200);
@@ -159,8 +163,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
@@ -196,8 +200,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should display submission status', async () => {
           assert.equal(
@@ -228,8 +232,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should display submission status', async () => {
           assert.equal(
@@ -286,8 +290,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         });
 
         it('should result in 1 grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 1);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 1);
         });
         it('should result in 1 "submission-block" component being rendered', async () => {
           // reload QuestionsPage to also check behaviour when results are ready on load
@@ -321,8 +325,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
@@ -376,8 +380,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         });
 
         it('should result in 1 grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 1);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 1);
         });
         it('should result in 1 "submission-block" component being rendered', async () => {
           // reload QuestionsPage to also check behaviour when results are ready on load
@@ -413,7 +417,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should submit "grade" action', async () => {
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'grade');
           assert.equal(gradeRes.status, 200);
@@ -422,8 +427,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should result in 1 grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 1);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 1);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
@@ -449,7 +454,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           await fetch(iqUrl);
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'save');
           assert.equal(gradeRes.status, 200);
@@ -458,8 +464,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
@@ -493,7 +499,9 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should be possible to submit a grade action to "Manual" type question', async () => {
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
+
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'grade');
           assert.equal(gradeRes.status, 200);
 
@@ -501,8 +509,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should display submission status', async () => {
           assert.equal(
@@ -531,7 +539,9 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should be possible to submit a save action', async () => {
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
+
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'save');
           assert.equal(gradeRes.status, 200);
 
@@ -539,8 +549,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should display submission status', async () => {
           assert.equal(
@@ -569,7 +579,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should submit "grade" action', async () => {
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'grade');
           assert.equal(gradeRes.status, 200);
@@ -578,8 +589,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should result in 1 grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 1);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 1);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);
@@ -601,7 +612,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           await fetch(iqUrl);
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
-          const variant = (await sqldb.queryOneRowAsync(sql.get_variant_by_iq, { iqId })).rows[0];
+          const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
+          assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'save');
           assert.equal(gradeRes.status, 200);
@@ -610,8 +622,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           $questionsPage = cheerio.load(questionsPage);
         });
         it('should NOT result in any grading jobs', async () => {
-          const grading_jobs = (await sqldb.queryAsync(sql.get_grading_jobs_by_iq, { iqId })).rows;
-          assert.lengthOf(grading_jobs, 0);
+          const gradingJobsRowCount = await sqldb.execute(sql.get_grading_jobs_by_iq, { iqId });
+          assert.equal(gradingJobsRowCount, 0);
         });
         it('should result in 1 "submission-block" component being rendered', () => {
           assert.lengthOf($questionsPage('[data-testid="submission-block"]'), 1);

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -119,7 +119,6 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
         });
         it('should submit "grade" action', async () => {
           const variant = await sqldb.queryRow(sql.get_variant_by_iq, { iqId }, VariantSchema);
-
           assert.ok(variant.params);
 
           gradeRes = await saveOrGrade(iqUrl, { c: variant.params.a + variant.params.b }, 'grade');

--- a/apps/prairielearn/src/tests/groupGenerateAndDelete.test.ts
+++ b/apps/prairielearn/src/tests/groupGenerateAndDelete.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import * as sqldb from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import * as groupUpdate from '../lib/group-update.js';
 import { deleteAllGroups } from '../lib/groups.js';
@@ -18,10 +19,9 @@ describe('test random groups and delete groups', { timeout: 20_000 }, function (
   afterAll(helperServer.after);
 
   test.sequential('get group-based homework assessment', async () => {
-    const result = await sqldb.queryAsync(sql.select_group_work_assessment, []);
-    assert.notEqual(result.rows.length, 0);
-    assert.notEqual(result.rows[0].id, undefined);
-    locals.assessment_id = result.rows[0].id;
+    const assessmentIds = await sqldb.queryRows(sql.select_group_work_assessment, IdSchema);
+    assert.equal(assessmentIds.length, 2);
+    locals.assessment_id = assessmentIds[0];
   });
 
   test.sequential('create 500 users', async () => {
@@ -45,26 +45,24 @@ describe('test random groups and delete groups', { timeout: 20_000 }, function (
   });
 
   test.sequential('check groups and users', async () => {
-    const groupUserCounts = await sqldb.queryAsync(
+    const groupUserCountsRowCount = await sqldb.execute(
       'SELECT count(group_id) FROM group_users GROUP BY group_id',
-      [],
     );
-    assert.equal(groupUserCounts.rows.length, 50);
+    assert.equal(groupUserCountsRowCount, 50);
 
-    const groupUsers = await sqldb.queryAsync('SELECT DISTINCT(user_id) FROM group_users', []);
-    assert.equal(groupUsers.rows.length, 500);
+    const groupUsersRowCount = await sqldb.execute('SELECT DISTINCT(user_id) FROM group_users');
+    assert.equal(groupUsersRowCount, 500);
   });
 
   test.sequential('delete groups', async () => {
     await deleteAllGroups(locals.assessment_id, '1');
 
-    const groups = await sqldb.queryAsync(
+    const groupsRowCount = await sqldb.execute(
       'SELECT deleted_at FROM groups WHERE deleted_at IS NULL',
-      [],
     );
-    assert.equal(groups.rows.length, 0);
+    assert.equal(groupsRowCount, 0);
 
-    const groupUsers = await sqldb.queryAsync('SELECT * FROM group_users', {});
-    assert.equal(groupUsers.rows.length, 0);
+    const groupUsersRowCount = await sqldb.execute('SELECT * FROM group_users');
+    assert.equal(groupUsersRowCount, 0);
   });
 });

--- a/apps/prairielearn/src/tests/helperQuestion.sql
+++ b/apps/prairielearn/src/tests/helperQuestion.sql
@@ -64,14 +64,6 @@ ORDER BY
 LIMIT
   1;
 
--- BLOCK select_question_by_qid
-SELECT
-  *
-FROM
-  questions
-WHERE
-  qid = $qid;
-
 -- BLOCK select_last_job_sequence
 SELECT
   *

--- a/apps/prairielearn/src/tests/helperQuestion.ts
+++ b/apps/prairielearn/src/tests/helperQuestion.ts
@@ -13,6 +13,7 @@ import {
   IssueSchema,
   JobSchema,
   JobSequenceSchema,
+  QuestionSchema,
   SubmissionSchema,
   VariantSchema,
 } from '../lib/db-types.js';
@@ -596,9 +597,7 @@ export function autoTestQuestion(locals: Record<string, any>, qid: string) {
   describe('auto-testing question ' + qid, function () {
     describe('the setup', function () {
       it('should find the question in the database', async function () {
-        const result = await sqldb.queryZeroOrOneRowAsync(sql.select_question_by_qid, { qid });
-        assert.equal(result.rowCount, 1);
-        locals.question = result.rows[0];
+        locals.question = await sqldb.queryRow(sql.select_question_by_qid, { qid }, QuestionSchema);
       });
       it('should be a Freeform question', function () {
         assert.equal(locals.question?.type, 'Freeform');

--- a/apps/prairielearn/src/tests/helperQuestion.ts
+++ b/apps/prairielearn/src/tests/helperQuestion.ts
@@ -13,10 +13,10 @@ import {
   IssueSchema,
   JobSchema,
   JobSequenceSchema,
-  QuestionSchema,
   SubmissionSchema,
   VariantSchema,
 } from '../lib/db-types.js';
+import { selectQuestionByQid } from '../models/question.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
@@ -597,7 +597,7 @@ export function autoTestQuestion(locals: Record<string, any>, qid: string) {
   describe('auto-testing question ' + qid, function () {
     describe('the setup', function () {
       it('should find the question in the database', async function () {
-        locals.question = await sqldb.queryRow(sql.select_question_by_qid, { qid }, QuestionSchema);
+        locals.question = await selectQuestionByQid({ qid, course_id: '1' });
       });
       it('should be a Freeform question', function () {
         assert.equal(locals.question?.type, 'Freeform');

--- a/apps/prairielearn/src/tests/issues.test.ts
+++ b/apps/prairielearn/src/tests/issues.test.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import * as sqldb from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import { config } from '../lib/config.js';
 
@@ -29,7 +30,7 @@ function doTest(issuesUrl: string, label: string) {
     let questionUrl;
 
     test.sequential('should report issues to a question', async () => {
-      const questionId = (await sqldb.queryOneRowAsync(sql.select_question_id, [])).rows[0].id;
+      const questionId = await sqldb.queryRow(sql.select_question_id, IdSchema);
       questionUrl = `${baseUrl}/course_instance/1/instructor/question/${questionId}/preview`;
       let res = await fetch(questionUrl);
       const $ = cheerio.load(await res.text());
@@ -80,8 +81,8 @@ function doTest(issuesUrl: string, label: string) {
       });
       assert.equal(res.status, 200);
 
-      const result = await sqldb.queryAsync(sql.select_open_issues, []);
-      assert.equal(result.rowCount, 3, 'Expected three open issues');
+      const rowCount = await sqldb.execute(sql.select_open_issues);
+      assert.equal(rowCount, 3, 'Expected three open issues');
     });
 
     test.sequential('should close issues matching a query', async () => {
@@ -109,8 +110,8 @@ function doTest(issuesUrl: string, label: string) {
       });
       assert.equal(res.status, 200);
 
-      const result = await sqldb.queryAsync(sql.select_open_issues, []);
-      assert.equal(result.rowCount, 2, 'Expected two open issues');
+      const rowCount = await sqldb.execute(sql.select_open_issues);
+      assert.equal(rowCount, 2, 'Expected two open issues');
     });
 
     test.sequential('should close all open issues', async () => {
@@ -137,8 +138,8 @@ function doTest(issuesUrl: string, label: string) {
       });
       assert.equal(res.status, 200);
 
-      const result = await sqldb.queryAsync(sql.select_open_issues, []);
-      assert.equal(result.rowCount, 0, 'Expected zero open issues');
+      const rowCount = await sqldb.execute(sql.select_open_issues);
+      assert.equal(rowCount, 0, 'Expected zero open issues');
     });
   });
 }

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -6,6 +6,7 @@ import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
+import { InstanceQuestionSchema } from '../lib/db-types.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
 import {
   insertCourseInstancePermissions,
@@ -423,10 +424,12 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
         iqId = parseInstanceQuestionId(iqUrl);
         manualGradingIQUrl = `${manualGradingAssessmentUrl}/instance_question/${iqId}`;
 
-        const instance_questions = (await sqldb.queryAsync(sql.get_instance_question, { iqId }))
-          .rows;
-        assert.lengthOf(instance_questions, 1);
-        assert.equal(instance_questions[0].requires_manual_grading, false);
+        const instanceQuestion = await sqldb.queryRow(
+          sql.get_instance_question,
+          { iqId },
+          InstanceQuestionSchema,
+        );
+        assert.equal(instanceQuestion.requires_manual_grading, false);
       });
 
       test.sequential('submit an answer to the question', async () => {
@@ -444,10 +447,12 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
       });
 
       test.sequential('should tag question as requiring grading', async () => {
-        const instanceQuestions = (await sqldb.queryAsync(sql.get_instance_question, { iqId }))
-          .rows;
-        assert.lengthOf(instanceQuestions, 1);
-        assert.equal(instanceQuestions[0].requires_manual_grading, true);
+        const instanceQuestion = await sqldb.queryRow(
+          sql.get_instance_question,
+          { iqId },
+          InstanceQuestionSchema,
+        );
+        assert.equal(instanceQuestion.requires_manual_grading, true);
       });
     });
 
@@ -1068,10 +1073,12 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
         iqId = parseInstanceQuestionId(iqUrl);
         manualGradingIQUrl = `${manualGradingAssessmentUrl}/instance_question/${iqId}`;
 
-        const instance_questions = (await sqldb.queryAsync(sql.get_instance_question, { iqId }))
-          .rows;
-        assert.lengthOf(instance_questions, 1);
-        assert.equal(instance_questions[0].requires_manual_grading, false);
+        const instanceQuestion = await sqldb.queryRow(
+          sql.get_instance_question,
+          { iqId },
+          InstanceQuestionSchema,
+        );
+        assert.equal(instanceQuestion.requires_manual_grading, false);
       });
 
       test.sequential('submit an answer to the question', async () => {
@@ -1089,10 +1096,12 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
       });
 
       test.sequential('should tag question as requiring grading', async () => {
-        const instanceQuestions = (await sqldb.queryAsync(sql.get_instance_question, { iqId }))
-          .rows;
-        assert.lengthOf(instanceQuestions, 1);
-        assert.equal(instanceQuestions[0].requires_manual_grading, true);
+        const instanceQuestion = await sqldb.queryRow(
+          sql.get_instance_question,
+          { iqId },
+          InstanceQuestionSchema,
+        );
+        assert.equal(instanceQuestion.requires_manual_grading, true);
       });
 
       test.sequential('student view should keep the old feedback/rubric', async () => {

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -250,12 +250,14 @@ describe('Question Sharing', function () {
         assert(!(await res.text()).includes(SHARING_QUESTION_QID));
 
         // Question can be accessed through the owning course
-        const questionId = (
-          await sqldb.queryOneRowAsync(sql.get_question_id, {
+        const questionId = await sqldb.queryRow(
+          sql.get_question_id,
+          {
             course_id: sharingCourse.id,
             qid: SHARING_QUESTION_QID,
-          })
-        ).rows[0].id;
+          },
+          IdSchema,
+        );
         const sharedQuestionUrl = `${baseUrl}/course/${sharingCourse.id}/question/${questionId}`;
         const sharedQuestionPage = await fetchCheerio(sharedQuestionUrl);
         assert(sharedQuestionPage.ok);
@@ -434,12 +436,14 @@ describe('Question Sharing', function () {
     let publiclySharedQuestionId;
 
     beforeAll(async () => {
-      publiclySharedQuestionId = (
-        await sqldb.queryOneRowAsync(sql.get_question_id, {
+      publiclySharedQuestionId = await sqldb.queryRow(
+        sql.get_question_id,
+        {
           course_id: sharingCourse.id,
           qid: PUBLICLY_SHARED_QUESTION_QID,
-        })
-      ).rows[0].id;
+        },
+        IdSchema,
+      );
     });
 
     test.sequential('Fail to Access Questions Not-yet shared publicly', async () => {
@@ -526,7 +530,7 @@ describe('Question Sharing', function () {
     test.sequential(
       'Ensure sync through sync page succeeds before renaming shared question',
       async () => {
-        await sqldb.queryAsync(sql.update_course_repository, {
+        await sqldb.execute(sql.update_course_repository, {
           course_path: sharingCourseLiveDir,
           course_repository: sharingCourseOriginDir,
         });

--- a/apps/prairielearn/src/tests/workspaceAccess.test.ts
+++ b/apps/prairielearn/src/tests/workspaceAccess.test.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import * as sqldb from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import { config } from '../lib/config.js';
 import { ensureEnrollment } from '../models/enrollment.js';
@@ -55,9 +56,9 @@ describe('Test workspace authorization access', { timeout: 20_000 }, function ()
   describe('workspaces created by instructors in a course instance', function () {
     let workspace_id: string | undefined;
     test.sequential('create instructor workspace', async () => {
-      const result = (await sqldb.queryOneRowAsync(sql.get_test_question, {})).rows[0];
+      const questionId = await sqldb.queryRow(sql.get_test_question, IdSchema);
       const workspace_url =
-        baseUrl + `/course_instance/1/instructor/question/${result.question_id}/preview`;
+        baseUrl + `/course_instance/1/instructor/question/${questionId}/preview`;
       const response = await fetch(workspace_url);
 
       const $ = cheerio.load(await response.text());
@@ -98,19 +99,19 @@ describe('Test workspace authorization access', { timeout: 20_000 }, function ()
   describe('workspaces created by instructors in a course (no instance)', function () {
     beforeAll(async () => {
       // Make the user a course owner.
-      await sqldb.queryAsync(sql.give_owner_access_to_uid, {
+      await sqldb.execute(sql.give_owner_access_to_uid, {
         uid: config.authUid,
       });
     });
     afterAll(async () => {
       // Remove owner permissions.
-      await sqldb.queryAsync(sql.revoke_owner_access, {});
+      await sqldb.execute(sql.revoke_owner_access);
     });
 
     let workspace_id: string | undefined;
     test.sequential('create instructor workspace', async () => {
-      const result = (await sqldb.queryOneRowAsync(sql.get_test_question, {})).rows[0];
-      const workspace_url = baseUrl + `/course/1/question/${result.question_id}/preview`;
+      const questionId = await sqldb.queryRow(sql.get_test_question, IdSchema);
+      const workspace_url = baseUrl + `/course/1/question/${questionId}/preview`;
       const response = await fetch(workspace_url);
 
       const $ = cheerio.load(await response.text());

--- a/packages/postgres/src/default-pool.ts
+++ b/packages/postgres/src/default-pool.ts
@@ -72,6 +72,8 @@ export const runInTransactionAsync = defaultPool.runInTransactionAsync.bind(defa
 /**
  * Executes a query with the specified parameters.
  *
+ * @deprecated Use {@link execute} instead.
+ *
  * Using the return value of this function directly is not recommended. Instead, use
  * {@link queryRows}, {@link queryRow}, or {@link queryOptionalRow}.
  */
@@ -80,7 +82,7 @@ export const queryAsync = defaultPool.queryAsync.bind(defaultPool);
  * Executes a query with the specified parameters. Errors if the query does
  * not return exactly one row.
  *
- * @deprecated Use {@link queryRow} instead.
+ * @deprecated Use {@link executeRow} or {@link queryRow} instead.
  */
 export const queryOneRowAsync = defaultPool.queryOneRowAsync.bind(defaultPool);
 /**
@@ -160,6 +162,17 @@ export const callRow = defaultPool.callRow.bind(defaultPool);
  * or a single row that conforms to the given Zod schema.
  */
 export const callOptionalRow = defaultPool.callOptionalRow.bind(defaultPool);
+
+/**
+ * Executes a query with the specified parameters. Returns the number of rows affected.
+ */
+export const execute = defaultPool.execute.bind(defaultPool);
+
+/**
+ * Executes a query with the specified parameter, and errors if the query doesn't return exactly one row.
+ */
+export const executeRow = defaultPool.executeRow.bind(defaultPool);
+
 /**
  * Returns an {@link CursorIterator} that can be used to iterate over the
  * results of the query in batches, which is useful for large result sets.

--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -453,6 +453,11 @@ export class PostgresPool {
 
   /**
    * Executes a query with the specified parameters.
+   *
+   * @deprecated Use {@link execute} instead.
+   *
+   * Using the return value of this function directly is not recommended. Instead, use
+   * {@link queryRows}, {@link queryRow}, or {@link queryOptionalRow}.
    */
   async queryAsync(sql: string, params: QueryParams): Promise<QueryResult> {
     debug('query()', 'sql:', debugString(sql));
@@ -471,6 +476,8 @@ export class PostgresPool {
   /**
    * Executes a query with the specified parameters. Errors if the query does
    * not return exactly one row.
+   *
+   * @deprecated Use {@link executeRow} or {@link queryRow} instead.
    */
   async queryOneRowAsync(sql: string, params: QueryParams): Promise<pg.QueryResult> {
     debug('queryOneRow()', 'sql:', debugString(sql));
@@ -784,6 +791,27 @@ export class PostgresPool {
       return model.parse(results.rows[0][columnName]);
     } else {
       return model.parse(results.rows[0]);
+    }
+  }
+
+  /**
+   * Executes a query with the specified parameters. Returns the number of rows affected.
+   */
+  async execute(sql: string, params: QueryParams = {}): Promise<number> {
+    const result = await this.queryAsync(sql, params);
+    return result.rowCount ?? 0;
+  }
+
+  /**
+   * Executes a query with the specified parameter, and errors if the query doesn't return exactly one row.
+   */
+  async executeRow(sql: string, params: QueryParams = {}) {
+    const rowCount = await this.execute(sql, params);
+    if (rowCount !== 1) {
+      throw new PostgresError('Incorrect rowCount: ' + rowCount, {
+        sql,
+        sqlParams: params,
+      });
     }
   }
 


### PR DESCRIPTION
- Cleans up some missed conversions to typed SQL
- Helpers pulled out of https://github.com/PrairieLearn/PrairieLearn/pull/12627