### PR TITLE
Always record both errors and warnings when syncing

### DIFF
--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -719,12 +719,9 @@ async function loadAndValidateJson<T extends ZodSchema>({
   loadedJson.data = result.data;
 
   const validationResult = validate(loadedJson.data);
-  if (validationResult.errors.length > 0) {
-    infofile.addErrors(loadedJson, validationResult.errors);
-    return loadedJson;
-  }
-
+  infofile.addErrors(loadedJson, validationResult.errors);
   infofile.addWarnings(loadedJson, validationResult.warnings);
+
   return loadedJson;
 }
 


### PR DESCRIPTION
# Description

This came up in #12461 while I was working on tests. I was actually surprised to see that sync warnings weren't being recorded if an error was recorded. This PR changes that behavior.

There's really two types of errors in play:

- Errors that are caught by the schema (e.g. a missing `topic`)
- Errors that are added dynamically during programmatic validation (e.g. malformed emails in the `authors` array.

This PR only really applies to the latter. If we have the former kind of errors, we won't ever have warnings because we don't try to do further validation of data that doesn't match the schema.

# Testing

Tested in the context of #12461. I can add some automated tests if folks want.