### PR TITLE
Preserve HTML tags in AI grading submission text

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
@@ -118,7 +118,7 @@ describe('parseSubmission', () => {
     expect(result).toEqual([{ type: 'image', fileName: 'old.jpg', fileData: 'olddata' }]);
   });
 
-  it('should skip image segment when file data is not found', () => {
+  it('should include image segment with null fileData when file data is not found', () => {
     const result = parseSubmission({
       submission_text: [
         '<p>Text</p>',
@@ -128,7 +128,10 @@ describe('parseSubmission', () => {
         _files: [{ name: 'other.jpg', contents: 'otherdata' }],
       },
     });
-    expect(result).toEqual([{ type: 'text', text: '<p>Text</p>' }]);
+    expect(result).toEqual([
+      { type: 'text', text: '<p>Text</p>' },
+      { type: 'image', fileName: 'missing.jpg', fileData: null },
+    ]);
   });
 
   it('should throw when image found but no submitted_answer', () => {

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -346,21 +346,17 @@ export function parseSubmission({
 
   // Get the HTML with markers in place of images, then split on them.
   const htmlWithMarkers = $('body').html() ?? '';
-  const parts = htmlWithMarkers.split(
-    new RegExp(`(__AI_GRADING_IMAGE_${nonce}_\\d+__)`),
-  );
+  const parts = htmlWithMarkers.split(new RegExp(`(__AI_GRADING_IMAGE_${nonce}_\\d+__)`));
 
   const segments: SubmissionHTMLSegment[] = [];
   for (const part of parts) {
     const imageData = imageDataByMarker.get(part);
     if (imageData) {
-      if (imageData.fileData) {
-        segments.push({
-          type: 'image',
-          fileName: imageData.fileName,
-          fileData: imageData.fileData,
-        });
-      }
+      segments.push({
+        type: 'image',
+        fileName: imageData.fileName,
+        fileData: imageData.fileData,
+      });
     } else {
       const text = part.trim();
       if (text) {


### PR DESCRIPTION
## Description

This PR fixes the AI grading prompt to preserve HTML tags from student submissions, ensuring the text segments in the prompt match what instructors see on the AI grading preview page. This is critical for elements like `pl-rich-text-editor` which emit HTML for formatting (bold, underline, etc.) that impacts grading quality.

Refactor `parseSubmission()` to use a marker-based approach that preserves full HTML structure in text segments while correctly extracting images at any nesting depth (fixing a latent bug where nested images were missed - see https://github.com/PrairieLearn/PrairieLearn/issues/13128).

Closes https://github.com/PrairieLearn/PrairieLearn/issues/13128.

## Testing

Added comprehensive unit tests.