### PR TITLE
Ensure undo in pl-file-editor does not erase initial content

### DIFF
--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.js
@@ -68,7 +68,7 @@ window.PLFileEditor = function (uuid, options) {
   if (options.currentContents) {
     currentContents = this.b64DecodeUnicode(options.currentContents);
   }
-  this.setEditorContents(currentContents, true);
+  this.setEditorContents(currentContents, { resetUndo: true });
 
   if (options.preview) {
     this.editor.session.on('change', () => this.updatePreview(options.preview));
@@ -269,7 +269,7 @@ window.PLFileEditor.prototype.initRestoreOriginalButton = function () {
   });
 };
 
-window.PLFileEditor.prototype.setEditorContents = function (contents, resetUndo = false) {
+window.PLFileEditor.prototype.setEditorContents = function (contents, { resetUndo = false } = {}) {
   if (resetUndo) {
     // Setting the value of the session causes the undo manager to be reset.
     // https://github.com/ajaxorg/ace/blob/35e1be52fd8172405cf0f219bab1ef7571b3363f/src/edit_session.js#L321-L328


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This was causing confusion for some students, [as reported on Slack](https://prairielearn.slack.com/archives/C266KEH9A/p1760982291303879). In essence, hitting Ctrl-Z as the page was loaded would remove the initial content. This PR changes it so that the initial setting of the content (either from the source file/content or from the previously submitted content) is not part of the undo list of operations. In essence, it resets the undo manager as soon as the content is loaded.

Hitting "restore original content" button still adds the content as an operation that can be undone.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Open a question with pl-file-editor. Focus on the editor, then hit Ctrl-Z (or Cmd-Z on Mac) right away. On master the content is blank. On this branch the content is kept.

Change some content, then hit Ctrl-Z/Cmd-Z again. The changed content should be undone in both branches.

Save a submission. Upon loading, focus on the editor and hit Ctrl-Z/Cmd-Z again. On master the content is lost. On this branch the content is kept.

Hit the "restore original content" button. Then focus on the editor and hit Ctrl-Z/Cmd-Z again. On both branches the content should be restored to what it was before restoring the original content.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
