### PR TITLE
Increase width for point input element

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -704,7 +704,7 @@ export function RubricRow({
         <input
           type="number"
           class="form-control"
-          style="width:4rem"
+          style="width:5rem"
           step="any"
           disabled={!editMode}
           value={item.points}


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

<img width="2145" height="346" alt="image" src="https://github.com/user-attachments/assets/a27d4bf5-0d01-45ee-aec9-5772a5f60480" />
The current Preact component has width 4rem for point input, which seem too narrow for a point with two decimal places (or negative and one decimal place). I'm changing from 4rem to 5rem, which is also consistent with what the rubric editing modal uses. 

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
<img width="2161" height="276" alt="image" src="https://github.com/user-attachments/assets/00ccf24c-fd55-4e2f-a837-b5018d3581fa" />
Now displays correctly without overflow. 