### PR TITLE
Use consistent JSON formatting on assessment creation

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -859,7 +859,7 @@ export class AssessmentAddEditor extends Editor {
     };
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
 
-    // We use outputFile to create the directory this.assessmentsPath if it
+    // We use outputFile to create the directory assessmentPath if it
     // does not exist (which it shouldn't). We use the file system flag 'wx'
     // to throw an error if `assessmentPath` already exists.
     await fs.outputFile(path.join(assessmentPath, 'infoAssessment.json'), formattedJson, {
@@ -1270,7 +1270,7 @@ export class CourseInstanceAddEditor extends Editor {
     };
     const formattedJson = await formatJsonWithPrettier(JSON.stringify(infoJson));
 
-    // We use outputFile to create the directory this.courseInstancePath if it
+    // We use outputFile to create the directory courseInstancePath if it
     // does not exist (which it shouldn't). We use the file system flag 'wx' to
     // throw an error if this.courseInstancePath already exists.
     await fs.outputFile(path.join(courseInstancePath, 'infoCourseInstance.json'), formattedJson, {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

Fixes #13955. Most editor operations that update the JSON file run prettier on the resulting JSON for consistency. This wasn't being done when adding assessments or course instances.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Create an assessment, the resulting JSON should be formatted with 2 spaces as in prettier.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
