### PR TITLE
Fix point type in rubric settings to allow for partial input

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -1079,11 +1079,11 @@ function RubricRow({
           aria-label="Points"
           disabled={!hasCourseInstancePermissionEdit}
           required
-          onInput={(e) =>
+          onInput={({ currentTarget }) =>
             updateRubricItem({
-              // e.currentTarget.value will be an empty string if the input is not valid yet
+              // currentTarget.value will be an empty string if the input is not valid yet
               // so we can use this to check for partially done inputs such as just a "-" as well
-              points: e.currentTarget.value.length > 0 ? Number(e.currentTarget.value) : null,
+              points: currentTarget.value.length > 0 ? Number(currentTarget.value) : null,
             })
           }
         />


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The React component for rubric editing automatically parses all inputs in real time and stores in its states. It does not allow for empty inputs (deleting the current point to start over) or an input with only a negative sign (since we start by typing the negative sign). This PR modifies the type for points in the internal state to allow for empty or partially entered inputs. 
# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

<img width="1153" height="111" alt="image" src="https://github.com/user-attachments/assets/43e7f688-57d4-4a65-a385-4b819c047f99" />
You can now delete whatever is in the box and it won't get rendered to 0

<img width="1129" height="107" alt="image" src="https://github.com/user-attachments/assets/30dab437-6b92-4b64-b610-3adefae62c8a" />
Or start with typing the negative sign

<img width="841" height="201" alt="image" src="https://github.com/user-attachments/assets/14e8fd08-cb4f-4028-ab6f-07d9e0a20451" />
In this case, exporting the rubric or saving the rubric would not be allowed since we don't want to save/export invalid things

<img width="1146" height="111" alt="image" src="https://github.com/user-attachments/assets/4f14aa0b-8f97-4d77-a098-abef267c0e39" />
You can then continue typing to finish the points