### PR TITLE
Avoid use of existsSync

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1437,8 +1437,10 @@ export class QuestionAddEditor extends Editor {
           z.number(),
         );
 
-        while (fs.existsSync(path.join(questionsPath, '__drafts__', `draft_${draftNumber}`))) {
-          //increment and sync to postgres
+        while (
+          await fs.pathExists(path.join(questionsPath, '__drafts__', `draft_${draftNumber}`))
+        ) {
+          // increment and sync to postgres
           draftNumber = await sqldb.queryRow(
             sql.update_draft_number,
             { course_id: this.course.id },


### PR DESCRIPTION
# Description

Using synchronous filesystem functions will block the entire event loop; we want to avoid that.

# Testing

None; this is a trivial change.