### PR TITLE
Fix MathJax initializing multiple times on same page

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/mathjax.ts
+++ b/apps/prairielearn/assets/scripts/lib/mathjax.ts
@@ -1,3 +1,5 @@
+import { withResolvers } from '@prairielearn/utils';
+
 // Default to SVG, as lines were sometimes disappearing when using the CHTML renderer. Note that
 // some elements (e.g., pl-drawing) depend on an SVG output.
 const outputComponent = 'output/svg';
@@ -8,11 +10,18 @@ declare global {
   }
 }
 
-const mathjaxPromise = new Promise<void>((resolve, reject) => {
+const {
+  promise: mathjaxPromise,
+  resolve: mathjaxResolve,
+  reject: mathjaxReject,
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+} = withResolvers<void>();
+
+(() => {
   if (window.MathJax) {
     // Something else already loaded MathJax on this page. Just resolve the promise
     // once MathJax reports that it is ready.
-    window.MathJax.startup.promise.then(resolve, reject);
+    window.MathJax.startup.promise.then(mathjaxResolve, mathjaxReject);
     return;
   }
 
@@ -21,6 +30,7 @@ const mathjaxPromise = new Promise<void>((resolve, reject) => {
       // We previously documented the `tex2jax_ignore` class, so we'll keep
       // supporting it for backwards compatibility.
       ignoreHtmlClass: 'mathjax_ignore|tex2jax_ignore',
+      processHtmlClass: 'mathjax_process',
     },
     tex: {
       inlineMath: [
@@ -67,8 +77,8 @@ const mathjaxPromise = new Promise<void>((resolve, reject) => {
       },
       pageReady: () => {
         return window.MathJax.startup.defaultPageReady().then(
-          () => resolve(),
-          (err: any) => reject(err),
+          () => mathjaxResolve(),
+          (err: any) => mathjaxReject(err),
         );
       },
     },
@@ -89,7 +99,7 @@ const mathjaxPromise = new Promise<void>((resolve, reject) => {
     configurable: true,
     enumerable: true,
   });
-});
+})();
 
 export async function mathjaxTypeset(elements?: Element[]) {
   await mathjaxPromise;


### PR DESCRIPTION
# Description

This PR fixes a bug where loading two bundles on one page, each of which imported the MathJax initializer, would produce the following error:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'then')
    at mathjax.ts:15:36
    at new Promise (<anonymous>)
    at mathjax.ts:11:24
    at instructorAssessmentManualGradingInstanceQuestion.js:921:1
```

This is readily reproducible from the instance question manual grading page.

The root cause is that the return value of the `Promise` constructor isn't defined when the constructor's function runs:

```
const val = new Promise(() => {
    console.log(val);
});

// Errors with "ReferenceError: val is not defined"
```

However, this gets transformed into `var` by the bundler. This "works" in the sense that it doesn't crash, but it still doesn't do what we want.

```ts
var val = new Promise(() => {
    console.log(val);
});

// Logs "undefined"
```

# Testing

Visit any instance question manual grading page. On `master`, you'll see an error:

```
TypeError: Cannot read properties of undefined (reading 'then')
```

On this branch, you will not.