### PR TITLE
Always show error explanation for authz helper

### DIFF
--- a/apps/prairielearn/src/middlewares/AuthzAccessMismatch.tsx
+++ b/apps/prairielearn/src/middlewares/AuthzAccessMismatch.tsx
@@ -145,6 +145,25 @@ function formatUser(user: StaffUser) {
   return `${user.name} (${user.uid})`;
 }
 
+function getPermissionDescription(permissionKeys: CheckablePermissionKeys[]): string {
+  const descriptions = permissionKeys.map((key) => {
+    const permission = PERMISSIONS_META.find((p) => p.key === key);
+    return permission?.label.toLowerCase() || key.toString().replaceAll('_', ' ');
+  });
+
+  if (descriptions.length === 1) {
+    return descriptions[0];
+  } else if (descriptions.length === 2) {
+    return descriptions.join(' or ');
+  } else {
+    return descriptions.slice(0, -1).join(', ') + ', or ' + descriptions.at(-1);
+  }
+}
+
+export function getErrorExplanation(permissionKeys: CheckablePermissionKeys[]): string {
+  return `This page requires ${getPermissionDescription(permissionKeys)} permissions.`;
+}
+
 export function AuthzAccessMismatch({
   errorExplanation,
   oneOfPermissionKeys,
@@ -192,7 +211,7 @@ export function AuthzAccessMismatch({
           <h1>Effective user has insufficient access</h1>
         </div>
         <div class="card-body">
-          <p>{errorExplanation}</p>
+          <p>{errorExplanation ?? getErrorExplanation(oneOfPermissionKeys)}</p>
           {hasEffectiveUser ? (
             <p>
               The current effective user {authzUser && <strong>{formatUser(authzUser)}</strong>}{' '}

--- a/apps/prairielearn/src/middlewares/authzHelper.tsx
+++ b/apps/prairielearn/src/middlewares/authzHelper.tsx
@@ -15,27 +15,8 @@ import { Hydrate } from '../lib/preact.js';
 import {
   AuthzAccessMismatch,
   type CheckablePermissionKeys,
-  PERMISSIONS_META,
+  getErrorExplanation,
 } from './AuthzAccessMismatch.js';
-
-function getPermissionDescription(permissionKeys: CheckablePermissionKeys[]): string {
-  const descriptions = permissionKeys.map((key) => {
-    const permission = PERMISSIONS_META.find((p) => p.key === key);
-    return permission?.label.toLowerCase() || key.toString().replaceAll('_', ' ');
-  });
-
-  if (descriptions.length === 1) {
-    return descriptions[0];
-  } else if (descriptions.length === 2) {
-    return descriptions.join(' or ');
-  } else {
-    return descriptions.slice(0, -1).join(', ') + ', or ' + descriptions.at(-1);
-  }
-}
-
-function getErrorExplanation(permissionKeys: CheckablePermissionKeys[]): string {
-  return `This page requires ${getPermissionDescription(permissionKeys)} permissions.`;
-}
 
 export const createAuthzMiddleware =
   ({
@@ -80,7 +61,7 @@ export const createAuthzMiddleware =
           content: (
             <Hydrate>
               <AuthzAccessMismatch
-                errorExplanation={errorExplanation ?? getErrorExplanation(oneOfPermissions)}
+                errorExplanation={errorExplanation}
                 oneOfPermissionKeys={oneOfPermissions}
                 authzData={authzData}
                 authnUser={pageContext.authn_user}


### PR DESCRIPTION
# Description

One usage of `<AuthzAccessMismatch>` doesn't include an `errorExplanation`:

https://github.com/PrairieLearn/PrairieLearn/blob/1f29c43893bdf90db6b6194d81ae47e88063088c/apps/prairielearn/src/middlewares/authzHasCoursePreviewOrInstanceView.tsx#L44-L52

This PR ensures that one is always generated if one is defined.

# Testing

- In one browser, auth as `student@example.com` and enroll in a course instance inthe test course.
- In a different browser, as an instructor, view the course instance as an instructor.
- Open the user menu in the upper-right and enter `student@example.com` as the UID.

On `master`, there's no error explanation given. On this branch, there is.