### PR TITLE
Update Python version in docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: '3.10'
+    python: '3.13'
   jobs:
     pre_build:
       - curl -fsSL https://d2lang.com/install.sh | sh -s --


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://prairielearn.readthedocs.io/en/latest/contributing

-->

# Description

For some reason the readthedocs config was not updated to Python 3.13 with the rest of the Python bumps. This updates the remaining build. I don't expect this to make a big difference in behaviour, this is mostly for consistency. Also updates the image to Ubuntu 24.04 for consistency with other CI tasks.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

A successful CI should mean it works.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
