### PR TITLE
Fix GitHub token permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - "master"
+      - 'master'
 
 jobs:
   release:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: "yarn"
+          cache: 'yarn'
 
       # We need to be running the latest version of `npm` to support OIDC trusted publishing
       - name: Upgrade npm


### PR DESCRIPTION
# Description

This regressed a bit in #13562. Adding an explicit `permissions:` block wiped the default permissions that `GITHUB_TOKEN` would otherwise have. This is an educated guess at which permissions need to be added in order for the release workflow to succeed.

# Testing

This will be tested once it lands on master.