### PR TITLE
Remove back button from AI question generation draft editor

### DIFF
--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/components/AiQuestionGenerationEditor.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/components/AiQuestionGenerationEditor.tsx
@@ -87,17 +87,6 @@ function AiQuestionGenerationEditorInner({
       />
 
       <div className="d-flex flex-row align-items-stretch bg-light app-preview-tabs z-1">
-        <div className="d-flex align-items-center border-bottom ps-2">
-          <a
-            href={`${urlPrefix}/ai_generate_question_drafts`}
-            className="btn btn-sm btn-ghost"
-            aria-label="Back to AI questions"
-            data-bs-toggle="tooltip"
-            data-bs-title="Back to AI questions"
-          >
-            <i className="fa fa-arrow-left" aria-hidden="true" />
-          </a>
-        </div>
         <ul className="nav nav-tabs me-auto ps-2 pt-2">
           <li className="nav-item">
             <a


### PR DESCRIPTION
# Description

Removes the back button from the AI question generation draft editor. The button is no longer needed in this editor interface.

Breaking this out into its own change because I ended up making this change in a few other ongoing changes and agents keep getting confused about this being batched in with "unrelated" changes during review.

# Testing

This is a simple UI change - the back button has been removed from the left side of the editor tab bar.