### PR TITLE
Fix nested popover on course instances page

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/InstructorCourseAdminInstances.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/InstructorCourseAdminInstances.html.tsx
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Button, Popover } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import { formatDate } from '@prairielearn/formatter';
 import { OverlayTrigger } from '@prairielearn/ui';
@@ -13,56 +13,37 @@ import { CreateCourseInstanceModal } from './components/CreateCourseInstanceModa
 import { EmptyState } from './components/EmptyState.js';
 import type { InstructorCourseAdminInstanceRow } from './instructorCourseAdminInstances.shared.js';
 
-function renderPopoverStartDate(courseInstanceId: string) {
-  // React Bootstrap's OverlayTrigger expects the overlay prop to be JSX (or a render function)
-  // so we don't make this a component.
-  return (
-    <Popover id={`popover-start-date-${courseInstanceId}`}>
-      <Popover.Header as="h3">Earliest access date</Popover.Header>
-      <Popover.Body>
-        <p>
-          This date is the earliest <code>startDate</code> that appears in any{' '}
-          <code>accessRule</code> for the course instance. Course instances are listed in order from
-          newest to oldest according to this date.
-        </p>
-        <p>
-          It is recommended that you define at least one <code>accessRule</code> that makes the
-          course instance accessible to students only during the semester or other time period in
-          which that particular course instance is offered. You can do so by editing the{' '}
-          <code>infoCourseInstance.json</code> file for the course instance. For more information,
-          see the{' '}
-          <a href="https://docs.prairielearn.com/accessControl/">documentation on access control</a>
-          .
-        </p>
-      </Popover.Body>
-    </Popover>
-  );
-}
+const accessRuleRecommendation = (
+  <p>
+    It is recommended that you define at least one <code>accessRule</code> that makes the course
+    instance accessible to students only during the semester or other time period in which that
+    particular course instance is offered. You can do so by editing the{' '}
+    <code>infoCourseInstance.json</code> file for the course instance. For more information, see the{' '}
+    <a href="https://docs.prairielearn.com/accessControl/">documentation on access control</a>.
+  </p>
+);
 
-function renderPopoverEndDate(courseInstanceId: string) {
-  return (
-    <Popover id={`popover-end-date-${courseInstanceId}`}>
-      <Popover.Header as="h3">Latest Access Date</Popover.Header>
-      <Popover.Body>
-        <p>
-          This date is the latest <code>endDate</code> that appears in any <code>accessRule</code>{' '}
-          for the course instance. If two course instances have the same &quot;Earliest Access
-          Date,&quot; then they are listed from newest to oldest according to this &quot;Latest
-          Access Date.&quot;
-        </p>
-        <p>
-          It is recommended that you define at least one <code>accessRule</code> that makes the
-          course instance accessible to students only during the semester or other time period in
-          which that particular course instance is offered. You can do so by editing the{' '}
-          <code>infoCourseInstance.json</code> file for the course instance. For more information,
-          see the{' '}
-          <a href="https://docs.prairielearn.com/accessControl/">documentation on access control</a>
-          .
-        </p>
-      </Popover.Body>
-    </Popover>
-  );
-}
+const popoverStartDateBody = (
+  <>
+    <p>
+      This date is the earliest <code>startDate</code> that appears in any <code>accessRule</code>{' '}
+      for the course instance. Course instances are listed in order from newest to oldest according
+      to this date.
+    </p>
+    {accessRuleRecommendation}
+  </>
+);
+
+const popoverEndDateBody = (
+  <>
+    <p>
+      This date is the latest <code>endDate</code> that appears in any <code>accessRule</code> for
+      the course instance. If two course instances have the same &quot;Earliest Access Date,&quot;
+      then they are listed from newest to oldest according to this &quot;Latest Access Date.&quot;
+    </p>
+    {accessRuleRecommendation}
+  </>
+);
 
 interface InstructorCourseAdminInstancesInnerProps {
   courseInstances: InstructorCourseAdminInstanceRow[];
@@ -164,7 +145,8 @@ export function InstructorCourseAdminInstancesInner({
                               props: {
                                 id: `popover-start-date-${row.id}`,
                               },
-                              body: renderPopoverStartDate(row.id),
+                              header: 'Earliest access date',
+                              body: popoverStartDateBody,
                             }}
                           >
                             <Button
@@ -187,7 +169,8 @@ export function InstructorCourseAdminInstancesInner({
                               props: {
                                 id: `popover-end-date-${row.id}`,
                               },
-                              body: renderPopoverEndDate(row.id),
+                              header: 'Latest access date',
+                              body: popoverEndDateBody,
                             }}
                           >
                             <Button


### PR DESCRIPTION
## Description

Fixed a nested popover issue on the course instances admin page where the `renderPopoverStartDate` and `renderPopoverEndDate` functions were returning full `<Popover>` components, but these were passed as `popover.body` to the custom `OverlayTrigger` component, which already wraps content in its own `<Popover>`. This created a double-popover structure causing styling issues and broken dismiss behavior. This regressed in #13404.

The fix passes the header via the `popover.header` prop and body content directly, allowing the OverlayTrigger to construct a single proper popover.

Fixes #14120.

Before:
<img width="414" height="675" alt="Screenshot 2026-02-13 at 16 19 30" src="https://github.com/user-attachments/assets/d2714ffe-f952-4532-bab9-bf5f6c43739c" />

After:
<img width="405" height="568" alt="Screenshot 2026-02-13 at 16 19 19" src="https://github.com/user-attachments/assets/5b380504-4307-43ca-9f0c-e9c0569b2878" />

## Testing

This change removes the nested popover structure, fixing the tooltip dismissal, repositioning, and styling issues mentioned in the issue.

🤖 AI assistance: Claude Opus 4.6 implemented the fix based on analysis of the code and issue description.