### PR TITLE
Display alternative group icon inline with 'Choose X of Y' text

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
@@ -171,9 +171,9 @@ export function TreeQuestionBlockNode({
           ariaLabel={isCollapsed ? 'Expand alternatives' : 'Collapse alternatives'}
           onToggle={toggleCollapse}
         />
-        <i className="bi bi-stack text-primary me-1" aria-hidden="true" />
         <div className="flex-grow-1" style={{ minWidth: 0 }}>
           <div className="text-truncate text-primary">
+            <i className="bi bi-stack me-1" aria-hidden="true" />
             {run(() => {
               const choose = zoneQuestionBlock.numberChoose;
               if (choose == null) return `Choose ${alternativeCount} of ${alternativeCount}`;


### PR DESCRIPTION
# Description

Moves the stack icon to be inline with the 'Choose X of Y' text instead of appearing to the left of all text content in the alternative group row. This improves the visual hierarchy in non-edit mode by aligning the left edge of the row consistently with other rows in the tree, rather than creating a misleading extra level of indentation.

Before:
<img width="551" height="516" alt="Screenshot 2026-03-06 at 15 29 58" src="https://github.com/user-attachments/assets/0c1dadcd-4a64-4121-984f-bd63e672d645" />

After:
<img width="750" height="517" alt="Screenshot 2026-03-06 at 15 29 38" src="https://github.com/user-attachments/assets/edc24dba-1e31-4890-991e-2386eb56ab87" />

# Testing

The change is purely visual.