### PR TITLE
Fix point calculation when AI grading result is present

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -214,9 +214,7 @@ function computePointsFromRubric(sourceInput = null) {
       if (!manualInput) return;
       const replaceAutoPoints = form.dataset.rubricReplaceAutoPoints === 'true';
       const startingPoints = Number(form.dataset.rubricStartingPoints ?? 0);
-      const itemsSum = Array.from(
-        form.querySelectorAll('.js-selectable-rubric-item:checked:not(.js-ai-rubric-item)'),
-      )
+      const itemsSum = Array.from(form.querySelectorAll('.js-selectable-rubric-item:checked'))
         .map((item) => Number(item.dataset.rubricItemPoints))
         .reduce((a, b) => a + b, startingPoints);
       const rubricValue =

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
@@ -175,7 +175,6 @@ function RubricItem({
                 type="checkbox"
                 style="margin-left: 3px; margin-right: 8px;"
                 name="rubric_item_selected_ai"
-                class="js-selectable-rubric-item js-ai-rubric-item"
                 value="${item.rubric_item.id}"
                 ${ai_checked ? 'checked' : ''}
                 disabled


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

The existence of an AI grading result column is current causing the rubric grading panel points/percentage to not be calculated correct. This PR removes the js class used for point calculation for ai rubric selections. 

# Testing

Before: when the second column is present, point (and percentage) will always be 0. 
<img width="400" height="600" alt="Screenshot 2026-01-29 230749" src="https://github.com/user-attachments/assets/45614583-3221-4c3c-9ae3-85b9d4a39f11" />

The calculation will work now
<img width="400" height="550" alt="Screenshot 2026-01-29 231012" src="https://github.com/user-attachments/assets/1e7e2361-cd92-417e-b111-03eda7d95144" />
