### PR TITLE
Fix rich text editor handling of formulas if content is unmodified

### DIFF
--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.js
@@ -184,11 +184,11 @@
     }
 
     static updateNode(node, value) {
+      node.setAttribute('data-value', value);
       MathJax.startup.promise.then(async () => {
         const html = await (MathJax.tex2chtmlPromise || MathJax.tex2svgPromise)(value);
         node.innerHTML = html.innerHTML;
         node.contentEditable = 'false';
-        node.setAttribute('data-value', value);
       });
     }
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Fixes #13005. The issue was a race condition: when the page was loaded, the formula element was initialized, but the data-value attribute was only set after MathJax was set up. This caused the initial update of the hidden input (which ran before MathJax was initialized) to take the embedding of the formula without the data-value attribute properly set.

The solution was to update the attribute in sync, outside of the promise result function. Since the hidden input update function sanitizes the content of the formula in a way that ignores its content anyway, this means that having the attribute in place is enough for the content to be saved as expected.

Unfortunately this fix does not solve the content for any submission that was saved before the fix, and the workaround is still needed for those cases, but it should keep this from happening again in the future.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

See original issue for the steps to reproduce the issue. In this branch the error no longer happens.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
