### PR TITLE
Fix question dropdowns so they extend outside the question panel

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.js
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.js
@@ -36,7 +36,7 @@ window.PLMultipleChoice = function (uuid) {
       const content = dropdown.querySelector('.ts-dropdown-content');
       content.style.maxHeight = `${window.innerHeight - content.getBoundingClientRect().top}px`;
 
-      // The first time the dropdown is opened, this even is fired before the
+      // The first time the dropdown is opened, this event is fired before the
       // options are actually present in the DOM. We'll wait for the next tick
       // to ensure that the options are present.
       setTimeout(() => MathJax.typesetPromise([dropdown]), 0);


### PR DESCRIPTION
# Description

When a dropdown is near the bottom of a question panel it be hidden inside the panel, making it unclear to students what to do. This PR assigns dropdowns to have `<body>` as the parent so they can extend outside the question panel.

# Testing

## Before this PR:

<img width="881" height="223" alt="image" src="https://github.com/user-attachments/assets/e2e8f951-5082-4d82-a7d1-ea41b5e84d6e" />

## After this PR:

<img width="880" height="356" alt="image" src="https://github.com/user-attachments/assets/3b7e81ae-bba9-4d61-8dd9-7d0b82c5273a" />
