### PR TITLE
Symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
# Description

If I'm understanding https://github.com/anthropics/claude-code/issues/6235 correctly, Claude Code hasn't been picking up on our `AGENTS.md` file. It's been doing insanely well in spite of that, but still, we should expose it to our curated guidance.

# Testing

I ran `claude` and then `/context` after making this change, it now shows that it's picking up a `CLAUDE.md` file:

```
     Memory files · /memory
     └ CLAUDE.md: 1.5k tokens
```