### PR TITLE
Fix issues with React lifecycle

### DIFF
--- a/apps/prairielearn/src/components/DeleteCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/components/DeleteCourseInstanceModal.tsx
@@ -76,7 +76,9 @@ export function DeleteCourseInstanceModal({
                     type="checkbox"
                     id="impact"
                     checked={checks.impact}
-                    onChange={(e) => setChecks((c) => ({ ...c, impact: e.currentTarget.checked }))}
+                    onChange={({ currentTarget }) => {
+                      setChecks((c) => ({ ...c, impact: currentTarget.checked }));
+                    }}
                   />
                   <label className="form-check-label" htmlFor="impact">
                     I understand that <strong>{enrolledCount}</strong> enrolled{' '}
@@ -90,9 +92,9 @@ export function DeleteCourseInstanceModal({
                     type="checkbox"
                     id="irreversible"
                     checked={checks.irreversible}
-                    onChange={(e) =>
-                      setChecks((c) => ({ ...c, irreversible: e.currentTarget.checked }))
-                    }
+                    onChange={({ currentTarget }) => {
+                      setChecks((c) => ({ ...c, irreversible: currentTarget.checked }));
+                    }}
                   />
                   <label className="form-check-label" htmlFor="irreversible">
                     I understand that once deleted, this course instance cannot be restored through
@@ -105,8 +107,8 @@ export function DeleteCourseInstanceModal({
                     type="checkbox"
                     id="recovery"
                     checked={checks.recovery}
-                    onChange={(e) =>
-                      setChecks((c) => ({ ...c, recovery: e.currentTarget.checked }))
+                    onChange={({ currentTarget }) =>
+                      setChecks((c) => ({ ...c, recovery: currentTarget.checked }))
                     }
                   />
                   <label className="form-check-label" htmlFor="recovery">

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/components/AdministratorInstitutionSsoForm.tsx
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/components/AdministratorInstitutionSsoForm.tsx
@@ -72,10 +72,10 @@ export function AdministratorInstitutionSsoForm({
                 name="enabled_authn_provider_ids"
                 checked={isEnabled}
                 disabled={provider.name === 'SAML' && !hasSamlProvider}
-                onChange={(e) => {
+                onChange={({ currentTarget }) => {
                   setEnabledProviderIds((prev) => {
                     const newSet = new Set(prev);
-                    if (e.currentTarget.checked) {
+                    if (currentTarget.checked) {
                       newSet.add(provider.id);
                     } else {
                       newSet.delete(provider.id);
@@ -84,7 +84,7 @@ export function AdministratorInstitutionSsoForm({
                   });
 
                   // If the default provider is being disabled, reset to null (none).
-                  if (!e.currentTarget.checked && defaultProviderId === provider.id) {
+                  if (!currentTarget.checked && defaultProviderId === provider.id) {
                     setDefaultProviderId(null);
                   }
                 }}


### PR DESCRIPTION
# Description

React's lifecycle for the callback form of `useState` appears to be different from Preact's. Namely, the callback isn't always invoked synchronously, so attempts to read `e.currentEvent` will sometimes fail because it ends up unset as it's processed.

The fix is to immediately destructure `currentTarget` so that later accesses aren't doing property accesses on the event itself.

Maybe there's a lint rule we could use here? 🤷

# Testing

The bug that's fixed here manifests on the course instance settings page. Try to delete a course instance and check the checkboxes on the resulting modal. For me, after clicking the second checkbox, an error was thrown and rendering failed.