### PR TITLE
Fix handling of radio groups in focus utilities

### DIFF
--- a/.changeset/salty-papers-share.md
+++ b/.changeset/salty-papers-share.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/browser-utils': minor
+---
+
+Improved support for focus on radio groups

--- a/packages/browser-utils/README.md
+++ b/packages/browser-utils/README.md
@@ -115,3 +115,26 @@ import { focusFirstFocusableChild } from '@prairielearn/browser-utils';
 const modal = document.querySelector('.modal');
 focusFirstFocusableChild(modal);
 ```
+
+### `focusElementOrCheckedOption`
+
+This function will focus the provided element. If the element is a radio button, it will follow the W3C recommendation of focusing the checked radio button in the group instead.
+
+```ts
+import { focusElementOrCheckedOption } from '@prairielearn/browser-utils';
+
+const radio = document.querySelector('input[type="radio"]');
+focusElementOrCheckedOption(radio);
+```
+
+### `isSameFocusContext`
+
+This function checks if two elements correspond to the same tab focus context. For most elements, this corresponds to being the same element, however for radio buttons, this corresponds to being in the same radio button group.
+
+```ts
+import { isSameFocusContext } from '@prairielearn/browser-utils';
+
+const radio1 = document.querySelector('input[type="radio"][name="group1"][value="option1"]');
+const radio2 = document.querySelector('input[type="radio"][name="group1"][value="option2"]');
+console.log(isSameFocusContext(radio1, radio2)); // true
+```

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -2,4 +2,9 @@ export { onDocumentReady } from './on-document-ready.js';
 export { parseHTML, parseHTMLElement } from './parse-html.js';
 export { EncodedData, decodeData } from './encode-data.js';
 export { templateFromAttributes } from './template-from-attributes.js';
-export { trapFocus, focusFirstFocusableChild } from './focus.js';
+export {
+  trapFocus,
+  focusFirstFocusableChild,
+  focusElementOrCheckedOption,
+  isSameFocusContext,
+} from './focus.js';


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Fixes #13052.

When focusing on a radio button, the proper procedure according to the specs is to select the radio button that is currently checked, if there is one. This PR updates the browser-utils package to use this procedure on:

* The selection of the first focusable child of a popover;
* The Tab/Shift-Tab process when rotating through a trapped focus context (e.g., popovers).

Two new functions are also exported in case the same behavior is needed outside the package: one to focus on the element or another radio in the group, and one to check if two elements are part of the same group. I'm open to bikeshedding the names of these functions.

Changes were done manually, with some auto-complete support from GitHub Copilot on VSCode.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

This can be tested by merging with #13046, which introduces popovers where the first focusable child is a radio. Opening the popover with a user that has something other than "None" as its role should cause the checked radio to be focused. Also, tab/shift tab on the popover should iterate through the elements and come back to the checked radio once the rotation comes back to the start, and should remain in the popover is tabbing back from the radio button.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
