### PR TITLE
Fix description of default-selected action in time limit editor

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.tsx
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentInstancesClient.tsx
@@ -452,7 +452,7 @@ onDocumentReady(() => {
     };
   }) {
     const [form, setForm] = useState(() => ({
-      action: run(() => {
+      action: run((): TimeLimitAction => {
         if (row.time_remaining_sec !== null) return 'add';
         return 'set_total';
       }),


### PR DESCRIPTION
# Description

Previously, we would show an incorrect description under the default-selected option when an assessment instance didn't have a time limit:

<img width="426" height="366" alt="Screenshot 2025-09-22 at 16 34 22" src="https://github.com/user-attachments/assets/f17f2da3-00f7-4433-bb09-0a43dcc34509" />

This PR changes things to show the correct one:

<img width="423" height="392" alt="Screenshot 2025-09-22 at 16 34 52" src="https://github.com/user-attachments/assets/aa6e8db3-1d2e-44f2-8968-74f9ef79002d" />

# Testing

- Start `E1` in the test course in "Student view without access restrictions"
- Visit the "Students" tab of the assessment
- Click to edit the time limit

On master, the default option would have the wrong description. On this branch, it has the correct description.