### PR TITLE
Add enrollment management feature flag

### DIFF
--- a/apps/prairielearn/src/lib/client/page-context.test.ts
+++ b/apps/prairielearn/src/lib/client/page-context.test.ts
@@ -49,6 +49,7 @@ describe('getPageContext', () => {
         },
       },
       __csrf_token: '123',
+      plainUrlPrefix: '/pl',
       urlPrefix: '/pl/course/1/course_instance/1',
       access_as_administrator: false,
       authn_user: {

--- a/apps/prairielearn/src/lib/client/page-context.test.ts
+++ b/apps/prairielearn/src/lib/client/page-context.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 import type z from 'zod';
 
 import {
+  type RawPageContextSchema,
   type StaffCourseInstanceContextSchema,
   type StudentCourseInstanceContextSchema,
   getCourseInstanceContext,
   getPageContext,
 } from './page-context.js';
+import type { StaffUser } from './safe-db-types.js';
 
 describe('getPageContext', () => {
   it('strips extra fields from the data', () => {
@@ -40,9 +42,9 @@ describe('getPageContext', () => {
           name: 'Test User',
           uid: 'test@illinois.edu',
           email: 'test@illinois.edu',
-          institution_id: 1,
+          institution_id: '1',
           uin: '123456789',
-          user_id: 1,
+          user_id: '1',
           foo: 'bar',
         },
       },
@@ -53,9 +55,9 @@ describe('getPageContext', () => {
         name: 'Test User',
         uid: 'test@illinois.edu',
         email: 'test@illinois.edu',
-        institution_id: 1,
+        institution_id: '1',
         uin: '123456789',
-        user_id: 1,
+        user_id: '1',
         foo: 'bar',
       },
       navbarType: 'student',
@@ -63,7 +65,7 @@ describe('getPageContext', () => {
       anotherExtraField: 123,
     };
 
-    const expected = {
+    const expected: z.infer<typeof RawPageContextSchema> = {
       authz_data: {
         authn_is_administrator: false,
         authn_has_course_permission_preview: true,
@@ -96,9 +98,10 @@ describe('getPageContext', () => {
           institution_id: '1',
           uin: '123456789',
           user_id: '1',
-        },
+        } as StaffUser,
       },
       __csrf_token: '123',
+      plainUrlPrefix: '/pl',
       urlPrefix: '/pl/course/1/course_instance/1',
       access_as_administrator: false,
       authn_user: {
@@ -108,7 +111,7 @@ describe('getPageContext', () => {
         institution_id: '1',
         uin: '123456789',
         user_id: '1',
-      },
+      } as StaffUser,
       navbarType: 'student',
     };
 

--- a/apps/prairielearn/src/lib/client/page-context.ts
+++ b/apps/prairielearn/src/lib/client/page-context.ts
@@ -15,7 +15,7 @@ import {
   StaffUserSchema,
 } from './safe-db-types.js';
 
-const RawPageContextSchema = z.object({
+export const RawPageContextSchema = z.object({
   __csrf_token: z.string(),
   authz_data: z.object({
     // TODO: Type these more accurately into a course instance version.

--- a/apps/prairielearn/src/lib/client/page-context.ts
+++ b/apps/prairielearn/src/lib/client/page-context.ts
@@ -49,6 +49,7 @@ const RawPageContextSchema = z.object({
   }),
 
   urlPrefix: z.string(),
+  plainUrlPrefix: z.string(),
   access_as_administrator: z.boolean(),
 
   authn_user: StaffUserSchema,

--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -17,6 +17,7 @@ const featureNames = [
   // Should only be applied globally.
   'legacy-navigation-user-toggle',
   // Can be applied to any context.
+  'enrollment-management',
   'legacy-navigation',
 ] as const;
 

--- a/apps/prairielearn/src/lib/features/manager.ts
+++ b/apps/prairielearn/src/lib/features/manager.ts
@@ -45,7 +45,7 @@ type FeatureContext =
   | CourseInstanceContext;
 
 export class FeatureManager<FeatureName extends string> {
-  features: Set<string>;
+  features: Set<FeatureName>;
   als: AsyncLocalStorage<FeatureOverrides>;
   globalOverrides: FeatureOverrides = {};
 
@@ -67,11 +67,11 @@ export class FeatureManager<FeatureName extends string> {
   }
 
   hasFeature(feature: string): feature is FeatureName {
-    return this.features.has(feature);
+    return this.features.has(feature as FeatureName);
   }
 
   allFeatures() {
-    return [...this.features] as FeatureName[];
+    return [...this.features];
   }
 
   /**

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -6,6 +6,7 @@ import { html } from '@prairielearn/html';
 import { Modal } from '../../components/Modal.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { type Course, type CourseInstance, type Institution } from '../../lib/db-types.js';
+import type { FeatureName } from '../../lib/features/index.js';
 
 export const FeatureGrantRowSchema = z.object({
   id: z.string(),
@@ -30,7 +31,7 @@ export function AdministratorFeatures({
   features,
   resLocals,
 }: {
-  features: string[];
+  features: FeatureName[];
   resLocals: Record<string, any>;
 }) {
   return PageLayout({

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -25,6 +25,7 @@ export function InstructorInstanceAdminSettings({
   instanceGHLink,
   canEdit,
   enrollmentCount,
+  enrollmentManagementEnabled,
 }: {
   resLocals: Record<string, any>;
   shortNames: string[];
@@ -37,6 +38,7 @@ export function InstructorInstanceAdminSettings({
   instanceGHLink: string | null;
   canEdit: boolean;
   enrollmentCount: number;
+  enrollmentManagementEnabled: boolean;
 }) {
   return PageLayout({
     resLocals,
@@ -227,7 +229,9 @@ export function InstructorInstanceAdminSettings({
                 to share with students.
               </small>
             </div>
-            ${renderHtml(<SelfEnrollmentSettings selfEnrollLink={selfEnrollLink} />)}
+            ${enrollmentManagementEnabled
+              ? renderHtml(<SelfEnrollmentSettings selfEnrollLink={selfEnrollLink} />)
+              : ''}
 
             <h2 class="h4">Sharing</h2>
             ${CourseInstanceSharing({ courseInstance: resLocals.course_instance, publicLink })}

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -93,14 +93,11 @@ router.get(
     const { authz_data } = pageContext;
     const canEdit = authz_data.has_course_permission_edit && !course.example_course;
 
-    // For now, this is a development-only feature, so that can can get PRs merged without affecting users.
-    const hasEnrollmentManagementFeature = await features.enabled('enrollment-management', {
+    const enrollmentManagementEnabled = await features.enabled('enrollment-management', {
       institution_id: institution.id,
       course_id: course.id,
       course_instance_id: courseInstance.id,
     });
-    const enrollmentManagementEnabled =
-      hasEnrollmentManagementFeature && authz_data.is_administrator;
 
     res.send(
       InstructorInstanceAdminSettings({

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.ts
@@ -11,6 +11,7 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
+import { getCourseInstanceContext, getPageContext } from '../../lib/client/page-context.js';
 import { getSelfEnrollmentLinkUrl } from '../../lib/client/url.js';
 import {
   CourseInstanceCopyEditor,
@@ -20,6 +21,7 @@ import {
   MultiEditor,
   propertyValueWithDefault,
 } from '../../lib/editors.js';
+import { features } from '../../lib/features/index.js';
 import { courseRepoContentUrl } from '../../lib/github.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
@@ -37,43 +39,44 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 router.get(
   '/',
   asyncHandler(async (req, res) => {
-    const shortNames = await sqldb.queryRows(
-      sql.short_names,
-      { course_id: res.locals.course.id },
-      z.string(),
-    );
+    const {
+      course_instance: courseInstance,
+      course,
+      institution,
+    } = getCourseInstanceContext(res.locals, 'instructor');
+    const pageContext = getPageContext(res.locals);
+    const { plainUrlPrefix } = pageContext;
+
+    const shortNames = await sqldb.queryRows(sql.short_names, { course_id: course.id }, z.string());
     const enrollmentCount = await sqldb.queryRow(
       sql.select_enrollment_count,
-      { course_instance_id: res.locals.course_instance.id },
+      { course_instance_id: courseInstance.id },
       z.number(),
     );
     const host = getCanonicalHost(req);
-    const studentLink = new URL(
-      `${res.locals.plainUrlPrefix}/course_instance/${res.locals.course_instance.id}`,
-      host,
-    ).href;
+    const studentLink = new URL(`${plainUrlPrefix}/course_instance/${courseInstance.id}`, host)
+      .href;
     const publicLink = new URL(
-      `${res.locals.plainUrlPrefix}/public/course_instance/${res.locals.course_instance.id}/assessments`,
+      `${plainUrlPrefix}/public/course_instance/${courseInstance.id}/assessments`,
       host,
     ).href;
 
     const selfEnrollLink = new URL(
       getSelfEnrollmentLinkUrl({
-        courseInstanceId: res.locals.course_instance.id,
-        enrollmentCode: res.locals.course_instance.enrollment_code,
+        courseInstanceId: courseInstance.id,
+        // TODO: after the enrollment code backfill, this should be non-nullable
+        enrollmentCode: courseInstance.enrollment_code ?? '',
       }),
       host,
     ).href;
-    const availableTimezones = await getCanonicalTimezones([
-      res.locals.course_instance.display_timezone,
-    ]);
+    const availableTimezones = await getCanonicalTimezones([courseInstance.display_timezone]);
 
     const infoCourseInstancePath = path.join(
       'courseInstances',
-      res.locals.course_instance.short_name,
+      courseInstance.short_name,
       'infoCourseInstance.json',
     );
-    const fullInfoCourseInstancePath = path.join(res.locals.course.path, infoCourseInstancePath);
+    const fullInfoCourseInstancePath = path.join(course.path, infoCourseInstancePath);
     const infoCourseInfoPathExists = await fs.pathExists(fullInfoCourseInstancePath);
     let origHash = '';
     if (infoCourseInfoPathExists) {
@@ -84,11 +87,20 @@ router.get(
 
     const instanceGHLink = courseRepoContentUrl(
       res.locals.course,
-      `courseInstances/${res.locals.course_instance.short_name}`,
+      `courseInstances/${courseInstance.short_name}`,
     );
 
-    const canEdit =
-      res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
+    const { authz_data } = pageContext;
+    const canEdit = authz_data.has_course_permission_edit && !course.example_course;
+
+    // For now, this is a development-only feature, so that can can get PRs merged without affecting users.
+    const hasEnrollmentManagementFeature = await features.enabled('enrollment-management', {
+      institution_id: institution.id,
+      course_id: course.id,
+      course_instance_id: courseInstance.id,
+    });
+    const enrollmentManagementEnabled =
+      hasEnrollmentManagementFeature && authz_data.is_administrator;
 
     res.send(
       InstructorInstanceAdminSettings({
@@ -103,6 +115,7 @@ router.get(
         instanceGHLink,
         canEdit,
         enrollmentCount,
+        enrollmentManagementEnabled,
       }),
     );
   }),


### PR DESCRIPTION
# Description

#12655 was merged, but it adds features that aren't available yet. I had a similar story in #12604, but that PR is still in review. In order to deploy correctly, we should gate #12655 behind a feature flag and local development. This will ensure that instructors don't get confused.

This PR does three things:

- Adds a feature flag (and fixes some associated typing)
- Uses that feature flag to hide the self-enrollment settings
- Uses the res.locals helpers for better type safety on this page.

AI tab completion was used when switching to the res.locals helpers.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

I ran this locally. The first screenshot is before turning on the `enrollment-management` toggle. The second screenshot is after turning on the `enrollment-management` toggle.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->

<img width="2072" height="1472" alt="CleanShot 2025-09-03 at 09 37 44@2x" src="https://github.com/user-attachments/assets/0ac7429a-731d-43d6-ade8-d957725ab7ad" />

<img width="2074" height="1024" alt="CleanShot 2025-09-03 at 09 38 19@2x" src="https://github.com/user-attachments/assets/a025fd9d-16f0-4c23-a759-ea09c2c9efc7" />

