### PR TITLE
Fix unknown action error message

### DIFF
--- a/apps/prairielearn/src/pages/enroll/enroll.ts
+++ b/apps/prairielearn/src/pages/enroll/enroll.ts
@@ -106,7 +106,7 @@ router.post('/', [
       flash('success', `You have left ${courseDisplayName}.`);
       res.redirect(req.originalUrl);
     } else {
-      throw new error.HttpStatusError(400, 'unknown action: ' + res.locals.__action);
+      throw new error.HttpStatusError(400, 'unknown action: ' + req.body.__action);
     }
   }),
 ]);


### PR DESCRIPTION
Tiny drive-by fix. This was the only thing that a grep for `locals\.__[^c]` yielded.