### PR TITLE
Add Playwright MCP files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ coverage.xml
 test-results/
 apps/prairielearn/test-results/
 apps/prairielearn/playwright/.cache/
+.playwright-mcp/
 
 ## TypeScript cache
 *.tsbuildinfo


### PR DESCRIPTION
# Description

This keeps us from committing things like screenshots that the Playwright MCP server produces.

# Testing

N/A