### PR TITLE
Clean conda files on Python grader

### DIFF
--- a/graders/python/Dockerfile
+++ b/graders/python/Dockerfile
@@ -21,7 +21,8 @@ RUN dnf -y update \
     && arch="$(uname -m)" \
     && curl -LO "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${arch}.sh" \
     && bash "Miniforge3-Linux-${arch}.sh" -b -p /usr/local -f \
-    && rm "Miniforge3-Linux-${arch}.sh"
+    && rm "Miniforge3-Linux-${arch}.sh" \
+    && /usr/local/bin/conda clean -afy
 
 COPY requirements.txt /
 RUN python3 -m pip install --no-cache-dir -r /requirements.txt


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

From https://github.com/PrairieLearn/PrairieLearn/pull/14101#issuecomment-3887091220. The latest release of Miniforge include several updates, including Python 3.13 and a new version of conda and mamba. This update also increases the size of the image due to cached files during the installation process. This PR (1) regenerates the Python grader with the new version of Miniforge, and (2) cleans the conda caches to reduce the image size. Results are significant.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Python grader still works as expected in local tests.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
