### PR TITLE
Add student view link to staff information panel

### DIFF
--- a/apps/prairielearn/src/components/InstructorInfoPanel.tsx
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.tsx
@@ -296,7 +296,11 @@ function AssessmentInstanceInfo({
       <div>${formatInterval(duration)}</div>
     </div>
 
-    <div class="pb-2">
+    <div class="pb-2 d-flex flex-wrap gap-2">
+      <a
+        href="/pl/course_instance/${assessment.course_instance_id}/assessment_instance/${assessment_instance.id}"
+        >Student view</a
+      >
       <a href="${instructorUrlPrefix}/assessment_instance/${assessment_instance.id}">View log</a>
     </div>
   `;


### PR DESCRIPTION
## Summary
- Adds a "Student view" link to the assessment instance section of the staff information panel, alongside the existing "View log" link

This is a small, pulled out comment from #1825 that I added when I closed that issue.

## Test plan

I tested that the link works. You can get here by going to the "student view" on a instance question.

<img width="335" height="196" alt="image" src="https://github.com/user-attachments/assets/6beca897-7ff4-4ae2-9a55-e8c19f965978" />

<img width="460" height="568" alt="image" src="https://github.com/user-attachments/assets/37d7f6a0-e2bd-460d-80e7-886c5e600fa4" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)