### PR TITLE
Configure Dependabot to update uv lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
 
+# The Python strategy comes from this comment:
+# https://github.com/dependabot/dependabot-core/issues/12609#issuecomment-3407284321
 multi-ecosystem-groups:
   python:
     schedule:


### PR DESCRIPTION
# Description

I noticed in e.g. #13684 that `uv.lock` wasn't being updated alongside `pyproject.toml`. This PR aims to fix that.

This is based on the strategy documented here: https://github.com/dependabot/dependabot-core/issues/12609#issuecomment-3407284321

# Testing

We'll see if this works once it hits master!