### PR TITLE
Assessment score upload: use info message in final status

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -164,7 +164,7 @@ export async function uploadAssessmentInstanceScores(
   });
 
   serverJob.executeInBackground(async (job) => {
-    job.verbose('Uploading total scores for ' + assessment_label);
+    job.info('Uploading total scores for ' + assessment_label);
 
     // accumulate output lines in the "output" variable and actually
     // output put them in blocks, to avoid spamming the updates


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Verbose messages in the job page have been set to be hidden by default. When uploading assessment scores via CSV, the final result is using job.verbose to provide a success status message, which causes the status not to show by default. Also, error messages are only shown when verbose is enabled.

<img width="748" height="203" alt="image" src="https://github.com/user-attachments/assets/2fbabcf5-cdef-445f-bc31-4c79a07a0a70" />

This PR uses job.info and job.error to ensure that relevant information that might be important for a user to see right away is shown by default.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

Similar changes may be needed in other kinds of jobs, I added these because I noticed it in production.

# Testing

Tested locally, works as expected.

<img width="653" height="220" alt="image" src="https://github.com/user-attachments/assets/5d037565-7e3d-4844-8293-dd0dbfe2801a" />

<img width="705" height="277" alt="image" src="https://github.com/user-attachments/assets/193fed4c-5361-4743-a137-e7b148c92510" />

Verbose messages still show if enabled:

<img width="1660" height="420" alt="image" src="https://github.com/user-attachments/assets/b0999d90-b041-46f3-a492-4ed3801e68b9" />


<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
