### PR TITLE
Use `crypto.randomUUID()` for UUID generation

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -237,7 +237,6 @@
     "ua-parser-js": "^1.0.41",
     "unified": "^11.0.5",
     "unzipper": "^0.12.3",
-    "uuid": "^11.1.0",
     "vite": "^7.1.7",
     "winston": "^3.18.3",
     "xml-formatter": "^3.6.7",

--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import debugfn from 'debug';
@@ -269,7 +268,7 @@ function queueDailyJobs(jobsList: CronJob[]) {
 
 async function runJobs(jobsList: CronJob[]) {
   debug('runJobs()');
-  const cronUuid = randomUUID();
+  const cronUuid = crypto.randomUUID();
   logger.verbose('cron: jobs starting', { cronUuid });
 
   for (const job of jobsList) {

--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -1,8 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import debugfn from 'debug';
 import _ from 'lodash';
-import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '@prairielearn/logger';
 import * as namedLocks from '@prairielearn/named-locks';
@@ -269,7 +269,7 @@ function queueDailyJobs(jobsList: CronJob[]) {
 
 async function runJobs(jobsList: CronJob[]) {
   debug('runJobs()');
-  const cronUuid = uuidv4();
+  const cronUuid = randomUUID();
   logger.verbose('cron: jobs starting', { cronUuid });
 
   for (const job of jobsList) {

--- a/apps/prairielearn/src/ee/lib/ai-question-generation-benchmark.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation-benchmark.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
 import { execa } from 'execa';
@@ -198,7 +197,7 @@ export async function benchmarkAiQuestionGeneration({
     const courseTitle = `AI Question Generation Benchmark ${Date.now()}`;
     const courseName = `ai-question-generation-benchmark-${Date.now()}`;
     await fs.writeJson(path.join(courseDirectory.path, 'infoCourse.json'), {
-  uuid: randomUUID(),
+      uuid: crypto.randomUUID(),
       name: courseName,
       title: courseTitle,
       topics: [],

--- a/apps/prairielearn/src/ee/lib/ai-question-generation-benchmark.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation-benchmark.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
 import { execa } from 'execa';
@@ -5,7 +6,6 @@ import fs from 'fs-extra';
 import { type OpenAI } from 'openai';
 import { zodTextFormat } from 'openai/helpers/zod';
 import * as tmp from 'tmp-promise';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
@@ -198,7 +198,7 @@ export async function benchmarkAiQuestionGeneration({
     const courseTitle = `AI Question Generation Benchmark ${Date.now()}`;
     const courseName = `ai-question-generation-benchmark-${Date.now()}`;
     await fs.writeJson(path.join(courseDirectory.path, 'infoCourse.json'), {
-      uuid: uuidv4(),
+  uuid: randomUUID(),
       name: courseName,
       title: courseTitle,
       topics: [],

--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -6,7 +6,6 @@ import * as path from 'node:path';
 
 import express, { Router } from 'express';
 import { type HashElementNode, hashElement } from 'folder-hash';
-import { v4 as uuid } from 'uuid';
 
 import * as compiledAssets from '@prairielearn/compiled-assets';
 import { type HtmlSafeString } from '@prairielearn/html';
@@ -135,7 +134,7 @@ function getNodeModulesAssetHash(assetPath: string): string {
     // a repeatable hash that would cause the browser to cache the asset. This
     // is because we want to be able to change them without changing the package
     // version number.
-    return uuid();
+    return crypto.randomUUID();
   }
 
   // Reading files synchronously and computing cryptographic hashes are both

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import * as child_process from 'child_process';
+import { randomUUID } from 'crypto';
 import * as path from 'path';
 import { PassThrough as PassThroughStream } from 'stream';
 import * as util from 'util';
@@ -9,7 +10,6 @@ import { Upload } from '@aws-sdk/lib-storage';
 import * as async from 'async';
 import fs from 'fs-extra';
 import * as tar from 'tar';
-import { v4 as uuidv4 } from 'uuid';
 import z from 'zod';
 
 import * as namedLocks from '@prairielearn/named-locks';
@@ -681,7 +681,7 @@ export async function createAndUploadChunks(
     const chunkDirectory = coursePathForChunk(coursePath, chunk);
 
     // Generate a UUId for this chunk
-    const chunkUuid = uuidv4();
+    const chunkUuid = randomUUID();
 
     // Let's create a tarball for this chunk and send it off to S3
     const tarball = tar.create(

--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import * as child_process from 'child_process';
-import { randomUUID } from 'crypto';
 import * as path from 'path';
 import { PassThrough as PassThroughStream } from 'stream';
 import * as util from 'util';
@@ -681,7 +680,7 @@ export async function createAndUploadChunks(
     const chunkDirectory = coursePathForChunk(coursePath, chunk);
 
     // Generate a UUId for this chunk
-    const chunkUuid = randomUUID();
+    const chunkUuid = crypto.randomUUID();
 
     // Let's create a tarball for this chunk and send it off to S3
     const tarball = tar.create(

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -8,7 +9,6 @@ import { execa } from 'execa';
 import fs from 'fs-extra';
 import MemoryStream from 'memorystream';
 import * as tmp from 'tmp-promise';
-import { v4 as uuidv4 } from 'uuid';
 
 import * as bindMount from '@prairielearn/bind-mount';
 import { setupDockerAuth } from '@prairielearn/docker-utils';
@@ -159,7 +159,7 @@ export class CodeCallerContainer implements CodeCaller {
 
   private constructor(options: CodeCallerContainerOptions) {
     this.state = CREATED;
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
 
     this.debug('enter constructor()');
 

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -159,7 +158,7 @@ export class CodeCallerContainer implements CodeCaller {
 
   private constructor(options: CodeCallerContainerOptions) {
     this.state = CREATED;
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
 
     this.debug('enter constructor()');
 

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.ts
@@ -1,12 +1,12 @@
 import { type ChildProcess } from 'child_process';
 import * as child_process from 'node:child_process';
 import { type SpawnOptions } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import { type Readable, type Writable } from 'stream';
 
 import debugfn from 'debug';
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 
 import { run } from '@prairielearn/run';
 import { withResolvers } from '@prairielearn/utils';
@@ -140,7 +140,7 @@ export class CodeCallerNative implements CodeCaller {
    */
   private constructor(options: CodeCallerNativeOptionsInternal) {
     this.state = CREATED;
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
 
     this.debug('enter constructor()');
 

--- a/apps/prairielearn/src/lib/code-caller/code-caller-native.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-native.ts
@@ -1,7 +1,6 @@
 import { type ChildProcess } from 'child_process';
 import * as child_process from 'node:child_process';
 import { type SpawnOptions } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import { type Readable, type Writable } from 'stream';
 
@@ -140,7 +139,7 @@ export class CodeCallerNative implements CodeCaller {
    */
   private constructor(options: CodeCallerNativeOptionsInternal) {
     this.state = CREATED;
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
 
     this.debug('enter constructor()');
 

--- a/apps/prairielearn/src/lib/code-caller/index.ts
+++ b/apps/prairielearn/src/lib/code-caller/index.ts
@@ -1,8 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import * as os from 'node:os';
 
 import debugfn from 'debug';
 import { type Pool, createPool } from 'generic-pool';
-import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '@prairielearn/logger';
 import { run } from '@prairielearn/run';
@@ -168,7 +168,7 @@ export async function withCodeCaller<T>(
     });
   }
 
-  const jobUuid = uuidv4();
+  const jobUuid = randomUUID();
   load.startJob('python_callback_waiting', jobUuid);
 
   const codeCaller = await pool.acquire();

--- a/apps/prairielearn/src/lib/code-caller/index.ts
+++ b/apps/prairielearn/src/lib/code-caller/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as os from 'node:os';
 
 import debugfn from 'debug';
@@ -168,7 +167,7 @@ export async function withCodeCaller<T>(
     });
   }
 
-  const jobUuid = randomUUID();
+  const jobUuid = crypto.randomUUID();
   load.startJob('python_callback_waiting', jobUuid);
 
   const codeCaller = await pool.acquire();

--- a/apps/prairielearn/src/lib/copy-content.ts
+++ b/apps/prairielearn/src/lib/copy-content.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 
 import { type Response } from 'express';
@@ -145,7 +144,7 @@ async function initiateFileTransfer({
   // directly. This would allow us to completely get rid of the endpoints ending in
   // 'copy_public_*' and the file_transfers database table.
 
-  const f = randomUUID();
+  const f = crypto.randomUUID();
   const relDir = path.join(f.slice(0, 3), f.slice(3, 6));
   const params = {
     from_course_id: fromCourse.id,

--- a/apps/prairielearn/src/lib/copy-content.ts
+++ b/apps/prairielearn/src/lib/copy-content.ts
@@ -1,8 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 
 import { type Response } from 'express';
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
@@ -145,7 +145,7 @@ async function initiateFileTransfer({
   // directly. This would allow us to completely get rid of the endpoints ending in
   // 'copy_public_*' and the file_transfers database table.
 
-  const f = uuidv4();
+  const f = randomUUID();
   const relDir = path.join(f.slice(0, 3), f.slice(3, 6));
   const params = {
     from_course_id: fromCourse.id,

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import { type Temporal } from '@js-temporal/polyfill';
@@ -6,7 +7,6 @@ import * as async from 'async';
 import sha256 from 'crypto-js/sha256.js';
 import debugfn from 'debug';
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
 import { AugmentedError, HttpStatusError } from '@prairielearn/error';
@@ -654,7 +654,7 @@ export class AssessmentCopyEditor extends Editor {
     this.assessment = assessment;
     this.course_instance = course_instance;
 
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
   }
 
   async write() {
@@ -845,7 +845,7 @@ export class AssessmentAddEditor extends Editor {
 
     this.course_instance = course_instance;
 
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
 
     this.aid = params.aid;
     this.title = params.title;
@@ -959,7 +959,7 @@ export class CourseInstanceCopyEditor extends Editor {
     this.from_path = params.from_path;
     this.is_transfer = is_transfer;
 
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
   }
 
   async write() {
@@ -1059,7 +1059,7 @@ export class CourseInstanceCopyEditor extends Editor {
           // All non-deleted questions should have a UUID.
           assert(question.uuid, 'question.uuid is required');
 
-          if (existingQuestionUuids.has(question.uuid)) return uuidv4();
+          if (existingQuestionUuids.has(question.uuid)) return randomUUID();
 
           return question.uuid;
         });
@@ -1282,7 +1282,7 @@ export class CourseInstanceAddEditor extends Editor {
       description: 'Add course instance',
     });
 
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
 
     this.short_name = params.short_name;
     this.long_name = params.long_name;
@@ -1417,7 +1417,7 @@ export class QuestionAddEditor extends Editor {
       description: 'Add question',
     });
 
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
     this.qid = params.qid;
     this.title = params.title;
     this.template_source = params.template_source;
@@ -1861,7 +1861,7 @@ export class QuestionCopyEditor extends Editor {
     this.from_course = from_course;
     this.is_transfer = is_transfer;
 
-    this.uuid = uuidv4();
+    this.uuid = randomUUID();
   }
 
   async write() {

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert';
-import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import { type Temporal } from '@js-temporal/polyfill';
@@ -654,7 +653,7 @@ export class AssessmentCopyEditor extends Editor {
     this.assessment = assessment;
     this.course_instance = course_instance;
 
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
   }
 
   async write() {
@@ -845,7 +844,7 @@ export class AssessmentAddEditor extends Editor {
 
     this.course_instance = course_instance;
 
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
 
     this.aid = params.aid;
     this.title = params.title;
@@ -959,7 +958,7 @@ export class CourseInstanceCopyEditor extends Editor {
     this.from_path = params.from_path;
     this.is_transfer = is_transfer;
 
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
   }
 
   async write() {
@@ -1059,7 +1058,7 @@ export class CourseInstanceCopyEditor extends Editor {
           // All non-deleted questions should have a UUID.
           assert(question.uuid, 'question.uuid is required');
 
-          if (existingQuestionUuids.has(question.uuid)) return randomUUID();
+          if (existingQuestionUuids.has(question.uuid)) return crypto.randomUUID();
 
           return question.uuid;
         });
@@ -1282,7 +1281,7 @@ export class CourseInstanceAddEditor extends Editor {
       description: 'Add course instance',
     });
 
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
 
     this.short_name = params.short_name;
     this.long_name = params.long_name;
@@ -1417,7 +1416,7 @@ export class QuestionAddEditor extends Editor {
       description: 'Add question',
     });
 
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
     this.qid = params.qid;
     this.title = params.title;
     this.template_source = params.template_source;
@@ -1861,7 +1860,7 @@ export class QuestionCopyEditor extends Editor {
     this.from_course = from_course;
     this.is_transfer = is_transfer;
 
-    this.uuid = randomUUID();
+    this.uuid = crypto.randomUUID();
   }
 
   async write() {

--- a/apps/prairielearn/src/lib/file-store.ts
+++ b/apps/prairielearn/src/lib/file-store.ts
@@ -1,10 +1,10 @@
+import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 import { type Stream } from 'stream';
 
 import debugfn from 'debug';
-import { v4 as uuidv4 } from 'uuid';
 
 import * as sqldb from '@prairielearn/postgres';
 
@@ -74,7 +74,7 @@ export async function uploadFile({
   let storage_filename;
   if (storage_type === StorageTypes.S3) {
     // use a UUIDv4 as the filename for S3
-    storage_filename = uuidv4();
+    storage_filename = randomUUID();
 
     const res = await uploadToS3(config.fileStoreS3Bucket, storage_filename, null, false, contents);
     debug('upload() : uploaded to ' + res.Location);
@@ -82,7 +82,7 @@ export async function uploadFile({
     // Make a filename to store the file. We use a UUIDv4 as the filename,
     // and put it in two levels of directories corresponding to the first-3
     // and second-3 characters of the filename.
-    const f = uuidv4();
+    const f = randomUUID();
     const relDir = path.join(f.slice(0, 3), f.slice(3, 6));
     storage_filename = path.join(relDir, f.slice(6));
     const dir = path.join(config.filesRoot, relDir);

--- a/apps/prairielearn/src/lib/file-store.ts
+++ b/apps/prairielearn/src/lib/file-store.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
@@ -74,7 +73,7 @@ export async function uploadFile({
   let storage_filename;
   if (storage_type === StorageTypes.S3) {
     // use a UUIDv4 as the filename for S3
-    storage_filename = randomUUID();
+    storage_filename = crypto.randomUUID();
 
     const res = await uploadToS3(config.fileStoreS3Bucket, storage_filename, null, false, contents);
     debug('upload() : uploaded to ' + res.Location);
@@ -82,7 +81,7 @@ export async function uploadFile({
     // Make a filename to store the file. We use a UUIDv4 as the filename,
     // and put it in two levels of directories corresponding to the first-3
     // and second-3 characters of the filename.
-    const f = randomUUID();
+    const f = crypto.randomUUID();
     const relDir = path.join(f.slice(0, 3), f.slice(3, 6));
     storage_filename = path.join(relDir, f.slice(6));
     const dir = path.join(config.filesRoot, relDir);

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import { Octokit } from '@octokit/rest';
@@ -161,7 +160,7 @@ export async function createCourseRepoJob(
     const infoCoursePath = path.join(TEMPLATE_COURSE_PATH, 'infoCourse.json');
     const infoCourse = JSON.parse(await fs.readFile(infoCoursePath, 'utf-8'));
 
-    infoCourse.uuid = randomUUID();
+    infoCourse.uuid = crypto.randomUUID();
     infoCourse.name = options.short_name;
     infoCourse.title = options.title;
     infoCourse.timezone = options.display_timezone;

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -1,8 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import { Octokit } from '@octokit/rest';
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
@@ -161,7 +161,7 @@ export async function createCourseRepoJob(
     const infoCoursePath = path.join(TEMPLATE_COURSE_PATH, 'infoCourse.json');
     const infoCourse = JSON.parse(await fs.readFile(infoCoursePath, 'utf-8'));
 
-    infoCourse.uuid = uuidv4();
+    infoCourse.uuid = randomUUID();
     infoCourse.name = options.short_name;
     infoCourse.title = options.title;
     infoCourse.timezone = options.display_timezone;

--- a/apps/prairielearn/src/lib/ltiOutcomes.ts
+++ b/apps/prairielearn/src/lib/ltiOutcomes.ts
@@ -3,7 +3,6 @@ import * as crypto from 'node:crypto';
 import _ from 'lodash';
 import fetch from 'node-fetch';
 import oauthSignature from 'oauth-signature';
-import { v4 as uuid } from 'uuid';
 import * as xml2js from 'xml2js';
 import z from 'zod';
 
@@ -93,7 +92,7 @@ export async function updateScore(assessment_instance_id: string) {
     oauth_consumer_key: info.consumer_key,
     oauth_version: '1.0',
     oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
-    oauth_nonce: uuid().replaceAll('-', ''),
+    oauth_nonce: crypto.randomUUID().replaceAll('-', ''),
     oauth_signature_method: 'HMAC-SHA1',
     oauth_body_hash: Buffer.from(sha1, 'hex').toString('base64'),
   };

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -1,5 +1,6 @@
 import { promises as fsPromises } from 'fs';
 import { ok as assert } from 'node:assert';
+import { randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import * as path from 'path';
 
@@ -13,7 +14,6 @@ import mustache from 'mustache';
 import fetch from 'node-fetch';
 import type { Socket } from 'socket.io';
 import * as tmp from 'tmp-promise';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
 import { logger } from '@prairielearn/logger';
@@ -377,7 +377,7 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
 
   const root = config.workspaceHomeDirRoot;
   const destinationPath = path.join(root, remotePath);
-  const sourcePath = `${destinationPath}-${uuidv4()}`;
+  const sourcePath = `${destinationPath}-${randomUUID()}`;
 
   const { fileGenerationErrors } = await generateWorkspaceFiles({
     serverFilesCoursePath,

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -1,6 +1,5 @@
 import { promises as fsPromises } from 'fs';
 import { ok as assert } from 'node:assert';
-import { randomUUID } from 'node:crypto';
 import { setTimeout as sleep } from 'node:timers/promises';
 import * as path from 'path';
 
@@ -377,7 +376,7 @@ async function initialize(workspace_id: string): Promise<InitializeResult> {
 
   const root = config.workspaceHomeDirRoot;
   const destinationPath = path.join(root, remotePath);
-  const sourcePath = `${destinationPath}-${randomUUID()}`;
+  const sourcePath = `${destinationPath}-${crypto.randomUUID()}`;
 
   const { fileGenerationErrors } = await generateWorkspaceFiles({
     serverFilesCoursePath,

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.ts
@@ -1,10 +1,10 @@
+import * as crypto from 'node:crypto';
 import * as path from 'path';
 
 import sha256 from 'crypto-js/sha256.js';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
@@ -141,7 +141,7 @@ router.post(
       return res.redirect(req.originalUrl);
     } else if (req.body.__action === 'add_configuration') {
       const infoJson = {
-        uuid: uuidv4(),
+        uuid: crypto.randomUUID(),
         name: path.basename(res.locals.course.path),
         title: path.basename(res.locals.course.path),
         timezone: res.locals.institution.display_timezone,

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/components/InstructorCourseAdminTopicsTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/components/InstructorCourseAdminTopicsTable.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'preact/compat';
-import { v4 as uuidv4 } from 'uuid';
 
 import { TopicBadge } from '../../../components/TopicBadge.js';
 import { TopicDescription } from '../../../components/TopicDescription.js';
@@ -61,7 +60,7 @@ export function InstructorCourseAdminTopicsTable({
 
   const handleNewTopic = () => {
     setAddTopic(true);
-    setSelectedTopic({ ...emptyTopic, id: uuidv4() });
+    setSelectedTopic({ ...emptyTopic, id: crypto.randomUUID() });
     setShowModal(true);
   };
 

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -2,7 +2,6 @@ import * as crypto from 'crypto';
 
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import { v4 as uuidv4 } from 'uuid';
 
 import { HttpStatusError } from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
@@ -106,8 +105,8 @@ router.post(
         throw new HttpStatusError(403, 'Cannot generate access tokens in exam mode.');
       }
 
-      const name = req.body.token_name;
-      const token = uuidv4();
+  const name = req.body.token_name;
+  const token = crypto.randomUUID();
       const token_hash = crypto.createHash('sha256').update(token, 'utf8').digest('hex');
 
       await sqldb.execute(sql.insert_access_token, {

--- a/apps/prairielearn/src/pages/userSettings/userSettings.ts
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.ts
@@ -105,8 +105,8 @@ router.post(
         throw new HttpStatusError(403, 'Cannot generate access tokens in exam mode.');
       }
 
-  const name = req.body.token_name;
-  const token = crypto.randomUUID();
+      const name = req.body.token_name;
+      const token = crypto.randomUUID();
       const token_hash = crypto.createHash('sha256').update(token, 'utf8').digest('hex');
 
       await sqldb.execute(sql.insert_access_token, {

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -7,7 +7,6 @@ import * as opentelemetry from '@prairielearn/opentelemetry';
 import * as Sentry from '@prairielearn/sentry';
 /* eslint-enable import-x/order */
 
-import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
@@ -385,7 +384,7 @@ export async function initExpress(): Promise<Express> {
   // Middleware for all requests
   // response_id is logged on request, response, and error to link them together
   app.use(function (req, res, next) {
-    res.locals.response_id = randomUUID();
+    res.locals.response_id = crypto.randomUUID();
     res.set('X-Response-ID', res.locals.response_id);
     next();
   });

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -7,6 +7,7 @@ import * as opentelemetry from '@prairielearn/opentelemetry';
 import * as Sentry from '@prairielearn/sentry';
 /* eslint-enable import-x/order */
 
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
@@ -33,7 +34,6 @@ import multer from 'multer';
 import onFinished from 'on-finished';
 import passport from 'passport';
 import favicon from 'serve-favicon';
-import { v4 as uuidv4 } from 'uuid';
 
 import { cache } from '@prairielearn/cache';
 import { flashMiddleware } from '@prairielearn/flash';
@@ -385,7 +385,7 @@ export async function initExpress(): Promise<Express> {
   // Middleware for all requests
   // response_id is logged on request, response, and error to link them together
   app.use(function (req, res, next) {
-    res.locals.response_id = uuidv4();
+    res.locals.response_id = randomUUID();
     res.set('X-Response-ID', res.locals.response_id);
     next();
   });

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/dot-notation */
-import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import * as cheerio from 'cheerio';
@@ -659,7 +658,8 @@ async function createSharedCourse() {
   sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test'] = structuredClone(
     sharingCourseData.courseInstances['Fa19'].assessments['test'],
   );
-  sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test']['uuid'] = randomUUID();
+  sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test']['uuid'] =
+    crypto.randomUUID();
 
   await syncUtil.writeAndSyncCourseData(sharingCourseData);
 }

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/dot-notation */
+import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import * as cheerio from 'cheerio';
@@ -7,7 +8,6 @@ import fs from 'fs-extra';
 import klaw from 'klaw';
 import fetch from 'node-fetch';
 import * as tmp from 'tmp';
-import { v4 as uuidv4 } from 'uuid';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
 import * as sqldb from '@prairielearn/postgres';
@@ -659,7 +659,7 @@ async function createSharedCourse() {
   sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test'] = structuredClone(
     sharingCourseData.courseInstances['Fa19'].assessments['test'],
   );
-  sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test']['uuid'] = uuidv4();
+  sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test']['uuid'] = randomUUID();
 
   await syncUtil.writeAndSyncCourseData(sharingCourseData);
 }

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/dot-notation */
-import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import fs from 'fs-extra';
@@ -46,7 +45,7 @@ function makeAssessment(
 ): AssessmentJsonInput {
   const assessmentSet = courseData.course.assessmentSets?.[0].name ?? '';
   return {
-    uuid: randomUUID(),
+    uuid: crypto.randomUUID(),
     type,
     title: 'Test assessment',
     set: assessmentSet,

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/dot-notation */
+import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
 import { z } from 'zod';
 
@@ -46,7 +46,7 @@ function makeAssessment(
 ): AssessmentJsonInput {
   const assessmentSet = courseData.course.assessmentSets?.[0].name ?? '';
   return {
-    uuid: uuidv4(),
+    uuid: randomUUID(),
     type,
     title: 'Test assessment',
     set: assessmentSet,

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/dot-notation */
+import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import { Temporal } from '@js-temporal/polyfill';
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
 
 import { CourseInstanceAccessRuleSchema, CourseInstanceSchema } from '../../lib/db-types.js';
@@ -21,7 +21,7 @@ import * as util from './util.js';
 function makeCourseInstance(): util.CourseInstanceData {
   return {
     courseInstance: {
-      uuid: uuidv4(),
+      uuid: randomUUID(),
       longName: 'Test course instance',
     },
     assessments: {},

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/dot-notation */
-import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import { Temporal } from '@js-temporal/polyfill';
@@ -21,7 +20,7 @@ import * as util from './util.js';
 function makeCourseInstance(): util.CourseInstanceData {
   return {
     courseInstance: {
-      uuid: randomUUID(),
+      uuid: crypto.randomUUID(),
       longName: 'Test course instance',
     },
     assessments: {},

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/dot-notation */
+import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import fs from 'fs-extra';
-import { v4 as uuidv4 } from 'uuid';
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
 
 import { QuestionSchema, QuestionTagSchema, TagSchema, TopicSchema } from '../../lib/db-types.js';
@@ -22,7 +22,7 @@ import * as util from './util.js';
  */
 function makeQuestion(courseData: util.CourseData): QuestionJsonInput {
   return {
-    uuid: uuidv4(),
+    uuid: randomUUID(),
     title: 'Test question',
     type: 'v3',
     topic: courseData.course.topics[0].name,

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/dot-notation */
-import { randomUUID } from 'node:crypto';
 import * as path from 'path';
 
 import fs from 'fs-extra';
@@ -22,7 +21,7 @@ import * as util from './util.js';
  */
 function makeQuestion(courseData: util.CourseData): QuestionJsonInput {
   return {
-    uuid: randomUUID(),
+    uuid: crypto.randomUUID(),
     title: 'Test question',
     type: 'v3',
     topic: courseData.course.topics[0].name,

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
@@ -1,4 +1,5 @@
-import { v4 as uuid } from 'uuid';
+import { randomUUID } from 'node:crypto';
+
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import { config } from '../lib/config.js';
@@ -44,7 +45,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
   ];
   course.courseInstances[COURSE_INSTANCE_ID].assessments = {
     'homework-1': {
-      uuid: uuid(),
+      uuid: randomUUID(),
       title: 'Homework 1',
       type: 'Homework',
       set: 'Homeworks',
@@ -52,7 +53,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
       number: '1',
     },
     'exam-1': {
-      uuid: uuid(),
+      uuid: randomUUID(),
       title: 'Exam 1',
       type: 'Exam',
       set: 'Exams',
@@ -60,7 +61,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
       number: '1',
     },
     'homework-2': {
-      uuid: uuid(),
+      uuid: randomUUID(),
       title: 'Homework 2',
       type: 'Homework',
       set: 'Homeworks',
@@ -68,7 +69,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
       number: '2',
     },
     'exam-2': {
-      uuid: uuid(),
+      uuid: randomUUID(),
       title: 'Exam 2',
       type: 'Exam',
       set: 'Exams',

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import { config } from '../lib/config.js';
@@ -45,7 +43,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
   ];
   course.courseInstances[COURSE_INSTANCE_ID].assessments = {
     'homework-1': {
-      uuid: randomUUID(),
+      uuid: crypto.randomUUID(),
       title: 'Homework 1',
       type: 'Homework',
       set: 'Homeworks',
@@ -53,7 +51,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
       number: '1',
     },
     'exam-1': {
-      uuid: randomUUID(),
+      uuid: crypto.randomUUID(),
       title: 'Exam 1',
       type: 'Exam',
       set: 'Exams',
@@ -61,7 +59,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
       number: '1',
     },
     'homework-2': {
-      uuid: randomUUID(),
+      uuid: crypto.randomUUID(),
       title: 'Homework 2',
       type: 'Homework',
       set: 'Homeworks',
@@ -69,7 +67,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
       number: '2',
     },
     'exam-2': {
-      uuid: randomUUID(),
+      uuid: crypto.randomUUID(),
       title: 'Exam 2',
       type: 'Exam',
       set: 'Exams',

--- a/apps/prairielearn/src/tests/workspaceHost.test.ts
+++ b/apps/prairielearn/src/tests/workspaceHost.test.ts
@@ -1,4 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
+
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
 import { z } from 'zod';
 
@@ -39,7 +40,7 @@ async function insertWorkspaceHost(id: string | number, state = 'launching') {
     'INSERT INTO workspace_hosts (id, instance_id, state) VALUES ($id, $instance_id, $state) RETURNING *;',
     {
       id,
-      instance_id: uuidv4(),
+  instance_id: randomUUID(),
       state,
     },
     WorkspaceHostSchema,

--- a/apps/prairielearn/src/tests/workspaceHost.test.ts
+++ b/apps/prairielearn/src/tests/workspaceHost.test.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
 import { z } from 'zod';
 
@@ -40,7 +38,7 @@ async function insertWorkspaceHost(id: string | number, state = 'launching') {
     'INSERT INTO workspace_hosts (id, instance_id, state) VALUES ($id, $instance_id, $state) RETURNING *;',
     {
       id,
-  instance_id: randomUUID(),
+      instance_id: crypto.randomUUID(),
       state,
     },
     WorkspaceHostSchema,

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -40,7 +40,6 @@
     "minimist": "^1.2.8",
     "node-fetch": "3.3.2",
     "shlex": "^3.0.0",
-    "uuid": "^11.1.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as http from 'node:http';
 import * as net from 'node:net';
@@ -890,7 +889,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
   // send 200 immediately to prevent socket hang up from _pullImage()
   res.status(200).send(`Preparing container for workspace ${workspace_id}`);
 
-  const uuid = randomUUID();
+  const uuid = crypto.randomUUID();
   const params = {
     workspace_id,
     launch_uuid: uuid,

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as http from 'node:http';
 import * as net from 'node:net';
@@ -20,7 +21,6 @@ import { type Entry } from 'fast-glob';
 import minimist from 'minimist';
 import fetch from 'node-fetch';
 import * as shlex from 'shlex';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 
 import { cache } from '@prairielearn/cache';
@@ -890,7 +890,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
   // send 200 immediately to prevent socket hang up from _pullImage()
   res.status(200).send(`Preparing container for workspace ${workspace_id}`);
 
-  const uuid = uuidv4();
+  const uuid = randomUUID();
   const params = {
     workspace_id,
     launch_uuid: uuid,

--- a/contrib/dump-anonymize.mjs
+++ b/contrib/dump-anonymize.mjs
@@ -1,7 +1,6 @@
 // usage:
 // $ node dump-anonymize.mjs <data-dump-folder> <anonymous-output-folder>
 
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -12,7 +11,7 @@ const outfolder = process.argv[3];
 
 function getUUID(map, key) {
   if (!map[key]) {
-    map[key] = randomUUID();
+    map[key] = crypto.randomUUID();
   }
   return map[key];
 }

--- a/contrib/dump-anonymize.mjs
+++ b/contrib/dump-anonymize.mjs
@@ -1,18 +1,18 @@
 // usage:
 // $ node dump-anonymize.mjs <data-dump-folder> <anonymous-output-folder>
 
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import async from 'async';
-import { v4 as uuidv4 } from 'uuid';
 
 const infolder = process.argv[2];
 const outfolder = process.argv[3];
 
 function getUUID(map, key) {
   if (!map[key]) {
-    map[key] = uuidv4();
+    map[key] = randomUUID();
   }
   return map[key];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4282,7 +4282,6 @@ __metadata:
     ua-parser-js: "npm:^1.0.41"
     unified: "npm:^11.0.5"
     unzipper: "npm:^0.12.3"
-    uuid: "npm:^11.1.0"
     vite: "npm:^7.1.7"
     vitest: "npm:^3.2.4"
     winston: "npm:^3.18.3"
@@ -4508,7 +4507,6 @@ __metadata:
     tsx: "npm:^4.20.6"
     typescript: "npm:^5.9.3"
     typescript-cp: "npm:^0.1.9"
-    uuid: "npm:^11.1.0"
     vitest: "npm:^3.2.4"
     zod: "npm:^3.25.76"
   languageName: unknown
@@ -18217,15 +18215,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/eab18c27fe4ab9fb9709a5d5f40119b45f2ec8314f8d4cf12ce27e4c6f4ffa4a6321dc7db6c515068fa373c075b49691ba969f0010bf37f44c37ca40cd6bf7fe
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

[`crypto.randomUUID()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) is now considered baseline available in both Node and browsers. Let's use it!

This was implemented by GPT-5-Codex while I was doing other things. I did some manual cleanup to change it to use the `crypto` global.

# Testing

None; let's let the test suite do its thing.