### PR TITLE
Specialize pl-code rendering for AI grading

### DIFF
--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -313,6 +313,14 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     if normalize_whitespace:
         code = dedent(code).rstrip()
 
+    if data["ai_grading"]:
+        # Return just the raw code for AI grading.
+        #
+        # As we're never actually rendering this as HTML, we don't have to think
+        # carefully about escaping. We can also introduce leading/trailing newlines
+        # to make it easier for a human to read.
+        return f"<pre><code>\n{code.strip()}\n</code></pre>"
+
     lexer = NoHighlightingLexer() if language is None else get_lexer_by_name(language)
 
     pygments_style = get_style_by_name(style_name)


### PR DESCRIPTION
# Description

Before this change, `<pl-code>` would render complex HTML in AI grading mode thanks to the server-side syntax highlighting we do:

```html
<p>
  Write a short, high-level English language description of the code below.
  <i>Do not give a line-by-line description.</i>
</p>

<p>
  <b>Assume that the variables <code>x</code> and <code>y</code> are integers.</b>
  <i>You can assume that the code compiles and runs without error.</i>
</p>

<div>
  <div onselectstart=\"return false;\" onmousedown=\"return false;\" oncontextmenu=\"return false;\">
    <div>
      <table>
        <tbody>
          <tr>
            <td>
              <div>
                <pre><span>1</span>
<span>2</span>
<span>3</span>
<span>4</span>
<span>5</span></pre>
              </div>
            </td>
            <td>
              <div>
                <pre><span>def</span><span>f</span>(x, y):
    z <span>=</span> <span>0</span>
    <span>for</span> val <span>in</span> <span>range</span>(x, y <span>+</span> <span>1</span>):
        z <span>+=</span> val
    <span>return</span> z  
</pre>
              </div>
            </td>
          </tr>
        </tbody>
      </table>
    </div>
  </div>
</div>
```

Output after this change:

```html
<p>
  Write a short, high-level English language description of the code below.
  <i>Do not give a line-by-line description.</i>
</p>

<p>
  <b>Assume that the variables <code>x</code> and <code>y</code> are integers.</b>
  <i>You can assume that the code compiles and runs without error.</i>
</p>

<pre><code>
def f(x, y):
    z = 0
    for val in range(x, y + 1):
        z += val
    return z
</code></pre>
```

# Testing

I tested this locally on a coding question.
