### PR TITLE
Increase timeout for ip_to_mode

### DIFF
--- a/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/ip_to_mode.test.ts
@@ -34,7 +34,7 @@ describe('sproc ip_to_mode tests', function () {
   });
 
   describe('Center exam with IP restrictions', () => {
-    describe('before check-in', () => {
+    describe('before check-in', { timeout: 20_000 }, () => {
       // This test is oddly flaky in CI (it times out), but not locally. In an
       // effort to figure out what's happening, we're temporarily adding some
       // extra logging here.


### PR DESCRIPTION
# Description

> That flaky test is really annoying... can we just increase the timeout?
> Definitely worth a try. It seems like it's taking just slightly more than 10s to complete? @nwalters512 

This tries to resolve the flaky test by increasing the timeout which has been causing failing CI status checks recently.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

None

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
