### PR TITLE
Remove all reads of duration_stat_threshold_labels and _seconds

### DIFF
--- a/apps/prairielearn/src/lib/assessment.sql
+++ b/apps/prairielearn/src/lib/assessment.sql
@@ -747,6 +747,7 @@ SET
   duration_stat_mean = duration_stats.mean,
   duration_stat_median = duration_stats.median,
   duration_stat_thresholds = duration_stats.thresholds,
+  -- Deprecated, but still updated for backwards compatibility until all servers are using thresholds directly
   duration_stat_threshold_seconds = interval_array_to_seconds (duration_stats.thresholds),
   duration_stat_threshold_labels = interval_array_to_strings (duration_stats.thresholds),
   duration_stat_hist = duration_hist_stats.hist

--- a/apps/prairielearn/src/lib/client/safe-db-types.test.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.test.ts
@@ -115,8 +115,6 @@ const minimalStaffAssessment: z.input<typeof StaffAssessmentSchema> = {
   duration_stat_mean: 24 * 60 * 60 * 1000,
   duration_stat_median: 24 * 60 * 60 * 1000,
   duration_stat_min: 24 * 60 * 60 * 1000,
-  duration_stat_threshold_labels: [],
-  duration_stat_threshold_seconds: [],
   duration_stat_thresholds: [],
   id: '2',
   number: 'A1',

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -226,8 +226,6 @@ export const AssessmentSchema = z.object({
   duration_stat_mean: IntervalSchema,
   duration_stat_median: IntervalSchema,
   duration_stat_min: IntervalSchema,
-  duration_stat_threshold_labels: z.string().array(),
-  duration_stat_threshold_seconds: z.number().array(),
   duration_stat_thresholds: IntervalSchema.array(),
   group_work: z.boolean().nullable(),
   honor_code: z.string().nullable(),

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.html.tsx
@@ -18,8 +18,7 @@ export const DurationStatSchema = z.object({
   min_minutes: z.number(),
   max_minutes: z.number(),
   mean_minutes: z.number(),
-  threshold_seconds: AssessmentSchema.shape.duration_stat_threshold_seconds,
-  threshold_labels: AssessmentSchema.shape.duration_stat_threshold_labels,
+  thresholds: AssessmentSchema.shape.duration_stat_thresholds,
   hist: AssessmentSchema.shape.duration_stat_hist,
 });
 export type DurationStat = z.infer<typeof DurationStatSchema>;
@@ -172,12 +171,14 @@ export function InstructorAssessmentStatistics({
                 <div
                   class="js-histogram"
                   data-histogram="${JSON.stringify(durationStat.hist)}"
-                  data-xgrid="${JSON.stringify(durationStat.threshold_seconds)}"
+                  data-xgrid="${JSON.stringify(
+                    durationStat.thresholds.map((durationMs) => durationMs / 1000),
+                  )}"
                   data-options="${JSON.stringify({
                     ymin: 0,
                     xlabel: 'duration',
                     ylabel: 'number of students',
-                    xTickLabels: durationStat.threshold_labels,
+                    xTickLabels: durationStat.thresholds.map(durationLabel),
                   })}"
                 ></div>
               </div>
@@ -233,11 +234,11 @@ export function InstructorAssessmentStatistics({
                   data-xdata="${JSON.stringify(userScores.map((user) => user.duration_secs))}"
                   data-ydata="${JSON.stringify(userScores.map((user) => user.score_perc))}"
                   data-options="${JSON.stringify({
-                    xgrid: durationStat.threshold_seconds,
+                    xgrid: durationStat.thresholds.map((durationMs) => durationMs / 1000),
                     ygrid: _.range(0, 110, 10),
                     xlabel: 'duration',
                     ylabel: 'score / %',
-                    xTickLabels: durationStat.threshold_labels,
+                    xTickLabels: durationStat.thresholds.map(durationLabel),
                   })}"
                 ></div>
               </div>
@@ -299,4 +300,18 @@ export function InstructorAssessmentStatistics({
       </div>
     `,
   });
+}
+
+function durationLabel(durationMs: number) {
+  const days = Math.floor(durationMs / (24 * 60 * 60 * 1000));
+  const hours = Math.floor(durationMs / (60 * 60 * 1000)) % 24;
+  const mins = Math.floor(durationMs / (60 * 1000)) % 60;
+  const secs = Math.floor(durationMs / 1000) % 60;
+
+  let label = '';
+  if (days > 0) label += `${days}d`;
+  if (hours > 0) label += `${hours}h`;
+  if (mins > 0) label += `${mins}m`;
+  if (secs > 0) label += `${secs}s`;
+  return label || '0';
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.sql
@@ -16,8 +16,7 @@ SELECT
   DATE_PART('epoch', duration_stat_min) / 60 AS min_minutes,
   DATE_PART('epoch', duration_stat_max) / 60 AS max_minutes,
   DATE_PART('epoch', duration_stat_mean) / 60 AS mean_minutes,
-  duration_stat_threshold_seconds AS threshold_seconds,
-  duration_stat_threshold_labels AS threshold_labels,
+  duration_stat_thresholds AS thresholds,
   duration_stat_hist AS hist
 FROM
   assessments

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import z from 'zod';
 
 import { stringify } from '@prairielearn/csv';
 import * as error from '@prairielearn/error';

--- a/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentStatistics/instructorAssessmentStatistics.ts
@@ -153,19 +153,7 @@ router.get(
       const duration_stat = await sqldb.queryRow(
         sql.select_duration_stats,
         { assessment_id: res.locals.assessment.id },
-        z.object({
-          median_formatted: z.string(),
-          min_formatted: z.string(),
-          max_formatted: z.string(),
-          mean_formatted: z.string(),
-          median_minutes: z.number(),
-          min_minutes: z.number(),
-          max_minutes: z.number(),
-          mean_minutes: z.number(),
-          threshold_seconds: AssessmentSchema.shape.duration_stat_threshold_seconds,
-          threshold_labels: AssessmentSchema.shape.duration_stat_threshold_labels,
-          hist: z.array(z.number()),
-        }),
+        DurationStatSchema,
       );
 
       const csvData = [
@@ -181,7 +169,7 @@ router.get(
           duration_stat.median_minutes,
           duration_stat.min_minutes,
           duration_stat.max_minutes,
-          ...duration_stat.threshold_seconds,
+          ...duration_stat.thresholds.map((interval_ms) => interval_ms / 1000),
           ...duration_stat.hist,
         ],
       ];
@@ -201,7 +189,7 @@ router.get(
           'Median duration (min)',
           'Min duration (min)',
           'Max duration (min)',
-          ...duration_stat.threshold_seconds.map((_, i) => `Hist boundary ${i + 1} (s)`),
+          ...duration_stat.thresholds.map((_, i) => `Hist boundary ${i + 1} (s)`),
           ...duration_stat.hist.map((_, i) => `Hist ${i + 1}`),
         ],
       }).pipe(res);


### PR DESCRIPTION
These two columns are only used in the statistics page, and can be easily computed on demand from the `duration_stat_thresholds` column. Once this is merged and deployed, future PRs can (in this order):

* remove all updates of these columns;
  * this should be safe because, even though the columns are not-null, they have a default value.
  * this will also allow the sprocs `format_interval_short`, `interval_array_to_seconds` and `interval_array_to_strings` to be removed.
* drop the columns altogether.