### PR TITLE
Modify API to return `NULL` scores last, tiebreak on `DATE`

### DIFF
--- a/apps/prairielearn/src/api/v1/endpoints/queries.sql
+++ b/apps/prairielearn/src/api/v1/endpoints/queries.sql
@@ -86,7 +86,8 @@ WITH
           PARTITION BY
             u.id
           ORDER BY
-            score_perc DESC,
+            score_perc DESC NULLS LAST,
+            ai.date DESC,
             ai.number DESC,
             ai.id DESC
         )
@@ -361,7 +362,8 @@ WITH
           PARTITION BY
             v.id
           ORDER BY
-            s.score DESC,
+            s.score DESC NULLS LAST,
+            s.date DESC,
             s.id DESC
         )
       ) = 1 AS best_submission_per_variant


### PR DESCRIPTION
Fix cases where `best_submission_per_variant` (and related “highest score” selection) can pick rows with `score = NULL`.

PostgreSQL sorts NULLs first for `ORDER BY ... DESC`, so `row_number()` may mark an ungradable submission (NULL score) as “best”. This change adds `NULLS LAST` to score-based ordering in the API queries and adds a date-based tie-breaker so the most recent row is selected when scores are equal.

AI assistance: PR text only.

Fixes #13898

# Testing

Not run automated tests.