### PR TITLE
Fixup issue with authz middleware and workspaces

### DIFF
--- a/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx
+++ b/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx
@@ -4,7 +4,6 @@ import asyncHandler from 'express-async-handler';
 import * as error from '@prairielearn/error';
 
 import { PageLayout } from '../components/PageLayout.js';
-import { getPageContext } from '../lib/client/page-context.js';
 import { Hydrate } from '../lib/preact.js';
 
 import { AuthzAccessMismatch } from './AuthzAccessMismatch.js';
@@ -21,11 +20,12 @@ export async function authzHasCoursePreviewOrInstanceView(req: Request, res: Res
   if (effectiveAccess) {
     return;
   } else if (authenticatedAccess) {
-    const pageContext = getPageContext(res.locals);
+    // This middleware can run before the csrfToken middleware, so we can't use getPageContext.
+
     return PageLayout({
       resLocals: res.locals,
       navContext: {
-        type: pageContext.navbarType,
+        type: res.locals.navbarType,
         page: 'error',
       },
       pageTitle: 'Insufficient access',
@@ -36,9 +36,9 @@ export async function authzHasCoursePreviewOrInstanceView(req: Request, res: Res
               'has_course_permission_preview',
               'has_course_instance_permission_view',
             ]}
-            authzData={pageContext.authz_data}
-            authnUser={pageContext.authn_user}
-            authzUser={pageContext.authz_data.user}
+            authzData={res.locals.authz_data}
+            authnUser={res.locals.authn_user}
+            authzUser={res.locals.authz_data.user}
           />
         </Hydrate>
       ),

--- a/apps/prairielearn/src/middlewares/authzHelper.tsx
+++ b/apps/prairielearn/src/middlewares/authzHelper.tsx
@@ -9,7 +9,6 @@ import { type NextFunction, type Request, type Response } from 'express';
 import { HttpStatusError } from '@prairielearn/error';
 
 import { PageLayout } from '../components/PageLayout.js';
-import { getPageContext } from '../lib/client/page-context.js';
 import { Hydrate } from '../lib/preact.js';
 
 import {
@@ -67,13 +66,13 @@ export const createAuthzMiddleware =
     }
 
     if (authenticatedAccess && !req.cookies.pl_test_user) {
-      const pageContext = getPageContext(res.locals);
+      // This middleware can run before the csrfToken middleware, so we can't use getPageContext.
 
       res.status(403).send(
         PageLayout({
           resLocals: res.locals,
           navContext: {
-            type: pageContext.navbarType,
+            type: res.locals.navbarType,
             page: 'error',
           },
           pageTitle: 'Insufficient access',
@@ -83,7 +82,7 @@ export const createAuthzMiddleware =
                 errorExplanation={errorExplanation ?? getErrorExplanation(oneOfPermissions)}
                 oneOfPermissionKeys={oneOfPermissions}
                 authzData={authzData}
-                authnUser={pageContext.authn_user}
+                authnUser={res.locals.authn_user}
                 authzUser={authzData.user ?? null}
               />
             </Hydrate>


### PR DESCRIPTION
# Description

@nwalters512 Noticed that certain workspace routes, like `/pl/workspace/3448334/container/JuliaMono-RegularItalic.2433c41d.woff2` don't run the csrf middleware before they run the `authzHasCoursePreviewOrInstanceView` middleware. Thus, we shouldn't use `getPageContext` in the middleware, since the purpose of that function is to make strong assumptions about the structure of `res.locals`. Additionally, we don't need the csrf token on this page.

I also fixed this in the other middleware to avoid other potential issues.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

No testing was done.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
