### PR TITLE
Fixup docker image with mounted local source

### DIFF
--- a/packages/postgres/src/pool.ts
+++ b/packages/postgres/src/pool.ts
@@ -4,9 +4,8 @@ import { Readable, Transform } from 'node:stream';
 import debugfn from 'debug';
 import _ from 'lodash';
 import multipipe from 'multipipe';
-import pg, { type QueryResult } from 'pg';
+import pg, { DatabaseError, type QueryResult } from 'pg';
 import Cursor from 'pg-cursor';
-import { DatabaseError } from 'pg-protocol';
 import { z } from 'zod';
 
 export type QueryParams = Record<string, any> | any[];


### PR DESCRIPTION
Closes #12771 

Tested by rebuilding an image locally, and rerunning the reproduction. I didn't investigate further into why this issue exists, it seems somewhat related to it being a type-only import, and in some scenarios it doesn't load the file, and it other scenarios it does?