### PR TITLE
Fix the question finalize message to use QID

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -330,7 +330,7 @@ router.post(
       }
 
       // TODO: any membership checks needed here?
-      const qid = await saveGeneratedQuestion(
+      const question_id = await saveGeneratedQuestion(
         res,
         prompts[prompts.length - 1].html || undefined,
         prompts[prompts.length - 1].python || undefined,
@@ -355,9 +355,9 @@ router.post(
         );
       }
 
-      flash('success', `Your question is ready for use as ${qid}.`);
+      flash('success', `Your question is ready for use as ${req.body.qid}.`);
 
-      res.redirect(res.locals.urlPrefix + '/question/' + qid + '/preview');
+      res.redirect(res.locals.urlPrefix + '/question/' + question_id + '/preview');
     } else if (req.body.__action === 'submit_manual_revision') {
       await saveRevisedQuestion({
         course: res.locals.course,


### PR DESCRIPTION
# Description

The finalization code was storing the numeric `question_id` in a variable called `qid`. This led to it inadvertently using the numeric `question_id` for the user-facing message when it presumably meant to use the QID.

# Testing

Before this change:

<img width="340" height="55" alt="image" src="https://github.com/user-attachments/assets/0402af4d-3825-4cde-8ba6-de131cc8c3b1" />

After this change:

<img width="330" height="56" alt="image" src="https://github.com/user-attachments/assets/70252e8c-5402-4e9d-ad0c-9d4bdd60d935" />
