### PR TITLE
Switch away from JSX.Element to ReactNode

### DIFF
--- a/.changeset/replace-jsx-element-with-reactnode.md
+++ b/.changeset/replace-jsx-element-with-reactnode.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': patch
+---
+
+Replace `JSX.Element` with `ReactNode` in component type definitions

--- a/apps/prairielearn/src/pages/instructorGradebook/components/InstructorGradebookTable.tsx
+++ b/apps/prairielearn/src/pages/instructorGradebook/components/InstructorGradebookTable.tsx
@@ -397,7 +397,7 @@ function GradebookTable({
   const filters = useMemo(() => {
     const assessmentFilters: Record<
       string,
-      (props: { header: Header<GradebookRow, unknown> }) => React.JSX.Element
+      (props: { header: Header<GradebookRow, unknown> }) => React.ReactNode
     > = {};
 
     courseAssessments.forEach((assessment) => {

--- a/apps/prairielearn/src/pages/instructorQuestionCreate/components/WireframePreview.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionCreate/components/WireframePreview.tsx
@@ -613,7 +613,7 @@ function ImageCapturePreview() {
  * requires adding a corresponding entry here.
  */
 const BASIC_QUESTION_MAP: Partial<
-  Record<string, { label: string; description: string; Preview: () => React.JSX.Element }>
+  Record<string, { label: string; description: string; Preview: () => React.ReactNode }>
 > = {
   'template/multiple-choice/fixed': {
     label: 'Multiple choice',

--- a/packages/ui/src/components/CategoricalColumnFilter.tsx
+++ b/packages/ui/src/components/CategoricalColumnFilter.tsx
@@ -1,6 +1,6 @@
 import type { Column } from '@tanstack/react-table';
 import clsx from 'clsx';
-import { type JSX, useMemo, useState } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 
 function computeSelected<TValue extends string>(
@@ -38,7 +38,7 @@ export function CategoricalColumnFilter<TData, TValue extends string = string>({
 }: {
   column: Column<TData, unknown>;
   allColumnValues: TValue[] | readonly TValue[];
-  renderValueLabel?: (props: { value: TValue; isSelected: boolean }) => JSX.Element;
+  renderValueLabel?: (props: { value: TValue; isSelected: boolean }) => ReactNode;
 }) {
   const [mode, setMode] = useState<'include' | 'exclude'>('include');
 

--- a/packages/ui/src/components/MultiSelectColumnFilter.tsx
+++ b/packages/ui/src/components/MultiSelectColumnFilter.tsx
@@ -1,6 +1,6 @@
 import type { Column } from '@tanstack/table-core';
 import clsx from 'clsx';
-import { type JSX, useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 
 function defaultRenderValueLabel({ value }: { value: string }) {
@@ -27,7 +27,7 @@ export function MultiSelectColumnFilter<TData, TValue extends string = string>({
 }: {
   column: Column<TData, unknown>;
   allColumnValues: TValue[];
-  renderValueLabel?: (props: { value: TValue; isSelected: boolean }) => JSX.Element;
+  renderValueLabel?: (props: { value: TValue; isSelected: boolean }) => ReactNode;
 }) {
   const columnId = column.id;
 

--- a/packages/ui/src/components/TanstackTable.tsx
+++ b/packages/ui/src/components/TanstackTable.tsx
@@ -2,15 +2,7 @@ import { flexRender } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Cell, Header, Row, Table } from '@tanstack/table-core';
 import clsx from 'clsx';
-import {
-  type ComponentProps,
-  type JSX,
-  type ReactNode,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { type ComponentProps, type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import { useDebouncedCallback } from 'use-debounce';
@@ -92,10 +84,10 @@ const DefaultEmptyState = (
 interface TanstackTableProps<RowDataModel> {
   table: Table<RowDataModel>;
   title: string;
-  filters?: Record<string, (props: { header: Header<RowDataModel, unknown> }) => JSX.Element>;
+  filters?: Record<string, (props: { header: Header<RowDataModel, unknown> }) => ReactNode>;
   rowHeight?: number;
-  noResultsState?: JSX.Element;
-  emptyState?: JSX.Element;
+  noResultsState?: ReactNode;
+  emptyState?: ReactNode;
   scrollRef?: React.RefObject<HTMLDivElement | null> | null;
 }
 

--- a/packages/ui/src/components/TanstackTableHeaderCell.tsx
+++ b/packages/ui/src/components/TanstackTableHeaderCell.tsx
@@ -1,7 +1,7 @@
 import { flexRender } from '@tanstack/react-table';
 import type { Header, SortDirection, Table } from '@tanstack/table-core';
 import clsx from 'clsx';
-import type { CSSProperties, JSX } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 function SortIcon({ sortMethod }: { sortMethod: false | SortDirection }) {
   if (sortMethod === 'asc') {
@@ -104,7 +104,7 @@ export function TanstackTableHeaderCell<RowDataModel>({
   measurementMode = false,
 }: {
   header: Header<RowDataModel, unknown>;
-  filters: Record<string, (props: { header: Header<RowDataModel, unknown> }) => JSX.Element>;
+  filters: Record<string, (props: { header: Header<RowDataModel, unknown> }) => ReactNode>;
   table: Table<RowDataModel>;
   handleResizeEnd?: () => void;
   isPinned: 'left' | false;

--- a/packages/ui/src/components/useAutoSizeColumns.tsx
+++ b/packages/ui/src/components/useAutoSizeColumns.tsx
@@ -1,5 +1,5 @@
 import type { ColumnSizingState, Header, Table } from '@tanstack/react-table';
-import { type JSX, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { type Root, createRoot } from 'react-dom/client';
 
@@ -12,7 +12,7 @@ function HiddenMeasurementHeader<TData>({
 }: {
   table: Table<TData>;
   columnsToMeasure: { id: string }[];
-  filters?: Record<string, (props: { header: Header<TData, unknown> }) => JSX.Element>;
+  filters?: Record<string, (props: { header: Header<TData, unknown> }) => ReactNode>;
 }) {
   const headerGroups = table.getHeaderGroups();
   const leafHeaderGroup = headerGroups[headerGroups.length - 1];
@@ -64,7 +64,7 @@ function HiddenMeasurementHeader<TData>({
 export function useAutoSizeColumns<TData>(
   table: Table<TData>,
   tableRef: RefObject<HTMLDivElement | null>,
-  filters?: Record<string, (props: { header: Header<TData, unknown> }) => JSX.Element>,
+  filters?: Record<string, (props: { header: Header<TData, unknown> }) => ReactNode>,
 ): boolean {
   const measurementContainerRef = useRef<HTMLDivElement | null>(null);
   const measurementRootRef = useRef<Root | null>(null);


### PR DESCRIPTION
# Description

Fixes #14088

Replaces all occurrences of `JSX.Element` with `ReactNode` across the codebase, aligning with React's recommended types. `ReactNode` is more accurate for component return types and callbacks since it includes all valid JSX children (elements, primitives, fragments, null, etc.).

# Testing

All TypeScript files typecheck cleanly. No runtime behavior changes — this is purely a type change.

<!--
AI assistance used for implementation.
-->