### PR TITLE
Improve server job output buffering and flushing

### DIFF
--- a/apps/prairielearn/src/lib/server-jobs.ts
+++ b/apps/prairielearn/src/lib/server-jobs.ts
@@ -127,6 +127,8 @@ class ServerJobAbortError extends Error {
 }
 
 class ServerJobImpl implements ServerJob, ServerJobExecutor {
+  private static readonly FLUSH_INTERVAL_MS = 500;
+
   public jobSequenceId: string;
   public jobId: string;
   public data: Record<string, unknown> = {};
@@ -134,6 +136,7 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
   private finished = false;
   public output = '';
   private lastSent = Date.now();
+  private flushTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   constructor(jobSequenceId: string, jobId: string) {
     this.jobSequenceId = jobSequenceId;
@@ -266,22 +269,38 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
   }
 
   private flush(force = false) {
-    if (Date.now() - this.lastSent > 1000 || force) {
-      const ansifiedOutput = ansiToHtml(this.output);
-      socketServer.io
-        ?.to('job-' + this.jobId)
-        .emit('change:output', { job_id: this.jobId, output: ansifiedOutput });
-      this.lastSent = Date.now();
+    const elapsed = Date.now() - this.lastSent;
+
+    if (elapsed >= ServerJobImpl.FLUSH_INTERVAL_MS || force) {
+      // Clear any pending trailing flush since we're flushing now.
+      if (this.flushTimeoutId) {
+        clearTimeout(this.flushTimeoutId);
+        this.flushTimeoutId = null;
+      }
+
+      this.doFlush();
+    } else if (!this.flushTimeoutId) {
+      // Schedule a trailing flush to ensure buffered output is sent
+      // even if no more output arrives.
+      this.flushTimeoutId = setTimeout(() => {
+        this.flushTimeoutId = null;
+        this.doFlush();
+      }, ServerJobImpl.FLUSH_INTERVAL_MS - elapsed);
     }
+  }
+
+  private doFlush() {
+    const ansifiedOutput = ansiToHtml(this.output);
+    socketServer.io
+      ?.to('job-' + this.jobId)
+      .emit('change:output', { job_id: this.jobId, output: ansifiedOutput });
+    this.lastSent = Date.now();
   }
 
   private async finish(err: any = undefined) {
     // Guard against handling job finish more than once.
     if (this.finished) return;
     this.finished = true;
-
-    // Force a send on the current output to ensure all messages are shown.
-    this.flush(true);
 
     // A `ServerJobAbortError` is thrown by the `fail` method. We won't print
     // any details about the error object itself, as `fail` will have already
@@ -299,6 +318,14 @@ class ServerJobImpl implements ServerJob, ServerJobExecutor {
         this.verbose('\n' + JSON.stringify(err.data, null, 2));
       }
     }
+
+    // Cancel any pending trailing flush and force a final send to ensure all
+    // output (including error details above) is shown before cleanup.
+    if (this.flushTimeoutId) {
+      clearTimeout(this.flushTimeoutId);
+      this.flushTimeoutId = null;
+    }
+    this.flush(true);
 
     delete liveJobs[this.jobId];
 


### PR DESCRIPTION
## Description

This PR improves the responsiveness and reliability of server job output streaming by implementing a trailing-edge flush mechanism and reducing the flush interval.

**Changes:**
- Reduced flush interval from 1000ms to 500ms for more responsive output updates
- Implemented trailing-edge timeout to ensure buffered output is always sent within the flush interval, even when output arrives in bursts
- Reordered `finish()` logic to flush error details after adding them, preventing errors from being lost during throttling

These changes address issues where output seemed stuck or didn't appear when expected, particularly during jobs with intermittent output.

## Testing

Existing tests pass. I performed manual testing and things feel noticeably more responsive, as expected.