### PR TITLE
Remove .gitignore lines for unused test directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,11 +55,6 @@ docker-compose.override.yml
 /server.log
 /apps/prairielearn/server.log
 
-### Tests
-/tests/testFileEditor/courseLive/
-/tests/testFileEditor/courseOrigin/
-/tests/testFileEditor/courseDev/
-
 ## Yarn
 node_modules
 yarn-error.log


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

In #5352 (almost 4 years ago!), some tests were modified to no longer write to directories inside the repository. https://github.com/PrairieLearn/PrairieLearn/pull/5352/changes#r797205662 mentions that some .gitignore rules can now be removed, but didn't actually remove them. This PR removes those directories from .gitignore.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

CI should be enough. There are no longer any references to these directories with the outdated path in any tests, all references have a temporary directory as a base. The only references to testFileEditor refer to the courseTemplate itself, which is still there.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
