### PR TITLE
Drop redundant `questions_course_id_number_nondeleted_key` index

### DIFF
--- a/apps/prairielearn/src/migrations/20260225004042_questions__course_id_number_nondeleted_key__drop_index.sql
+++ b/apps/prairielearn/src/migrations/20260225004042_questions__course_id_number_nondeleted_key__drop_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS questions_course_id_number_nondeleted_key;

--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -44,7 +44,6 @@ columns
 
 indexes
     questions_pkey: PRIMARY KEY (id) USING btree (id)
-    questions_course_id_number_nondeleted_key: UNIQUE USING btree (course_id, uuid) WHERE deleted_at IS NULL
     questions_course_id_uuid_key: UNIQUE USING btree (course_id, uuid)
     questions_course_id_publicly_shared_idx: USING btree (course_id) WHERE deleted_at IS NULL AND (share_publicly = true OR share_source_publicly = true)
     questions_template_directory_idx: USING btree (template_directory)


### PR DESCRIPTION
## Summary

- Drop the redundant partial unique index `questions_course_id_number_nondeleted_key` on `(course_id, uuid) WHERE deleted_at IS NULL`
- This index is fully covered by the unconditional `questions_course_id_uuid_key` unique index on `(course_id, uuid)`
- It was left behind when migration `20200913144809` re-added the full unique constraint but only dropped `questions_course_id_uuid_nondeleted_key`

Closes #3162

## Test plan

None, CI should still pass, this is just cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)