### PR TITLE
Fix rendering of `<pl-distributed-load>`

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -1078,6 +1078,9 @@ mechanicsObjects.DistTrianLoad = fabric.util.createClass(fabric.Object, {
     this.flipped = options.flipped || false;
     this.flipX = this.flipped;
 
+    // This is important to render the controls and drawing at the correct size.
+    this.strokeUniform = true;
+
     this.label1 = options.label1;
     this.offsetx1 = options.offsetx1;
     this.offsety1 = options.offsety1;
@@ -1111,6 +1114,14 @@ mechanicsObjects.DistTrianLoad = fabric.util.createClass(fabric.Object, {
     const arrowheadOffsetRatio = this.arrowheadOffsetRatio;
     const arrowheadWidthRatio = this.arrowheadWidthRatio;
     const strokeWidth = this.strokeWidth;
+
+    // We need to adjust the end of the arrowhead so that it sits within the
+    // bounding box that students will use when resizing the element. This
+    // ensures that what's rendered is as close as possible to the values
+    // that are being graded.
+    //
+    // This offset was determined empirically. Don't ask about the math.
+    y2 -= this.strokeWidth;
 
     // Forward vector
     let fwdx = x2 - x1;
@@ -1152,15 +1163,20 @@ mechanicsObjects.DistTrianLoad = fabric.util.createClass(fabric.Object, {
     ctx.fill();
   },
   _render(ctx) {
-    const nSpaces = Math.ceil(this.getScaledWidth() / this.spacing);
-    const dx = this.getScaledWidth() / nSpaces;
+    // We manually compute these values as `getScaledWidth()` and `getScaledHeight()`
+    // include the stroke width, which we don't want.
+    const scaledWidth = this.width * this.scaleX;
+    const scaledHeight = this.height * this.scaleY;
+
+    const nSpaces = Math.ceil(scaledWidth / this.spacing);
+    const dx = scaledWidth / nSpaces;
 
     // Undo Fabric's scale transformation.
     ctx.scale(1 / this.scaleX, 1 / this.scaleY);
 
     // Centered coordinates
-    const cx = this.getScaledWidth() / 2;
-    const cy = this.getScaledHeight() / 2;
+    const cx = scaledWidth / 2;
+    const cy = scaledHeight / 2;
 
     // Draw all the force arrows
     for (let i = 0; i <= nSpaces; i++) {
@@ -1173,13 +1189,10 @@ mechanicsObjects.DistTrianLoad = fabric.util.createClass(fabric.Object, {
         this.drawArrow(ctx, i * dx - cx, cy - height, i * dx - cx, cy);
       }
     }
+
     // Draw the head/base line
-    if (this.anchor_is_tail) {
-      this.drawLine(ctx, -cx, -cy, cx, -cy);
-    } else {
-      const xoff = this.strokeWidth / 2;
-      this.drawLine(ctx, -cx - xoff, cy - this.w1, cx + xoff, cy - this.w2);
-    }
+    const xoff = this.strokeWidth / 2;
+    this.drawLine(ctx, -cx - xoff, cy - this.w1, cx + xoff, cy - this.w2);
 
     this.label1obj.left = this.offsetx1 - cx;
     this.label1obj.top = this.w1 + this.offsety1 - cy;


### PR DESCRIPTION
# Description

This PR resolves the underlying issue that was identified in #12525.

I made these fixes largely by trial and error. The two key changes were adding `this.strokeUniform = true` and dropping the use of `this.getScaledWidth()` and `this.getScaledHeight()`. I could probably explain the math if I tried hard enough, but hopefully it's clear that the end result is doing the right thing.

While I was here, I tweaked the arrows to draw within the bounding box. See the inline comment for why this is important.

# Testing

Create a question with the following `question.html`:

```html
<p>
  <pl-drawing
    gradable="true"
    answers-name="vm_diag"
    width="540"
    height="500"
    hide-answer-panel="false"
  >
    <pl-drawing-initial>
      <pl-rectangle
        x1="160"
        y1="310"
        width="160"
        height="20"
        color="white"
      ></pl-rectangle>
      <pl-point x1="160" y1="310" label="Anchor"></pl-point>
    </pl-drawing-initial>

    <pl-drawing-answer draw-error-box="true">
      <pl-distributed-load
        x1="160"
        y1="310"
        anchor-is-tail="false"
        width="160"
        angle="0"
        offset-forward="10"
        offset-backward="70"
      ></pl-distributed-load>
    </pl-drawing-answer>

    <pl-controls>
      <pl-controls-group label="Graded objects:">
        <pl-drawing-button type="pl-distributed-load"></pl-drawing-button>
      </pl-controls-group>
      <pl-controls-group label="Help buttons (not graded):">
        <pl-drawing-button type="delete"></pl-drawing-button>
      </pl-controls-group>
    </pl-controls>
  </pl-drawing>
</p>
```

Follow the instructions from https://github.com/PrairieLearn/PrairieLearn/issues/12525#issuecomment-3276671620 to test. They'll get 100% on this branch, 0% on master.

To really check the math, add a log of `range` after this:

https://github.com/PrairieLearn/PrairieLearn/blob/1db7d5c3525d139134117924cd01013efe03adee/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js#L1106

Size the load to be as close to the width of the beam as possible:

<img width="550" height="456" alt="Screenshot 2025-09-10 at 16 32 52" src="https://github.com/user-attachments/assets/2ba647e2-248f-416e-aefc-d92e7e3f5a08" />

Check the console. On this branch, that value should be something very close to 160. On `master`, it'll be a smaller value (for me, closer to 152).

For completeness, here's an answer rendered with `stroke-width="1"`, everything still looks good:

<img width="453" height="274" alt="Screenshot 2025-09-10 at 16 38 45" src="https://github.com/user-attachments/assets/e77103b0-a22e-4a1d-bd1f-c42a1eb97c2e" />