### PR TITLE
Add workflow to dedupe dependencies on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -1,0 +1,37 @@
+name: 'Dedupe Dependabot PRs'
+
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+
+jobs:
+  dedupe:
+    name: 'Dedupe dependencies'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: corepack enable
+
+      - name: 'Configure Git'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: 'Dedupe dependencies'
+        run: yarn dedupe
+        env:
+          HUSKY: 0
+
+      - name: 'Commit and push changes'
+        run: |
+          git add .
+          git commit -m 'Dedupe dependencies' || true
+          git push


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs `yarn dedupe` when Dependabot pushes to a branch
- Commits any deduplication changes back to the branch automatically
- Keeps the lockfile optimized without manual intervention

## How it works

1. Triggers on push to `dependabot/**` branches
2. Runs `yarn dedupe` to optimize the lockfile
3. Commits and pushes changes (no-op if nothing changed)

Since [October 2021](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/), the `permissions` key is respected for Dependabot-triggered workflows, so `contents: write` works.

## Test plan

```sh
  git checkout master
  git checkout -b dependabot/npm_and_yarn/test-workflow
  # Make a trivial change to yarn.lock or just push as-is
  git push -u origin dependabot/npm_and_yarn/test-workflow
  # Check if when PR is up, if workflow trigger a dedupe
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)