### PR TITLE
Fix regression in pl-multiple-choice dropdown positioning

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.js
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.js
@@ -50,11 +50,10 @@ window.PLMultipleChoice = function (uuid) {
   });
 
   // Reposition the dropdown when the main container is scrolled. This doesn't exist
-  // on student pages.
-  const appMainContainer = selectElement.closest('.app-main-container');
-  if (appMainContainer) {
-    appMainContainer.addEventListener('scroll', () => select.positionDropdown());
-  }
+  // on student pages, so we take care to handle that case.
+  selectElement
+    .closest('.app-main-container')
+    ?.addEventListener('scroll', () => select.positionDropdown());
 
   // By default, `tom-select` will set the placeholder as the "active" option,
   // but this means that the active option can't be changed with the up/down keys


### PR DESCRIPTION
# Description

https://github.com/PrairieLearn/PrairieLearn/pull/13137 broke the dropdown display of `<pl-multiple-choice>` on student pages by referencing an element that doesn't exist on those pages.

This PR does the dumbest possible fix and just uses optional chaining on the result of `closest(...)`.

We should consider if there are better options here. `body` not being the scrollable element caused weirdness here, and presumably makes it harder for similar elements to build themselves. Elements ideally shouldn't have to be aware of the broader page.

# Testing

Tested with `element/multipleChoice` in both instructor and student view. It works in both.
