### PR TITLE
Improve display of empty UID regexp on admin institutions table

### DIFF
--- a/apps/prairielearn/src/pages/administratorInstitutions/components/AdministratorInstitutionsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorInstitutions/components/AdministratorInstitutionsTable.tsx
@@ -65,7 +65,13 @@ export function AdministratorInstitutionsTable({
                   </td>
                   <td>{institution.long_name}</td>
                   <td>{institution.display_timezone}</td>
-                  <td>{institution.uid_regexp ? <code>{institution.uid_regexp}</code> : '—'}</td>
+                  <td>
+                    {institution.uid_regexp ? (
+                      <span class="font-monospace">{institution.uid_regexp}</span>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
                   <td>{authn_providers.join(', ')}</td>
                 </tr>
               ))}


### PR DESCRIPTION
# Description

Before this change:

<img width="208" height="177" alt="Screenshot 2025-11-03 at 15 33 45" src="https://github.com/user-attachments/assets/a70162b0-483c-4beb-815a-86858cb2ac67" />

After this change:

<img width="187" height="173" alt="Screenshot 2025-11-03 at 15 35 09" src="https://github.com/user-attachments/assets/c3cf2701-43ef-4426-a82c-21ce3b7e6c7a" />

# Testing

Visually it looks good!
