### PR TITLE
Question authors UI

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
@@ -18,6 +18,7 @@ import {
   AssessmentSchema,
   AssessmentSetSchema,
   IdSchema,
+  type Author,
   type Question,
   type Tag,
   type Topic,
@@ -56,6 +57,7 @@ export function InstructorQuestionSettings({
   questionGHLink,
   questionTags,
   qids,
+  authors,
   assessmentsWithQuestion,
   sharingEnabled,
   sharingSetsIn,
@@ -72,6 +74,7 @@ export function InstructorQuestionSettings({
   questionGHLink: string | null;
   questionTags: Tag[];
   qids: string[];
+  authors: Author[];
   assessmentsWithQuestion: SelectedAssessments[];
   sharingEnabled: boolean;
   sharingSetsIn: SharingSetRow[];
@@ -86,6 +89,27 @@ export function InstructorQuestionSettings({
   // in the context of a course instance.
   const shouldShowAssessmentsList = !!resLocals.course_instance;
   const questionTagNames = new Set(questionTags.map((tag) => tag.name));
+
+  const hasAuthors = authors.length > 0;
+
+  const authorsData = authors.map((author) => {
+    let parsedORCIDId = '';
+    if (author.orcid !== null) {
+      for (let index = 0; index < author.orcid.length; index++) {
+        parsedORCIDId += author.orcid[index];
+        if ((index + 1) % 4 === 0 && index !== author.orcid.length - 1) {
+          parsedORCIDId += '-';
+        }
+      }
+    }
+    return {
+      author_name: author.author_name,
+      email: author.email,
+      id: author.id,
+      orcid: parsedORCIDId,
+      origin_course: author.origin_course,
+    };
+  });
 
   return PageLayout({
     resLocals,
@@ -248,6 +272,83 @@ export function InstructorQuestionSettings({
                 </tbody>
               </table>
             </div>
+            ${hasAuthors
+              ? html`<div class="mb-3">
+                  <label id="authors-table-label" for="authors-table">Author Information</label>
+                  <table
+                    class="table table-sm table-hover tablesorter table-bordered"
+                    aria-label="Author information"
+                  >
+                    <thead>
+                      <tr>
+                        <th class="text-center">Name</th>
+                        <th class="text-center">Email</th>
+                        <th class="text-center">ORCID identifier</th>
+                        <th class="text-center">Reference Course</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${authorsData.map((author, index) => {
+                        return html`
+                          <tr>
+                            <td>
+                              ${canEdit
+                                ? html`<input
+                                    type="text"
+                                    class="form-control font-monospace"
+                                    id="${'author_name_' + index}"
+                                    name="${'author_name_' + index}"
+                                    value="${author?.author_name ?? ''}"
+                                  />`
+                                : html`
+                                    <small class="text-center">${author?.author_name ?? ''}</small>
+                                  `}
+                            </td>
+                            <td>
+                              ${canEdit
+                                ? html`<input
+                                    type="email"
+                                    class="form-control font-monospace"
+                                    id="${'author_email_' + index}"
+                                    name="${'author_email_' + index}"
+                                    value="${author?.email ?? ''}"
+                                    ${canEdit ? '' : 'disabled'}
+                                  />`
+                                : html`<small class="text-center">${author?.email ?? ''}</small>`}
+                            </td>
+                            <td>
+                              ${canEdit
+                                ? html`<input
+                                    type="text"
+                                    class="form-control font-monospace"
+                                    id="${'author_orcid_' + index}"
+                                    name="${'author_orcid_' + index}"
+                                    value="${author?.orcid ?? ''}"
+                                    ${canEdit ? '' : 'disabled'}
+                                  />`
+                                : html`<small class="text-center">${author?.orcid ?? ''}</small>`}
+                            </td>
+                            <td>
+                              ${canEdit
+                                ? html`<input
+                                    type="text"
+                                    class="form-control font-monospace"
+                                    id="${'author_reference_course_' + index}"
+                                    name="${'author_reference_course_' + index}"
+                                    value="${author?.origin_course ?? ''}"
+                                    ${canEdit ? '' : 'disabled'}
+                                  />`
+                                : html`<small class="text-center"
+                                    >${author?.origin_course ?? ''}</small
+                                  >`}
+                            </td>
+                          </tr>
+                        `;
+                      })}
+                    </tbody>
+                  </table>
+                </div>`
+              : ''}
             <div class="mb-3">
               <label class="form-label" for="grading_method">Grading method</label>
               <select

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.sql
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.sql
@@ -77,3 +77,23 @@ FROM
   LEFT OUTER JOIN sharing_set_questions AS ssq ON ssq.sharing_set_id = ss.id
 WHERE
   ss.course_id = $course_id;
+
+-- BLOCK author_for_qid
+WITH
+  author_to_qid AS (
+    SELECT
+      author_id
+    FROM
+      question_authors
+    WHERE
+      question_id = $question_id
+  )
+SELECT
+  authors.author_name,
+  authors.email,
+  authors.orcid,
+  authors.origin_course,
+  authors.id
+FROM
+  author_to_qid
+  LEFT JOIN authors ON author_to_qid.author_id = authors.id

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -492,8 +492,8 @@ router.get(
       origHash = sha256(b64EncodeUnicode(await fs.readFile(fullInfoPath, 'utf8'))).toString();
     }
 
-    const canEdit = false;
-    // res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
+    const canEdit =
+      res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
 
     const authors = await sqldb.queryRows(
       sql.author_for_qid,

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.ts
@@ -21,7 +21,7 @@ import {
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { config } from '../../lib/config.js';
 import { copyQuestionBetweenCourses } from '../../lib/copy-content.js';
-import { EnumGradingMethodSchema } from '../../lib/db-types.js';
+import { AuthorSchema, EnumGradingMethodSchema } from '../../lib/db-types.js';
 import {
   FileModifyEditor,
   MultiEditor,
@@ -492,8 +492,14 @@ router.get(
       origHash = sha256(b64EncodeUnicode(await fs.readFile(fullInfoPath, 'utf8'))).toString();
     }
 
-    const canEdit =
-      res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
+    const canEdit = false;
+    // res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
+
+    const authors = await sqldb.queryRows(
+      sql.author_for_qid,
+      { question_id: res.locals.question.id },
+      AuthorSchema,
+    );
 
     res.send(
       InstructorQuestionSettings({
@@ -503,6 +509,7 @@ router.get(
         questionGHLink,
         questionTags,
         qids,
+        authors,
         assessmentsWithQuestion,
         sharingEnabled,
         sharingSetsIn,


### PR DESCRIPTION
This commit is just redoing the branch where I made these changes before, but on a clean pulled branch off of master for an easier PR.  See closed PR https://github.com/PrairieLearn/PrairieLearn/pull/12855 for the initial information.

# Description

In this PR, I am adding a UI to display the authors of a PL question in the settings of that question. This follows on Nico's work to add the authors to the JSON data, in https://github.com/PrairieLearn/PrairieLearn/pull/12816. In this PR, I add an SQL query to instructorQuestionSettings to fetch the authors for a question. I then pipe that data through to the html, where we display it as a table of text inputs. Follow-up PRs will ensure that the fields can be edited through the settings page, as well as verifying that the inputs are the appropriate type (email, valid orcid, etc).

# Testing
I tested this manually by going into PL for the test course and verifying that authors appeared when there were authors for the question. I also verified that authors did not appear when a question had no authors. See the screenshots below.

Question with no authors:
<img width="1498" height="843" alt="Screenshot 2025-10-06 at 2 56 08 PM" src="https://github.com/user-attachments/assets/6d756899-691c-4e8b-9454-40c693827dd1" />

Question with editable authors:
<img width="1502" height="784" alt="Screenshot 2025-10-06 at 2 52 28 PM" src="https://github.com/user-attachments/assets/653e8fc5-fffb-4067-8c7a-62254a025132" />

Question with non-editable authors:
<img width="1506" height="841" alt="Screenshot 2025-10-06 at 2 53 58 PM" src="https://github.com/user-attachments/assets/f28be66b-f50b-41ab-9c6a-0e1fde47082b" />

