### PR TITLE
Track usage in agent-based AI question generation

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
@@ -44,6 +44,7 @@ import {
 import { DefaultMap } from '../../../lib/default-map.js';
 import { REPOSITORY_ROOT_PATH } from '../../../lib/paths.js';
 import { createServerJob } from '../../../lib/server-jobs.js';
+import { updateCourseInstanceUsagesForAiQuestionGeneration } from '../../../models/course-instance-usages.js';
 import { selectQuestionById } from '../../../models/question.js';
 import { selectAiQuestionGenerationContextMessages } from '../../models/ai-question-generation-message.js';
 import {
@@ -720,6 +721,13 @@ export async function editQuestionWithAgent({
       user,
       usage: totalUsage,
       model: modelId,
+    });
+
+    await updateCourseInstanceUsagesForAiQuestionGeneration({
+      courseId: course.id,
+      authnUserId: authnUser.id,
+      model: modelId,
+      usage: totalUsage,
     });
   });
 

--- a/apps/prairielearn/src/models/course-instance-usages.sql
+++ b/apps/prairielearn/src/models/course-instance-usages.sql
@@ -111,12 +111,10 @@ SELECT
   $authn_user_id,
   FALSE
 FROM
-  ai_question_generation_prompts AS p
-  JOIN questions AS q ON (q.id = p.question_id)
-  JOIN courses AS c ON (c.id = q.course_id)
+  courses AS c
   JOIN institutions AS i ON (i.id = c.institution_id)
 WHERE
-  p.id = $prompt_id
+  c.id = $course_id
 ON CONFLICT (
   type,
   course_id,

--- a/apps/prairielearn/src/models/course-instance-usages.ts
+++ b/apps/prairielearn/src/models/course-instance-usages.ts
@@ -72,24 +72,24 @@ export async function updateCourseInstanceUsagesForGradingJob({
  * Update the course instance usages for an AI question generation prompt.
  *
  * @param param
- * @param param.promptId The ID of the AI question generation prompt.
+ * @param param.courseId The ID of the course.
  * @param param.authnUserId The ID of the user who generated the prompt.
  * @param param.model The model used for the prompt.
  * @param param.usage The usage object returned by the model provider's API.
  */
 export async function updateCourseInstanceUsagesForAiQuestionGeneration({
-  promptId,
+  courseId,
   authnUserId,
   model,
   usage,
 }: {
-  promptId: string;
+  courseId: string;
   authnUserId: string;
   model: keyof (typeof config)['costPerMillionTokens'];
   usage: LanguageModelUsage | undefined;
 }) {
   await execute(sql.update_course_instance_usages_for_ai_question_generation, {
-    prompt_id: promptId,
+    course_id: courseId,
     authn_user_id: authnUserId,
     cost_ai_question_generation: calculateResponseCost({ model, usage }),
   });


### PR DESCRIPTION
## Description

The agent-based AI question generation flow only tracked usage in Redis for rate limiting but did not persist usage data to the database for billing. This change updates `updateCourseInstanceUsagesForAiQuestionGeneration` to accept `courseId` directly instead of `promptId`, allowing it to work with both the modern agent-based flow and the older flow.

Since the agent-based flow doesn't create `ai_question_generation_prompts` records during generation (only in `ai_question_generation_messages`), the SQL query was refactored to look up the institution from the `courses` table directly rather than joining through prompts.

## Testing

- Typechecking passes on all modified files
- Linting and formatting verified
- Changes are backwards compatible with the unused `generateQuestion` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)