### PR TITLE
Improve SAML missing attributes error message

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -150,25 +150,26 @@ router.post(
     ) {
       throw new Error('Missing one or more SAML attribute mappings');
     }
-    const nameAttributeDescription = institutionSamlProvider.name_attribute
-      ? institutionSamlProvider.name_attribute
-      : `${institutionSamlProvider.given_name_attribute} + ${institutionSamlProvider.family_name_attribute}`;
-    const missingAttributes = [
-      ...(!resolved.uid ? [`uid (${institutionSamlProvider.uid_attribute})`] : []),
-      ...(!resolved.uin ? [`uin (${institutionSamlProvider.uin_attribute})`] : []),
-      ...(!resolved.name ? [`name (${nameAttributeDescription})`] : []),
-    ];
-    if (missingAttributes.length > 0) {
+    const { uid, uin, name, email } = resolved;
+    if (!uid || !uin || !name) {
+      const nameAttributeDescription =
+        institutionSamlProvider.name_attribute ||
+        `${institutionSamlProvider.given_name_attribute} + ${institutionSamlProvider.family_name_attribute}`;
+      const missingAttributes = [
+        ...(!uid ? [`uid (${institutionSamlProvider.uid_attribute})`] : []),
+        ...(!uin ? [`uin (${institutionSamlProvider.uin_attribute})`] : []),
+        ...(!name ? [`name (${nameAttributeDescription})`] : []),
+      ];
       throw new Error(
         `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
       );
     }
 
     const authnParams = {
-      uid: resolved.uid,
-      name: resolved.name,
-      uin: resolved.uin,
-      email: resolved.email,
+      uid,
+      name,
+      uin,
+      email,
       provider: 'SAML',
       institution_id: institutionId,
     };


### PR DESCRIPTION
# Description

When SAML authentication fails due to missing attributes, the error message `"Missing one or more SAML attributes"` provides no insight into which attributes are missing or what the institution's IdP team should look for.

This change improves the error message to include both the missing attribute names and their configured SAML attribute mappings. For example: `"Missing values for the following SAML attributes: uid (urn:oid:0.9.2342.19200300.100.1.1), name (urn:oid:2.5.4.3)"`. This gives support teams and IdP administrators the crucial information needed to track down and resolve these issues quickly.

I'm going to leave this as a draft until #14243 is merged, and then update it based on those changes.

# Testing

This is a runtime error message change. The error path would need to be tested manually by:
1. Configuring SAML for an institution with attribute mappings
2. Having the IdP intentionally omit one or more of the required attributes
3. Verifying that the error message clearly indicates which attributes are missing

The code change is minimal and only affects the error message text thrown when validation fails.