### PR TITLE
Fix potential race condition in Redis socket adapter initialization

### DIFF
--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -2570,7 +2570,7 @@ if (shouldStartServer) {
     app = await initExpress();
     const httpServer = await startServer(app);
 
-    socketServer.init(httpServer);
+    await socketServer.init(httpServer);
 
     externalGradingSocket.init();
     externalGrader.init();
@@ -2681,7 +2681,7 @@ if (shouldStartServer) {
   await socketServer.close();
   app = await initExpress();
   const httpServer = await startServer(app);
-  socketServer.init(httpServer);
+  await socketServer.init(httpServer);
 }
 
 /**

--- a/apps/prairielearn/src/tests/helperServer.ts
+++ b/apps/prairielearn/src/tests/helperServer.ts
@@ -77,7 +77,7 @@ export function before(courseDir: string | string[] = TEST_COURSE_PATH): () => P
       const httpServer = await server.startServer(app);
 
       debug('before(): initialize socket server');
-      socketServer.init(httpServer);
+      await socketServer.init(httpServer);
 
       debug('before(): initialize cache');
       await cache.init({


### PR DESCRIPTION
## Description

This change prevents a potential race condition in the Redis socket adapter initialization where the subscriber client could be put into subscriber mode before the connection's handshake completes. We use `lazyConnect: true` to defer connection until we explicitly call `connect()`, and await both clients reaching the ready state before setting up the adapter.

This matches the fix applied in PrairieTest (https://github.com/PrairieLearnInc/PrairieTest/pull/2500).

## Testing

Existing socket server initialization tests pass. The fix ensures Redis connections are fully ready before the adapter uses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)