### PR TITLE
Fix course instance usage attribution for shared questions

### DIFF
--- a/apps/prairielearn/src/models/course-instance-usages.sql
+++ b/apps/prairielearn/src/models/course-instance-usages.sql
@@ -21,7 +21,7 @@ FROM
   submissions AS s
   JOIN variants AS v ON (v.id = s.variant_id)
   JOIN questions AS q ON (q.id = v.question_id)
-  JOIN courses AS c ON (c.id = q.course_id)
+  JOIN courses AS c ON (c.id = v.course_id)
   JOIN institutions AS i ON (i.id = c.institution_id)
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
   LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
@@ -66,7 +66,7 @@ FROM
   JOIN submissions AS s ON (s.id = gj.submission_id)
   JOIN variants AS v ON (v.id = s.variant_id)
   JOIN questions AS q ON (q.id = v.question_id)
-  JOIN courses AS c ON (c.id = q.course_id)
+  JOIN courses AS c ON (c.id = v.course_id)
   JOIN institutions AS i ON (i.id = c.institution_id)
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
   LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)

--- a/packages/workspace-utils/src/index.sql
+++ b/packages/workspace-utils/src/index.sql
@@ -156,7 +156,7 @@ FROM
   workspaces AS w
   JOIN variants AS v ON (v.workspace_id = w.id)
   JOIN questions AS q ON (q.id = v.question_id)
-  JOIN courses AS c ON (c.id = q.course_id)
+  JOIN courses AS c ON (c.id = v.course_id)
   JOIN institutions AS i ON (i.id = c.institution_id)
   LEFT JOIN instance_questions AS iq ON (iq.id = v.instance_question_id)
   LEFT JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)


### PR DESCRIPTION
## Summary

- Use `v.course_id` (variant's course) instead of `q.course_id` (question's course) when recording usage data in `course_instance_usages`
- Fixes all three real-time usage queries: submissions, external grading, and workspaces

For shared questions, `q.course_id` points to the sharing/source course, but usage should be attributed to the consuming course where students are actually doing work. This caused impossible `course_id`/`course_instance_id` pairings — a `course_instance_id` from the consuming course would appear under the sharing course's `course_id`.

`variants.course_id` is always the consuming course context (set in `makeAndInsertVariant()`, validated against the course instance in `question-variant.ts:289`), so it's the correct source for attribution.

Closes #11849

A follow-up backfill PR will be needed to correct historical data — see the issue that will be filed after this PR is created.

## Test plan

- [x] Verify the three changed lines use `v.course_id` instead of `q.course_id`
- [x] Confirm no other queries in the same files are affected (AI question generation and AI grading queries correctly use their own course derivation and don't go through variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)