### PR TITLE
Only sync test course in Playwright tests

### DIFF
--- a/apps/prairielearn/src/tests/e2e/fixtures.ts
+++ b/apps/prairielearn/src/tests/e2e/fixtures.ts
@@ -6,8 +6,7 @@ import path from 'node:path';
 import { test as base } from '@playwright/test';
 import * as tmp from 'tmp-promise';
 
-import { STANDARD_COURSE_DIRS } from '../../lib/config.js';
-import { EXAMPLE_COURSE_PATH, TEST_COURSE_PATH } from '../../lib/paths.js';
+import { TEST_COURSE_PATH } from '../../lib/paths.js';
 
 import { setupWorkerServer } from './serverUtils.js';
 
@@ -64,7 +63,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   workerPort: [
     async ({ testCoursePath }, use, workerInfo) => {
       await setupWorkerServer(workerInfo, use, {
-        courseDirs: [...STANDARD_COURSE_DIRS, EXAMPLE_COURSE_PATH, testCoursePath],
+        courseDirs: [testCoursePath],
       });
     },
     { scope: 'worker' },


### PR DESCRIPTION
# Description

I believe this is responsible for the test failures we've seen from the new assessment sets editor tests.

In https://github.com/PrairieLearn/PrairieLearn/pull/13629#discussion_r2743314029, I (incorrectly) assumed that the Playwright tests ran just against a test course - but that wasn't true. This PR makes it so. IMO this is a more sensible default.

# Testing

The tests should now pass.
