### PR TITLE
Remove unneeded changeset

### DIFF
--- a/.changeset/blue-flies-clap.md
+++ b/.changeset/blue-flies-clap.md
@@ -1,5 +1,0 @@
----
-'@prairielearn/preact': major
----
-
-Initial version of `@prairielearn/preact` package


### PR DESCRIPTION
# Description

This changeset was added in #12903 to satisfy the CI check, but after being merged, that opened https://github.com/PrairieLearn/PrairieLearn/pull/12953. There's no point in bumping the version of a brand-new package, so I'm just removing the file.

# Testing

N/A
