### PR TITLE
Drop `config.urlPrefix`

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.tsx
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.tsx
@@ -1,7 +1,6 @@
 import { formatDate, formatInterval } from '@prairielearn/formatter';
 import { type HtmlValue, html } from '@prairielearn/html';
 
-import { config } from '../lib/config.js';
 import {
   type Assessment,
   type AssessmentInstance,
@@ -161,12 +160,12 @@ function QuestionInfo({
 }) {
   if (question == null || variant == null) return '';
 
-  const questionPreviewUrl = `${config.urlPrefix}/${
+  const questionPreviewUrl = `/pl/${
     course_instance != null
       ? `course_instance/${course_instance.id}/instructor`
       : `course/${course.id}`
   }/question/${question.id}?variant_seed=${variant.variant_seed}`;
-  const publicPreviewUrl = `${config.urlPrefix}/public/course/${question.course_id}/question/${question.id}/preview`;
+  const publicPreviewUrl = `/pl/public/course/${question.course_id}/question/${question.id}/preview`;
 
   // We don't show the sharing name in the QID if the question is not shared
   // publicly for importing, such as if only `share_source_publicly` is set.
@@ -267,7 +266,7 @@ function AssessmentInstanceInfo({
 }) {
   if (assessment == null || assessment_instance == null) return '';
 
-  const instructorUrlPrefix = `${config.urlPrefix}/course_instance/${assessment.course_instance_id}/instructor`;
+  const instructorUrlPrefix = `/pl/course_instance/${assessment.course_instance_id}/instructor`;
 
   // Some legacy queries still return the duration and date as a string, so parse them before formatting
   const duration =
@@ -325,7 +324,7 @@ function ManualGradingInfo({
     return '';
   }
 
-  const manualGradingUrl = `${config.urlPrefix}/course_instance/${assessment.course_instance_id}/instructor/assessment/${assessment.id}/manual_grading/instance_question/${instance_question.id}`;
+  const manualGradingUrl = `/pl/course_instance/${assessment.course_instance_id}/instructor/assessment/${assessment.id}/manual_grading/instance_question/${instance_question.id}`;
 
   return html`
     <h3 class="card-title h5">Manual grading</h3>

--- a/apps/prairielearn/src/components/Navbar.tsx
+++ b/apps/prairielearn/src/components/Navbar.tsx
@@ -296,13 +296,9 @@ function UserDropdownMenu({
               `
             : ''}
           ${!authz_data || authz_data?.mode === 'Public'
-            ? html`
-                <a class="dropdown-item" href="${config.urlPrefix}/request_course">
-                  Course Requests
-                </a>
-              `
+            ? html` <a class="dropdown-item" href="/pl/request_course"> Course Requests </a> `
             : ''}
-          <a class="dropdown-item" href="${config.urlPrefix}/settings">Settings</a>
+          <a class="dropdown-item" href="/pl/settings">Settings</a>
           <a
             class="dropdown-item news-item-link"
             href="${urlPrefix}/news_items"
@@ -318,7 +314,7 @@ function UserDropdownMenu({
               : ''}
           </a>
 
-          <a class="dropdown-item" href="${config.urlPrefix}/logout">Log out</a>
+          <a class="dropdown-item" href="/pl/logout">Log out</a>
         </div>
       </li>
     </ul>
@@ -399,9 +395,9 @@ function ViewTypeMenu({ resLocals }: { resLocals: Record<string, any> }) {
   let studentLink = '#';
   if (viewType === 'instructor') {
     if (assessment?.id) {
-      studentLink = `${config.urlPrefix}/course_instance/${course_instance.id}/assessment/${assessment.id}`;
+      studentLink = `/pl/course_instance/${course_instance.id}/assessment/${assessment.id}`;
     } else {
-      studentLink = `${config.urlPrefix}/course_instance/${course_instance.id}/assessments`;
+      studentLink = `/pl/course_instance/${course_instance.id}/assessments`;
     }
   } else {
     if (question?.id) {
@@ -591,9 +587,9 @@ function AuthnOverrides({
     // It is ok to use the instructor route only to the effectiveUser page - this will redirect
     // to the student route if necessary.
     if (course_instance) {
-      effectiveUserUrl = `${config.urlPrefix}/course_instance/${course_instance.id}/instructor/effectiveUser`;
+      effectiveUserUrl = `/pl/course_instance/${course_instance.id}/instructor/effectiveUser`;
     } else {
-      effectiveUserUrl = `${config.urlPrefix}/course/${course.id}/effectiveUser`;
+      effectiveUserUrl = `/pl/course/${course.id}/effectiveUser`;
     }
   }
 
@@ -661,7 +657,7 @@ function NavbarPlain({ resLocals, navPage }: { resLocals: Record<string, any>; n
 
   return html`
     <li class="nav-item ${navPage === 'admin' ? 'active' : ''}">
-      <a class="nav-link" href="${config.urlPrefix}/administrator/admins">Admin</a>
+      <a class="nav-link" href="/pl/administrator/admins">Admin</a>
     </li>
   `;
 }
@@ -930,7 +926,7 @@ function NavbarInstructor({
               !(navSubPage === 'assessments' || navSubPage === 'gradebook')
                 ? 'active'
                 : ''}"
-              href="${config.urlPrefix}/course_instance/${course_instance.id}/instructor/instance_admin"
+              href="/pl/course_instance/${course_instance.id}/instructor/instance_admin"
             >
               ${course_instance.short_name}
             </a>

--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -39,7 +39,7 @@ export function PersonalNotesPanel({
                   <li class="list-group-item d-flex align-items-center">
                     <a
                       class="text-break me-2"
-                      href="${config.urlPrefix}/course_instance/${courseInstanceId}/assessment_instance/${assessment_instance.id}/file/${file.id}/${file.display_filename}"
+                      href="/pl/course_instance/${courseInstanceId}/assessment_instance/${assessment_instance.id}/file/${file.id}/${file.display_filename}"
                       data-testid="attached-file"
                     >
                       ${file.display_filename}

--- a/apps/prairielearn/src/components/SubmissionPanel.tsx
+++ b/apps/prairielearn/src/components/SubmissionPanel.tsx
@@ -5,7 +5,6 @@ import { z } from 'zod';
 
 import { type HtmlValue, html, unsafeHtml } from '@prairielearn/html';
 
-import { config } from '../lib/config.js';
 import {
   type AssessmentQuestion,
   type GradingJob,
@@ -401,8 +400,8 @@ function SubmissionInfoModal({
   const gradingJobStats = buildGradingJobStats(submission.grading_job);
   const gradingJobUrl =
     course_instance_id == null
-      ? `${config.urlPrefix}/course/${course_id}/grading_job/${submission.grading_job?.id}`
-      : `${config.urlPrefix}/course_instance/${course_instance_id}/instructor/grading_job/${
+      ? `/pl/course/${course_id}/grading_job/${submission.grading_job?.id}`
+      : `/pl/course_instance/${course_instance_id}/instructor/grading_job/${
           submission.grading_job?.id
         }`;
   return Modal({

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -233,9 +233,7 @@ router.post(
         unsafe_lti13_instance_id: req.params.unsafe_lti13_instance_id,
       });
       flash('success', 'Instance deleted.');
-      return res.redirect(
-        `${config.urlPrefix}/administrator/institution/${req.params.institution_id}/lti13`,
-      );
+      return res.redirect(`/pl/administrator/institution/${req.params.institution_id}/lti13`);
     } else {
       throw new error.HttpStatusError(400, `unknown __action: ${req.body.__action}`);
     }

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
@@ -3,7 +3,6 @@ import { html } from '@prairielearn/html';
 import { HeadContents } from '../../../components/HeadContents.js';
 import { Modal } from '../../../components/Modal.js';
 import { Navbar } from '../../../components/Navbar.js';
-import { config } from '../../../lib/config.js';
 import { type Course } from '../../../lib/db-types.js';
 import { STUDENT_ROLE } from '../../lib/lti13.js';
 
@@ -133,7 +132,7 @@ export function Lti13CourseNavigationNotReady({
           <p>An instructor has not yet configured ${courseName} in PrairieLearn.</p>
           <p>Please come back later.</p>
           <p>
-            <a href="${config.urlPrefix}" class="btn btn-primary">
+            <a href="/pl" class="btn btn-primary">
               <i class="fa fa-home" aria-hidden="true"></i>
               PrairieLearn home
             </a>

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -73,7 +73,6 @@ export const ConfigSchema = z.object({
     .array(z.string())
     .default([...STANDARD_COURSE_DIRS, EXAMPLE_COURSE_PATH, TEST_COURSE_PATH]),
   courseRepoDefaultBranch: z.string().default('master'),
-  urlPrefix: z.string().default('/pl'),
   homeUrl: z.string().default('/'),
   assetsPrefix: z
     .string()
@@ -658,7 +657,7 @@ export function resetConfig() {
 }
 
 export function setLocalsFromConfig(locals: Record<string, any>) {
-  locals.urlPrefix = config.urlPrefix;
-  locals.plainUrlPrefix = config.urlPrefix;
+  locals.urlPrefix = '/pl';
+  locals.plainUrlPrefix = '/pl';
   locals.navbarType = 'plain';
 }

--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -760,7 +760,7 @@ export async function renderPanelsForSubmission({
 
   const locals = {
     urlPrefix,
-    plainUrlPrefix: config.urlPrefix,
+    plainUrlPrefix: '/pl',
     questionRenderContext,
     ...buildQuestionUrls(urlPrefix, variant, question, instance_question),
     ...buildLocals({

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessment.html.ts
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessment.html.ts
@@ -2,7 +2,6 @@ import { html } from '@prairielearn/html';
 
 import { HeadContents } from '../components/HeadContents.js';
 import { Navbar } from '../components/Navbar.js';
-import { config } from '../lib/config.js';
 
 export function AccessDenied({ resLocals }: { resLocals: Record<string, any> }) {
   return html`
@@ -26,7 +25,7 @@ export function AccessDenied({ resLocals }: { resLocals: Record<string, any> }) 
                 >
                   Go to assessments
                 </a>
-                <a href="${config.urlPrefix}" class="btn btn-primary">
+                <a href="/pl" class="btn btn-primary">
                   <i class="fa fa-home" aria-hidden="true"></i>
                   PrairieLearn home
                 </a>

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -9,7 +9,6 @@ import {
 } from '../../admin_queries/lib/util.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { nodeModulesAssetPath } from '../../lib/assets.js';
-import { config } from '../../lib/config.js';
 import { type QueryRun, QueryRunSchema } from '../../lib/db-types.js';
 
 export const AdministratorQueryRunParamsSchema = z.object({
@@ -268,20 +267,20 @@ function renderCell(row: any, col: string, columns: string[], info: Administrato
   if (col === 'course' && 'course_id' in row) {
     return html`
       <td ${tdAttributes}>
-        <a href="${config.urlPrefix}/course/${row.course_id}">${row[col]}</a>
+        <a href="/pl/course/${row.course_id}">${row[col]}</a>
       </td>
     `;
   } else if (col === 'course_instance' && 'course_instance_id' in row) {
     return html`
       <td ${tdAttributes}>
-        <a href="${config.urlPrefix}/course_instance/${row.course_instance_id}">${row[col]}</a>
+        <a href="/pl/course_instance/${row.course_instance_id}">${row[col]}</a>
       </td>
     `;
   } else if (col === 'assessment' && 'assessment_id' in row && 'course_instance_id' in row) {
     return html`
       <td ${tdAttributes}>
         <a
-          href="${config.urlPrefix}/course_instance/${row.course_instance_id}/instructor/assessment/${row.assessment_id}"
+          href="/pl/course_instance/${row.course_instance_id}/instructor/assessment/${row.assessment_id}"
         >
           ${row[col]}
         </a>

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -6,7 +6,6 @@ import { html, unsafeHtml } from '@prairielearn/html';
 import { formatQueryWithErrorPosition } from '@prairielearn/postgres';
 
 import { PageLayout } from '../../components/PageLayout.js';
-import { config } from '../../lib/config.js';
 
 function formatJson(value: any): string {
   return jsonStringifySafe(value, null, '    ');
@@ -68,7 +67,7 @@ export function ErrorPage({
               <i class="fa fa-arrow-left" aria-hidden="true"></i>
               Back to previous page
             </a>
-            <a href="${config.urlPrefix}" class="btn btn-primary">
+            <a href="/pl" class="btn btn-primary">
               <i class="fa fa-home" aria-hidden="true"></i>
               PrairieLearn home
             </a>

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -5,7 +5,6 @@ import { html } from '@prairielearn/html';
 
 import { HeadContents } from '../../components/HeadContents.js';
 import { Navbar } from '../../components/Navbar.js';
-import { config } from '../../lib/config.js';
 import { GradingJobSchema, QuestionSchema, UserSchema, VariantSchema } from '../../lib/db-types.js';
 
 export const GradingJobRowSchema = z.object({
@@ -37,7 +36,7 @@ export function InstructorGradingJob({
       : html`&mdash;`;
   const variantLink =
     gradingJobRow.instance_question_id != null
-      ? `${config.urlPrefix}/course_instance/${resLocals.course_instance.id}/instance_question/${gradingJobRow.instance_question_id}?variant_id=${gradingJobRow.variant_id}`
+      ? `/pl/course_instance/${resLocals.course_instance.id}/instance_question/${gradingJobRow.instance_question_id}?variant_id=${gradingJobRow.variant_id}`
       : `${resLocals.urlPrefix}/question/${gradingJobRow.question_id}/preview?variant_id=${gradingJobRow.variant_id}`;
 
   return html`

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
@@ -11,7 +11,6 @@ import { PageLayout } from '../../components/PageLayout.js';
 import { Pager } from '../../components/Pager.js';
 import { CourseSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.js';
 import { compiledStylesheetTag } from '../../lib/assets.js';
-import { config } from '../../lib/config.js';
 import {
   AssessmentSetSchema,
   CourseInstanceSchema,
@@ -238,7 +237,7 @@ function IssueRow({
   authz_data: Record<string, any>;
   csrfToken: string;
 }) {
-  const plainUrlPrefix = config.urlPrefix;
+  const plainUrlPrefix = '/pl';
   const mailtoLink = `mailto:${
     issue.user_email || issue.user_uid || '-'
   }?subject=Reported%20PrairieLearn%20Issue&body=${encodeURIComponent(

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
@@ -13,7 +13,6 @@ import { TagDescription } from '../../components/TagDescription.js';
 import { TopicBadgeHtml } from '../../components/TopicBadge.js';
 import { TopicDescription } from '../../components/TopicDescription.js';
 import { compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
-import { config } from '../../lib/config.js';
 import {
   AssessmentSchema,
   AssessmentSetSchema,
@@ -766,7 +765,7 @@ function DeleteQuestionModal({
                     <div class="h6">${a_with_q.short_name} (${a_with_q.long_name})</div>
                     ${a_with_q.assessments.map((assessment) =>
                       AssessmentBadgeHtml({
-                        plainUrlPrefix: config.urlPrefix,
+                        plainUrlPrefix: '/pl',
                         courseInstanceId: a_with_q.course_instance_id,
                         assessment,
                       }),

--- a/apps/prairielearn/src/tests/exampleCourseQuestionsComplete.test.ts
+++ b/apps/prairielearn/src/tests/exampleCourseQuestionsComplete.test.ts
@@ -308,7 +308,7 @@ describe('Internally graded question lifecycle tests', { timeout: 60_000 }, func
       // Render
       const locals = {
         urlPrefix: '/prefix1',
-        plainUrlPrefix: config.urlPrefix,
+        plainUrlPrefix: '/pl',
         questionRenderContext: undefined,
         ...buildQuestionUrls(
           '/prefix2',

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -83,10 +83,6 @@
       "type": "string",
       "default": "master"
     },
-    "urlPrefix": {
-      "type": "string",
-      "default": "/pl"
-    },
     "homeUrl": {
       "type": "string",
       "default": "/"

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -340,10 +340,6 @@
       "type": "string",
       "default": "master"
     },
-    "urlPrefix": {
-      "type": "string",
-      "default": "/pl"
-    },
     "homeUrl": {
       "type": "string",
       "default": "/"


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

We already hardcode `/pl` in a LOT of locations. Lets not pretend this is customizable, and start to clean up a bunch of code that passes this around. I did a find and replace and a build to check this.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note any AI assistance used (i.e. specific IDEs, models, or tools).

-->

# Testing

None, test suite should be sufficient.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.

Thank you for contributing to PrairieLearn!

-->
