### PR TITLE
Switch to buildx+caching for PrairieLearn docker smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,7 @@ jobs:
           context: .
           push: false
           load: true
-          tags: |
-            prairielearn/prairielearn:${{ env.COMMIT_SHA }}
+          tags: prairielearn/prairielearn:${{ env.COMMIT_SHA }}
           cache-from: type=registry,ref=prairielearn/prairielearn:buildcache-linux-amd64
 
       # We run the following steps in this job instead of separately to avoid the


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This should let us use the build cache for the test job, so it will run a little faster. I also stopped building the executor in the test job, that appears to have been an oversight. Saves ~1:15 in the build step of that job.

This means that native is now the slower job...

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
