### PR TITLE
Fix question plan grant checking, part 2

### DIFF
--- a/apps/prairielearn/src/ee/lib/billing/plans.ts
+++ b/apps/prairielearn/src/ee/lib/billing/plans.ts
@@ -262,10 +262,7 @@ export function planGrantsMatchFeatures(
 ): boolean {
   const grantedPlans = getPlansForPlanGrants(planGrants);
   const grantedFeatures = getFeaturesForPlans(grantedPlans);
-  return (
-    grantedFeatures.length === features.length &&
-    grantedFeatures.every((feature) => features.includes(feature))
-  );
+  return features.every((feature) => grantedFeatures.includes(feature));
 }
 
 /**


### PR DESCRIPTION
# Description

This is a continuation of #12785. That PR meant that we're now actually hitting this checking codepath, which unfortunately was just broken.

# Testing

I tested this locally with the following steps:

- Enable the `course-instance-billing` and `enforce-plan-grants-for-questions` feature flags.
- In QA 101 Spring 2015, enable student billing with external graders and workspaces from the "Billing" tab under settings.
- Insert plan grants for a `student@example.com` user (I had previously logged in as the user)
    ```sql
    SELECT user_id FROM users WHERE uid = 'student@example.com';
    INSERT INTO plan_grants (institution_id, course_instance_id, plan_name, type, user_id) VALUES (1, $course_instance_id, 'basic', 'gift', $user_id);
    INSERT INTO plan_grants (institution_id, course_instance_id, plan_name, type, user_id) VALUES (1, $course_instance_id, 'compute', 'gift',$user_id);
    ```
- Log in as "student@example.com", enroll in QA 101 Spring 2015, open Homework 9 ("Homework for Internal, External, Manual grading methods").
- Try to open the question "External Grading: Alpine Linux smoke test".

On master, you'd be greeted with an error. On this branch, the student can access the question as expected.
