### PR TITLE
Remove all reads to `assessment.allow_real_time_grading`

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
@@ -150,11 +150,7 @@ router.post(
       await processDeleteFile(req, res);
       res.redirect(req.originalUrl);
     } else if (['grade', 'finish', 'timeLimitFinish'].includes(req.body.__action)) {
-      if (req.body.__action === 'grade') {
-        if (!res.locals.assessment.allow_real_time_grading) {
-          throw new HttpStatusError(403, 'Real-time grading is not allowed for this assessment');
-        }
-      } else if (req.body.__action === 'timeLimitFinish') {
+      if (req.body.__action === 'timeLimitFinish') {
         // Only close if the timer expired due to time limit, not for access end
         if (!res.locals.assessment_instance_time_limit_expired) {
           return res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1978,7 +1978,6 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['newexam'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedData = await getSyncedAssessmentData('newexam');
-    assert.isTrue(syncedData.assessment.allow_real_time_grading);
     assert.isNull(syncedData.assessment.json_allow_real_time_grading);
     assert.lengthOf(syncedData.assessment_questions, 1);
     assert.isTrue(syncedData.assessment_questions[0].allow_real_time_grading);
@@ -1996,7 +1995,6 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['newexam'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedData = await getSyncedAssessmentData('newexam');
-    assert.isTrue(syncedData.assessment.allow_real_time_grading);
     assert.isTrue(syncedData.assessment.json_allow_real_time_grading);
     assert.lengthOf(syncedData.assessment_questions, 1);
     assert.isTrue(syncedData.assessment_questions[0].allow_real_time_grading);
@@ -2014,7 +2012,6 @@ describe('Assessment syncing', () => {
     courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['newexam'] = assessment;
     await util.writeAndSyncCourseData(courseData);
     const syncedData = await getSyncedAssessmentData('newexam');
-    assert.isFalse(syncedData.assessment.allow_real_time_grading);
     assert.isFalse(syncedData.assessment.json_allow_real_time_grading);
     assert.lengthOf(syncedData.assessment_questions, 1);
     assert.isFalse(syncedData.assessment_questions[0].allow_real_time_grading);
@@ -3159,10 +3156,6 @@ describe('Assessment syncing', () => {
 
       const syncedData = await getSyncedAssessmentData('allowRealTimeGradingDefault');
 
-      // Assessment-level value should be true. This is only temporary for
-      // backwards compatibility.
-      assert.isTrue(syncedData.assessment.allow_real_time_grading);
-
       // Assessment JSON config is not explicitly set.
       assert.isNull(syncedData.assessment.json_allow_real_time_grading);
 
@@ -3214,7 +3207,6 @@ describe('Assessment syncing', () => {
       const syncedData = await getSyncedAssessmentData('allowRealTimeGradingAssessmentFalse');
 
       // Assessment-level should be false
-      assert.isFalse(syncedData.assessment.allow_real_time_grading);
       assert.isFalse(syncedData.assessment.json_allow_real_time_grading);
 
       // All lower levels should be null (inheriting from assessment)
@@ -3258,7 +3250,6 @@ describe('Assessment syncing', () => {
       const syncedData = await getSyncedAssessmentData('allowRealTimeGradingZoneOverride');
 
       // Assessment-level should be false
-      assert.isFalse(syncedData.assessment.allow_real_time_grading);
       assert.isFalse(syncedData.assessment.json_allow_real_time_grading);
 
       // Zone-level should override to true
@@ -3299,7 +3290,6 @@ describe('Assessment syncing', () => {
       const syncedData = await getSyncedAssessmentData('allowRealTimeGradingQuestionOverride');
 
       // Assessment and zone should have expected values
-      assert.isTrue(syncedData.assessment.allow_real_time_grading);
       assert.isTrue(syncedData.assessment.json_allow_real_time_grading);
       assert.isNull(syncedData.zones[0].json_allow_real_time_grading);
 
@@ -3408,7 +3398,6 @@ describe('Assessment syncing', () => {
       const syncedData = await getSyncedAssessmentData('allowRealTimeGradingMixedHierarchy');
 
       // Assessment should be false
-      assert.isFalse(syncedData.assessment.allow_real_time_grading);
       assert.isFalse(syncedData.assessment.json_allow_real_time_grading);
 
       // Zone 1 should override to true


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This PR starts work on cleaning up the `assessment.allow_real_time_grading` column, which we want to remove.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

None.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
