### PR TITLE
Use stable Dockerfile syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile-upstream:master-labs
 FROM amazonlinux:2023
 ARG CACHEBUST=2026-01-15-14-21-34
 


### PR DESCRIPTION
# Description

`--parents` is no longer in "labs", we can just use it!

https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.20.0

# Testing

We'll see if the image builds.