### PR TITLE
Replace deprecated @stylistic/jsx-sort-props with perfectionist/sort-jsx-props

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -428,18 +428,6 @@ export default tseslint.config([
           html: true,
         },
       ],
-      '@stylistic/jsx-sort-props': [
-        'error',
-        {
-          callbacksLast: true,
-          ignoreCase: true,
-          locale: 'auto',
-          multiline: 'ignore',
-          noSortAlphabetically: true,
-          reservedFirst: true,
-          shorthandLast: true,
-        },
-      ],
       '@stylistic/jsx-tag-spacing': [
         'error',
         {
@@ -488,6 +476,19 @@ export default tseslint.config([
       // https://github.com/TanStack/query/blob/6402d756b702ac560b69a5ce84d6e4e764b96451/packages/eslint-plugin-query/src/index.ts#L43
       ...pluginQuery.configs['flat/recommended'][0].rules,
       '@tanstack/query/no-rest-destructuring': 'error',
+
+      'perfectionist/sort-jsx-props': [
+        'error',
+        {
+          customGroups: [
+            { elementNamePattern: '^on[A-Z]', groupName: 'callback' },
+            { elementNamePattern: '^(key|ref)$', groupName: 'reserved' },
+          ],
+          groups: ['reserved', 'unknown', 'shorthand-prop', 'callback'],
+          ignoreCase: true,
+          type: 'unsorted',
+        },
+      ],
 
       // The _.omit function is still useful in some contexts.
       'you-dont-need-lodash-underscore/omit': 'off',


### PR DESCRIPTION
# Description

This PR replaces the deprecated `@stylistic/jsx-sort-props` rule with the equivalent `perfectionist/sort-jsx-props` rule. The deprecated rule triggers a linter warning that we should address.

The new rule is configured to preserve the same behavior with custom groups for reserved props (key, ref) and event handlers (on*), maintaining consistent JSX prop ordering.

# Testing

Ran ESLint across the codebase to verify the new rule works correctly and all files pass linting without any deprecation warnings.