### PR TITLE
Improve ResLocals type

### DIFF
--- a/apps/prairielearn/src/lib/res-locals.ts
+++ b/apps/prairielearn/src/lib/res-locals.ts
@@ -22,62 +22,52 @@ import type {
   ResLocalsInstanceQuestionRender,
   ResLocalsQuestionRender,
 } from './question-render.types.js';
-import type { UntypedResLocals } from './res-locals.types.js';
-import type { Prettify } from './types.js';
+import type { MergeUnion, Prettify } from './types.js';
 
 export interface ResLocals extends ResLocalsAuthnUser, ResLocalsConfig {
   __csrf_token: string;
 }
 
-export interface ResLocalsForPage {
-  course: Prettify<ResLocals & ResLocalsCourse & ResLocalsCourseIssueCount>;
-  'course-instance': Prettify<ResLocals & ResLocalsCourseInstance>;
-  'instructor-instance-question': Prettify<
-    ResLocals &
-      ResLocalsCourseInstance &
-      ResLocalsInstructorQuestionWithCourseInstance &
-      ResLocalsInstanceQuestion &
-      ResLocalsInstanceQuestionRender &
-      ResLocalsQuestionRender & {
-        questionRenderContext: 'manual_grading' | 'ai_grading';
-        navbarType: 'instructor';
-      }
-  >;
-  'instructor-question': Prettify<
-    ResLocals &
-      ResLocalsCourse &
-      Partial<ResLocalsCourseInstance> &
-      ResLocalsInstructorQuestion &
-      ResLocalsQuestionRender
-  >;
-  'instructor-assessment-question': Prettify<
-    ResLocals &
-      ResLocalsCourseInstance &
-      ResLocalsInstructorQuestion &
-      ResLocalsQuestionRender &
-      ResLocalsAssessment &
-      ResLocalsAssessmentQuestion
-  >;
-  'instance-question': Prettify<
-    ResLocals &
-      ResLocalsCourseInstance &
-      ResLocalsInstanceQuestion &
-      ResLocalsInstanceQuestionRender
-  >;
-  'assessment-question': Prettify<
-    ResLocals & ResLocalsAssessment & ResLocalsAssessmentQuestion & ResLocalsInstanceQuestionRender
-  >;
-  'assessment-instance': Prettify<ResLocals & ResLocalsAssessment & ResLocalsAssessmentInstance>;
-  assessment: Prettify<ResLocals & ResLocalsCourseInstance & ResLocalsAssessment>;
+interface ResLocalsForPageLookup {
+  course: ResLocals & ResLocalsCourse & ResLocalsCourseIssueCount;
+  'course-instance': ResLocals & ResLocalsCourseInstance;
+  'instructor-instance-question': ResLocals &
+    ResLocalsCourseInstance &
+    ResLocalsInstructorQuestionWithCourseInstance &
+    ResLocalsInstanceQuestion &
+    ResLocalsInstanceQuestionRender &
+    ResLocalsQuestionRender & {
+      questionRenderContext: 'manual_grading' | 'ai_grading';
+      navbarType: 'instructor';
+    };
+  'instructor-question': ResLocals &
+    ResLocalsCourse &
+    Partial<ResLocalsCourseInstance> &
+    ResLocalsInstructorQuestion &
+    ResLocalsQuestionRender;
+  'instructor-assessment-question': ResLocals &
+    ResLocalsCourseInstance &
+    ResLocalsInstructorQuestion &
+    ResLocalsQuestionRender &
+    ResLocalsAssessment &
+    ResLocalsAssessmentQuestion;
+  'instance-question': ResLocals &
+    ResLocalsCourseInstance &
+    ResLocalsInstanceQuestion &
+    ResLocalsInstanceQuestionRender;
+  'assessment-question': ResLocals &
+    ResLocalsAssessment &
+    ResLocalsAssessmentQuestion &
+    ResLocalsInstanceQuestionRender;
+  'assessment-instance': ResLocals & ResLocalsAssessment & ResLocalsAssessmentInstance;
+  assessment: ResLocals & ResLocalsCourseInstance & ResLocalsAssessment;
 }
 
-export type PageType = keyof ResLocalsForPage;
+export type ResLocalsForPage<T extends keyof ResLocalsForPageLookup> = MergeUnion<
+  ResLocalsForPageLookup[T]
+>;
 
-export function getResLocalsForPage<T extends PageType>(
-  locals: UntypedResLocals,
-): ResLocalsForPage[T] {
-  return locals as ResLocalsForPage[T];
-}
+export type PageType = keyof ResLocalsForPageLookup;
 
 /**
  * A wrapper around {@link asyncHandler} that ensures that the locals
@@ -105,7 +95,7 @@ export function getResLocalsForPage<T extends PageType>(
  * @param handler - The handler function to wrap.
  * @returns A wrapped handler function.
  */
-export const typedAsyncHandler = <T extends keyof ResLocalsForPage, ExtraLocals = object>(
+export const typedAsyncHandler = <T extends PageType, ExtraLocals = object>(
   handler: (
     ...args: Parameters<
       express.RequestHandler<
@@ -113,7 +103,7 @@ export const typedAsyncHandler = <T extends keyof ResLocalsForPage, ExtraLocals 
         any,
         any,
         core.Query,
-        ResLocalsForPage[T] & ExtraLocals
+        Prettify<ResLocalsForPage<T> & ExtraLocals>
       >
     >
   ) => void | Promise<void>,

--- a/apps/prairielearn/src/lib/types.ts
+++ b/apps/prairielearn/src/lib/types.ts
@@ -82,3 +82,38 @@ export function withBrand<B extends Brand<any, any>>(
 export type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
+
+// All keys from any member of union T
+type UnionKeys<T> = T extends any ? keyof T : never;
+
+// Keys that exist in ALL members of union T
+type KeysInAllMembers<T> = {
+  [K in UnionKeys<T>]: [T] extends [Record<K, any>] ? K : never;
+}[UnionKeys<T>];
+
+// Keys that exist in SOME but not ALL members
+type KeysInSomeMembers<T> = Exclude<UnionKeys<T>, KeysInAllMembers<T>>;
+
+// Value type for key K across all members that have it
+type UnionPropValue<T, K extends PropertyKey> = T extends any
+  ? K extends keyof T
+    ? T[K]
+    : never
+  : never;
+
+/**
+ * Merges a union of object types into a single object type.
+ * Keys present in all members become required, keys present in some become optional.
+ *
+ * ```ts
+ * type A = { id: string; name: string };
+ * type B = { id: string; age: number };
+ * type Merged = MergeUnion<A | B>;
+ * // Merged is { id: string } & { name?: string; age?: number }
+ * ```
+ */
+export type MergeUnion<T> = {
+  [K in KeysInAllMembers<T>]: UnionPropValue<T, K>;
+} & {
+  [K in KeysInSomeMembers<T>]?: UnionPropValue<T, K>;
+};

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
@@ -436,7 +436,7 @@ export async function authzCourseOrInstance(req: Request, res: Response) {
     });
   }
 
-  const req_date = run(() => {
+  const req_date = run<Date>(() => {
     if (req.cookies.pl2_requested_date) {
       const req_date = parseISO(req.cookies.pl2_requested_date);
       if (!isValid(req_date)) {
@@ -683,7 +683,9 @@ export async function authzCourseOrInstance(req: Request, res: Response) {
   res.locals.course = authnCourse;
   res.locals.institution = authnInstitution;
   res.locals.user = effectiveAuthzData.user;
-  res.locals.course_instance = authnCourseInstance;
+  if (authnCourseInstance) {
+    res.locals.course_instance = authnCourseInstance;
+  }
 
   // The session middleware does not run for API requests.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -35,7 +35,7 @@ export function GradingPanel({
   instanceQuestionGroups,
   skip_graded_submissions,
 }: {
-  resLocals: ResLocalsForPage['instance-question'];
+  resLocals: ResLocalsForPage<'instance-question'>;
   context: 'main' | 'existing' | 'conflicting';
   graders?: User[] | null;
   disable?: boolean;

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -42,7 +42,7 @@ export function InstanceQuestion({
   instanceQuestionGroups,
   skipGradedSubmissions,
 }: {
-  resLocals: ResLocalsForPage['instance-question'];
+  resLocals: ResLocalsForPage<'instance-question'>;
   conflict_grading_job: GradingJobData | null;
   graders: User[] | null;
   assignedGrader: User | null;
@@ -270,7 +270,7 @@ function ConflictGradingJobModal({
   lastGrader,
   skipGradedSubmissions,
 }: {
-  resLocals: ResLocalsForPage['instance-question'];
+  resLocals: ResLocalsForPage<'instance-question'>;
   conflict_grading_job: GradingJobData;
   graders: User[] | null;
   lastGrader: User | null;

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -51,7 +51,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 async function prepareLocalsForRender(
   query: Record<string, any>,
-  resLocals: ResLocalsForPage['instructor-instance-question'],
+  resLocals: ResLocalsForPage<'instructor-instance-question'>,
 ) {
   // Even though getAndRenderVariant will select variants for the instance question, if the
   // question has multiple variants, by default getAndRenderVariant may select a variant without

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -22,16 +22,14 @@ export function InstructorGradingJob({
   resLocals,
   gradingJobRow,
 }: {
-  resLocals: ResLocalsForPage['course'] | ResLocalsForPage['course-instance'];
+  resLocals: ResLocalsForPage<'course' | 'course-instance'>;
   gradingJobRow: GradingJobRow;
 }) {
   const formatGradingJobDate = (date: Date | null) =>
     date
       ? formatDate(
           date,
-          'course_instance' in resLocals
-            ? resLocals.course_instance.display_timezone
-            : resLocals.course.display_timezone,
+          resLocals.course_instance?.display_timezone ?? resLocals.course.display_timezone,
           { includeMs: true },
         )
       : html`&mdash;`;

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.ts
@@ -26,7 +26,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
  * Throws an error if the user does not have access to the grading job.
  */
 async function assertHasAccessToGradingJob(
-  resLocals: ResLocalsForPage['course'] | ResLocalsForPage['course-instance'],
+  resLocals: ResLocalsForPage<'course' | 'course-instance'>,
   gradingJobRow: GradingJobRow,
 ) {
   // We'll reuse the variant access logic to gate access. This will let us know
@@ -37,7 +37,7 @@ async function assertHasAccessToGradingJob(
   await selectAndAuthzVariant({
     unsafe_variant_id: gradingJobRow.variant_id,
     variant_course: resLocals.course,
-    course_instance_id: 'course_instance' in resLocals ? resLocals.course_instance.id : undefined,
+    course_instance_id: resLocals.course_instance?.id ?? undefined,
     question_id: gradingJobRow.question_id,
     // IMPORTANT: We pass `undefined` here to indicate that we haven't yet authenticated
     // that the current user should have access to this instance question. This forces
@@ -57,7 +57,6 @@ router.get(
       sql.select_job,
       {
         job_id: req.params.job_id,
-        // @ts-expect-error - TODO: We need a better type to represent a 'course' OR 'course-instance' context.
         course_instance_id: res.locals.course_instance?.id ?? null,
         course_id: res.locals.course.id,
       },
@@ -89,7 +88,6 @@ router.get(
       sql.select_job,
       {
         job_id: req.params.job_id,
-        // @ts-expect-error - TODO: We need a better type to represent a 'course' OR 'course-instance' context.
         course_instance_id: res.locals.course_instance?.id ?? null,
         course_id: res.locals.course.id,
       },

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.tsx
@@ -31,7 +31,7 @@ export function InstructorQuestionPreview({
   renderSubmissionSearchParams: URLSearchParams;
   readmeHtml: string;
   questionCopyTargets: CopyTarget[] | null;
-  resLocals: ResLocalsForPage['instructor-question'];
+  resLocals: ResLocalsForPage<'instructor-question'>;
 }) {
   assert(resLocals.question.qid !== null);
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This PR adds a new `MergeUnion` type helper to better type `ResLocals`. Additionally, I fixed a bug where `res.locals.course_instance` was set to null instead of being unset.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

None; this is a type-level change.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
