### PR TITLE
Add new cards for empty state

### DIFF
--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -270,12 +270,12 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
             <div class="mb-3">
               <i class="bi bi-person-badge text-primary" style="font-size: 3rem;" />
             </div>
-            <h3 class="card-title text-secondary mb-3">Students</h3>
-            <p class="card-text text-muted mb-4">Join a course and start learning.</p>
+            <h3 class="card-title mb-3">Students</h3>
+            <p class="card-text mb-4">Join a course and start learning.</p>
             <div class="mt-auto">
               <a href={`${urlPrefix}/enroll`} class="btn btn-primary btn-lg">
                 <i class="bi bi-plus-circle me-2" />
-                Add or remove courses
+                Add course
               </a>
             </div>
           </div>
@@ -287,8 +287,8 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
             <div class="mb-3">
               <i class="bi bi-mortarboard text-primary" style="font-size: 3rem;" />
             </div>
-            <h3 class="card-title text-secondary mb-3">Instructors</h3>
-            <p class="card-text text-muted mb-4">Create and manage courses for your students.</p>
+            <h3 class="card-title mb-3">Instructors</h3>
+            <p class="card-text mb-4">Create and manage courses for your students.</p>
             <div class="mt-auto">
               <div class="d-flex gap-2">
                 <a

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -51,25 +51,38 @@ export function Home({
   urlPrefix: string;
   isDevMode: boolean;
 }) {
+  const listedStudentCourses = studentCourses.filter(
+    (ci) => ci.enrollment.status === 'joined' || ci.enrollment.status === 'invited',
+  );
+
+  const hasInstructorCourses = instructorCourses.length > 0;
+  const hasCourses = (listedStudentCourses.length > 0 || hasInstructorCourses) && false;
+
   return (
     <>
       <h1 class="visually-hidden">PrairieLearn Homepage</h1>
-      <ActionsHeader urlPrefix={urlPrefix} />
+      {hasCourses && <ActionsHeader urlPrefix={urlPrefix} />}
 
       <div class="container pt-5">
         <DevModeCard isDevMode={isDevMode} />
         <AdminInstitutionsCard adminInstitutions={adminInstitutions} />
-        <InstructorCoursesCard instructorCourses={instructorCourses} urlPrefix={urlPrefix} />
-        <Hydrate>
-          <StudentCoursesCard
-            studentCourses={studentCourses}
-            hasInstructorCourses={instructorCourses.length > 0}
-            canAddCourses={canAddCourses}
-            csrfToken={csrfToken}
-            urlPrefix={urlPrefix}
-            isDevMode={isDevMode}
-          />
-        </Hydrate>
+        {hasCourses ? (
+          <>
+            <InstructorCoursesCard instructorCourses={instructorCourses} urlPrefix={urlPrefix} />
+            <Hydrate>
+              <StudentCoursesCard
+                studentCourses={listedStudentCourses}
+                hasInstructorCourses={instructorCourses.length > 0}
+                canAddCourses={canAddCourses}
+                csrfToken={csrfToken}
+                urlPrefix={urlPrefix}
+                isDevMode={isDevMode}
+              />
+            </Hydrate>
+          </>
+        ) : (
+          <EmptyStateCards urlPrefix={urlPrefix} />
+        )}
       </div>
     </>
   );
@@ -244,6 +257,58 @@ function CourseInstanceList({ courseInstances, urlPrefix }: CourseInstanceListPr
           {courseInstance.long_name}
         </a>
       ))}
+    </div>
+  );
+}
+
+function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
+  return (
+    <div class="row">
+      <div class="col-lg-6 mb-4">
+        <div class="card h-100">
+          <div class="card-body text-center d-flex flex-column">
+            <div class="mb-3">
+              <i class="bi bi-person-badge text-primary" style="font-size: 3rem;" />
+            </div>
+            <h3 class="card-title text-secondary mb-3">Students</h3>
+            <p class="card-text text-muted mb-4">Join a course and start learning.</p>
+            <div class="mt-auto">
+              <a href={`${urlPrefix}/enroll`} class="btn btn-primary btn-lg">
+                <i class="bi bi-plus-circle me-2" />
+                Add or remove courses
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="col-lg-6 mb-4">
+        <div class="card h-100">
+          <div class="card-body text-center d-flex flex-column">
+            <div class="mb-3">
+              <i class="bi bi-mortarboard text-primary" style="font-size: 3rem;" />
+            </div>
+            <h3 class="card-title text-secondary mb-3">Instructors</h3>
+            <p class="card-text text-muted mb-4">Create and manage courses for your students.</p>
+            <div class="mt-auto">
+              <div class="d-flex gap-2">
+                <a
+                  href="https://prairielearn.readthedocs.io/en/latest"
+                  class="btn btn-outline-primary btn-lg flex-fill"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <i class="bi bi-journal-text me-2" />
+                  View docs
+                </a>
+                <a href={`${urlPrefix}/request_course`} class="btn btn-primary btn-lg flex-fill">
+                  <i class="bi bi-book me-2" />
+                  Request course
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -273,8 +273,11 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
             <h3 class="card-title mb-3">Students</h3>
             <p class="card-text mb-4">Add a course and start learning.</p>
             <div class="mt-auto">
-              <a href={`${urlPrefix}/enroll`} class="btn btn-primary btn-lg">
-                <i class="bi bi-plus-circle me-2" />
+              <a
+                href={`${urlPrefix}/enroll`}
+                class="btn btn-primary d-flex gap-2 justify-content-center"
+              >
+                <i class="bi bi-plus-circle" />
                 Add course
               </a>
             </div>
@@ -293,15 +296,18 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
               <div class="d-flex gap-2">
                 <a
                   href="https://prairielearn.readthedocs.io/en/latest"
-                  class="btn btn-outline-primary btn-lg flex-fill"
+                  class="btn btn-outline-primary flex-fill d-flex gap-2 justify-content-center"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <i class="bi bi-journal-text me-2" />
+                  <i class="bi bi-journal-text" />
                   View docs
                 </a>
-                <a href={`${urlPrefix}/request_course`} class="btn btn-primary btn-lg flex-fill">
-                  <i class="bi bi-book me-2" />
+                <a
+                  href={`${urlPrefix}/request_course`}
+                  class="btn btn-primary flex-fill d-flex gap-2 justify-content-center"
+                >
+                  <i class="bi bi-book" />
                   Request course
                 </a>
               </div>

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -56,7 +56,7 @@ export function Home({
   );
 
   const hasInstructorCourses = instructorCourses.length > 0;
-  const hasCourses = (listedStudentCourses.length > 0 || hasInstructorCourses) && false;
+  const hasCourses = listedStudentCourses.length > 0 || hasInstructorCourses;
 
   return (
     <>

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -55,8 +55,7 @@ export function Home({
     (ci) => ci.enrollment.status === 'joined' || ci.enrollment.status === 'invited',
   );
 
-  const hasInstructorCourses = instructorCourses.length > 0;
-  const hasCourses = listedStudentCourses.length > 0 || hasInstructorCourses;
+  const hasCourses = listedStudentCourses.length > 0 || instructorCourses.length > 0;
 
   return (
     <>

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -294,6 +294,13 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
             <div class="mt-auto">
               <div class="d-flex flex-wrap gap-2">
                 <a
+                  href={`${urlPrefix}/request_course`}
+                  class="btn btn-primary flex-fill d-flex gap-2 justify-content-center"
+                >
+                  <i class="bi bi-book" />
+                  Request course
+                </a>
+                <a
                   href="https://prairielearn.readthedocs.io/en/latest"
                   class="btn btn-outline-primary flex-fill d-flex gap-2 justify-content-center"
                   target="_blank"
@@ -301,13 +308,6 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
                 >
                   <i class="bi bi-journal-text" />
                   View docs
-                </a>
-                <a
-                  href={`${urlPrefix}/request_course`}
-                  class="btn btn-primary flex-fill d-flex gap-2 justify-content-center"
-                >
-                  <i class="bi bi-book" />
-                  Request course
                 </a>
               </div>
             </div>

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -56,7 +56,7 @@ export function Home({
   );
 
   const hasInstructorCourses = instructorCourses.length > 0;
-  const hasCourses = listedStudentCourses.length > 0 || hasInstructorCourses;
+  const hasCourses = (listedStudentCourses.length > 0 || hasInstructorCourses) && false;
 
   return (
     <>
@@ -271,7 +271,7 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
               <i class="bi bi-person-badge text-primary" style="font-size: 3rem;" />
             </div>
             <h3 class="card-title mb-3">Students</h3>
-            <p class="card-text mb-4">Join a course and start learning.</p>
+            <p class="card-text mb-4">Add a course and start learning.</p>
             <div class="mt-auto">
               <a href={`${urlPrefix}/enroll`} class="btn btn-primary btn-lg">
                 <i class="bi bi-plus-circle me-2" />

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -293,7 +293,7 @@ function EmptyStateCards({ urlPrefix }: { urlPrefix: string }) {
             <h3 class="card-title mb-3">Instructors</h3>
             <p class="card-text mb-4">Create and manage courses for your students.</p>
             <div class="mt-auto">
-              <div class="d-flex gap-2">
+              <div class="d-flex flex-wrap gap-2">
                 <a
                   href="https://prairielearn.readthedocs.io/en/latest"
                   class="btn btn-outline-primary flex-fill d-flex gap-2 justify-content-center"


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This PR adds an empty state for PrairieLearn. It should let us remove the action header in future PR.

<img width="2058" height="144" alt="CleanShot 2025-09-16 at 17 40 01@2x" src="https://github.com/user-attachments/assets/448c93d3-6075-4540-82e6-7bb9e1d244e1" />

When we move the enrollment page to a modal, we will want to remove that action header.

This PR was initially created with this prompt:

> Add a new 'EmptyStateCards' component. It should render two cards side by side on desktop, and vertically on mobile. One card should be for if the user is a student, and the other if the user is an instructor. It should mirror the content of 'ActionsHeader' -- except it should make the call to action buttons a little larger with some nice bootstrap-icons.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
See attached image:

<img width="2536" height="1518" alt="CleanShot 2025-09-16 at 19 30 20@2x" src="https://github.com/user-attachments/assets/5cc65965-fa20-4d65-8fb4-e9df0b562202" />
<img width="906" height="1630" alt="CleanShot 2025-09-16 at 17 43 53@2x" src="https://github.com/user-attachments/assets/e1d44e76-5e92-41a9-8e3f-96ea96b8d370" />


To try yourself, set `hasCourses` to `false`.