### PR TITLE
Upgrade npm before publishing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - "master"
+      - 'master'
 
 jobs:
   release:
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: "yarn"
+          cache: 'yarn'
 
       # We need to be running the latest version of `npm` to support OIDC trusted publishing
       - name: Upgrade npm


### PR DESCRIPTION
# Description

Followup to #13562. The default version of `npm` installed on Actions runners is too old.

# Testing

To be tested on master.