### PR TITLE
Upgrade from ES2021 to ES2022

### DIFF
--- a/apps/prairielearn/assets/scripts/tsconfig.json
+++ b/apps/prairielearn/assets/scripts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021", "DOM"],
+    "lib": ["ES2022", "DOM"],
     "noEmit": true,
     "rootDir": "../../",
     "outDir": "../../public/build/scripts",


### PR DESCRIPTION
# Description

This bumps the version for `assets/scripts` from ES2021 to ES2022 so that I can use [`Intl.supportedValuesOf('timeZone')`](https://github.com/microsoft/TypeScript/issues/49231#issuecomment-1740901574) in #12835.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

No testing done.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
