### PR TITLE
Fix bug with AI question generation revert buttons

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.html.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.html.tsx
@@ -171,6 +171,28 @@ export function InstructorAiGenerateDraftEditor({
   `.toString();
 }
 
+/**
+ * Returns the index of the prompt that represents the latest revision that would have been shown
+ * to the user after the prompt at the specified index. This specifically addresses the case where
+ * one or more `auto_revision` prompts follow an `initial` or `human_revision` prompt.
+ */
+function findLatestRevisionIndexForPrompt(
+  prompts: AiQuestionGenerationPrompt[],
+  currentIndex: number,
+): number {
+  let targetIndex = currentIndex;
+
+  for (let nextIndex = currentIndex + 1; nextIndex < prompts.length; nextIndex += 1) {
+    if (prompts[nextIndex].prompt_type !== 'auto_revision') {
+      break;
+    }
+
+    targetIndex = nextIndex;
+  }
+
+  return targetIndex;
+}
+
 function PromptHistory({
   prompts,
   urlPrefix,
@@ -182,12 +204,14 @@ function PromptHistory({
   csrfToken: string;
   showJobLogs: boolean;
 }) {
-  return prompts.map((prompt, index, filteredPrompts) => {
-    // TODO: Once we can upgrade to Bootstrap 5.3, we can use the official
-    // `bg-secondary-subtle` class instead of the custom styles here.
+  return prompts.map((prompt, index) => {
+    // Exclude auto-revision prompts from the visible history (we still use them internally to
+    // determine what to revert to).
+    if (prompt.prompt_type === 'auto_revision') return '';
+
     return html`
       <div class="d-flex flex-row-reverse">
-        <div class="p-3 mb-2 rounded" style="background: #e2e3e5; max-width: 90%">
+        <div class="p-3 mb-2 rounded bg-secondary-subtle" style="max-width: 90%">
           ${run(() => {
             // We'll special-case these two "prompts" and show a custom italic
             // message
@@ -237,13 +261,15 @@ function PromptHistory({
           </div>
         </div>
         ${run(() => {
-          // There's no point showing an option to revert to the most recent prompt.
-          if (index === filteredPrompts.length - 1) return '';
+          const revertTargetIndex = findLatestRevisionIndexForPrompt(prompts, index);
+          const revertTargetPrompt = prompts[revertTargetIndex];
+
+          if (revertTargetIndex === prompts.length - 1) return '';
 
           return html`
             <form method="post">
               <input type="hidden" name="__action" value="revert_edit_version" />
-              <input type="hidden" name="unsafe_prompt_id" value="${prompt.id}" />
+              <input type="hidden" name="unsafe_prompt_id" value="${revertTargetPrompt.id}" />
               <input type="hidden" name="__csrf_token" value="${csrfToken}" />
               <button
                 type="submit"

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.sql
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.sql
@@ -8,7 +8,6 @@ WHERE
   questions.id = $question_id
   AND questions.course_id = $course_id
   AND questions.deleted_at IS NULL
-  AND ai_question_generation_prompts.prompt_type <> 'auto_revision'
 ORDER BY
   ai_question_generation_prompts.id;
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
@@ -178,9 +178,7 @@ export function InstructorQuestionSettings({
                     <th class="align-middle">
                       <label id="topic-label" for="topic">Topic</label>
                     </th>
-                    <!-- The style attribute is necessary until we upgrade to Bootstrap 5.3 -->
-                    <!-- This is used by tom-select to style the active item in the dropdown -->
-                    <td style="--bs-tertiary-bg: #f8f9fa">
+                    <td>
                       ${canEdit
                         ? html`
                             <select


### PR DESCRIPTION
# Description

This bug was first identified in https://github.com/PrairieLearn/PrairieLearn/pull/12859/files#r2380556041. I'm pulling the complete fix into a separate PR.

The latest auto-revision after a human prompt revision is the one that contains the final HTML/Python for the corresponding human prompt. However, we were previously filtering out the auto-revisions, meaning that clicking the "Revert" button would revert to a broken revision if the revision later had auto-revisions that fixed issues with it.

This PR updates the query to remove that filtering and updates the UI to use the correct revision ID when reverting.

# Testing

To reproduce the error on `master`, create a question with the following prompt:

> Generate a question that asks students to add two random integers between 1 and 20. For the sake of testing, please deliberately introduce a mistake in the attributes on your FIRST generation - specifically, add an invalid attribute. If you're later asked to fix it, please do.

Make a follow-up revision prompt:

> Change the range to be 1-50.

Click the "Revert to this revision" button next to the first reply. Assuming the LLM followed your instructions, you should now see a rendering error complaining about an invalid attribute.

On this branch, you should see no such error.