### PR TITLE
Restore lodash in pl-drawing reference

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/info.json
+++ b/apps/prairielearn/elements/pl-drawing/info.json
@@ -1,7 +1,7 @@
 {
   "controller": "pl-drawing.py",
   "dependencies": {
-    "nodeModulesScripts": ["fabric/dist/fabric.js", "es-toolkit/dist/browser.global.js"],
+    "nodeModulesScripts": ["fabric/dist/fabric.js", "lodash/lodash.js"],
     "coreScripts": ["sylvester.js"],
     "elementScripts": ["pl-drawing.js", "mechanicsObjects.js"],
     "elementStyles": ["pl-drawing.css"]


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

As discussed with @nwalters512, follow-up to #13707. While the use of es-toolkit in the pl-drawing context makes sense, it could lead to issues if other client code (custom elements, question references, etc.) make use of the `_` global in client code expecting the lodash interface. This is because both es-toolkit and lodash would be competing for setting that global.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Tested locally.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
