### PR TITLE
Use the standard TypeScript language server in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,6 @@
   },
   "typescript.preferences.autoImportSpecifierExcludeRegexes": ["^react$"],
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.experimental.useTsgo": true,
   "json.schemaDownload.enable": true,
   "json.schemas": [
     {


### PR DESCRIPTION
# Description

I've found that the new `tsgo` LSP regularly loses sync between diagnostics and the editor contents. Here's one such example:

<img width="1002" height="436" alt="Screenshot 2026-01-20 at 11 12 03" src="https://github.com/user-attachments/assets/dcc52b52-4672-47d7-84b3-13107f665d75" />

Until things are more stable and reliable, let's revert back to the standard TypeScript LSP.

# Testing

N/A