### PR TITLE
Add note regarding rebases to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ We follow the [GitHub flow](https://docs.github.com/en/get-started/quickstart/gi
 - Monitor the [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks). If they fail, you should check the output to see why. You may need to fix a broken test, adjust the formatting of your code, or fix a lint error.
 - Like many open-source projects, we require you to "sign" a contributor license agreement (CLA) prior to accepting any contributions. When you open your first pull request, a bot will prompt you to leave a comment stating that you accept the terms of [our CLA](https://github.com/PrairieLearn/cla).
 - One or more PrairieLearn maintainers will review your PR. You should be prepared to engage with the maintainers to answer questions, update code, etc. Additional etiquette, expectations, and information for code reviews can be found in the [contributing](https://prairielearn.readthedocs.io/en/latest/contributing/) section of the documentation.
+  - If further changes are requested, you should make those changes in your branch and push them to GitHub. The PR will automatically update. You do not need to open a new PR. Also, do not rebase your branch unless absolutely necessary, since PRs are merged using "squash and merge" by default, and it is easier to review further changes if they are performed in separate commits.
 
 - Once the PR is in a satisfactory state, a maintainer will approve and merge your change! :tada:
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

This adds a note to the contributing guidelines regarding further changes after the initial commit. I have seen some contributors using rebase to keep the PR clean, but this is not that helpful in our case where additional changes may be needed as the PR is reviewed.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Docs only, no tests.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
