### PR TITLE
Remove stray curly braces from instructor assessment instance page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
@@ -343,10 +343,10 @@ export function InstructorAssessmentInstance({
                           <th colspan="9">
                             ${instance_question.zone_title}
                             ${instance_question.zone_has_max_points
-                              ? html`(maximum ${instance_question.zone_max_points} points)}`
+                              ? html`(maximum ${instance_question.zone_max_points} points)`
                               : ''}
                             ${instance_question.zone_has_best_questions
-                              ? html`(best ${instance_question.zone_best_questions} questions)}`
+                              ? html`(best ${instance_question.zone_best_questions} questions)`
                               : ''}
                           </th>
                         </tr>


### PR DESCRIPTION
# Description

There's a stray curly brace:

<img width="473" height="49" alt="Screenshot 2025-09-15 at 14 43 16" src="https://github.com/user-attachments/assets/b5f50525-05ff-44e4-a889-08af5224644b" />

This PR removes it.


# Testing

N/A
