### PR TITLE
Disable VS Code YAML extension formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,9 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
+  "[json]": {
+    "files.insertFinalNewline": true
+  },
   "typescript.preferences.autoImportSpecifierExcludeRegexes": ["^react$"],
   "typescript.tsdk": "node_modules/typescript/lib",
   "json.schemaDownload.enable": true,
@@ -71,9 +74,8 @@
   "python.testing.pytestArgs": ["apps/prairielearn/elements", "apps/prairielearn/python/test"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "[json]": {
-    "files.insertFinalNewline": true
-  },
+  "sqlfluff.executablePath": "${workspaceFolder}/.venv/bin/sqlfluff",
   "vitest.maximumConfigs": 100,
-  "sqlfluff.executablePath": "${workspaceFolder}/.venv/bin/sqlfluff"
+  // This conflicts with the Prettier formatter, so we disable it.
+  "yaml.format.enable": false
 }


### PR DESCRIPTION
# Description

On master, saving a YAML file (like one in `.github/workflows`) would cause the file to be reformatted with double quotes instead of single quotes.

# Testing

After saving a YAML file, it isn't reformatted by the YAML extension - just Prettier, which is how it should be.