### PR TITLE
Ignore Python package upgrades that drop Python 3.10 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,15 @@ updates:
       # We're not ready to jump to the latest version of `numpy` yet.
       - dependency-name: 'numpy'
         versions: ['>=2']
+      # The following dependencies have dropped support for Python 3.10 in their
+      # recent versions. Since PrairieLearn still uses Python 3.10 in the question
+      # runtime environment, we need to ignore these updates for now.
+      - dependency-name: 'networkx'
+        versions: ['>=3.5.0']
+      - dependency-name: 'Pint'
+        versions: ['>=0.25']
+      - dependency-name: 'scipy'
+        versions: ['>=1.16.0']
     groups:
       all-patch-minor:
         update-types:


### PR DESCRIPTION
# Description

This will help avoid near-mistakes like that from https://github.com/PrairieLearn/PrairieLearn/pull/13263.

I grabbed this list of dependencies from my notes on https://github.com/PrairieLearn/PrairieLearn/pull/13225#issue-3572631299.

# Testing

N/A