### PR TITLE
Organize template questions by randomization type

### DIFF
--- a/exampleCourse/courseInstances/SectionA/assessments/questionTemplates/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/questionTemplates/infoAssessment.json
@@ -20,20 +20,20 @@
     {
       "title": "Intermediate questions: randomization without Python",
       "questions": [
-        { "id": "template/multiple-choice/random", "points": 1, "maxPoints": 4 },
-        { "id": "template/multiple-choice/images", "points": 1, "maxPoints": 4 }
+        { "id": "template/multiple-choice/random", "points": 1, "maxPoints": 3 },
+        { "id": "template/multiple-choice/images", "points": 1, "maxPoints": 3 }
       ]
     },
     {
       "title": "Advanced questions: randomization with Python",
       "questions": [
-        { "id": "template/multiple-choice/random-prompt", "points": 1, "maxPoints": 4 },
-        { "id": "template/multiple-choice/numeric", "points": 1, "maxPoints": 4 },
-        { "id": "template/multiple-choice/random-prompt-true-false", "points": 1, "maxPoints": 4 },
-        { "id": "template/integer-input/random", "points": 1, "maxPoints": 4 },
-        { "id": "template/number-input/random", "points": 1, "maxPoints": 4 },
-        { "id": "template/symbolic-input/random", "points": 1, "maxPoints": 4 },
-        { "id": "template/figure/dynamic", "points": 1, "maxPoints": 4 }
+        { "id": "template/multiple-choice/random-prompt", "points": 1, "maxPoints": 3 },
+        { "id": "template/multiple-choice/numeric", "points": 1, "maxPoints": 3 },
+        { "id": "template/multiple-choice/random-prompt-true-false", "points": 1, "maxPoints": 3 },
+        { "id": "template/integer-input/random", "points": 1, "maxPoints": 3 },
+        { "id": "template/number-input/random", "points": 1, "maxPoints": 3 },
+        { "id": "template/symbolic-input/random", "points": 1, "maxPoints": 3 },
+        { "id": "template/figure/dynamic", "points": 1, "maxPoints": 3 }
       ]
     }
   ]


### PR DESCRIPTION
# Description

This is part of the organization work we want to do to address https://github.com/PrairieLearn/PrairieLearn/issues/14055. This PR splits the template questions assessment into three focused zones based on randomization approach:

1. **Fixed templates** — questions with no randomization
2. **Element-level randomization** — uses element-level features like `number-answers` (no Python code)
3. **Server-side randomization** — uses `server.py` for question generation

Also removed non-template (`demo/*`) questions from the template zones to focus the assessment on actual templates for copying and editing.

@reteps suggested to organize templates this way: https://github.com/PrairieLearn/PrairieLearn/pull/14077#discussion_r2785201157

# Testing

Verified all question IDs exist and are in the correct zones based on presence/absence of `server.py`.