### PR TITLE
Add timeouts to Git network operations

### DIFF
--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -32,6 +32,7 @@ interface CreateServerJobOptions {
 interface ServerJobExecOptions {
   cwd: string;
   env?: NodeJS.ProcessEnv;
+  cancelSignal?: AbortSignal;
 }
 
 export interface ServerJobResult {


### PR DESCRIPTION
# Description

During what we suspect was a recent GitHub incident, we observed some Git operations (specifically pushes) taking multiple minutes to complete. This resulted in users seeing 504s after their edits didn't complete in the 60 seconds allotted by our load balancer. Other edits that were made while the sync was hanging would error due to a failure to acquire a lock on the course.

To allow things to fail in a more controlled manner, we add timeouts to Git operations that hit the network. Note that it's possible that the remote could in fact receive and persist data but not acknowledge it before the timeout. This is a risk we're willing to take; it'll be resolved the next time Git operations complete successfully.

# Testing

None. Execa and abort signals will just work.