### PR TITLE
Don't render feedback for pl-order-blocks on submission panel

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -288,8 +288,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 "indent": (attempt["indent"] or 0) * TAB_SIZE_PX,
                 "badge_type": attempt.get("badge_type", ""),
                 "icon": attempt.get("icon", ""),
-                "distractor_feedback": attempt.get("distractor_feedback", ""),
-                "ordering_feedback": attempt.get("ordering_feedback", ""),
+                # We intentionally don't include distractor_feedback and ordering_feedback here.
             }
             for attempt in data["submitted_answers"].get(answer_name, [])
         ]


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This fixes a bug reported by Julian Schiavo on Slack where students were abusing the 'Save' feature, which renders a submission, to gain early feedback to get closer to the correct answer.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

On the `orderBlocks` question, select a distractor for `Example 3`. On master, when you save a submission, the distractor feedback is visible. On this branch, it should not be visible.

<img width="1464" height="1094" alt="CleanShot 2025-09-18 at 14 18 18@2x" src="https://github.com/user-attachments/assets/f626e490-c987-422d-abf2-c9f814f3f9f0" />


<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
