### PR TITLE
Consistently use pretty-printing when rendering Preact

### DIFF
--- a/.changeset/hip-things-cut.md
+++ b/.changeset/hip-things-cut.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/preact': patch
+---
+
+Use pretty rendering in dev mode in `renderHtmlDocument(...)`

--- a/packages/preact/src/server.tsx
+++ b/packages/preact/src/server.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { isFragment, isValidElement } from 'preact/compat';
-import { render } from 'preact-render-to-string/jsx';
 import superjson from 'superjson';
 
 import { compiledScriptPath, compiledScriptPreloadPaths } from '@prairielearn/compiled-assets';
@@ -37,7 +36,7 @@ function escapeJsonForHtml(value: any): string {
  * @returns An HTML string containing the rendered content.
  */
 export function renderHtmlDocument(content: VNode) {
-  return `<!doctype html>\n${render(content, {}, { pretty: true, jsx: false })}`;
+  return `<!doctype html>\n${renderHtml(content)}`;
 }
 
 interface HydrateProps {


### PR DESCRIPTION
# Description

Noticed this while reading the code. The inlined `render(...)` call was the same as that used by `renderHtml`, except that the latter will make pretty-printing conditional on the environment:

https://github.com/PrairieLearn/PrairieLearn/blob/d691e8b9cbd6c533db2eb0df61854a799517a117/packages/preact/src/index.ts#L18-L25

# Testing

N/A; AFAICT this isn't used anywhere. This is just about increasing consistency for if/when we do start using it.