### PR TITLE
Fix AuthzMismatch component for cases where `authzData` is not defined

### DIFF
--- a/apps/prairielearn/src/lib/client/page-context.ts
+++ b/apps/prairielearn/src/lib/client/page-context.ts
@@ -87,8 +87,8 @@ export function getPageContext(
 
 export function getPageContext(
   resLocals: Record<string, any>,
-  options?: {
-    withAuthzData?: false;
+  options: {
+    withAuthzData: false;
   },
 ): PageContext;
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Closes #12957 . We discussed that in this case, we will just show the original error, since you can't clear the "is_administrator" flag without updating the "Clear Effective User" to also unset the associated cookie here.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

<img width="2368" height="800" alt="CleanShot 2025-09-22 at 20 42 07@2x" src="https://github.com/user-attachments/assets/88441d96-b60d-4295-9451-cc4bcaa93664" />

See attached issue.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
