### PR TITLE
Refine student invitation modal

### DIFF
--- a/apps/prairielearn/src/pages/instructorStudents/components/InviteStudentModal.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/components/InviteStudentModal.tsx
@@ -75,6 +75,7 @@ export function InviteStudentModal({
             id="invite-uid"
             class={clsx('form-control', errors.uid && 'is-invalid')}
             type="email"
+            placeholder="student@example.com"
             aria-invalid={errors.uid ? 'true' : 'false'}
             {...register('uid', {
               validate: async (uid) => {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This makes two small refinements to the invitation modal on the "Students" page:

- Adds a more useful placeholder
- Drops unnecessary vertical spacing

# Testing

## Before

<img width="527" height="287" alt="Screenshot 2025-12-09 at 13 17 15" src="https://github.com/user-attachments/assets/33b8e497-a5db-460e-ad35-5ec1b6af2f61" />

## After

<img width="526" height="278" alt="Screenshot 2025-12-09 at 13 16 41" src="https://github.com/user-attachments/assets/a5ea46d3-a79e-4017-a91a-c874bc5d0224" />