### PR TITLE
Fix broken navbar link on public assessment page

### DIFF
--- a/apps/prairielearn/src/components/Navbar.tsx
+++ b/apps/prairielearn/src/components/Navbar.tsx
@@ -982,13 +982,13 @@ function NavbarInstructor({
 }
 
 function NavbarPublic({ resLocals }: { resLocals: UntypedResLocals }) {
-  const { course, urlPrefix } = resLocals;
+  const { course } = resLocals;
   return html`
     <li class="nav-item btn-group">
       <a
         class="nav-link"
         aria-label="Link to page showing all public questions for the course."
-        href="${urlPrefix}/questions"
+        href="/pl/public/course/${course?.id}/questions"
       >
         ${course?.short_name ?? ''}
       </a>


### PR DESCRIPTION
## Description

Fixes the broken navbar link on public course instance pages (e.g., `/pl/public/course_instance/XXX/assessments`). The navbar was pointing to `/pl/questions` instead of the correct public questions page. 

The issue was that the `NavbarPublic` component relied on `urlPrefix` which is not set for some routes. Now the component constructs the URL directly using the course ID.

Closes #12057

## Testing

I tested the new link, it reliably leads to the course's public questions page.