### PR TITLE
Remove Number and Color columns from course settings tables

### DIFF
--- a/apps/prairielearn/src/components/TagsTopicsTable.tsx
+++ b/apps/prairielearn/src/components/TagsTopicsTable.tsx
@@ -130,9 +130,7 @@ export function TagsTopicsTable<Entity extends StaffTag | StaffTopic>({
                     <span class="visually-hidden">Edit and Delete</span>
                   </th>
                 )}
-                <th>Number</th>
                 <th>Name</th>
-                <th>Color</th>
                 <th class="col-9">Description</th>
               </tr>
             </thead>
@@ -162,11 +160,9 @@ export function TagsTopicsTable<Entity extends StaffTag | StaffTopic>({
                         </div>
                       </td>
                     )}
-                    <td class="align-middle">{index + 1}</td>
                     <td class="align-middle">
                       {entityType === 'topic' ? <TopicBadge topic={row} /> : <TagBadge tag={row} />}
                     </td>
-                    <td class="align-middle">{row.color}</td>
                     <td class="align-middle">
                       {entityType === 'topic' ? (
                         <TopicDescription topic={row} />

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/instructorCourseAdminModules.html.tsx
@@ -32,7 +32,6 @@ export function InstructorCourseAdminModules({
           <table class="table table-sm table-hover table-striped" aria-label="Assessment sets">
             <thead>
               <tr>
-                <th>Number</th>
                 <th>Name</th>
                 <th>Heading</th>
               </tr>
@@ -41,7 +40,6 @@ export function InstructorCourseAdminModules({
               ${modules.map(function (module) {
                 return html`
                   <tr>
-                    <td class="align-middle">${module.number}</td>
                     <td>${module.name}</td>
                     <td class="align-middle">
                       ${AssessmentModuleHeadingHtml({ assessment_module: module })}

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/components/AssessmentSetsTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/components/AssessmentSetsTable.tsx
@@ -11,18 +11,15 @@ export function AssessmentSetsTable({ assessmentSets }: { assessmentSets: StaffA
         <table class="table table-sm table-hover table-striped" aria-label="Assessment sets">
           <thead>
             <tr>
-              <th>Number</th>
               <th>Abbreviation</th>
               <th>Name</th>
               <th>Heading</th>
-              <th>Color</th>
             </tr>
           </thead>
           <tbody>
             {assessmentSets.map((assessmentSet) => {
               return (
                 <tr key={assessmentSet.id}>
-                  <td class="align-middle">{assessmentSet.number}</td>
                   <td class="align-middle">
                     <span class={`badge color-${assessmentSet.color}`}>
                       {assessmentSet.abbreviation}
@@ -32,7 +29,6 @@ export function AssessmentSetsTable({ assessmentSets }: { assessmentSets: StaffA
                   <td class="align-middle">
                     <AssessmentSetHeading assessmentSet={assessmentSet} />
                   </td>
-                  <td class="align-middle">{assessmentSet.color}</td>
                 </tr>
               );
             })}


### PR DESCRIPTION
# Description

This PR removes the "Number" and Color" columns from the "Tags", "Topics", "Assessment Sets" and "Modules" tables in the course settings. After a recent decent discussion, we decided that these columns were not showing any useful information and were unnecessary. 

<img width="1645" height="244" alt="Screenshot 2025-12-29 at 9 59 27 AM" src="https://github.com/user-attachments/assets/cc1f0c16-4292-4e74-bc25-cf08710c6de9" />


<img width="1652" height="245" alt="Screenshot 2025-12-29 at 10 00 03 AM" src="https://github.com/user-attachments/assets/431c5684-d6e8-48d6-97c9-bbab721eb7d6" />

<img width="1655" height="169" alt="Screenshot 2025-12-29 at 10 00 35 AM" src="https://github.com/user-attachments/assets/89fb17e2-78fb-4bdf-a8ee-3b7a7837977e" />

<img width="1653" height="239" alt="Screenshot 2025-12-29 at 10 00 46 AM" src="https://github.com/user-attachments/assets/418bb883-9d33-4e79-bf3a-f621da7666a6" />

# Testing

Reviewing these tables in the browser will show that these columns have now been removed. 
