### PR TITLE
fix: order blocks grading incorrectly when wrong block is at end

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -672,6 +672,7 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
         if order_blocks_options.partial_credit is PartialCreditType.NONE:
             if (
                 num_initial_correct == true_answer_length
+                # The student can't select additional incorrect options
                 and len(submission) == true_answer_length
             ):
                 final_score = 1


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description
fixes #13426

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing
Manually tested with multiple different grading modes, with `partial-credit="none"` and `partial-credit="lcs"`

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
