### PR TITLE
Fix regrading for group assessments

### DIFF
--- a/apps/prairielearn/src/lib/regrading.sql
+++ b/apps/prairielearn/src/lib/regrading.sql
@@ -23,14 +23,17 @@ WHERE
 SELECT
   ai.id AS assessment_instance_id,
   assessment_instance_label (ai, a, aset),
-  u.uid AS user_uid
+  u.uid AS user_uid,
+  g.name AS group_name
 FROM
   assessments AS a
   JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
   JOIN assessment_instances AS ai ON (ai.assessment_id = a.id)
-  JOIN users AS u ON (u.user_id = ai.user_id)
+  LEFT JOIN users AS u ON (u.user_id = ai.user_id)
+  LEFT JOIN groups AS g ON (g.id = ai.group_id)
 WHERE
   a.id = $assessment_id
+  AND g.deleted_at IS NULL
 ORDER BY
   u.uid,
   u.user_id,


### PR DESCRIPTION
# Description

Closes #12946.

The core change was implemented entirely by Claude Sonnet 4. I renamed from `jobInfo` to `userOrGroup` manually.

# Testing

- As a student: create a group, start an assessment instance, answer a question.
- As an instructor: regrade all assessment instances for that assessment.

On `master`, the server job output would indicate that zero jobs were selected and zero were updated. On this branch, it'll report the instance for the group, but that there was no change.

For bonus points: repeat the above with an exam, making sure that the submission didn't earn full credit. Then add `"forceMaxPoints": true` to the question config on the assessment and regrade. You should see the job output report a score increase.
