### PR TITLE
Allow external graders to produce null or undefined score

### DIFF
--- a/apps/prairielearn/src/lib/externalGraderCommon.ts
+++ b/apps/prairielearn/src/lib/externalGraderCommon.ts
@@ -177,7 +177,7 @@ export function makeGradingResult(jobId: string, rawData: Record<string, any> | 
     return makeGradingFailureWithMessage(jobId, data, "results did not contain 'results' object.");
   }
 
-  // Scores can be undefined/null or a number.
+  // Scores can be undefined/null (if the submission wasn't gradable) or a number.
   let score = 0;
   if (data.results.score != null) {
     if (typeof data.results.score === 'number' && !Number.isNaN(data.results.score)) {


### PR DESCRIPTION
This reverts commit 2e2fc041a98a944ae41e6d424d211ea245c9e34b.

<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This validation is causing issues where graders aren't setting a score, but still want to display a message to students.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

None.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
