### PR TITLE
Update reference to viz-js library bundle in pl-file-editor

### DIFF
--- a/apps/prairielearn/elements/pl-file-editor/info.json
+++ b/apps/prairielearn/elements/pl-file-editor/info.json
@@ -13,7 +13,7 @@
     "nodeModulesScripts": {
       "marked": "marked/lib/marked.esm.js",
       "@prairielearn/marked-mathjax": "@prairielearn/marked-mathjax/dist/index.js",
-      "@viz-js/viz": "@viz-js/viz/lib/viz-standalone.mjs"
+      "@viz-js/viz": "@viz-js/viz/dist/viz.js"
     }
   }
 }

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -64,16 +64,16 @@ window.PLFileEditor = function (uuid, options) {
 
   this.plOptionFocus = options.plOptionFocus;
 
-  if (options.preview) {
-    this.editor.session.on('change', () => this.updatePreview(options.preview));
-    this.updatePreview(options.preview);
-  }
-
   let currentContents = '';
   if (options.currentContents) {
     currentContents = this.b64DecodeUnicode(options.currentContents);
   }
   this.setEditorContents(currentContents);
+
+  if (options.preview) {
+    this.editor.session.on('change', () => this.updatePreview(options.preview));
+    this.updatePreview(options.preview);
+  }
 
   this.syncSettings();
 

--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -103,13 +103,6 @@ window.PLFileEditor.prototype.syncSettings = function () {
 };
 
 window.PLFileEditor.prototype.updatePreview = async function (preview_type) {
-  const editor_value = this.editor.getValue();
-  const default_preview_text = '<p>Begin typing above to preview</p>';
-  const html_contents = editor_value
-    ? ((await Promise.resolve(this.preview[preview_type]?.(editor_value))) ??
-      `<p>Unknown preview type: <code>${preview_type}</code></p>`)
-    : '';
-
   /** @type {HTMLElement} */
   const preview = this.element.find('.preview')[0];
   let shadowRoot = preview.shadowRoot;
@@ -127,6 +120,14 @@ window.PLFileEditor.prototype.updatePreview = async function (preview_type) {
       shadowRoot.adoptedStyleSheets.push(style);
     }
   }
+
+  const editor_value = this.editor.getValue();
+  const default_preview_text = '<p>Begin typing above to preview</p>';
+  const html_contents = editor_value
+    ? ((await Promise.resolve(this.preview[preview_type]?.(editor_value))) ??
+      `<p>Unknown preview type: <code>${preview_type}</code></p>`)
+    : '';
+
   if (html_contents.trim().length === 0) {
     shadowRoot.innerHTML = default_preview_text;
   } else {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

As discussed on Slack. The @viz-js/viz package updated its bundle location, which caused issues in the `pl-file-editor preview="dot"` code. This PR changes the code to make reference to the new location for the bundle.

As I was testing this code, I also noticed a race condition, where the following sequence of events would happen:

* Question has a `pl-file-editor` with a preview setting, and some initial content.
* As the page is loaded, the `updatePreview` function is called with the initial value (empty). This function is async without calling await, so it would be done in the background.
* The first call to `updatePreview` would initialize the shadow root, waiting on mathjax to be started.
* In parallel, the editor contents would be updated, causing the change listener to call `updatePreview` as well.
* While mathjax was being awaited, the second call to `updatePreview` would be triggered. Since the shadowRoot would have been set already, it would proceed with updating the preview content.
* After mathjax was initialized, the first `updatePreview` would proceed, but with the old value of the editor content.

This caused the initial preview to start with a blank slate instead of the initial content. This was fixed with two changes:
* The call to `updatePreview` and the setup of the change listener were moved to after the initial content was set;
* The creation of the shadow root of the previewer was moved to before the process of reading the editor value and computing the previewer content.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

In master, the demo/graphvizEditorPreview question in the example course causes an error in preview. In this PR, it shows a preview of the initial content.

@nwalters512 suggested creating a test that checks that all dependencies listed in the elements info.json files exist in the proper location. I'm leaving that for a separate PR, and tracking it in #12949.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
