### PR TITLE
Exclude deleted rubric items when comparing AI and human grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-stats.sql
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-stats.sql
@@ -64,6 +64,10 @@ WITH
     FROM
       rubric_grading_items AS rgi
       JOIN rubric_items AS ri ON rgi.rubric_item_id = ri.id
+    WHERE
+      -- Exclude deleted rubric items. They won't show up elsewhere in the UI
+      -- and thus shouldn't be included in comparisons of grading jobs.
+      ri.deleted_at IS NULL
   )
 SELECT
   grading_job_id,


### PR DESCRIPTION
# Description

This PR fixes a bugs where deleted rubric items were being included in AI/human grading comparisons. If a human graded some submissions with the rubric item, deleted it, and then performed AI grading, this bug manifested as the rubric item always being reported as a false negative.

# Testing

- As a student, make a submission to a manually-graded question.
- From the instructor assessment question page, create a rubric item "A".
- Apply that rubric item to the instance question.
- Delete the rubric item and create a new one "B".
- Perform AI grading.

Before this change, "A" would have been shown as a false negative. After this change, "A" isn't shown at all after being deleted.
