### PR TITLE
Fix self-enrollment restrict to institution checkbox not persisting

### DIFF
--- a/apps/prairielearn/src/sprocs/sync_course_instances.sql
+++ b/apps/prairielearn/src/sprocs/sync_course_instances.sql
@@ -156,6 +156,7 @@ BEGIN
         publishing_end_date = input_date(src.data->>'publishing_end_date', COALESCE(src.data->>'display_timezone', c.display_timezone)),
         self_enrollment_enabled = (src.data->>'self_enrollment_enabled')::boolean,
         self_enrollment_enabled_before_date = input_date(src.data->>'self_enrollment_enabled_before_date', COALESCE(src.data->>'display_timezone', c.display_timezone)),
+        self_enrollment_restrict_to_institution = (src.data->>'self_enrollment_restrict_to_institution')::boolean,
         self_enrollment_use_enrollment_code = (src.data->>'self_enrollment_use_enrollment_code')::boolean,
         share_source_publicly = (src.data->>'share_source_publicly')::boolean,
         sync_errors = NULL,

--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
@@ -66,6 +66,7 @@ function getParamsForCourseInstance(courseInstance: CourseInstanceJson | null | 
     publishing_end_date: courseInstance.publishing?.endDate ?? null,
     self_enrollment_enabled: courseInstance.selfEnrollment.enabled,
     self_enrollment_enabled_before_date: courseInstance.selfEnrollment.beforeDate,
+    self_enrollment_restrict_to_institution: courseInstance.selfEnrollment.restrictToInstitution,
     self_enrollment_use_enrollment_code: courseInstance.selfEnrollment.useEnrollmentCode,
     share_source_publicly: courseInstance.shareSourcePublicly,
     access_rules: accessRules ?? [],

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -715,6 +715,7 @@ describe('Course instance syncing', () => {
       db: {
         self_enrollment_enabled: boolean;
         self_enrollment_enabled_before_date: Date | null;
+        self_enrollment_restrict_to_institution: boolean;
         self_enrollment_use_enrollment_code: boolean;
       } | null;
       errors: string[];
@@ -727,6 +728,7 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: null,
+          self_enrollment_restrict_to_institution: true,
           self_enrollment_use_enrollment_code: true,
         },
         errors: [],
@@ -740,6 +742,7 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: false,
           self_enrollment_enabled_before_date: date,
+          self_enrollment_restrict_to_institution: true,
           self_enrollment_use_enrollment_code: true,
         },
         errors: [],
@@ -752,6 +755,7 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: date,
+          self_enrollment_restrict_to_institution: true,
           self_enrollment_use_enrollment_code: true,
         },
         errors: [],
@@ -761,6 +765,7 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: null,
+          self_enrollment_restrict_to_institution: true,
           self_enrollment_use_enrollment_code: false,
         },
         errors: [],
@@ -772,6 +777,7 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: false,
           self_enrollment_enabled_before_date: null,
+          self_enrollment_restrict_to_institution: true,
           self_enrollment_use_enrollment_code: false,
         },
         errors: [],
@@ -783,6 +789,20 @@ describe('Course instance syncing', () => {
         db: {
           self_enrollment_enabled: true,
           self_enrollment_enabled_before_date: null,
+          self_enrollment_restrict_to_institution: true,
+          self_enrollment_use_enrollment_code: false,
+        },
+        errors: [],
+      },
+      {
+        json: {
+          enabled: true,
+          restrictToInstitution: false,
+        },
+        db: {
+          self_enrollment_enabled: true,
+          self_enrollment_enabled_before_date: null,
+          self_enrollment_restrict_to_institution: false,
           self_enrollment_use_enrollment_code: false,
         },
         errors: [],
@@ -829,6 +849,8 @@ describe('Course instance syncing', () => {
           self_enrollment_enabled: syncedCourseInstance.self_enrollment_enabled,
           self_enrollment_enabled_before_date:
             syncedCourseInstance.self_enrollment_enabled_before_date,
+          self_enrollment_restrict_to_institution:
+            syncedCourseInstance.self_enrollment_restrict_to_institution,
           self_enrollment_use_enrollment_code:
             syncedCourseInstance.self_enrollment_use_enrollment_code,
         };


### PR DESCRIPTION
## Description

The "Restrict self-enrollment to institution" checkbox on the instructor course instance settings page was not being persisted to the database. When instructors toggled it and clicked save, the value was correctly stored in `infoCourseInstance.json` but was never synced to the database because the `self_enrollment_restrict_to_institution` field was missing from the sync process.

This fix adds the missing field to both the sync parameters builder and the stored procedure update statement.

This bug was found and fixed by Claude Opus 4.5; I reviewed its changes.

## Testing

Updated the self-enrollment sync tests to verify the `self_enrollment_restrict_to_institution` field is correctly synced to the database, including a test case that explicitly sets it to `false` to ensure non-default values persist.