### PR TITLE
Use OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - "master"
+      - 'master'
 
 jobs:
   release:
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: "yarn"
+          cache: 'yarn'
 
       - name: Preinstall node-gyp headers
         run: yarn dlx node-gyp install


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Now that npm has deprecated legacy access tokens, we need a new way to publish packages. We've decided to go with [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers). It's a little annoying in that it requires manual configuration for each package we want to publish, but it avoids us having to regenerate a new token every 90 days.

# Testing

We won't see if this works until it lands on master.