### PR TITLE
Fix external grader accepting scores without number validation

### DIFF
--- a/apps/prairielearn/src/lib/externalGraderCommon.ts
+++ b/apps/prairielearn/src/lib/externalGraderCommon.ts
@@ -178,7 +178,7 @@ export function makeGradingResult(jobId: string, rawData: Record<string, any> | 
   }
 
   let score = 0;
-  if (typeof data.results.score === 'number' || !Number.isNaN(data.results.score)) {
+  if (typeof data.results.score === 'number' && !Number.isNaN(data.results.score)) {
     score = data.results.score;
   } else {
     return makeGradingFailureWithMessage(


### PR DESCRIPTION
# Description

I noticed this logic bug while working on something else. If the score provided passes `!Number.isNaN` (which is almost everything), it doesn't need to be a number.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

No testing was done.

```ts
Number.isNaN('WHAT')
// false
```

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
