### PR TITLE
Backfill `assessments.team_work`

### DIFF
--- a/apps/prairielearn/src/batched-migrations/20260108222123_assessments__team_work__backfill.sql
+++ b/apps/prairielearn/src/batched-migrations/20260108222123_assessments__team_work__backfill.sql
@@ -1,0 +1,24 @@
+-- BLOCK select_bounds
+WITH
+  null_assessments AS (
+    SELECT
+      id
+    FROM
+      assessments
+    WHERE
+      team_work IS NULL
+  )
+SELECT
+  MIN(id) AS min,
+  MAX(id) AS max
+FROM
+  null_assessments;
+
+-- BLOCK backfill_team_work
+UPDATE assessments
+SET
+  team_work = FALSE
+WHERE
+  team_work IS NULL
+  AND id >= $start
+  AND id <= $end;

--- a/apps/prairielearn/src/batched-migrations/20260108222123_assessments__team_work__backfill.ts
+++ b/apps/prairielearn/src/batched-migrations/20260108222123_assessments__team_work__backfill.ts
@@ -1,0 +1,26 @@
+import z from 'zod';
+
+import { makeBatchedMigration } from '@prairielearn/migrations';
+import { execute, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+export default makeBatchedMigration({
+  async getParameters() {
+    const results = await queryRow(
+      sql.select_bounds,
+      z.object({
+        min: z.bigint({ coerce: true }).nullable(),
+        max: z.bigint({ coerce: true }).nullable(),
+      }),
+    );
+    return {
+      min: results.min,
+      max: results.max,
+      batchSize: 1000,
+    };
+  },
+  async execute(start: bigint, end: bigint): Promise<void> {
+    await execute(sql.backfill_team_work, { start, end });
+  },
+});

--- a/apps/prairielearn/src/migrations/20260108222123_assessments__team_work__backfill.ts
+++ b/apps/prairielearn/src/migrations/20260108222123_assessments__team_work__backfill.ts
@@ -1,0 +1,5 @@
+import { enqueueBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await enqueueBatchedMigration('20260108222123_assessments__team_work__backfill');
+}


### PR DESCRIPTION
Enqueues a batched migration that sets team_work = FALSE for any assessments where team_work IS NULL. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This is in preparation for adding a NOT NULL constraint to the column. See #13732. This value should be become null from sync normally.
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

See #13732

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
