### PR TITLE
Workaround MathJax 4 bug in older safari versions

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -994,6 +994,11 @@ mechanicsObjects.LatexText = fabric.util.createClass(fabric.Object, {
     svg.setAttribute('width', width + 'px');
     svg.setAttribute('height', height + 'px');
 
+    // Use XMLSerializer instead of outerHTML so that the SVG is serialized
+    // as valid XML. outerHTML uses HTML serialization rules, which don't
+    // escape '<' and '>' inside attribute values. MathJax 4's Speech Rule
+    // Engine adds data-semantic-speech attributes containing SSML markup
+    // (e.g. <prosody>, <say-as>) that include these characters.
     const svgSource = new XMLSerializer().serializeToString(svg);
 
     const base64svg = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(svgSource)));


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes a bug with older Safari versions and MathJax 4. Reported on Slack.

~~Fixed upstream in https://github.com/mathjax/MathJax-src/pull/1432.~~

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

I actually can't test that this resolves the issue, but I tested that a `pl-drawing` question still functions.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
