### PR TITLE
Remove editing mode for rubric Preact component

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import { useMemo, useRef, useState } from 'preact/hooks';
 import { Modal } from 'react-bootstrap';
 
@@ -37,7 +36,6 @@ export function RubricSettings({
   }));
 
   // Define states
-  const [editMode, setEditMode] = useState(false);
   const [rubricItems, setRubricItems] = useState<RubricItemData[]>(rubricItemDataMerged);
   const [replaceAutoPoints, setReplaceAutoPoints] = useState<boolean>(
     rubricData?.replace_auto_points ?? !assessmentQuestion.max_manual_points,
@@ -146,7 +144,6 @@ export function RubricSettings({
     setMinPoints(rubricData?.min_points ?? 0);
     setMaxExtraPoints(rubricData?.max_extra_points ?? 0);
     setSettingsError(null);
-    setEditMode(false);
   };
 
   const exportRubric = () => {
@@ -338,7 +335,6 @@ export function RubricSettings({
                       <input
                         class="form-check-input"
                         type="radio"
-                        disabled={!editMode}
                         checked={!replaceAutoPoints}
                         onChange={() => {
                           setReplaceAutoPoints(false);
@@ -358,7 +354,6 @@ export function RubricSettings({
                       <input
                         class="form-check-input"
                         type="radio"
-                        disabled={!editMode}
                         checked={replaceAutoPoints}
                         onChange={() => {
                           setReplaceAutoPoints(true);
@@ -384,7 +379,6 @@ export function RubricSettings({
                   <input
                     class="form-check-input"
                     type="radio"
-                    disabled={!editMode}
                     checked={startingPoints === 0}
                     onChange={() => setStartingPoints(0)}
                   />
@@ -396,7 +390,6 @@ export function RubricSettings({
                   <input
                     class="form-check-input"
                     type="radio"
-                    disabled={!editMode}
                     checked={startingPoints !== 0}
                     onChange={() =>
                       setStartingPoints(
@@ -421,7 +414,6 @@ export function RubricSettings({
                 <input
                   class="form-control"
                   type="number"
-                  disabled={!editMode}
                   value={minPoints}
                   onInput={(e: any) => setMinPoints(Number(e.target.value))}
                 />
@@ -433,7 +425,6 @@ export function RubricSettings({
                 <input
                   class="form-control"
                   type="number"
-                  disabled={!editMode}
                   value={maxExtraPoints}
                   onInput={(e: any) => setMaxExtraPoints(Number(e.target.value))}
                 />
@@ -462,7 +453,6 @@ export function RubricSettings({
                   <RubricRow
                     key={it.id ?? `row-${idx}`}
                     item={it}
-                    editMode={editMode}
                     showAiGradingStats={showAiGradingStats}
                     submissionCount={aiGradingStats?.submission_rubric_count ?? 0}
                     deleteRow={() => deleteRow(idx)}
@@ -502,20 +492,10 @@ export function RubricSettings({
           </div>
         ))}
         <div class="mb-3 gap-1 d-flex">
-          <button
-            type="button"
-            class="btn btn-sm btn-secondary"
-            disabled={!editMode}
-            onClick={addRubricItemRow}
-          >
+          <button type="button" class="btn btn-sm btn-secondary" onClick={addRubricItemRow}>
             Add item
           </button>
-          <button
-            type="button"
-            class="btn btn-sm btn-primary"
-            disabled={!editMode}
-            onClick={exportRubric}
-          >
+          <button type="button" class="btn btn-sm btn-primary" onClick={exportRubric}>
             <i class="fas fa-download" />
             Export rubric
           </button>
@@ -523,7 +503,6 @@ export function RubricSettings({
             id="import-rubric-button"
             type="button"
             class="btn btn-sm btn-primary"
-            disabled={!editMode}
             onClick={() => setShowImportModal(!showImportModal)}
           >
             <i class="fas fa-upload" />
@@ -579,7 +558,6 @@ export function RubricSettings({
           <button
             type="button"
             class="btn btn-sm btn-ghost"
-            disabled={!editMode}
             data-bs-toggle="tooltip"
             data-bs-placement="bottom"
             data-bs-title="Imported rubric point values will be scaled to match the maximum points for this question."
@@ -609,20 +587,12 @@ export function RubricSettings({
               Delete rubric
             </button>
           )}
-          {!editMode ? (
-            <button type="button" class="btn btn-secondary" onClick={() => setEditMode(true)}>
-              Edit rubric
-            </button>
-          ) : (
-            <>
-              <button type="button" class="btn btn-secondary me-2" onClick={onCancel}>
-                Cancel
-              </button>
-              <button type="button" class="btn btn-primary" onClick={() => submitSettings(true)}>
-                Save
-              </button>
-            </>
-          )}
+          <button type="button" class="btn btn-secondary me-2" onClick={onCancel}>
+            Reset
+          </button>
+          <button type="button" class="btn btn-primary" onClick={() => submitSettings(true)}>
+            Save
+          </button>
         </div>
       </div>
     </div>
@@ -631,7 +601,6 @@ export function RubricSettings({
 
 export function RubricRow({
   item,
-  editMode,
   showAiGradingStats,
   submissionCount,
   deleteRow,
@@ -642,7 +611,6 @@ export function RubricRow({
   onDragOver,
 }: {
   item: RubricItemData;
-  editMode: boolean;
   showAiGradingStats: boolean;
   submissionCount: number;
   deleteRow: () => void;
@@ -662,37 +630,22 @@ export function RubricRow({
       <td class="text-nowrap align-middle">
         <span
           role="button"
-          tabIndex={editMode ? 0 : -1}
-          aria-disabled={!editMode}
-          class={`btn btn-sm btn-ghost ${clsx({ disabled: !editMode })}`}
+          tabIndex={0}
+          class="btn btn-sm btn-ghost"
           style={{ cursor: 'grab' }}
-          draggable={editMode}
           onDragStart={onDragStart}
         >
           <i class="fas fa-arrows-up-down" />
         </span>
-        <button
-          type="button"
-          class="visually-hidden"
-          disabled={!editMode}
-          aria-label="Move up"
-          onClick={moveUp}
-        >
+        <button type="button" class="visually-hidden" aria-label="Move up" onClick={moveUp}>
           <i class="fas fa-arrow-up" />
         </button>
-        <button
-          type="button"
-          class="visually-hidden"
-          disabled={!editMode}
-          aria-label="Move down"
-          onClick={moveDown}
-        >
+        <button type="button" class="visually-hidden" aria-label="Move down" onClick={moveDown}>
           <i class="fas fa-arrow-down" />
         </button>
         <button
           type="button"
           class="btn btn-sm btn-ghost text-danger"
-          disabled={!editMode}
           aria-label="Delete"
           onClick={deleteRow}
         >
@@ -706,7 +659,6 @@ export function RubricRow({
           class="form-control"
           style="width:5rem"
           step="any"
-          disabled={!editMode}
           value={item.points}
           aria-label="Points"
           required
@@ -718,7 +670,6 @@ export function RubricRow({
         <input
           type="text"
           class="form-control"
-          disabled={!editMode}
           maxLength={100}
           style="min-width:15rem"
           value={item.description}
@@ -731,7 +682,6 @@ export function RubricRow({
       <td class="align-middle">
         <textarea
           class="form-control"
-          disabled={!editMode}
           maxLength={10000}
           style="min-width:15rem"
           aria-label="Explanation"
@@ -744,7 +694,6 @@ export function RubricRow({
       <td class="align-middle">
         <textarea
           class="form-control"
-          disabled={!editMode}
           maxLength={10000}
           style="min-width:15rem"
           aria-label="Grader note"
@@ -760,7 +709,6 @@ export function RubricRow({
             <input
               type="radio"
               class="form-check-input"
-              disabled={!editMode}
               checked={item.always_show_to_students}
               onChange={() => updateRubricItem({ always_show_to_students: true })}
             />
@@ -772,7 +720,6 @@ export function RubricRow({
             <input
               type="radio"
               class="form-check-input"
-              disabled={!editMode}
               checked={!item.always_show_to_students}
               onChange={() => updateRubricItem({ always_show_to_students: false })}
             />


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

Because of the use of collapsible element, we agree that we don't need the editing mode for the rubric editing Preact component, and everything should be editable all the time. 

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->

<img width="2176" height="642" alt="image" src="https://github.com/user-attachments/assets/575ea34d-d382-4ac5-9c22-282652aae01a" />

Everything should be enabled on load