### PR TITLE
Render mustache patterns in rubric information in AI grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -3,7 +3,6 @@ import * as cheerio from 'cheerio';
 import mustache from 'mustache';
 import { z } from 'zod';
 
-import { markdownToHtml } from '@prairielearn/markdown';
 import {
   callRow,
   execute,
@@ -87,14 +86,11 @@ export async function generatePrompt({
         },
         {
           role: 'user',
-          content: markdownToHtml(
-            mustache.render(grader_guidelines, {
-              submitted_answers: submitted_answer,
-              correct_answers: true_answer,
-              params,
-            }),
-            { inline: true },
-          ),
+          content: mustache.render(grader_guidelines, {
+            submitted_answers: submitted_answer,
+            correct_answers: true_answer,
+            params,
+          }),
         },
       ] satisfies ModelMessage[])
     : [];

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
@@ -9,7 +9,6 @@ import mustache from 'mustache';
 import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
-import { markdownToHtml } from '@prairielearn/markdown';
 import { loadSqlEquiv, queryRow, runInTransactionAsync } from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { IdSchema } from '@prairielearn/zod';
@@ -246,21 +245,12 @@ export async function aiGrade({
         submitted_answers: submission.submitted_answer,
       };
       for (const rubric_item of rubric_items) {
-        rubric_item.description = markdownToHtml(
-          mustache.render(rubric_item.description, mustacheParams),
-          {
-            inline: true,
-          },
-        );
+        rubric_item.description = mustache.render(rubric_item.description, mustacheParams);
         rubric_item.explanation = rubric_item.explanation
-          ? markdownToHtml(mustache.render(rubric_item.explanation, mustacheParams), {
-              inline: true,
-            })
+          ? mustache.render(rubric_item.explanation, mustacheParams)
           : null;
         rubric_item.grader_note = rubric_item.grader_note
-          ? markdownToHtml(mustache.render(rubric_item.grader_note, mustacheParams), {
-              inline: true,
-            })
+          ? mustache.render(rubric_item.grader_note, mustacheParams)
           : null;
       }
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Similar to the changes in #13833 , currently AI grading doesn't support rubric items that use mustache patterns. This PR renders these patterns when they are sent to the AI so the AI could better read the necessary information. 

# Testing

Before:
<img width="1411" height="286" alt="image" src="https://github.com/user-attachments/assets/732a46b9-2385-4716-b466-ee0fcb7b1737" />

After:
<img width="1424" height="296" alt="image" src="https://github.com/user-attachments/assets/3fdad0f9-5b44-4aca-ac1a-a1e5b5840f6a" />

