### PR TITLE
Refactor course instance models to use modern authz pattern

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -18,6 +18,7 @@ import {
 } from '@prairielearn/postgres';
 
 import { selectAssessmentInstanceLastSubmissionDate } from '../../lib/assessment.js';
+import type { AuthzData } from '../../lib/authz-data-lib.js';
 import { config } from '../../lib/config.js';
 import {
   AssessmentSchema,
@@ -855,12 +856,14 @@ class Lti13ContextMembership {
 }
 
 export async function updateLti13Scores({
-  course_instance,
+  courseInstance,
+  authzData,
   unsafe_assessment_id,
   instance,
   job,
 }: {
-  course_instance: CourseInstance;
+  courseInstance: CourseInstance;
+  authzData: AuthzData;
   unsafe_assessment_id: string | number;
   instance: Lti13CombinedInstance;
   job: ServerJob;
@@ -894,8 +897,10 @@ export async function updateLti13Scores({
   );
 
   const courseStaff = await selectUsersWithCourseInstanceAccess({
-    course_instance,
-    minimal_role: 'Student Data Viewer',
+    courseInstance,
+    authzData,
+    requiredRole: ['Student Data Viewer'],
+    minimalRole: 'Student Data Viewer',
   });
   const courseStaffUids = new Set(courseStaff.map((staff) => staff.uid));
 

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.ts
@@ -296,7 +296,8 @@ router.post(
 
       serverJob.executeInBackground(async (job) => {
         await updateLti13Scores({
-          course_instance: res.locals.course_instance,
+          courseInstance: res.locals.course_instance,
+          authzData: res.locals.authz_data,
           unsafe_assessment_id: assessment.id,
           instance,
           job,

--- a/apps/prairielearn/src/lib/authz-data-lib.ts
+++ b/apps/prairielearn/src/lib/authz-data-lib.ts
@@ -134,7 +134,10 @@ export type CourseOrInstanceContextData = z.infer<typeof CourseOrInstanceContext
 
 export type AuthzDataWithoutEffectiveUser = PlainAuthzData | DangerousSystemAuthzData;
 
-export type AuthzDataWithEffectiveUser = PageAuthzData | DangerousSystemAuthzData;
+export type AuthzDataWithEffectiveUser =
+  | RawPageAuthzData
+  | PageAuthzData
+  | DangerousSystemAuthzData;
 
 export type AuthzData = AuthzDataWithoutEffectiveUser | AuthzDataWithEffectiveUser;
 

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -36,7 +36,7 @@ router.get(
 
     // Look up the course instance by enrollment code
     const courseInstanceId = await selectOptionalCourseInstanceIdByEnrollmentCode({
-      enrollment_code: code,
+      enrollmentCode: code,
     });
     if (!courseInstanceId) {
       // User-facing terminology is to use "course" instead of "course instance"

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.ts
@@ -49,7 +49,9 @@ router.get(
     );
     const num_open_instances = questions[0]?.num_open_instances || 0;
     const courseStaff = await selectCourseInstanceGraderStaff({
-      course_instance: res.locals.course_instance,
+      courseInstance: res.locals.course_instance,
+      authzData: res.locals.authz_data,
+      requiredRole: ['Student Data Viewer'],
     });
     const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
     res.send(
@@ -82,7 +84,9 @@ router.post(
       const allowedGraderIds = new Set(
         (
           await selectCourseInstanceGraderStaff({
-            course_instance: res.locals.course_instance,
+            courseInstance: res.locals.course_instance,
+            authzData: res.locals.authz_data,
+            requiredRole: ['Student Data Editor'],
           })
         ).map((user) => user.user_id),
       );

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.tsx
@@ -57,7 +57,9 @@ router.get(
   typedAsyncHandler<'instructor-assessment-question'>(async (req, res) => {
     const courseStaff = z.array(StaffUserSchema).parse(
       await selectCourseInstanceGraderStaff({
-        course_instance: res.locals.course_instance,
+        courseInstance: res.locals.course_instance,
+        authzData: res.locals.authz_data,
+        requiredRole: ['Student Data Viewer'],
       }),
     );
     const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
@@ -345,7 +347,9 @@ router.post(
           : [req.body.instance_question_id];
         if (action_data?.assigned_grader != null) {
           const courseStaff = await selectCourseInstanceGraderStaff({
-            course_instance: res.locals.course_instance,
+            courseInstance: res.locals.course_instance,
+            authzData: res.locals.authz_data,
+            requiredRole: ['Student Data Editor'],
           });
           if (!courseStaff.some((staff) => idsEqual(staff.user_id, action_data.assigned_grader))) {
             throw new error.HttpStatusError(

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -86,7 +86,9 @@ async function prepareLocalsForRender(
   }
 
   const graders = await selectCourseInstanceGraderStaff({
-    course_instance: resLocals.course_instance,
+    courseInstance: resLocals.course_instance,
+    authzData: resLocals.authz_data,
+    requiredRole: ['Student Data Viewer'],
   });
   return { resLocals, conflict_grading_job, graders };
 }
@@ -611,7 +613,9 @@ router.post(
       const assigned_grader = ['nobody', 'graded'].includes(actionPrompt) ? null : actionPrompt;
       if (assigned_grader != null) {
         const courseStaff = await selectCourseInstanceGraderStaff({
-          course_instance: res.locals.course_instance,
+          courseInstance: res.locals.course_instance,
+          authzData: res.locals.authz_data,
+          requiredRole: ['Student Data Editor'],
         });
         if (!courseStaff.some((staff) => idsEqual(staff.user_id, assigned_grader))) {
           throw new error.HttpStatusError(

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
@@ -11,7 +11,7 @@ import { Hydrate } from '@prairielearn/preact/server';
 import { PageLayout } from '../../components/PageLayout.js';
 import { CourseSyncErrorsAndWarnings } from '../../components/SyncErrorsAndWarnings.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
-import { type Course, CourseInstanceSchema } from '../../lib/db-types.js';
+import { CourseInstanceSchema } from '../../lib/db-types.js';
 import { CourseInstanceAddEditor } from '../../lib/editors.js';
 import { idsEqual } from '../../lib/id.js';
 import {
@@ -206,7 +206,7 @@ router.post(
 
       const courseInstance = await selectCourseInstanceByUuid({
         uuid: editor.uuid,
-        course: course as unknown as Course, // TODO: We need to write up proper model functions for Courses.
+        course,
       });
 
       res.json({ course_instance_id: courseInstance.id });

--- a/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
+++ b/apps/prairielearn/src/pages/instructorFileTransfer/instructorFileTransfer.ts
@@ -98,7 +98,7 @@ router.get(
 
         const fromCourseInstance = await selectCourseInstanceByShortName({
           course,
-          short_name: shortName,
+          shortName,
         });
 
         const editor = new CourseInstanceCopyEditor({

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -19,7 +19,6 @@ import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { getSelfEnrollmentLinkUrl } from '../../lib/client/url.js';
 import { config } from '../../lib/config.js';
-import type { Course } from '../../lib/db-types.js';
 import {
   CourseInstanceCopyEditor,
   CourseInstanceDeleteEditor,
@@ -268,7 +267,7 @@ router.post(
 
       const copiedInstance = await selectCourseInstanceByUuid({
         uuid: editor.uuid,
-        course: course as unknown as Course, // TODO: We need to write up proper model functions for Courses.
+        course,
       });
 
       res.status(200).json({ course_instance_id: copiedInstance.id });

--- a/apps/prairielearn/src/tests/chunks.test.ts
+++ b/apps/prairielearn/src/tests/chunks.test.ts
@@ -759,7 +759,7 @@ describe('chunks', () => {
       // Get the new course instance.
       const courseInstance = await selectCourseInstanceByShortName({
         course: await selectCourseById(courseId),
-        short_name: 'new',
+        shortName: 'new',
       });
 
       // Generate new chunks.
@@ -841,7 +841,7 @@ describe('chunks', () => {
       // Assert that we produced a course instance without sync errors/warnings.
       const newCourseInstance = await selectCourseInstanceByShortName({
         course: await selectCourseById(courseId),
-        short_name: 'new',
+        shortName: 'new',
       });
       assert.equal(newCourseInstance.id, courseInstance.id);
       expect(newCourseInstance.sync_errors).toBeFalsy();

--- a/apps/prairielearn/src/tests/permissions/institutionAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/institutionAdminAccess.test.ts
@@ -78,7 +78,7 @@ describe('institution administrators', () => {
     await insertUser(INSTITUTION_ADMIN_USER);
     courseInstance = await selectCourseInstanceByShortName({
       course: await selectCourseById('1'),
-      short_name: 'Sp15',
+      shortName: 'Sp15',
     });
     assessment = await selectAssessmentByTid({
       course_instance_id: courseInstance.id,

--- a/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
+++ b/apps/prairielearn/src/tests/testAssessmentOrdering.test.ts
@@ -112,7 +112,7 @@ describe('Course with assessments grouped by Set vs Module', { timeout: 60_000 }
   test.sequential('should default to grouping by Set', async function () {
     const courseInstance = await selectCourseInstanceByShortName({
       course: await selectCourseById('1'),
-      short_name: 'Fa19',
+      shortName: 'Fa19',
     });
     assert.equal(courseInstance.assessments_group_by, 'Set');
   });

--- a/apps/prairielearn/src/tests/variantAccess.test.ts
+++ b/apps/prairielearn/src/tests/variantAccess.test.ts
@@ -187,7 +187,7 @@ describe('Variant access', () => {
   test.sequential('get relevant entities', async () => {
     courseInstance = await selectCourseInstanceByShortName({
       course: await selectCourseById('1'),
-      short_name: 'Sp15',
+      shortName: 'Sp15',
     });
     question = await selectQuestionByQid({ course_id: '1', qid: 'variantAccess' });
     assessment = await queryRow(


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This PR refactors the course instance model functions that select users to use the modern authz pattern, and switches them to `camelCase`. It continues work on #13436.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

WIP

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
