### PR TITLE
Use `order` instead of `fixed-order` for all multiple choice questions

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -796,7 +796,7 @@ The attributes `none-of-the-above` and `all-of-the-above` can be set to one of t
 
 ##### :pencil: Notes
 
-- "All of the above" and "None of the above", if set, are bounded by the `number-answers` value above. Also, these two values are always shown as the last choices, regardless of the setting for `fixed-order`. If both choices are shown, then "All of the above" will be listed before "None of the above".
+- "All of the above" and "None of the above", if set, are bounded by the `number-answers` value above. Also, these two values are always shown as the last choices, regardless of the setting for `order`. If both choices are shown, then "All of the above" will be listed before "None of the above".
 - Defining answer choices with external JSON files via the `external-json` attribute is now deprecated.
 
 Inside the `pl-multiple-choice` element, each choice must be specified with

--- a/exampleCourse/questions/demo/insertEmbeddedVideo/question.html
+++ b/exampleCourse/questions/demo/insertEmbeddedVideo/question.html
@@ -15,7 +15,7 @@
   >
     <p>Did you find this video beneficial?</p>
 
-    <pl-multiple-choice answers-name="survey" weight="1" inline="true" fixed-order="true">
+    <pl-multiple-choice answers-name="survey" weight="1" inline="true" order="fixed">
       <pl-answer correct="true">Yes</pl-answer>
       <pl-answer correct="false">No</pl-answer>
     </pl-multiple-choice>

--- a/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/README.md
+++ b/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/README.md
@@ -1,1 +1,1 @@
-This question randomly selects a statement from a list of four options and asks students to select if the statement is true or false. It uses the `fixed-order="true"` option of `<pl-multiple-choice>` to ensure that the "True" option always appears first.
+This question randomly selects a statement from a list of four options and asks students to select if the statement is true or false. It uses the `order="fixed"` option of `<pl-multiple-choice>` to ensure that the "True" option always appears first.

--- a/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/question.html
+++ b/exampleCourse/questions/template/multiple-choice/random-prompt-true-false/question.html
@@ -2,7 +2,7 @@
   <p>Canada is {{params.question_prompt}} of the United States.</p>
 </pl-question-panel>
 
-<pl-multiple-choice answers-name="ans" fixed-order="true">
+<pl-multiple-choice answers-name="ans" order="fixed">
   <pl-answer correct="{{params.true_answer}}">True</pl-answer>
   <pl-answer correct="{{params.false_answer}}">False</pl-answer>
 </pl-multiple-choice>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

As of #8903, `fixed-order="true"` has been deprecated in favor of `order="fixed"` on the `<pl-multiple-choice>` element. This PR cleans up the remaining usages of the old attribute. This is important for both users and LLMs, both of which should be given modern, correct examples.

# Testing

N/A