### PR TITLE
Link from student assessment page to instructor assessment page

### DIFF
--- a/apps/prairielearn/src/components/Navbar.tsx
+++ b/apps/prairielearn/src/components/Navbar.tsx
@@ -406,6 +406,8 @@ function ViewTypeMenu({ resLocals }: { resLocals: Record<string, any> }) {
       instructorLink = `${urlPrefix}/instructor/question/${question.id}`;
     } else if (assessment_instance?.assessment_id) {
       instructorLink = `${urlPrefix}/instructor/assessment/${assessment_instance.assessment_id}`;
+    } else if (assessment?.id) {
+      instructorLink = `${urlPrefix}/instructor/assessment/${assessment.id}`;
     } else {
       instructorLink = `${urlPrefix}/instructor/instance_admin`;
     }


### PR DESCRIPTION
# Description

This is a small quality of life improvement. When starting an exam from student view, you start at a URL like `/pl/course_instance/1/assessment/6`. Ideally if you're switching back to staff view from that page, you'd end up back on the assessment. That wasn't previously the case; now it is!

# Testing

- Visit the instructor page of an Exam-type assessment
- Switch to "Student view without access restrictions"
- Switch back to "Staff view"

On `master`, you'd end up back at the course instance list page. On this branch, you end up on the Questions tab of the assessment.