### PR TITLE
Upgrade to Hadolint 2.14.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install additional dependencies
         run: |-
-          sudo curl -fsSL https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 -o /bin/hadolint && \
+          sudo curl -fsSL https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64 -o /bin/hadolint && \
           sudo chmod +x /bin/hadolint
 
       - name: Install OS packages


### PR DESCRIPTION
# Description

Necessary for #11039.

# Testing

```
$ hadolint --version
Haskell Dockerfile Linter 2.14.0

$ make lint-docker
# No output: success!
```