### PR TITLE
Show real-time grading warning only in student view

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -638,7 +638,7 @@ export function QuestionFooterContent({
                   : ''}
             <div class="d-flex flex-column">
               ${AvailablePointsNotes({ questionContext, instance_question, assessment_question })}
-              ${!assessment_question || assessment_question.allow_real_time_grading
+              ${assessment_question == null || assessment_question.allow_real_time_grading
                 ? ''
                 : html`
                     <small class="fst-italic text-end">


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The recent implementation of real-time grading per question included a warning in the question footer. The implementation shows the warning even in instructor preview. It should only be shown in student view.

Before:

<img width="1475" height="118" alt="image" src="https://github.com/user-attachments/assets/9336e173-9217-4e1b-9295-e4812db4a461" />

After:

<img width="1472" height="111" alt="image" src="https://github.com/user-attachments/assets/99cf9cb0-ee14-48a1-94cc-a77577306278" />


<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Tested in instructor view and student view. Manual grading does not include the footer.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
