### PR TITLE
Remove `pl-image-capture` Space/Enter shortcuts

### DIFF
--- a/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
+++ b/apps/prairielearn/elements/pl-image-capture/pl-image-capture.js
@@ -66,7 +66,6 @@ const MAX_ZOOM_SCALE = 5;
       }
 
       this.createCropRotateListeners();
-      this.createApplyChangesListeners();
     }
 
     /**
@@ -327,24 +326,6 @@ const MAX_ZOOM_SCALE = 5;
           confirmDeletionButton,
         });
         confirmDeletionButton.removeEventListener('click', confirmDeletion);
-      });
-    }
-
-    /**
-     * When the user clicks Enter or Space, apply any pending changes based on the current container.
-     * - If in crop-rotate, confirm the crop/rotate changes.
-     * - If in local-camera-capture, capture the current image.
-     */
-    createApplyChangesListeners() {
-      document.addEventListener('keypress', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          if (this.selectedContainerName === 'crop-rotate') {
-            this.confirmCropRotateChanges();
-          } else if (this.selectedContainerName === 'local-camera-capture') {
-            this.handleCaptureImage();
-          }
-        }
       });
     }
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description
- Removed `pl-image-capture` Enter and Space shortcuts for capturing images. 
- They were particularly problematic if a question had both a text editor and `pl-image-capture`, since users could no longer type a Space or create a newline in the text editor.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing
- Open a question with `pl-image-capture`, and Space/Enter should no longer capture the image.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
