### PR TITLE
Remove deleted packages from changeset

### DIFF
--- a/.changeset/wild-badgers-doubt.md
+++ b/.changeset/wild-badgers-doubt.md
@@ -3,7 +3,6 @@
 '@prairielearn/express-list-endpoints': patch
 '@prairielearn/vite-plugin-express': patch
 '@prairielearn/express-test-utils': patch
-'@prairielearn/preact-cjs-compat': patch
 '@prairielearn/compiled-assets': patch
 '@prairielearn/postgres-tools': patch
 '@prairielearn/browser-utils': patch
@@ -13,7 +12,6 @@
 '@prairielearn/named-locks': patch
 '@prairielearn/bind-mount': patch
 '@prairielearn/migrations': patch
-'@prairielearn/preact-cjs': patch
 '@prairielearn/formatter': patch
 '@prairielearn/aws-imds': patch
 '@prairielearn/html-ejs': patch
@@ -22,7 +20,6 @@
 '@prairielearn/session': patch
 '@prairielearn/config': patch
 '@prairielearn/logger': patch
-'@prairielearn/preact': patch
 '@prairielearn/sentry': patch
 '@prairielearn/cache': patch
 '@prairielearn/error': patch


### PR DESCRIPTION
# Description

The release task on `master` failed with the following:

```
🦋  error Error: Found changeset wild-badgers-doubt for package @prairielearn/preact-cjs-compat which is not in the workspace
🦋  error     at getRelevantChangesets (/home/runner/work/PrairieLearn/PrairieLearn/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:564:15)
🦋  error     at Object.assembleReleasePlan [as default] (/home/runner/work/PrairieLearn/PrairieLearn/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:493:30)
🦋  error     at version (/home/runner/work/PrairieLearn/PrairieLearn/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1174:60)
🦋  error     at async run (/home/runner/work/PrairieLearn/PrairieLearn/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1339:11)
```

This PR removes all deleted packages from the new changeset. It's a shame `changeset status` doesn't catch this before merging.

# Testing

N/A, we'll see what happens on master.