### PR TITLE
Restore ability for instructor in student view to customize overrides

### DIFF
--- a/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.ts
+++ b/apps/prairielearn/src/middlewares/authzAuthnHasCoursePreviewOrInstanceView.ts
@@ -1,6 +1,17 @@
-import { createAuthzMiddleware } from './authzHelper.js';
+import { type NextFunction, type Request, type Response } from 'express';
 
-export default createAuthzMiddleware({
-  oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
-  unauthorizedUsers: 'block',
-});
+import { HttpStatusError } from '@prairielearn/error';
+
+export default function (req: Request, res: Response, next: NextFunction) {
+  // We're not using the authz middleware helper because this page uses
+  // permissions from the authenticated user, not the effective user.
+  if (
+    !res.locals.authz_data.authn_has_course_permission_preview &&
+    !res.locals.authz_data.authn_has_course_instance_permission_view
+  ) {
+    return next(
+      new HttpStatusError(403, 'Requires either course preview access or student data view access'),
+    );
+  }
+  next();
+}

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -15,20 +15,6 @@ const sql = loadSqlEquiv(import.meta.url);
 router.get(
   '/',
   asyncHandler(async (req, res) => {
-    // We're not using the authz middleware helper because this page uses
-    // permissions from the authenticated user, not the effective user.
-    if (
-      !(
-        res.locals.authz_data.authn_has_course_permission_preview ||
-        res.locals.authz_data.authn_has_course_instance_permission_view
-      )
-    ) {
-      throw new HttpStatusError(
-        403,
-        'Access denied (must be course previewer or student data viewer)',
-      );
-    }
-
     const courseRoles = await queryRow(
       sql.select,
       {
@@ -52,18 +38,6 @@ router.get(
 router.post(
   '/',
   asyncHandler(async (req, res) => {
-    if (
-      !(
-        res.locals.authz_data.authn_has_course_permission_preview ||
-        res.locals.authz_data.authn_has_course_instance_permission_view
-      )
-    ) {
-      throw new HttpStatusError(
-        403,
-        'Access denied (must be course previewer or student data viewer)',
-      );
-    }
-
     if (req.body.__action === 'reset') {
       clearCookie(res, ['pl_requested_uid', 'pl2_requested_uid']);
       clearCookie(res, ['pl_requested_course_role', 'pl2_requested_course_role']);

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -106,7 +106,7 @@ router.post(
       setCookie(res, ['pl_requested_data_changed', 'pl2_requested_data_changed'], 'true');
       res.redirect(req.originalUrl);
     } else {
-      throw new HttpStatusError(400, 'unknown action: ' + res.locals.__action);
+      throw new HttpStatusError(400, 'unknown action: ' + req.body.__action);
     }
   }),
 );

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -6,7 +6,6 @@ import { HttpStatusError } from '@prairielearn/error';
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
 import { clearCookie, setCookie } from '../../lib/cookie.js';
-import { createAuthzMiddleware } from '../../middlewares/authzHelper.js';
 
 import { CourseRolesSchema, InstructorEffectiveUser } from './instructorEffectiveUser.html.js';
 
@@ -15,13 +14,21 @@ const sql = loadSqlEquiv(import.meta.url);
 
 router.get(
   '/',
-  createAuthzMiddleware({
-    oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
-    errorExplanation:
-      'This page requires either course preview access or student data view access.',
-    unauthorizedUsers: 'block',
-  }),
   asyncHandler(async (req, res) => {
+    // We're not using the authz middleware helper because this page uses
+    // permissions from the authenticated user, not the effective user.
+    if (
+      !(
+        res.locals.authz_data.authn_has_course_permission_preview ||
+        res.locals.authz_data.authn_has_course_instance_permission_view
+      )
+    ) {
+      throw new HttpStatusError(
+        403,
+        'Access denied (must be course previewer or student data viewer)',
+      );
+    }
+
     const courseRoles = await queryRow(
       sql.select,
       {


### PR DESCRIPTION
#12496 introduced a better view when an instructor with overrides accesses a page that the effective user/role does not have access to. However, this was applied to pages that have permissions based on the authenticated user, not the effective user; namely, the effective user customization page. This means, in practice, that once an instructor switches to student view (or customizes the course/course instance roles to None/None), they can no longer customize further (e.g., switch only one of the roles back to not None, or change the effective date). This PR restores the previous functionality for the effective user page to be based on the authenticated role, not the effective role. Both the page and the corresponding middleware are restored to their status before #12496, just adding a comment to clarify why they don't use the common middleware helper.