### PR TITLE
Handle integer expansion ValueError in pl-big-o-input

### DIFF
--- a/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.py
+++ b/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.py
@@ -293,7 +293,7 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
             weight=weight,
         )
     except ValueError as e:
-        # See pl-symbolic-input.py for why we catch this error in this way.
+        # See https://github.com/PrairieLearn/PrairieLearn/pull/13178 for more context as to why we catch this error.
         if "integer string conversion" in str(e):
             data["format_errors"][name] = (
                 f"Your expression expands integers longer than {get_int_max_str_digits()} digits, "


### PR DESCRIPTION
# Description
Closes #13270 
`pl-big-o-input` uses the same sympy backend, which is subject to the integer expansion error. This catches that error as we did in #13178.

# Testing

Tested that large expressions (2^(65000*2n)) result in a format error, and other inputs format and grade as normal.
