### PR TITLE
Fix flaky sympy timeout test

### DIFF
--- a/apps/prairielearn/python/test/timeout_utils_test.py
+++ b/apps/prairielearn/python/test/timeout_utils_test.py
@@ -32,8 +32,11 @@ def test_timeout_exc():
 
 def test_sympy_timeout():
     x = symbols("x")
-    expr1 = exp(sin(x)) * (1 + sin(x) ** 10) ** 5
-    expr2 = exp(sin(x)) * (1 + sin(x) ** 2) ** 125
+    # Use exponents large enough that the computation will reliably take much
+    # longer than the timeout. Threading-based timeouts in Python can have
+    # inconsistent timing, so we want a large margin of safety.
+    expr1 = exp(sin(x)) * (1 + sin(x) ** 10) ** 50
+    expr2 = exp(sin(x)) * (1 + sin(x) ** 2) ** 500
     with ThreadingTimeout(0.1) as ctx:
         eq = Eq(expr1, expr2)
         simplify(eq.lhs - eq.rhs)  # type: ignore


### PR DESCRIPTION
# Description

The `test_sympy_timeout` test was intermittently failing in CI because the sympy `simplify` operation could sometimes complete within the 0.1 second timeout on fast machines. Python's threading-based timeout mechanism has inherent timing variability because async exceptions are only delivered at Python bytecode boundaries.

Increased the polynomial exponents from `**5`/`**125` to `**50`/`**500` to create a significantly larger computation that reliably exceeds the timeout, providing a safe margin against timing inconsistencies.

# Testing

- Ran the test 20 times consecutively with 100% pass rate
- Verified all other timeout tests still pass
- The computation now reliably takes much longer than 0.1 seconds, ensuring the timeout is consistently triggered