### PR TITLE
Fix `pl-file-upload` empty file detection across browsers

### DIFF
--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -179,16 +179,22 @@
       reader.onload = (e) => {
         const dataUrl = e.target.result;
 
+        // Extract base64 data from the data URL. The data URL format is
+        // "data:<mime>;base64,<data>". For empty files, some browsers (e.g.
+        // Chrome) return just "data:" with no comma, while others (e.g.
+        // Firefox) return "data:...;base64," with an empty string after
+        // the comma. We check for both cases.
         const commaSplitIdx = dataUrl.indexOf(',');
-        if (commaSplitIdx === -1) {
+        const base64FileData = commaSplitIdx === -1 ? '' : dataUrl.slice(commaSplitIdx + 1);
+
+        if (!base64FileData) {
           this.addWarningMessage(
             `<strong>${escapeFileName(name)}</strong> is empty, ignoring file.`,
           );
+          this.renderFileList();
           return;
         }
 
-        // Store the file as base-64 encoded data
-        const base64FileData = dataUrl.slice(commaSplitIdx + 1);
         this.saveSubmittedFile(name, size, isFromDownload ? null : new Date(), base64FileData);
         this.refreshRequiredRegex();
         this.renderFileList();


### PR DESCRIPTION

<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

In Firefox and Safari, the current behavior meant that empty files weren't reported as an error. Closes #12331

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing


Before:

https://github.com/user-attachments/assets/c94cdcff-9eea-4bad-8960-6a9e4c36ce3b

After:

https://github.com/user-attachments/assets/89dda0cb-9f32-4696-915c-8ad1500e324f



<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
