### PR TITLE
Block user-specified group names with system-generated format

### DIFF
--- a/apps/prairielearn/src/lib/groups.ts
+++ b/apps/prairielearn/src/lib/groups.ts
@@ -362,6 +362,18 @@ export async function createGroup(
         'The group name is invalid. Only alphanumerical characters (letters and digits) are allowed.',
       );
     }
+    if (/^group[0-9]{7,}$/.test(group_name)) {
+      // This test is used to simplify the logic behind system-generated group
+      // names. These are created automatically by adding one to the latest
+      // group name with a number. Allowing a user to specify a group name with
+      // this format could cause an issue if the number is too long, as it would
+      // cause integer overflows in the group calculation. While changing the
+      // process to generate group names that don't take these numbers into
+      // account is possible, this validation is simpler.
+      throw new GroupOperationError(
+        'User-specified group names cannot start with "group" followed by a large number.',
+      );
+    }
   }
 
   if (uids.length === 0) {


### PR DESCRIPTION
In https://github.com/PrairieLearn/PrairieLearn/pull/12065, the ability to allow PL to generate group names was introduced. Originally this was based on the largest group number in the form of group[0-9]+, but this can cause problems if a user-defined group name has a number that is too big for an integer (e.g., a number with more than 10 digits). Increasing it to bigint only defers the problem.

This PR blocks user-specified group names to use this format, with a conservative limit of 7 digits to keep enough space for future system-generated group names to still be created using the same method.

Alternative to #12747. If this PR is merged then #12747 may become unnecessary (and vice-versa), though there's nothing blocking them from both being used.