### PR TITLE
Add e2e test for assessment sets editor

### DIFF
--- a/apps/prairielearn/src/tests/e2e/assessmentSetsEditor.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/assessmentSetsEditor.spec.ts
@@ -35,7 +35,9 @@ async function setupTestData() {
 }
 
 function getRowIndex(row: Locator) {
-  return row.evaluate((el: HTMLElement) => Array.from(el.parentElement?.children ?? []).indexOf(el));
+  return row.evaluate((el: HTMLElement) =>
+    Array.from(el.parentElement?.children ?? []).indexOf(el),
+  );
 }
 
 test.describe('Assessment sets editor', () => {
@@ -124,6 +126,8 @@ test.describe('Assessment sets editor', () => {
       has: page.locator('.badge', { hasText: abbrev2 }),
     });
 
-    expect(await getRowIndex(betaRowAfterReload)).toBeLessThan(await getRowIndex(alphaRowAfterReload));
+    expect(await getRowIndex(betaRowAfterReload)).toBeLessThan(
+      await getRowIndex(alphaRowAfterReload),
+    );
   });
 });


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This is an e2e test for reordering sets on the assessment sets page (#13629 ). This was entirely written by Claude.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

This is a test suite; but we should wait on #13751 
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
