### PR TITLE
Don't use cache when linting in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       # Build on all code freeze branches since we will deploy from them.
-      - "**-code-freeze"
+      - '**-code-freeze'
   pull_request:
   merge_group:
 
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
-          cache: "yarn"
+          node-version: '22'
+          cache: 'yarn'
       - name: Preinstall node-gyp headers
         run: yarn dlx node-gyp install
       - name: Install Node dependencies
@@ -130,19 +130,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: '3.10'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
+          cache-dependency-glob: 'pyproject.toml'
       - name: Install all Python dependencies
         run: make python-deps
 
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: '22'
       - name: Set up Yarn
         # We only install the dependencies in the root workspace to avoid
         # installing dependencies that won't be used.
@@ -188,13 +188,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: '3.10'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-          cache-suffix: "dev"
+          cache-dependency-glob: 'pyproject.toml'
+          cache-suffix: 'dev'
       - name: Install Python dependencies
         run: make python-deps-dev
 


### PR DESCRIPTION
# Description

We can't use the cache for linting in CI. Because we use type-aware lint rules, it's possible for an unmodified file to end up with a lint error.

# Testing

N/A