### PR TITLE
Set course instance ID when uploading submissions

### DIFF
--- a/apps/prairielearn/src/lib/submissions-upload.sql
+++ b/apps/prairielearn/src/lib/submissions-upload.sql
@@ -42,6 +42,7 @@ RETURNING
 INSERT INTO
   variants (
     course_id,
+    course_instance_id,
     instance_question_id,
     question_id,
     authn_user_id,
@@ -55,6 +56,7 @@ INSERT INTO
 VALUES
   (
     $course_id,
+    $course_instance_id,
     $instance_question_id,
     $question_id,
     $authn_user_id,

--- a/apps/prairielearn/src/lib/submissions-upload.ts
+++ b/apps/prairielearn/src/lib/submissions-upload.ts
@@ -164,6 +164,7 @@ export async function uploadSubmissions(
               sql.insert_variant,
               {
                 course_id,
+                course_instance_id,
                 instance_question_id,
                 question_id: question.id,
                 authn_user_id: user.user_id,


### PR DESCRIPTION
After using the assessment "Upload submissions" option, I noticed that I couldn't report an issue from the manual grading page because this check was failing:

https://github.com/PrairieLearn/PrairieLearn/blob/dd7f0eee78673b253cb866de099e313b5ac5fd1f/apps/prairielearn/src/models/variant.ts#L195

This PR sets the course instance ID so that our usual invariant will hold.