### PR TITLE
Fix spacing for homepage documentation link

### DIFF
--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -119,9 +119,8 @@ function DevModeCard({ isDevMode }: { isDevMode: boolean }) {
           different page or if you reload the current page in your web browser.
         </p>
         <p className="mb-0">
-          See the
-          <a href="https://prairielearn.readthedocs.io">PrairieLearn documentation</a>
-          for information on creating questions and assessments.
+          See the <a href="https://prairielearn.readthedocs.io">PrairieLearn documentation</a> for
+          information on creating questions and assessments.
         </p>
       </div>
     </div>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

When we upgraded to React, we lost our pretty printer for JSX. This now exposes some whitespace bugs, including this one.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

<img width="1064" height="156" alt="CleanShot 2026-01-16 at 16 09 01@2x" src="https://github.com/user-attachments/assets/43d0eff9-a87b-4a36-8b07-c1db34d1bd40" />

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
