### PR TITLE
Generate dynamic files during question testing

### DIFF
--- a/apps/prairielearn/src/lib/question-testing.ts
+++ b/apps/prairielearn/src/lib/question-testing.ts
@@ -35,6 +35,10 @@ function extractDynamicFileUrls(html: string, variantId: string): string[] {
   const pattern = new RegExp(`generatedFilesQuestion/variant/${variantId}/([^?#]+)$`);
   const filenames = new Set<string>();
 
+  // We intentionally look for more than just `a[href]` and `img[src]` in case
+  // other tags or attributes are used to reference dynamic files. For instance,
+  // people might use `srcset`, or use `data-*` attributes for lazy loading or
+  // other client-side purposes.
   $('*').each((_, el) => {
     if (el.type !== ElementType.Tag) return;
     for (const value of Object.values(el.attribs)) {


### PR DESCRIPTION
# Description

This came out of the Python 3.13 migration work. This helps us ensure we're executing as many code paths as possible.

Claude Code with Opus 4.5 wrote most of the code here.

# Testing

I added a `raise Exception(...)` to `file()` in `exampleCourse/questions/gallery/includeFigure/complex/server.py` and ran the tests for that question. The tests were reported as failed, and the relevant issues were shown in the "Issues" tab.

<img width="1078" height="219" alt="Screenshot 2026-01-07 at 08 56 19" src="https://github.com/user-attachments/assets/72a5f722-3300-4f7a-8019-308a92949af9" />