### PR TITLE
Fix answer panel visibility in real-time grading updates

### DIFF
--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -661,6 +661,7 @@ export async function renderPanelsForSubmission({
   authorizedEdit,
   renderScorePanels,
   groupRolePermissions,
+  authz_result,
 }: {
   unsafe_submission_id: string;
   question: Question;
@@ -673,6 +674,7 @@ export async function renderPanelsForSubmission({
   authorizedEdit: boolean;
   renderScorePanels: boolean;
   groupRolePermissions: { can_view: boolean; can_submit: boolean } | null;
+  authz_result?: { active: boolean };
 }): Promise<SubmissionPanels> {
   const submissionInfo = await sqldb.queryOptionalRow(
     sql.select_submission_info,
@@ -730,6 +732,7 @@ export async function renderPanelsForSubmission({
       assessment_instance,
       assessment_question,
       group_config,
+      authz_result,
     }),
   };
 

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -296,6 +296,7 @@ router.get(
       authorizedEdit: res.locals.authz_result.authorized_edit,
       renderScorePanels: req.query.render_score_panels === 'true',
       groupRolePermissions: res.locals.group_role_permissions ?? null,
+      authz_result: res.locals.authz_result,
     });
     res.json(panels);
   }),


### PR DESCRIPTION
# Description

> Human note: Claude pointed this out while investigating another bug. We're unlikely to actually hit this case; this would only happen if an assessment transitioned from active to not while an external grading job was being processed.
>
> However, the change here is strictly more correct, so I decided to run with it.

When a grading job completes and results are sent back via real-time updates (used for external grading), the answer panel visibility is determined inconsistently with the full page render path. Specifically, the `renderPanelsForSubmission()` function was not passing `authz_result` to `buildLocals()`, which meant the check for inactive assessments (`authz_result.active === false`) never triggered during real-time updates.

This fix ensures that when an assessment's access window closes, the answer panel is properly revealed via real-time grading updates, consistent with what would be shown on a full page reload.

# Testing

The change is minimal and localized—it simply passes an optional parameter through to an existing function that already knows how to handle it. The real-time grading update path now matches the full page render path in how it handles answer panel visibility.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)