### PR TITLE
Fix MathJax overflow in pl-order-blocks on small screens

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.css
@@ -153,3 +153,9 @@ div.pl-order-blocks-header {
   outline: 3px solid #ff6200;
   outline-offset: -3px;
 }
+
+/* Ensure MathJax SVG equations scale down responsively on small screens */
+div.pl-order-blocks-container mjx-container svg,
+div.pl-order-blocks-answer-container mjx-container svg {
+  max-width: 100%;
+}

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -122,11 +122,6 @@ mjx-container {
   text-rendering: geometricPrecision;
 }
 
-/* Ensure MathJax SVG equations scale down responsively on small screens */
-mjx-container svg {
-  max-width: 100%;
-}
-
 .popover-wide {
   max-width: min(800px, 90vw);
 }


### PR DESCRIPTION
# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

Small PR to fix a MathJax equation overflow issue found in pl-order-blocks, by making SVGs responsive on small screens.


Closes #13075 

# Testing
To reproduce the issue:
1. Open a question that uses `pl-order-blocks` containing a long MathJax equation
2. Switch to a mobile viewport (e.g. Chrome DevTools)
3. Notice that the equation slightly overflows horizontally

With the fix in place, equations now scale within the container and no longer overflow.
Verified the fix on Chrome.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
**Screenshots:**

Before: <img width="287" height="341" alt="Screenshot 2025-10-09 at 8 21 06 PM" src="https://github.com/user-attachments/assets/fc4ae6b5-20a5-44cd-bcab-1fca36e94649" /> After: <img width="287" height="341" alt="Screenshot 2025-10-09 at 8 20 35 PM" src="https://github.com/user-attachments/assets/b9c9105c-1b6e-43d4-82f0-92976d4eb5c9" />

