### PR TITLE
Use request sessions in API download script

### DIFF
--- a/contrib/api_download.py
+++ b/contrib/api_download.py
@@ -47,13 +47,12 @@ def main():
     os.makedirs(args.output_dir, exist_ok=True)
     print("successfully ensured directory existence")
 
-    session = requests.Session()
-
-    logfilename = os.path.join(args.output_dir, "download_log.txt")
-    print(f"opening log file {logfilename} ...")
-    with open(logfilename, "a" if args.resume else "w") as logfile:
-        print("successfully opened log file")
-        download_course_instance(args, session, logfile)
+    with requests.Session() as session:
+        logfilename = os.path.join(args.output_dir, "download_log.txt")
+        print(f"opening log file {logfilename} ...")
+        with open(logfilename, "a" if args.resume else "w") as logfile:
+            print("successfully opened log file")
+            download_course_instance(args, session, logfile)
 
 
 def download_course_instance(

--- a/contrib/api_download.py
+++ b/contrib/api_download.py
@@ -47,31 +47,41 @@ def main():
     os.makedirs(args.output_dir, exist_ok=True)
     print("successfully ensured directory existence")
 
+    session = requests.Session()
+
     logfilename = os.path.join(args.output_dir, "download_log.txt")
     print(f"opening log file {logfilename} ...")
     with open(logfilename, "a" if args.resume else "w") as logfile:
         print("successfully opened log file")
-        download_course_instance(args, logfile)
+        download_course_instance(args, session, logfile)
 
 
-def download_course_instance(args: argparse.Namespace, logfile: typing.TextIO):
+def download_course_instance(
+    args: argparse.Namespace, session: requests.Session, logfile: typing.TextIO
+):
     log(logfile, f"starting download at {local_iso_time()} ...")
     start_time = time.time()
     course_instance_path = f"/course_instances/{args.course_instance_id}"
-    get_and_save_json(course_instance_path, "course_instance_info", args, logfile)
-    get_and_save_json(f"{course_instance_path}/gradebook", "gradebook", args, logfile)
     get_and_save_json(
+        session, course_instance_path, "course_instance_info", args, logfile
+    )
+    get_and_save_json(
+        session, f"{course_instance_path}/gradebook", "gradebook", args, logfile
+    )
+    get_and_save_json(
+        session,
         f"{course_instance_path}/course_instance_access_rules",
         "course_instance_access_rules",
         args,
         logfile,
     )
     assessments = get_and_save_json(
-        f"{course_instance_path}/assessments", "assessments", args, logfile
+        session, f"{course_instance_path}/assessments", "assessments", args, logfile
     )
 
     for assessment in assessments:
         assessment_instances = get_and_save_json(
+            session,
             f"{course_instance_path}/assessments/{assessment['assessment_id']}/assessment_instances",
             f"assessment_{assessment['assessment_id']}_instances",
             args,
@@ -79,6 +89,7 @@ def download_course_instance(args: argparse.Namespace, logfile: typing.TextIO):
         )
 
         get_and_save_json(
+            session,
             f"{course_instance_path}/assessments/{assessment['assessment_id']}/assessment_access_rules",
             f"assessment_{assessment['assessment_id']}_access_rules",
             args,
@@ -87,6 +98,7 @@ def download_course_instance(args: argparse.Namespace, logfile: typing.TextIO):
 
         for assessment_instance in assessment_instances:
             get_and_save_json(
+                session,
                 f"{course_instance_path}/assessment_instances/{assessment_instance['assessment_instance_id']}/instance_questions",
                 f"assessment_instance_{assessment_instance['assessment_instance_id']}_instance_questions",
                 args,
@@ -94,6 +106,7 @@ def download_course_instance(args: argparse.Namespace, logfile: typing.TextIO):
             )
 
             get_and_save_json(
+                session,
                 f"{course_instance_path}/assessment_instances/{assessment_instance['assessment_instance_id']}/submissions",
                 f"assessment_instance_{assessment_instance['assessment_instance_id']}_submissions",
                 args,
@@ -101,6 +114,7 @@ def download_course_instance(args: argparse.Namespace, logfile: typing.TextIO):
             )
 
             get_and_save_json(
+                session,
                 f"{course_instance_path}/assessment_instances/{assessment_instance['assessment_instance_id']}/log",
                 f"assessment_instance_{assessment_instance['assessment_instance_id']}_log",
                 args,
@@ -113,7 +127,11 @@ def download_course_instance(args: argparse.Namespace, logfile: typing.TextIO):
 
 
 def get_and_save_json(
-    endpoint: str, filename: str, args: argparse.Namespace, logfile: typing.TextIO
+    session: requests.Session,
+    endpoint: str,
+    filename: str,
+    args: argparse.Namespace,
+    logfile: typing.TextIO,
 ):
     full_filename = os.path.join(args.output_dir, filename + ".json")
     if args.resume and os.path.exists(full_filename):
@@ -134,7 +152,7 @@ def get_and_save_json(
     retry_502_max = 30
     retry_502_i = 0
     while True:
-        r = requests.get(url, headers=headers)
+        r = session.get(url, headers=headers)
         if r.status_code == 200:
             break
         if r.status_code == 502:


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The use of sessions means that the same TCP connection can be reused across calls. Since all calls go to the same server, this is considerable. I haven't measured, but the performance improvement is noticeable, and the incidence of errors that interrupt the download is reduced considerably.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Functionally it remains the same, but code runs significantly faster for a large enough course instance.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
