### PR TITLE
Begin work to remove self_enrollment_enabled_before_date_enabled

### DIFF
--- a/apps/prairielearn/src/lib/client/page-context.test.ts
+++ b/apps/prairielearn/src/lib/client/page-context.test.ts
@@ -196,7 +196,8 @@ describe('getCourseInstanceContext', () => {
       self_enrollment_enabled: true,
       self_enrollment_use_enrollment_code: false,
       self_enrollment_enabled_before_date: null,
-      self_enrollment_enabled_before_date_enabled: false,
+      // TODO: delete this, not in use.
+      self_enrollment_enabled_before_date_enabled: null,
       sync_errors: null,
       sync_job_sequence_id: null,
       sync_warnings: null,

--- a/apps/prairielearn/src/lib/client/safe-db-types.test.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.test.ts
@@ -82,7 +82,8 @@ const minimalStaffCourseInstance: z.input<typeof StaffCourseInstanceSchema> = {
   long_name: null,
   self_enrollment_enabled: true,
   self_enrollment_enabled_before_date: null,
-  self_enrollment_enabled_before_date_enabled: false,
+  // TODO: delete this, not in use
+  self_enrollment_enabled_before_date_enabled: null,
   self_enrollment_use_enrollment_code: false,
   share_source_publicly: false,
   short_name: null,

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -594,7 +594,8 @@ export const CourseInstanceSchema = z.object({
   long_name: z.string().nullable(),
   self_enrollment_enabled: z.boolean(),
   self_enrollment_enabled_before_date: DateFromISOString.nullable(),
-  self_enrollment_enabled_before_date_enabled: z.boolean(),
+  // TODO: fully delete this column.
+  self_enrollment_enabled_before_date_enabled: z.unknown(),
   self_enrollment_use_enrollment_code: z.boolean(),
   share_source_publicly: z.boolean(),
   short_name: z.string().nullable(),

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/SelfEnrollmentSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/SelfEnrollmentSettings.tsx
@@ -131,11 +131,6 @@ export function SelfEnrollmentSettings({
     name: 'self_enrollment_use_enrollment_code',
   });
 
-  const selfEnrollmentEnabledBeforeDate = useWatch({
-    control,
-    name: 'self_enrollment_enabled_before_date',
-  });
-
   const selfEnrollmentEnabledBeforeDateEnabled = useWatch({
     control,
     name: 'self_enrollment_enabled_before_date_enabled',
@@ -259,20 +254,7 @@ export function SelfEnrollmentSettings({
               return true;
             },
           })}
-          // HACK: Make the accessibility checker happy
-          // See https://gitlab.com/html-validate/html-validate/-/issues/294
-          {...(!selfEnrollmentEnabledBeforeDateEnabled
-            ? { name: 'self_enrollment_enabled_before_date__IGNORE' }
-            : {})}
         />
-        {/* Disabled inputs are not submitted in a HTTP POST request. However, we still want to send the updated value. */}
-        {!selfEnrollmentEnabledBeforeDateEnabled && (
-          <input
-            type="hidden"
-            name="self_enrollment_enabled_before_date"
-            value={selfEnrollmentEnabledBeforeDate}
-          />
-        )}
         {selfEnrollmentEnabledBeforeDateError && (
           <div class="invalid-feedback">{selfEnrollmentEnabledBeforeDateError.message}</div>
         )}

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -56,7 +56,7 @@ export function InstructorInstanceAdminSettings({
     self_enrollment_enabled: courseInstance.self_enrollment_enabled,
     self_enrollment_use_enrollment_code: courseInstance.self_enrollment_use_enrollment_code,
     self_enrollment_enabled_before_date_enabled:
-      courseInstance.self_enrollment_enabled_before_date_enabled,
+      !!courseInstance.self_enrollment_enabled_before_date,
     self_enrollment_enabled_before_date: courseInstance.self_enrollment_enabled_before_date
       ? Temporal.Instant.fromEpochMilliseconds(
           courseInstance.self_enrollment_enabled_before_date.getTime(),
@@ -296,4 +296,5 @@ export function InstructorInstanceAdminSettings({
     </div>
   );
 }
+
 InstructorInstanceAdminSettings.displayName = 'InstructorInstanceAdminSettings';

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -272,24 +272,19 @@ router.post(
         parsedBody.self_enrollment_use_enrollment_code,
         false,
       );
-      const selfEnrollmentBeforeDateEnabled = propertyValueWithDefault(
-        courseInstanceInfo.selfEnrollment?.beforeDateEnabled,
-        parsedBody.self_enrollment_enabled_before_date_enabled,
-        false,
-        { isUIBoolean: true },
-      );
 
       const selfEnrollmentBeforeDate = propertyValueWithDefault(
         parseDateTime(courseInstanceInfo.selfEnrollment?.beforeDate ?? ''),
-        parseDateTime(parsedBody.self_enrollment_enabled_before_date),
+        // We'll only serialize the value if self-enrollment is enabled.
+        parsedBody.self_enrollment_enabled && parsedBody.self_enrollment_enabled_before_date
+          ? parseDateTime(parsedBody.self_enrollment_enabled_before_date)
+          : undefined,
         undefined,
       );
 
       const hasSelfEnrollmentSettings =
-        (selfEnrollmentEnabled ??
-          selfEnrollmentUseEnrollmentCode ??
-          selfEnrollmentBeforeDateEnabled ??
-          selfEnrollmentBeforeDate) !== undefined;
+        (selfEnrollmentEnabled ?? selfEnrollmentUseEnrollmentCode ?? selfEnrollmentBeforeDate) !==
+        undefined;
 
       const {
         course_instance: courseInstance,
@@ -307,7 +302,6 @@ router.post(
         courseInstanceInfo.selfEnrollment = {
           enabled: selfEnrollmentEnabled,
           useEnrollmentCode: selfEnrollmentUseEnrollmentCode,
-          beforeDateEnabled: selfEnrollmentBeforeDateEnabled,
           beforeDate: selfEnrollmentBeforeDate,
         };
       } else {

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.types.ts
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.types.ts
@@ -10,8 +10,10 @@ export const SettingsFormBodySchema = z.object({
   show_in_enroll_page: BooleanFromCheckboxSchema,
   self_enrollment_enabled: BooleanFromCheckboxSchema,
   self_enrollment_use_enrollment_code: BooleanFromCheckboxSchema,
-  self_enrollment_enabled_before_date: z.string(),
+  // This isn't ever used by the backend, but it's included here because this
+  // type is used to drive the form state on the frontend.
   self_enrollment_enabled_before_date_enabled: BooleanFromCheckboxSchema,
+  self_enrollment_enabled_before_date: z.string().optional(),
 });
 
 export type SettingsFormValues = z.infer<typeof SettingsFormBodySchema>;

--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -58,16 +58,9 @@ export const CourseInstanceJsonSchema = z
         beforeDate: z
           .string()
           .describe(
-            'Before this date, self-enrollment is enabled if beforeDateEnabled is true. After this date, self-enrollment is disabled. If not specified, self-enrollment depends on enabled property.',
+            'If specified, self-enrollment is allowed before this date and forbidden after this date. If not specified, self-enrollment depends on enabled property.',
           )
           .optional(),
-        beforeDateEnabled: z
-          .boolean()
-          .describe(
-            'If true, self-enrollment is enabled before the beforeDate. If false, self-enrollment is controlled by the enabled property.',
-          )
-          .optional()
-          .default(false),
         useEnrollmentCode: z
           .boolean()
           .describe(

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -42,13 +42,8 @@
           "default": true
         },
         "beforeDate": {
-          "description": "Before this date, self-enrollment is enabled if beforeDateEnabled is true. After this date, self-enrollment is disabled. If not specified, self-enrollment depends on enabled property.",
+          "description": "If specified, self-enrollment is allowed before this date and forbidden after this date. If not specified, self-enrollment depends on enabled property.",
           "type": "string"
-        },
-        "beforeDateEnabled": {
-          "description": "If true, self-enrollment is enabled before the beforeDate. If false, self-enrollment is controlled by the enabled property.",
-          "type": "boolean",
-          "default": false
         },
         "useEnrollmentCode": {
           "description": "If true, self-enrollment requires an enrollment code to enroll. If false, any link to the course instance will allow self-enrollment.",

--- a/apps/prairielearn/src/sprocs/sync_course_instances.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_instances.sql
@@ -154,7 +154,6 @@ BEGIN
         json_comment = (src.data->>'comment')::jsonb,
         self_enrollment_enabled = (src.data->>'self_enrollment_enabled')::boolean,
         self_enrollment_enabled_before_date = input_date(src.data->>'self_enrollment_enabled_before_date', COALESCE(src.data->>'display_timezone', c.display_timezone)),
-        self_enrollment_enabled_before_date_enabled = (src.data->>'self_enrollment_enabled_before_date_enabled')::boolean,
         self_enrollment_use_enrollment_code = (src.data->>'self_enrollment_use_enrollment_code')::boolean,
         share_source_publicly = (src.data->>'share_source_publicly')::boolean,
         sync_errors = NULL,

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -1471,16 +1471,6 @@ function validateCourseInstance({
     }
   }
 
-  if (courseInstance.selfEnrollment.beforeDateEnabled !== false) {
-    warnings.push('"selfEnrollment.beforeDateEnabled" is not configurable yet.');
-
-    if (courseInstance.selfEnrollment.beforeDate == null) {
-      errors.push(
-        '"selfEnrollment.beforeDate" is required if "selfEnrollment.beforeDateEnabled" is true.',
-      );
-    }
-  }
-
   if (courseInstance.selfEnrollment.useEnrollmentCode !== false) {
     warnings.push('"selfEnrollment.useEnrollmentCode" is not configurable yet.');
   }

--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
@@ -63,7 +63,6 @@ function getParamsForCourseInstance(courseInstance: CourseInstanceJson | null | 
     access_rules: accessRules,
     self_enrollment_enabled: courseInstance.selfEnrollment.enabled,
     self_enrollment_enabled_before_date: courseInstance.selfEnrollment.beforeDate,
-    self_enrollment_enabled_before_date_enabled: courseInstance.selfEnrollment.beforeDateEnabled,
     self_enrollment_use_enrollment_code: courseInstance.selfEnrollment.useEnrollmentCode,
     assessments_group_by: courseInstance.groupAssessmentsBy,
     comment: JSON.stringify(courseInstance.comment),

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -592,7 +592,6 @@ describe('Course instance syncing', () => {
       {
         json: {
           beforeDate: jsonDate,
-          beforeDateEnabled: true,
           useEnrollmentCode: true,
         },
         db: {

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -557,7 +557,6 @@ describe('Course instance syncing', () => {
       db: {
         self_enrollment_enabled: boolean;
         self_enrollment_enabled_before_date: Date | null;
-        self_enrollment_enabled_before_date_enabled: boolean;
         self_enrollment_use_enrollment_code: boolean;
       } | null;
       errors: string[];
@@ -570,7 +569,6 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: null,
-          self_enrollment_enabled_before_date_enabled: false,
           self_enrollment_use_enrollment_code: true,
         },
         errors: [],
@@ -584,7 +582,6 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: false,
           self_enrollment_enabled_before_date: date,
-          self_enrollment_enabled_before_date_enabled: false,
           self_enrollment_use_enrollment_code: true,
         },
         errors: [],
@@ -597,7 +594,6 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: date,
-          self_enrollment_enabled_before_date_enabled: true,
           self_enrollment_use_enrollment_code: true,
         },
         errors: [],
@@ -607,7 +603,6 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: null,
-          self_enrollment_enabled_before_date_enabled: false,
           self_enrollment_use_enrollment_code: false,
         },
         errors: [],
@@ -619,7 +614,6 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: false,
           self_enrollment_enabled_before_date: null,
-          self_enrollment_enabled_before_date_enabled: false,
           self_enrollment_use_enrollment_code: false,
         },
         errors: [],
@@ -631,7 +625,6 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: null,
-          self_enrollment_enabled_before_date_enabled: false,
           self_enrollment_use_enrollment_code: false,
         },
         errors: [],
@@ -676,8 +669,6 @@ describe('Course instance syncing', () => {
           self_enrollment_enabled: syncedCourseInstance.self_enrollment_enabled,
           self_enrollment_enabled_before_date:
             syncedCourseInstance.self_enrollment_enabled_before_date,
-          self_enrollment_enabled_before_date_enabled:
-            syncedCourseInstance.self_enrollment_enabled_before_date_enabled,
           self_enrollment_use_enrollment_code:
             syncedCourseInstance.self_enrollment_use_enrollment_code,
         };


### PR DESCRIPTION
# Description

Originally we thought it'd be nice to persist settings values even when a given setting was disabled, which led to the introduction of this `self_enrollment_enabled_before_date_enabled` boolean (and the corresponding `selfEnrollment.beforeDateEnabled` value in JSON). However, after further discussion with @reteps and @mwest1066, we're going to stop storing these "enabled" booleans and stop trying to persist form state through an enabled -> disabled -> enabled transition.

Note that we still persist values during the lifetime of a page on the client, so if you set a "before date", disable self-enrollment, and then enable it again (all without refreshing the page), the "before date" won't be lost. It'll only potentially be lost on form submission if either self-enrollment as a whole is disabled or the "before date" checkbox is unchecked.

# Testing

I interacted with the page a bunch, enabling/disabling things and saving at random. Everything seems to work correctly.
