### PR TITLE
Use random numbers for system-generated group names

### DIFF
--- a/apps/prairielearn/src/lib/groups.sql
+++ b/apps/prairielearn/src/lib/groups.sql
@@ -30,7 +30,7 @@ WITH
         )
       ) AS gs (n) ON TRUE
     WHERE
-      gc.assessment_id = 14
+      gc.assessment_id = $assessment_id
       AND NOT EXISTS (
         SELECT
           1


### PR DESCRIPTION
In #12065, the ability to allow PL to generate group names was introduced. Originally this was based on the largest group number in the form of `group[0-9]+`, but this can cause problems if a user-defined group name has a number that is too big for an integer (e.g., a number with more than 10 digits). Increasing it to bigint only defers the problem.

This PR changes the process to choose a random number in a reasonable range, large enough that it will always have available numbers to choose.

At this point this PR is a proposal, it still needs a bit of testing and consideration to ensure it won't cause performance problems or be subject to race conditions.

Alternative to #12748. If this PR is merged then #12748 may become unnecessary (and vice-versa), though there's nothing blocking them from both being used.