### PR TITLE
Fix race condition in job sequence creation

### DIFF
--- a/apps/prairielearn/src/lib/server-jobs.sql
+++ b/apps/prairielearn/src/lib/server-jobs.sql
@@ -5,6 +5,10 @@ WITH
     -- job sequence number. We use the course_id as the lock key, with a fixed
     -- namespace (1) to avoid collisions with other advisory locks. For NULL
     -- course_id, we use 0 as the key.
+    --
+    -- Note that the two-argument form here uses integers, not bigints, so this
+    -- will cause problems if we ever have course IDs outside the range of an
+    -- integer. In practice, this is highly unlikely to be a problem.
     SELECT
       pg_advisory_xact_lock(1, coalesce($course_id::integer, 0))
   ),


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This fixes a bug where creating job sequences can fail with an error like the following:

```
duplicate key value violates unique constraint "job_sequences_course_id_number_key"
```

The fix was largely developed by Claude Opus 4.5. Originally it tried to do it with retries in TypeScript; I steered it towards using explicit locking.

# Testing

Job sequence creation still works.