### PR TITLE
fix(publishing): Improve the legacy access rule card by guiding user to config file

### DIFF
--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/LegacyAccessRuleCard.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/LegacyAccessRuleCard.tsx
@@ -3,24 +3,43 @@ import { run } from '@prairielearn/run';
 
 import { CommentPopover } from '../../../components/CommentPopover.js';
 import type { CourseInstance, CourseInstanceAccessRule } from '../../../lib/db-types.js';
+import { encodePathNoNormalize } from '../../../lib/uri-util.shared.js';
 
 export function LegacyAccessRuleCard({
   accessRules,
   showComments,
   courseInstance,
   hasCourseInstancePermissionView,
+  urlPrefix,
 }: {
   accessRules: CourseInstanceAccessRule[];
   showComments: boolean;
   courseInstance: CourseInstance;
   hasCourseInstancePermissionView: boolean;
+  urlPrefix: string;
 }) {
+  const infoCourseInstancePath = courseInstance.short_name
+    ? `courseInstances/${courseInstance.short_name}/infoCourseInstance.json`
+    : null;
   return (
     <>
       <div class="alert alert-warning" role="alert">
         <strong>Legacy Access Rules Active:</strong> This course instance is using the legacy
         <code>allowAccess</code> system. To use the new publishing system, you must first remove all
-        <code>allowAccess</code> rules from the course configuration.
+        <code>allowAccess</code> rules from the{' '}
+        {infoCourseInstancePath ? (
+          <a
+            data-testid="edit-course-instance-configuration-link"
+            href={encodePathNoNormalize(
+              `${urlPrefix}/instance_admin/file_edit/${infoCourseInstancePath}`,
+            )}
+          >
+            course instance configuration
+          </a>
+        ) : (
+          'course instance configuration'
+        )}
+        .
       </div>
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex align-items-center justify-content-between">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/instructorInstanceAdminPublishing.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/instructorInstanceAdminPublishing.tsx
@@ -211,6 +211,7 @@ router.get(
                 showComments={showComments}
                 courseInstance={courseInstance}
                 hasCourseInstancePermissionView={hasCourseInstancePermissionView}
+                urlPrefix={res.locals.urlPrefix}
               />
             )}
           </>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

As someone unfamiliar with the product, it was quite hard to find where I can remove the `allowAccess`. I thought this is slightly more helpful:


https://github.com/user-attachments/assets/09e52276-68eb-4163-a9b7-cdbeb4d5ddb3



<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

1) Go to a course instance that is using the legacy `allowAccess` system
2) Click on `instance settings`
3) Go to publishing
4) Click on `course instance configuration`
5) You should be guided to the file where you can remove the `allowAccess`.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
