### PR TITLE
Transcribe data out of images when using AI grading

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -240,7 +240,9 @@ function AIGradingExplanation({ explanation }: { explanation: string }) {
         id="ai-grading-explanation-body"
       >
         <div class="card-body">
-          <pre class="mb-0" style="white-space: pre-wrap;">${explanation}</pre>
+          <pre class="mb-0 overflow-visible mathjax_process" style="white-space: pre-wrap;">
+${explanation}</pre
+          >
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

We've noticed that when AI-grading images, it's impossible to tell after the fact what the LLM "saw".

# Testing

AI grade a submission that uses `<pl-image-capture>`. Open the instance question manual grading page and look at the explanation field, it should specifically mention aspects of the image.
