### PR TITLE
Clarify that SAML cannot require email addresses

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -101,11 +101,10 @@ router.post(
 
     // Only perform validation if we aren't rendering the above test page.
     //
-    // Support for pulling in email from an attribute was added after all initial
-    // attributes, so we can't yet require it to be present. In the future, once
-    // we've specified such an attribute for all institutions, we can assert that
-    // the email attribute mapping and the corresponding value are both present.
-    //
+    // We cannot safely require emails for users. For some categories of users,
+    // such as FERPA-suppressed students, an IdP may not pass an email address.
+    // So even if an email attribute is configured and we get it for the vast
+    // majority of users, there may be some for which it is not present.
     if (!uidAttribute || !uinAttribute || !nameAttribute) {
       throw new Error('Missing one or more SAML attribute mappings');
     }


### PR DESCRIPTION
This came out of discussion with a university today where I was setting up SAML auth. They clarified that some users with various types of protections may be missing email addresses. I wanted to bake this into a comment so that we don't start failing to authenticate users that are missing an email in the future.