### PR TITLE
Fix `pl-file-upload` rejecting empty files

### DIFF
--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -179,16 +179,12 @@
       reader.onload = (e) => {
         const dataUrl = e.target.result;
 
+        // Extract base64 data from the data URL. For non-empty files, the
+        // data URL has the format "data:<mime>;base64,<data>". For empty files,
+        // some browsers (e.g. Chrome) return just "data:" with no comma, so we
+        // treat missing comma as empty content.
         const commaSplitIdx = dataUrl.indexOf(',');
-        if (commaSplitIdx === -1) {
-          this.addWarningMessage(
-            `<strong>${escapeFileName(name)}</strong> is empty, ignoring file.`,
-          );
-          return;
-        }
-
-        // Store the file as base-64 encoded data
-        const base64FileData = dataUrl.slice(commaSplitIdx + 1);
+        const base64FileData = commaSplitIdx === -1 ? '' : dataUrl.slice(commaSplitIdx + 1);
         this.saveSubmittedFile(name, size, isFromDownload ? null : new Date(), base64FileData);
         this.refreshRequiredRegex();
         this.renderFileList();


### PR DESCRIPTION
## Summary

- Fix bug where `pl-file-upload` silently rejected empty files
- In Chrome, `FileReader.readAsDataURL()` returns `"data:"` (no comma) for empty files, which the code treated as an error
- Now treats a missing comma as empty base64 content, allowing empty files to be uploaded

Fixes #12331

## Test plan

- [ ] Upload an empty file (0 bytes) using `pl-file-upload` — it should be accepted and saved
- [ ] Upload a non-empty file — should still work as before
- [ ] Verify in both Chrome and Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)