### PR TITLE
Skip broken variants when grading assessments

### DIFF
--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -289,6 +289,11 @@ export async function gradeAssessmentInstance(
   debug('gradeAssessmentInstance()', 'selected variants', 'count:', variants.length);
   await async.eachSeries(variants, async (row) => {
     debug('gradeAssessmentInstance()', 'loop', 'variant.id:', row.variant.id);
+
+    // Skip grading broken variants, as `gradeVariant` will consider an attempt
+    // to grade a broken variant as an error.
+    if (row.variant.broken_at) return;
+
     const check_submission_id = null;
     await gradeVariant(
       row.variant,


### PR DESCRIPTION
# Description

We recently saw some a few Sentry errors coming from here:

https://github.com/PrairieLearn/PrairieLearn/blob/f785122710e0e14e486b209b49651ddb4197eaa2/apps/prairielearn/src/question-servers/freeform.ts#L1542

The normal grading path that's triggered by a submission will refuse to attempt grading if the variant is broken:

https://github.com/PrairieLearn/PrairieLearn/blob/f785122710e0e14e486b209b49651ddb4197eaa2/apps/prairielearn/src/lib/question-submission.ts#L70-L72

However, this doesn't account for grading the assessment as a whole, specifically when an instructor has marked a variant as broken in between when a student saved (but not graded) an answer and when the assessment as a whole was graded.

Note that we already warn instructors about this scenario:

https://github.com/PrairieLearn/PrairieLearn/blob/f785122710e0e14e486b209b49651ddb4197eaa2/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/ResetQuestionVariantsModal.tsx#L22

# Testing

IMO, none needed, this is a trivially-correct change.