### PR TITLE
Update eslint rules to detect unused lodash

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -1,6 +1,5 @@
 import { type Options as CsvParseOptions, parse as csvParse } from 'csv-parse';
 import isPlainObject from 'is-plain-obj';
-import _ from 'lodash';
 import * as streamifier from 'streamifier';
 import { z } from 'zod';
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -401,22 +401,6 @@ export default tseslint.config([
       '@prairielearn/jsx-no-dollar-interpolation': 'error',
       '@prairielearn/no-unused-sql-blocks': 'error',
 
-      '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
-
-      // We use empty functions in quite a few places, so we'll disable this rule.
-      '@typescript-eslint/no-empty-function': 'off',
-
-      // Look, sometimes we just want to use `any`.
-      '@typescript-eslint/no-explicit-any': 'off',
-
-      // This was enabled when we upgraded to `@typescript-eslint/*` v6.
-      // TODO: fix the violations so we can enable this rule.
-      '@typescript-eslint/no-dynamic-delete': 'off',
-
-      // We use `!` to assert that a value is not `null` or `undefined`.
-      '@typescript-eslint/no-non-null-assertion': 'off',
-
-      // Replaces the standard `no-unused-vars` rule.
       '@stylistic/jsx-curly-brace-presence': [
         'error',
         { children: 'never', propElementValues: 'always', props: 'never' },
@@ -456,17 +440,29 @@ export default tseslint.config([
         { exceptAfterSingleLine: true },
       ],
       '@stylistic/no-tabs': 'error',
+      // Blocks double-quote strings (unless a single quote is present in the
+      // string) and backticks (unless there is a tag or substitution in place).
+      '@stylistic/quotes': ['error', 'single', { avoidEscape: true }],
+
+      '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
+      // We use empty functions in quite a few places, so we'll disable this rule.
+      '@typescript-eslint/no-empty-function': 'off',
+      // Look, sometimes we just want to use `any`.
+      '@typescript-eslint/no-explicit-any': 'off',
+      // This was enabled when we upgraded to `@typescript-eslint/*` v6.
+      // TODO: fix the violations so we can enable this rule.
+      '@typescript-eslint/no-dynamic-delete': 'off',
+      // We use `!` to assert that a value is not `null` or `undefined`.
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      // Replaces the standard `no-unused-vars` rule.
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
           args: 'after-used',
-          argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_', // Args can be _
+          varsIgnorePattern: '^_.', // This includes lodash, which should be considered
         },
       ],
-      // Blocks double-quote strings (unless a single quote is present in the
-      // string) and backticks (unless there is a tag or substitution in place).
-      '@stylistic/quotes': ['error', 'single', { avoidEscape: true }],
 
       // https://github.com/TanStack/query/blob/6402d756b702ac560b69a5ce84d6e4e764b96451/packages/eslint-plugin-query/src/index.ts#L43
       ...pluginQuery.configs['flat/recommended'][0].rules,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The check for unused variables wasn't detecting lodash, since it technically starts with `_`. This updates the rules so that `_` is only used for ignoring if it is followed by any other character. `_` by itself is still allowed in arguments.

As I was updating this I also noticed that some comments in the eslint config file were in the wrong place. This also caused a few issues with the auto-fix for key ordering. The comments should now be in their proper places.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Eslint now detects an unused lodash import.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
