### PR TITLE
Add CI test to check if element dependencies exist in node modules

### DIFF
--- a/apps/prairielearn/src/middlewares/staticNodeModules.ts
+++ b/apps/prairielearn/src/middlewares/staticNodeModules.ts
@@ -4,7 +4,8 @@ import express, { Router } from 'express';
 import { type ServeStaticOptions } from 'serve-static';
 
 import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from '../lib/paths.js';
-const NODE_MODULES_PATHS = [
+
+export const NODE_MODULES_PATHS = [
   path.resolve(APP_ROOT_PATH, 'node_modules'),
   path.resolve(REPOSITORY_ROOT_PATH, 'node_modules'),
 ];

--- a/apps/prairielearn/src/tests/elementDependencies.test.ts
+++ b/apps/prairielearn/src/tests/elementDependencies.test.ts
@@ -25,10 +25,10 @@ export async function nodeModulesFileExists(assetPath: string): Promise<boolean>
 
 describe('Element dependencies', () => {
   test('All dependencies in info.json files exist in node_modules', async () => {
-    const elementDirs = await fs.readdir(ELEMENTS_PATH, { withFileTypes: true });
+    const elementDirs = await fs.readdir(ELEMENTS_PATH);
 
-    for (const dir of elementDirs) {
-      const infoJsonPath = path.join(ELEMENTS_PATH, dir.name, 'info.json');
+    for (const element of elementDirs) {
+      const infoJsonPath = path.join(ELEMENTS_PATH, element, 'info.json');
       const infoJsonContent = await fs.readFile(infoJsonPath, 'utf-8');
       const info = JSON.parse(infoJsonContent);
 
@@ -39,10 +39,9 @@ describe('Element dependencies', () => {
       ];
 
       for (const dependency of dependencies) {
-        const exists = await nodeModulesFileExists(dependency);
         assert.isTrue(
-          exists,
-          `Dependency "${dependency}" in element "${dir.name}" does not exist in node_modules`,
+          await nodeModulesFileExists(dependency),
+          `Dependency "${dependency}" in element "${element}" does not exist in node_modules`,
         );
       }
     }

--- a/apps/prairielearn/src/tests/elementDependencies.test.ts
+++ b/apps/prairielearn/src/tests/elementDependencies.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs/promises';
+import path from 'path';
+
+import { assert, describe, test } from 'vitest';
+
+import { APP_ROOT_PATH } from '../lib/paths.js';
+import { NODE_MODULES_PATHS } from '../middlewares/staticNodeModules.js';
+
+const ELEMENTS_PATH = path.resolve(APP_ROOT_PATH, 'elements');
+
+export async function nodeModulesFileExists(assetPath: string): Promise<boolean> {
+  for (const p of NODE_MODULES_PATHS) {
+    const resolvedPath = path.resolve(p, assetPath);
+    if (
+      await fs.access(resolvedPath).then(
+        () => true,
+        () => false,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe('Element dependencies', () => {
+  test('All dependencies in info.json files exist in node_modules', async () => {
+    const elementDirs = await fs.readdir(ELEMENTS_PATH, { withFileTypes: true });
+
+    for (const dir of elementDirs) {
+      const infoJsonPath = path.join(ELEMENTS_PATH, dir.name, 'info.json');
+      const infoJsonContent = await fs.readFile(infoJsonPath, 'utf-8');
+      const info = JSON.parse(infoJsonContent);
+
+      const dependencies = [
+        ...(info.dependencies?.nodeModulesScripts || []),
+        ...(info.dependencies?.nodeModulesStyles || []),
+        ...Object.values(info.dynamicDependencies?.nodeModulesScripts || {}),
+      ];
+
+      for (const dependency of dependencies) {
+        const exists = await nodeModulesFileExists(dependency);
+        assert.isTrue(
+          exists,
+          `Dependency "${dependency}" in element "${dir.name}" does not exist in node_modules`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Resolves #12949. Adds a test in CI that checks if all element node modules dependencies actually correspond to existing files in node_modules. This should fail until #12950 is merged.

The initial version of the code was written by GitHub Copilot (4o model). The code was reviewed and updated to account for the proper format of info.json.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

This was tested locally by changing random dependencies to invalid file names, with the test failing when the file does not exist. It is also being tested in GitHub itself by submitting it in a merge without #12950, which should cause it to fail. Once that fails I'll change the target branch to that of #12950, so it is merged after that PR.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
