### PR TITLE
Improve validation of AI-generated question HTML

### DIFF
--- a/apps/prairielearn/src/ee/lib/validateHTML.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.ts
@@ -325,7 +325,6 @@ function checkIntegerInput(ast: DocumentFragment | ChildNode): ValidationResult 
             );
           }
           break;
-        // string attributes are valid as strings, and these don't affect other tags, so no validation required
         case 'label':
         case 'suffix':
         case 'placeholder':


### PR DESCRIPTION
# Description

This PR improves the handling of the `correct-answer` attribute in the question HTML validator used in AI question generation.

# Testing

I verified that I could prompt the LLM to use a fixed correct answer and that it generated validation-passing HTML that did so.

## `pl-number-input`

> Write a question that asks the user to calculate the area of a rectangle given fixed dimensions. Provide a numeric input box for the user to enter the area. The correct answer is the product of the rectangle dimensions.

```html
<pl-question-panel>
  <p>
    Calculate the area of a rectangle with a width of 7 units and a height of 5 units.
  </p>
</pl-question-panel>

<pl-number-input answers-name="area" label="Area =" correct-answer="35"></pl-number-input>
```

## `pl-integer-input`

> Write a question that asks the user to calculate the area of a rectangle of width 8 and height 5. Provide a integer input box for the user to enter the area. The correct answer is the product of the rectangle dimensions.

```html
<pl-question-panel>
  <p>
    Calculate the area of a rectangle with a width of 8 and a height of 5.
  </p>
</pl-question-panel>

<pl-integer-input answers-name="area" label="Area ="></pl-integer-input>
```

## `pl-symbolic-input`

> Write a question that asks the student to compute the derivative of x^2. Note that the answer is not dynamic.

(This was a bit contrived, it really wanted to use a Python file)

```html
<pl-question-panel>
  <p>Find the derivative of the following function with respect to \(x\).</p>
  <p>\(f(x) = x^2\)</p>
</pl-question-panel>

<pl-symbolic-input
  answers-name="derivative"
  label="\( \dfrac{df(x)}{dx} = \)"
  variables="x"
  correct-answer="2*x"
  display="block"
></pl-symbolic-input>
```