### PR TITLE
Fix flaky complex test

### DIFF
--- a/exampleCourse/questions/gallery/multipleChoice/complex/server.py
+++ b/exampleCourse/questions/gallery/multipleChoice/complex/server.py
@@ -5,21 +5,37 @@ import random
 def generate(data):
     # gravity (m/s^2)
     g = 9.8
-    # mass of the ball (kg)
-    m = random.choice([3, 1.4, 1.6, 1.8])
-    # horizontal distance (m)
-    d = random.randint(4, 16)
-    # angle with horizontal (in degrees)
-    theta = random.randint(20, 40)
-    # initial velocity  (m/s)
-    v0 = random.randint(18, 25)
-    # initial velocity components (m/s)
-    v0x = v0 * math.cos(theta * math.pi / 180)
-    v0y = v0 * math.sin(theta * math.pi / 180)
-    # time in the air (s)
-    t = d / v0x
-    # height of the cliff (m)
-    h = round(v0y * t + 0.5 * g * t**2, 3)
+
+    # Keep regenerating until all choices are unique
+    while True:
+        # mass of the ball (kg)
+        m = random.choice([3, 1.4, 1.6, 1.8])
+        # horizontal distance (m)
+        d = random.randint(4, 16)
+        # angle with horizontal (in degrees)
+        theta = random.randint(20, 40)
+        # initial velocity  (m/s)
+        v0 = random.randint(18, 25)
+        # initial velocity components (m/s)
+        v0x = v0 * math.cos(theta * math.pi / 180)
+        v0y = v0 * math.sin(theta * math.pi / 180)
+        # time in the air (s)
+        t = d / v0x
+        # height of the cliff (m)
+        h = round(v0y * t + 0.5 * g * t**2, 3)
+
+        # this is the correct answer
+        t_c = round(t, 3)
+        # these are the distractors
+        t_x1 = round(math.sqrt(2 * h / g), 3)
+        t_x2 = round(d / v0, 3)
+        t_x3 = round(d / v0y, 3)
+        t_x4 = round(h / v0y, 3)
+
+        # Check that all choices are unique
+        choices = [t_c, t_x1, t_x2, t_x3, t_x4]
+        if len(choices) == len(set(choices)):
+            break
 
     # storing the parameters
     data["params"]["m"] = m
@@ -31,10 +47,8 @@ def generate(data):
     # determines if the option "none of the above" will be used or not
     data["params"]["none"] = random.choice(["false", "true"])
 
-    # this is the correct answer
-    data["params"]["t_c"] = round(t, 3)
-    # these are the distractors
-    data["params"]["t_x1"] = round(math.sqrt(2 * h / g), 3)
-    data["params"]["t_x2"] = round(d / v0, 3)
-    data["params"]["t_x3"] = round(d / v0y, 3)
-    data["params"]["t_x4"] = round(h / v0y, 3)
+    data["params"]["t_c"] = t_c
+    data["params"]["t_x1"] = t_x1
+    data["params"]["t_x2"] = t_x2
+    data["params"]["t_x3"] = t_x3
+    data["params"]["t_x4"] = t_x4


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

```
 The test found a bug on iteration 95. The gallery/multipleChoice/complex question generated duplicate choices due to randomization - both t_x1 and t_x3 ended up with the
  same value 1.402, causing the error:

  ValueError: pl-multiple-choice element has duplicate choices: ['$t = 1.402\\rm\\ s$'
```

This updates the question to regenerate until all values are unique.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

CI should stop failing with low probability.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
