### PR TITLE
Fix empty card footer on student assessment instance page

### DIFF
--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -71,7 +71,7 @@ export function PersonalNotesPanel({
                   `
                 : !authz_result.authorized_edit
                   ? html`
-                      <div class="alert alert-warning mt-2" role="alert">
+                      <div class="alert alert-warning mb-0" role="alert">
                         You are viewing the ${context} instance of a different user and so are not
                         authorized to add or delete personal notes.
                       </div>

--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -522,7 +522,7 @@ export function QuestionFooterContent({
     }
 
     if (authz_result?.authorized_edit === false) {
-      return html`<div class="alert alert-warning mt-2" role="alert">
+      return html`<div class="alert alert-warning mb-0" role="alert">
         You are viewing the question instance of a different user and so are not authorized to save
         answers, to submit answers for grading, or to try a new variant of this same question.
       </div>`;

--- a/apps/prairielearn/src/components/QuestionScore.tsx
+++ b/apps/prairielearn/src/components/QuestionScore.tsx
@@ -49,7 +49,7 @@ export function QuestionScorePanel(
             <div class="card-footer">
               ${authz_result?.authorized_edit === false
                 ? html`
-                    <div class="alert alert-warning mt-2" role="alert">
+                    <div class="alert alert-warning mb-0" role="alert">
                       You are viewing the question instance of a different user and so are not
                       authorized to report an error.
                     </div>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.ts
@@ -530,7 +530,7 @@ export function StudentAssessmentInstance({
                                     </button>
                                   `}
                             </form>
-                            <ul class="my-1">
+                            <ul class="mb-0">
                               ${suspendedSavedAnswers > 1
                                 ? html`
                                     <li>
@@ -597,7 +597,7 @@ export function StudentAssessmentInstance({
                             </ul>
                           `
                         : html`
-                            <ul class="my-1">
+                            <ul class="mb-0">
                               <li>
                                 Submit your answer to each question with the
                                 <strong>Save</strong> button on the question page.


### PR DESCRIPTION
# Description

The card footer on the student assessment instance page was rendering as empty in certain scenarios. The `<div class="card-footer">` was always rendered, but its content was conditional. When neither the exam footer instructions nor the staff warning applied (e.g., Homework assessments viewed by the student, or closed Exams), the footer div would appear empty with just border/padding visible.

Before:

<img width="1323" height="179" alt="Screenshot 2026-02-10 at 15 17 34" src="https://github.com/user-attachments/assets/9899fb4b-553e-455f-b0d8-84a9a9db1940" />

After:

<img width="1330" height="170" alt="Screenshot 2026-02-10 at 15 18 21" src="https://github.com/user-attachments/assets/df7baa28-4cf1-4f3e-a2c3-13c8bb0a0145" />

Majority of implementation using Claude Opus 4.6.

# Testing

Tested on Homework and Exam pages - the footer was visible when needed, and hidden otherwise.