### PR TITLE
Bump workspace/jupyterlab-r to 4.5.2

### DIFF
--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -237,8 +237,8 @@ PrairieLearn provides and maintains the following workspace images:
 - [`prairielearn/workspace-desktop`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/desktop/): An Ubuntu 24.04 desktop
 - [`prairielearn/workspace-jupyterlab-base`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/jupyterlab-base/): JupyterLab without any additions (used to build the Python and R workspaces below)
 - [`prairielearn/workspace-jupyterlab-python`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/jupyterlab-python/): JupyterLab with Python 3.12
-- [`prairielearn/workspace-jupyterlab-r`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/jupyterlab-r/): JupyterLab with R 4.4
-- [`prairielearn/workspace-rstudio`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/rstudio/): RStudio with R version 4.4
+- [`prairielearn/workspace-jupyterlab-r`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/jupyterlab-r/): JupyterLab with R 4.5
+- [`prairielearn/workspace-rstudio`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/rstudio/): RStudio with R version 4.5
 - [`prairielearn/workspace-vscode-base`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/vscode-base/): Basic VS Code without any additions (used to build the C/C++ and Python workspaces below)
 - [`prairielearn/workspace-vscode-cpp`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/vscode-cpp/): VS Code with C/C++ (using `gcc` and `g++`)
 - [`prairielearn/workspace-vscode-java`](https://github.com/PrairieLearn/PrairieLearn/tree/master/workspaces/vscode-java/): VS Code with Java 21

--- a/workspaces/jupyterlab-r/install.sh
+++ b/workspaces/jupyterlab-r/install.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Install all R dependencies.
-mamba install -y -c conda-forge r-base=4.5.1 r-irkernel=1.3.2
+mamba install -y -c conda-forge r-base=4.5.2 r-irkernel=1.3.2
 
 # Clear various caches to minimize the final image size.
 mamba clean --all -f -y


### PR DESCRIPTION
# Description

Incremented the version of R from 4.5.1 to 4.5.2 in the jupyterlab-r workspace

Also updated the docs to reflect 4.5 instead of 4.4 for both R workspaces

<img width="456" height="309" alt="image" src="https://github.com/user-attachments/assets/3f79da40-935c-4fa6-b793-d2dea4f165f4" />

# Testing

Tested by building the workspace locally, deploying to a course on the live PL server, and then submitting a question to be graded.

I did not rebuild the docs for testing as it was such a small change on that front


