### PR TITLE
Require type parameter when fetching from the cache

### DIFF
--- a/.changeset/dark-radios-punch.md
+++ b/.changeset/dark-radios-punch.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/cache': minor
+---
+
+Require a type parameter for fetching from the cache

--- a/.changeset/dark-radios-punch.md
+++ b/.changeset/dark-radios-punch.md
@@ -2,4 +2,4 @@
 '@prairielearn/cache': minor
 ---
 
-Require a type parameter for fetching from the cache
+Add support for an optional type parameter to `cache.get(...)`

--- a/.changeset/dark-radios-punch.md
+++ b/.changeset/dark-radios-punch.md
@@ -1,5 +1,5 @@
 ---
-'@prairielearn/cache': major
+'@prairielearn/cache': minor
 ---
 
 Require a type parameter for fetching from the cache

--- a/.changeset/dark-radios-punch.md
+++ b/.changeset/dark-radios-punch.md
@@ -1,5 +1,5 @@
 ---
-'@prairielearn/cache': minor
+'@prairielearn/cache': major
 ---
 
 Require a type parameter for fetching from the cache

--- a/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
+++ b/apps/prairielearn/src/ee/lib/aiQuestionGeneration.ts
@@ -264,7 +264,7 @@ const intervalLengthMs = 3600 * 1000;
  */
 export async function getIntervalUsage({ userId }: { userId: number }) {
   const cache = await getAiQuestionGenerationCache();
-  return (await cache.get(getIntervalUsageKey(userId))) ?? 0;
+  return (await cache.get<number>(getIntervalUsageKey(userId))) ?? 0;
 }
 
 /**

--- a/apps/prairielearn/src/ee/lib/billing/stripe.ts
+++ b/apps/prairielearn/src/ee/lib/billing/stripe.ts
@@ -66,7 +66,7 @@ function stripeProductCacheKey(id: string): string {
  */
 export async function getStripeProduct(id: string): Promise<Stripe.Product> {
   const cacheKey = stripeProductCacheKey(id);
-  let product: Stripe.Product = await cache.get(cacheKey);
+  let product = await cache.get<Stripe.Product>(cacheKey);
   if (!product) {
     const stripe = getStripeClient();
     product = await stripe.products.retrieve(id, { expand: ['default_price'] });

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -97,7 +97,7 @@ export class Cache {
   /**
    * Returns the value for the corresponding key if it exists in the cache; null otherwise.
    */
-  async get(key: string): Promise<any> {
+  async get<T>(key: string): Promise<T | null> {
     if (!this.enabled) return null;
 
     const scopedKey = this.keyPrefix + key;
@@ -109,7 +109,7 @@ export class Cache {
         if (typeof value === 'string') {
           return JSON.parse(value);
         }
-        return undefined;
+        return null;
       }
 
       case 'redis': {
@@ -118,7 +118,7 @@ export class Cache {
         if (typeof value === 'string') {
           return JSON.parse(value);
         }
-        return undefined;
+        return null;
       }
 
       default: {


### PR DESCRIPTION
# Description

Noticed in #12818 that cache accesses are typed as any, which makes downstream types incorrect
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

None.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
