### PR TITLE
Rework `propertyValueWithDefault` to not require old value

### DIFF
--- a/apps/prairielearn/src/lib/editors.test.ts
+++ b/apps/prairielearn/src/lib/editors.test.ts
@@ -179,29 +179,54 @@ describe('editors', () => {
     });
   });
 
-  describe('propertyValueWithDefault', () => {
+  // TODO: remove this once reviewer is convinced this change is sound.
+  describe('propertyValueWithDefault (old)', () => {
+    const propertyValueWithDefaultOld = (_, newValue, defaultValue) =>
+      propertyValueWithDefault(newValue, defaultValue);
     it('should return the new value if it differs from the default value', () => {
-      const property = propertyValueWithDefault('Existing', 'New', 'Default');
+      const property = propertyValueWithDefaultOld('Existing', 'New', 'Default');
       assert.equal(property, 'New');
     });
     it('should return undefined if the new value is the same as the default value', () => {
-      const property = propertyValueWithDefault('Existing', 'Default', 'Default');
+      const property = propertyValueWithDefaultOld('Existing', 'Default', 'Default');
       assert.equal(property, undefined);
     });
     it('should return the new value if it differs from the default value, even if the existing value is undefined', () => {
-      const property = propertyValueWithDefault(undefined, 'New', 'Default');
+      const property = propertyValueWithDefaultOld(undefined, 'New', 'Default');
       assert.equal(property, 'New');
     });
     it('should return the new value if it differs from the default value, even if the default value is null', () => {
-      const property = propertyValueWithDefault('Existing', null, 'Default');
+      const property = propertyValueWithDefaultOld('Existing', null, 'Default');
       assert.equal(property, null);
     });
     it('should return the new value if it differs from the default value, even if the values are numbers', () => {
-      const property = propertyValueWithDefault(0, 1, 0);
+      const property = propertyValueWithDefaultOld(0, 1, 0);
       assert.equal(property, 1);
     });
     it('should return the new value if it differs from the default value, even if the values are booleans', () => {
-      const property = propertyValueWithDefault(true, false, true);
+      const property = propertyValueWithDefaultOld(true, false, true);
+      assert.equal(property, false);
+    });
+  });
+  describe('propertyValueWithDefault (new)', () => {
+    it('should return the new value if it differs from the default value', () => {
+      const property = propertyValueWithDefault('New', 'Default');
+      assert.equal(property, 'New');
+    });
+    it('should return undefined if the new value is the same as the default value', () => {
+      const property = propertyValueWithDefault('Default', 'Default');
+      assert.equal(property, undefined);
+    });
+    it('should return the new value if it differs from the default value, even if the new value is null', () => {
+      const property = propertyValueWithDefault(null, 'Default');
+      assert.equal(property, null);
+    });
+    it('should return the new value if it differs from the default value, even if the values are numbers', () => {
+      const property = propertyValueWithDefault(1, 0);
+      assert.equal(property, 1);
+    });
+    it('should return the new value if it differs from the default value, even if the values are booleans', () => {
+      const property = propertyValueWithDefault(false, true);
       assert.equal(property, false);
     });
   });

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -193,24 +193,14 @@ export function getUniqueNames({
  * that accepts a value and returns a boolean to indicate if it should be considered
  * a default value.
  */
-export function propertyValueWithDefault(existingValue: any, newValue: any, defaultValue: any) {
-  const isExistingDefault =
-    typeof defaultValue === 'function'
-      ? defaultValue(existingValue)
-      : existingValue === defaultValue;
+export function propertyValueWithDefault(newValue: any, defaultValue: any) {
   const isNewDefault =
     typeof defaultValue === 'function' ? defaultValue(newValue) : newValue === defaultValue;
 
-  if (existingValue === undefined) {
-    if (!isNewDefault) {
-      return newValue;
-    }
+  if (!isNewDefault) {
+    return newValue;
   } else {
-    if (!isExistingDefault && isNewDefault) {
-      return undefined;
-    } else {
-      return newValue;
-    }
+    return undefined;
   }
 }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.ts
@@ -173,35 +173,26 @@ router.post(
         assessmentInfo.module = req.body.module;
       }
       const normalizedText = req.body.text?.replace(/\r\n/g, '\n');
-      assessmentInfo.text = propertyValueWithDefault(assessmentInfo.text, normalizedText, '');
+      assessmentInfo.text = propertyValueWithDefault(normalizedText, '');
       assessmentInfo.allowIssueReporting = propertyValueWithDefault(
-        assessmentInfo.allowIssueReporting,
         req.body.allow_issue_reporting === 'on',
         true,
       );
       assessmentInfo.allowPersonalNotes = propertyValueWithDefault(
-        assessmentInfo.allowPersonalNotes,
         req.body.allow_personal_notes === 'on',
         true,
       );
       if (res.locals.assessment.type === 'Exam') {
         assessmentInfo.multipleInstance = propertyValueWithDefault(
-          assessmentInfo.multipleInstance,
           req.body.multiple_instance === 'on',
           false,
         );
-        assessmentInfo.autoClose = propertyValueWithDefault(
-          assessmentInfo.autoClose,
-          req.body.auto_close === 'on',
-          true,
-        );
+        assessmentInfo.autoClose = propertyValueWithDefault(req.body.auto_close === 'on', true);
         assessmentInfo.requireHonorCode = propertyValueWithDefault(
-          assessmentInfo.requireHonorCode,
           req.body.require_honor_code === 'on',
           true,
         );
         assessmentInfo.honorCode = propertyValueWithDefault(
-          assessmentInfo.honorCode,
           req.body.honor_code?.replace(/\r\n/g, '\n').trim(),
           '',
         );

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -234,17 +234,14 @@ router.post(
       );
       courseInstanceInfo.longName = req.body.long_name;
       courseInstanceInfo.timezone = propertyValueWithDefault(
-        courseInstanceInfo.timezone,
         req.body.display_timezone,
         res.locals.course.display_timezone,
       );
       courseInstanceInfo.groupAssessmentsBy = propertyValueWithDefault(
-        courseInstanceInfo.groupAssessmentsBy,
         req.body.group_assessments_by,
         'Set',
       );
       courseInstanceInfo.hideInEnrollPage = propertyValueWithDefault(
-        courseInstanceInfo.hideInEnrollPage,
         req.body.hide_in_enroll_page === 'on',
         false,
       );

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -170,69 +170,27 @@ router.post(
       const origHash = body.orig_hash;
       questionInfo.title = body.title;
       questionInfo.topic = body.topic;
-      questionInfo.tags = propertyValueWithDefault(
-        questionInfo.tags,
-        body.tags,
-        (val) => !val || val.length === 0,
-      );
+      questionInfo.tags = propertyValueWithDefault(body.tags, (val) => !val || val.length === 0);
 
-      questionInfo.gradingMethod = propertyValueWithDefault(
-        questionInfo.gradingMethod,
-        body.grading_method,
-        'Internal',
-      );
+      questionInfo.gradingMethod = propertyValueWithDefault(body.grading_method, 'Internal');
 
-      questionInfo.singleVariant = propertyValueWithDefault(
-        questionInfo.singleVariant,
-        body.single_variant,
-        false,
-      );
+      questionInfo.singleVariant = propertyValueWithDefault(body.single_variant, false);
 
-      questionInfo.showCorrectAnswer = propertyValueWithDefault(
-        questionInfo.showCorrectAnswer,
-        body.show_correct_answer,
-        true,
-      );
+      questionInfo.showCorrectAnswer = propertyValueWithDefault(body.show_correct_answer, true);
 
       const workspaceOptions = {
         comment: questionInfo.workspaceOptions?.comment ?? undefined,
-        image: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.image,
-          body.workspace_image?.trim(),
-          '',
-        ),
-        port: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.port,
-          body.workspace_port,
-          null,
-        ),
-        home: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.home,
-          body.workspace_home?.trim(),
-          '',
-        ),
-        args: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.args,
-          body.workspace_args,
-          (v) => !v || v.length === 0,
-        ),
-        rewriteUrl: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.rewriteUrl,
-          body.workspace_rewrite_url,
-          true,
-        ),
+        image: propertyValueWithDefault(body.workspace_image?.trim(), ''),
+        port: propertyValueWithDefault(body.workspace_port, null),
+        home: propertyValueWithDefault(body.workspace_home?.trim(), ''),
+        args: propertyValueWithDefault(body.workspace_args, (v) => !v || v.length === 0),
+        rewriteUrl: propertyValueWithDefault(body.workspace_rewrite_url, true),
         gradedFiles: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.gradedFiles,
           body.workspace_graded_files,
           (v) => !v || v.length === 0,
         ),
-        enableNetworking: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.enableNetworking,
-          body.workspace_enable_networking,
-          false,
-        ),
+        enableNetworking: propertyValueWithDefault(body.workspace_enable_networking, false),
         environment: propertyValueWithDefault(
-          questionInfo.workspaceOptions?.environment,
           JSON.parse(body.workspace_environment?.replace(/\r\n/g, '\n') || '{}'),
           (val) => !val || Object.keys(val).length === 0,
         ),
@@ -245,7 +203,6 @@ router.post(
         const filteredOptions = Object.fromEntries(
           Object.entries(
             propertyValueWithDefault(
-              questionInfo.workspaceOptions,
               workspaceOptions,
               (val) => !val || Object.keys(val).length === 0,
             ),


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This caused an issue in #12884 where `propertyValueWithDefault(null, null, null) === null`, which is wrong from the documentation. We don't even need the old value here, which I remove and prove is sound since the existing tests pass.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

See the attached test suite, it should be pretty convincing that the old value doesn't help us compute this value.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
