### PR TITLE
Fix rendering issue with `pl-number-input`

### DIFF
--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -102,8 +102,8 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
 def format_true_ans(
     element: lxml.html.HtmlElement, data: pl.QuestionData, name: str
 ) -> str:
-    correct_answer = pl.from_json(data["correct_answers"].get(name, ""))
-    if correct_answer != "":
+    correct_answer = pl.from_json(data["correct_answers"].get(name, None))
+    if correct_answer is not None and correct_answer != "":
         # Get format and comparison parameters
         custom_format = pl.get_string_attrib(element, "custom-format", None)
         comparison = pl.get_enum_attrib(


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

If a correct answer is not set for `pl-number-input`, the element will not render on master. This was a regression from the `allow-blank` setup.

The bug should be obvious:

If `data["correct_answer"]` is not set, then `format_true_ans` compares `None` to `""`, which crashes the element when it tries to parse `None` as a number.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

N/A, I think this is a straightforward fix

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
