### PR TITLE
feat: add randomize-distractors-when-ordered option to pl-order-blocks

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
+++ b/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
@@ -133,8 +133,8 @@ class OrderBlocksOptions:
         )
         self.code_language = pl.get_string_attrib(html_element, "code-language", None)
         self.inline = pl.get_boolean_attrib(html_element, "inline", INLINE_DEFAULT)
-        self.randomize_distractors_when_ordered = pl.get_boolean_attrib(
-            html_element, "randomize-distractors-when-ordered", False
+        self.randomize_distractors = pl.get_boolean_attrib(
+            html_element, "randomize-distractors", False
         )
 
         self.answer_options = collect_answer_options(html_element, self.grading_method)
@@ -175,7 +175,7 @@ class OrderBlocksOptions:
             "format",
             "code-language",
             "allow-blank",
-            "randomize-distractors-when-ordered",
+            "randomize-distractors",
         ]
         pl.check_attribs(
             html_element,

--- a/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
+++ b/apps/prairielearn/elements/pl-order-blocks/order_blocks_options_parsing.py
@@ -133,6 +133,9 @@ class OrderBlocksOptions:
         )
         self.code_language = pl.get_string_attrib(html_element, "code-language", None)
         self.inline = pl.get_boolean_attrib(html_element, "inline", INLINE_DEFAULT)
+        self.randomize_distractors_when_ordered = pl.get_boolean_attrib(
+            html_element, "randomize-distractors-when-ordered", False
+        )
 
         self.answer_options = collect_answer_options(html_element, self.grading_method)
         self.correct_answers = [
@@ -172,6 +175,7 @@ class OrderBlocksOptions:
             "format",
             "code-language",
             "allow-blank",
+            "randomize-distractors-when-ordered",
         ]
         pl.check_attribs(
             html_element,

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -134,6 +134,36 @@ def prepare(html: str, data: pl.QuestionData) -> None:
         random.shuffle(all_blocks)
     elif order_blocks_options.source_blocks_order == SourceBlocksOrderType.ORDERED:
         all_blocks.sort(key=lambda a: a["index"])
+
+        if order_blocks_options.randomize_distractors_when_ordered:
+            # Find groups where a correct answer has distractors and shuffle each group
+            i = 0
+            while i < len(all_blocks):
+                current_block = all_blocks[i]
+
+                # Check if this correct answer has distractors
+                if not current_block.get("distractor_for"):
+                    # Look ahead to see if the next blocks are distractors for this correct answer
+                    tag = current_block["tag"]
+                    group_blocks = [current_block]
+                    j = i + 1
+
+                    # Collect all consecutive distractors for this tag
+                    while j < len(all_blocks) and all_blocks[j].get("distractor_for") == tag:
+                        group_blocks.append(all_blocks[j])
+                        j += 1
+
+                    # If we found distractors, shuffle the entire group (correct + distractors)
+                    if len(group_blocks) > 1:
+                        random.shuffle(group_blocks)
+                        # Put the shuffled group back
+                        for k, block in enumerate(group_blocks):
+                            all_blocks[i + k] = block
+
+                    # Move to the next block after this group
+                    i = j
+                else:
+                    i += 1
     elif order_blocks_options.source_blocks_order == SourceBlocksOrderType.ALPHABETIZED:
         all_blocks.sort(key=lambda a: a["inner_html"])
     else:

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -127,7 +127,7 @@ has become increasingly complex, with many different possible combinations of op
 </pl-order-blocks>
 
 <pl-order-blocks answers-name="randomize-distractors-when-ordered" grading-method="dag" feedback="first-wrong-verbose" partial-credit="lcs" source-blocks-order="ordered" randomize-distractors-when-ordered="true">
-  <pl-answer correct="true" tag="correct-block" correct="true">Correct code</pl-answer>
+  <pl-answer correct="true" tag="correct-block">Correct code</pl-answer>
   <pl-answer correct="false" distractor-for="correct-block">Distractor 1</pl-answer>
   <pl-answer correct="false" distractor-for="correct-block">Distractor 2</pl-answer>
 </pl-order-blocks>

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -126,7 +126,7 @@ has become increasingly complex, with many different possible combinations of op
   <pl-answer correct="true" tag="5" depends="4">By definition $a|c.$</pl-answer>
 </pl-order-blocks>
 
-<pl-order-blocks answers-name="randomize-distractors-when-ordered" grading-method="dag" feedback="first-wrong-verbose" partial-credit="lcs" source-blocks-order="ordered" randomize-distractors-when-ordered="true">
+<pl-order-blocks answers-name="randomize-distractors-when-ordered" grading-method="dag" feedback="first-wrong-verbose" partial-credit="lcs" source-blocks-order="ordered" randomize-distractors="true">
   <pl-answer correct="true" tag="correct-block">Correct code</pl-answer>
   <pl-answer correct="false" distractor-for="correct-block">Distractor 1</pl-answer>
   <pl-answer correct="false" distractor-for="correct-block">Distractor 2</pl-answer>

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -127,7 +127,7 @@ has become increasingly complex, with many different possible combinations of op
 </pl-order-blocks>
 
 <pl-order-blocks answers-name="randomize-distractors-when-ordered" grading-method="dag" feedback="first-wrong-verbose" partial-credit="lcs" source-blocks-order="ordered" randomize-distractors-when-ordered="true">
-  <pl-answer tag="correct-block">Correct code</pl-answer>
+  <pl-answer correct="true" tag="correct-block" correct="true">Correct code</pl-answer>
   <pl-answer correct="false" distractor-for="correct-block">Distractor 1</pl-answer>
   <pl-answer correct="false" distractor-for="correct-block">Distractor 2</pl-answer>
 </pl-order-blocks>

--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -126,5 +126,8 @@ has become increasingly complex, with many different possible combinations of op
   <pl-answer correct="true" tag="5" depends="4">By definition $a|c.$</pl-answer>
 </pl-order-blocks>
 
-
-
+<pl-order-blocks answers-name="randomize-distractors-when-ordered" grading-method="dag" feedback="first-wrong-verbose" partial-credit="lcs" source-blocks-order="ordered" randomize-distractors-when-ordered="true">
+  <pl-answer tag="correct-block">Correct code</pl-answer>
+  <pl-answer correct="false" distractor-for="correct-block">Distractor 1</pl-answer>
+  <pl-answer correct="false" distractor-for="correct-block">Distractor 2</pl-answer>
+</pl-order-blocks>


### PR DESCRIPTION
## Summary
Adds a new `randomize-distractors-when-ordered` attribute to `pl-order-blocks` element that allows randomizing the order of blocks within each "Pick One" group while maintaining the overall logical structure.

## Motivation
When using `source-blocks-order="ordered"` for Parsons problems, instructors may want to maintain the logical flow of the solution while still adding variety to distractor placement within choice groups. This prevents students from memorizing the exact order of distractors.

## Changes
- Added `randomize-distractors-when-ordered` boolean attribute (defaults to `false`)
- When enabled with `source-blocks-order="ordered"`, shuffles correct answers with their distractors within each group
- Preserves backward compatibility - existing questions are unaffected

## Example Usage
```html
<pl-order-blocks source-blocks-order="ordered" randomize-distractors-when-ordered="true">
  <pl-answer tag="correct-block">Correct code</pl-answer>
  <pl-answer correct="false" distractor-for="correct-block">Distractor 1</pl-answer>
  <pl-answer correct="false" distractor-for="correct-block">Distractor 2</pl-answer>
</pl-order-blocks>
```

In this example, the three blocks (1 correct + 2 distractors) will be shuffled together within their "Pick One" group, while maintaining their position relative to other groups.