### PR TITLE
Add tooltip for AI agreement icons

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingAssessmentQuestionClient.ts
@@ -407,17 +407,17 @@ onDocumentReady(() => {
                           ? html`
                               <i
                                 class="bi bi-plus-square-fill text-danger"
-                                data-toggle="tooltip"
-                                data-placement="top"
-                                title="Selected by AI but not by human"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="top"
+                                data-bs-title="Selected by AI but not by human"
                               ></i>
                             `
                           : html`
                               <i
                                 class="bi bi-dash-square-fill text-danger"
-                                data-toggle="tooltip"
-                                data-placement="top"
-                                title="Selected by human but not by AI"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="top"
+                                data-bs-title="Selected by human but not by AI"
                               ></i>
                             `}
                         <span>${item.description}</span>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

In AI grading mode, the 'AI agreement' column in manual grading instance question table shows the rubric or point difference between human and AI. When using rubric, we use plus and minus icons for false positive/negative cases, but it doesn't seem obvious what these cases mean. We are adding tooltips to these icons. 

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->

<img width="420" height="147" alt="image" src="https://github.com/user-attachments/assets/564bcd2a-faf2-4014-9153-2a422cb7a667" />

This PR only added a tooltip to the icons