### PR TITLE
Handle floating-point error in rubric total points warning

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -59,10 +59,11 @@ export function RubricSettings({
     return { totalPositive: roundPoints(pos), totalNegative: roundPoints(neg) };
   }, [rubricItems, startingPoints]);
 
-  const maxPoints =
+  const maxPoints = roundPoints(
     (replaceAutoPoints
       ? (assessmentQuestion.max_points ?? 0)
-      : (assessmentQuestion.max_manual_points ?? 0)) + maxExtraPoints;
+      : (assessmentQuestion.max_manual_points ?? 0)) + maxExtraPoints,
+  );
 
   const pointsWarnings: string[] = useMemo(() => {
     const warnings: string[] = [];

--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -56,7 +56,7 @@ export function RubricSettings({
       .reduce<
         [number, number]
       >(([p, n], v) => (v > 0 ? [p + v, n] : [p, n + v]), [startingPoints, startingPoints]);
-    return { totalPositive: pos, totalNegative: neg };
+    return { totalPositive: roundPoints(pos), totalNegative: roundPoints(neg) };
   }, [rubricItems, startingPoints]);
 
   const maxPoints =
@@ -68,9 +68,9 @@ export function RubricSettings({
     const warnings: string[] = [];
     if (totalPositive < maxPoints) {
       warnings.push(
-        `Rubric item points reach at most ${totalPositive} points. ${
-          maxPoints - totalPositive
-        } left to reach maximum.`,
+        `Rubric item points reach at most ${totalPositive} points. ${roundPoints(
+          maxPoints - totalPositive,
+        )} left to reach maximum.`,
       );
     }
     if (totalNegative > minPoints) {

--- a/apps/prairielearn/src/lib/points.test.ts
+++ b/apps/prairielearn/src/lib/points.test.ts
@@ -11,6 +11,10 @@ describe('roundPoints', () => {
     expect(roundPoints(0.3125)).toBe(0.3125);
   });
 
+  it('handles a large number', () => {
+    expect(roundPoints(1.23e40)).toBe(1.23e40);
+  });
+
   it('truncates long decimal places', () => {
     expect(roundPoints(0.31256789)).toBe(0.312568);
   });

--- a/apps/prairielearn/src/lib/points.test.ts
+++ b/apps/prairielearn/src/lib/points.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { roundPoints } from './points.js';
+
+describe('roundPoints', () => {
+  it('handles an integer', () => {
+    expect(roundPoints(5)).toBe(5);
+  });
+
+  it('handles a number with many decimal places', () => {
+    expect(roundPoints(0.3125)).toBe(0.3125);
+  });
+
+  it('truncates long decimal places', () => {
+    expect(roundPoints(0.31256789)).toBe(0.312568);
+  });
+
+  it('rounds to nearest integer', () => {
+    expect(roundPoints(3 + 0.4 + 0.3 + 0.3)).toBe(4);
+  });
+
+  it('avoids trailing zeroes', () => {
+    expect(roundPoints(0.1 + 0.2)).toBe(0.3);
+  });
+});

--- a/apps/prairielearn/src/lib/points.ts
+++ b/apps/prairielearn/src/lib/points.ts
@@ -1,0 +1,11 @@
+/**
+ * Rounds points in such a way that we can try to avoid accumulated floating
+ * point errors. Specifically, we format the number to a string with 6 decimal
+ * places and then re-parse it as a number. This ensures that values like
+ * `0.30000000000000004` become `0.3` and `3.9999999999999996` become `4`.
+ *
+ * See {@link https://github.com/PrairieLearn/PrairieLearn/issues/10928} for more context.
+ */
+export function roundPoints(points: number): number {
+  return Number.parseFloat(points.toFixed(6));
+}


### PR DESCRIPTION
# Description

We recently got a report of an unexpected warning when configuring rubric points:

<img width="1408" height="678" alt="image" src="https://github.com/user-attachments/assets/79567422-52ae-485d-a111-c769adcb2f90" />

Floating point math is tricky! See #10928 for other examples of this.

This PR uses the approach suggested in https://github.com/PrairieLearn/PrairieLearn/issues/10928#issuecomment-2815809010 to avoid that.



# Testing

Here's a somewhat simplified test case:

<img width="873" height="409" alt="Screenshot 2025-09-30 at 13 43 37" src="https://github.com/user-attachments/assets/eb87a34a-1f24-4100-933d-8b261ea7e840" />

Here's how things look after this PR:

<img width="529" height="413" alt="Screenshot 2025-09-30 at 13 44 18" src="https://github.com/user-attachments/assets/e7dcce52-60b5-4662-b7ac-625bf5fee647" />
