### PR TITLE
Remove addVectors from 9 testCourse assessments

### DIFF
--- a/apps/prairielearn/src/tests/activeAccessRestriction.test.ts
+++ b/apps/prairielearn/src/tests/activeAccessRestriction.test.ts
@@ -184,7 +184,7 @@ describe(
       context.__csrf_token = response.$('span[id=test_csrf_token]').text();
       const questionWithVariantPath = response.$('a:contains("Question 1")').attr('href');
       const questionWithoutVariantPath = response.$('a:contains("Question 2")').attr('href');
-      const questionWithWorkspace = response.$('a:contains("Question 7")').attr('href');
+      const questionWithWorkspace = response.$('a:contains("Question 6")').attr('href');
       context.examQuestionUrl = `${context.siteUrl}${questionWithVariantPath}`;
       context.examQuestionWithoutVariantUrl = `${context.siteUrl}${questionWithoutVariantPath}`;
       context.examQuestionWithWorkspaceUrl = `${context.siteUrl}${questionWithWorkspace}`;

--- a/testCourse/courseInstances/Sp15/assessments/exam11-activeAccessRestriction/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam11-activeAccessRestriction/infoAssessment.json
@@ -36,7 +36,6 @@
       "title": "Hard questions",
       "questions": [
         { "id": "addNumbers", "points": [5, 3, 1] },
-        { "id": "addVectors", "points": [11, 9] },
         { "id": "fossilFuelsRadio", "points": [17, 13, 7, 2] },
         { "id": "partialCredit1", "points": [19] },
         { "id": "partialCredit2", "points": [9, 7, 5, 3] },

--- a/testCourse/courseInstances/Sp15/assessments/exam12-sequentialQuestions/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam12-sequentialQuestions/infoAssessment.json
@@ -23,10 +23,7 @@
     },
     { "advanceScorePerc": 75, "questions": [{ "id": "partialCredit2", "points": 1 }] },
     { "questions": [{ "id": "partialCredit4_v2", "points": 1, "advanceScorePerc": 0 }] },
-    {
-      "advanceScorePerc": 35,
-      "questions": [{ "id": "addVectors", "points": 1, "advanceScorePerc": 30 }]
-    },
-    { "questions": [{ "id": "addNumbers", "points": 1 }] }
+    { "questions": [{ "id": "addNumbers", "points": 1, "advanceScorePerc": 30 }] },
+    { "questions": [{ "id": "internalGrade/addingNumbers", "points": 1 }] }
   ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam14-groupWork/infoAssessment.json
@@ -14,10 +14,7 @@
   "zones": [
     {
       "title": "Hard questions",
-      "questions": [
-        { "id": "addVectors", "points": [10, 5, 1] },
-        { "id": "positionTimeGraph", "points": [10] }
-      ]
+      "questions": [{ "id": "positionTimeGraph", "points": [10] }]
     }
   ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam2-miscProblems/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam2-miscProblems/infoAssessment.json
@@ -17,10 +17,7 @@
   "zones": [
     {
       "title": "Hard questions",
-      "questions": [
-        { "id": "addVectors", "points": [10, 5, 1] },
-        { "id": "positionTimeGraph", "points": [10] }
-      ]
+      "questions": [{ "id": "positionTimeGraph", "points": [10] }]
     }
   ],
   "honorCode": "## Honor Code \nI, {{user_name}}, pledge that I am allowed to take the following assessment and will not receive any unauthorized assistance."

--- a/testCourse/courseInstances/Sp15/assessments/exam6-password/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam6-password/infoAssessment.json
@@ -17,10 +17,7 @@
   "zones": [
     {
       "title": "Hard questions",
-      "questions": [
-        { "id": "addVectors", "points": [10, 5, 1] },
-        { "id": "positionTimeGraph", "points": [10] }
-      ]
+      "questions": [{ "id": "positionTimeGraph", "points": [10] }]
     }
   ]
 }

--- a/testCourse/courseInstances/Sp15/assessments/exam7-modePublic/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam7-modePublic/infoAssessment.json
@@ -10,7 +10,6 @@
       "title": "Hard questions",
       "questions": [
         { "id": "addNumbers", "points": [5, 3, 1] },
-        { "id": "addVectors", "points": [11, 9] },
         { "id": "fossilFuelsRadio", "points": [17, 13, 7, 2] },
         { "id": "partialCredit1", "points": [19] },
         { "id": "partialCredit2", "points": [9, 7, 5, 3] },

--- a/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam8-disableRealTimeGrading/infoAssessment.json
@@ -11,7 +11,6 @@
       "title": "Hard questions",
       "questions": [
         { "id": "addNumbers", "points": 5 },
-        { "id": "addVectors", "points": 11 },
         { "id": "fossilFuelsRadio", "points": 17 },
         { "id": "partialCredit1", "points": 19 },
         { "id": "partialCredit2", "points": 9 },

--- a/testCourse/courseInstances/Sp15/assessments/exam9-disableRealTimeGradingWithholdGrades/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/exam9-disableRealTimeGradingWithholdGrades/infoAssessment.json
@@ -18,7 +18,6 @@
       "title": "Hard questions",
       "questions": [
         { "id": "addNumbers", "points": 5 },
-        { "id": "addVectors", "points": 11 },
         { "id": "fossilFuelsRadio", "points": 17 },
         { "id": "partialCredit1", "points": 19 },
         { "id": "partialCredit2", "points": 9 },

--- a/testCourse/courseInstances/Sp15/assessments/hw2-miscProblems/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw2-miscProblems/infoAssessment.json
@@ -30,7 +30,6 @@
   "zones": [
     {
       "questions": [
-        { "id": "addVectors", "points": 1, "maxPoints": 5 },
         { "id": "fossilFuelsRadio", "points": 2, "maxPoints": 10 },
         { "id": "positionTimeGraph", "points": 2, "maxPoints": 10 },
         { "id": "downloadFile", "points": 2, "maxPoints": 10 },


### PR DESCRIPTION
## Description

Remove the `addVectors` question from 9 non-critical test assessments while preserving it in the two assessments that have tests specifically exercising its grading and regrading functionality (`exam1-automaticTestSuite` and `hw1-automaticTestSuite`).

Updated related tests to account for question reordering and restored full test coverage by adding `internalGrade/addingNumbers` as a final question in `exam12-sequentialQuestions` to verify cascade unlocking stops at non-zero thresholds.

`addVectors` is a v2 question and AFAICT was just being copy/pasted between test assessments, so I opted to remove it to stop the proliferation.

## Testing

All affected tests pass:
- `activeAccessRestriction.test.ts`
- `testSequentialQuestions.test.ts`
- `honorCode.test.ts`
- `teamExam.test.ts`
- `realTimeGradingDisabled.test.ts`

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>