### PR TITLE
Fix overlay boundary for staff page dropdowns

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.tsx
@@ -429,6 +429,7 @@ function StaffTable({
                               type="button"
                               class="btn btn-sm btn-outline-primary dropdown-toggle"
                               data-bs-toggle="dropdown"
+                              data-bs-boundary="body"
                               aria-haspopup="true"
                               aria-expanded="false"
                             >
@@ -563,6 +564,7 @@ function StaffTable({
                                   type="button"
                                   class="btn btn-sm btn-outline-primary dropdown-toggle"
                                   data-bs-toggle="dropdown"
+                                  data-bs-boundary="body"
                                   aria-haspopup="true"
                                   aria-expanded="false"
                                 >
@@ -649,6 +651,7 @@ function StaffTable({
                               type="button"
                               class="btn btn-sm btn-outline-dark dropdown-toggle"
                               data-bs-toggle="dropdown"
+                              data-bs-boundary="body"
                               aria-haspopup="true"
                               aria-expanded="false"
                             >


### PR DESCRIPTION
The change to responsive tables in #12689 has caused the dropdowns in the staff page to be restricted to the boundaries of the table itself, which causes weird UI artifacts:

<img width="732" height="148" alt="image" src="https://github.com/user-attachments/assets/7c00b7ca-c764-451f-bbe4-ae18d57d1b47" />

This PR changes the dropdowns to use the body as the boundary, allowing the dropdown to be shown as expected.

<img width="704" height="375" alt="image" src="https://github.com/user-attachments/assets/c69d07fa-fa46-4215-8288-4ac881264083" />

I did some quick check in other pages, and this didn't seem to be a major issue in those, though my tests may have been somewhat limited, so this may need to be applied in a few other places too, either here or in future PRs.