### PR TITLE
Show only joined students in gradebook

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.sql
+++ b/apps/prairielearn/src/pages/instructorGradebook/instructorGradebook.sql
@@ -51,7 +51,7 @@ WITH
   ),
   user_ids AS (
     -- Select all users that:
-    -- 1. Are enrolled in the course instance;
+    -- 1. Are enrolled in the course instance and have status 'joined';
     -- 2. Have at least one assessment instance in the course (typically previously enrolled);
     -- 3. Have some staff permission in the course or instance.
     (
@@ -68,6 +68,7 @@ WITH
         enrollments
       WHERE
         course_instance_id = $course_instance_id
+        AND status = 'joined'
     )
     UNION
     (


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This is a tweak to only show the joined students in the gradebook. Other students can be found on the "Students" tab.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

<img width="2052" height="366" alt="CleanShot 2025-10-25 at 17 34 16@2x" src="https://github.com/user-attachments/assets/fa7b9bb6-8e54-487c-afe9-fc4a26b93844" />
<img width="2014" height="446" alt="CleanShot 2025-10-25 at 17 34 31@2x" src="https://github.com/user-attachments/assets/ed4086d6-b9b0-477d-ac3b-0ef63e758db3" />


<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
