### PR TITLE
Fix Playwright merge-reports step to fail on test failures

### DIFF
--- a/apps/prairielearn/src/tests/e2e/gradebook.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/gradebook.spec.ts
@@ -67,11 +67,6 @@ async function createTestData(): Promise<string> {
   return assessment.label;
 }
 
-// TODO: Remove this test - it's here to test CI failure behavior
-test('intentionally failing test', async () => {
-  expect(1).toBe(2);
-});
-
 test.describe('Gradebook numeric filter', () => {
   // Request baseURL to ensure the worker fixture (and database) is initialized
   test.beforeAll(async () => {


### PR DESCRIPTION
# Description

The "Merge Playwright reports" GitHub Actions step wasn't actually failing when there were test failures. The fix checks the status of the testing jobs directly.

# Testing

This change affects the GitHub Actions workflow behavior when test failures are present. The step will now correctly fail and be reported in the PR status.