### PR TITLE
Use csv-parse for score uploads

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -1,4 +1,4 @@
-import { parse as csvParse } from 'csv-parse';
+import { type Options as CsvParseOptions, parse as csvParse } from 'csv-parse';
 import isPlainObject from 'is-plain-obj';
 import _ from 'lodash';
 import * as streamifier from 'streamifier';
@@ -15,12 +15,13 @@ import { createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
-const DEFAULT_CSV_PARSE_OPTIONS = {
-  columns: (header: string[]) => header.map((column) => column.toLowerCase()),
+const DEFAULT_CSV_PARSE_OPTIONS: CsvParseOptions = {
+  columns: (header) => header.map((column) => column.toLowerCase()),
   info: true, // include line number info
   bom: true, // handle byte order mark if present (sometimes present in files from Excel)
   trim: true, // trim whitespace around values
   skipEmptyLines: true,
+  relaxColumnCount: true, // allow rows with different number of columns
   maxRecordSize: 10000,
 };
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The csvtojson library hasn't been updated in a long time, and it has had a few security issues. This PR starts a transition to replace this library with csv-parse, which is already in use in the codebase anyway, mainly in tests. This also makes the csv parsing process compatible with the @prairielearn/csv package, which uses the sibling csv-stringify package from [the same project](https://csv.js.org/).

Future PRs can take care of other uses of csvtojson, such as group uploads and submission dev uploads. Once that is moved, we can remove the csvtojson dependency.

Changes done manually with minor help from Copilot.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Tested both manually (score upload process) and via CI.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
