### PR TITLE
Add note about using a recent master in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ If you get stuck, reach out to the friendly folks in the `#pl-dev` channel on th
 We follow the [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow) for all changes:
 
 - You should work on a distinct branch, not `master`. While this isn't strictly necessary for forks, it's helpful if you want to be working on multiple independent changes at the same time.
-- Make sure you use a recent version of `master` as the base for your branch. You can do this by syncing your fork's `master` branch with the upstream `master` branch, then rebasing or merging `master` into your feature branch.
+- Make sure you use a recent version of `master` as the base for your branch. You can do this by [syncing your fork's `master` branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) with the upstream `master` branch, then rebasing or merging `master` into your feature branch.
 - When committing your changes, use a short but meaningful commit message, e.g. `fix rate limiting` instead of `fix`.
 - Once you're happy with your changes, [open a pull request (PR)](https://docs.github.com/en/articles/creating-a-pull-request).
   - You should include a reasonable amount of information with your pull request, such as a summary of what changes you made and why they were made. The [pull request template](.github/PULL_REQUEST_TEMPLATE.md) should be used as a guide for what to include.


### PR DESCRIPTION
# Description

A recent PR was submitted with a relatively old version of master. This can cause issues with merge conflicts or miss recent changes in linting/testing that are not properly considered by the contributor. This PR adds a note in the contributing guidelines to remind contributors to use a recent version of master.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Nothing to test.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
