### PR TITLE
Fix AttributeError in Python autograder `addFailure`

### DIFF
--- a/graders/python/python_autograder/pl_result.py
+++ b/graders/python/python_autograder/pl_result.py
@@ -130,11 +130,11 @@ class PLTestResult(unittest.TestResult):
 
     def addFailure(self, test: unittest.TestCase, err: Any) -> None:  # noqa: N802
         unittest.TestResult.addFailure(self, test, err)
-        # # We can't easily import PLTestCase to type these fields
-        if test.points is None:  # type: ignore
+        points = getattr(test, "points", None)
+        if points is None:
             self.results[-1]["points"] = 0
         else:
-            self.results[-1]["points"] = test.points * self.results[-1]["max_points"]  # type: ignore
+            self.results[-1]["points"] = points * self.results[-1]["max_points"]
 
     def stopTest(self, test: unittest.TestCase) -> None:  # noqa: N802
         # Never write output back to the console


### PR DESCRIPTION
## Summary

- Use `getattr(test, "points", None)` in `addFailure`, matching the safe pattern already used by `addSuccess` and `addError`. This prevents an `AttributeError` when a failure occurs before `setUp` has initialized `self.points`.

Closes #5691

## Testing

None, fix seems straighforward. We should start unit testing external graders eventually though.

🤖 Generated with [Claude Code](https://claude.com/claude-code)