### PR TITLE
Allow inviting users without PL account

### DIFF
--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.test.ts
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.test.ts
@@ -59,7 +59,7 @@ describe('Instructor Students - Invite by UID', () => {
     assert.isString(csrfToken);
   });
 
-  test.sequential('should return error when user does not exist', async () => {
+  test.sequential('should successfully invite a nonexistent user', async () => {
     const response = await fetch(studentsUrl, {
       method: 'POST',
       headers: {
@@ -74,9 +74,10 @@ describe('Instructor Students - Invite by UID', () => {
       }),
     });
 
-    assert.equal(response.status, 400);
+    assert.equal(response.status, 200);
     const data = await response.json();
-    assert.equal(data.error, 'User not found');
+    assert.isObject(data.data);
+    assert.equal(data.data.status, 'invited');
   });
 
   test.sequential('should return error when user is an instructor', async () => {

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
@@ -101,18 +101,16 @@ router.post(
 
     const user = await selectOptionalUserByUid(body.uid);
 
-    if (user == null) {
-      throw new HttpStatusError(400, 'User not found');
-    }
+    if (user) {
+      const isInstructor = await callRow(
+        'users_is_instructor_in_course_instance',
+        [user.user_id, courseInstance.id],
+        z.boolean(),
+      );
 
-    const isInstructor = await callRow(
-      'users_is_instructor_in_course_instance',
-      [user.user_id, courseInstance.id],
-      z.boolean(),
-    );
-
-    if (isInstructor) {
-      throw new HttpStatusError(400, 'The user is an instructor');
+      if (isInstructor) {
+        throw new HttpStatusError(400, 'The user is an instructor');
+      }
     }
 
     // Try to find an existing enrollment so we can error gracefully.


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The previous invitation system didn't allow invitations of users without a PL account. This allows that. The original thinking was more closely related to the problem of LTI syncing with a changing UID. However, invitations are instructor controlled, never system controlled. The instructor can simply delete invitations manually.
 
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Test suite was updated -- this is not a technical limitation, but a backend check that got removed.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
