### PR TITLE
Raise error for group max/min size of 0

### DIFF
--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1248,19 +1248,19 @@ function validateAssessment({
 
     // Ensure values for role minimum and maximum are within bounds
     assessment.groupRoles.forEach((role) => {
-      if (assessment.groupMinSize && role.minimum > assessment.groupMinSize) {
+      if (assessment.groupMinSize != null && role.minimum > assessment.groupMinSize) {
         warnings.push(
           `Group role "${role.name}" has a minimum greater than the group's minimum size.`,
         );
       }
-      if (assessment.groupMaxSize && role.minimum > assessment.groupMaxSize) {
+      if (assessment.groupMaxSize != null && role.minimum > assessment.groupMaxSize) {
         errors.push(
           `Group role "${role.name}" contains an invalid minimum. (Expected at most ${assessment.groupMaxSize}, found ${role.minimum}).`,
         );
       }
       if (
         role.maximum != null &&
-        assessment.groupMaxSize &&
+        assessment.groupMaxSize != null &&
         role.maximum > assessment.groupMaxSize
       ) {
         errors.push(


### PR DESCRIPTION
# Description

Closes #12735 . This was a bug noticed in #12675 . Cursor wrote both the test cases, and the fix, and they were manually vetted. This has the possibility to raise a new error/warning for existing courses that relied on this bug, but I think that we do want to do that.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

No testing was done outside of the test cases added. There is no test for the third branch. The fix and tests look reasonable.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
