### PR TITLE
Finalize v4 course instance usage backfills

### DIFF
--- a/apps/prairielearn/src/migrations/20260216151142_course_instance_usages__submissions__backfill_v4__finalize.ts
+++ b/apps/prairielearn/src/migrations/20260216151142_course_instance_usages__submissions__backfill_v4__finalize.ts
@@ -1,0 +1,5 @@
+import { finalizeBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await finalizeBatchedMigration('20260214020000_course_instance_usages__submissions__backfill_v4');
+}

--- a/apps/prairielearn/src/migrations/20260216151143_course_instance_usages__external_grading_jobs__backfill_v4__finalize.ts
+++ b/apps/prairielearn/src/migrations/20260216151143_course_instance_usages__external_grading_jobs__backfill_v4__finalize.ts
@@ -1,0 +1,7 @@
+import { finalizeBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await finalizeBatchedMigration(
+    '20260214020001_course_instance_usages__external_grading_jobs__backfill_v4',
+  );
+}

--- a/apps/prairielearn/src/migrations/20260216151144_course_instance_usages__workspaces__backfill_v4__finalize.ts
+++ b/apps/prairielearn/src/migrations/20260216151144_course_instance_usages__workspaces__backfill_v4__finalize.ts
@@ -1,0 +1,5 @@
+import { finalizeBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await finalizeBatchedMigration('20260214020002_course_instance_usages__workspaces__backfill_v4');
+}


### PR DESCRIPTION
# Description

Followup to #14129. Adds finalize migrations for the three v4 `course_instance_usages` batched backfills (submissions, external grading jobs, workspaces). These block deployment until the async backfills complete, ensuring all data is recomputed using `variant.course_id` before the next deploy proceeds.

AI-assisted implementation.

# Testing

Finalize migrations follow the established pattern and call `finalizeBatchedMigration()` with the corresponding batched migration identifier from #14129. No manual testing is possible before merge; the finalization runs automatically on deployment.