### PR TITLE
Support answer and submission panels in AI question generation

### DIFF
--- a/apps/prairielearn/src/ee/lib/context-parsers/documentation.ts
+++ b/apps/prairielearn/src/ee/lib/context-parsers/documentation.ts
@@ -3,21 +3,9 @@ import remarkParse from 'remark-parse';
 import remarkStringify from 'remark-stringify';
 import { unified } from 'unified';
 
-const DEPRECATED_ELEMENTS = new Set(['pl-prairiedraw-figure', 'pl-threejs', 'pl-variable-score']);
-const ALLOWED_ELEMENTS = new Set([
-  // Decorative elements
-  'pl-question-panel',
-  'pl-answer-panel',
-  'pl-submission-panel',
+import { SUPPORTED_ELEMENTS } from '../validateHTML.js';
 
-  // Submission elements
-  'pl-multiple-choice',
-  'pl-checkbox',
-  'pl-integer-input',
-  'pl-number-input',
-  'pl-string-input',
-  'pl-symbolic-input',
-]);
+const DEPRECATED_ELEMENTS = new Set(['pl-prairiedraw-figure', 'pl-threejs', 'pl-variable-score']);
 
 interface ElementSection {
   elementName: string;
@@ -132,10 +120,8 @@ export function buildContextForSingleElementDoc(
     return null;
   }
 
-  // Skip elements that are not in the allowed list.
-  if (!ALLOWED_ELEMENTS.has(elementName)) {
-    return null;
-  }
+  // Skip unsupported elements.
+  if (!SUPPORTED_ELEMENTS.has(elementName)) return null;
 
   const file = unified().use(remarkParse).use(remarkGfm).parse(rawMarkdown);
 

--- a/apps/prairielearn/src/ee/lib/validateHTML.ts
+++ b/apps/prairielearn/src/ee/lib/validateHTML.ts
@@ -4,6 +4,21 @@ import * as parse5 from 'parse5';
 type DocumentFragment = parse5.DefaultTreeAdapterMap['documentFragment'];
 type ChildNode = parse5.DefaultTreeAdapterMap['childNode'];
 
+export const SUPPORTED_ELEMENTS = new Set([
+  // Decorative elements
+  'pl-question-panel',
+  'pl-answer-panel',
+  'pl-submission-panel',
+
+  // Submission elements
+  'pl-multiple-choice',
+  'pl-checkbox',
+  'pl-integer-input',
+  'pl-number-input',
+  'pl-string-input',
+  'pl-symbolic-input',
+]);
+
 const BOOLEAN_TRUE_VALUES = ['true', 't', '1', 'True', 'T', 'TRUE', 'yes', 'y', 'Yes', 'Y', 'YES'];
 const BOOLEAN_FALSE_VALUES = ['false', 'f', '0', 'False', 'F', 'FALSE', 'no', 'n', 'No', 'N', 'NO'];
 const BOOLEAN_VALUES = [...BOOLEAN_TRUE_VALUES, ...BOOLEAN_FALSE_VALUES];
@@ -151,6 +166,8 @@ function isBooleanTrue(val: string): boolean {
  */
 function checkTag(ast: DocumentFragment | ChildNode): ValidationResult {
   if ('tagName' in ast) {
+    // The elements supported here should be kept in sync with those in
+    // `context-parsers/documentation.ts`.
     switch (ast.tagName) {
       case 'pl-multiple-choice':
         return checkMultipleChoice(ast);
@@ -172,9 +189,10 @@ function checkTag(ast: DocumentFragment | ChildNode): ValidationResult {
         return { errors: [] }; // covered elsewhere
       default:
         if (ast.tagName.startsWith('pl-')) {
+          const formattedSupportedElements = Array.from(SUPPORTED_ELEMENTS).join(', ');
           return {
             errors: [
-              `${ast.tagName} is not a valid tag. Please use tags from the following: \`pl-question-panel\`, \`pl-multiple-choice\`, \`pl-checkbox\`, \`pl-integer-input\`, \`pl-number-input\`,\`pl-string-input\`, \`pl-symbolic-input\``,
+              `${ast.tagName} is not a valid tag. You must use only the following tags: ${formattedSupportedElements}`,
             ],
           };
         }


### PR DESCRIPTION
# Description

This allows `<pl-answer-panel>` and `<pl-submission-panel>` to be used as context by the AI question generator.

# Testing

I generated a few questions to confirm that things generally still work. They do!