### PR TITLE
Improve guidance when PrairieLearn is missing in Canvas nav

### DIFF
--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -4,8 +4,6 @@ PrairieLearn can connect to Learning Management Systems (LMSes) using [LTI 1.3](
 
 PrairieLearn LTI 1.3 integration is primarily designed and documented for Canvas. Support for other LMS platforms will be coming in the future.
 
-## Prerequisites
-
 ## Make sure you have the right permissions
 
 Linking a PrairieLearn course instance with a Canvas course requires the following permissions:

--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -4,6 +4,8 @@ PrairieLearn can connect to Learning Management Systems (LMSes) using [LTI 1.3](
 
 PrairieLearn LTI 1.3 integration is primarily designed and documented for Canvas. Support for other LMS platforms will be coming in the future.
 
+## Prerequisites
+
 ## Make sure you have the right permissions
 
 Linking a PrairieLearn course instance with a Canvas course requires the following permissions:
@@ -24,7 +26,9 @@ go to "Settings" in the left-hand menu, then choose the "Navigation" tab and fin
 PrairieLearn in the list of hidden items. Drag PrairieLearn to the top visible list and
 click Save. When the page reloads, you should see PrairieLearn in your Canvas course left menu.
 
-If PrairieLearn is not listed under "Settings" / "Navigation" then it needs to be enabled for your university. Please email <support@prairielearn.com> to get it set up.
+!!! note
+
+    A Canvas administrator at your institution must have worked with the PrairieLearn team to configure the integration before it will be available to your course. If PrairieLearn is not listed under "Settings" / "Navigation", either the integration hasn't been configured, or it hasn't been enabled for your course. Reach out to your Canvas administrator for more details. If they need to configure the integration, they can contact <support@prairielearn.com> to work with the PrairieLearn team.
 
 The next step is to set up a connection between the Canvas course and a PrairieLearn course
 instance. As a Canvas Teacher, click the PrairieLearn left menu link. You will be presented


### PR DESCRIPTION
We recently got a support email from someone who was trying to get Canvas working in their course. It had already been set up at their institution, so there was nothing for us to do; they had to reach out to their Canvas admin to get it enabled.

Providing guidance here is a bit tricky, as there's no way for an instructor to know which state they're in ("not set up at institution" vs. just "not enabled in course"). This guidance tries to funnel all questions through their local Canvas admin, which I think will be reasonable most of the time.