### PR TITLE
Improve ordering of draft questions table

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.sql
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.sql
@@ -14,18 +14,18 @@ WHERE
   AND q.deleted_at IS NULL
   AND q.qid IS NOT NULL
 ORDER BY
-  -- Put UIDs with numeric suffixes first. This orders expected QIDs of the form
-  -- `__drafts__/draft_###` before unexpected QIDs like `__drafts__/draft_extra`.
+  -- Order expected QIDs of the form `__drafts__/draft_###` before unexpected
+  -- QIDs like `__drafts__/draft_extra`.
   (
     CASE
-      WHEN substring(q.qid, 18) ~ '^[0-9]+$' THEN 0
+      WHEN q.qid ~ '^__drafts__/draft_[0-9]+$' THEN 0
       ELSE 1
     END
   ) ASC,
   -- Order numeric QIDs numerically.
   (
     CASE
-      WHEN substring(q.qid, 18) ~ '^[0-9]+$' THEN substring(q.qid, 18)::numeric
+      WHEN q.qid ~ '^__drafts__/draft_[0-9]+$' THEN regexp_replace(q.qid, '^__drafts__/draft_', '')::numeric
       ELSE NULL
     END
   ) ASC,


### PR DESCRIPTION
# Description

Draft questions were sorted unexpectedly on the AI question generation page:

<img width="1184" height="2186" alt="Screenshot 2025-09-25 at 16 46 34" src="https://github.com/user-attachments/assets/d1ae93ec-5c7c-4c53-bc15-e2f20eb327dd" />

This PR changes the sorting to use the numerical suffix if one is present, and to sort numerically by that suffix.

# Testing

Before this change:

<img width="582" height="188" alt="Screenshot 2025-09-30 at 09 11 03" src="https://github.com/user-attachments/assets/8df5ae7d-b441-4a72-95c4-c02f610755d0" />


After this change:

<img width="586" height="188" alt="Screenshot 2025-09-30 at 09 10 33" src="https://github.com/user-attachments/assets/f9ee4a3f-9f20-466f-9e2a-9d1633db7b11" />