### PR TITLE
Add dedupe job to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -229,20 +229,3 @@ jobs:
 
       - name: Check for duplicate Node dependencies
         run: yarn dedupe --check
-
-  all-checks:
-    name: All checks passed
-    if: ${{ !cancelled() }}
-    needs: [check-js, check-python, check-other, dedupe]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify all jobs passed
-        run: |
-          if [[ "${{ needs.check-js.result }}" != "success" ]] || \
-             [[ "${{ needs.check-python.result }}" != "success" ]] || \
-             [[ "${{ needs.check-other.result }}" != "success" ]] || \
-             [[ "${{ needs.dedupe.result }}" != "success" ]]; then
-            echo "One or more jobs failed"
-            exit 1
-          fi
-          echo "All checks passed!"


### PR DESCRIPTION
# Description

Moves `yarn dedupe --check` to a separate job for better visibility when dependabot PRs fail only on this check.

https://github.com/PrairieLearnInc/PrairieTest/pull/2572

# Testing

This is a configuration change to CI workflows. Once merged, the CI will run with a separate dedupe job.