### PR TITLE
Switch FontAwesome from JS to CSS

### DIFF
--- a/apps/prairielearn/src/components/HeadContents.tsx
+++ b/apps/prairielearn/src/components/HeadContents.tsx
@@ -47,7 +47,10 @@ export function HeadContents(titleOptions: TitleOptions) {
     <link href="${assetPath('stylesheets/local.css')}" rel="stylesheet" />
     <script src="${nodeModulesAssetPath('jquery/dist/jquery.min.js')}"></script>
     <script src="${nodeModulesAssetPath('bootstrap/dist/js/bootstrap.bundle.min.js')}"></script>
-    <link href="${nodeModulesAssetPath('@fortawesome/fontawesome-free/css/all.min.css')}" rel="stylesheet" />
+    <link
+      href="${nodeModulesAssetPath('@fortawesome/fontawesome-free/css/all.min.css')}"
+      rel="stylesheet"
+    />
     ${compiledStylesheetTag('prairielearn-ui.css')} ${compiledScriptTag('application.ts')}
     ${compiledScriptTag('navbarClient.ts')}
   `;


### PR DESCRIPTION
# Description

Use CSS-based FontAwesome icons instead of JavaScript. This also fixes a react-dom issue where fontawesome is rewriting the dom, and react isn't expecting it.


# Testing

Verified icons render correctly in local development server.

<img width="2698" height="848" alt="CleanShot 2026-01-21 at 20 26 46@2x" src="https://github.com/user-attachments/assets/20ec19ee-7303-41a9-acb3-5333ad0709a4" />
