### PR TITLE
Improve Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,15 @@ refresh-workspace-hosts:
 refresh-workspace-hosts-dev:
 	@yarn refresh-workspace-hosts-dev
 
-dev: start-support python-deps-core
+dev: start-support python-deps
 	@yarn dev
-dev-vite: start-support python-deps-core
+dev-vite: start-support python-deps
 	@yarn dev-vite
-dev-bun: python-deps-core
+dev-bun: python-deps
 	@yarn dev-bun
 dev-workspace-host: start-support
 	@yarn dev-workspace-host
-dev-all: start-support python-deps-core
+dev-all:
 	@$(MAKE) -s -j2 dev dev-workspace-host
 
 start: start-support


### PR DESCRIPTION
# Description

Followup to #13628. This PR resolves two issues:

- `python-deps-core` will actually _uninstall_ all non-core deps, which is undesirable for development. Using `python-deps` fixes that.
- There's no reason for `dev-all` to depend on either `start-support` or `python-deps`, since both `dev` and `dev-workspace-host` declare their own dependencies on them as needed.

# Testing

Tested the targets locally, they do the right thing.
