### PR TITLE
Fix fingerprint tracking when URL contains variant ID

### DIFF
--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import url from 'node:url';
 
 import { type Request, type Response, Router } from 'express';
 
@@ -30,6 +31,10 @@ const router = Router({ mergeParams: true });
 
 router.use(enterpriseOnly(() => checkPlanGrantsForQuestion));
 router.use((req, res, next) => {
+  // We deliberately use `url` instead of `originalUrl`. The former is relative to
+  // where this router is mounted, while the latter is absolute to the app.
+  const pathname = url.parse(req.url).pathname ?? '/';
+
   // Because this router is mounted a general path, its middleware will also
   // be run for sub-routes like `submissions/:submission_id/file/:filename`
   // and `clientFilesQuestion/:filename`.
@@ -38,7 +43,7 @@ router.use((req, res, next) => {
   // as that's the only page that will record log entries with fingerprints. It
   // would be confusing if the fingerprint change count was incremented without
   // a corresponding log entry.
-  if (req.url !== '/') {
+  if (pathname !== '/') {
     next();
     return;
   }


### PR DESCRIPTION
# Description

Closes #12935.

This regressed in #12582. After the first submission to a given question, the URL would be something like `.../instance_question/12345?variant_id=54321`. In this middleware, `req.url` would then be `/?variant_id=12345`, which would obviously pass the `!== '/'` check.

See https://github.com/PrairieLearn/PrairieLearn/pull/12582#discussion_r2258562258: over and over again we've proven to ourselves that using middleware for fingerprints is a Bad Idea. This PR is making the minimal change to get things working again until we can do a comprehensive refactor.

# Testing

- Open a homework as a student; open a question.
- Make a submission; the URL should now have a `?variant_id=...` query param.
- Make another submission.

On `master`, only the first "view variant" and "submission" events will have a fingerprint. The latter two will not.

On this branch, all "view variant" and "submission" events will have a fingerprint.