### PR TITLE
Support nested `pl-image-capture` elements for AI grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -6,6 +6,8 @@ import type {
   UserContent,
 } from 'ai';
 import * as cheerio from 'cheerio';
+import { Tag, Text } from 'domelementtype';
+import type { AnyNode } from 'domhandler';
 import { z } from 'zod';
 
 import {
@@ -259,9 +261,9 @@ export function generateSubmissionMessage({
   const $submission_html = cheerio.load(submission_text);
   let submissionTextSegment = '';
 
-  const processNode = (node: cheerio.Cheerio<AnyNode>) => {
+  const processNode = (node: AnyNode) => {
     const imageCaptureUUID = $submission_html(node).data('image-capture-uuid');
-    
+
     if (imageCaptureUUID) {
       // Found an image capture element
       if (submissionTextSegment) {
@@ -320,9 +322,9 @@ export function generateSubmissionMessage({
     }
 
     // If this is a text node, add its text to the current segment
-    if (node.type === 'text') {
+    if (node.type === Text) {
       submissionTextSegment += $submission_html(node).text();
-    } else if (node.type === 'tag') {
+    } else if (node.type === Tag) {
       // For element nodes, recursively process all children
       $submission_html(node)
         .contents()

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -261,6 +261,14 @@ export function generateSubmissionMessage({
   const $submission_html = cheerio.load(submission_text);
   let submissionTextSegment = '';
 
+  // div
+  //    <div data-image-capture-uuid="..."></div>
+  // /div
+
+  // Split by image capture
+  // Non-image capture -> text parts
+  // Image capture parts -> image parts
+
   const processNode = (node: AnyNode) => {
     const imageCaptureUUID = $submission_html(node).data('image-capture-uuid');
 

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -259,8 +259,7 @@ export function generateSubmissionMessage({
   const $submission_html = cheerio.load(submission_text);
   let submissionTextSegment = '';
 
-  // Helper function to recursively process nodes and their descendants
-  const processNode = (node: any) => {
+  const processNode = (node: cheerio.Cheerio<AnyNode>) => {
     const imageCaptureUUID = $submission_html(node).data('image-capture-uuid');
     
     if (imageCaptureUUID) {

--- a/exampleCourse/questions/element/imageCapture/question.html
+++ b/exampleCourse/questions/element/imageCapture/question.html
@@ -2,15 +2,17 @@
   <p>This question demonstrates the image capture element, which enables students to submit images to questions using their local camera or an external device (e.g. a phone or tablet).</p>
 </pl-question-panel> 
 
-<p>If you plan to use AI grading, do not wrap <code>pl-image-capture</code> within another PrairieLearn element, such as <code>pl-card</code>.</p> 
-
-<p>Consider the function $f(x) = arcsin(2x) + cos(4x^3-5x)+e^{x^3}$. Find $f'(x)$ and show your work.</p>
-<pl-image-capture file-name="solution-1.jpg"></pl-image-capture>
+<pl-card>
+  <p>Consider the function $f(x) = arcsin(2x) + cos(4x^3-5x)+e^{x^3}$. Find $f'(x)$ and show your work.</p>
+  <pl-image-capture file-name="solution-1.jpg"></pl-image-capture>
+</pl-card>
 
 <p>If necessary, mobile capture can be disabled.</p>
 
-<p>Sketch the bounded region enclosed by the curves $y=-x^2+3$ and $y=2x^2$.</p>
-<pl-image-capture file-name="solution-2.jpg" mobile-capture-enabled="false"></pl-image-capture>
+<pl-card>
+  <p>Sketch the bounded region enclosed by the curves $y=-x^2+3$ and $y=2x^2$.</p>
+  <pl-image-capture file-name="solution-2.jpg" mobile-capture-enabled="false"></pl-image-capture>
+</pl-card>
 
 <pl-submission-panel>
   <pl-file-preview></pl-file-preview>

--- a/testCourse/questions/aiGradingSingleImageCapture/question.html
+++ b/testCourse/questions/aiGradingSingleImageCapture/question.html
@@ -2,4 +2,6 @@
   <p>Find the derivative of the following function: </p>
   <p>$ f(x) = arcsin(2x)+cos(4x^3-5x)+e^{x^3} $</p>
 </pl-question-panel>
-<pl-image-capture file-name="solution.jpeg"></pl-image-capture>
+<pl-card>
+    <pl-image-capture file-name="solution.jpeg"></pl-image-capture>
+</pl-card>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description
- Closes #13128
- Previously, `pl-image-capture` could not parse nested image capture elements.
- This PR adds functionality to the AI grading `generateSubmissionMessage` function so it can parse `pl-image-capture` element `div`s nested within other elements. 

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing
- Test AI grading with the image capture question in `XC 101`, which contains `pl-image-capture` elements nested within `pl-card` elements.
- Test AI grading with the "AI Grading: Multiple image capture" question in `QA 101`, which contains `pl-image-capture` elements not nested within other elements. 
- Test AI grading a question without image capture, e.g. "AI Grading: Using rubrics to grade free response" in `QA 101`

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
