### PR TITLE
Fix redirection after deleting institution LTI instance

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -232,7 +232,9 @@ router.post(
         unsafe_lti13_instance_id: req.params.unsafe_lti13_instance_id,
       });
       flash('success', 'Instance deleted.');
-      return res.redirect(req.originalUrl);
+      return res.redirect(
+        `${config.urlPrefix}/administrator/institution/${req.params.institution_id}/lti13`,
+      );
     } else {
       throw new error.HttpStatusError(400, `unknown __action: ${req.body.__action}`);
     }


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Minor issue found while testing something unrelated. Deleting an institution LTI 1.3 instance currently causes the page to be redirected to the same page, i.e., the instance that was just deleted, which causes an error. This PR changes it to redirect it to the list of instances instead.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

With enterprise enabled, in institution admin, create an LTI 1.3 instance and delete it. In master, it will show an error due to the instance no longer existing. In this branch, it redirects back to the instance list.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
