### PR TITLE
Fix checking of plan grants on student instance questions

### DIFF
--- a/apps/prairielearn/src/ee/lib/billing/plan-grants.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plan-grants.ts
@@ -76,7 +76,7 @@ export async function checkPlanGrants({
 }
 
 export async function checkPlanGrantsForQuestion(res: Response) {
-  if (userHasRole(res)) {
+  if (userHasRole(res.locals.authz_data)) {
     return true;
   }
 

--- a/apps/prairielearn/src/ee/middlewares/checkPlanGrantsForQuestion.ts
+++ b/apps/prairielearn/src/ee/middlewares/checkPlanGrantsForQuestion.ts
@@ -1,5 +1,7 @@
 import asyncHandler from 'express-async-handler';
 
+import { HttpStatusError } from '@prairielearn/error';
+
 import { checkPlanGrantsForQuestion } from '../lib/billing/plan-grants.js';
 
 export default asyncHandler(async (req, res, next) => {
@@ -8,7 +10,7 @@ export default asyncHandler(async (req, res, next) => {
   if (!hasPlanGrants) {
     // TODO: Show a fancier error page explaining what happened and prompting
     // the user to contact their instructor.
-    throw new Error('Access denied');
+    throw new HttpStatusError(403, 'Access denied (plan grants missing)');
   }
 
   next();


### PR DESCRIPTION
# Description

Peter called out in https://github.com/PrairieLearn/PrairieLearn/pull/12746#discussion_r2310539064 something that looked suspicious, and ended up being a pretty bad bug.

The `userHasRole` helper function expects an `authz_data` object:

https://github.com/PrairieLearn/PrairieLearn/blob/74e462e62ae98e4ff3cd2088de46ddb12496add7/apps/prairielearn/src/ee/lib/billing/plan-grants.ts#L23-L32

But we were passing the entire `res` object to it:

https://github.com/PrairieLearn/PrairieLearn/blob/74e462e62ae98e4ff3cd2088de46ddb12496add7/apps/prairielearn/src/ee/lib/billing/plan-grants.ts#L79

`res.course_role` is of course not `'None'`, so we'd incorrectly assume the user has some kind of permission in the course.

This could in theory break production courses that were relying on external grader or workspace questions but which didn't have the correct plan grant requirement. In practice, we've been careful about settings this up in the few courses that use it so I don't anticipate any problems.

# Testing

To test/reproduce:

- Globally enable the `enforce-plan-grants-for-questions` feature flag.
- Open the `Sp15` course instance of the test course.
- Switch to student view and open the "Homework for Internal, External, Manual grading methods" assessment.
- Access the "External Grading: Alpine Linux smoke test" question.

On master, the above steps will (incorrectly) allow you to access the question.

On this branch, you'll now correctly see a 403 error page.
