### PR TITLE
Handle integer expansion ValueError in pl-symbolic-input

### DIFF
--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -657,9 +657,13 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
     try:
         pl.grade_answer_parameterized(data, name, grade_function, weight=weight)
     except ValueError as e:
-        # We only want to catch the integer string conversion limit ValueError. Others might be outside of the student's control and should error like normal.
-        # Entering an expression like 2^(20000*x) will cause this error, despite the fact an expression like 2^(14000x) will render the exponent as expected.
-        # Sympy expands constants internally, so these expressions evaluate to ((2^c)^x), then 2^c is evaluated and converted to a string.
+        # We only want to catch the integer string conversion limit ValueError.
+        # Others might be outside of the student's control and should error like normal.
+        #
+        # Entering an expression like 2^(20000*x) will cause this error, despite the fact
+        # an expression like 2^(14000x) will render the exponent as expected. Sympy
+        # expands constants internally, so these expressions evaluate to ((2^c)^x),
+        # then 2^c is evaluated and converted to a string.
         if "integer string conversion" in str(e):
             data["format_errors"][name] = (
                 f"Your expression expands integers longer than {get_int_max_str_digits()} digits, "


### PR DESCRIPTION
# Description

The symbolic input element will expand out functions when grading. If this generates very large integers, it will raise a ValueError due to int to string conversion limits. This is the only ValueError, I believe, that is under the student's control, and thus we raise a format error to inform them why it doesn't work. Granted, an instructor could accidently make a question which would imply such an expansion, so the format error informs them to raise an issue if they believe this is a correct answer. If some other value error was raised, this passes through, as likely something else is broken that the student cannot fix.

# Testing

Tested locally that egregious functions (e.g. 2^(65556*2x)) raises such a value error. Made sure that other functions correctly parse as normal.
