### PR TITLE
Disable coderabbit pre-merge checks for docstrings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,6 +24,9 @@ reviews:
     drafts: false
     base_branches:
       - master
+  pre_merge_checks:
+    docstrings:
+      mode: 'off'
   finishing_touches:
     docstrings:
       enabled: true


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

We ignore these warnings anyway. It's not entirely clear to me what docstrings represent in the context of TS, and given that sometimes warnings are added for code that does not involve anything that would benefit from one, I don't think they are useful.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

The PR itself is the test...

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
