### PR TITLE
Use stable answer in example question for symbolic input

### DIFF
--- a/exampleCourse/questions/element/symbolicInput/question.html
+++ b/exampleCourse/questions/element/symbolicInput/question.html
@@ -35,7 +35,7 @@
 
 <pl-card header="An example that uses the formula editor input">
     <pl-question-panel>
-        <p>Submit $test(\sqrt{\frac{x^2}{e^x}})$</p>
+        <p>Submit $\displaystyle {\rm test}(\sqrt{\frac{e^x}{x^2}})$</p>
     </pl-question-panel>
     <pl-symbolic-input label="$y = $" aria-label="Function expression" formula-editor="true" answers-name="formula_editor" variables="x" show-score="false" custom-functions="test"></pl-symbolic-input>
 </pl-card>

--- a/exampleCourse/questions/element/symbolicInput/server.py
+++ b/exampleCourse/questions/element/symbolicInput/server.py
@@ -34,5 +34,5 @@ def generate(data):
     data["correct_answers"]["custom_function_2"] = pl.to_json(ans)
 
     test = sympy.Function("test")
-    ans2 = test(sympy.sqrt(x**2 / sympy.E**x))
+    ans2 = test(sympy.sqrt(sympy.E**x / x**2))
     data["correct_answers"]["formula_editor"] = pl.to_json(ans2)


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The previous example caused the $e^x$ in the denominator to be converted by sympy to a multiplication by $e^{-x}$. While these are equivalent, having the answer/submission panel not match the suggested answer can be confusing in a demonstration question.

<img width="251" height="89" alt="image" src="https://github.com/user-attachments/assets/09bdb205-d8be-417f-bdb4-c61ac93a8107" />

The proposed answer is replaced with another answer that has the same features (function, square root, fraction, exponents) but that is not converted by sympy.

I also used an `\rm` to have the function name use the same style as the editor, and `\displaystyle` to ensure the fraction uses the full size as in the editor.

Before: 
<img width="447" height="236" alt="image" src="https://github.com/user-attachments/assets/77e68aa4-38f0-4064-9240-0a2fe7c85b39" />

After: 
<img width="427" height="249" alt="image" src="https://github.com/user-attachments/assets/550a32c9-25c0-4e31-8fe5-0058959319d0" />


<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
