### PR TITLE
Temporary fix for rendering blank submissions to pl-number-input

### DIFF
--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -294,9 +294,13 @@ def render(element_html: str, data: pl.QuestionData) -> str:
             submitted_answer = pl.from_json(submitted_answer)
 
             html_params["suffix"] = suffix
-            html_params["submitted_answer"] = ("{:" + custom_format + "}").format(
-                submitted_answer
-            )
+
+            if isinstance(submitted_answer, str) and submitted_answer.strip() == "":
+                html_params["submitted_answer"] = ""
+            else:
+                html_params["submitted_answer"] = ("{:" + custom_format + "}").format(
+                    submitted_answer
+                )
         elif name not in data["submitted_answers"]:
             html_params["missing_input"] = True
             html_params["parse_error"] = None


### PR DESCRIPTION
# Description

This is a temporary fix for the ability of `pl-number-input` to render blank submissions.

# Testing

Tested locally.
