### PR TITLE
Replace conda/forge with uv in Python grader

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
@@ -1,6 +1,157 @@
 import { describe, expect, it } from 'vitest';
 
-import { correctGeminiMalformedRubricGradingJson } from './ai-grading-util.js';
+import { correctGeminiMalformedRubricGradingJson, parseSubmission } from './ai-grading-util.js';
+
+describe('parseSubmission', () => {
+  it('should return empty array for empty HTML', () => {
+    const result = parseSubmission({ submission_text: '', submitted_answer: null });
+    expect(result).toEqual([]);
+  });
+
+  it('should return plain text as a single text segment', () => {
+    const result = parseSubmission({
+      submission_text: 'Hello world',
+      submitted_answer: null,
+    });
+    expect(result).toEqual([{ type: 'text', text: 'Hello world' }]);
+  });
+
+  it('should preserve HTML tags in text content', () => {
+    const result = parseSubmission({
+      submission_text: '<p>This is <b>bold</b> and <u>underlined</u> text</p>',
+      submitted_answer: null,
+    });
+    expect(result).toEqual([
+      { type: 'text', text: '<p>This is <b>bold</b> and <u>underlined</u> text</p>' },
+    ]);
+  });
+
+  it('should preserve nested HTML structure', () => {
+    const result = parseSubmission({
+      submission_text: '<div><p>Paragraph 1</p><p>Paragraph 2</p></div>',
+      submitted_answer: null,
+    });
+    expect(result).toEqual([
+      { type: 'text', text: '<div><p>Paragraph 1</p><p>Paragraph 2</p></div>' },
+    ]);
+  });
+
+  it('should extract a single image segment', () => {
+    const result = parseSubmission({
+      submission_text:
+        '<div data-image-capture-uuid="abc123" data-file-name="photo.jpg">Image</div>',
+      submitted_answer: {
+        _files: [{ name: 'photo.jpg', contents: 'base64data' }],
+      },
+    });
+    expect(result).toEqual([{ type: 'image', fileName: 'photo.jpg', fileData: 'base64data' }]);
+  });
+
+  it('should produce alternating text and image segments', () => {
+    const result = parseSubmission({
+      submission_text: [
+        '<p>Before image</p>',
+        '<div data-image-capture-uuid="abc" data-file-name="img.jpg">Image</div>',
+        '<p>After image</p>',
+      ].join(''),
+      submitted_answer: {
+        _files: [{ name: 'img.jpg', contents: 'imgdata' }],
+      },
+    });
+    expect(result).toEqual([
+      { type: 'text', text: '<p>Before image</p>' },
+      { type: 'image', fileName: 'img.jpg', fileData: 'imgdata' },
+      { type: 'text', text: '<p>After image</p>' },
+    ]);
+  });
+
+  it('should handle image nested inside other elements', () => {
+    const result = parseSubmission({
+      submission_text:
+        '<div><p>Text</p><div data-image-capture-uuid="abc" data-file-name="nested.jpg">Image</div></div>',
+      submitted_answer: {
+        _files: [{ name: 'nested.jpg', contents: 'nesteddata' }],
+      },
+    });
+    // The image element is replaced with a marker inside the <div>, so the
+    // surrounding HTML is split at the image boundary.
+    expect(result).toEqual([
+      { type: 'text', text: '<div><p>Text</p>' },
+      { type: 'image', fileName: 'nested.jpg', fileData: 'nesteddata' },
+      { type: 'text', text: '</div>' },
+    ]);
+  });
+
+  it('should handle multiple images', () => {
+    const result = parseSubmission({
+      submission_text: [
+        '<p>Start</p>',
+        '<div data-image-capture-uuid="a" data-file-name="first.jpg">Img1</div>',
+        '<p>Middle</p>',
+        '<div data-image-capture-uuid="b" data-file-name="second.jpg">Img2</div>',
+        '<p>End</p>',
+      ].join(''),
+      submitted_answer: {
+        _files: [
+          { name: 'first.jpg', contents: 'data1' },
+          { name: 'second.jpg', contents: 'data2' },
+        ],
+      },
+    });
+    expect(result).toEqual([
+      { type: 'text', text: '<p>Start</p>' },
+      { type: 'image', fileName: 'first.jpg', fileData: 'data1' },
+      { type: 'text', text: '<p>Middle</p>' },
+      { type: 'image', fileName: 'second.jpg', fileData: 'data2' },
+      { type: 'text', text: '<p>End</p>' },
+    ]);
+  });
+
+  it('should handle old-style data-options attribute for file name', () => {
+    const options = JSON.stringify({ submitted_file_name: 'old.jpg' });
+    const result = parseSubmission({
+      submission_text: `<div data-image-capture-uuid="abc" data-options='${options}'>Image</div>`,
+      submitted_answer: {
+        _files: [{ name: 'old.jpg', contents: 'olddata' }],
+      },
+    });
+    expect(result).toEqual([{ type: 'image', fileName: 'old.jpg', fileData: 'olddata' }]);
+  });
+
+  it('should include image segment with null fileData when file data is not found', () => {
+    const result = parseSubmission({
+      submission_text: [
+        '<p>Text</p>',
+        '<div data-image-capture-uuid="abc" data-file-name="missing.jpg">Image</div>',
+      ].join(''),
+      submitted_answer: {
+        _files: [{ name: 'other.jpg', contents: 'otherdata' }],
+      },
+    });
+    expect(result).toEqual([
+      { type: 'text', text: '<p>Text</p>' },
+      { type: 'image', fileName: 'missing.jpg', fileData: null },
+    ]);
+  });
+
+  it('should throw when image found but no submitted_answer', () => {
+    expect(() =>
+      parseSubmission({
+        submission_text: '<div data-image-capture-uuid="abc" data-file-name="img.jpg">Image</div>',
+        submitted_answer: null,
+      }),
+    ).toThrow('No submitted answers found.');
+  });
+
+  it('should throw when image element has no file name', () => {
+    expect(() =>
+      parseSubmission({
+        submission_text: '<div data-image-capture-uuid="abc">Image</div>',
+        submitted_answer: { _files: [] },
+      }),
+    ).toThrow('No file name found.');
+  });
+});
 
 describe('correctGeminiMalformedRubricGradingJson', function () {
   it('should escape single backslash preceding unescapable character', () => {

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -282,77 +282,87 @@ type SubmissionHTMLSegment =
 
 /**
  * Helper function that returns parsed text and image segments from the HTML of a student submission.
+ *
+ * The submission HTML is expected to have already been processed by `stripHtmlForAiGrading`
+ * (this happens in `freeform.ts` when `questionRenderContext === 'ai_grading'`). This function
+ * preserves the full HTML structure for text segments, ensuring the prompt matches what the
+ * instructor sees on the AI grading preview page. Images (identified by `data-image-capture-uuid`
+ * attributes) are extracted and returned as separate segments.
  */
-function parseSubmission({
+export function parseSubmission({
   submission_text,
   submitted_answer,
 }: {
   submission_text: string;
   submitted_answer: Record<string, any> | null;
 }): SubmissionHTMLSegment[] {
-  const segments: SubmissionHTMLSegment[] = [];
+  const $ = cheerio.load(submission_text);
+  const imageElements = $('[data-image-capture-uuid]');
 
-  const $submission_html = cheerio.load(submission_text);
-  let submissionTextSegment = '';
+  // If there are no images, return the full HTML as a single text segment.
+  if (imageElements.length === 0) {
+    const text = $('body').html()?.trim();
+    if (!text) return [];
+    return [{ type: 'text', text }];
+  }
 
-  // Walk through the submitted HTML from top to bottom, appending alternating text and image segments.
-  $submission_html
-    .root()
-    .find('body')
-    .contents()
-    .each((_, node) => {
-      const imageCaptureUUID = $submission_html(node).data('image-capture-uuid');
-      if (imageCaptureUUID) {
-        if (submissionTextSegment) {
-          // Push and reset the current text segment before adding the image.
-          segments.push({
-            type: 'text',
-            text: submissionTextSegment.trim(),
-          });
-          submissionTextSegment = '';
-        }
+  // Extract image data and replace each image element with a unique marker
+  // so we can split the HTML into alternating text/image segments.
+  // The nonce prevents students from injecting markers into their submissions.
+  const nonce = crypto.randomUUID();
+  const imageDataByMarker = new Map<string, { fileName: string; fileData: string | null }>();
 
-        const fileName = run(() => {
-          // New style, where `<pl-image-capture>` has been specialized for AI grading rendering.
-          const submittedFileName = $submission_html(node).data('file-name');
-          if (submittedFileName && typeof submittedFileName === 'string') {
-            return submittedFileName.trim();
-          }
+  imageElements.each((i, el) => {
+    const marker = `__AI_GRADING_IMAGE_${nonce}_${i}__`;
 
-          // Old style, where we have to pick the filename out of the `data-options` attribute.
-          const options = $submission_html(node).data('options') as Record<string, string> | null;
-
-          return options?.submitted_file_name;
-        });
-
-        if (!submitted_answer) {
-          throw new Error('No submitted answers found.');
-        }
-
-        if (!fileName) {
-          throw new Error('No file name found.');
-        }
-
-        const fileData = submitted_answer._files?.find(
-          (file: { name: string; contents: string }) => file.name === fileName,
-        );
-
-        if (fileData) {
-          segments.push({
-            type: 'image',
-            fileName: fileData.name,
-            fileData: fileData.contents,
-          });
-        }
-      } else {
-        submissionTextSegment += $submission_html(node).text();
+    const fileName = run(() => {
+      // New style, where `<pl-image-capture>` has been specialized for AI grading rendering.
+      const submittedFileName = $(el).data('file-name');
+      if (submittedFileName && typeof submittedFileName === 'string') {
+        return submittedFileName.trim();
       }
+
+      // Old style, where we have to pick the filename out of the `data-options` attribute.
+      const options = $(el).data('options') as Record<string, string> | null;
+      return options?.submitted_file_name;
     });
-  if (submissionTextSegment) {
-    segments.push({
-      type: 'text',
-      text: submissionTextSegment.trim(),
-    });
+
+    if (!submitted_answer) {
+      throw new Error('No submitted answers found.');
+    }
+
+    if (!fileName) {
+      throw new Error('No file name found.');
+    }
+
+    const fileData =
+      submitted_answer._files?.find(
+        (file: { name: string; contents: string }) => file.name === fileName,
+      )?.contents ?? null;
+
+    imageDataByMarker.set(marker, { fileName, fileData });
+    $(el).replaceWith(marker);
+  });
+
+  // Get the HTML with markers in place of images, then split on them.
+  const htmlWithMarkers = $('body').html() ?? '';
+  const parts = htmlWithMarkers.split(new RegExp(`(__AI_GRADING_IMAGE_${nonce}_\\d+__)`));
+
+  const segments: SubmissionHTMLSegment[] = [];
+  for (const part of parts) {
+    const imageData = imageDataByMarker.get(part);
+    if (imageData) {
+      segments.push({
+        type: 'image',
+        fileName: imageData.fileName,
+        fileData: imageData.fileData,
+      });
+    } else {
+      const text = part.trim();
+      if (text) {
+        segments.push({ type: 'text', text });
+      }
+    }
   }
 
   return segments;

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/InstructorCourseAdminInstances.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/InstructorCourseAdminInstances.html.tsx
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Button, Popover } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import { formatDate } from '@prairielearn/formatter';
 import { OverlayTrigger } from '@prairielearn/ui';
@@ -13,56 +13,37 @@ import { CreateCourseInstanceModal } from './components/CreateCourseInstanceModa
 import { EmptyState } from './components/EmptyState.js';
 import type { InstructorCourseAdminInstanceRow } from './instructorCourseAdminInstances.shared.js';
 
-function renderPopoverStartDate(courseInstanceId: string) {
-  // React Bootstrap's OverlayTrigger expects the overlay prop to be JSX (or a render function)
-  // so we don't make this a component.
-  return (
-    <Popover id={`popover-start-date-${courseInstanceId}`}>
-      <Popover.Header as="h3">Earliest access date</Popover.Header>
-      <Popover.Body>
-        <p>
-          This date is the earliest <code>startDate</code> that appears in any{' '}
-          <code>accessRule</code> for the course instance. Course instances are listed in order from
-          newest to oldest according to this date.
-        </p>
-        <p>
-          It is recommended that you define at least one <code>accessRule</code> that makes the
-          course instance accessible to students only during the semester or other time period in
-          which that particular course instance is offered. You can do so by editing the{' '}
-          <code>infoCourseInstance.json</code> file for the course instance. For more information,
-          see the{' '}
-          <a href="https://docs.prairielearn.com/accessControl/">documentation on access control</a>
-          .
-        </p>
-      </Popover.Body>
-    </Popover>
-  );
-}
+const accessRuleRecommendation = (
+  <p>
+    It is recommended that you define at least one <code>accessRule</code> that makes the course
+    instance accessible to students only during the semester or other time period in which that
+    particular course instance is offered. You can do so by editing the{' '}
+    <code>infoCourseInstance.json</code> file for the course instance. For more information, see the{' '}
+    <a href="https://docs.prairielearn.com/accessControl/">documentation on access control</a>.
+  </p>
+);
 
-function renderPopoverEndDate(courseInstanceId: string) {
-  return (
-    <Popover id={`popover-end-date-${courseInstanceId}`}>
-      <Popover.Header as="h3">Latest Access Date</Popover.Header>
-      <Popover.Body>
-        <p>
-          This date is the latest <code>endDate</code> that appears in any <code>accessRule</code>{' '}
-          for the course instance. If two course instances have the same &quot;Earliest Access
-          Date,&quot; then they are listed from newest to oldest according to this &quot;Latest
-          Access Date.&quot;
-        </p>
-        <p>
-          It is recommended that you define at least one <code>accessRule</code> that makes the
-          course instance accessible to students only during the semester or other time period in
-          which that particular course instance is offered. You can do so by editing the{' '}
-          <code>infoCourseInstance.json</code> file for the course instance. For more information,
-          see the{' '}
-          <a href="https://docs.prairielearn.com/accessControl/">documentation on access control</a>
-          .
-        </p>
-      </Popover.Body>
-    </Popover>
-  );
-}
+const popoverStartDateBody = (
+  <>
+    <p>
+      This date is the earliest <code>startDate</code> that appears in any <code>accessRule</code>{' '}
+      for the course instance. Course instances are listed in order from newest to oldest according
+      to this date.
+    </p>
+    {accessRuleRecommendation}
+  </>
+);
+
+const popoverEndDateBody = (
+  <>
+    <p>
+      This date is the latest <code>endDate</code> that appears in any <code>accessRule</code> for
+      the course instance. If two course instances have the same &quot;Earliest Access Date,&quot;
+      then they are listed from newest to oldest according to this &quot;Latest Access Date.&quot;
+    </p>
+    {accessRuleRecommendation}
+  </>
+);
 
 interface InstructorCourseAdminInstancesInnerProps {
   courseInstances: InstructorCourseAdminInstanceRow[];
@@ -164,7 +145,8 @@ export function InstructorCourseAdminInstancesInner({
                               props: {
                                 id: `popover-start-date-${row.id}`,
                               },
-                              body: renderPopoverStartDate(row.id),
+                              header: 'Earliest access date',
+                              body: popoverStartDateBody,
                             }}
                           >
                             <Button
@@ -187,7 +169,8 @@ export function InstructorCourseAdminInstancesInner({
                               props: {
                                 id: `popover-end-date-${row.id}`,
                               },
-                              body: renderPopoverEndDate(row.id),
+                              header: 'Latest access date',
+                              body: popoverEndDateBody,
                             }}
                           >
                             <Button


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

As discussed with @nwalters512. All other images use `uv` to manage Python versions, so it makes sense to migrate the Python grader as well. As a bonus, the resulting image is ~10% smaller.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Running the grader locally still works as expected.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
