### PR TITLE
Log sharing sync errors to job output

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -414,7 +414,7 @@ export abstract class Editor {
           const sharingConfigurationValid = await syncFromDisk.checkSharingConfigurationValid(
             this.course.id,
             possibleCourseData,
-            logger,
+            job,
           );
           if (!sharingConfigurationValid) {
             await cleanAndResetRepository(this.course, startGitHash, gitEnv, job);


### PR DESCRIPTION
## Description

When course sync fails due to invalid sharing operations, the validation errors are now properly logged to the job output visible to users instead of just system logs. This makes it clear what specific sharing constraints were violated.

The fix changes one line in `editors.ts` to pass the `job` object (which implements `ServerJobLogger`) instead of the system-level `logger` to `checkSharingConfigurationValid()`.

Claude discovered this bug and made the fix.

## Testing

N/A, this is an obviously correct fix.