### PR TITLE
Exclude URL parameters in CSRF check

### DIFF
--- a/apps/prairielearn/src/middlewares/csrfToken.ts
+++ b/apps/prairielearn/src/middlewares/csrfToken.ts
@@ -6,10 +6,9 @@ import { checkSignedToken, generateSignedToken } from '@prairielearn/signed-toke
 import { config } from '../lib/config.js';
 
 export default asyncHandler(async (req, res, next) => {
-  // We don't want to include the query params in the CSRF token checks.
-  const baseUrl = req.originalUrl.split('?')[0];
   const tokenData = {
-    url: baseUrl,
+    // We don't want to include the query params in the CSRF token checks.
+    url: req.originalUrl.split('?')[0],
     authn_user_id: res.locals.authn_user?.user_id,
   };
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

I noticed this while testing #12854 . We shouldn't consider URL parameters when doing a CSRF check.

# Testing

On master:

- Navigate to the students page, which gets a CSRF token based on the current URL.
- Apply a filter which changes the URL parameters
- Invite a student
- This considers URL parameters, and fails with a 403

On this branch:

- This works

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
