### PR TITLE
Lock assessment instance row on manual grading

### DIFF
--- a/apps/prairielearn/src/lib/manualGrading.sql
+++ b/apps/prairielearn/src/lib/manualGrading.sql
@@ -462,8 +462,9 @@ ORDER BY
   s.id DESC NULLS LAST
 LIMIT
   1
+  -- The assessment instance must be locked as a convention for any operation that updates scores.
 FOR NO KEY UPDATE OF
-  iq;
+  ai;
 
 -- BLOCK insert_grading_job
 INSERT INTO


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

As per [the docs](https://github.com/PrairieLearn/PrairieLearn/blob/2b161b7597b4c6e1b0c7929e453f22a67793fb60/docs/dev-guide/guide.md#L346), the modification of any grade should be preceded by a lock on the corresponding assessment instance row. The manual grading was locking the instance question row instead. This had the potential of causing a race condition if two grading events (e.g., two graders grading separate questions of the same assessment instance at the same time) overlapped with each other, causing a potential miscalculation of assessment instance scores.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Not easily testable. Change is trivial.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
