### PR TITLE
Fix question label formatting on assessment manual grading page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
@@ -194,7 +194,7 @@ function AssessmentQuestionRow({
       <td class="align-middle">
         <a href={gradingUrl}>
           {question.alternative_group_number}.
-          {question.alternative_group_size === 1 ? '' : `${question.number_in_alternative_group}.`}
+          {question.alternative_group_size === 1 ? '' : `${question.number_in_alternative_group}.`}{' '}
           {question.title}
         </a>
         {question.manual_rubric_id != null && (


### PR DESCRIPTION
# Description

This regressed in #13146.

# Testing

Before this change:

<img width="479" height="334" alt="Screenshot 2025-10-27 at 15 58 50" src="https://github.com/user-attachments/assets/ce64e2f2-2bb5-4b80-8cb1-8d9ecca3d11b" />

After this change:

<img width="485" height="332" alt="Screenshot 2025-10-27 at 15 59 00" src="https://github.com/user-attachments/assets/7daee0d0-90d3-4b80-a974-38f02a823226" />