### PR TITLE
Mark rubric field as potentially nullable

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -361,8 +361,8 @@ const PostBodySchema = z.union([
           order: z.coerce.number(),
           points: z.coerce.number(),
           description: z.string(),
-          explanation: z.string().optional(),
-          grader_note: z.string().optional(),
+          explanation: z.string().nullable().optional(),
+          grader_note: z.string().nullable().optional(),
           always_show_to_students: z.boolean(),
         }),
       )


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This should resolve https://prairielearn-inc.sentry.io/issues/7044466007, which means that modifying rubric settings on the instance question page isn't working correctly when grader note/explanation are unset.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

I followed test instructions from @nwalters512 with this fix and did not observe any save errors.

repro steps:
add new rubric item, save
reload page
add another rubric item, save
the save produces that error

alternatively, save the same rubric without modifications

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
