### PR TITLE
Completely drop self_enrollment_enabled_before_date_enabled column

### DIFF
--- a/apps/prairielearn/src/lib/client/page-context.test.ts
+++ b/apps/prairielearn/src/lib/client/page-context.test.ts
@@ -196,8 +196,6 @@ describe('getCourseInstanceContext', () => {
       self_enrollment_enabled: true,
       self_enrollment_use_enrollment_code: false,
       self_enrollment_enabled_before_date: null,
-      // TODO: delete this, not in use.
-      self_enrollment_enabled_before_date_enabled: null,
       sync_errors: null,
       sync_job_sequence_id: null,
       sync_warnings: null,

--- a/apps/prairielearn/src/lib/client/safe-db-types.test.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.test.ts
@@ -82,8 +82,6 @@ const minimalStaffCourseInstance: z.input<typeof StaffCourseInstanceSchema> = {
   long_name: null,
   self_enrollment_enabled: true,
   self_enrollment_enabled_before_date: null,
-  // TODO: delete this, not in use
-  self_enrollment_enabled_before_date_enabled: null,
   self_enrollment_use_enrollment_code: false,
   share_source_publicly: false,
   short_name: null,

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -594,8 +594,6 @@ export const CourseInstanceSchema = z.object({
   long_name: z.string().nullable(),
   self_enrollment_enabled: z.boolean(),
   self_enrollment_enabled_before_date: DateFromISOString.nullable(),
-  // TODO: fully delete this column.
-  self_enrollment_enabled_before_date_enabled: z.unknown(),
   self_enrollment_use_enrollment_code: z.boolean(),
   share_source_publicly: z.boolean(),
   short_name: z.string().nullable(),

--- a/apps/prairielearn/src/migrations/20251007223022_course_instances__self_enrollment_enabled_before_date_enabled__drop.sql
+++ b/apps/prairielearn/src/migrations/20251007223022_course_instances__self_enrollment_enabled_before_date_enabled__drop.sql
@@ -1,0 +1,2 @@
+ALTER TABLE course_instances
+DROP COLUMN self_enrollment_enabled_before_date_enabled;

--- a/database/tables/course_instances.pg
+++ b/database/tables/course_instances.pg
@@ -11,7 +11,6 @@ columns
     long_name: text
     self_enrollment_enabled: boolean default true
     self_enrollment_enabled_before_date: timestamp with time zone
-    self_enrollment_enabled_before_date_enabled: boolean default false
     self_enrollment_use_enrollment_code: boolean default false
     share_source_publicly: boolean not null default false
     short_name: text


### PR DESCRIPTION
# Description

Continuation of #13063. Should not be merged until after that PR is deployed.

# Testing

None.