### PR TITLE
Add small delay to nodemon restarting

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -305,6 +305,7 @@
       "dist/*",
       "public/*"
     ],
-    "ext": "js,jsx,ts,tsx,json,sql"
+    "ext": "js,jsx,ts,tsx,json,sql",
+    "delay": 100
   }
 }

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -55,6 +55,7 @@
     "vitest": "^3.2.4"
   },
   "nodemonConfig": {
-    "ext": "js,jsx,ts,tsx,json,sql"
+    "ext": "js,jsx,ts,tsx,json,sql",
+    "delay": 100
   }
 }


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

I've noticed that when I have `make dev` running and I run a `git checkout ...` where a lot of files have changed, Nodemon restarts dozens of times in rapid succession. The weirder part: that makes `git` operations in other terminals hang for a while, almost like there's contention to read things? I don't know why that happens, but I know that minimizing the number of restarts helps, and that's what this PR does.

This delay is small enough that it shouldn't be perceptible to a developer, but still large enough to ensure that we'll only restart once or twice during periods when lots of files are changing.

# Testing

See above.