### PR TITLE
Fix Zod schemas for instructor assessment downloads

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -89,6 +89,8 @@ type AssessmentInstanceSubmissionRow = z.infer<typeof AssessmentInstanceSubmissi
 const ManualGradingSubmissionRowSchema = z.object({
   uid: UserSchema.shape.uid.nullable(),
   uin: UserSchema.shape.uin.nullable(),
+  zone_number: z.number(),
+  zone_title: z.string().nullable(),
   qid: QuestionSchema.shape.qid,
   old_score_perc: InstanceQuestionSchema.shape.score_perc,
   old_auto_points: InstanceQuestionSchema.shape.auto_points,
@@ -421,7 +423,7 @@ router.get(
       const cursor = await sqldb.queryCursor(
         sql.submissions_for_manual_grading,
         { assessment_id: res.locals.assessment.id, include_files: false },
-        z.unknown(),
+        ManualGradingSubmissionRowSchema,
       );
 
       // Replace user-friendly column names with upload-friendly names
@@ -546,7 +548,7 @@ router.get(
         sql.group_configs,
         { assessment_id: res.locals.assessment.id },
         z.object({
-          group_name: GroupSchema.shape.name,
+          name: GroupSchema.shape.name,
           uid: UserSchema.shape.uid,
           roles: z.array(GroupRoleSchema.shape.role_name),
         }),


### PR DESCRIPTION
# Description

This PR fixes two independent issues:

- https://github.com/PrairieLearn/PrairieLearn/pull/12402 added a schema for the `group_configs` query that incorrectly used a `group_name` property; the column is named `name` in the query: https://github.com/PrairieLearn/PrairieLearn/blob/9bc08384fe83bb97b6175eed489fb97d9e2dc069/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql#L366-L368
- #11300 added zone number/title to CSV exports, but didn't add it to the `ManualGradingSubmissionRowSchema` schema. This wasn't a problem, as the schema wasn't used in that particular query at the time. In this PR, I opted to actually use the schema, which required adding `zone_number` and `zone_title` to it.

I used Copilot with Claude Sonnet 4 to check for differences. I was expecting to find the `group_name`/`name` issue since we saw that in production, but it happened to catch the other one too.

# Testing

For the first fix: create a group and add a user (e.g. `dev@example.com`) to it. Download the `*_groups.csv` from the assessment's Downloads page. On master, this will fail completely, but it'll succeed on this branch.

For the second one: open an assessment, make a submission, and download the `*_submissions_for_manual_grading.csv` file. Observe that all columns are as expected.