### PR TITLE
Update status and manual grading flag on regrading process

### DIFF
--- a/apps/prairielearn/src/lib/regrading.sql
+++ b/apps/prairielearn/src/lib/regrading.sql
@@ -60,7 +60,7 @@ WITH
       auto_points = aq.max_auto_points,
       manual_points = aq.max_manual_points,
       score_perc = 100,
-      requires_manual_grading = false,
+      requires_manual_grading = FALSE,
       status = 'complete',
       modified_at = now()
     FROM

--- a/apps/prairielearn/src/lib/regrading.sql
+++ b/apps/prairielearn/src/lib/regrading.sql
@@ -60,6 +60,8 @@ WITH
       auto_points = aq.max_auto_points,
       manual_points = aq.max_manual_points,
       score_perc = 100,
+      requires_manual_grading = false,
+      status = 'complete',
       modified_at = now()
     FROM
       assessment_questions AS aq


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Resolves #13020. Updates the status and requires_manual_grading flag so that, after a forced regrading to full score, grades are no longer listed as pending, as per discussion in the original issue.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Tested with the same sequence of events listed in the original issue.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
