### PR TITLE
Skip changeset check in merge CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,9 +84,13 @@ jobs:
       - name: Run the GitHub Actions linter
         run: make lint-actions
       # Requires Git history and yarn install. Not using the make version
-      # because the base ref is potentially different.
+      # because the base ref is potentially different. Does not run in
+      # changeset-release or dependabot PRs, since they are expected to change
+      # packages without creating a changeset. Also does not run in merge_group
+      # events due to issues with the check for changeset, which can be tricky
+      # in merge branches.
       - name: Check if a changeset is required
-        if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+        if: ${{github.event_name == 'pull_request'
           && !contains(github.event.pull_request.head.ref, 'changeset-release')
           && github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: yarn changeset status --since origin/${{ github.base_ref || 'master' }}


### PR DESCRIPTION
# Description

Follow-up to #12822, which didn't resolve the issue. After changing ideas with @nwalters512, we decided that it should be ok to skip this test altogether in merge CI.

# Testing

Again, we can only test it by merging it and then merging #12800.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
