### PR TITLE
Fix course instance link spacing on homepage

### DIFF
--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -217,17 +217,17 @@ interface CourseInstanceListProps {
 
 function CourseInstanceList({ courseInstances }: CourseInstanceListProps) {
   return (
-    <>
+    <div class="d-flex flex-wrap gap-2 my-1">
       {courseInstances.map((courseInstance) => (
         <a
           key={courseInstance.id}
-          class="btn btn-outline-primary btn-sm my-1"
+          class="btn btn-outline-primary btn-sm"
           href={`${config.urlPrefix}/course_instance/${courseInstance.id}/instructor`}
         >
           {courseInstance.long_name}
         </a>
       ))}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
# Description

Before this change:

<img width="933" height="378" alt="Screenshot 2025-09-04 at 12 56 12" src="https://github.com/user-attachments/assets/3541b763-2b62-4c1e-859f-da238909a710" />

After this change:

<img width="932" height="383" alt="Screenshot 2025-09-04 at 12 50 44" src="https://github.com/user-attachments/assets/d2eabc8a-a60c-4f59-a099-9570fe72b8d2" />

This was a regression from #12728.

# Testing

This is only reproducible in production mode, where we're not rendering "pretty" JSX. The simplest way to reproduce this is to edit this to `pretty = false`:

https://github.com/PrairieLearn/PrairieLearn/blob/d6f506ef590d274fd6f80147c4994cd0abab7bd3/apps/prairielearn/src/lib/preact-html.ts#L24

Note that `renderHtmlDocument` unconditionally uses pretty rendering:

https://github.com/PrairieLearn/PrairieLearn/blob/d6f506ef590d274fd6f80147c4994cd0abab7bd3/apps/prairielearn/src/lib/preact.tsx#L39-L42

We should probably make `renderHtml` and that both behave the same way. I stand by the fact that "pretty" HTML is much easier to debug and that we should keep using it in dev mode, even if there are inconsistencies like this in the render result. IMO it should almost always be a mistake to rely on whitespace for layout.