### PR TITLE
Add confirmation dialog when removing user from staff

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/instructorCourseAdminStaff.html.tsx
@@ -364,7 +364,7 @@ function CoursePermissionsRemoveStaffForm({
   csrfToken: string;
 }) {
   return html`
-    <form name="student-data-access-remove-${courseUser.user.user_id}" method="POST">
+    <form method="POST">
       <input type="hidden" name="__action" value="course_permissions_delete" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
       <input type="hidden" name="user_id" value="${courseUser.user.user_id}" />


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

- Adds the same confirmation dialog used for 'Delete non-owners' to the 'Delete User' button on the staff page
  - One of the items from https://github.com/PrairieLearn/PrairieLearn/issues/4661
  - Added the user name to the dialog to confirm user clicked on correct dialog
    - Will just display as 'staff' in the header and 'staff member' in the body if the user does not have a name
- Changes wording to be 'Remove staff' to better suit the function
  - <details>
    <summary>Slack discussion screenshot</summary>
    <img width="290" height="202" alt="Slack message" src="https://github.com/user-attachments/assets/33aeb864-3734-45a9-84d7-63c9fe409eb7" />
</details>

- Updates other delete confirmations to be red
  - See https://github.com/PrairieLearn/PrairieLearn/pull/13177#issuecomment-3444982203 for details
 

<img width="465" height="154" alt="remove named staff" src="https://github.com/user-attachments/assets/a46f7926-5ee1-484c-b77a-c8fef93c9db3" />

<img width="524" height="152" alt="remove unnamed staff" src="https://github.com/user-attachments/assets/1c68fc62-6706-4b63-965e-fcf68262f006" />




_Note: Copilot autocomplete for VS Code was used in this PR_

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

Ran as local host and removed a staff member that was added to a course through the new confirmation

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
