### PR TITLE
Fix broken links in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you want to make a larger change, such as implementing a new feature, changin
 
 Before you start contributing, you'll need to [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repo.
 
-Once you've forked, you'll need to clone your fork and set up your development environment. Depending on your preferred workflow, you can [develop "natively" directly on your computer](https://prairielearn.readthedocs.io/en/latest/installingNative/) (preferred) or [develop inside of a Docker container](https://prairielearn.readthedocs.io/en/latest/installingLocal/) that has all the dependencies pre-installed.
+Once you've forked, you'll need to clone your fork and set up your development environment. Depending on your preferred workflow, you can [develop "natively" directly on your computer](https://prairielearn.readthedocs.io/en/latest/dev-guide/installingNative/) (preferred) or [develop inside of a Docker container](https://prairielearn.readthedocs.io/en/latest/dev-guide/installingLocal/) that has all the dependencies pre-installed.
 
 ## Development
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description
The links that lead to developing locally and in docker seems to be broken:


https://github.com/user-attachments/assets/f1c644a0-31e5-492e-b1cf-da449bef653b

The urls seem to be outdated and I have updated them to the ones that are working correctly.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
