### PR TITLE
Fix check for pull request user in changeset CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Check if a changeset is required
         if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group')
           && !contains(github.head_ref, 'changeset-release')
-          && github.actor != 'dependabot[bot]' }}
+          && github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: yarn changeset status --since origin/${{ github.base_ref || 'master' }}
       # This step runs at the end, since it is common for it to fail in
       # dependabot PRs, but we still want all other tests above to run


### PR DESCRIPTION
# Description

Follow-up to #12783. The CI job that checks for changesets has a condition that it doesn't run if github.actor is dependabot. From what I could gather, github.actor is the user that triggered the action, which in the case of PRs is the user that pushed the latest commit. So this will likely not run when dependabot creates the PR, but might run if anyone adds a commit to a dependabot PR (e.g., yarn dedupe or merge with master). This PR changes the check for the PR author, not the commit author.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
