### PR TITLE
Handle broken course instance syncs on question settings page

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
@@ -15,6 +15,7 @@ import { compiledScriptTag, nodeModulesAssetPath } from '../../lib/assets.js';
 import {
   AssessmentSchema,
   AssessmentSetSchema,
+  CourseInstanceSchema,
   IdSchema,
   type Question,
   type Tag,
@@ -26,8 +27,8 @@ import { encodePath } from '../../lib/uri-util.js';
 import { type CourseWithPermissions } from '../../models/course.js';
 
 export const SelectedAssessmentsSchema = z.object({
-  short_name: z.string(),
-  long_name: z.string(),
+  short_name: CourseInstanceSchema.shape.short_name,
+  long_name: CourseInstanceSchema.shape.long_name,
   course_instance_id: IdSchema,
   assessments: z.array(
     z.object({
@@ -759,7 +760,10 @@ function DeleteQuestionModal({
               ${assessmentsWithQuestion.map((a_with_q) => {
                 return html`
                   <li class="list-group-item">
-                    <div class="h6">${a_with_q.short_name} (${a_with_q.long_name})</div>
+                    <div class="h6">
+                      ${a_with_q.short_name ?? html`<i>Unknown</i>`}
+                      (${a_with_q.long_name ?? html`<i>Unknown</i>`})
+                    </div>
                     ${a_with_q.assessments.map((assessment) =>
                       AssessmentBadgeHtml({
                         courseInstanceId: a_with_q.course_instance_id,


### PR DESCRIPTION
# Description

Consider the case where a new course instance has a sync error (e.g. an invalid access rule). It won't sync properly, and thus won't have a `long_name` in the database. When we try to render the question settings page for a question that's used on an assessment in that broken course instance, we'd see an error like the following:

```
ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      1,
      "long_name"
    ],
    "message": "Expected string, received null"
  }
]
    at get error (file:///PrairieLearn/node_modules/zod/v3/types.js:39:31)
    at ZodArray.parse (file:///PrairieLearn/node_modules/zod/v3/types.js:114:22)
    at PostgresPool.queryRows (file:///PrairieLearn/packages/postgres/dist/pool.js:572:35)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:///PrairieLearn/apps/prairielearn/dist/pages/instructorQuestionSettings/instructorQuestionSettings.js:303:37
```

This PR fixes that by forcing the code to handle the null case.

# Testing

I tested this manually:

- I removed a course instance that used a certain question on its assessments
- I added back the course instance with a JSON error

On master, one saw the above error. On this branch, one does not, and the "Delete question" modal shows an "Unknown" where expected:

<img width="754" height="460" alt="Screenshot 2025-12-15 at 09 01 36" src="https://github.com/user-attachments/assets/0e6419e1-0bfe-4a0a-881d-c80f8763ea52" />