### PR TITLE
Shrink output of `actions-report-image-sizes`

### DIFF
--- a/packages/actions-report-image-sizes/src/index.ts
+++ b/packages/actions-report-image-sizes/src/index.ts
@@ -223,11 +223,7 @@ async function commentSizeReport(title: string, changedImages: ChangedImage[]) {
 
   // Generate new comment body with collapsible format.
   const lines = [
-    `<details><summary><b>${title}</b>`,
-    '',
-    summaryLine,
-    '',
-    '</summary>',
+    `<details><summary><b>${title}</b></summary>`,
     '',
     // Markdown table header
     '| Image | Platform | Old Size | New Size | Change |',
@@ -253,7 +249,7 @@ async function commentSizeReport(title: string, changedImages: ChangedImage[]) {
     );
   }
 
-  lines.push('', '</details>');
+  lines.push('', '</details>', '', summaryLine);
 
   const body = lines.join('\n');
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This shrinks the output from `actions-report-image-sizes` to declutter review output.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

See posted comment.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
