### PR TITLE
Add additional instructor assessment download tests

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -111,7 +111,7 @@ const ManualGradingSubmissionRowSchema = z.object({
 
 type ManualGradingSubmissionRow = z.infer<typeof ManualGradingSubmissionRowSchema>;
 
-function getFilenames(locals: ResLocalsForPage<'assessment'>) {
+export function getFilenames(locals: ResLocalsForPage<'assessment'>) {
   const prefix = assessmentFilenamePrefix(
     locals.assessment,
     locals.assessment_set,

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -9,8 +9,12 @@ import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import {
+  type Assessment,
   AssessmentInstanceSchema,
   AssessmentQuestionSchema,
+  type AssessmentSet,
+  type Course,
+  type CourseInstance,
   InstanceQuestionSchema,
   QuestionSchema,
   RubricGradingItemSchema,
@@ -24,7 +28,7 @@ import {
   type Variant,
   VariantSchema,
 } from '../../lib/db-types.js';
-import { type ResLocalsForPage, typedAsyncHandler } from '../../lib/res-locals.js';
+import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
 import { getTeamConfig } from '../../lib/teams.js';
 
@@ -111,7 +115,12 @@ const ManualGradingSubmissionRowSchema = z.object({
 
 type ManualGradingSubmissionRow = z.infer<typeof ManualGradingSubmissionRowSchema>;
 
-export function getFilenames(locals: ResLocalsForPage<'assessment'>) {
+export function getFilenames(locals: {
+  assessment: Pick<Assessment, 'number' | 'team_work'>;
+  assessment_set: Pick<AssessmentSet, 'abbreviation'>;
+  course_instance: Pick<CourseInstance, 'short_name'>;
+  course: Pick<Course, 'short_name'>;
+}) {
   const prefix = assessmentFilenamePrefix(
     locals.assessment,
     locals.assessment_set,

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.ts
@@ -9,12 +9,8 @@ import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import {
-  type Assessment,
   AssessmentInstanceSchema,
   AssessmentQuestionSchema,
-  type AssessmentSet,
-  type Course,
-  type CourseInstance,
   InstanceQuestionSchema,
   QuestionSchema,
   RubricGradingItemSchema,
@@ -28,7 +24,7 @@ import {
   type Variant,
   VariantSchema,
 } from '../../lib/db-types.js';
-import { typedAsyncHandler } from '../../lib/res-locals.js';
+import { type ResLocalsForPage, typedAsyncHandler } from '../../lib/res-locals.js';
 import { assessmentFilenamePrefix } from '../../lib/sanitize-name.js';
 import { getTeamConfig } from '../../lib/teams.js';
 
@@ -115,12 +111,7 @@ const ManualGradingSubmissionRowSchema = z.object({
 
 type ManualGradingSubmissionRow = z.infer<typeof ManualGradingSubmissionRowSchema>;
 
-export function getFilenames(locals: {
-  assessment: Pick<Assessment, 'number' | 'team_work'>;
-  assessment_set: Pick<AssessmentSet, 'abbreviation'>;
-  course_instance: Pick<CourseInstance, 'short_name'>;
-  course: Pick<Course, 'short_name'>;
-}) {
+export function getFilenames(locals: ResLocalsForPage<'assessment'>) {
   const prefix = assessmentFilenamePrefix(
     locals.assessment,
     locals.assessment_set,

--- a/apps/prairielearn/src/tests/helperExam.ts
+++ b/apps/prairielearn/src/tests/helperExam.ts
@@ -18,7 +18,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 export interface TestExamQuestion {
   qid: string;
-  type: 'Freeform' | 'Calculation' | 'External';
+  type: 'Freeform' | 'Calculation';
   maxPoints: number;
   points?: number;
   id?: string;
@@ -28,7 +28,6 @@ export interface TestExamQuestion {
 interface TestExam {
   maxPoints: number;
   tid: string;
-  number: string;
   title: string;
   questions: TestExamQuestion[];
   keyedQuestions: Record<string, TestExamQuestion>;
@@ -44,35 +43,13 @@ const exam1AutomaticTestSuiteQuestions: TestExamQuestion[] = [
   { qid: 'partialCredit3', type: 'Freeform', maxPoints: 13 },
 ];
 
-const exam14GroupWorkQuestions: TestExamQuestion[] = [
-  {
-    qid: 'addVectors',
-    type: 'Calculation',
-    maxPoints: 10,
-  },
-  {
-    qid: 'positionTimeGraph',
-    type: 'Freeform',
-    maxPoints: 10,
-  },
-];
-
 export const exams: Record<string, TestExam> = {
   'exam1-automaticTestSuite': {
     maxPoints: 94,
     tid: 'exam1-automaticTestSuite',
-    number: '1',
     title: 'Exam for automatic test suite',
     questions: exam1AutomaticTestSuiteQuestions,
     keyedQuestions: _.keyBy(exam1AutomaticTestSuiteQuestions, 'qid'),
-  },
-  'exam14-groupWork': {
-    maxPoints: 20,
-    tid: 'exam14-groupWork',
-    number: '14',
-    title: 'Group Activity Exam Example',
-    questions: exam14GroupWorkQuestions,
-    keyedQuestions: _.keyBy(exam14GroupWorkQuestions, 'qid'),
   },
 };
 
@@ -120,7 +97,7 @@ export function startExam(locals: Record<string, any>, examTid: keyof typeof exa
     it('should contain E1', async function () {
       const { id: assessmentId } = await selectAssessmentByTid({
         course_instance_id: '1',
-        tid: examTid,
+        tid: 'exam1-automaticTestSuite',
       });
       locals.assessment_id = assessmentId;
     });
@@ -134,10 +111,9 @@ export function startExam(locals: Record<string, any>, examTid: keyof typeof exa
       const page = await response.text();
       locals.$ = cheerio.load(page);
     });
-    it(`should contain title: "${exam.title}" with the correct link`, function () {
+    it('should contain E1 and have the correct link', function () {
       assert(locals.$);
-      const selector = `td a:contains("${exam.title}")`;
-      const elemList = locals.$(selector);
+      const elemList = locals.$('td a:contains("Exam for automatic test suite")');
       assert.lengthOf(elemList, 1);
       locals.assessmentUrl = locals.siteUrl + elemList[0].attribs.href;
       assert.equal(
@@ -155,10 +131,9 @@ export function startExam(locals: Record<string, any>, examTid: keyof typeof exa
       const page = await response.text();
       locals.$ = cheerio.load(page);
     });
-    it(`should contain "Exam ${exam.number}"`, function () {
+    it('should contain "Exam 1"', function () {
       assert(locals.$);
-      const selector = `p.lead strong:contains("Exam ${exam.number}")`;
-      const elemList = locals.$(selector);
+      const elemList = locals.$('p.lead strong:contains("Exam 1")');
       assert.lengthOf(elemList, 1);
     });
     it('should contain "QA 101"', function () {

--- a/apps/prairielearn/src/tests/helperExam.ts
+++ b/apps/prairielearn/src/tests/helperExam.ts
@@ -18,7 +18,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 export interface TestExamQuestion {
   qid: string;
-  type: 'Freeform' | 'Calculation';
+  type: 'Freeform' | 'Calculation' | 'External';
   maxPoints: number;
   points?: number;
   id?: string;
@@ -28,6 +28,7 @@ export interface TestExamQuestion {
 interface TestExam {
   maxPoints: number;
   tid: string;
+  number: string;
   title: string;
   questions: TestExamQuestion[];
   keyedQuestions: Record<string, TestExamQuestion>;
@@ -43,13 +44,35 @@ const exam1AutomaticTestSuiteQuestions: TestExamQuestion[] = [
   { qid: 'partialCredit3', type: 'Freeform', maxPoints: 13 },
 ];
 
+const exam14GroupWorkQuestions: TestExamQuestion[] = [
+  {
+    qid: 'addVectors',
+    type: 'Freeform',
+    maxPoints: 10,
+  },
+  {
+    qid: 'positionTimeGraph',
+    type: 'Freeform',
+    maxPoints: 10,
+  },
+];
+
 export const exams: Record<string, TestExam> = {
   'exam1-automaticTestSuite': {
     maxPoints: 94,
     tid: 'exam1-automaticTestSuite',
+    number: '1',
     title: 'Exam for automatic test suite',
     questions: exam1AutomaticTestSuiteQuestions,
     keyedQuestions: _.keyBy(exam1AutomaticTestSuiteQuestions, 'qid'),
+  },
+  'exam14-groupWork': {
+    maxPoints: 20,
+    tid: 'exam14-groupWork',
+    number: '14',
+    title: 'Group Activity Exam Example',
+    questions: exam14GroupWorkQuestions,
+    keyedQuestions: _.keyBy(exam14GroupWorkQuestions, 'qid'),
   },
 };
 
@@ -97,7 +120,7 @@ export function startExam(locals: Record<string, any>, examTid: keyof typeof exa
     it('should contain E1', async function () {
       const { id: assessmentId } = await selectAssessmentByTid({
         course_instance_id: '1',
-        tid: 'exam1-automaticTestSuite',
+        tid: examTid,
       });
       locals.assessment_id = assessmentId;
     });
@@ -111,9 +134,10 @@ export function startExam(locals: Record<string, any>, examTid: keyof typeof exa
       const page = await response.text();
       locals.$ = cheerio.load(page);
     });
-    it('should contain E1 and have the correct link', function () {
+    it(`should contain title: "${exam.title}" with the correct link`, function () {
       assert(locals.$);
-      const elemList = locals.$('td a:contains("Exam for automatic test suite")');
+      const selector = `td a:contains("${exam.title}")`;
+      const elemList = locals.$(selector);
       assert.lengthOf(elemList, 1);
       locals.assessmentUrl = locals.siteUrl + elemList[0].attribs.href;
       assert.equal(
@@ -131,9 +155,10 @@ export function startExam(locals: Record<string, any>, examTid: keyof typeof exa
       const page = await response.text();
       locals.$ = cheerio.load(page);
     });
-    it('should contain "Exam 1"', function () {
+    it(`should contain "Exam ${exam.number}"`, function () {
       assert(locals.$);
-      const elemList = locals.$('p.lead strong:contains("Exam 1")');
+      const selector = `p.lead strong:contains("Exam ${exam.number}")`;
+      const elemList = locals.$(selector);
       assert.lengthOf(elemList, 1);
     });
     it('should contain "QA 101"', function () {

--- a/apps/prairielearn/src/tests/helperExam.ts
+++ b/apps/prairielearn/src/tests/helperExam.ts
@@ -47,7 +47,7 @@ const exam1AutomaticTestSuiteQuestions: TestExamQuestion[] = [
 const exam14GroupWorkQuestions: TestExamQuestion[] = [
   {
     qid: 'addVectors',
-    type: 'Freeform',
+    type: 'Calculation',
     maxPoints: 10,
   },
   {

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -8,9 +8,11 @@ import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
 import type { ResLocalsForPage } from '../lib/res-locals.js';
 import { selectAssessmentSetById } from '../models/assessment-set.js';
-import { selectAssessmentById } from '../models/assessment.js';
+import { selectAssessmentById, selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectCourseById } from '../models/course.js';
+import { config } from '../lib/config.js';
+import { generateAndEnrollUsers } from '../models/enrollment.js';
 import { getFilenames } from '../pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js';
 
 import * as helperExam from './helperExam.js';
@@ -335,6 +337,210 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
   });
 });
 
-// TODO: Add Group Work tests once team creation helpers are available.
-// Group work exams require creating and joining teams before starting the assessment,
-// which is not currently supported by helperExam.startExam().
+describe('Instructor Assessment Downloads - Group Work', { timeout: 60_000 }, function () {
+  const storedConfig: Record<string, any> = {};
+
+  beforeAll(helperServer.before());
+
+  beforeAll(function () {
+    // Save the original config so we can restore it later
+    storedConfig.authUid = config.authUid;
+    storedConfig.authName = config.authName;
+    storedConfig.authUin = config.authUin;
+  });
+
+  afterAll(helperServer.after);
+
+  afterAll(function () {
+    // Restore the original config
+    Object.assign(config, storedConfig);
+  });
+
+  const groupLocals: Record<string, any> = {};
+
+  describe('1. Initialize group work assessment', function () {
+    it('should get the group work assessment', async () => {
+      const assessment = await selectAssessmentByTid({
+        course_instance_id: '1',
+        tid: 'exam14-groupWork',
+      });
+      groupLocals.assessment_id = assessment.id;
+      groupLocals.siteUrl = 'http://localhost:' + config.serverPort;
+      groupLocals.courseInstanceBaseUrl = groupLocals.siteUrl + '/pl/course_instance/1';
+      groupLocals.assessmentUrl = groupLocals.courseInstanceBaseUrl + '/assessment/' + assessment.id;
+      groupLocals.instructorAssessmentGroupsUrl =
+        groupLocals.courseInstanceBaseUrl + '/instructor/assessment/' + assessment.id + '/groups';
+      groupLocals.instructorAssessmentDownloadsUrl =
+        groupLocals.courseInstanceBaseUrl + '/instructor/assessment/' + assessment.id + '/downloads';
+    });
+  });
+
+  describe('2. Create users and team via instructor interface', function () {
+    it('should create 2 users for the team', async () => {
+      // exam14-groupWork requires minimum 2 users
+      groupLocals.studentUsers = await generateAndEnrollUsers({ count: 2, course_instance_id: '1' });
+      assert.lengthOf(groupLocals.studentUsers, 2);
+    });
+
+    it('should load the groups page', async () => {
+      const res = await fetch(groupLocals.instructorAssessmentGroupsUrl);
+      assert.equal(res.status, 200);
+      const page = await res.text();
+      groupLocals.$ = cheerio.load(page);
+    });
+
+    it('should have a CSRF token', function () {
+      const elemList = groupLocals.$('form input[name="__csrf_token"]');
+      assert.isAtLeast(elemList.length, 1);
+      groupLocals.__csrf_token = elemList[0].attribs.value;
+    });
+
+    it('should create a team with 2 users', async () => {
+      const res = await fetch(groupLocals.instructorAssessmentGroupsUrl, {
+        method: 'POST',
+        body: new URLSearchParams({
+          __action: 'add_team',
+          __csrf_token: groupLocals.__csrf_token,
+          team_name: 'testteam',
+          uids: groupLocals.studentUsers[0].uid + ',' + groupLocals.studentUsers[1].uid,
+        }),
+      });
+      assert.equal(res.status, 200);
+    });
+  });
+
+  describe('3. Start the assessment as first student', function () {
+    it('should switch to first student user', function () {
+      const student = groupLocals.studentUsers[0];
+      config.authUid = student.uid;
+      config.authName = student.name;
+      config.authUin = student.uin;
+    });
+
+    it('should load assessment page', async () => {
+      const res = await fetch(groupLocals.assessmentUrl);
+      assert.equal(res.status, 200);
+      const page = await res.text();
+      groupLocals.$ = cheerio.load(page);
+    });
+
+    it('should have a CSRF token', function () {
+      const elemList = groupLocals.$('form input[name="__csrf_token"]');
+      assert.isAtLeast(elemList.length, 1);
+      groupLocals.__csrf_token = elemList[0].attribs.value;
+    });
+
+    it('should start the assessment', async () => {
+      const res = await fetch(groupLocals.assessmentUrl, {
+        method: 'POST',
+        body: new URLSearchParams({
+          __action: 'new_instance',
+          __csrf_token: groupLocals.__csrf_token,
+        }),
+      });
+      assert.equal(res.status, 200);
+      const page = await res.text();
+      groupLocals.$ = cheerio.load(page);
+      groupLocals.assessmentInstanceUrl = res.url;
+    });
+  });
+
+  describe('4. Answer the first question (addVectors)', function () {
+    it('should find the question link', function () {
+      // Find any question link in the assessment instance
+      const questionLinks = groupLocals.$('a[href*="/instance_question/"]');
+      assert.isAtLeast(questionLinks.length, 1, 'Should have at least one question link');
+      groupLocals.questionUrl = groupLocals.siteUrl + questionLinks[0].attribs.href;
+    });
+
+    it('should load the question page', async () => {
+      const res = await fetch(groupLocals.questionUrl);
+      assert.equal(res.status, 200);
+      const page = await res.text();
+      groupLocals.$ = cheerio.load(page);
+    });
+
+    it('should have variant_id and CSRF token', function () {
+      const variantInput = groupLocals.$('.question-form input[name="__variant_id"]');
+      assert.lengthOf(variantInput, 1);
+      groupLocals.variant_id = variantInput[0].attribs.value;
+
+      const csrfInput = groupLocals.$('.question-form input[name="__csrf_token"]');
+      assert.lengthOf(csrfInput, 1);
+      groupLocals.__csrf_token = csrfInput[0].attribs.value;
+    });
+
+    it('should get the variant from the database', async () => {
+      const { queryRow } = await import('@prairielearn/postgres');
+      const { VariantSchema } = await import('../lib/db-types.js');
+      groupLocals.variant = await queryRow(
+        'SELECT * FROM variants WHERE id = $1',
+        [groupLocals.variant_id],
+        VariantSchema,
+      );
+    });
+
+    it('should submit the correct answer', async () => {
+      const res = await fetch(groupLocals.questionUrl, {
+        method: 'POST',
+        body: new URLSearchParams({
+          __action: 'grade',
+          __csrf_token: groupLocals.__csrf_token,
+          __variant_id: groupLocals.variant_id,
+          wx: String(groupLocals.variant.true_answer.wx),
+          wy: String(groupLocals.variant.true_answer.wy),
+        }),
+      });
+      assert.equal(res.status, 200);
+    });
+  });
+
+  describe('5. Comprehensive test of all downloads for group work assessment', function () {
+    it('should switch back to instructor user', function () {
+      // Restore instructor credentials to access download URLs
+      config.authUid = storedConfig.authUid;
+      config.authName = storedConfig.authName;
+      config.authUin = storedConfig.authUin;
+    });
+
+    it('should attempt to download every file in getFilenames', async () => {
+      const assessment = await selectAssessmentById(groupLocals.assessment_id);
+      assert.isNotNull(assessment.assessment_set_id);
+      assert.isTrue(assessment.team_work);
+
+      const filenames: string[] = Object.values(
+        getFilenames({
+          assessment,
+          assessment_set: await selectAssessmentSetById(assessment.assessment_set_id),
+          course_instance: await selectCourseInstanceById(groupLocals.variant.course_instance_id),
+          course: await selectCourseById(groupLocals.variant.course_id),
+        } as ResLocalsForPage<'assessment'>),
+      );
+
+      // Group work assessments should have additional team-related files
+      assert.isTrue(
+        filenames.some((f) => f.includes('group')),
+        'Group work assessment should have group-related download files',
+      );
+
+      await Promise.all(
+        filenames.map(async (filename) => {
+          const downloadUrl = groupLocals.instructorAssessmentDownloadsUrl + '/' + filename;
+          const res = await fetch(downloadUrl);
+          assert.equal(res.status, 200, `Failed to download ${filename}`);
+          if (filename.endsWith('.csv')) {
+            const csvContent = await res.text();
+            const data = csvParse<any>(csvContent, { columns: true, cast: true });
+            assert.isAtLeast(data.length, 1, `CSV file ${filename} should have at least 1 row`);
+          } else if (filename.endsWith('.zip')) {
+            const zipContent = Buffer.from(await res.arrayBuffer());
+            const zip = await unzipper.Open.buffer(zipContent);
+            assert.isAtLeast(zip.files.length, 1, `ZIP file ${filename} should have at least 1 file`);
+          } else {
+            assert.fail(`Unknown file type: ${filename}`);
+          }
+        }),
+      );
+    });
+  });
+});

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -9,8 +9,7 @@ import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 import { queryRow } from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
-import type { Assessment, User, Variant } from '../lib/db-types.js';
-import { VariantSchema } from '../lib/db-types.js'; // eslint-disable-line no-duplicate-imports
+import { type Assessment, type User, type Variant, VariantSchema } from '../lib/db-types.js';
 import type { ResLocalsForPage } from '../lib/res-locals.js';
 import { selectAssessmentSetById } from '../models/assessment-set.js';
 import { selectAssessmentById, selectAssessmentByTid } from '../models/assessment.js';
@@ -358,7 +357,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
   });
 
   describe('Group Work Downloads', function () {
-    interface GroupWorkTestContext {
+    const ctx = {} as {
       assessment_id: string;
       siteUrl: string;
       courseInstanceBaseUrl: string;
@@ -371,9 +370,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
       variant: Variant;
       assessment: Assessment;
       filenames: Filenames;
-    }
-
-    const ctx: Partial<GroupWorkTestContext> = {};
+    };
 
     beforeAll(async function () {
       const assessment = await selectAssessmentByTid({
@@ -444,7 +441,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
             __action: 'grade',
             __csrf_token: getCSRFToken(ctx.$),
             __variant_id: variantId as string,
-            c: String(ctx.variant.true_answer.c),
+            c: String(ctx.variant.true_answer!.c),
           }),
         });
         assert.equal(studentRes.status, 200);
@@ -453,8 +450,8 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
       ctx.assessment = await selectAssessmentById(ctx.assessment_id);
       ctx.filenames = getFilenames({
         assessment: ctx.assessment,
-        assessment_set: await selectAssessmentSetById(ctx.assessment.assessment_set_id),
-        course_instance: await selectCourseInstanceById(ctx.variant.course_instance_id),
+        assessment_set: await selectAssessmentSetById(ctx.assessment.assessment_set_id!),
+        course_instance: await selectCourseInstanceById(ctx.variant.course_instance_id!),
         course: await selectCourseById(ctx.variant.course_id),
       } as ResLocalsForPage<'assessment'>);
     });
@@ -474,8 +471,8 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
       assert.lengthOf(teamRows, 2);
 
       const uids = teamRows.map((row) => row['UID']);
-      assert.include(uids, ctx.studentUsers![0].uid);
-      assert.include(uids, ctx.studentUsers![1].uid);
+      assert.include(uids, ctx.studentUsers[0].uid);
+      assert.include(uids, ctx.studentUsers[1].uid);
     });
 
     it('scores_by_group.csv should contain team with valid score', async () => {

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 import * as unzipper from 'unzipper';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
+import type { ResLocalsForPage } from '../lib/res-locals.js';
 import { selectAssessmentSetById } from '../models/assessment-set.js';
 import { selectAssessmentById } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
@@ -45,7 +46,7 @@ const locals = {} as {
   };
 };
 
-const assessmentPoints = helperExam.exams['exam1-automaticTestSuite'].maxPoints;
+const addNumbersMaxPoints = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.maxPoints;
 
 describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
   beforeAll(helperServer.before());
@@ -66,11 +67,11 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
         locals.expectedResult = {
           submission_score: 1,
           submission_correct: true,
-          instance_question_points: assessmentPoints,
-          instance_question_score_perc: (assessmentPoints / 5) * 100,
-          assessment_instance_points: assessmentPoints,
+          instance_question_points: addNumbersMaxPoints,
+          instance_question_score_perc: 100,
+          assessment_instance_points: addNumbersMaxPoints,
           assessment_instance_score_perc:
-            (assessmentPoints / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
+            (addNumbersMaxPoints / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant: any) {
           return {
@@ -304,7 +305,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
           assessment_set: await selectAssessmentSetById(assessment.assessment_set_id),
           course_instance: await selectCourseInstanceById(locals.variant.course_instance_id),
           course: await selectCourseById(locals.variant.course_id),
-        }),
+        } as ResLocalsForPage<'assessment'>),
       );
 
       await Promise.all(
@@ -334,113 +335,6 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
   });
 });
 
-describe('Instructor Assessment Downloads - Group Work', { timeout: 60_000 }, function () {
-  beforeAll(helperServer.before());
-
-  afterAll(helperServer.after);
-
-  const groupWorkAssessmentPoints = helperExam.exams['exam14-groupWork'].maxPoints;
-  const firstQuestionPoints = helperExam.exams['exam14-groupWork'].questions[0].maxPoints;
-
-  helperExam.startExam(locals, 'exam14-groupWork');
-
-  describe('1. grade correct answer to question addNumbers', function () {
-    describe('setting up the submission data', function () {
-      it('should succeed', function () {
-        locals.shouldHaveButtons = ['grade', 'save'];
-        locals.postAction = 'grade';
-        locals.question = helperExam.exams['exam14-groupWork'].keyedQuestions.addNumbers;
-        locals.expectedResult = {
-          submission_score: 1,
-          submission_correct: true,
-          instance_question_points: groupWorkAssessmentPoints,
-          instance_question_score_perc: (groupWorkAssessmentPoints / firstQuestionPoints) * 100,
-          assessment_instance_points: groupWorkAssessmentPoints,
-          assessment_instance_score_perc:
-            (groupWorkAssessmentPoints / helperExam.exams['exam14-groupWork'].maxPoints) * 100,
-        };
-        locals.getSubmittedAnswer = function (variant) {
-          console.log(variant);
-          return {
-            wx: variant.true_answer.wx,
-            wy: variant.true_answer.wy,
-          };
-        };
-      });
-    });
-    helperQuestion.getInstanceQuestion(locals);
-    helperQuestion.postInstanceQuestion(locals);
-    helperQuestion.checkQuestionScore(locals);
-    helperQuestion.checkAssessmentScore(locals);
-  });
-
-  describe('2. grade correct answer to question positionTimeGraph', function () {
-    describe('setting up the submission data', function () {
-      it('should succeed', function () {
-        locals.shouldHaveButtons = ['grade', 'save'];
-        locals.postAction = 'grade';
-        locals.question = helperExam.exams['exam14-groupWork'].keyedQuestions.positionTimeGraph;
-        locals.expectedResult = {
-          submission_score: 1,
-          submission_correct: true,
-          instance_question_points: groupWorkAssessmentPoints,
-          instance_question_score_perc: (groupWorkAssessmentPoints / firstQuestionPoints) * 100,
-          assessment_instance_points: groupWorkAssessmentPoints,
-          assessment_instance_score_perc:
-            (groupWorkAssessmentPoints / helperExam.exams['exam14-groupWork'].maxPoints) * 100,
-        };
-        locals.getSubmittedAnswer = function (variant) {
-          return {
-            x: variant.true_answer.x,
-            y: variant.true_answer.y,
-          };
-        };
-      });
-    });
-    helperQuestion.getInstanceQuestion(locals);
-    helperQuestion.postInstanceQuestion(locals);
-    helperQuestion.checkQuestionScore(locals);
-    helperQuestion.checkAssessmentScore(locals);
-  });
-
-  describe('3. Comprehensive test of all downloads', function () {
-    it('should attempt to download every file in getFilenames', async () => {
-      const assessment = await selectAssessmentById(locals.assessment_id);
-      assert.isNotNull(assessment.assessment_set_id);
-      assert.isTrue(assessment.team_work);
-
-      const filenames: string[] = Object.values(
-        getFilenames({
-          assessment,
-          assessment_set: await selectAssessmentSetById(assessment.assessment_set_id),
-          course_instance: await selectCourseInstanceById(locals.variant.course_instance_id),
-          course: await selectCourseById(locals.variant.course_id),
-        }),
-      );
-
-      await Promise.all(
-        filenames.map(async (filename) => {
-          const downloadUrl =
-            locals.courseInstanceBaseUrl +
-            '/instructor/assessment/' +
-            locals.assessment_id +
-            '/downloads/' +
-            filename;
-          const res = await fetch(downloadUrl);
-          assert.equal(res.status, 200, `Failed to download ${filename}`);
-          if (filename.endsWith('.csv')) {
-            const csvContent = await res.text();
-            const data = csvParse<any>(csvContent, { columns: true, cast: true });
-            assert.isAtLeast(data.length, 1);
-          } else if (filename.endsWith('.zip')) {
-            const zipContent = Buffer.from(await res.arrayBuffer());
-            const zip = await unzipper.Open.buffer(zipContent);
-            assert.isAtLeast(zip.files.length, 1);
-          } else {
-            assert.fail(`Unknown file type: ${filename}`);
-          }
-        }),
-      );
-    });
-  });
-});
+// TODO: Add Group Work tests once team creation helpers are available.
+// Group work exams require creating and joining teams before starting the assessment,
+// which is not currently supported by helperExam.startExam().

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -6,7 +6,10 @@ import fetch from 'node-fetch';
 import * as unzipper from 'unzipper';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
+import { queryRow } from '@prairielearn/postgres';
+
 import { config } from '../lib/config.js';
+import { VariantSchema } from '../lib/db-types.js';
 import type { ResLocalsForPage } from '../lib/res-locals.js';
 import { selectAssessmentSetById } from '../models/assessment-set.js';
 import { selectAssessmentById, selectAssessmentByTid } from '../models/assessment.js';
@@ -405,8 +408,6 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
         assert.isAtLeast(variantInput.length, 1, 'Should have variant_id input');
         ctx.variant_id = variantInput[0].attribs.value;
 
-        const { queryRow } = await import('@prairielearn/postgres');
-        const { VariantSchema } = await import('../lib/db-types.js');
         ctx.variant = await queryRow(
           'SELECT * FROM variants WHERE id = $1',
           [ctx.variant_id],

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -39,6 +39,10 @@ const locals = {} as {
     points: number;
   };
   getSubmittedAnswer: (variant: any) => object;
+  variant: {
+    course_instance_id: string;
+    course_id: string;
+  };
 };
 
 const assessmentPoints = helperExam.exams['exam1-automaticTestSuite'].maxPoints;
@@ -292,7 +296,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
     it('should attempt to download every file in getFilenames', async () => {
       const assessment = await selectAssessmentById(locals.assessment_id);
       assert.isNotNull(assessment.assessment_set_id);
-      assert.isFalse(assessment.group_work);
+      assert.isFalse(assessment.team_work);
 
       const filenames: string[] = Object.values(
         getFilenames({
@@ -403,7 +407,7 @@ describe('Instructor Assessment Downloads - Group Work', { timeout: 60_000 }, fu
     it('should attempt to download every file in getFilenames', async () => {
       const assessment = await selectAssessmentById(locals.assessment_id);
       assert.isNotNull(assessment.assessment_set_id);
-      assert.isTrue(assessment.group_work);
+      assert.isTrue(assessment.team_work);
 
       const filenames: string[] = Object.values(
         getFilenames({

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -299,7 +299,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
 
       assert.isFalse(assessment.group_work);
 
-      const filenames = Object.values(
+      const filenames: string[] = Object.values(
         getFilenames({
           assessment,
           assessment_set: await selectAssessmentSetById(assessment.assessment_set_id),

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -6,12 +6,12 @@ import fetch from 'node-fetch';
 import * as unzipper from 'unzipper';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
+import { config } from '../lib/config.js';
 import type { ResLocalsForPage } from '../lib/res-locals.js';
 import { selectAssessmentSetById } from '../models/assessment-set.js';
 import { selectAssessmentById, selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectCourseById } from '../models/course.js';
-import { config } from '../lib/config.js';
 import { generateAndEnrollUsers } from '../models/enrollment.js';
 import { getFilenames } from '../pages/instructorAssessmentDownloads/instructorAssessmentDownloads.js';
 
@@ -367,18 +367,25 @@ describe('Instructor Assessment Downloads - Group Work', { timeout: 60_000 }, fu
       groupLocals.assessment_id = assessment.id;
       groupLocals.siteUrl = 'http://localhost:' + config.serverPort;
       groupLocals.courseInstanceBaseUrl = groupLocals.siteUrl + '/pl/course_instance/1';
-      groupLocals.assessmentUrl = groupLocals.courseInstanceBaseUrl + '/assessment/' + assessment.id;
+      groupLocals.assessmentUrl =
+        groupLocals.courseInstanceBaseUrl + '/assessment/' + assessment.id;
       groupLocals.instructorAssessmentGroupsUrl =
         groupLocals.courseInstanceBaseUrl + '/instructor/assessment/' + assessment.id + '/groups';
       groupLocals.instructorAssessmentDownloadsUrl =
-        groupLocals.courseInstanceBaseUrl + '/instructor/assessment/' + assessment.id + '/downloads';
+        groupLocals.courseInstanceBaseUrl +
+        '/instructor/assessment/' +
+        assessment.id +
+        '/downloads';
     });
   });
 
   describe('2. Create users and team via instructor interface', function () {
     it('should create 2 users for the team', async () => {
       // exam14-groupWork requires minimum 2 users
-      groupLocals.studentUsers = await generateAndEnrollUsers({ count: 2, course_instance_id: '1' });
+      groupLocals.studentUsers = await generateAndEnrollUsers({
+        count: 2,
+        course_instance_id: '1',
+      });
       assert.lengthOf(groupLocals.studentUsers, 2);
     });
 
@@ -535,7 +542,11 @@ describe('Instructor Assessment Downloads - Group Work', { timeout: 60_000 }, fu
           } else if (filename.endsWith('.zip')) {
             const zipContent = Buffer.from(await res.arrayBuffer());
             const zip = await unzipper.Open.buffer(zipContent);
-            assert.isAtLeast(zip.files.length, 1, `ZIP file ${filename} should have at least 1 file`);
+            assert.isAtLeast(
+              zip.files.length,
+              1,
+              `ZIP file ${filename} should have at least 1 file`,
+            );
           } else {
             assert.fail(`Unknown file type: ${filename}`);
           }

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -60,8 +60,8 @@ async function fetchPage(url: string): Promise<cheerio.CheerioAPI> {
   return cheerio.load(await res.text());
 }
 
-function getCsrfToken($: cheerio.CheerioAPI): string {
-  const elemList = $('form input[name="__csrf_token"]');
+function getCsrfToken($: cheerio.CheerioAPI, selector = 'form'): string {
+  const elemList = $(`${selector} input[name="__csrf_token"]`);
   assert.isAtLeast(elemList.length, 1);
   return elemList[0].attribs.value;
 }
@@ -418,7 +418,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
           method: 'POST',
           body: new URLSearchParams({
             __action: 'grade',
-            __csrf_token: getCsrfToken(ctx.$),
+            __csrf_token: getCsrfToken(ctx.$, '.question-form'),
             __variant_id: ctx.variant_id,
             wx: String(ctx.variant.true_answer.wx),
             wy: String(ctx.variant.true_answer.wy),

--- a/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
@@ -14,7 +14,11 @@
   "zones": [
     {
       "title": "Hard questions",
-      "questions": [{ "id": "positionTimeGraph", "points": [10] }]
+      "questions": [
+        { "id": "addNumbers", "points": [10, 5, 1] },
+        { "id": "addVectors", "points": [10, 5, 1] },
+        { "id": "positionTimeGraph", "points": [10] }
+      ]
     }
   ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
@@ -16,7 +16,6 @@
       "title": "Hard questions",
       "questions": [
         { "id": "addNumbers", "points": [10, 5, 1] },
-        { "id": "addVectors", "points": [10, 5, 1] },
         { "id": "positionTimeGraph", "points": [10] }
       ]
     }


### PR DESCRIPTION
# Description

Closes #12782 . Given the bug found in #12402, I wanted to add a test suite that would hit most instructor download links to make sure they are working.

Initial code was written by Cursor, and then rewritten.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

The coverage report shows that new branches are reached with this change:

<img width="1532" height="1052" alt="CleanShot 2025-09-03 at 09 49 37@2x" src="https://github.com/user-attachments/assets/2eab8a11-0e85-456e-ac9e-17561bd34e99" />


However, this does not test the 'group work' downloads.

<img width="1324" height="1236" alt="CleanShot 2025-09-03 at 09 50 20@2x" src="https://github.com/user-attachments/assets/4ca18ecf-a5b8-419a-9b54-509882d9f0be" />

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
