### PR TITLE
Enable autoRenew on cron job named locks to prevent idle timeout

### DIFF
--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -328,7 +328,7 @@ async function tryJobWithLock(job: CronJob, cronUuid: string) {
   const lockName = 'cron:' + job.name;
   const didLock = await namedLocks.doWithLock(
     lockName,
-    { onNotAcquired: () => false },
+    { onNotAcquired: () => false, autoRenew: true },
     async () => {
       debug(`tryJobWithLock(): ${job.name}: acquired lock`);
       logger.verbose('cron: ' + job.name + ' acquired lock', { cronUuid });


### PR DESCRIPTION
## Summary

Enable autoRenew on the cron lock to periodically send keepalive queries,
preventing the lock connection from being considered idle. This matches
the pattern already used by migrations.

Closes #4913

https://claude.ai/code/session_01MiUULBdWcAbqtEaXFBVLQP

## Testing

None