### PR TITLE
Add an `AGENTS.md` file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is a monorepo that contains both applications (in `apps/*`) and libraries (in `packages/*`).
 
-- Use `yarn` to manage dependencies and run scripts.
+- Use `yarn` (v4) to manage dependencies and run scripts.
 - The `Makefile` at the root of the repository contains commands for common tasks.
 
 ## Applications
@@ -17,7 +17,7 @@ Migrations are stored in `apps/prairielearn/src/migrations`. See the `README.md`
 
 ## Building and type checking
 
-When possible, use a dedicated tool call to check for type errors/issues/problems during iteration.
+When possible, use a dedicated tool call to check for type errors/issues/problems in individual files during iteration, as this is faster than checking every file.
 
 Run `make build` from the root directory to build all TypeScript code and check types.
 
@@ -25,7 +25,7 @@ Run `make typecheck-python` from the root directory to type check all Python cod
 
 ## Linting and formatting
 
-When possible, use a dedicated tool call to check for linting and formatting issues during iteration, as this is faster than checking every file.
+When possible, use a dedicated tool call to check for linting and formatting issues in individual files during iteration, as this is faster than checking every file.
 
 If you don't have a suitable tool available, you can still format and lint individual files: use `yarn eslint ...`/`yarn prettier ...` for TypeScript files and `ruff ...` for Python files.
 
@@ -48,3 +48,5 @@ Avoid running the entire test suite unless necessary, as it can be time-consumin
 
 - To run all TypeScript tests, use `yarn test` from the root directory
 - To run all Python tests, use `make test-python` from the root directory.
+
+Tests expect Postgres, Redis, and an S3-compatible store to be running, and usually they already are. If you suspect that they're not, run `make start-support` from the root directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# Organization
+
+This is a monorepo that contains both applications (in `apps/*`) and libraries (in `packages/*`).
+
+- Use `yarn` to manage dependencies and run scripts.
+- The `Makefile` at the root of the repository contains commands for common tasks.
+
+## Applications
+
+- `apps/prairielearn`: The main PrairieLearn web application.
+- `apps/grader-host`: The application that runs external grading jobs.
+- `apps/workspace-host`: The application that runs workspace containers.
+
+All applications share a single Postgres database. See `database/` for descriptions of the database tables and enums. All tables have corresponding Zod types in `apps/prairielearn/src/lib/db-types.ts`.
+
+Migrations are stored in `apps/prairielearn/src/migrations`. See the `README.md` file in that directory for details on how to create and run migrations.
+
+## Building and type checking
+
+When possible, use a dedicated tool call to check for type errors/issues/problems during iteration.
+
+Run `make build` from the root directory to build all TypeScript code and check types.
+
+Run `make typecheck-python` from the root directory to type check all Python code.
+
+## Linting and formatting
+
+When possible, use a dedicated tool call to check for linting and formatting issues during iteration, as this is faster than checking every file.
+
+If you don't have a suitable tool available, you can still format and lint individual files: use `yarn eslint ...`/`yarn prettier ...` for TypeScript files and `ruff ...` for Python files.
+
+Run `make format-js`/`make lint-js` from the root directory to format/lint all TypeScript code.
+
+Run `make format-python`/`make lint-python` from the root directory to format/lint all Python code.
+
+## Testing
+
+TypeScript tests are written with Vitest. Unit tests are located next to the code they test in files with a `.test.ts` suffix. Integration tests are located in dedicated `tests` directories, e.g. `apps/prairielearn/src/tests`.
+
+Python tests are written with Pytest.
+
+When possible, use a dedicated tool call to run individual tests during iteration. If you do not have a suitable tool available, you can run single test files:
+
+- For TypeScript tests, use `yarn test path/to/file.test.ts` from the root directory.
+- For Python tests, use `pytest path/to/testfile.py` from the root directory.
+
+Avoid running the entire test suite unless necessary, as it can be time-consuming. However, if you must:
+
+- To run all TypeScript tests, use `yarn test` from the root directory
+- To run all Python tests, use `make test-python` from the root directory.

--- a/apps/prairielearn/src/migrations/README.md
+++ b/apps/prairielearn/src/migrations/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The PrairieLearn database is built with a series of consecutive "migrations". A migration is a modification to table schema and is represented as a file in this `migrations/` directory. Each migration is uniquely identified and oredered by a timestamp in the filename of the form `YYYYMMDDHHMMSS`. This timestamp must be unique.
+The PrairieLearn database is built with a series of consecutive "migrations". A migration is a modification to table schema and is represented as a file in this `migrations/` directory. Each migration is uniquely identified and ordered by a timestamp in the filename of the form `YYYYMMDDHHMMSS`. This timestamp must be unique.
 
 The database has a special `migrations` table that tracks with migrations have already been applied. This ensures that migrations are always applied exactly once.
 


### PR DESCRIPTION
# Description

This PR adds an `AGENTS.md` file (https://agents.md/) for use by coding agents.

I focused on explaining the things that I've noticed agents generally mess up, namely, how to interact with our tests, linters/formatters, and build tools. Outside of those, my experience has been that modern agents are really good at figuring things out for themselves. I didn't feel the need to fill up the context window with a bunch of other explanations, a la the dev guide. This is consistent with [the bitter lesson](http://www.incompleteideas.net/IncIdeas/BitterLesson.html).

# Testing

I haven't yet tested this with any tasks. We should iterate on this as needed.