### PR TITLE
Migrate to oxlint with residual ESLint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -105,7 +105,7 @@
         "jsdoc/implements-on-classes": "error",
         "jsdoc/no-defaults": "error",
         "jsdoc/require-param": "off",
-        "jsdoc/require-param-description": "error",
+        "jsdoc/require-param-description": "off",
         "jsdoc/require-param-name": "error",
         "jsdoc/require-param-type": "off",
         "jsdoc/require-property": "error",
@@ -258,12 +258,6 @@
       }
     },
     {
-      "files": ["apps/prairielearn/src/tests/**/*", "scripts/**/*", "contrib/**/*"],
-      "rules": {
-        "no-console": "off"
-      }
-    },
-    {
       "files": ["apps/prairielearn/src/models/**/*"],
       "rules": {
         "no-restricted-imports": [
@@ -358,7 +352,7 @@
         "no-implicit-coercion": "off",
         "no-import-assign": "error",
         "no-inline-comments": "off",
-        "no-inner-declarations": "error",
+        "no-inner-declarations": "off",
         "no-invalid-regexp": "error",
         "no-irregular-whitespace": "error",
         "no-iterator": "error",
@@ -400,7 +394,7 @@
         "no-template-curly-in-string": "error",
         "no-ternary": "off",
         "no-this-before-super": "error",
-        "no-throw-literal": "error",
+        "no-throw-literal": "off",
         "no-unassigned-vars": "error",
         "no-undefined": "off",
         "no-unexpected-multiline": "error",
@@ -441,7 +435,7 @@
         "prefer-rest-params": "error",
         "prefer-spread": "error",
         "prefer-template": "off",
-        "preserve-caught-error": "error",
+        "preserve-caught-error": "off",
         "radix": ["error", "as-needed"],
         "require-await": "off",
         "require-yield": "error",
@@ -490,7 +484,7 @@
         "unicorn/no-document-cookie": "error",
         "unicorn/no-empty-file": "error",
         "unicorn/no-hex-escape": "off",
-        "unicorn/no-immediate-mutation": "error",
+        "unicorn/no-immediate-mutation": "off",
         "unicorn/no-instanceof-builtins": "error",
         "unicorn/no-invalid-fetch-options": "error",
         "unicorn/no-invalid-remove-event-listener": "error",
@@ -551,7 +545,7 @@
         "unicorn/prefer-logical-operator-over-ternary": "error",
         "unicorn/prefer-math-min-max": "error",
         "unicorn/prefer-math-trunc": "error",
-        "unicorn/prefer-modern-dom-apis": "error",
+        "unicorn/prefer-modern-dom-apis": "off",
         "unicorn/prefer-modern-math-apis": "error",
         "unicorn/prefer-native-coercion-functions": "error",
         "unicorn/prefer-negative-index": "error",
@@ -597,6 +591,8 @@
         "vitest/require-local-test-context-for-concurrent-snapshots": "error",
         "vitest/valid-describe-callback": "off",
         "vitest/valid-expect": "error",
+        "vitest/no-conditional-tests": "off",
+        "react/no-this-in-sfc": "off",
         "@prairielearn/aws-client-mandatory-config": "error",
         "@prairielearn/aws-client-shared-config": "error",
         "@prairielearn/jsx-no-dollar-interpolation": "error",
@@ -753,6 +749,12 @@
       "plugins": ["react", "unicorn", "vitest", "jsx-a11y", "import", "promise"],
       "env": {
         "commonjs": true
+      }
+    },
+    {
+      "files": ["apps/prairielearn/src/tests/**/*", "scripts/**/*", "contrib/**/*"],
+      "rules": {
+        "no-console": "off"
       }
     }
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -675,10 +675,69 @@
         ],
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-dynamic-delete": "off",
-        "@typescript-eslint/no-non-null-assertion": "off"
+        "@typescript-eslint/no-non-null-assertion": "off",
+
+        "jsx-a11y/alt-text": "error",
+        "jsx-a11y/anchor-has-content": "error",
+        "jsx-a11y/anchor-is-valid": "error",
+        "jsx-a11y/aria-activedescendant-has-tabindex": "error",
+        "jsx-a11y/aria-props": "error",
+        "jsx-a11y/aria-proptypes": "error",
+        "jsx-a11y/aria-role": "error",
+        "jsx-a11y/aria-unsupported-elements": "error",
+        "jsx-a11y/autocomplete-valid": "error",
+        "jsx-a11y/click-events-have-key-events": "error",
+        "jsx-a11y/heading-has-content": "error",
+        "jsx-a11y/html-has-lang": "error",
+        "jsx-a11y/iframe-has-title": "error",
+        "jsx-a11y/img-redundant-alt": "error",
+        "jsx-a11y/interactive-supports-focus": "error",
+        "jsx-a11y/label-has-associated-control": "error",
+        "jsx-a11y/lang": "error",
+        "jsx-a11y/media-has-caption": "error",
+        "jsx-a11y/mouse-events-have-key-events": "error",
+        "jsx-a11y/no-access-key": "error",
+        "jsx-a11y/no-aria-hidden-on-focusable": "error",
+        "jsx-a11y/no-autofocus": "error",
+        "jsx-a11y/no-distracting-elements": "error",
+        "jsx-a11y/no-redundant-roles": "error",
+        "jsx-a11y/prefer-tag-over-role": "error",
+        "jsx-a11y/role-has-required-aria-props": "error",
+        "jsx-a11y/role-supports-aria-props": "error",
+        "jsx-a11y/scope": "error",
+        "jsx-a11y/tabindex-no-positive": "error",
+
+        "react-you-might-not-need-an-effect/no-adjust-state-on-prop-change": "error",
+        "react-you-might-not-need-an-effect/no-chain-state-updates": "error",
+        "react-you-might-not-need-an-effect/no-derived-state": "error",
+        "react-you-might-not-need-an-effect/no-empty-effect": "error",
+        "react-you-might-not-need-an-effect/no-event-handler": "error",
+        "react-you-might-not-need-an-effect/no-initialize-state": "error",
+        "react-you-might-not-need-an-effect/no-pass-data-to-parent": "error",
+        "react-you-might-not-need-an-effect/no-pass-live-state-to-parent": "error",
+        "react-you-might-not-need-an-effect/no-pass-ref-to-parent": "error",
+        "react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change": "error",
+
+        "@tanstack/query/exhaustive-deps": "error",
+        "@tanstack/query/infinite-query-property-order": "error",
+        "@tanstack/query/mutation-property-order": "error",
+        "@tanstack/query/no-rest-destructuring": "error",
+        "@tanstack/query/no-unstable-deps": "error",
+        "@tanstack/query/no-void-query-fn": "error",
+        "@tanstack/query/stable-query-client": "error",
+
+        "no-floating-promise/no-floating-promise": "error",
+
+        "you-dont-need-lodash-underscore/omit": "off",
+
+        "promise/no-callback-in-promise": "off"
       },
       "jsPlugins": [
-        "@prairielearn/eslint-plugin"
+        "@prairielearn/eslint-plugin",
+        "eslint-plugin-react-you-might-not-need-an-effect",
+        "eslint-plugin-you-dont-need-lodash-underscore",
+        "@tanstack/eslint-plugin-query",
+        "eslint-plugin-no-floating-promise"
       ],
       "globals": {
         "__dirname": "readonly",
@@ -759,7 +818,10 @@
       "plugins": [
         "react",
         "unicorn",
-        "vitest"
+        "vitest",
+        "jsx-a11y",
+        "import",
+        "promise"
       ],
       "env": {
         "commonjs": true

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,8 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [
-    "typescript"
-  ],
+  "plugins": ["typescript"],
   "categories": {
     "correctness": "off"
   },
@@ -76,12 +74,7 @@
   ],
   "overrides": [
     {
-      "files": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.mts",
-        "**/*.cts"
-      ],
+      "files": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       "rules": {
         "constructor-super": "off",
         "no-class-assign": "off",
@@ -103,9 +96,7 @@
       }
     },
     {
-      "files": [
-        "**/*.{ts,tsx}"
-      ],
+      "files": ["**/*.{ts,tsx}"],
       "rules": {
         "jsdoc/check-access": "error",
         "jsdoc/check-property-names": "error",
@@ -130,9 +121,7 @@
           {
             "paths": [
               {
-                "importNames": [
-                  "OverlayTrigger"
-                ],
+                "importNames": ["OverlayTrigger"],
                 "message": "Use OverlayTrigger from @prairielearn/ui.",
                 "name": "react-bootstrap"
               }
@@ -140,14 +129,10 @@
           }
         ]
       },
-      "plugins": [
-        "jsdoc"
-      ]
+      "plugins": ["jsdoc"]
     },
     {
-      "files": [
-        "**/*.js"
-      ],
+      "files": ["**/*.js"],
       "rules": {
         "jsdoc/check-access": "error",
         "jsdoc/check-property-names": "error",
@@ -168,14 +153,10 @@
         "jsdoc/require-returns-type": "error",
         "jsdoc/require-yields": "error"
       },
-      "plugins": [
-        "jsdoc"
-      ]
+      "plugins": ["jsdoc"]
     },
     {
-      "files": [
-        "apps/prairielearn/**/*.{ts,tsx}"
-      ],
+      "files": ["apps/prairielearn/**/*.{ts,tsx}"],
       "rules": {
         "constructor-super": "off",
         "no-class-assign": "off",
@@ -251,11 +232,7 @@
             "allow": [
               {
                 "from": "lib",
-                "name": [
-                  "Error",
-                  "URL",
-                  "URLSearchParams"
-                ]
+                "name": ["Error", "URL", "URLSearchParams"]
               }
             ],
             "allowAny": true,
@@ -269,42 +246,32 @@
         "@typescript-eslint/non-nullable-type-assertion-style": "error",
         "@typescript-eslint/prefer-includes": "error",
         "@typescript-eslint/prefer-nullish-coalescing": "off",
-        "@typescript-eslint/prefer-optional-chain": "error"
+        // See https://github.com/oxc-project/oxc/issues/17968
+        "@typescript-eslint/prefer-optional-chain": "off"
       }
     },
     {
-      "files": [
-        "apps/prairielearn/assets/scripts/**/*",
-        "apps/prairielearn/elements/**/*.js"
-      ],
+      "files": ["apps/prairielearn/assets/scripts/**/*", "apps/prairielearn/elements/**/*.js"],
       "env": {
         "browser": true,
         "jquery": true
       }
     },
     {
-      "files": [
-        "apps/prairielearn/src/tests/**/*",
-        "scripts/**/*",
-        "contrib/**/*"
-      ],
+      "files": ["apps/prairielearn/src/tests/**/*", "scripts/**/*", "contrib/**/*"],
       "rules": {
         "no-console": "off"
       }
     },
     {
-      "files": [
-        "apps/prairielearn/src/models/**/*"
-      ],
+      "files": ["apps/prairielearn/src/models/**/*"],
       "rules": {
         "no-restricted-imports": [
           "error",
           {
             "patterns": [
               {
-                "group": [
-                  "**/safe-db-types.js"
-                ],
+                "group": ["**/safe-db-types.js"],
                 "message": "Import from db-types instead of safe-db-types in the models directory. Otherwise, this code should live in the lib directory."
               }
             ]
@@ -313,9 +280,7 @@
       }
     },
     {
-      "files": [
-        "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}"
-      ],
+      "files": ["**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}"],
       "rules": {
         "accessor-pairs": "error",
         "array-callback-return": "off",
@@ -325,18 +290,11 @@
         "class-methods-use-this": "off",
         "complexity": "off",
         "constructor-super": "error",
-        "curly": [
-          "error",
-          "multi-line",
-          "consistent"
-        ],
+        "curly": ["error", "multi-line", "consistent"],
         "default-case": "off",
         "default-case-last": "error",
         "default-param-last": "error",
-        "eqeqeq": [
-          "error",
-          "smart"
-        ],
+        "eqeqeq": ["error", "smart"],
         "for-direction": "error",
         "func-names": "off",
         "func-style": "off",
@@ -364,12 +322,7 @@
         "no-console": [
           "error",
           {
-            "allow": [
-              "warn",
-              "error",
-              "table",
-              "trace"
-            ]
+            "allow": ["warn", "error", "table", "trace"]
           }
         ],
         "no-const-assign": "error",
@@ -434,11 +387,7 @@
         "no-prototype-builtins": "error",
         "no-redeclare": "off",
         "no-regex-spaces": "error",
-        "no-restricted-globals": [
-          "error",
-          "__filename",
-          "__dirname"
-        ],
+        "no-restricted-globals": ["error", "__filename", "__dirname"],
         "no-restricted-imports": "error",
         "no-return-assign": "error",
         "no-script-url": "error",
@@ -493,10 +442,7 @@
         "prefer-spread": "error",
         "prefer-template": "off",
         "preserve-caught-error": "error",
-        "radix": [
-          "error",
-          "as-needed"
-        ],
+        "radix": ["error", "as-needed"],
         "require-await": "off",
         "require-yield": "error",
         "sort-imports": [
@@ -504,12 +450,7 @@
           {
             "ignoreDeclarationSort": true,
             "ignoreMemberSort": false,
-            "memberSyntaxSortOrder": [
-              "none",
-              "all",
-              "multiple",
-              "single"
-            ]
+            "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
           }
         ],
         "sort-keys": "off",
@@ -642,18 +583,12 @@
         "unicorn/switch-case-braces": "off",
         "unicorn/text-encoding-identifier-case": "off",
         "unicorn/throw-new-error": "off",
-        "vitest/expect-expect": [
-          "off"
-        ],
+        "vitest/expect-expect": ["off"],
         "vitest/no-conditional-expect": "error",
-        "vitest/no-disabled-tests": [
-          "off"
-        ],
+        "vitest/no-disabled-tests": ["off"],
         "vitest/no-focused-tests": "error",
         "vitest/no-commented-out-tests": "error",
-        "vitest/no-identical-title": [
-          "off"
-        ],
+        "vitest/no-identical-title": ["off"],
         "vitest/no-import-node-test": "error",
         "vitest/no-interpolation-in-snapshots": "error",
         "vitest/no-mocks-import": "error",
@@ -815,14 +750,7 @@
         "WritableStreamDefaultController": "readonly",
         "WritableStreamDefaultWriter": "readonly"
       },
-      "plugins": [
-        "react",
-        "unicorn",
-        "vitest",
-        "jsx-a11y",
-        "import",
-        "promise"
-      ],
+      "plugins": ["react", "unicorn", "vitest", "jsx-a11y", "import", "promise"],
       "env": {
         "commonjs": true
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,769 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript"
+  ],
+  "categories": {
+    "correctness": "off"
+  },
+  "env": {
+    "builtin": true
+  },
+  "rules": {
+    "@typescript-eslint/adjacent-overload-signatures": "error",
+    "@typescript-eslint/array-type": "error",
+    "@typescript-eslint/ban-tslint-comment": "error",
+    "@typescript-eslint/consistent-generic-constructors": "error",
+    "@typescript-eslint/consistent-indexed-object-style": "error",
+    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/no-confusing-non-null-assertion": "error",
+    "no-empty-function": "error",
+    "@typescript-eslint/no-inferrable-types": "error",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/ban-ts-comment": [
+      "error",
+      {
+        "minimumDescriptionLength": 10
+      }
+    ],
+    "no-array-constructor": "error",
+    "@typescript-eslint/no-duplicate-enum-values": "error",
+    "@typescript-eslint/no-dynamic-delete": "error",
+    "@typescript-eslint/no-empty-object-type": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-extra-non-null-assertion": "error",
+    "@typescript-eslint/no-extraneous-class": "error",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-this-alias": "error",
+    "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unsafe-declaration-merging": "error",
+    "@typescript-eslint/no-unsafe-function-type": "error",
+    "no-unused-expressions": "error",
+    "no-unused-vars": "error",
+    "no-useless-constructor": "error",
+    "@typescript-eslint/no-wrapper-object-types": "error",
+    "@typescript-eslint/prefer-as-const": "error",
+    "@typescript-eslint/prefer-literal-enum-member": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/triple-slash-reference": "error"
+  },
+  "jsPlugins": [],
+  "ignorePatterns": [
+    ".venv/*",
+    ".yarn/*",
+    "docs/*",
+    "node_modules/*",
+    "testCourse",
+    "exampleCourse/**/*.js",
+    "coverage/*",
+    "out/*",
+    "workspaces/*",
+    "site/*",
+    "apps/*/coverage/*",
+    "packages/*/coverage/*",
+    "apps/prairielearn/v2-question-servers/*",
+    "apps/prairielearn/public/*",
+    "apps/*/dist/*",
+    "apps/prairielearn/public/build/*",
+    "packages/*/dist/*",
+    "apps/prairielearn/src/news_items/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.mts",
+        "**/*.cts"
+      ],
+      "rules": {
+        "constructor-super": "off",
+        "no-class-assign": "off",
+        "no-const-assign": "off",
+        "no-dupe-class-members": "off",
+        "no-dupe-keys": "off",
+        "no-func-assign": "off",
+        "no-import-assign": "off",
+        "no-new-native-nonconstructor": "off",
+        "no-obj-calls": "off",
+        "no-redeclare": "off",
+        "no-setter-return": "off",
+        "no-this-before-super": "off",
+        "no-unsafe-negation": "off",
+        "no-var": "error",
+        "no-with": "off",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error"
+      }
+    },
+    {
+      "files": [
+        "**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "jsdoc/check-access": "error",
+        "jsdoc/check-property-names": "error",
+        "jsdoc/check-tag-names": "error",
+        "jsdoc/empty-tags": "error",
+        "jsdoc/implements-on-classes": "error",
+        "jsdoc/no-defaults": "error",
+        "jsdoc/require-param": "off",
+        "jsdoc/require-param-description": "error",
+        "jsdoc/require-param-name": "error",
+        "jsdoc/require-param-type": "off",
+        "jsdoc/require-property": "error",
+        "jsdoc/require-property-description": "error",
+        "jsdoc/require-property-name": "error",
+        "jsdoc/require-property-type": "off",
+        "jsdoc/require-returns": "off",
+        "jsdoc/require-returns-description": "error",
+        "jsdoc/require-returns-type": "off",
+        "jsdoc/require-yields": "error",
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "importNames": [
+                  "OverlayTrigger"
+                ],
+                "message": "Use OverlayTrigger from @prairielearn/ui.",
+                "name": "react-bootstrap"
+              }
+            ]
+          }
+        ]
+      },
+      "plugins": [
+        "jsdoc"
+      ]
+    },
+    {
+      "files": [
+        "**/*.js"
+      ],
+      "rules": {
+        "jsdoc/check-access": "error",
+        "jsdoc/check-property-names": "error",
+        "jsdoc/check-tag-names": "error",
+        "jsdoc/empty-tags": "error",
+        "jsdoc/implements-on-classes": "error",
+        "jsdoc/no-defaults": "error",
+        "jsdoc/require-param": "off",
+        "jsdoc/require-param-description": "off",
+        "jsdoc/require-param-name": "error",
+        "jsdoc/require-param-type": "error",
+        "jsdoc/require-property": "error",
+        "jsdoc/require-property-description": "error",
+        "jsdoc/require-property-name": "error",
+        "jsdoc/require-property-type": "error",
+        "jsdoc/require-returns": "off",
+        "jsdoc/require-returns-description": "error",
+        "jsdoc/require-returns-type": "error",
+        "jsdoc/require-yields": "error"
+      },
+      "plugins": [
+        "jsdoc"
+      ]
+    },
+    {
+      "files": [
+        "apps/prairielearn/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "constructor-super": "off",
+        "no-class-assign": "off",
+        "no-const-assign": "off",
+        "no-dupe-class-members": "off",
+        "no-dupe-keys": "off",
+        "no-func-assign": "off",
+        "no-import-assign": "off",
+        "no-new-native-nonconstructor": "off",
+        "no-obj-calls": "off",
+        "no-redeclare": "off",
+        "no-setter-return": "off",
+        "no-this-before-super": "off",
+        "no-unsafe-negation": "off",
+        "no-var": "error",
+        "no-with": "off",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "@typescript-eslint/await-thenable": "error",
+        "@typescript-eslint/no-array-delete": "error",
+        "@typescript-eslint/no-base-to-string": "off",
+        "@typescript-eslint/no-duplicate-type-constituents": "error",
+        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/no-for-in-array": "error",
+        "@typescript-eslint/no-implied-eval": "error",
+        "@typescript-eslint/no-misused-promises": [
+          "error",
+          {
+            "checksConditionals": true,
+            "checksSpreads": true,
+            "checksVoidReturn": {
+              "arguments": false,
+              "attributes": false,
+              "inheritedMethods": true,
+              "properties": false,
+              "returns": true,
+              "variables": true
+            }
+          }
+        ],
+        "@typescript-eslint/no-redundant-type-constituents": "error",
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-enum-comparison": "error",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/no-unsafe-unary-minus": "error",
+        "no-throw-literal": "off",
+        "@typescript-eslint/only-throw-error": [
+          "error",
+          {
+            "allow": [
+              {
+                "from": "file",
+                "name": "HttpRedirect"
+              }
+            ],
+            "allowRethrowing": true,
+            "allowThrowingAny": true,
+            "allowThrowingUnknown": true
+          }
+        ],
+        "prefer-promise-reject-errors": "off",
+        "@typescript-eslint/prefer-promise-reject-errors": "off",
+        "require-await": "off",
+        "@typescript-eslint/require-await": "off",
+        "@typescript-eslint/restrict-plus-operands": "error",
+        "@typescript-eslint/restrict-template-expressions": [
+          "error",
+          {
+            "allow": [
+              {
+                "from": "lib",
+                "name": [
+                  "Error",
+                  "URL",
+                  "URLSearchParams"
+                ]
+              }
+            ],
+            "allowAny": true,
+            "allowBoolean": true,
+            "allowNullish": true,
+            "allowNumber": true,
+            "allowRegExp": true
+          }
+        ],
+        "@typescript-eslint/unbound-method": "error",
+        "@typescript-eslint/non-nullable-type-assertion-style": "error",
+        "@typescript-eslint/prefer-includes": "error",
+        "@typescript-eslint/prefer-nullish-coalescing": "off",
+        "@typescript-eslint/prefer-optional-chain": "error"
+      }
+    },
+    {
+      "files": [
+        "apps/prairielearn/assets/scripts/**/*",
+        "apps/prairielearn/elements/**/*.js"
+      ],
+      "env": {
+        "browser": true,
+        "jquery": true
+      }
+    },
+    {
+      "files": [
+        "apps/prairielearn/src/tests/**/*",
+        "scripts/**/*",
+        "contrib/**/*"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    },
+    {
+      "files": [
+        "apps/prairielearn/src/models/**/*"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": [
+                  "**/safe-db-types.js"
+                ],
+                "message": "Import from db-types instead of safe-db-types in the models directory. Otherwise, this code should live in the lib directory."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}"
+      ],
+      "rules": {
+        "accessor-pairs": "error",
+        "array-callback-return": "off",
+        "arrow-body-style": "off",
+        "block-scoped-var": "error",
+        "capitalized-comments": "off",
+        "class-methods-use-this": "off",
+        "complexity": "off",
+        "constructor-super": "error",
+        "curly": [
+          "error",
+          "multi-line",
+          "consistent"
+        ],
+        "default-case": "off",
+        "default-case-last": "error",
+        "default-param-last": "error",
+        "eqeqeq": [
+          "error",
+          "smart"
+        ],
+        "for-direction": "error",
+        "func-names": "off",
+        "func-style": "off",
+        "grouped-accessor-pairs": "error",
+        "guard-for-in": "off",
+        "id-length": "off",
+        "init-declarations": "off",
+        "max-classes-per-file": "off",
+        "max-depth": "off",
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "max-nested-callbacks": "error",
+        "max-params": "off",
+        "max-statements": "off",
+        "new-cap": "off",
+        "no-alert": "error",
+        "no-async-promise-executor": "error",
+        "no-await-in-loop": "off",
+        "no-bitwise": "off",
+        "no-caller": "error",
+        "no-case-declarations": "error",
+        "no-class-assign": "error",
+        "no-compare-neg-zero": "error",
+        "no-cond-assign": "error",
+        "no-console": [
+          "error",
+          {
+            "allow": [
+              "warn",
+              "error",
+              "table",
+              "trace"
+            ]
+          }
+        ],
+        "no-const-assign": "error",
+        "no-constant-binary-expression": "error",
+        "no-constant-condition": "error",
+        "no-constructor-return": "error",
+        "no-continue": "off",
+        "no-control-regex": "error",
+        "no-debugger": "error",
+        "no-delete-var": "error",
+        "no-div-regex": "error",
+        "no-dupe-class-members": "error",
+        "no-dupe-else-if": "error",
+        "no-dupe-keys": "error",
+        "no-duplicate-case": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "off",
+        "no-empty": "error",
+        "no-empty-character-class": "error",
+        "no-empty-function": "off",
+        "no-empty-pattern": "error",
+        "no-empty-static-block": "error",
+        "no-eq-null": "off",
+        "no-eval": "error",
+        "no-ex-assign": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-boolean-cast": "error",
+        "no-extra-label": "error",
+        "no-fallthrough": "error",
+        "no-func-assign": "error",
+        "no-global-assign": "error",
+        "no-implicit-coercion": "off",
+        "no-import-assign": "error",
+        "no-inline-comments": "off",
+        "no-inner-declarations": "error",
+        "no-invalid-regexp": "error",
+        "no-irregular-whitespace": "error",
+        "no-iterator": "error",
+        "no-label-var": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "off",
+        "no-loop-func": "off",
+        "no-loss-of-precision": "error",
+        "no-magic-numbers": "off",
+        "no-multi-assign": "error",
+        "no-multi-str": "error",
+        "no-negated-condition": "off",
+        "no-nested-ternary": "off",
+        "no-new": "off",
+        "no-new-func": "error",
+        "no-new-native-nonconstructor": "error",
+        "no-new-wrappers": "error",
+        "no-nonoctal-decimal-escape": "error",
+        "no-obj-calls": "error",
+        "no-object-constructor": "error",
+        "no-param-reassign": "off",
+        "no-plusplus": "off",
+        "no-promise-executor-return": "off",
+        "no-proto": "error",
+        "no-prototype-builtins": "error",
+        "no-redeclare": "off",
+        "no-regex-spaces": "error",
+        "no-restricted-globals": [
+          "error",
+          "__filename",
+          "__dirname"
+        ],
+        "no-restricted-imports": "error",
+        "no-return-assign": "error",
+        "no-script-url": "error",
+        "no-self-assign": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-setter-return": "error",
+        "no-shadow-restricted-names": "error",
+        "no-sparse-arrays": "error",
+        "no-template-curly-in-string": "error",
+        "no-ternary": "off",
+        "no-this-before-super": "error",
+        "no-throw-literal": "error",
+        "no-unassigned-vars": "error",
+        "no-undefined": "off",
+        "no-unexpected-multiline": "error",
+        "no-unneeded-ternary": "off",
+        "no-unsafe-finally": "error",
+        "no-unsafe-negation": "error",
+        "no-unsafe-optional-chaining": "error",
+        "no-unused-labels": "error",
+        "no-unused-private-class-members": "error",
+        "no-unused-vars": [
+          "error",
+          {
+            "args": "after-used",
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_."
+          }
+        ],
+        "no-useless-backreference": "error",
+        "no-useless-call": "error",
+        "no-useless-catch": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "off",
+        "no-useless-constructor": "off",
+        "no-useless-escape": "error",
+        "no-useless-rename": "error",
+        "no-useless-return": "off",
+        "no-var": "error",
+        "no-void": "off",
+        "no-warning-comments": "off",
+        "no-with": "error",
+        "operator-assignment": "error",
+        "prefer-destructuring": "off",
+        "prefer-exponentiation-operator": "error",
+        "prefer-numeric-literals": "error",
+        "prefer-object-has-own": "off",
+        "prefer-object-spread": "error",
+        "prefer-promise-reject-errors": "error",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "prefer-template": "off",
+        "preserve-caught-error": "error",
+        "radix": [
+          "error",
+          "as-needed"
+        ],
+        "require-await": "off",
+        "require-yield": "error",
+        "sort-imports": [
+          "error",
+          {
+            "ignoreDeclarationSort": true,
+            "ignoreMemberSort": false,
+            "memberSyntaxSortOrder": [
+              "none",
+              "all",
+              "multiple",
+              "single"
+            ]
+          }
+        ],
+        "sort-keys": "off",
+        "sort-vars": "off",
+        "symbol-description": "error",
+        "unicode-bom": "error",
+        "use-isnan": "error",
+        "valid-typeof": "error",
+        "vars-on-top": "error",
+        "yoda": "error",
+        "react-hooks/exhaustive-deps": "error",
+        "react-hooks/rules-of-hooks": "error",
+        "unicorn/catch-error-name": "off",
+        "unicorn/consistent-assert": "off",
+        "unicorn/consistent-date-clone": "error",
+        "unicorn/consistent-empty-array-spread": "error",
+        "unicorn/consistent-existence-index-check": "error",
+        "unicorn/consistent-function-scoping": "off",
+        "unicorn/empty-brace-spaces": "error",
+        "unicorn/error-message": "off",
+        "unicorn/escape-case": "off",
+        "unicorn/explicit-length-check": "error",
+        "unicorn/filename-case": "off",
+        "unicorn/new-for-builtins": "error",
+        "unicorn/no-abusive-eslint-disable": "error",
+        "unicorn/no-accessor-recursion": "error",
+        "unicorn/no-anonymous-default-export": "off",
+        "unicorn/no-array-callback-reference": "off",
+        "unicorn/no-array-for-each": "off",
+        "unicorn/no-array-method-this-argument": "off",
+        "unicorn/no-array-reduce": "off",
+        "unicorn/no-array-reverse": "off",
+        "unicorn/no-array-sort": "off",
+        "unicorn/no-await-expression-member": "off",
+        "unicorn/no-await-in-promise-methods": "error",
+        "unicorn/no-console-spaces": "error",
+        "unicorn/no-document-cookie": "error",
+        "unicorn/no-empty-file": "error",
+        "unicorn/no-hex-escape": "off",
+        "unicorn/no-immediate-mutation": "error",
+        "unicorn/no-instanceof-builtins": "error",
+        "unicorn/no-invalid-fetch-options": "error",
+        "unicorn/no-invalid-remove-event-listener": "error",
+        "unicorn/no-lonely-if": "off",
+        "unicorn/no-magic-array-flat-depth": "error",
+        "unicorn/no-negated-condition": "off",
+        "unicorn/no-negation-in-equality-check": "error",
+        "unicorn/no-nested-ternary": "off",
+        "unicorn/no-new-array": "error",
+        "unicorn/no-new-buffer": "error",
+        "unicorn/no-null": "off",
+        "unicorn/no-object-as-default-parameter": "off",
+        "unicorn/no-process-exit": "error",
+        "unicorn/no-single-promise-in-promise-methods": "error",
+        "unicorn/no-static-only-class": "off",
+        "unicorn/no-thenable": "error",
+        "unicorn/no-this-assignment": "off",
+        "unicorn/no-typeof-undefined": "error",
+        "unicorn/no-unnecessary-array-flat-depth": "error",
+        "unicorn/no-unnecessary-array-splice-count": "error",
+        "unicorn/no-unnecessary-await": "error",
+        "unicorn/no-unnecessary-slice-end": "error",
+        "unicorn/no-unreadable-array-destructuring": "error",
+        "unicorn/no-unreadable-iife": "error",
+        "unicorn/no-useless-collection-argument": "error",
+        "unicorn/no-useless-error-capture-stack-trace": "error",
+        "unicorn/no-useless-fallback-in-spread": "error",
+        "unicorn/no-useless-length-check": "error",
+        "unicorn/no-useless-promise-resolve-reject": "error",
+        "unicorn/no-useless-spread": "error",
+        "unicorn/no-useless-switch-case": "error",
+        "unicorn/no-useless-undefined": "off",
+        "unicorn/no-zero-fractions": "error",
+        "unicorn/number-literal-case": "off",
+        "unicorn/numeric-separators-style": "off",
+        "unicorn/prefer-add-event-listener": "off",
+        "unicorn/prefer-array-find": "error",
+        "unicorn/prefer-array-flat": "error",
+        "unicorn/prefer-array-flat-map": "error",
+        "unicorn/prefer-array-index-of": "error",
+        "unicorn/prefer-array-some": "error",
+        "unicorn/prefer-at": "off",
+        "unicorn/prefer-bigint-literals": "error",
+        "unicorn/prefer-blob-reading-methods": "error",
+        "unicorn/prefer-class-fields": "error",
+        "unicorn/prefer-classlist-toggle": "error",
+        "unicorn/prefer-code-point": "off",
+        "unicorn/prefer-date-now": "error",
+        "unicorn/prefer-default-parameters": "error",
+        "unicorn/prefer-dom-node-append": "error",
+        "unicorn/prefer-dom-node-dataset": "off",
+        "unicorn/prefer-dom-node-remove": "error",
+        "unicorn/prefer-dom-node-text-content": "off",
+        "unicorn/prefer-event-target": "off",
+        "unicorn/prefer-global-this": "off",
+        "unicorn/prefer-includes": "error",
+        "unicorn/prefer-keyboard-event-key": "error",
+        "unicorn/prefer-logical-operator-over-ternary": "error",
+        "unicorn/prefer-math-min-max": "error",
+        "unicorn/prefer-math-trunc": "error",
+        "unicorn/prefer-modern-dom-apis": "error",
+        "unicorn/prefer-modern-math-apis": "error",
+        "unicorn/prefer-native-coercion-functions": "error",
+        "unicorn/prefer-negative-index": "error",
+        "unicorn/prefer-node-protocol": "off",
+        "unicorn/prefer-number-properties": "error",
+        "unicorn/prefer-object-from-entries": "error",
+        "unicorn/prefer-optional-catch-binding": "error",
+        "unicorn/prefer-prototype-methods": "error",
+        "unicorn/prefer-query-selector": "off",
+        "unicorn/prefer-reflect-apply": "error",
+        "unicorn/prefer-regexp-test": "error",
+        "unicorn/prefer-response-static-json": "error",
+        "unicorn/prefer-set-has": "error",
+        "unicorn/prefer-set-size": "error",
+        "unicorn/prefer-spread": "off",
+        "unicorn/prefer-string-raw": "off",
+        "unicorn/prefer-string-replace-all": "error",
+        "unicorn/prefer-string-slice": "error",
+        "unicorn/prefer-string-starts-ends-with": "error",
+        "unicorn/prefer-string-trim-start-end": "error",
+        "unicorn/prefer-structured-clone": "error",
+        "unicorn/prefer-top-level-await": "off",
+        "unicorn/prefer-type-error": "off",
+        "unicorn/require-array-join-separator": "error",
+        "unicorn/require-module-attributes": "error",
+        "unicorn/require-module-specifiers": "error",
+        "unicorn/require-number-to-fixed-digits-argument": "error",
+        "unicorn/require-post-message-target-origin": "off",
+        "unicorn/switch-case-braces": "off",
+        "unicorn/text-encoding-identifier-case": "off",
+        "unicorn/throw-new-error": "off",
+        "vitest/expect-expect": [
+          "off"
+        ],
+        "vitest/no-conditional-expect": "error",
+        "vitest/no-disabled-tests": [
+          "off"
+        ],
+        "vitest/no-focused-tests": "error",
+        "vitest/no-commented-out-tests": "error",
+        "vitest/no-identical-title": [
+          "off"
+        ],
+        "vitest/no-import-node-test": "error",
+        "vitest/no-interpolation-in-snapshots": "error",
+        "vitest/no-mocks-import": "error",
+        "vitest/no-standalone-expect": "error",
+        "vitest/no-unneeded-async-expect-function": "error",
+        "vitest/require-local-test-context-for-concurrent-snapshots": "error",
+        "vitest/valid-describe-callback": "off",
+        "vitest/valid-expect": "error",
+        "@prairielearn/aws-client-mandatory-config": "error",
+        "@prairielearn/aws-client-shared-config": "error",
+        "@prairielearn/jsx-no-dollar-interpolation": "error",
+        "@prairielearn/no-unused-sql-blocks": "error",
+        "@prairielearn/safe-db-types": "off",
+        "@typescript-eslint/consistent-type-imports": [
+          "error",
+          {
+            "fixStyle": "inline-type-imports"
+          }
+        ],
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-dynamic-delete": "off",
+        "@typescript-eslint/no-non-null-assertion": "off"
+      },
+      "jsPlugins": [
+        "@prairielearn/eslint-plugin"
+      ],
+      "globals": {
+        "__dirname": "readonly",
+        "__filename": "readonly",
+        "AbortController": "readonly",
+        "AbortSignal": "readonly",
+        "AsyncDisposableStack": "readonly",
+        "atob": "readonly",
+        "Blob": "readonly",
+        "BroadcastChannel": "readonly",
+        "btoa": "readonly",
+        "Buffer": "readonly",
+        "ByteLengthQueuingStrategy": "readonly",
+        "clearImmediate": "readonly",
+        "clearInterval": "readonly",
+        "clearTimeout": "readonly",
+        "CloseEvent": "readonly",
+        "CompressionStream": "readonly",
+        "console": "readonly",
+        "CountQueuingStrategy": "readonly",
+        "crypto": "readonly",
+        "Crypto": "readonly",
+        "CryptoKey": "readonly",
+        "CustomEvent": "readonly",
+        "DecompressionStream": "readonly",
+        "DisposableStack": "readonly",
+        "DOMException": "readonly",
+        "Event": "readonly",
+        "EventTarget": "readonly",
+        "fetch": "readonly",
+        "File": "readonly",
+        "FormData": "readonly",
+        "Headers": "readonly",
+        "MessageChannel": "readonly",
+        "MessageEvent": "readonly",
+        "MessagePort": "readonly",
+        "navigator": "readonly",
+        "Navigator": "readonly",
+        "performance": "readonly",
+        "Performance": "readonly",
+        "PerformanceEntry": "readonly",
+        "PerformanceMark": "readonly",
+        "PerformanceMeasure": "readonly",
+        "PerformanceObserver": "readonly",
+        "PerformanceObserverEntryList": "readonly",
+        "PerformanceResourceTiming": "readonly",
+        "process": "readonly",
+        "queueMicrotask": "readonly",
+        "ReadableByteStreamController": "readonly",
+        "ReadableStream": "readonly",
+        "ReadableStreamBYOBReader": "readonly",
+        "ReadableStreamBYOBRequest": "readonly",
+        "ReadableStreamDefaultController": "readonly",
+        "ReadableStreamDefaultReader": "readonly",
+        "Request": "readonly",
+        "Response": "readonly",
+        "setImmediate": "readonly",
+        "setInterval": "readonly",
+        "setTimeout": "readonly",
+        "structuredClone": "readonly",
+        "SubtleCrypto": "readonly",
+        "SuppressedError": "readonly",
+        "TextDecoder": "readonly",
+        "TextDecoderStream": "readonly",
+        "TextEncoder": "readonly",
+        "TextEncoderStream": "readonly",
+        "TransformStream": "readonly",
+        "TransformStreamDefaultController": "readonly",
+        "URL": "readonly",
+        "URLPattern": "readonly",
+        "URLSearchParams": "readonly",
+        "WebAssembly": "readonly",
+        "WebSocket": "readonly",
+        "WritableStream": "readonly",
+        "WritableStreamDefaultController": "readonly",
+        "WritableStreamDefaultWriter": "readonly"
+      },
+      "plugins": [
+        "react",
+        "unicorn",
+        "vitest"
+      ],
+      "env": {
+        "commonjs": true
+      }
+    }
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
+    "oxc.oxc-vscode",
     // If you haven't run `make python-deps`, this is going to give you errors.
     "dorzey.vscode-sqlfluff",
     "ms-playwright.playwright",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,9 +20,11 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
+      "source.fixAll.oxc": "explicit",
       "source.fixAll.eslint": "explicit"
     }
   },
+  "oxc.typeAware": true,
   "[html][css][scss][json][jsonc][yaml][github-actions-workflow][sql][markdown][toml][shellscript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true

--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,13 @@ lint-all: lint-js lint-python lint-html lint-docs lint-docker lint-actions lint-
 
 lint: lint-js lint-python lint-html lint-links lint-changeset
 lint-js:
-	@yarn eslint "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
+	@yarn oxlint -c .oxlintrc.json
+	@yarn eslint -c eslint.config.residual.mjs "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check
 # This is a separate target since the caches don't respect updates to plugins.
 lint-js-cached:
-	@yarn eslint --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
+	@yarn oxlint -c .oxlintrc.json
+	@yarn eslint -c eslint.config.residual.mjs --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check --cache --cache-strategy content
 lint-python:
 	@uv run ruff check ./
@@ -146,11 +148,13 @@ format-sql:
 	@uv run sqlfluff fix
 
 format-js:
-	@yarn eslint --ext js --fix "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
+	@yarn oxlint -c .oxlintrc.json --fix
+	@yarn eslint -c eslint.config.residual.mjs --fix "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier --write "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}"
 # This is a separate target since the caches don't respect updates to plugins.
 format-js-cached:
-	@yarn eslint --ext js --fix --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
+	@yarn oxlint -c .oxlintrc.json --fix
+	@yarn eslint -c eslint.config.residual.mjs --fix --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier --write --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}"
 
 format-python:

--- a/Makefile
+++ b/Makefile
@@ -107,12 +107,12 @@ lint-all: lint-js lint-python lint-html lint-docs lint-docker lint-actions lint-
 
 lint: lint-js lint-python lint-html lint-links lint-changeset
 lint-js:
-	@yarn oxlint -c .oxlintrc.json
+	@yarn oxlint -c .oxlintrc.json --deny-warnings --type-aware
 	@yarn eslint -c eslint.config.residual.mjs "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check
 # This is a separate target since the caches don't respect updates to plugins.
 lint-js-cached:
-	@yarn oxlint -c .oxlintrc.json
+	@yarn oxlint -c .oxlintrc.json --deny-warnings --type-aware
 	@yarn eslint -c eslint.config.residual.mjs --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check --cache --cache-strategy content
 lint-python:
@@ -148,12 +148,12 @@ format-sql:
 	@uv run sqlfluff fix
 
 format-js:
-	@yarn oxlint -c .oxlintrc.json --fix
+	@yarn oxlint -c .oxlintrc.json --fix --type-aware
 	@yarn eslint -c eslint.config.residual.mjs --fix "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier --write "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}"
 # This is a separate target since the caches don't respect updates to plugins.
 format-js-cached:
-	@yarn oxlint -c .oxlintrc.json --fix
+	@yarn oxlint -c .oxlintrc.json --fix --type-aware
 	@yarn eslint -c eslint.config.residual.mjs --fix --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier --write --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}"
 

--- a/apps/grader-host/src/lib/config.ts
+++ b/apps/grader-host/src/lib/config.ts
@@ -86,7 +86,7 @@ function makeAutoScalingGroupConfigSource(): ConfigSource {
       // but this client will really only be used once, typically at application
       // startup.
       //
-      // eslint-disable-next-line @prairielearn/aws-client-shared-config
+      // oxlint-disable-next-line @prairielearn/aws-client-shared-config
       const autoscaling = new AutoScaling({ region: existingConfig.awsRegion as string });
       const data = await autoscaling.describeAutoScalingInstances({
         InstanceIds: [existingConfig.instanceId as string],
@@ -116,7 +116,7 @@ function makeQueueUrlConfigSource(): ConfigSource {
       // about reusing credentials here, since this client will only be used
       // once at application startup.
       //
-      // eslint-disable-next-line @prairielearn/aws-client-shared-config
+      // oxlint-disable-next-line @prairielearn/aws-client-shared-config
       const sqs = new SQSClient({ region: existingConfig.awsRegion as string });
 
       for (const prefix of queuePrefixes) {

--- a/apps/prairielearn/assets/scripts/bootstrap-table-sticky-header.js
+++ b/apps/prairielearn/assets/scripts/bootstrap-table-sticky-header.js
@@ -4,6 +4,7 @@
 // This version makes the sticky header aware of non-window scrolling containers, necessary for
 // the side nav component when enhanced navigation is enabled.
 
+/* oxlint-disable jsdoc/check-tag-names -- Third-party license comment */
 /**
  * (The MIT License)
  *

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -270,6 +270,7 @@
     "@types/express-serve-static-core": "^4.19.8",
     "@types/folder-hash": "^4.0.4",
     "@types/fs-extra": "^11.0.4",
+    "@types/he": "^1.2.3",
     "@types/jju": "^1.4.5",
     "@types/jquery": "^3.5.33",
     "@types/js-cookie": "^3.0.6",

--- a/apps/prairielearn/src/api/v1/error.ts
+++ b/apps/prairielearn/src/api/v1/error.ts
@@ -15,7 +15,7 @@ export default (function (err, req, res, _next) {
     response_id: res.locals.response_id,
   });
   res.status(statusCode).send({
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
     message: status[statusCode as keyof typeof status] ?? 'Unknown status code',
     status: statusCode,
   });

--- a/apps/prairielearn/src/components/DeleteCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/components/DeleteCourseInstanceModal.tsx
@@ -142,7 +142,7 @@ export function DeleteCourseInstanceModal({
                     className="form-control"
                     value={confirmationText}
                     autoComplete="off"
-                    // eslint-disable-next-line jsx-a11y-x/no-autofocus
+                    // oxlint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                     onInput={(e) => setConfirmationText(e.currentTarget.value)}
                   />

--- a/apps/prairielearn/src/components/EditQuestionPointsScore.tsx
+++ b/apps/prairielearn/src/components/EditQuestionPointsScore.tsx
@@ -393,7 +393,7 @@ export function EditQuestionPointsScoreButton({
     return () => {
       scrollContainer.removeEventListener('scroll', handleScroll);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [show]);
 
   return (

--- a/apps/prairielearn/src/components/JobStatus.tsx
+++ b/apps/prairielearn/src/components/JobStatus.tsx
@@ -2,7 +2,7 @@ import { html } from '@prairielearn/html';
 
 import type { Job, JobSequence } from '../lib/db-types.js';
 
-// eslint-disable-next-line @typescript-eslint/no-duplicate-type-constituents
+// oxlint-disable-next-line @typescript-eslint/no-duplicate-type-constituents
 export function JobStatus({ status }: { status: Job['status'] | JobSequence['status'] }) {
   if (status === 'Running') {
     return html`<span class="badge text-bg-primary">Running</span>`;

--- a/apps/prairielearn/src/components/ServerJobProgress/useServerJobProgress.ts
+++ b/apps/prairielearn/src/components/ServerJobProgress/useServerJobProgress.ts
@@ -45,7 +45,7 @@ export function useServerJobProgress({
       onProgressChange();
       // We do not include onProgressChange in the dependency array because it
       // would cause an infinite loop if the callback is not memoized.
-    }, // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, // oxlint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 

--- a/apps/prairielearn/src/components/TeamWorkInfoContainer.tsx
+++ b/apps/prairielearn/src/components/TeamWorkInfoContainer.tsx
@@ -192,7 +192,7 @@ function TeamRoleTable({
                                     ? 'disabled'
                                     : ''}
                                   ${
-                                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                                    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
                                     rolesInfo.roleAssignments[user.uid]?.some((a) =>
                                       idsEqual(a.team_role_id, role.id),
                                     )

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
@@ -143,7 +143,7 @@ export async function aiGrade({
   const instance_questions = all_instance_questions.filter((instance_question) => {
     switch (mode) {
       case 'human_graded':
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
         return instanceQuestionGradingJobs[instance_question.id]?.some(
           (job) => job.grading_method === 'Manual',
         );
@@ -193,7 +193,7 @@ export async function aiGrade({
       instance_question: InstanceQuestion,
       logger: AIGradingLogger,
     ): Promise<boolean> => {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
       const shouldUpdateScore = !instanceQuestionGradingJobs[instance_question.id]?.some(
         (job) => job.grading_method === 'Manual',
       );

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -361,7 +361,7 @@ export class Lti13Claim {
   get(property: _.PropertyPath): any {
     this.assertValid();
     // Uses lodash.get to expand path representation in text to the object, like 'a[0].b.c'
-    // eslint-disable-next-line you-dont-need-lodash-underscore/get
+    // oxlint-disable-next-line you-dont-need-lodash-underscore/get
     return _.get(this.claims, property);
   }
 
@@ -840,7 +840,7 @@ class Lti13ContextMembership {
 
       const memberResults = this.#membershipsByEmail[key];
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!memberResults) continue;
 
       // member.email cannot be duplicated in memberships

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -72,7 +72,7 @@ router.get(
     let paramInstance: Lti13Instance | undefined;
 
     // Handle the / (no id passed case)
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (req.params.unsafe_lti13_instance_id === undefined) {
       if (lti13Instances.length > 0) {
         return res.redirect(

--- a/apps/prairielearn/src/lib/assessment.test.ts
+++ b/apps/prairielearn/src/lib/assessment.test.ts
@@ -1,0 +1,26 @@
+import he from 'he';
+import { assert, describe, it } from 'vitest';
+
+import { renderText } from './assessment.js';
+
+describe('assessment', () => {
+  describe('renderText', () => {
+    it('returns null for null text', () => {
+      assert.isNull(renderText({ id: '1', text: null }, '/pl'));
+    });
+
+    it('renders assessment text with URL prefix', () => {
+      const result = renderText(
+        { id: '123', text: 'File: <%= clientFilesAssessment %>/test.txt' },
+        '/pl',
+      );
+      assert.equal(result, 'File: /pl/assessment/123/clientFilesAssessment/test.txt');
+    });
+
+    it('decodes HTML entities in rendered text', () => {
+      const result = renderText({ id: '1', text: '&lt;p&gt;Hello &amp; world&lt;/p&gt;' }, '/pl');
+      const decoded = he.decode(result ?? '');
+      assert.equal(decoded, '<p>Hello & world</p>');
+    });
+  });
+});

--- a/apps/prairielearn/src/lib/client/mathjax.ts
+++ b/apps/prairielearn/src/lib/client/mathjax.ts
@@ -14,7 +14,7 @@ const {
   promise: mathjaxPromise,
   resolve: mathjaxResolve,
   reject: mathjaxReject,
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  // oxlint-disable-next-line @typescript-eslint/no-invalid-void-type
 } = withResolvers<void>();
 
 (() => {

--- a/apps/prairielearn/src/lib/id.ts
+++ b/apps/prairielearn/src/lib/id.ts
@@ -21,6 +21,6 @@
  * parsing IDs as `BigInt` objects as they come out of the database.
  */
 export function idsEqual(id1: string | number, id2: string | number): boolean {
-  // eslint-disable-next-line eqeqeq
+  // oxlint-disable-next-line eqeqeq
   return id1 == id2;
 }

--- a/apps/prairielearn/src/lib/ltiOutcomes.ts
+++ b/apps/prairielearn/src/lib/ltiOutcomes.ts
@@ -125,7 +125,7 @@ export async function updateScore(assessment_instance_id: string) {
 
   // Inspect the XML result, log the action
   const result = await parser.parseStringPromise(await res.text());
-  // eslint-disable-next-line you-dont-need-lodash-underscore/get
+  // oxlint-disable-next-line you-dont-need-lodash-underscore/get
   const imsx_codeMajor = _.get(
     result,
     [

--- a/apps/prairielearn/src/lib/socket-server.ts
+++ b/apps/prairielearn/src/lib/socket-server.ts
@@ -110,7 +110,7 @@ export async function close() {
   // Close the adapters. This will remove the pub/sub subscriptions to ensure we
   // don't receive any more messages from Redis.
   // The type signature of `close()` is `Promise<void> | void`, so we need to disable the rule about the unneeded `Promise.all`.
-  // eslint-disable-next-line @typescript-eslint/await-thenable
+  // oxlint-disable-next-line @typescript-eslint/await-thenable
   await Promise.all(adapters.map((adapter) => adapter.close()));
 
   // Close any remaining client connections.

--- a/apps/prairielearn/src/lib/types.ts
+++ b/apps/prairielearn/src/lib/types.ts
@@ -49,7 +49,7 @@ export type ExpandRecursively<T> = T extends object
   : T;
 
 export function assertNever(value: never): never {
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  // oxlint-disable-next-line @typescript-eslint/restrict-template-expressions
   throw new Error(`Unexpected value: ${value}`);
 }
 

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
@@ -688,7 +688,7 @@ export async function authzCourseOrInstance(req: Request, res: Response) {
   }
 
   // The session middleware does not run for API requests.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
   res.locals.side_nav_expanded = req.session?.side_nav_expanded ?? true; // The side nav is expanded by default.
 
   res.locals.course_has_course_instances = await selectCourseHasCourseInstances({

--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -76,7 +76,7 @@ function getRequestPath(req: Request): string {
   // `req.originalUrl` won't be defined for websocket requests, but for
   // non-websocket requests, `req.url` won't contain the full path. So we
   // need to handle both.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return req.originalUrl ?? req.url;
 }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
@@ -192,7 +192,7 @@ function AssessmentQuestionRow({
         </a>
         {question.manual_rubric_id != null && (
           // TODO: Fix this
-          // eslint-disable-next-line jsx-a11y-x/anchor-is-valid
+          // oxlint-disable-next-line jsx-a11y/anchor-is-valid
           <a
             href="#"
             className="ms-2 text-info"

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
@@ -491,7 +491,7 @@ export function AssessmentQuestionTable({
   // Update column visibility when AI grading mode changes
   useEffect(() => {
     // https://github.com/NickvanDyke/eslint-plugin-react-you-might-not-need-an-effect/issues/58
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-ref-to-parent
+    // oxlint-disable-next-line react-you-might-not-need-an-effect/no-pass-ref-to-parent
     void setColumnVisibility((prev) => ({
       ...prev,
       // Hide these columns in AI grading mode

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/utils/columnDefinitions.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/utils/columnDefinitions.tsx
@@ -169,7 +169,7 @@ export function createColumns({
                   // for keyboard users, but we don't want it to be announced as a button by screen
                   // readers. So we give it role="status" to indicate that it's just a status indicator.
                   // It's possible there are better ways to handle this?
-                  // eslint-disable-next-line jsx-a11y-x/no-interactive-element-to-noninteractive-role
+                  // oxlint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
                   role="status"
                   className="btn btn-xs btn-ghost"
                   aria-label="Assessment instance is still open"

--- a/apps/prairielearn/src/pages/instructorGradebook/components/InstructorGradebookTable.tsx
+++ b/apps/prairielearn/src/pages/instructorGradebook/components/InstructorGradebookTable.tsx
@@ -305,7 +305,7 @@ function GradebookTable({
             columnHelper.accessor(
               (row) => {
                 const data = row.scores[assessment.assessment_id];
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 return data ? data.score_perc : null;
               },
               {
@@ -331,7 +331,7 @@ function GradebookTable({
                   const row = info.row.original;
                   const assessmentData = row.scores[assessment.assessment_id];
 
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                  // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
                   if (score == null || !assessmentData?.assessment_instance_id) {
                     return '—';
                   }
@@ -482,7 +482,7 @@ function GradebookTable({
             for (const assessment of courseAssessments) {
               data.push({
                 name: assessment.label,
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
                 value: row.scores[assessment.assessment_id]?.score_perc ?? null,
               });
             }

--- a/apps/prairielearn/src/pages/navbarCourseInstanceSwitcher/navbarCourseInstanceSwitcher.ts
+++ b/apps/prairielearn/src/pages/navbarCourseInstanceSwitcher/navbarCourseInstanceSwitcher.ts
@@ -26,7 +26,7 @@ router.get(
     res.send(
       NavbarCourseInstanceSwitcher({
         course_instances,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
         current_course_instance_id: req.params.course_instance_id ?? null,
       }),
     );

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts
@@ -40,7 +40,7 @@ router.get(
   logPageView('studentAssessmentInstance'),
   typedAsyncHandler<'assessment'>(async function (req, res) {
     // TODO: Investigate if `authz_result` can be null/undefined
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!(res.locals.authz_result?.active ?? true)) {
       // If the student had started the assessment already, they would have been
       // redirected to the assessment instance by the `studentAssessmentRedirect`

--- a/apps/prairielearn/src/question-servers/freeform.ts
+++ b/apps/prairielearn/src/question-servers/freeform.ts
@@ -199,7 +199,7 @@ async function loadElements(sourceDir: string, elementType: 'core' | 'course') {
 
 export async function loadElementsForCourse(course: Course) {
   if (
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
     courseElementsCache[course.id]?.commit_hash &&
     courseElementsCache[course.id].commit_hash === course.commit_hash
   ) {
@@ -294,7 +294,7 @@ async function loadExtensionsForCourse({
   course_dir_host: string;
 }) {
   if (
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
     courseExtensionsCache[course.id]?.commit_hash &&
     courseExtensionsCache[course.id].commit_hash === course.commit_hash
   ) {

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -102,7 +102,7 @@ if ('h' in argv || 'help' in argv) {
     --sync-course <course_id>           Synchronize a course and exit
 `;
 
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.log(msg);
   process.exit(0);
 }
@@ -2084,7 +2084,7 @@ export async function startServer(app: express.Express) {
 
   // @ts-expect-error: Hack to get us running in Bun, which doesn't currently support `getConnections`:
   // https://github.com/oven-sh/bun/issues/4459
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (server.getConnections) {
     opentelemetry.createObservableValueGauges(
       meter,

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as path from 'path';
 
 import * as cheerio from 'cheerio';

--- a/apps/prairielearn/src/tests/database.test.ts
+++ b/apps/prairielearn/src/tests/database.test.ts
@@ -78,7 +78,7 @@ describe('database', { timeout: 20_000 }, function () {
         const [, keyName, otherTable, deleteAction] = match;
 
         // Skip table/column pairs that are exceptions to the rule.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (SOFT_DELETE_CASCADE_EXCEPTIONS[table]?.includes(keyName)) continue;
 
         if (deleteAction === 'CASCADE' && hardDeleteTables.includes(otherTable)) {

--- a/apps/prairielearn/src/tests/e2e/fixtures.ts
+++ b/apps/prairielearn/src/tests/e2e/fixtures.ts
@@ -1,4 +1,4 @@
-/* eslint-disable react-hooks/rules-of-hooks */
+/* oxlint-disable react-hooks/rules-of-hooks */
 import { execSync } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -41,7 +41,7 @@ interface WorkerFixtures {
  */
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   testCoursePath: [
-    // eslint-disable-next-line no-empty-pattern
+    // oxlint-disable-next-line no-empty-pattern
     async ({}, use) => {
       const tempDir = await tmp.dir({ unsafeCleanup: true });
       const tempTestCoursePath = path.join(tempDir.path, 'testCourse');

--- a/apps/prairielearn/src/tests/e2e/serverUtils.ts
+++ b/apps/prairielearn/src/tests/e2e/serverUtils.ts
@@ -1,4 +1,4 @@
-/* eslint-disable react-hooks/rules-of-hooks */
+/* oxlint-disable react-hooks/rules-of-hooks */
 import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as cheerio from 'cheerio';
 import { parse as csvParse } from 'csv-parse/sync';
 import type { Element } from 'domhandler';

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as path from 'node:path';
 
 import { execa } from 'execa';

--- a/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentSetsSync.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
 
 import { type AssessmentSet, AssessmentSetSchema, CourseSchema } from '../../lib/db-types.js';

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as path from 'path';
 
 import fs from 'fs-extra';

--- a/apps/prairielearn/src/tests/sync/courseDb.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as path from 'path';
 
 import fs from 'fs-extra';

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as path from 'path';
 
 import { Temporal } from '@js-temporal/polyfill';

--- a/apps/prairielearn/src/tests/sync/questionsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/questionsSync.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/dot-notation */
+/* oxlint-disable @typescript-eslint/dot-notation */
 import * as path from 'path';
 
 import fs from 'fs-extra';

--- a/eslint.config.residual.mjs
+++ b/eslint.config.residual.mjs
@@ -1,0 +1,357 @@
+/**
+ * Residual ESLint configuration for rules that oxlint cannot handle.
+ *
+ * This config includes:
+ * - @html-eslint: HTML/Mustache file linting (oxlint can't parse HTML)
+ * - @stylistic: Stylistic rules (token-based, not supported by oxlint)
+ * - perfectionist: Sorting rules (token-based)
+ * - jsx-a11y-x: JSX accessibility rules
+ * - @eslint-react: React-specific rules
+ * - react-hooks: React hooks rules
+ * - no-floating-promise: Promise handling
+ * - react-you-might-not-need-an-effect: React effect optimization
+ * - you-dont-need-lodash-underscore: Lodash alternatives
+ * - @tanstack/eslint-plugin-query: React Query rules
+ *
+ * Run oxlint first for faster feedback, then this config for remaining rules.
+ */
+// @ts-check
+import { FlatCompat } from '@eslint/eslintrc';
+import eslintReact from '@eslint-react/eslint-plugin';
+import html from '@html-eslint/eslint-plugin';
+import htmlParser from '@html-eslint/parser';
+import stylistic from '@stylistic/eslint-plugin';
+import pluginQuery from '@tanstack/eslint-plugin-query';
+import { globalIgnores } from 'eslint/config';
+import importX from 'eslint-plugin-import-x';
+import jsdoc from 'eslint-plugin-jsdoc';
+import jsxA11yX from 'eslint-plugin-jsx-a11y-x';
+import noFloatingPromise from 'eslint-plugin-no-floating-promise';
+import perfectionist from 'eslint-plugin-perfectionist';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect';
+import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+import prairielearn from '@prairielearn/eslint-plugin';
+
+const compat = new FlatCompat({ baseDirectory: import.meta.dirname });
+
+export default tseslint.config([
+  // Global ignores - same as main config
+  globalIgnores([
+    '.venv/*',
+    '.yarn/*',
+    'docs/*',
+    'node_modules/*',
+    'testCourse',
+    'exampleCourse/**/*.js',
+    'coverage/*',
+    'out/*',
+    'workspaces/*',
+    'site/*',
+    'apps/*/coverage/*',
+    'packages/*/coverage/*',
+    'apps/prairielearn/v2-question-servers/*',
+    'apps/prairielearn/public/*',
+    'apps/*/dist/*',
+    'apps/prairielearn/public/build/*',
+    'packages/*/dist/*',
+    'apps/prairielearn/src/news_items/*',
+  ]),
+
+  // HTML/Mustache linting
+  {
+    plugins: {
+      '@html-eslint': html,
+    },
+    rules: {
+      ...Object.fromEntries(
+        Object.keys(html.rules).map((value) => ['@html-eslint/' + value, 'error']),
+      ),
+      '@html-eslint/attrs-newline': 'off',
+      '@html-eslint/element-newline': 'off',
+      '@html-eslint/indent': 'off',
+      '@html-eslint/no-inline-styles': 'off',
+      '@html-eslint/no-trailing-spaces': 'off',
+      '@html-eslint/sort-attrs': 'off',
+      '@html-eslint/no-heading-inside-button': 'off',
+      '@html-eslint/require-explicit-size': 'off',
+      '@html-eslint/require-form-method': 'off',
+      '@html-eslint/require-input-label': 'off',
+      '@html-eslint/no-extra-spacing-attrs': [
+        'error',
+        {
+          disallowInAssignment: true,
+          disallowMissing: true,
+          disallowTabs: true,
+          enforceBeforeSelfClose: true,
+        },
+      ],
+      '@html-eslint/require-closing-tags': ['error', { selfClosing: 'always' }],
+      '@html-eslint/use-baseline': 'off',
+      '@html-eslint/id-naming-convention': 'off',
+      '@html-eslint/quotes': ['error', 'double', { enforceTemplatedAttrValue: true }],
+      '@html-eslint/require-button-type': 'off',
+    },
+  },
+
+  // JS/TS files - plugins that oxlint can't handle
+  // Note: We include typescript-eslint plugin (with rules disabled) to support eslint-disable comments
+  {
+    extends: [
+      // Include tseslint but we'll disable its rules - needed for eslint-disable comments
+      ...tseslint.configs.recommended,
+      ...compat.extends('plugin:you-dont-need-lodash-underscore/all'),
+    ],
+    files: ['**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}'],
+    languageOptions: {
+      globals: { ...globals.node },
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: [
+            '.dependency-cruiser.js',
+            'eslint.config.mjs',
+            'eslint.config.residual.mjs',
+            'vitest.config.ts',
+            'scripts/check-npm-packages.mjs',
+            'scripts/fix-workspace-versions-before-publish.mjs',
+            'scripts/gen-trace-sample-cookie.mjs',
+            'scripts/validate-links.mjs',
+            'apps/grader-host/vitest.config.ts',
+            'apps/prairielearn/playwright.config.ts',
+            'apps/prairielearn/vitest.config.ts',
+            'apps/prairielearn/vite.config.ts',
+            'apps/workspace-host/vitest.config.ts',
+            'packages/zod/vitest.config.ts',
+            'packages/eslint-plugin-prairielearn/vitest.config.ts',
+            'packages/ui/vitest.config.ts',
+            'packages/migrations/vitest.config.ts',
+            'packages/config/vitest.config.ts',
+            'packages/opentelemetry/vitest.config.ts',
+            'packages/sanitize/vitest.config.ts',
+            'packages/markdown/vitest.config.ts',
+            'packages/html-ejs/vitest.config.ts',
+            'packages/docker-utils/vitest.config.ts',
+            'packages/utils/vitest.config.ts',
+            'packages/html/vitest.config.ts',
+            'packages/flash/vitest.config.ts',
+            'packages/formatter/vitest.config.ts',
+            'packages/postgres/vitest.config.ts',
+            'packages/marked-mathjax/vitest.config.ts',
+            'packages/csv/vitest.config.ts',
+            'packages/path-utils/vitest.config.ts',
+            'packages/express-list-endpoints/vitest.config.ts',
+            'packages/run/vitest.config.ts',
+            'packages/compiled-assets/vitest.config.ts',
+            'packages/error/vitest.config.ts',
+            'packages/session/vitest.config.ts',
+          ],
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 50,
+        },
+      },
+    },
+    plugins: {
+      ...eslintReact.configs['recommended-typescript'].plugins,
+      '@prairielearn': prairielearn,
+      '@stylistic': stylistic,
+      '@tanstack/query': pluginQuery,
+      'import-x': importX,
+      jsdoc,
+      'jsx-a11y-x': jsxA11yX,
+      'no-floating-promise': noFloatingPromise,
+      perfectionist,
+      'react-hooks': reactHooks,
+      'react-you-might-not-need-an-effect': reactYouMightNotNeedAnEffect,
+      unicorn: eslintPluginUnicorn,
+    },
+    rules: {
+      // Disable all @typescript-eslint rules - they're handled by oxlint
+      // We include the plugin only to support eslint-disable comments in code
+      ...Object.fromEntries(
+        Object.keys(tseslint.configs.recommended[2]?.rules || {}).map((rule) => [rule, 'off']),
+      ),
+      ...Object.fromEntries(
+        Object.keys(tseslint.configs.strict[3]?.rules || {}).map((rule) => [rule, 'off']),
+      ),
+      ...Object.fromEntries(
+        Object.keys(tseslint.configs.stylistic[3]?.rules || {}).map((rule) => [rule, 'off']),
+      ),
+
+      // Disable all unicorn rules - they're handled by oxlint
+      // We include the plugin only to support eslint-disable comments in code
+      ...Object.fromEntries(
+        Object.keys(eslintPluginUnicorn.rules || {}).map((rule) => [`unicorn/${rule}`, 'off']),
+      ),
+
+      // Disable all jsdoc rules - they're handled by oxlint
+      // We include the plugin only to support eslint-disable comments in code
+      ...Object.fromEntries(
+        Object.keys(jsdoc.rules || {}).map((rule) => [`jsdoc/${rule}`, 'off']),
+      ),
+
+      // Disable all import-x rules - they're handled by oxlint
+      // We include the plugin only to support eslint-disable comments in code
+      ...Object.fromEntries(
+        Object.keys(importX.rules || {}).map((rule) => [`import-x/${rule}`, 'off']),
+      ),
+
+      // no-floating-promise
+      'no-floating-promise/no-floating-promise': 'error',
+
+      // react-hooks
+      'react-hooks/exhaustive-deps': 'error',
+      'react-hooks/rules-of-hooks': 'error',
+
+      // react-you-might-not-need-an-effect
+      'react-you-might-not-need-an-effect/no-adjust-state-on-prop-change': 'error',
+      'react-you-might-not-need-an-effect/no-chain-state-updates': 'error',
+      'react-you-might-not-need-an-effect/no-derived-state': 'error',
+      'react-you-might-not-need-an-effect/no-empty-effect': 'error',
+      'react-you-might-not-need-an-effect/no-event-handler': 'error',
+      'react-you-might-not-need-an-effect/no-initialize-state': 'error',
+      'react-you-might-not-need-an-effect/no-pass-data-to-parent': 'error',
+      'react-you-might-not-need-an-effect/no-pass-live-state-to-parent': 'error',
+      'react-you-might-not-need-an-effect/no-pass-ref-to-parent': 'error',
+      'react-you-might-not-need-an-effect/no-reset-all-state-on-prop-change': 'error',
+
+      // @eslint-react
+      ...eslintReact.configs['recommended-typescript'].rules,
+      '@eslint-react/dom/no-string-style-prop': 'off',
+      '@eslint-react/dom/no-unknown-property': 'off',
+      '@eslint-react/jsx-no-undef': 'off',
+      '@eslint-react/jsx-uses-react': 'off',
+      '@eslint-react/jsx-uses-vars': 'off',
+      '@eslint-react/naming-convention/use-state': 'off',
+      '@eslint-react/no-forbidden-props': ['error', { forbid: ['/_/'] }],
+
+      // jsx-a11y-x (strict config)
+      ...jsxA11yX.flatConfigs.strict.rules,
+      'jsx-a11y-x/control-has-associated-label': [
+        'off',
+        {
+          ignoreElements: ['audio', 'canvas', 'embed', 'input', 'textarea', 'tr', 'video'],
+          ignoreRoles: [
+            'grid',
+            'listbox',
+            'menu',
+            'menubar',
+            'radiogroup',
+            'row',
+            'tablist',
+            'toolbar',
+            'tree',
+            'treegrid',
+          ],
+          includeRoles: ['alert', 'dialog'],
+        },
+      ],
+      'jsx-a11y-x/no-noninteractive-element-interactions': [
+        'error',
+        {
+          body: ['onError', 'onLoad'],
+          iframe: ['onError', 'onLoad'],
+          img: ['onError', 'onLoad'],
+        },
+      ],
+
+      // @stylistic rules
+      '@stylistic/jsx-curly-brace-presence': [
+        'error',
+        { children: 'never', propElementValues: 'always', props: 'never' },
+      ],
+      '@stylistic/jsx-self-closing-comp': ['error', { component: true, html: true }],
+      '@stylistic/jsx-tag-spacing': [
+        'error',
+        {
+          afterOpening: 'never',
+          beforeClosing: 'allow',
+          beforeSelfClosing: 'always',
+          closingSlash: 'never',
+        },
+      ],
+      '@stylistic/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+      '@stylistic/no-tabs': 'error',
+      '@stylistic/padding-line-between-statements': [
+        'error',
+        { blankLine: 'always', next: 'function', prev: '*' },
+        { blankLine: 'always', next: '*', prev: 'import' },
+        { blankLine: 'any', next: 'import', prev: 'import' },
+      ],
+      '@stylistic/quotes': ['error', 'single', { avoidEscape: true }],
+
+      // @prairielearn rules (safe-db-types uses TypeScript APIs not supported in oxlint JS plugins)
+      '@prairielearn/safe-db-types': [
+        'error',
+        { allowDbTypes: ['SprocUsersGetDisplayedRoleSchema'] },
+      ],
+
+      // perfectionist - sorting rules
+      'perfectionist/sort-jsx-props': [
+        'error',
+        {
+          customGroups: [
+            { elementNamePattern: '^on[A-Z]', groupName: 'callback' },
+            { elementNamePattern: '^(key|ref)$', groupName: 'reserved' },
+          ],
+          groups: ['reserved', 'unknown', 'shorthand-prop', 'callback'],
+          ignoreCase: true,
+          type: 'unsorted',
+        },
+      ],
+
+      // @tanstack/query
+      '@tanstack/query/exhaustive-deps': 'error',
+      '@tanstack/query/infinite-query-property-order': 'error',
+      '@tanstack/query/mutation-property-order': 'error',
+      '@tanstack/query/no-rest-destructuring': 'error',
+      '@tanstack/query/no-unstable-deps': 'error',
+      '@tanstack/query/no-void-query-fn': 'error',
+      '@tanstack/query/stable-query-client': 'error',
+
+      // Disable lodash rules that we allow
+      'you-dont-need-lodash-underscore/omit': 'off',
+    },
+  },
+
+  // HTML files
+  {
+    files: ['**/*.html'],
+    languageOptions: {
+      parser: htmlParser,
+    },
+  },
+
+  // Mustache files
+  {
+    files: ['**/*.mustache'],
+    languageOptions: {
+      parser: htmlParser,
+    },
+    rules: {
+      '@html-eslint/no-duplicate-attrs': 'off',
+      '@html-eslint/no-duplicate-id': 'off',
+      '@html-eslint/no-extra-spacing-attrs': 'off',
+      '@html-eslint/no-nested-interactive': 'off',
+      '@html-eslint/require-closing-tags': 'off',
+      '@html-eslint/require-img-alt': 'off',
+    },
+  },
+
+  // Browser scripts - disable type-aware linting (these aren't in tsconfig)
+  {
+    files: ['apps/prairielearn/assets/scripts/**/*', 'apps/prairielearn/elements/**/*.js'],
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.jquery },
+      parserOptions: {
+        projectService: false,
+      },
+    },
+    rules: {
+      // Disable type-aware rules for browser scripts
+      '@prairielearn/safe-db-types': 'off',
+      'no-floating-promise/no-floating-promise': 'off',
+    },
+  },
+]);

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "linkinator": "^7.5.3",
     "markdownlint-cli": "^0.47.0",
     "oxlint": "^1.39.0",
+    "oxlint-tsgolint": "^0.11.1",
     "prettier": "3.8.0",
     "prettier-plugin-pkg": "^0.21.2",
     "prettier-plugin-sh": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "htmlhint": "^1.8.0",
     "linkinator": "^7.5.3",
     "markdownlint-cli": "^0.47.0",
+    "oxlint": "^1.39.0",
     "prettier": "3.8.0",
     "prettier-plugin-pkg": "^0.21.2",
     "prettier-plugin-sh": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-plugin-jsdoc": "^62.0.0",
     "eslint-plugin-jsx-a11y-x": "^0.1.1",
     "eslint-plugin-no-floating-promise": "^2.0.0",
+    "eslint-plugin-oxlint": "^1.39.0",
     "eslint-plugin-perfectionist": "^5.3.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-you-might-not-need-an-effect": "^0.8.5",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -69,7 +69,7 @@ export function makeSecretsManagerConfigSource(tagKey: string): ConfigSource {
       // configs between clients in this case. We only want to share configs
       // to avoid spamming the IMDS API when creating lots of clients, but
       // this client will only be used once, typically at application startup.
-      // eslint-disable-next-line @prairielearn/aws-client-shared-config
+      // oxlint-disable-next-line @prairielearn/aws-client-shared-config
       const ec2Client = new EC2Client({ region: identity.region });
       const tags = await ec2Client.send(
         new DescribeTagsCommand({
@@ -81,7 +81,7 @@ export function makeSecretsManagerConfigSource(tagKey: string): ConfigSource {
       if (!secretId) return {};
 
       // As above, we don't care about sharing configs between clients.
-      // eslint-disable-next-line @prairielearn/aws-client-shared-config
+      // oxlint-disable-next-line @prairielearn/aws-client-shared-config
       const secretsManagerClient = new SecretsManagerClient({ region: identity.region });
       const secretValue = await secretsManagerClient.send(
         new GetSecretValueCommand({ SecretId: secretId }),

--- a/packages/eslint-plugin-prairielearn/src/tests/jsx-no-dollar-interpolation.test.ts
+++ b/packages/eslint-plugin-prairielearn/src/tests/jsx-no-dollar-interpolation.test.ts
@@ -34,7 +34,7 @@ ruleTester.run('jsx-no-dollar-interpolation', rule, {
   ],
   invalid: [
     {
-      // eslint-disable-next-line no-template-curly-in-string
+      // oxlint-disable-next-line no-template-curly-in-string
       code: '<div>${message}</div>',
       errors: [
         {

--- a/packages/markdown/src/benchmark.ts
+++ b/packages/markdown/src/benchmark.ts
@@ -10,7 +10,7 @@ for (let i = 1; ; i += 1) {
     const memUsage = process.memoryUsage();
     const heapUsedMB = (memUsage.heapUsed / 1024 / 1024).toFixed(2);
     const heapTotalMB = (memUsage.heapTotal / 1024 / 1024).toFixed(2);
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.log(`${i} calls | Heap: ${heapUsedMB}/${heapTotalMB} MB`);
 
     // Yield to the event loop to allow `jsdom` to clean up its resources.

--- a/packages/node-metrics/src/index.ts
+++ b/packages/node-metrics/src/index.ts
@@ -83,7 +83,7 @@ async function emit(options: NodeMetricsOptions) {
     ] as const;
 
     // We must use a config passed in from outside this package.
-    // eslint-disable-next-line @prairielearn/aws-client-shared-config
+    // oxlint-disable-next-line @prairielearn/aws-client-shared-config
     const cloudwatch = new CloudWatch(options.awsConfig);
     await cloudwatch.putMetricData({
       Namespace: options.namespace,

--- a/packages/postgres/src/test-utils.ts
+++ b/packages/postgres/src/test-utils.ts
@@ -116,7 +116,7 @@ async function dropDatabase(
 
   const databaseName = database ?? getDatabaseNameForCurrentTestWorker(options.database);
   if ('PL_KEEP_TEST_DB' in process.env && !force) {
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.log(`PL_KEEP_TEST_DB environment variable set, not dropping database ${databaseName}`);
     return;
   }

--- a/packages/sentry/src/express.ts
+++ b/packages/sentry/src/express.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jsdoc/check-param-names */
+/* oxlint-disable jsdoc/check-param-names */
 // This is a fork of Sentry's Express integration from `@sentry/node`that's not
 // available in the `@sentry/node-core` package`. It has been lightly modified
 // to remove unused code and conform to PrairieLearn's coding style.

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { type SessionStore } from './store.js';
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
+  // oxlint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       session: Session;

--- a/packages/ui/src/components/ColumnManager.tsx
+++ b/packages/ui/src/components/ColumnManager.tsx
@@ -293,7 +293,7 @@ export function ColumnManager<RowDataModel>({
     // When we use the pin or reset button, we want to refocus to another element.
     // We want this in a useEffect so that this code runs after the component re-renders.
 
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
+    // oxlint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (activeElementId) {
       document.getElementById(activeElementId)?.focus();
     }

--- a/packages/ui/src/components/OverlayTrigger.tsx
+++ b/packages/ui/src/components/OverlayTrigger.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import {
-  // eslint-disable-next-line no-restricted-imports
+  // oxlint-disable-next-line no-restricted-imports
   OverlayTrigger as BootstrapOverlayTrigger,
   type OverlayTriggerProps as BootstrapOverlayTriggerProps,
   Popover,

--- a/packages/ui/src/components/TanstackTable.tsx
+++ b/packages/ui/src/components/TanstackTable.tsx
@@ -255,7 +255,7 @@ export function TanstackTable<RowDataModel>({
   useEffect(() => {
     if (hasAutoSized) {
       // https://github.com/NickvanDyke/eslint-plugin-react-you-might-not-need-an-effect/issues/58
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-ref-to-parent
+      // oxlint-disable-next-line react-you-might-not-need-an-effect/no-pass-ref-to-parent
       columnVirtualizer.measure();
     }
   }, [columnVirtualizer, hasAutoSized]);

--- a/packages/ui/src/components/TanstackTableHeaderCell.tsx
+++ b/packages/ui/src/components/TanstackTableHeaderCell.tsx
@@ -63,7 +63,7 @@ function ResizeHandle<RowDataModel>({
         aria-valuemin={minSize}
         aria-valuemax={maxSize}
         aria-valuenow={header.getSize()}
-        // eslint-disable-next-line jsx-a11y-x/no-noninteractive-tabindex
+        // oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
         className="h-100"
         style={{

--- a/packages/ui/src/react-table.ts
+++ b/packages/ui/src/react-table.ts
@@ -2,7 +2,7 @@ import type { RowData } from '@tanstack/react-table';
 
 declare module '@tanstack/react-table' {
   // https://tanstack.com/table/latest/docs/api/core/column-def#meta
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // oxlint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     /** If true, the column will wrap text instead of being truncated. */
     wrapText?: boolean;
@@ -13,5 +13,5 @@ declare module '@tanstack/react-table' {
   }
 }
 
-// eslint-disable-next-line unicorn/require-module-specifiers
+// oxlint-disable-next-line unicorn/require-module-specifiers
 export {};

--- a/packages/vite-plugin-express/src/index.ts
+++ b/packages/vite-plugin-express/src/index.ts
@@ -43,7 +43,7 @@ async function getPluginConfig(server: ViteDevServer): Promise<VitePluginExpress
   const plugin = server.config.plugins.find((p) => p.name === PLUGIN_NAME) as unknown as {
     config: (...args: any[]) => UserConfig & { VitePluginExpressConfig: VitePluginExpressConfig };
   };
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  // oxlint-disable-next-line @typescript-eslint/no-invalid-void-type
   let userConfig: UserConfig | null | void = null;
 
   if (typeof plugin.config === 'function') {
@@ -100,7 +100,7 @@ async function createMiddleware(server: ViteDevServer): Promise<Connect.HandleFu
       logger.error(`Failed to find a named ${config.exportName} from ${config.appPath}`, {
         timestamp: true,
       });
-      // eslint-disable-next-line unicorn/no-process-exit
+      // oxlint-disable-next-line unicorn/no-process-exit
       process.exit(1);
     }
     return app;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,6 +3718,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxlint-tsgolint/darwin-arm64@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@oxlint-tsgolint/darwin-arm64@npm:0.11.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/darwin-x64@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@oxlint-tsgolint/darwin-x64@npm:0.11.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/linux-arm64@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@oxlint-tsgolint/linux-arm64@npm:0.11.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/linux-x64@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@oxlint-tsgolint/linux-x64@npm:0.11.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/win32-arm64@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@oxlint-tsgolint/win32-arm64@npm:0.11.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/win32-x64@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@oxlint-tsgolint/win32-x64@npm:0.11.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@oxlint/darwin-arm64@npm:1.39.0":
   version: 1.39.0
   resolution: "@oxlint/darwin-arm64@npm:1.39.0"
@@ -15427,6 +15469,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxlint-tsgolint@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "oxlint-tsgolint@npm:0.11.1"
+  dependencies:
+    "@oxlint-tsgolint/darwin-arm64": "npm:0.11.1"
+    "@oxlint-tsgolint/darwin-x64": "npm:0.11.1"
+    "@oxlint-tsgolint/linux-arm64": "npm:0.11.1"
+    "@oxlint-tsgolint/linux-x64": "npm:0.11.1"
+    "@oxlint-tsgolint/win32-arm64": "npm:0.11.1"
+    "@oxlint-tsgolint/win32-x64": "npm:0.11.1"
+  dependenciesMeta:
+    "@oxlint-tsgolint/darwin-arm64":
+      optional: true
+    "@oxlint-tsgolint/darwin-x64":
+      optional: true
+    "@oxlint-tsgolint/linux-arm64":
+      optional: true
+    "@oxlint-tsgolint/linux-x64":
+      optional: true
+    "@oxlint-tsgolint/win32-arm64":
+      optional: true
+    "@oxlint-tsgolint/win32-x64":
+      optional: true
+  bin:
+    tsgolint: bin/tsgolint.js
+  checksum: 10c0/d12f35a6953eed4849a4f4957503a86a64db449547bf7b960b8fed9f00912ec19507a954a9d868f265aa5203cdedea73d921925fce65eceac7b60c93c229a75c
+  languageName: node
+  linkType: hard
+
 "oxlint@npm:^1.39.0":
   version: 1.39.0
   resolution: "oxlint@npm:1.39.0"
@@ -16108,6 +16179,7 @@ __metadata:
     markdownlint-cli: "npm:^0.47.0"
     node-gyp: "npm:^12.1.0"
     oxlint: "npm:^1.39.0"
+    oxlint-tsgolint: "npm:^0.11.1"
     prettier: "npm:3.8.0"
     prettier-plugin-pkg: "npm:^0.21.2"
     prettier-plugin-sh: "npm:^0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11080,6 +11080,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-oxlint@npm:^1.39.0":
+  version: 1.39.0
+  resolution: "eslint-plugin-oxlint@npm:1.39.0"
+  dependencies:
+    jsonc-parser: "npm:^3.3.1"
+  checksum: 10c0/ce4bccb57cffb0c7209fd7adf616576cac5a6e94cae788f5a52cbba012dee8b0356fbb1ac28532e94824f00f6c57c9d95e550eb9fae2df40ad82677f8d5e8940
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-perfectionist@npm:^5.3.1":
   version: 5.3.1
   resolution: "eslint-plugin-perfectionist@npm:5.3.1"
@@ -13399,7 +13408,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:~3.3.1":
+"jsonc-parser@npm:^3.3.1, jsonc-parser@npm:~3.3.1":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10c0/269c3ae0a0e4f907a914bf334306c384aabb9929bd8c99f909275ebd5c2d3bc70b9bcd119ad794f339dec9f24b6a4ee9cd5a8ab2e6435e730ad4075388fc2ab6
@@ -16167,6 +16176,7 @@ __metadata:
     eslint-plugin-jsdoc: "npm:^62.0.0"
     eslint-plugin-jsx-a11y-x: "npm:^0.1.1"
     eslint-plugin-no-floating-promise: "npm:^2.0.0"
+    eslint-plugin-oxlint: "npm:^1.39.0"
     eslint-plugin-perfectionist: "npm:^5.3.1"
     eslint-plugin-react-hooks: "npm:^7.0.1"
     eslint-plugin-react-you-might-not-need-an-effect: "npm:^0.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,64 +71,64 @@ __metadata:
   linkType: hard
 
 "@ai-sdk/anthropic@npm:^3.0.13":
-  version: 3.0.13
-  resolution: "@ai-sdk/anthropic@npm:3.0.13"
+  version: 3.0.14
+  resolution: "@ai-sdk/anthropic@npm:3.0.14"
   dependencies:
     "@ai-sdk/provider": "npm:3.0.3"
-    "@ai-sdk/provider-utils": "npm:4.0.6"
+    "@ai-sdk/provider-utils": "npm:4.0.7"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/ab6ea401ef3c79728dd91345cb6cf3524c4e273beb47277cc52c0e283e8247f0998210cb8de1638ece6e0397fceb3206d07ea96591b437cd77448710be8dfa7b
+  checksum: 10c0/104b8c48ace183db680ddc9b717e1ea8d2a1676a8bc0bd3c91c360e7b630d7234bb23f380940ca679cf513cd985eca604570b414a2c6f17f38544b14ca872180
   languageName: node
   linkType: hard
 
-"@ai-sdk/gateway@npm:3.0.14":
-  version: 3.0.14
-  resolution: "@ai-sdk/gateway@npm:3.0.14"
+"@ai-sdk/gateway@npm:3.0.15":
+  version: 3.0.15
+  resolution: "@ai-sdk/gateway@npm:3.0.15"
   dependencies:
     "@ai-sdk/provider": "npm:3.0.3"
-    "@ai-sdk/provider-utils": "npm:4.0.6"
+    "@ai-sdk/provider-utils": "npm:4.0.7"
     "@vercel/oidc": "npm:3.1.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/8a52face570a809f96572bb0fdbcb81bde0905d89c1b0e54856bd1b57d78d236d274c83ad962e5d5197115af063966e6e9cdb3fc6246629efd5a838b3324e27f
+  checksum: 10c0/a0cc78d6609b2fa15d025c5e84acae2555893f549ead6fd96c1f19e456af3f0ceb410bbad45faed827a7792818f13a54b8afd5ea28c48ae54e42e5833b73f351
   languageName: node
   linkType: hard
 
 "@ai-sdk/google@npm:^3.0.8":
-  version: 3.0.8
-  resolution: "@ai-sdk/google@npm:3.0.8"
+  version: 3.0.9
+  resolution: "@ai-sdk/google@npm:3.0.9"
   dependencies:
     "@ai-sdk/provider": "npm:3.0.3"
-    "@ai-sdk/provider-utils": "npm:4.0.6"
+    "@ai-sdk/provider-utils": "npm:4.0.7"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/d2050b9e12668091ad1f78b514969a50d67ac3a72d3133913487d492ed7d95cd45bde2e4f0b9cfec9afe084ad39ea1c2d7cc7f067f003798eea891a2e738bfc2
+  checksum: 10c0/3042c6dbbdf67730566b566beb04d800a023157960b2b0fb2dc4ed50811601fd3601ac3d74a74d5c5293441a8ff26cac311039adc611168a6d4f15dc2d7a5da2
   languageName: node
   linkType: hard
 
 "@ai-sdk/openai@npm:^3.0.10":
-  version: 3.0.10
-  resolution: "@ai-sdk/openai@npm:3.0.10"
+  version: 3.0.11
+  resolution: "@ai-sdk/openai@npm:3.0.11"
   dependencies:
     "@ai-sdk/provider": "npm:3.0.3"
-    "@ai-sdk/provider-utils": "npm:4.0.6"
+    "@ai-sdk/provider-utils": "npm:4.0.7"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/5708aaac9a94836904e7a72476fcdbf6c16d45c9661c3e613fd98f31431fe79ece10dc85d63f8ae237ef5b5523c12d7258b28029e3b63d5339af769029d5843d
+  checksum: 10c0/012518df2e573a0fc1e6729e43de02e0b8c50042cdcdf1792e2c91a48ba32f3506b9af1c3e42254aade291a74fc47ed1f082bf20e98571b835412ba65fa20920
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:4.0.6":
-  version: 4.0.6
-  resolution: "@ai-sdk/provider-utils@npm:4.0.6"
+"@ai-sdk/provider-utils@npm:4.0.7":
+  version: 4.0.7
+  resolution: "@ai-sdk/provider-utils@npm:4.0.7"
   dependencies:
     "@ai-sdk/provider": "npm:3.0.3"
     "@standard-schema/spec": "npm:^1.1.0"
     eventsource-parser: "npm:^3.0.6"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/53d8f8315425f3589c5a0e8eaffb136b23ef521dcf8ff07fa052c6e2771b53bf25ef4e0573fb07efeb58c25fd6630d6a970bc2e6e82be52326a69b386e08ea07
+  checksum: 10c0/d32b98c4e3b83cff78d72a87d92359d3a9113dfb4ca320db937f74a6f3b282da69be74c4fba5ce9849b1b0cd658d4edd952f8a576c21b8a869ea8fdb2bba486a
   languageName: node
   linkType: hard
 
@@ -1218,13 +1218,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.969.0, @aws-sdk/types@npm:^3.222.0":
+"@aws-sdk/types@npm:3.969.0":
   version: 3.969.0
   resolution: "@aws-sdk/types@npm:3.969.0"
   dependencies:
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/cee8b3b7b1ffab838f44c9dae9565e23dc411e235ab5bf3b1e059b06e36b8f34573813f08959b10772d32d1277239db71f0daab2e04aeed92d1e27c1d6c1ae23
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0":
+  version: 3.965.0
+  resolution: "@aws-sdk/types@npm:3.965.0"
+  dependencies:
+    "@smithy/types": "npm:^4.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/59ee62046aef9ba74ccafcd3e28293075b085a99b5814af4a7539a05a81bb922abe9dbb2d08cecf789724ae4c65034ca6acf604e1fa915515438926db3a279e9
   languageName: node
   linkType: hard
 
@@ -3154,7 +3164,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:2.4.0, @opentelemetry/core@npm:^2.0.0, @opentelemetry/core@npm:^2.4.0":
+"@opentelemetry/core@npm:2.3.0, @opentelemetry/core@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@opentelemetry/core@npm:2.3.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/351e35444f3896fabb9c50e2742998119b19d53b683f1ce32381b241884c34bafac64f2e232aa0875a489ad903199032c02f088272cee5ec17eb9fc9806eb819
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:2.4.0, @opentelemetry/core@npm:^2.4.0":
   version: 2.4.0
   resolution: "@opentelemetry/core@npm:2.4.0"
   dependencies:
@@ -3554,7 +3575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:2.4.0, @opentelemetry/resources@npm:^2.0.0, @opentelemetry/resources@npm:^2.4.0":
+"@opentelemetry/resources@npm:2.4.0, @opentelemetry/resources@npm:^2.4.0":
   version: 2.4.0
   resolution: "@opentelemetry/resources@npm:2.4.0"
   dependencies:
@@ -3563,6 +3584,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10c0/891aa96804b88bdf9448da83c3a06f8747c9374d2a9ea8dd4291ba13528adea71e0d12c2d480ac6b6c6bf928718c8f3775183385e48af32ff27c5085a641179a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@opentelemetry/resources@npm:2.3.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.3.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/e46bc6c2465dcc669b289b297267bd115a5e9332d40a0f64c87b9e7d344852d275c9f06abcfaec03b0d5819cfb5708ff485b2f28d775cdc0a890f1545e6141e0
   languageName: node
   linkType: hard
 
@@ -3682,6 +3715,62 @@ __metadata:
   version: 1.1.2
   resolution: "@orchidjs/unicode-variants@npm:1.1.2"
   checksum: 10c0/7836e0766641d79a0337a2a8ca7f49051bb71e19e0e8fc64cdbafac4f2f718abd368b364ad79a9b13547a70e24cebb3cc4d71e75f22791ade8ba80654eb1323f
+  languageName: node
+  linkType: hard
+
+"@oxlint/darwin-arm64@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/darwin-arm64@npm:1.39.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/darwin-x64@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/darwin-x64@npm:1.39.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint/linux-arm64-gnu@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/linux-arm64-gnu@npm:1.39.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/linux-arm64-musl@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/linux-arm64-musl@npm:1.39.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/linux-x64-gnu@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/linux-x64-gnu@npm:1.39.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxlint/linux-x64-musl@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/linux-x64-musl@npm:1.39.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxlint/win32-arm64@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/win32-arm64@npm:1.39.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint/win32-x64@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@oxlint/win32-x64@npm:1.39.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5325,9 +5414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/core@npm:^3.20.5":
-  version: 3.20.5
-  resolution: "@smithy/core@npm:3.20.5"
+"@smithy/core@npm:^3.20.5, @smithy/core@npm:^3.20.6":
+  version: 3.20.6
+  resolution: "@smithy/core@npm:3.20.6"
   dependencies:
     "@smithy/middleware-serde": "npm:^4.2.9"
     "@smithy/protocol-http": "npm:^5.3.8"
@@ -5339,7 +5428,7 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.2.0"
     "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/f28bb670dfb929ddefb0d431ed86488a4ac9d2abbf1fce6fb60d41dccb504767e41b2a655c7da1b62f0dfaafe6f4388bdaabe6e07e60952a77e46de4cf10000c
+  checksum: 10c0/0ee2ffae99945881fd8dfa9003f0dce851f7a60aebc3ac3288f01f20be0b8d116b9de14b93f8f58a1d6bf96f82bb490998d65191bbbf14d52412ff88eba6aea2
   languageName: node
   linkType: hard
 
@@ -5499,10 +5588,10 @@ __metadata:
   linkType: hard
 
 "@smithy/middleware-compression@npm:^4.3.21":
-  version: 4.3.21
-  resolution: "@smithy/middleware-compression@npm:4.3.21"
+  version: 4.3.22
+  resolution: "@smithy/middleware-compression@npm:4.3.22"
   dependencies:
-    "@smithy/core": "npm:^3.20.5"
+    "@smithy/core": "npm:^3.20.6"
     "@smithy/is-array-buffer": "npm:^4.2.0"
     "@smithy/node-config-provider": "npm:^4.3.8"
     "@smithy/protocol-http": "npm:^5.3.8"
@@ -5512,7 +5601,7 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.2.0"
     fflate: "npm:0.8.1"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/d971d9ceb8a50c8bd132d55f4288223fadd59091a27e571f2fb78ec052738b1df46afd7926012f80b3702944f9d1097dc204dcb0d20c2faf2b245edc9d3b7e90
+  checksum: 10c0/968dc74222e1e301950fa638633914b7ae433cdfb25fc643c24099897bdc62d449ef8ff546c62cec273f96538864be88113b1bcfc78a93e2f34a24131728d022
   languageName: node
   linkType: hard
 
@@ -5527,11 +5616,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/middleware-endpoint@npm:^4.4.6":
-  version: 4.4.6
-  resolution: "@smithy/middleware-endpoint@npm:4.4.6"
+"@smithy/middleware-endpoint@npm:^4.4.6, @smithy/middleware-endpoint@npm:^4.4.7":
+  version: 4.4.7
+  resolution: "@smithy/middleware-endpoint@npm:4.4.7"
   dependencies:
-    "@smithy/core": "npm:^3.20.5"
+    "@smithy/core": "npm:^3.20.6"
     "@smithy/middleware-serde": "npm:^4.2.9"
     "@smithy/node-config-provider": "npm:^4.3.8"
     "@smithy/shared-ini-file-loader": "npm:^4.4.3"
@@ -5539,24 +5628,24 @@ __metadata:
     "@smithy/url-parser": "npm:^4.2.8"
     "@smithy/util-middleware": "npm:^4.2.8"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/a410bfa75ca80af24ddd28b1e726d8177181f288cdf7020539ef54b7d8249299e1ed7ca0063228a1d0c65b2aea6b13b9c66d526a1b49a81b9347e50d7bc40f56
+  checksum: 10c0/448f97a7e243f7bc5158f8f9a5ac58c14a23036ee3b4a46c53730ffb81be16dae501002f4b4f557c4f78a9ab0dbe9a390ab22adbb0464288443b2e473350f5b6
   languageName: node
   linkType: hard
 
 "@smithy/middleware-retry@npm:^4.4.22":
-  version: 4.4.22
-  resolution: "@smithy/middleware-retry@npm:4.4.22"
+  version: 4.4.23
+  resolution: "@smithy/middleware-retry@npm:4.4.23"
   dependencies:
     "@smithy/node-config-provider": "npm:^4.3.8"
     "@smithy/protocol-http": "npm:^5.3.8"
     "@smithy/service-error-classification": "npm:^4.2.8"
-    "@smithy/smithy-client": "npm:^4.10.7"
+    "@smithy/smithy-client": "npm:^4.10.8"
     "@smithy/types": "npm:^4.12.0"
     "@smithy/util-middleware": "npm:^4.2.8"
     "@smithy/util-retry": "npm:^4.2.8"
     "@smithy/uuid": "npm:^1.1.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/dca12c09f26332c7728c16ad06665cb8856d4a97a68c3ade2fe1f17c0cb4349d21a14806d10398ee2c4e3f5dd0423ccc8e9f378cdd302f1c10a3412321ed4ebd
+  checksum: 10c0/43ae7f279bb0af7e75bcac8147957c7cf679e275c17fe36e1605a742c307d8a3398457bac3fb3a902ced2a7946b158bd54758e78ab0402b10595f3bbe441614d
   languageName: node
   linkType: hard
 
@@ -5682,18 +5771,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/smithy-client@npm:^4.10.7":
-  version: 4.10.7
-  resolution: "@smithy/smithy-client@npm:4.10.7"
+"@smithy/smithy-client@npm:^4.10.7, @smithy/smithy-client@npm:^4.10.8":
+  version: 4.10.8
+  resolution: "@smithy/smithy-client@npm:4.10.8"
   dependencies:
-    "@smithy/core": "npm:^3.20.5"
-    "@smithy/middleware-endpoint": "npm:^4.4.6"
+    "@smithy/core": "npm:^3.20.6"
+    "@smithy/middleware-endpoint": "npm:^4.4.7"
     "@smithy/middleware-stack": "npm:^4.2.8"
     "@smithy/protocol-http": "npm:^5.3.8"
     "@smithy/types": "npm:^4.12.0"
     "@smithy/util-stream": "npm:^4.5.10"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/50f32b4f2888b15122c91a88fe2ea8117e9639b286bc510807badbc7ada5f3a65e019028e5eae01f4c775580c8af04a6b32f997c5cd7cd3e5ba17ca59cd0e5d3
+  checksum: 10c0/2b96d61bafd7da4ac2657d909b12e3ca0664880ebd1a46961df75097ea1535cfe60a1dc188d9bdd2ed878be28fe2a894db951031e847ae751de8e717bf13f5bc
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.11.0":
+  version: 4.11.0
+  resolution: "@smithy/types@npm:4.11.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/8be4af86df4a78fe43afe7dc3f875bf8ec6ce7c04f7bb167152bf3c7ab2eef26db38ed7ae365c2f283e8796e40372b01b4c857b8db43da393002c5638ef3f249
   languageName: node
   linkType: hard
 
@@ -5776,29 +5874,29 @@ __metadata:
   linkType: hard
 
 "@smithy/util-defaults-mode-browser@npm:^4.3.21":
-  version: 4.3.21
-  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.21"
+  version: 4.3.22
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.3.22"
   dependencies:
     "@smithy/property-provider": "npm:^4.2.8"
-    "@smithy/smithy-client": "npm:^4.10.7"
+    "@smithy/smithy-client": "npm:^4.10.8"
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/88a0223df5ddc18b50148eca09f96fa319f03b58530c1e952378be15495ada41fd1259e394e06a81089c36e41fe86592b65d9a811b0ac5e3dfb0fcfcde987445
+  checksum: 10c0/e0e7d7e3995607913c90465056d9f880631f1e881d8a0db929d8bbc8807bd4f6a9a921af2d4fdd6a8a53fc1c65cad7698dffafeaaeb80b1adf0365d3246ab4a0
   languageName: node
   linkType: hard
 
 "@smithy/util-defaults-mode-node@npm:^4.2.24":
-  version: 4.2.24
-  resolution: "@smithy/util-defaults-mode-node@npm:4.2.24"
+  version: 4.2.25
+  resolution: "@smithy/util-defaults-mode-node@npm:4.2.25"
   dependencies:
     "@smithy/config-resolver": "npm:^4.4.6"
     "@smithy/credential-provider-imds": "npm:^4.2.8"
     "@smithy/node-config-provider": "npm:^4.3.8"
     "@smithy/property-provider": "npm:^4.2.8"
-    "@smithy/smithy-client": "npm:^4.10.7"
+    "@smithy/smithy-client": "npm:^4.10.8"
     "@smithy/types": "npm:^4.12.0"
     tslib: "npm:^2.6.2"
-  checksum: 10c0/ff5a82a2cc5edc5aaf02aed95c2b4c22e16ef721dfdfdb5e41ead421f21ef4dc0749e768bc3fd168071f3b5af78fb887a0ca0eef5311a456b8970632846533d4
+  checksum: 10c0/958ff2decd165f5146e16909a9ceedd1b08298dfafc5a994194d6bd2e996157c367f419d9940ff1514eb91fb0ab6e8e050e7236162f4ff5dd3d1ce75c62343d6
   languageName: node
   linkType: hard
 
@@ -7149,12 +7247,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:>=13.7.0, @types/node@npm:^22.19.6":
-  version: 22.19.6
-  resolution: "@types/node@npm:22.19.6"
+"@types/node@npm:*, @types/node@npm:>=10.0.0, @types/node@npm:>=13.7.0":
+  version: 22.19.5
+  resolution: "@types/node@npm:22.19.5"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/0d4f305ee560e4261b3aefb186d9a42c0a07d2ab2201cc8cba24b72793a13c3b2a5f0c138fe704e9aaa7a545066d6baf0b98afc1ef7e776503af25cdfd040de0
+  checksum: 10c0/753c86850d2e3d9a7ccaa2569d565ab20d9a69389871e45283f71035c62fed649511aee7e05da8209b41e15438085c43b533d01e9ed3bb2e9dbd570aef732354
   languageName: node
   linkType: hard
 
@@ -7162,6 +7260,15 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.19.6":
+  version: 22.19.6
+  resolution: "@types/node@npm:22.19.6"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/0d4f305ee560e4261b3aefb186d9a42c0a07d2ab2201cc8cba24b72793a13c3b2a5f0c138fe704e9aaa7a545066d6baf0b98afc1ef7e776503af25cdfd040de0
   languageName: node
   linkType: hard
 
@@ -8203,16 +8310,16 @@ __metadata:
   linkType: hard
 
 "ai@npm:^6.0.35":
-  version: 6.0.35
-  resolution: "ai@npm:6.0.35"
+  version: 6.0.37
+  resolution: "ai@npm:6.0.37"
   dependencies:
-    "@ai-sdk/gateway": "npm:3.0.14"
+    "@ai-sdk/gateway": "npm:3.0.15"
     "@ai-sdk/provider": "npm:3.0.3"
-    "@ai-sdk/provider-utils": "npm:4.0.6"
+    "@ai-sdk/provider-utils": "npm:4.0.7"
     "@opentelemetry/api": "npm:1.9.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/2bb13b427c26869874787052cb47087fb57ec3d0e187c4fbc19dff8c70ff7edd490e4b1be49fd542e5cc08d00e39f37835df931ac21f45d538d8b55fdf6ba83f
+  checksum: 10c0/b9a00879ddc0eba8ba1b569d1261cf93a0fb65649be3949120a2f12249f2f1a11231f52276e883ed8ff5b96299be5df0dc34d97d642b1f09e59cc1987a4f5e25
   languageName: node
   linkType: hard
 
@@ -15320,6 +15427,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxlint@npm:^1.39.0":
+  version: 1.39.0
+  resolution: "oxlint@npm:1.39.0"
+  dependencies:
+    "@oxlint/darwin-arm64": "npm:1.39.0"
+    "@oxlint/darwin-x64": "npm:1.39.0"
+    "@oxlint/linux-arm64-gnu": "npm:1.39.0"
+    "@oxlint/linux-arm64-musl": "npm:1.39.0"
+    "@oxlint/linux-x64-gnu": "npm:1.39.0"
+    "@oxlint/linux-x64-musl": "npm:1.39.0"
+    "@oxlint/win32-arm64": "npm:1.39.0"
+    "@oxlint/win32-x64": "npm:1.39.0"
+  peerDependencies:
+    oxlint-tsgolint: ">=0.10.0"
+  dependenciesMeta:
+    "@oxlint/darwin-arm64":
+      optional: true
+    "@oxlint/darwin-x64":
+      optional: true
+    "@oxlint/linux-arm64-gnu":
+      optional: true
+    "@oxlint/linux-arm64-musl":
+      optional: true
+    "@oxlint/linux-x64-gnu":
+      optional: true
+    "@oxlint/linux-x64-musl":
+      optional: true
+    "@oxlint/win32-arm64":
+      optional: true
+    "@oxlint/win32-x64":
+      optional: true
+  peerDependenciesMeta:
+    oxlint-tsgolint:
+      optional: true
+  bin:
+    oxlint: bin/oxlint
+  checksum: 10c0/ef1e0d940332c6523228641b222d77bd67eae92185f8d82bda4feb26d0d195a62c73299896ddf87cceafb1e7089479128c0de416db05456b22c71badddfc0660
+  languageName: node
+  linkType: hard
+
 "p-filter@npm:^2.1.0":
   version: 2.1.0
   resolution: "p-filter@npm:2.1.0"
@@ -15717,11 +15864,11 @@ __metadata:
   linkType: hard
 
 "pg-cursor@npm:^2.16.0":
-  version: 2.16.0
-  resolution: "pg-cursor@npm:2.16.0"
+  version: 2.16.1
+  resolution: "pg-cursor@npm:2.16.1"
   peerDependencies:
     pg: ^8
-  checksum: 10c0/7afea584aa047835583caa2c9a60526539e87fb79f43acf72e3d3de7f9416467186b18c51fcad847818af9b436caab0c83680b6e3a5313f87fa2a3743c70a0f4
+  checksum: 10c0/5337a14d9c7ea23c9b8199f3eb4319f0bbeb2ef9f0fce82d8068b23b0f1cd04521bc1dd105d3e19a115b9ce92196f52f403e34336a109de8b4604aae84d9a09b
   languageName: node
   linkType: hard
 
@@ -15741,7 +15888,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pg-protocol@npm:*, pg-protocol@npm:^1.11.0":
+"pg-protocol@npm:*":
+  version: 1.10.3
+  resolution: "pg-protocol@npm:1.10.3"
+  checksum: 10c0/f7ef54708c93ee6d271e37678296fc5097e4337fca91a88a3d99359b78633dbdbf6e983f0adb34b7cdd261b7ec7266deb20c3233bf3dfdb498b3e1098e8750b9
+  languageName: node
+  linkType: hard
+
+"pg-protocol@npm:^1.11.0":
   version: 1.11.0
   resolution: "pg-protocol@npm:1.11.0"
   checksum: 10c0/93e83581781418c9173eba4e4545f73392cfe66b78dd1d3624d7339fbd37e7f4abebaf2615e68e0701a9bf0edf5b81a4ad533836f388f775fe25fa24a691c464
@@ -15762,8 +15916,8 @@ __metadata:
   linkType: hard
 
 "pg@npm:^8.17.0":
-  version: 8.17.0
-  resolution: "pg@npm:8.17.0"
+  version: 8.17.1
+  resolution: "pg@npm:8.17.1"
   dependencies:
     pg-cloudflare: "npm:^1.3.0"
     pg-connection-string: "npm:^2.10.0"
@@ -15779,7 +15933,7 @@ __metadata:
   peerDependenciesMeta:
     pg-native:
       optional: true
-  checksum: 10c0/3ccb9535a44fc4105edf36482a70af0e7aa56630247293b54b34468c74a46dfe62d3b20162a28b7247c2266d2cedbcf58480e2beb279f776346649783c7a9e12
+  checksum: 10c0/39a92391adfc73f793d195b4062bc2d21aa3537073e3973f3979d72901d92a59e129f31f42577ff916038a6c3f9fe423b6024717529609ae8548fda21248cfe7
   languageName: node
   linkType: hard
 
@@ -15953,6 +16107,7 @@ __metadata:
     linkinator: "npm:^7.5.3"
     markdownlint-cli: "npm:^0.47.0"
     node-gyp: "npm:^12.1.0"
+    oxlint: "npm:^1.39.0"
     prettier: "npm:3.8.0"
     prettier-plugin-pkg: "npm:^0.21.2"
     prettier-plugin-sh: "npm:^0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4577,6 +4577,7 @@ __metadata:
     "@types/express-serve-static-core": "npm:^4.19.8"
     "@types/folder-hash": "npm:^4.0.4"
     "@types/fs-extra": "npm:^11.0.4"
+    "@types/he": "npm:^1.2.3"
     "@types/jju": "npm:^1.4.5"
     "@types/jquery": "npm:^3.5.33"
     "@types/js-cookie": "npm:^3.0.6"
@@ -7065,6 +7066,13 @@ __metadata:
   version: 7946.0.14
   resolution: "@types/geojson@npm:7946.0.14"
   checksum: 10c0/54f3997708fa2970c03eeb31f7e4540a0eb6387b15e9f8a60513a1409c23cafec8d618525404573468b59c6fecbfd053724b3327f7fca416729c26271d799f55
+  languageName: node
+  linkType: hard
+
+"@types/he@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "@types/he@npm:1.2.3"
+  checksum: 10c0/562e4ec00e31e3d464e79e6da4b8a5c21999d38ceca6a8facaa96e89c2d646f410bb58bb81f48a7472aeb4655ce40d27b7d77e5a4fa5a2d9caa0f3037caab5b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR migrates PrairieLearn to use oxlint as the primary linter with a residual ESLint configuration for rules that oxlint cannot handle. Oxlint is significantly faster (~560ms on 1177 files vs several minutes for full ESLint) and includes native support for most linting rules. The residual ESLint config handles HTML/Mustache linting, stylistic rules, and the `safe-db-types` rule which requires TypeScript APIs.

Blockers:

- [x] https://github.com/oxc-project/oxc/issues/17968#issuecomment-3756139231
- [x] https://github.com/oxc-project/oxc/issues/15538

Plugins we must keep:

 - `@html-eslint`: HTML/Mustache file linting (oxlint can't parse HTML)
 - `@stylistic`: Stylistic rules (token-based, not supported by oxlint jsPlugins)
 - `perfectionist`: Sorting rules (token-based, not supported by oxlint jsPlugins)
 - `@prairielearn/safe-db-types`: Uses TypeScript type-checker APIs
 - `jsx-a11y-x/no-noninteractive-element-interactions`: Not in oxlint

## Testing

Validated that:
- Oxlint runs successfully on 1177 files in ~560ms
- Residual ESLint runs on JS/TS/HTML/Mustache files with proper configuration
- All errors found are pre-existing lint issues in the codebase, not configuration problems
- Custom @prairielearn rules work (4 via oxlint JS plugins, 1 via residual ESLint)

## AI Assistance

This PR was created with Claude Haiku 4.5 assistance. The implementation involved:
- Running the official oxlint migration tool
- Configuring oxlint with appropriate rules and custom plugin support
- Creating a residual ESLint config for unsupported rules
- Updating build pipeline to run oxlint first for speed