### PR TITLE
Fix Zod error when inserting issue for deleted variant

### DIFF
--- a/apps/prairielearn/src/lib/issues.ts
+++ b/apps/prairielearn/src/lib/issues.ts
@@ -2,7 +2,7 @@ import * as async from 'async';
 import { type Request, type Response } from 'express';
 
 import { HttpStatusError } from '@prairielearn/error';
-import { loadSqlEquiv, queryScalar } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryOptionalScalar } from '@prairielearn/postgres';
 import { recursivelyTruncateStrings } from '@prairielearn/sanitize';
 import { IdSchema } from '@prairielearn/zod';
 
@@ -55,7 +55,7 @@ export async function insertIssue({
   // Allow for a higher limit on the system data. This object contains output
   // from the Python subprocess, which can be especially useful for debugging.
   const truncatedSystemData = recursivelyTruncateStrings(systemData, 10000);
-  return await queryScalar(
+  const id = await queryOptionalScalar(
     sql.insert_issue,
     {
       variant_id: variantId,
@@ -70,6 +70,10 @@ export async function insertIssue({
     },
     IdSchema,
   );
+  if (id == null) {
+    throw new HttpStatusError(404, `Failed to insert issue: variant ${variantId} was not found`);
+  }
+  return id;
 }
 
 /**


### PR DESCRIPTION
## Summary

- The `insert_issue` SQL query joins against `variants` to populate related IDs. We got a Sentry error that this query has scenarios where there is no variant.
- Use `queryOptionalScalar` and throw a clear `HttpStatusError(404)` instead.

## Test plan

- Existing tests pass (`insertIssue` callers always have valid variants, so behavior is unchanged in the happy path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)