### PR TITLE
Enable feedback='first-wrong' on orderBlocks test2

### DIFF
--- a/testCourse/questions/orderBlocks/question.html
+++ b/testCourse/questions/orderBlocks/question.html
@@ -18,8 +18,8 @@ has become increasingly complex, with many different possible combinations of op
 <pl-order-blocks answers-name="test2"
   grading-method="ranking"
   indentation="true"
-  partial-credit="none">
-  <!-- feedback="first-wrong"> --> <!-- FIXME this option works fine in practice, but tests currently don't pass with it enabled -->
+  partial-credit="none"
+  feedback="first-wrong">
   <pl-answer correct="true" ranking="1" indent="0">def my_sum(first, second):</pl-answer>
   <pl-answer correct="true" ranking="2" indent="1">return first + second</pl-answer>
 </pl-order-blocks>


### PR DESCRIPTION
# Description

This PR removes a FIXME comment and enables the `feedback="first-wrong"` attribute on the `test2` pl-order-blocks element. The FIXME (added in January 2024) noted that this option works correctly in practice but tests didn't pass when enabled.

Since then, several important fixes have landed for pl-order-blocks, particularly commit 6fdd3ffbbe (December 2025) which fixed grading issues with `partial-credit="none"`. These fixes have resolved the underlying test failures.

All orderBlocks tests now pass with the feedback attribute enabled.

I noticed this while reviewing #14182.

# Testing

Verified that all 138 tests in `testCourseQuestions.test.ts` pass, including the orderBlocks question tests.