### PR TITLE
Fix invalid authentication provider message

### DIFF
--- a/apps/prairielearn/src/lib/authn.ts
+++ b/apps/prairielearn/src/lib/authn.ts
@@ -131,8 +131,6 @@ export async function loadUser(
       SprocUsersSelectOrInsertSchema,
     );
 
-    assert(userSelectOrInsertRes.user_id !== null);
-    user_id = userSelectOrInsertRes.user_id;
     const { result, user_institution_id } = userSelectOrInsertRes;
     if (result === 'invalid_authn_provider') {
       assert(user_institution_id !== null);
@@ -140,6 +138,9 @@ export async function loadUser(
         `/pl/login?unsupported_provider=true&institution_id=${user_institution_id}`,
       );
     }
+
+    assert(userSelectOrInsertRes.user_id !== null);
+    user_id = userSelectOrInsertRes.user_id;
   }
 
   const selectedUser = await sqldb.queryOptionalRow(sql.select_user, { user_id }, SelectUserSchema);


### PR DESCRIPTION
# Description

This regressed in #12703. The expected behavior is that `user_id` _will_ be null if `result === 'invalid_authn_provider'`; that PR was making the assertion too early.

This hasn't blocked anyone from being able to sign in with Azure who would otherwise be able to, but it has meant that students receive a completely opaque and unhelpful error message when they try to sign in with an invalid provider for their institution.

# Testing

Untested, but this should clearly work from looking at the Sentry error and the code here.
