### PR TITLE
Restore support to generate users via admin query without enrollment

### DIFF
--- a/apps/prairielearn/src/admin_queries/generate_and_enroll_users.ts
+++ b/apps/prairielearn/src/admin_queries/generate_and_enroll_users.ts
@@ -1,6 +1,10 @@
+import { runInTransactionAsync } from '@prairielearn/postgres';
+
+import type { Course, CourseInstance } from '../lib/db-types.js';
 import { selectOptionalCourseInstanceById } from '../models/course-instances.js';
 import { selectCourseById } from '../models/course.js';
 import { generateAndEnrollUsers } from '../models/enrollment.js';
+import { generateUsers } from '../models/user.js';
 
 import type { AdministratorQueryResult, AdministratorQuerySpecs } from './lib/util.js';
 
@@ -37,21 +41,28 @@ export default async function ({
   count: string;
   course_instance_id: string;
 }): Promise<AdministratorQueryResult> {
-  const course_instance = await selectOptionalCourseInstanceById(course_instance_id);
-  if (!course_instance) {
-    return { rows: [], columns };
+  let course_instance: CourseInstance | null = null;
+  let course: Course | null = null;
+  if (course_instance_id !== '') {
+    course_instance = await selectOptionalCourseInstanceById(course_instance_id);
+    if (!course_instance) {
+      return { rows: [], columns };
+    }
+    course = await selectCourseById(course_instance.course_id);
   }
-  const course = await selectCourseById(course_instance.course_id);
-  const users = await generateAndEnrollUsers({ count: Number(count), course_instance_id });
+  const users =
+    course_instance == null
+      ? await runInTransactionAsync(() => generateUsers(Number(count)))
+      : await generateAndEnrollUsers({ count: Number(count), course_instance_id });
   return {
     rows: users.map(({ user_id, uid, name }) => ({
       user_id,
       uid,
       name,
-      course_id: course.id,
-      course: course.short_name,
-      course_instance_id,
-      course_instance: course_instance.short_name,
+      course_id: course?.id,
+      course: course?.short_name,
+      course_instance_id: course_instance?.id,
+      course_instance: course_instance?.short_name,
     })),
     columns,
   };


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Resolves #13083. Adds support for generating users without enrolling them in a course instance in the generate_and_enroll_users admin query. This support used to exist before #10391, but wasn't properly moved to the new version of the query/sproc when it was converted to a library function.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Tested locally with and without a course instance, both work. An invalid course instance causes the query to fail, as expected.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
