### PR TITLE
Make helperExam more generic for doing other exams

### DIFF
--- a/apps/prairielearn/src/tests/api.test.ts
+++ b/apps/prairielearn/src/tests/api.test.ts
@@ -15,21 +15,22 @@ describe('API', { timeout: 60_000 }, function () {
 
   afterAll(helperServer.after);
 
-  helperExam.startExam(locals);
+  helperExam.startExam(locals, 'exam1-automaticTestSuite');
 
   describe('grade correct answer to question addNumbers', function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: 1,
           submission_correct: true,
           instance_question_points: assessmentPoints,
           instance_question_score_perc: (assessmentPoints / 5) * 100,
           assessment_instance_points: assessmentPoints,
-          assessment_instance_score_perc: (assessmentPoints / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc:
+            (assessmentPoints / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -186,7 +187,7 @@ describe('API', { timeout: 60_000 }, function () {
       const assessmentInstance = json[0];
       assert.equal(assessmentInstance.user_uid, 'dev@example.com');
       assert.equal(assessmentInstance.points, assessmentPoints);
-      assert.equal(assessmentInstance.max_points, helperExam.assessmentMaxPoints);
+      assert.equal(assessmentInstance.max_points, helperExam.exam1AutomaticTestSuite.maxPoints);
 
       // Persist the assessment instance ID for later requests
       locals.assessment_instance_id = assessmentInstance.assessment_instance_id;
@@ -209,7 +210,7 @@ describe('API', { timeout: 60_000 }, function () {
       assert.equal(json.assessment_id, locals.assessment_id);
       assert.equal(json.user_uid, 'dev@example.com');
       assert.equal(json.points, assessmentPoints);
-      assert.equal(json.max_points, helperExam.assessmentMaxPoints);
+      assert.equal(json.max_points, helperExam.exam1AutomaticTestSuite.maxPoints);
     });
 
     test.sequential('GET to API for assessment submissions succeeds', async function () {
@@ -265,7 +266,7 @@ describe('API', { timeout: 60_000 }, function () {
       const assessment = user.assessments.find((o) => o.assessment_label === 'E1');
       assert.exists(assessment);
       assert.equal(assessment.points, assessmentPoints);
-      assert.equal(assessment.max_points, helperExam.assessmentMaxPoints);
+      assert.equal(assessment.max_points, helperExam.exam1AutomaticTestSuite.maxPoints);
     });
 
     test.sequential('GET to API for assessment instance questions succeeds', async function () {

--- a/apps/prairielearn/src/tests/clientFiles.test.ts
+++ b/apps/prairielearn/src/tests/clientFiles.test.ts
@@ -32,7 +32,7 @@ describe('Client files endpoints', () => {
 
   // TODO: refactor this to be a function that we can call in a `before` hook.
   // Right now, this actually creates a bunch of `describe()` blocks and tests.
-  helperExam.startExam({});
+  helperExam.startExam({}, 'exam1-automaticTestSuite');
 
   describe('clientFilesCourse', () => {
     it('works for instructor course instance URL', async () => {

--- a/apps/prairielearn/src/tests/exam.test.ts
+++ b/apps/prairielearn/src/tests/exam.test.ts
@@ -592,7 +592,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
 
   let elemList;
 
-  helperExam.startExam(locals);
+  helperExam.startExam(locals, 'exam1-automaticTestSuite');
 
   describe('6. assessment_instance: set attach files page URL', function () {
     it('should succeed', function () {
@@ -626,7 +626,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('setting up the question data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
       });
     });
     helperQuestion.getInstanceQuestion(locals);
@@ -664,7 +664,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'save';
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
         locals.expectedResult = {
           submission_score: null,
           submission_correct: null,
@@ -673,7 +673,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 0,
-          assessment_instance_score_perc: (0 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (0 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -694,7 +694,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
         locals.expectedResult = {
           submission_score: 0,
           submission_correct: false,
@@ -703,7 +703,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 0,
-          assessment_instance_score_perc: (0 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (0 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (_variant) {
           return {
@@ -724,7 +724,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: 0,
           submission_correct: false,
@@ -733,7 +733,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 0,
-          assessment_instance_score_perc: (0 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (0 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -753,7 +753,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.fossilFuelsRadio;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
         locals.expectedResult = {
           submission_score: 0,
           submission_correct: false,
@@ -762,7 +762,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 0,
-          assessment_instance_score_perc: (0 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (0 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -782,7 +782,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: null,
           submission_correct: null,
@@ -791,7 +791,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 0,
-          assessment_instance_score_perc: (0 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (0 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (_variant) {
           return {
@@ -823,7 +823,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'save';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.getSubmittedAnswer = function (variant) {
           return {
             c: variant.true_answer.c - 1,
@@ -842,7 +842,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['tryAgain'];
         locals.postAction = 'save';
-        locals.question = helperExam.questions.brokenGeneration;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.brokenGeneration;
       });
       it('should result in no variants', async () => {
         const rowCount = await sqldb.execute(sql.select_variants_for_qid, {
@@ -883,7 +883,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
       });
     });
     helperQuestion.getInstanceQuestion(locals);
@@ -900,7 +900,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: 1,
           submission_correct: true,
@@ -909,7 +909,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 3,
           instance_question_manual_points: 0,
           assessment_instance_points: 3,
-          assessment_instance_score_perc: (3 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (3 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -927,7 +927,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
   describe('25. save correct answer to saved question addNumbers page', function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.postAction = 'save';
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -950,7 +950,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'save';
-        locals.question = helperExam.questions.fossilFuelsRadio;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
         locals.expectedResult = {
           submission_score: null,
           submission_correct: null,
@@ -959,7 +959,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 3,
-          assessment_instance_score_perc: (3 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (3 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -978,7 +978,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
       });
     });
     helperQuestion.getInstanceQuestion(locals);
@@ -995,7 +995,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
         locals.expectedResult = {
           submission_score: 0,
           submission_correct: false,
@@ -1004,7 +1004,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 3,
-          assessment_instance_score_perc: (3 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (3 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (_variant) {
           return {
@@ -1023,7 +1023,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
   describe('29. submit correct answer to saved question addVectors page', function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
         locals.postAction = 'save';
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -1046,7 +1046,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
-        locals.question = helperExam.questions.fossilFuelsRadio;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
       });
     });
     helperQuestion.getInstanceQuestion(locals);
@@ -1067,7 +1067,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
   describe('32. save correct answer to saved question fossilFuelsRadio page', function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
-        locals.question = helperExam.questions.fossilFuelsRadio;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
         locals.postAction = 'save';
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -1095,7 +1095,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the regrading succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             submission_score: 1,
             submission_correct: true,
@@ -1109,7 +1109,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             submission_score: 0,
             submission_correct: false,
@@ -1123,7 +1123,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             submission_score: null,
             submission_correct: null,
@@ -1139,7 +1139,8 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedResult = {
             assessment_instance_points: 24,
-            assessment_instance_score_perc: (24 / helperExam.assessmentMaxPoints) * 100,
+            assessment_instance_score_perc:
+              (24 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
           };
         });
       });
@@ -1161,7 +1162,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the instance question score upload succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             instance_question_points: 2,
             instance_question_score_perc: (2 / 5) * 100,
@@ -1173,7 +1174,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             instance_question_points: 10.5,
             instance_question_score_perc: (10.5 / 21) * 100,
@@ -1185,7 +1186,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             instance_question_points: 0,
             instance_question_score_perc: (0 / 17) * 100,
@@ -1199,7 +1200,8 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedResult = {
             assessment_instance_points: 12.5,
-            assessment_instance_score_perc: (12.5 / helperExam.assessmentMaxPoints) * 100,
+            assessment_instance_score_perc:
+              (12.5 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
           };
         });
       });
@@ -1208,7 +1210,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { manual: 'feedback numbers' },
           };
         });
@@ -1218,7 +1220,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.addVectors.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors.qid,
             feedback: { manual: 'feedback vectors' },
           };
         });
@@ -1228,7 +1230,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.fossilFuelsRadio.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio.qid,
             feedback: null,
           };
         });
@@ -1242,7 +1244,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should get the submission_ids for addNumbers', async () => {
         const result = await sqldb.queryRows(
           sql.select_submissions_by_qid,
-          { qid: helperExam.questions.addNumbers.qid },
+          { qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid },
           SubmissionSchema,
         );
         const rowCount = result.length;
@@ -1268,7 +1270,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the instance question score upload succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             instance_question_points: 4.7,
             instance_question_score_perc: (4.7 / 5) * 100,
@@ -1280,7 +1282,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             instance_question_points: 1.2,
             instance_question_score_perc: (1.2 / 21) * 100,
@@ -1292,7 +1294,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             instance_question_points: 0,
             instance_question_score_perc: (0 / 17) * 100,
@@ -1306,7 +1308,8 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedResult = {
             assessment_instance_points: 5.9,
-            assessment_instance_score_perc: (5.9 / helperExam.assessmentMaxPoints) * 100,
+            assessment_instance_score_perc:
+              (5.9 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
           };
         });
       });
@@ -1315,7 +1318,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_for_feedback,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { msg: 'feedback numbers 2' },
           };
         });
@@ -1325,7 +1328,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserve0,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: {},
           };
         });
@@ -1335,7 +1338,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserve1,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: null,
           };
         });
@@ -1345,7 +1348,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserveN,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { manual: 'feedback numbers' },
           };
         });
@@ -1355,7 +1358,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.addVectors.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors.qid,
             feedback: { manual: 'feedback vectors' },
           };
         });
@@ -1365,7 +1368,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.fossilFuelsRadio.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio.qid,
             feedback: null,
           };
         });
@@ -1384,7 +1387,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the assessment instance score upload succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             instance_question_points: 4.7,
             instance_question_score_perc: (4.7 / 5) * 100,
@@ -1396,7 +1399,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             instance_question_points: 1.2,
             instance_question_score_perc: (1.2 / 21) * 100,
@@ -1408,7 +1411,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             instance_question_points: 0,
             instance_question_score_perc: (0 / 17) * 100,
@@ -1421,7 +1424,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       describe('setting up the expected assessment results', function () {
         it('should succeed', function () {
           locals.expectedResult = {
-            assessment_instance_points: (43.7 / 100) * helperExam.assessmentMaxPoints,
+            assessment_instance_points: (43.7 / 100) * helperExam.exam1AutomaticTestSuite.maxPoints,
             assessment_instance_score_perc: 43.7,
           };
         });
@@ -1440,7 +1443,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the assessment instance score upload succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             instance_question_points: 4.7,
             instance_question_score_perc: (4.7 / 5) * 100,
@@ -1452,7 +1455,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             instance_question_points: 1.2,
             instance_question_score_perc: (1.2 / 21) * 100,
@@ -1464,7 +1467,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             instance_question_points: 0,
             instance_question_score_perc: (0 / 17) * 100,
@@ -1478,7 +1481,8 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedResult = {
             assessment_instance_points: 29.6,
-            assessment_instance_score_perc: (29.6 / helperExam.assessmentMaxPoints) * 100,
+            assessment_instance_score_perc:
+              (29.6 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
           };
         });
       });
@@ -1491,7 +1495,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should get the submission_ids for addNumbers', async () => {
         const result = await sqldb.queryRows(
           sql.select_submissions_by_qid,
-          { qid: helperExam.questions.addNumbers.qid },
+          { qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid },
           SubmissionSchema,
         );
         const rowCount = result.length;
@@ -1518,7 +1522,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the instance question score upload succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             instance_question_points: 3.5,
             instance_question_score_perc: (3.5 / 5) * 100,
@@ -1530,7 +1534,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             instance_question_points: 0.9,
             instance_question_score_perc: (0.9 / 21) * 100,
@@ -1542,7 +1546,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             instance_question_points: 2.9,
             instance_question_score_perc: (2.9 / 17) * 100,
@@ -1556,7 +1560,8 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedResult = {
             assessment_instance_points: 7.3,
-            assessment_instance_score_perc: (7.3 / helperExam.assessmentMaxPoints) * 100,
+            assessment_instance_score_perc:
+              (7.3 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
           };
         });
       });
@@ -1565,7 +1570,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_for_feedback,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { msg: 'feedback numbers 2' },
           };
         });
@@ -1575,7 +1580,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserve0,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: {},
           };
         });
@@ -1585,7 +1590,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserve1,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: null,
           };
         });
@@ -1595,7 +1600,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserveN,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { manual: 'feedback numbers' },
           };
         });
@@ -1605,7 +1610,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.addVectors.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors.qid,
             feedback: { manual: 'feedback vectors' },
           };
         });
@@ -1615,7 +1620,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.fossilFuelsRadio.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio.qid,
             feedback: null,
           };
         });
@@ -1629,7 +1634,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       it('should get the submission_ids for addNumbers', async () => {
         const result = await sqldb.queryRows(
           sql.select_submissions_by_qid,
-          { qid: helperExam.questions.addNumbers.qid },
+          { qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid },
           SubmissionSchema,
         );
         const rowCount = result.length;
@@ -1656,7 +1661,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
     describe('check the instance question score upload succeeded', function () {
       describe('setting up the expected question addNumbers results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addNumbers;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
           locals.expectedResult = {
             instance_question_points: 2.2,
             instance_question_score_perc: (2.2 / 5) * 100,
@@ -1668,7 +1673,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question addVectors results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.addVectors;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
           locals.expectedResult = {
             instance_question_points: 12.7,
             instance_question_score_perc: (12.7 / 21) * 100,
@@ -1680,7 +1685,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
       helperQuestion.checkQuestionScore(locals);
       describe('setting up the expected question fossilFuelsRadio results', function () {
         it('should succeed', function () {
-          locals.question = helperExam.questions.fossilFuelsRadio;
+          locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio;
           locals.expectedResult = {
             instance_question_points: 8,
             instance_question_score_perc: (8 / 17) * 100,
@@ -1694,7 +1699,8 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedResult = {
             assessment_instance_points: 22.9,
-            assessment_instance_score_perc: (22.9 / helperExam.assessmentMaxPoints) * 100,
+            assessment_instance_score_perc:
+              (22.9 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
           };
         });
       });
@@ -1703,7 +1709,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_for_feedback,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { msg: 'feedback numbers 2' },
           };
         });
@@ -1713,7 +1719,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserve0,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: {},
           };
         });
@@ -1723,7 +1729,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserve1,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: null,
           };
         });
@@ -1733,7 +1739,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: locals.submission_id_preserveN,
-            qid: helperExam.questions.addNumbers.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers.qid,
             feedback: { manual: 'feedback numbers' },
           };
         });
@@ -1743,7 +1749,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.addVectors.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors.qid,
             feedback: { manual: 'feedback vectors' },
           };
         });
@@ -1753,7 +1759,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         it('should succeed', function () {
           locals.expectedFeedback = {
             submission_id: null,
-            qid: helperExam.questions.fossilFuelsRadio.qid,
+            qid: helperExam.exam1AutomaticTestSuite.keyedQuestions.fossilFuelsRadio.qid,
             feedback: null,
           };
         });
@@ -1773,7 +1779,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
         });
       });
 
-      helperExam.startExam(locals);
+      helperExam.startExam(locals, 'exam1-automaticTestSuite');
 
       partialCreditTest.forEach(function (questionTest, iQuestionTest) {
         describe(`${questionTest.action} answer number #${iQuestionTest + 1} for question ${
@@ -1787,7 +1793,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
                 locals.shouldHaveButtons = ['grade', 'save'];
               }
               locals.postAction = questionTest.action;
-              locals.question = helperExam.questions[questionTest.qid];
+              locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions[questionTest.qid];
               locals.question.points += questionTest.sub_points;
               locals.totalPoints += questionTest.sub_points;
               locals.expectedResult = {
@@ -1801,7 +1807,7 @@ describe('Exam assessment', { timeout: 60_000 }, function () {
                 instance_question_manual_points: 0,
                 assessment_instance_points: locals.totalPoints,
                 assessment_instance_score_perc:
-                  (locals.totalPoints / helperExam.assessmentMaxPoints) * 100,
+                  (locals.totalPoints / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
                 instance_question_stats: questionTest.stats,
               };
               locals.getSubmittedAnswer = function (_variant) {

--- a/apps/prairielearn/src/tests/instructorAssessment.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessment.test.ts
@@ -17,14 +17,14 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
 
   let page, elemList;
 
-  helperExam.startExam(locals);
+  helperExam.startExam(locals, 'exam1-automaticTestSuite');
 
   describe('1. grade incorrect answer to question addNumbers', function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: 0,
           submission_correct: false,
@@ -33,7 +33,7 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
           instance_question_auto_points: 0,
           instance_question_manual_points: 0,
           assessment_instance_points: 0,
-          assessment_instance_score_perc: (0 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (0 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -53,7 +53,7 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: 1,
           submission_correct: true,
@@ -62,7 +62,7 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
           instance_question_auto_points: 3,
           instance_question_manual_points: 0,
           assessment_instance_points: 3,
-          assessment_instance_score_perc: (3 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (3 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -82,7 +82,7 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addVectors;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addVectors;
         locals.expectedResult = {
           submission_score: 1,
           submission_correct: true,
@@ -91,7 +91,7 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
           instance_question_auto_points: 11,
           instance_question_manual_points: 0,
           assessment_instance_points: 14,
-          assessment_instance_score_perc: (14 / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc: (14 / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -428,7 +428,10 @@ describe('Instructor assessment editing', { timeout: 20_000 }, function () {
       elemList = locals.$('#total-points');
       assert.lengthOf(elemList, 1);
       const totalPoints = Number.parseFloat(elemList[0].children[0].data);
-      assert.equal(totalPoints, (assessmentSetScorePerc / 100) * helperExam.assessmentMaxPoints);
+      assert.equal(
+        totalPoints,
+        (assessmentSetScorePerc / 100) * helperExam.exam1AutomaticTestSuite.maxPoints,
+      );
     });
   });
 

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -19,21 +19,22 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
 
   let elemList, page;
 
-  helperExam.startExam(locals);
+  helperExam.startExam(locals, 'exam1-automaticTestSuite');
 
   describe('1. grade correct answer to question addNumbers', function () {
     describe('setting up the submission data', function () {
       it('should succeed', function () {
         locals.shouldHaveButtons = ['grade', 'save'];
         locals.postAction = 'grade';
-        locals.question = helperExam.questions.addNumbers;
+        locals.question = helperExam.exam1AutomaticTestSuite.keyedQuestions.addNumbers;
         locals.expectedResult = {
           submission_score: 1,
           submission_correct: true,
           instance_question_points: assessmentPoints,
           instance_question_score_perc: (assessmentPoints / 5) * 100,
           assessment_instance_points: assessmentPoints,
-          assessment_instance_score_perc: (assessmentPoints / helperExam.assessmentMaxPoints) * 100,
+          assessment_instance_score_perc:
+            (assessmentPoints / helperExam.exam1AutomaticTestSuite.maxPoints) * 100,
         };
         locals.getSubmittedAnswer = function (variant) {
           return {
@@ -149,7 +150,11 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
       assert.equal(data[0]['Assessment'], 'Exam 1');
       assert.approximately(data[0]['Score (%)'], locals.assessment_instance.score_perc, 1e-6);
       assert.approximately(data[0]['Points'], locals.assessment_instance.points, 1e-6);
-      assert.approximately(data[0]['Max points'], helperExam.assessmentMaxPoints, 1e-6);
+      assert.approximately(
+        data[0]['Max points'],
+        helperExam.exam1AutomaticTestSuite.maxPoints,
+        1e-6,
+      );
     });
   });
 
@@ -168,7 +173,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
       assert(data.every((entry) => entry['UID'] === 'dev@example.com'));
       assert(data.every((entry) => entry['Assessment'] === 'Exam 1'));
       const questions = data.map((entry) => entry['Question']).sort();
-      const expectedQuestions = helperExam.questionsArray.map((q) => q.qid);
+      const expectedQuestions = helperExam.exam1AutomaticTestSuite.questions.map((q) => q.qid);
       assert.deepEqual(questions, expectedQuestions);
     });
   });


### PR DESCRIPTION
# Description

@mylesw27 pointed out in #12788 that we should really be testing exams other than the helperExam. This PR makes that generic, so that in #12788 I _can_ test a group exam somewhat easily. No AI was used.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

No testing done, the test suite should be sufficient.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
