### PR TITLE
Fix QR code modal UX issues

### DIFF
--- a/apps/prairielearn/src/components/QRCodeModal.tsx
+++ b/apps/prairielearn/src/components/QRCodeModal.tsx
@@ -17,15 +17,13 @@ export function QRCodeModalHtml({
 }) {
   const qrCodeSvg = new QR({ content, container: 'svg-viewbox' })
     .svg()
-    .replace('<svg ', '<svg style="width:100%;height:auto;" ');
+    .replace('<svg ', '<svg style="max-width:100%;max-height:calc(100vh - 150px);height:auto;" ');
 
   return HtmlModal({
     id,
     title,
     form: false,
-    body: html`<div class="d-flex justify-content-center" style="max-height: calc(100vh - 200px);">
-      ${unsafeHtml(qrCodeSvg)}
-    </div>`,
+    body: html`<div class="d-flex justify-content-center">${unsafeHtml(qrCodeSvg)}</div>`,
   });
 }
 
@@ -46,7 +44,10 @@ export function QRCodeModal({
     () =>
       new QR({ content, container: 'svg-viewbox' })
         .svg()
-        .replace('<svg ', '<svg style="width:100%;height:auto;" '),
+        .replace(
+          '<svg ',
+          '<svg style="max-width:100%;max-height:calc(100vh - 150px);height:auto;" ',
+        ),
     [content],
   );
   return (
@@ -57,7 +58,6 @@ export function QRCodeModal({
       <Modal.Body>
         <div
           className="d-flex justify-content-center"
-          style={{ maxHeight: 'calc(100vh - 200px)' }}
           // eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
           dangerouslySetInnerHTML={{ __html: svg }}
         />


### PR DESCRIPTION
## Summary

- Allow closing the QR code modal by clicking outside (remove `backdrop="static"`)
- Prevent QR code image from extending outside the modal on smaller screens

Reported by Victor on Slack.

## Test plan

- [x] Verify you can close the modal by clicking outside
- [x] Resize window to a smaller size and verify QR code stays within modal bounds

<img width="727" height="453" alt="CleanShot 2026-01-28 at 15 36 25" src="https://github.com/user-attachments/assets/c3dd8a45-8210-4ebb-8521-9324c92eaba3" />
<img width="655" height="893" alt="CleanShot 2026-01-28 at 15 36 43" src="https://github.com/user-attachments/assets/37cb34a2-a8eb-452c-9d7e-57b1404df229" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)