### PR TITLE
[WIP] Add `Administrator` role to modern authz pattern

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-question-generation-benchmark.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation-benchmark.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 
 import type { OpenAIModelId } from '../../lib/ai.js';
+import { dangerousFullSystemAuthz } from '../../lib/authz-data-lib.js';
 import { config } from '../../lib/config.js';
 import { AiQuestionGenerationPromptSchema, type User } from '../../lib/db-types.js';
 import { features } from '../../lib/features/index.js';
@@ -219,7 +220,8 @@ export async function benchmarkAiQuestionGeneration({
       path: courseDirectory.path,
       repository: null,
       branch: 'master',
-      authn_user_id: user.user_id,
+      authzData: dangerousFullSystemAuthz(),
+      requiredRole: ['System'],
     });
 
     // Sync the course to the database so future edits will do their thing.

--- a/apps/prairielearn/src/lib/authz-data-lib.ts
+++ b/apps/prairielearn/src/lib/authz-data-lib.ts
@@ -76,6 +76,7 @@ export interface DangerousSystemAuthzData {
   user: {
     user_id: null;
   };
+  is_administrator: boolean;
 }
 
 /**
@@ -98,6 +99,8 @@ interface RawPlainAuthzData {
   has_course_instance_permission_edit?: boolean;
   has_student_access_with_enrollment?: boolean;
   has_student_access?: boolean;
+
+  is_administrator?: boolean;
 
   mode: EnumMode;
   mode_reason: EnumModeReason;
@@ -153,11 +156,14 @@ export type CourseInstanceRole = StudentCourseInstanceRole | InstructorCourseIns
 
 export type CourseRole = 'Previewer' | 'Viewer' | 'Editor' | 'Owner';
 
+export type AdministratorRole = 'Administrator';
+
 export type Role =
   | SystemRole
   | StudentCourseInstanceRole
   | InstructorCourseInstanceRole
-  | CourseRole;
+  | CourseRole
+  | AdministratorRole;
 
 export function dangerousFullSystemAuthz(): DangerousSystemAuthzData {
   return {
@@ -169,6 +175,7 @@ export function dangerousFullSystemAuthz(): DangerousSystemAuthzData {
     user: {
       user_id: null,
     },
+    is_administrator: true,
   };
 }
 
@@ -227,6 +234,10 @@ export function hasRole(authzData: AuthzData, requiredRole: Role[]): boolean {
   }
 
   if (requiredRole.includes('Owner') && authzData.has_course_permission_own) {
+    return true;
+  }
+
+  if (requiredRole.includes('Administrator') && authzData.is_administrator) {
     return true;
   }
 

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -10,6 +10,7 @@ import * as Sentry from '@prairielearn/sentry';
 import { insertCourse, updateCourseCommitHash } from '../models/course.js';
 import { syncDiskToSql } from '../sync/syncFromDisk.js';
 
+import { dangerousFullSystemAuthz } from './authz-data-lib.js';
 import { logChunkChangesToJob, updateChunksForCourse } from './chunks.js';
 import { config } from './config.js';
 import { type Course, type User } from './db-types.js';
@@ -231,7 +232,8 @@ export async function createCourseRepoJob(
       path: options.path,
       repository,
       branch,
-      authn_user_id: authn_user.user_id,
+      authzData: dangerousFullSystemAuthz(),
+      requiredRole: ['System'],
     });
     job.verbose('Inserted course into database:');
     job.verbose(JSON.stringify(inserted_course, null, 4));

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.ts
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.ts
@@ -4,6 +4,7 @@ import asyncHandler from 'express-async-handler';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
+import { dangerousFullSystemAuthz } from '../../lib/authz-data-lib.js';
 import { config } from '../../lib/config.js';
 import {
   createCourseFromRequest,
@@ -48,7 +49,8 @@ router.post(
         path: req.body.path,
         repository: req.body.repository,
         branch: req.body.branch,
-        authn_user_id: res.locals.authn_user.user_id,
+        authzData: dangerousFullSystemAuthz(),
+        requiredRole: ['Administrator'],
       });
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'courses_update_column') {
@@ -68,8 +70,9 @@ router.post(
         );
       }
       await deleteCourse({
-        course_id: req.body.course_id,
-        authn_user_id: res.locals.authn_user.user_id,
+        course,
+        authzData: res.locals.authz_data,
+        requiredRole: ['Administrator'],
       });
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'approve_deny_course_request') {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This adds a new `Administrator` role to the modern authz pattern.

Some of these code paths expect `res.locals.authn_user`. I'm thinking we should change this to `res.locals.authzData.authn_user`. This was proposed in the past, but I think we now are in a good place to deal with this/use this idea.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
