### PR TITLE
Change condition for changeset check in version packages PR

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,7 +87,7 @@ jobs:
       # because the base ref is potentially different.
       - name: Check if a changeset is required
         if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group')
-          && !contains(github.head_ref, 'changeset-release')
+          && !contains(github.event.pull_request.head.ref, 'changeset-release')
           && github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: yarn changeset status --since origin/${{ github.base_ref || 'master' }}
       # This step runs at the end, since it is common for it to fail in


### PR DESCRIPTION
# Description

The new CI test for the existence of changesets has a condition that causes it not to run for dependabot and "Version packages" PRs. For the latter, the check is done using the head_ref variable. The problem is that, in merge commit checks, this variable will have the branch name of the merge group, not the original branch, which causes it to fail in "Version packages" PRs (see https://github.com/PrairieLearn/PrairieLearn/actions/runs/17480060088/job/49648594444).

The PR is an attempt to change this check so that the identification of "Version packages" PRs is based on the head ref of the pull request, not the current branch.

# Testing

I don't see a way to test this other than to merge it and then try to merge #12800.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
