### PR TITLE
Improve admin networks query and formatting

### DIFF
--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -764,11 +764,11 @@ export const EnrollmentSchema = z.object({
 export type Enrollment = z.infer<typeof EnrollmentSchema>;
 
 export const ExamModeNetworkSchema = z.object({
-  created_at: DateFromISOString,
-  during: z.unknown(), // https://github.com/PrairieLearn/PrairieLearn/pull/12437#discussion_r2219773815
+  created_at: DateFromISOString.nullable(),
+  during: z.unknown().nullable(), // https://github.com/PrairieLearn/PrairieLearn/pull/12437#discussion_r2219773815
   id: IdSchema,
   location: z.string().nullable(),
-  network: z.string().cidr(),
+  network: z.string().cidr().nullable(),
   purpose: z.string().nullable(),
 });
 export type ExamModeNetwork = z.infer<typeof ExamModeNetworkSchema>;

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.html.ts
@@ -1,6 +1,8 @@
 import z from 'zod';
 
+import { formatDate } from '@prairielearn/formatter';
 import { html } from '@prairielearn/html';
+import { DateFromISOString } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { ExamModeNetworkSchema } from '../../lib/db-types.js';
@@ -8,8 +10,8 @@ import type { ResLocalsForPage } from '../../lib/res-locals.js';
 
 export const AdministratorNetworksRowSchema = z.object({
   network: ExamModeNetworkSchema.shape.network,
-  start_date: z.string(),
-  end_date: z.string(),
+  start_date: DateFromISOString.nullable(),
+  end_date: DateFromISOString.nullable(),
   location: ExamModeNetworkSchema.shape.location,
   purpose: ExamModeNetworkSchema.shape.purpose,
 });
@@ -55,11 +57,11 @@ export function AdministratorNetworks({
               ${networks.map(
                 (network: AdministratorNetworksRow) => html`
                   <tr>
-                    <td>${network.network}</td>
-                    <td>${network.start_date}</td>
-                    <td>${network.end_date}</td>
-                    <td>${network.location}</td>
-                    <td>${network.purpose}</td>
+                    <td>${network.network ?? '—'}</td>
+                    <td>${network.start_date ? formatDate(network.start_date, 'UTC') : '—'}</td>
+                    <td>${network.end_date ? formatDate(network.end_date, 'UTC') : '—'}</td>
+                    <td>${network.location ?? '—'}</td>
+                    <td>${network.purpose ?? '—'}</td>
                   </tr>
                 `,
               )}

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.sql
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.sql
@@ -1,37 +1,12 @@
 -- BLOCK select
-WITH
-  select_networks AS (
-    SELECT
-      coalesce(
-        jsonb_agg(
-          jsonb_build_object(
-            'network',
-            n.network,
-            'start_date',
-            coalesce(
-              format_date_full_compact (lower(n.during), 'UTC'),
-              '—'
-            ),
-            'end_date',
-            coalesce(
-              format_date_full_compact (upper(n.during), 'UTC'),
-              '—'
-            ),
-            'location',
-            n.location,
-            'purpose',
-            n.purpose
-          )
-          ORDER BY
-            n.during,
-            n.network
-        ),
-        '[]'::jsonb
-      ) AS networks
-    FROM
-      exam_mode_networks AS n
-  )
 SELECT
-  networks
+  n.network,
+  lower(n.during) AS start_date,
+  upper(n.during) AS end_date,
+  n.location,
+  n.purpose
 FROM
-  select_networks;
+  exam_mode_networks AS n
+ORDER BY
+  n.during,
+  n.network;

--- a/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.ts
+++ b/apps/prairielearn/src/pages/administratorNetworks/administratorNetworks.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-import z from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
 
@@ -16,7 +15,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 router.get(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const networks = await sqldb.queryRow(sql.select, z.array(AdministratorNetworksRowSchema));
+    const networks = await sqldb.queryRows(sql.select, AdministratorNetworksRowSchema);
     res.send(AdministratorNetworks({ resLocals: res.locals, networks }));
   }),
 );


### PR DESCRIPTION
## Summary

@reteps pointed out in https://github.com/PrairieLearn/PrairieLearn/pull/14225#discussion_r2880351487 that the existing query was very strange. This PR refactors the exam-mode networks admin page to use a simpler SQL query and move date formatting to TypeScript:

- Removed the complex `jsonb_agg`/`jsonb_build_object` CTE that was aggregating all rows into a single JSON array
- Simplified the SQL query to return individual rows with raw timestamps (`lower()` and `upper()` on the `tstzrange`)
- Switched from `queryRow()` + `z.array()` to `queryRows()` for cleaner TypeScript code
- Replaced SQL date formatting with `formatDate()` from `@prairielearn/formatter` in the template
- Fixed `ExamModeNetworkSchema` nullability: `created_at`, `during`, and `network` are nullable in the database
- Added consistent null handling across all nullable columns (display em dash)

## Testing

Manually verified the page renders correctly with the simplified query. No new tests needed; this is a refactor of existing functionality with no behavior changes.