### PR TITLE
Fix handling of question/instance copy in case of sync errors

### DIFF
--- a/apps/prairielearn/src/lib/editors.sql
+++ b/apps/prairielearn/src/lib/editors.sql
@@ -30,7 +30,9 @@ FROM
   questions AS q
 WHERE
   q.course_id = $course_id
-  AND q.deleted_at IS NULL;
+  AND q.deleted_at IS NULL
+  -- Questions with sync errors may have null titles
+  AND q.title IS NOT NULL;
 
 -- BLOCK select_question_uuids_for_course
 SELECT

--- a/apps/prairielearn/src/lib/editors.sql
+++ b/apps/prairielearn/src/lib/editors.sql
@@ -19,7 +19,9 @@ FROM
   course_instances AS ci
 WHERE
   ci.course_id = $course_id
-  AND ci.deleted_at IS NULL;
+  AND ci.deleted_at IS NULL
+  -- Course instances with sync errors may have null long names
+  AND ci.long_name IS NOT NULL;
 
 -- BLOCK select_question_titles_for_course
 SELECT
@@ -39,7 +41,9 @@ WHERE
   -- We deliberately do not filter by deleted_at here. We want to fetch UUIDs
   -- even for deleted question so that we can avoid using the same UUID for a
   -- new question.
-  q.course_id = $course_id;
+  q.course_id = $course_id
+  -- Questions with sync errors may have null UUIDs
+  AND q.uuid IS NOT NULL;
 
 -- BLOCK update_draft_number
 UPDATE pl_courses

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -957,8 +957,6 @@ export class CourseInstanceCopyEditor extends Editor {
     const oldNamesLong = await sqldb.queryRows(
       sql.select_course_instances_with_course,
       { course_id: this.course.id },
-      // Although `course_instances.long_name` is nullable, we only retrieve non-deleted
-      // course instances, which should always have a non-null long name.
       z.string(),
     );
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Extracted from #12981. These issues can be a problem if there are sync errors in the questions/assessments being copied.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

To test, add a sync issue in a course (e.g., a question directory without info.json), then try to copy some question or course instance from the example course to the course that has the sync error. In master this will both cause a zod error and crash the server (since there are two redirects in the same response). In this PR it will cause the error page to properly be called with a reasonable error message.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
