### PR TITLE
Add note in docs regarding custom grade with testing

### DIFF
--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -443,6 +443,7 @@ The `test()` function is called to test the question. This function can be used 
 
     1. You don't set `correct_answers` in the `generate` or `prepare` stage of your question. In this scenario, the elements you use don't know how to generate the correct set of inputs, and the responsibility shifts to the `test()` function in `server.py`.
     2. You are using elements that haven't implemented the `test()` function. All first-party elements have this function implemented, so this is only a concern if you use a custom course element.
+    3. You are using a custom `grade` function that modifies the grading behavior of the question. In this case, you need to ensure that the `test()` function generates appropriate inputs to test your custom grading logic.
 
 The `test()` function receives the output of `prepare()`, along with a `test_type` parameter. The `test_type` is either `correct`, `incorrect`, or `invalid`. Your function should generate `raw_submitted_answers` based on the inputs (e.g. `data["correct_answers"]`) and `test_type`. It should also update `score` and `feedback`.
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

A question [came up on Slack](https://prairielearn.slack.com/archives/C266KEH9A/p1769197335004229?thread_ts=1769065102.519909&cid=C266KEH9A) regarding using the test functionality with a custom grader. In that case, the generated test cases may not match the expected values created by the custom grade function. To avoid confusion, this PR adds a note in the docs that, for custom graders, a custom test function may become necessary if the instructor wants to use the testing functionality.

Copilot suggested the wording of the warning.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Docs only, no change in behavior.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
