### PR TITLE
pl-order-blocks indentation doesn't line up with characters of text (Issue 4992)

### DIFF
--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.js
@@ -385,19 +385,15 @@ window.PLOrderBlocks = function (uuid, options) {
     const measureElement = document.createElement('span');
     const computedStyle = window.getComputedStyle(sourceElement);
     
-    // Copy all font-related properties to ensure accurate measurement
-    measureElement.style.fontFamily = computedStyle.fontFamily;
-    measureElement.style.fontSize = computedStyle.fontSize;
-    measureElement.style.fontWeight = computedStyle.fontWeight;
-    measureElement.style.fontStyle = computedStyle.fontStyle;
+    // Copy font-related properties to ensure accurate measurement
+    measureElement.style.font = computedStyle.font;
     measureElement.style.letterSpacing = computedStyle.letterSpacing;
-    measureElement.style.lineHeight = computedStyle.lineHeight;
     
     // Set visiblity and content
     measureElement.style.position = 'absolute';
     measureElement.style.visibility = 'hidden';
     measureElement.style.whiteSpace = 'pre';
-    measureElement.textContent = ' '.repeat(TAB_SPACES);
+    measureElement.style.width = `${TAB_SPACES}ch`;
 
     //Create element, measure, and remove
     document.body.append(measureElement);


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description
`TABWIDTH` was set as a constant of 50px. This was too wide for the monospace font being used. I introduced render-time calculations to determine the exact width of a four-space tab and set TABWIDTH to this value dynamically.

This PR closes https://github.com/PrairieLearn/PrairieLearn/issues/4922
<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing
- In the development site, navigate to pl/course_instance/1/instructor/question/130/preview
- Drag two blocks from the left box to the right, ensuring that the second block is indented beneath the first.
- Verify that the the first character of the lower block is aligned four spaces to the right of the first character of the upper block.
<img width="849" height="403" alt="Indentation" src="https://github.com/user-attachments/assets/bb7a049b-105d-4e39-9bce-51aa20d68804" />

- Zoom in and out and ensure that alignment remains correct
- On the browser, change the font-size and reload the page (alignment will not dynamically respond once the page is rendered).
- Ensure that alignment remains correct.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
