### PR TITLE
Remove unused border-gray class

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAiGenerateDraftsSampleQuestions.tsx
+++ b/apps/prairielearn/assets/scripts/instructorAiGenerateDraftsSampleQuestions.tsx
@@ -87,7 +87,7 @@ function SampleQuestionSelector({
           as="button"
           type="button"
           style={{ width: '100%' }}
-          class="btn dropdown-toggle border border-gray d-flex justify-content-between align-items-center bg-white"
+          class="btn dropdown-toggle border d-flex justify-content-between align-items-center bg-white"
         >
           {selectedQuestionName}
         </DropdownToggle>

--- a/apps/prairielearn/src/components/SideNav.tsx
+++ b/apps/prairielearn/src/components/SideNav.tsx
@@ -237,7 +237,7 @@ function CourseNav({
       <div id="course-dropdown" class="dropdown">
         <button
           type="button"
-          class="btn dropdown-toggle border border-gray bg-white w-100 d-flex justify-content-between align-items-center mb-2"
+          class="btn dropdown-toggle border bg-white w-100 d-flex justify-content-between align-items-center mb-2"
           aria-label="Change course"
           aria-haspopup="true"
           aria-expanded="false"
@@ -297,7 +297,7 @@ function CourseInstanceNav({
         <div id="course-instance-dropdown" class="dropdown">
           <button
             type="button"
-            class="btn dropdown-toggle border border-gray bg-white w-100 d-flex justify-content-between align-items-center mb-2"
+            class="btn dropdown-toggle border bg-white w-100 d-flex justify-content-between align-items-center mb-2"
             aria-label="Change course instance"
             aria-haspopup="true"
             aria-expanded="false"

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -127,7 +127,7 @@ export function InstructorInstanceAdminLti13({
               <div class="dropdown mb-2">
                 <button
                   type="button"
-                  class="btn dropdown-toggle border border-gray w-100 text-start pe-4"
+                  class="btn dropdown-toggle border w-100 text-start pe-4"
                   data-bs-toggle="dropdown"
                   aria-haspopup="true"
                   aria-expanded="false"


### PR DESCRIPTION
# Description

This `border-gray` class doesn't exist an has no impact. I'm removing it so it doesn't proliferate any further as we copy things around.

# Testing

Look at the relevant pages, they still look the same.
