### PR TITLE
Improvements for AI grading information display in instance question page

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -106,16 +106,16 @@ export function QuestionContainer({
           : ''
       }
       ${(questionContext === 'instructor' || questionContext === 'manual_grading') &&
+      aiGradingInfo?.explanation
+        ? AIGradingExplanation({
+            explanation: aiGradingInfo.explanation,
+          })
+        : ''}
+      ${(questionContext === 'instructor' || questionContext === 'manual_grading') &&
       aiGradingInfo?.prompt
         ? AIGradingPrompt({
             prompt: aiGradingInfo.prompt,
             promptImageUrls: aiGradingInfo.promptImageUrls,
-          })
-        : ''}
-      ${(questionContext === 'instructor' || questionContext === 'manual_grading') &&
-      aiGradingInfo?.explanation
-        ? AIGradingExplanation({
-            explanation: aiGradingInfo.explanation,
           })
         : ''}
       ${submissions.length > 0
@@ -180,16 +180,16 @@ function AIGradingPrompt({
         <h2>AI grading prompt</h2>
         <button
           type="button"
-          class="expand-icon-container btn btn-outline-light btn-sm text-nowrap ms-auto"
+          class="expand-icon-container btn btn-outline-light btn-sm text-nowrap ms-auto collapsed"
           data-bs-toggle="collapse"
           data-bs-target="#ai-grading-prompt-body"
-          aria-expanded="true"
+          aria-expanded="false"
           aria-controls="ai-grading-prompt-body"
         >
           <i class="fa fa-angle-up ms-1 expand-icon"></i>
         </button>
       </div>
-      <div class="js-submission-body js-collapsible-card-body show" id="ai-grading-prompt-body">
+      <div class="js-submission-body js-collapsible-card-body collapse" id="ai-grading-prompt-body">
         <ul class="list-group list-group-flush">
           <li class="list-group-item my-0">
             <h5 class="card-title mt-2 mb-3">Raw prompt</h5>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

As pointed out during a meeting with a BADM professor interested in using AI grading: The panels for showing information about an AI grading job (prompt sent to AI, explanation from AI) could be swapped so the explanation is shown first, and the prompt could be defaulted to collapse. 

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->

New UI, with positions swapped and collapsed by default. 
<img width="1454" height="761" alt="image" src="https://github.com/user-attachments/assets/04b1db4f-851f-4440-8215-b5a434d522d6" />

