### PR TITLE
Temporary grading job bug fix

### DIFF
--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
@@ -57,7 +57,8 @@ router.get(
       sql.select_job,
       {
         job_id: req.params.job_id,
-        course_instance_id: 'course_instance' in res.locals ? res.locals.course_instance.id : null,
+        // @ts-expect-error - TODO: We need a better type to represent a 'course' OR 'course-instance' context.
+        course_instance_id: res.locals.course_instance?.id ?? null,
         course_id: res.locals.course.id,
       },
       GradingJobRowSchema,
@@ -88,7 +89,8 @@ router.get(
       sql.select_job,
       {
         job_id: req.params.job_id,
-        course_instance_id: 'course_instance' in res.locals ? res.locals.course_instance.id : null,
+        // @ts-expect-error - TODO: We need a better type to represent a 'course' OR 'course-instance' context.
+        course_instance_id: res.locals.course_instance?.id ?? null,
         course_id: res.locals.course.id,
       },
       GradingJobRowSchema,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This fixes the Sentry bug: https://prairielearn-inc.sentry.io/issues/7088044959/?alert_rule_id=12128501&alert_type=issue&notification_uuid=96b1ff2c-fcbc-4a2d-84fd-d5959584b43c&project=6704263

```
> course_instance_id: 'course_instance' in res.locals ? res.locals.course_instance.id : null,
> Cannot read properties of null (reading 'id')
```

Somehow, `course_instance` is present in `res.locals` but set to `null`. We need to investigate that further.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

None; fix should be straightforward.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
