### PR TITLE
Capture value for UIN when using Microsoft/Azure auth

### DIFF
--- a/apps/prairielearn/src/ee/auth/azure/callback.ts
+++ b/apps/prairielearn/src/ee/auth/azure/callback.ts
@@ -42,7 +42,7 @@ router.post(
     const authnParams = {
       uid: user.upn,
       name: user.displayName,
-      uin: user.oid,
+      uin: user.oid || null,
       email: user._json.email || null,
       provider: 'Azure',
     };


### PR DESCRIPTION
# Description

Doing this as a part of https://github.com/PrairieLearn/PrairieLearn/issues/12690. We want to capture a value for UIN when someone authenticates with Microsoft to ensure that we can keep track of users across UID changes.

It's still the case that nothing good will happen for the following sequence:

- User authenticates with Google
- User changes their UID
- User authenticates with Microsoft

We'll still end up with two user accounts in this case. There's not much we can do about that; there's absolutely no way to match up those two users in this scenario. We're comfortable with this. We're making changes to guide administrators that are configuring institutions to only configure one of these two providers (and ideally neither of them if SAML is also enabled) - see https://github.com/PrairieLearn/PrairieLearn/pull/13074.

# Testing

I have not yet tested this, and don't really have a way to test it outside of a production-like environment. I plan to deploy this branch to our staging environment to test there.
