### PR TITLE
Fix temporary ID generation for new topics

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/components/InstructorCourseAdminTopicsTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/components/InstructorCourseAdminTopicsTable.tsx
@@ -12,7 +12,7 @@ const emptyTopic: Topic = {
   color: '',
   course_id: '',
   description: '',
-  id: uuidv4(),
+  id: '',
   implicit: false,
   json_comment: '',
   name: '',
@@ -61,7 +61,7 @@ export function InstructorCourseAdminTopicsTable({
 
   const handleNewTopic = () => {
     setAddTopic(true);
-    setSelectedTopic(emptyTopic);
+    setSelectedTopic({ ...emptyTopic, id: uuidv4() });
     setShowModal(true);
   };
 


### PR DESCRIPTION
# Description

This fixes a bug from #12292. The temporary ID generated was being generated too early and  was setting the same temporary ID for all new topics. This moves that function downstream so each new topic gets it's own temporary ID. 

# Testing

To test the bug, on master try adding two new topics and then deleting one. Both will be deleted rather than the intended one to be deleted. Now trying the same process on this branch should result in only the desired target to be deleted. 
