### PR TITLE
Return 404 for deleted questions on public question pages

### DIFF
--- a/apps/prairielearn/src/pages/publicQuestionFileBrowser/publicQuestionFileBrowser.ts
+++ b/apps/prairielearn/src/pages/publicQuestionFileBrowser/publicQuestionFileBrowser.ts
@@ -18,6 +18,7 @@ async function setLocals(req: Request, res: Response) {
   res.locals.question = await selectQuestionById(req.params.question_id);
 
   if (
+    res.locals.question.deleted_at != null ||
     !res.locals.question.share_source_publicly ||
     !idsEqual(res.locals.question.course_id, res.locals.course.id)
   ) {

--- a/apps/prairielearn/src/pages/publicQuestionFileDownload/publicQuestionFileDownload.ts
+++ b/apps/prairielearn/src/pages/publicQuestionFileDownload/publicQuestionFileDownload.ts
@@ -16,6 +16,7 @@ async function setLocals(req: Request, res: Response) {
   res.locals.question = await selectQuestionById(req.params.question_id);
 
   if (
+    res.locals.question.deleted_at != null ||
     !res.locals.question.share_source_publicly ||
     !idsEqual(res.locals.question.course_id, res.locals.course.id)
   ) {

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.ts
@@ -24,6 +24,7 @@ async function setLocals(req: Request, res: Response) {
   res.locals.question = await selectQuestionById(req.params.question_id);
 
   if (
+    res.locals.question.deleted_at != null ||
     !(res.locals.question.share_publicly || res.locals.question.share_source_publicly) ||
     res.locals.course.id !== res.locals.question.course_id
   ) {


### PR DESCRIPTION
# Description

The public question preview, file browser, and file download pages were not checking if a question had been deleted before rendering it. This meant a question that was deleted after being publicly shared could still be accessed via its direct URL, even though it was correctly filtered out from the public questions list page.

The fix adds a check for `deleted_at != null` in the authorization guards on all three pages (`publicQuestionPreview`, `publicQuestionFileBrowser`, `publicQuestionFileDownload`). Deleted questions now return a 404 "Not Found" response, which is appropriate for a public endpoint and prevents disclosing deletion status.

# Testing

No automated tests were added, as there are no existing tests for public question pages in the codebase. Testing was verified by code inspection and type checking.

The fix is minimal and straightforward: adding one condition to each of the three pages' authorization checks to filter out deleted questions, consistent with how other pages in the codebase handle deleted questions.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>