### PR TITLE
Implement `@prairielearn/workflows` package

### DIFF
--- a/.changeset/add-workflows-package.md
+++ b/.changeset/add-workflows-package.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/workflows': minor
+---
+
+Add workflow engine package for durable, multi-step workflows with pause/resume

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -76,6 +76,7 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@prairielearn/ui": "workspace:^",
     "@prairielearn/utils": "workspace:^",
+    "@prairielearn/workflows": "workspace:^",
     "@prairielearn/workspace-utils": "workspace:^",
     "@prairielearn/zod": "workspace:^",
     "@pyroscope/nodejs": "^0.4.10",

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -98,6 +98,15 @@ export const EnumQuestionTypeSchema = z.enum([
 ]);
 export type EnumQuestionType = z.infer<typeof EnumQuestionTypeSchema>;
 
+export const EnumWorkflowRunStatusSchema = z.enum([
+  'canceled',
+  'completed',
+  'error',
+  'running',
+  'waiting_for_input',
+]);
+export type EnumWorkflowRunStatus = z.infer<typeof EnumWorkflowRunStatusSchema>;
+
 // *******************************************************************************
 // Miscellaneous schemas; keep these alphabetized.
 // *******************************************************************************
@@ -1560,6 +1569,24 @@ export const VariantSchema = z.object({
   workspace_id: IdSchema.nullable(),
 });
 export type Variant = z.infer<typeof VariantSchema>;
+
+export const WorkflowRunSchema = z.object({
+  completed_at: DateFromISOString.nullable(),
+  context: z.record(z.unknown()),
+  created_at: DateFromISOString,
+  error_message: z.string().nullable(),
+  heartbeat_at: DateFromISOString.nullable(),
+  id: IdSchema,
+  locked_at: DateFromISOString.nullable(),
+  locked_by: z.string().nullable(),
+  output: z.string(),
+  phase: z.string().nullable(),
+  state: z.record(z.unknown()),
+  status: EnumWorkflowRunStatusSchema,
+  type: z.string(),
+  updated_at: DateFromISOString,
+});
+export type WorkflowRun = z.infer<typeof WorkflowRunSchema>;
 
 export const WorkspaceSchema = z.object({
   created_at: DateFromISOString,

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -54,6 +54,7 @@ import { run } from '@prairielearn/run';
 import { createSessionMiddleware } from '@prairielearn/session';
 import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
 import { assertNever } from '@prairielearn/utils';
+import * as workflows from '@prairielearn/workflows';
 
 import * as cron from './cron/index.js';
 import * as assets from './lib/assets.js';
@@ -2341,6 +2342,8 @@ if (shouldStartServer) {
       renewIntervalMs: config.namedLocksRenewIntervalMs,
     });
 
+    await workflows.init(pgConfig, idleErrorHandler);
+
     logger.verbose('Successfully connected to database');
 
     if (argv['refresh-workspace-hosts-and-exit']) {
@@ -2496,6 +2499,8 @@ if (shouldStartServer) {
         workDurationMs: config.batchedMigrationsWorkDurationMs,
         sleepDurationMs: config.batchedMigrationsSleepDurationMs,
       });
+
+      workflows.startCronLoop();
     }
 
     if ('sync-course' in argv) {
@@ -2621,6 +2626,7 @@ if (shouldStartServer) {
       assets.close(),
       codeCaller.finish(),
       stopBatchedMigrations(),
+      workflows.stopCronLoop(),
     ]);
     serviceResults.forEach((r) => {
       if (r.status === 'rejected') {
@@ -2630,7 +2636,11 @@ if (shouldStartServer) {
     });
 
     // Then close the database connections now that nothing is using them.
-    const dbResults = await Promise.allSettled([namedLocks.close(), sqldb.closeAsync()]);
+    const dbResults = await Promise.allSettled([
+      workflows.close(),
+      namedLocks.close(),
+      sqldb.closeAsync(),
+    ]);
     dbResults.forEach((r) => {
       if (r.status === 'rejected') {
         logger.error('Error closing database connections', r.reason);
@@ -2691,6 +2701,8 @@ export async function close() {
   await codeCaller.finish();
   load.close();
   await stopBatchedMigrations();
+  await workflows.stopCronLoop();
+  await workflows.close();
   await namedLocks.close();
   await sqldb.closeAsync();
 }

--- a/database/tables/workflow_runs.pg
+++ b/database/tables/workflow_runs.pg
@@ -1,0 +1,22 @@
+columns
+    completed_at: timestamp with time zone
+    context: jsonb not null default '{}'::jsonb
+    created_at: timestamp with time zone not null default now()
+    error_message: text
+    heartbeat_at: timestamp with time zone
+    id: bigint not null default nextval('workflow_runs_id_seq'::regclass)
+    locked_at: timestamp with time zone
+    locked_by: text
+    output: text not null default ''::text
+    phase: text
+    state: jsonb not null default '{}'::jsonb
+    status: text not null default 'running'::text
+    type: text not null
+    updated_at: timestamp with time zone not null default now()
+
+indexes
+    workflow_runs_pkey: PRIMARY KEY (id) USING btree (id)
+    workflow_runs_type_status_idx: USING btree (type, status)
+
+check constraints
+    workflow_runs_status_check: CHECK (status = ANY (ARRAY['running'::text, 'waiting_for_input'::text, 'completed'::text, 'error'::text, 'canceled'::text]))

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@prairielearn/workflows",
+  "version": "0.1.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PrairieLearn/PrairieLearn.git",
+    "directory": "packages/workflows"
+  },
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsgo && tscp",
+    "dev": "tsgo --watch --preserveWatchOutput & tscp --watch",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@prairielearn/logger": "workspace:^",
+    "@prairielearn/postgres": "workspace:^",
+    "pg": "^8.20.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "workspace:^",
+    "@types/node": "^24.11.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260305.1",
+    "@vitest/coverage-v8": "^4.0.18",
+    "typescript": "^5.9.3",
+    "typescript-cp": "^0.1.9",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/workflows/src/index.ts
+++ b/packages/workflows/src/index.ts
@@ -1,0 +1,27 @@
+export type {
+  CronLoopOptions,
+  StartWorkflowOptions,
+  StepResult,
+  WorkflowDefinition,
+  WorkflowLogger,
+  WorkflowRunRow,
+  WorkflowRunStatus,
+  WorkflowStepContext,
+} from './types.js';
+
+export { WorkflowRunRowSchema, WorkflowRunStatusSchema } from './workflow-run.js';
+
+export { init, close, pool } from './init.js';
+
+export { registerWorkflow, clearRegistry } from './workflow-registry.js';
+
+export {
+  startWorkflow,
+  resumeWorkflow,
+  cancelWorkflow,
+  continueWorkflow,
+  getWorkflowRun,
+  getActiveWorkflowRun,
+} from './workflow-engine.js';
+
+export { startCronLoop, stopCronLoop } from './workflow-cron.js';

--- a/packages/workflows/src/init.sql
+++ b/packages/workflows/src/init.sql
@@ -1,0 +1,27 @@
+-- BLOCK create_table
+CREATE TABLE IF NOT EXISTS workflow_runs (
+  id bigserial PRIMARY KEY,
+  type text NOT NULL,
+  status text NOT NULL DEFAULT 'running' CHECK (
+    status IN (
+      'running',
+      'waiting_for_input',
+      'completed',
+      'error',
+      'canceled'
+    )
+  ),
+  phase text,
+  state jsonb NOT NULL DEFAULT '{}'::jsonb,
+  locked_by text,
+  locked_at timestamptz,
+  heartbeat_at timestamptz,
+  context jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  error_message text,
+  output text NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS workflow_runs_type_status_idx ON workflow_runs (type, status);

--- a/packages/workflows/src/init.ts
+++ b/packages/workflows/src/init.ts
@@ -1,0 +1,19 @@
+import { type PoolConfig } from 'pg';
+
+import { type PoolClient, PostgresPool, loadSqlEquiv } from '@prairielearn/postgres';
+
+const sql = loadSqlEquiv(import.meta.filename);
+
+export const pool = new PostgresPool();
+
+export async function init(
+  pgConfig: PoolConfig,
+  idleErrorHandler: (error: Error, client: PoolClient) => void,
+): Promise<void> {
+  await pool.initAsync(pgConfig, idleErrorHandler);
+  await pool.execute(sql.create_table);
+}
+
+export async function close(): Promise<void> {
+  await pool.closeAsync();
+}

--- a/packages/workflows/src/types.ts
+++ b/packages/workflows/src/types.ts
@@ -1,0 +1,46 @@
+import type { z } from 'zod';
+
+import type { WorkflowRunRowSchema } from './workflow-run.js';
+
+export type WorkflowRunStatus =
+  | 'running'
+  | 'waiting_for_input'
+  | 'completed'
+  | 'error'
+  | 'canceled';
+
+export type WorkflowRunRow = z.infer<typeof WorkflowRunRowSchema>;
+
+export interface StepResult<TState> {
+  state: TState;
+  status: 'continue' | 'waiting_for_input' | 'completed' | 'error';
+  phase?: string;
+  error_message?: string;
+}
+
+export interface WorkflowLogger {
+  info(msg: string): void;
+  error(msg: string): void;
+}
+
+export interface WorkflowStepContext<TState> {
+  run: WorkflowRunRow & { state: TState };
+  logger: WorkflowLogger;
+  signal: AbortSignal;
+}
+
+export interface WorkflowDefinition<TState> {
+  type: string;
+  takeStep(context: WorkflowStepContext<TState>): Promise<StepResult<TState>>;
+}
+
+export interface StartWorkflowOptions<TState> {
+  initialState: TState;
+  context?: Record<string, unknown>;
+  phase?: string;
+}
+
+export interface CronLoopOptions {
+  /** How often to scan for recoverable workflows, in ms. Default 60000. */
+  intervalMs?: number;
+}

--- a/packages/workflows/src/workflow-cron.sql
+++ b/packages/workflows/src/workflow-cron.sql
@@ -1,0 +1,9 @@
+-- BLOCK select_stale_running_workflows
+SELECT
+  *
+FROM
+  workflow_runs
+WHERE
+  status = 'running'
+  AND locked_by IS NOT NULL
+  AND heartbeat_at < now() - interval '2 minutes';

--- a/packages/workflows/src/workflow-cron.ts
+++ b/packages/workflows/src/workflow-cron.ts
@@ -1,0 +1,74 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { logger } from '@prairielearn/logger';
+import { loadSqlEquiv } from '@prairielearn/postgres';
+
+import { pool } from './init.js';
+import type { CronLoopOptions } from './types.js';
+import { resumeWorkflow } from './workflow-engine.js';
+import { WorkflowRunRowSchema } from './workflow-run.js';
+
+const sql = loadSqlEquiv(import.meta.filename);
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+let abortController: AbortController | null = null;
+let running = false;
+
+export function startCronLoop(opts: CronLoopOptions = {}): void {
+  if (running) throw new Error('Workflow cron loop is already running');
+  abortController = new AbortController();
+  // Intentionally fire-and-forget; the loop runs until stopCronLoop() is called.
+  void loop(opts);
+}
+
+async function loop(opts: CronLoopOptions): Promise<void> {
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  running = true;
+
+  while (running) {
+    if (abortController?.signal.aborted) {
+      running = false;
+      return;
+    }
+
+    try {
+      await recoverStaleWorkflows();
+    } catch (err) {
+      logger.error('Error in workflow cron loop', err);
+    }
+
+    try {
+      await sleep(intervalMs, null, { ref: false, signal: abortController!.signal });
+    } catch {
+      continue;
+    }
+  }
+}
+
+async function recoverStaleWorkflows(): Promise<void> {
+  const staleRuns = await pool.queryRows(
+    sql.select_stale_running_workflows,
+    {},
+    WorkflowRunRowSchema,
+  );
+
+  for (const run of staleRuns) {
+    try {
+      await resumeWorkflow(run.id);
+    } catch (err) {
+      logger.error(`Failed to resume stale workflow run ${run.id}`, err);
+    }
+  }
+}
+
+export async function stopCronLoop(): Promise<void> {
+  if (!abortController) return;
+  abortController.abort();
+
+  while (running) {
+    await sleep(100);
+  }
+
+  abortController = null;
+}

--- a/packages/workflows/src/workflow-engine.test.ts
+++ b/packages/workflows/src/workflow-engine.test.ts
@@ -1,0 +1,382 @@
+import { afterAll, afterEach, assert, beforeAll, describe, it } from 'vitest';
+
+import { makePostgresTestUtils } from '@prairielearn/postgres';
+
+import { close, init, pool } from './init.js';
+import { startCronLoop, stopCronLoop } from './workflow-cron.js';
+import {
+  cancelWorkflow,
+  continueWorkflow,
+  getActiveWorkflowRun,
+  getWorkflowRun,
+  resumeWorkflow,
+  startWorkflow,
+} from './workflow-engine.js';
+import { clearRegistry, registerWorkflow } from './workflow-registry.js';
+import { WorkflowRunRowSchema } from './workflow-run.js';
+
+const postgresTestUtils = makePostgresTestUtils({
+  database: 'prairielearn_workflows',
+});
+
+beforeAll(async () => {
+  const pgConfig = await postgresTestUtils.createDatabase();
+  await init(pgConfig, (err) => {
+    throw err;
+  });
+});
+
+afterEach(() => {
+  clearRegistry();
+});
+
+afterAll(async () => {
+  await close();
+  await postgresTestUtils.dropDatabase();
+});
+
+describe('workflow engine', () => {
+  it('completes a multi-step workflow', async () => {
+    let stepCount = 0;
+
+    registerWorkflow<{ count: number }>({
+      type: 'test_complete',
+      async takeStep() {
+        stepCount++;
+        if (stepCount >= 3) {
+          return { state: { count: stepCount }, status: 'completed' };
+        }
+        return { state: { count: stepCount }, status: 'continue' };
+      },
+    });
+
+    const run = await startWorkflow('test_complete', {
+      initialState: { count: 0 },
+    });
+
+    // Wait for async execution to complete.
+    await waitForTerminalStatus(run.id);
+
+    const result = await getWorkflowRun(run.id);
+    assert.equal(result.status, 'completed');
+    assert.deepEqual(result.state, { count: 3 });
+    assert.isNotNull(result.completed_at);
+  });
+
+  it('pauses for input and resumes', async () => {
+    let step = 0;
+
+    registerWorkflow<{ phase: string; feedback?: string }>({
+      type: 'test_pause',
+      async takeStep(ctx) {
+        step++;
+        const state = ctx.run.state;
+        if (step === 1) {
+          return {
+            state: { ...state, phase: 'waiting' },
+            status: 'waiting_for_input',
+            phase: 'review',
+          };
+        }
+        return {
+          state: { ...state, phase: 'done' },
+          status: 'completed',
+        };
+      },
+    });
+
+    const run = await startWorkflow('test_pause', {
+      initialState: { phase: 'start' },
+    });
+
+    await waitForStatus(run.id, 'waiting_for_input');
+
+    const paused = await getWorkflowRun(run.id);
+    assert.equal(paused.status, 'waiting_for_input');
+    assert.equal(paused.phase, 'review');
+
+    await continueWorkflow(run.id, { feedback: 'approved' });
+
+    await waitForTerminalStatus(run.id);
+
+    const completed = await getWorkflowRun(run.id);
+    assert.equal(completed.status, 'completed');
+    const state = completed.state as Record<string, unknown>;
+    assert.equal(state.feedback, 'approved');
+    assert.equal(state.phase, 'done');
+  });
+
+  it('handles unhandled errors in takeStep', async () => {
+    registerWorkflow<Record<string, never>>({
+      type: 'test_throw',
+      async takeStep() {
+        throw new Error('Something went wrong');
+      },
+    });
+
+    const run = await startWorkflow('test_throw', {
+      initialState: {},
+    });
+
+    await waitForTerminalStatus(run.id);
+
+    const result = await getWorkflowRun(run.id);
+    assert.equal(result.status, 'error');
+    assert.equal(result.error_message, 'Something went wrong');
+    assert.include(result.output, '[ERROR] Unhandled error: Something went wrong');
+  });
+
+  it('handles explicit error status', async () => {
+    registerWorkflow<Record<string, never>>({
+      type: 'test_explicit_error',
+      async takeStep() {
+        return {
+          state: {},
+          status: 'error',
+          error_message: 'Explicit failure',
+        };
+      },
+    });
+
+    const run = await startWorkflow('test_explicit_error', {
+      initialState: {},
+    });
+
+    await waitForTerminalStatus(run.id);
+
+    const result = await getWorkflowRun(run.id);
+    assert.equal(result.status, 'error');
+    assert.equal(result.error_message, 'Explicit failure');
+    assert.isNotNull(result.completed_at);
+  });
+
+  it('cancels a workflow', async () => {
+    registerWorkflow<Record<string, never>>({
+      type: 'test_cancel',
+      async takeStep() {
+        return {
+          state: {},
+          status: 'waiting_for_input',
+        };
+      },
+    });
+
+    const run = await startWorkflow('test_cancel', {
+      initialState: {},
+    });
+
+    await waitForStatus(run.id, 'waiting_for_input');
+
+    await cancelWorkflow(run.id);
+
+    const result = await getWorkflowRun(run.id);
+    assert.equal(result.status, 'canceled');
+    assert.isNotNull(result.completed_at);
+  });
+
+  it('filters active workflows by type and context', async () => {
+    registerWorkflow<Record<string, never>>({
+      type: 'test_filter',
+      async takeStep() {
+        return { state: {}, status: 'waiting_for_input' };
+      },
+    });
+
+    const run1 = await startWorkflow('test_filter', {
+      initialState: {},
+      context: { assessment_id: '100' },
+    });
+
+    const run2 = await startWorkflow('test_filter', {
+      initialState: {},
+      context: { assessment_id: '200' },
+    });
+
+    await waitForStatus(run1.id, 'waiting_for_input');
+    await waitForStatus(run2.id, 'waiting_for_input');
+
+    const found = await getActiveWorkflowRun('test_filter', { assessment_id: '100' });
+    assert.isNotNull(found);
+    assert.equal(found!.id, run1.id);
+
+    const notFound = await getActiveWorkflowRun('test_filter', { assessment_id: '999' });
+    assert.isNull(notFound);
+
+    // Clean up
+    await cancelWorkflow(run1.id);
+    await cancelWorkflow(run2.id);
+  });
+
+  it('captures logger output', async () => {
+    registerWorkflow<Record<string, never>>({
+      type: 'test_logger',
+      async takeStep(ctx) {
+        ctx.logger.info('Processing step');
+        ctx.logger.error('Something is off');
+        return { state: {}, status: 'completed' };
+      },
+    });
+
+    const run = await startWorkflow('test_logger', {
+      initialState: {},
+    });
+
+    await waitForTerminalStatus(run.id);
+
+    const result = await getWorkflowRun(run.id);
+    assert.include(result.output, '[INFO] Processing step');
+    assert.include(result.output, '[ERROR] Something is off');
+  });
+
+  it('tracks phase updates', async () => {
+    let step = 0;
+
+    registerWorkflow<Record<string, never>>({
+      type: 'test_phase',
+      async takeStep() {
+        step++;
+        if (step === 1) {
+          return { state: {}, status: 'continue', phase: 'initializing' };
+        }
+        return { state: {}, status: 'completed', phase: 'done' };
+      },
+    });
+
+    const run = await startWorkflow('test_phase', {
+      initialState: {},
+    });
+
+    await waitForTerminalStatus(run.id);
+
+    const result = await getWorkflowRun(run.id);
+    assert.equal(result.phase, 'done');
+  });
+
+  it('prevents concurrent execution via soft lock', async () => {
+    let started = false;
+    registerWorkflow<Record<string, never>>({
+      type: 'test_lock',
+      async takeStep() {
+        started = true;
+        return { state: {}, status: 'waiting_for_input' };
+      },
+    });
+
+    const run = await startWorkflow('test_lock', {
+      initialState: {},
+    });
+
+    await waitForStatus(run.id, 'waiting_for_input');
+
+    // Manually set the run back to 'running' with a valid lock to simulate contention.
+    await pool.execute(
+      `UPDATE workflow_runs
+       SET status = 'running', locked_by = 'other-server', locked_at = now(), heartbeat_at = now()
+       WHERE id = $id`,
+      { id: run.id },
+    );
+
+    started = false;
+    await resumeWorkflow(run.id);
+
+    // The step function should not have been called because the lock is held.
+    assert.isFalse(started);
+
+    // Clean up
+    await pool.execute(
+      "UPDATE workflow_runs SET status = 'canceled', locked_by = NULL WHERE id = $id",
+      { id: run.id },
+    );
+  });
+
+  it('throws when starting workflow with unregistered type', async () => {
+    try {
+      await startWorkflow('nonexistent', { initialState: {} });
+      assert.fail('Expected an error');
+    } catch (err) {
+      assert.instanceOf(err, Error);
+      assert.include((err as Error).message, 'No workflow registered');
+    }
+  });
+
+  it('throws when registering duplicate type', () => {
+    registerWorkflow({
+      type: 'dup',
+      async takeStep() {
+        return { state: {}, status: 'completed' };
+      },
+    });
+    try {
+      registerWorkflow({
+        type: 'dup',
+        async takeStep() {
+          return { state: {}, status: 'completed' };
+        },
+      });
+      assert.fail('Expected an error');
+    } catch (err) {
+      assert.include((err as Error).message, 'already registered');
+    }
+  });
+});
+
+describe('workflow cron recovery', () => {
+  it('recovers stale workflows', async () => {
+    let recovered = false;
+
+    registerWorkflow<Record<string, never>>({
+      type: 'test_recover',
+      async takeStep() {
+        recovered = true;
+        return { state: {}, status: 'completed' };
+      },
+    });
+
+    // Insert a run that looks stale: running, locked, but heartbeat is old.
+    const [row] = await pool.queryRows(
+      `INSERT INTO workflow_runs (type, status, state, context, locked_by, locked_at, heartbeat_at)
+       VALUES ('test_recover', 'running', '{}'::jsonb, '{}'::jsonb, 'dead-server', now() - interval '5 minutes', now() - interval '5 minutes')
+       RETURNING *`,
+      {},
+      WorkflowRunRowSchema,
+    );
+
+    startCronLoop({ intervalMs: 100 });
+
+    // Wait for recovery.
+    const startTime = Date.now();
+    while (!recovered && Date.now() - startTime < 5000) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    await stopCronLoop();
+
+    assert.isTrue(recovered);
+
+    const result = await getWorkflowRun(row.id);
+    assert.equal(result.status, 'completed');
+  });
+});
+
+async function waitForStatus(runId: string, status: string, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const run = await getWorkflowRun(runId);
+    if (run.status === status) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const run = await getWorkflowRun(runId);
+  throw new Error(`Timed out waiting for status '${status}', current status: '${run.status}'`);
+}
+
+async function waitForTerminalStatus(runId: string, timeoutMs = 5000): Promise<void> {
+  const terminal = new Set(['completed', 'error', 'canceled']);
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const run = await getWorkflowRun(runId);
+    if (terminal.has(run.status)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const run = await getWorkflowRun(runId);
+  throw new Error(`Timed out waiting for terminal status, current status: '${run.status}'`);
+}

--- a/packages/workflows/src/workflow-engine.ts
+++ b/packages/workflows/src/workflow-engine.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from 'node:crypto';
+
+import { logger } from '@prairielearn/logger';
+
+import type {
+  StartWorkflowOptions,
+  StepResult,
+  WorkflowLogger,
+  WorkflowRunRow,
+  WorkflowStepContext,
+} from './types.js';
+import { getWorkflowDefinition } from './workflow-registry.js';
+import {
+  acquireLock,
+  cancelWorkflowRun,
+  continueWorkflowRun,
+  insertWorkflowRun,
+  releaseLock,
+  selectActiveWorkflowRun,
+  selectWorkflowRun,
+  updateHeartbeat,
+  updateWorkflowRunAfterStep,
+} from './workflow-run.js';
+
+const DEFAULT_MAX_STEPS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+export async function startWorkflow<TState>(
+  type: string,
+  opts: StartWorkflowOptions<TState>,
+): Promise<WorkflowRunRow> {
+  getWorkflowDefinition(type);
+
+  const run = await insertWorkflowRun({
+    type,
+    state: opts.initialState,
+    context: opts.context ?? {},
+    phase: opts.phase ?? null,
+  });
+
+  // Fire-and-forget execution; errors are caught inside executeWorkflow.
+  executeWorkflow(run.id).catch((err) => {
+    logger.error(`Failed to execute workflow run ${run.id}`, err);
+  });
+
+  return run;
+}
+
+export async function resumeWorkflow(runId: string): Promise<void> {
+  await executeWorkflow(runId);
+}
+
+export async function cancelWorkflow(runId: string): Promise<WorkflowRunRow | null> {
+  return await cancelWorkflowRun(runId);
+}
+
+export async function continueWorkflow<TState>(
+  runId: string,
+  stateUpdate: Partial<TState>,
+): Promise<void> {
+  await continueWorkflowRun(runId, stateUpdate as Record<string, unknown>);
+
+  // Fire-and-forget execution after continuing.
+  executeWorkflow(runId).catch((err) => {
+    logger.error(`Failed to execute workflow run ${runId} after continue`, err);
+  });
+}
+
+export async function getWorkflowRun(runId: string): Promise<WorkflowRunRow> {
+  return await selectWorkflowRun(runId);
+}
+
+export async function getActiveWorkflowRun(
+  type: string,
+  contextFilter: Record<string, unknown>,
+): Promise<WorkflowRunRow | null> {
+  return await selectActiveWorkflowRun(type, contextFilter);
+}
+
+async function executeWorkflow(runId: string, maxSteps: number = DEFAULT_MAX_STEPS): Promise<void> {
+  const lockId = randomUUID();
+
+  const lockedRun = await acquireLock(runId, lockId);
+  if (!lockedRun) {
+    return;
+  }
+
+  const heartbeatInterval = setInterval(() => {
+    updateHeartbeat(runId, lockId).catch((err) => {
+      logger.error(`Failed to update heartbeat for workflow run ${runId}`, err);
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+
+  try {
+    let stepCount = 0;
+
+    while (stepCount < maxSteps) {
+      const currentRun = await selectWorkflowRun(runId);
+      if (currentRun.status !== 'running') break;
+
+      const definition = getWorkflowDefinition(currentRun.type);
+
+      let output = currentRun.output;
+      const workflowLogger: WorkflowLogger = {
+        info(msg: string) {
+          output += `[INFO] ${msg}\n`;
+        },
+        error(msg: string) {
+          output += `[ERROR] ${msg}\n`;
+        },
+      };
+
+      const abortController = new AbortController();
+
+      const context: WorkflowStepContext<unknown> = {
+        run: currentRun as WorkflowRunRow & { state: unknown },
+        logger: workflowLogger,
+        signal: abortController.signal,
+      };
+
+      let stepResult: StepResult<unknown>;
+      try {
+        stepResult = await definition.takeStep(context);
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        output += `[ERROR] Unhandled error: ${errorMessage}\n`;
+        await updateWorkflowRunAfterStep(runId, {
+          status: 'error',
+          state: currentRun.state,
+          phase: currentRun.phase,
+          error_message: errorMessage,
+          output,
+        });
+        return;
+      }
+
+      const dbStatus = stepResult.status === 'continue' ? 'running' : stepResult.status;
+
+      await updateWorkflowRunAfterStep(runId, {
+        status: dbStatus,
+        state: stepResult.state,
+        phase: stepResult.phase ?? null,
+        error_message: stepResult.error_message ?? null,
+        output,
+      });
+
+      if (stepResult.status !== 'continue') return;
+
+      stepCount++;
+    }
+
+    if (stepCount >= maxSteps) {
+      const currentRun = await selectWorkflowRun(runId);
+      await updateWorkflowRunAfterStep(runId, {
+        status: 'error',
+        state: currentRun.state,
+        phase: currentRun.phase,
+        error_message: `Workflow exceeded maximum step limit of ${maxSteps}`,
+        output: currentRun.output + `[ERROR] Exceeded maximum step limit of ${maxSteps}\n`,
+      });
+    }
+  } finally {
+    clearInterval(heartbeatInterval);
+    try {
+      await releaseLock(runId, lockId);
+    } catch (err) {
+      logger.error(`Failed to release lock for workflow run ${runId}`, err);
+    }
+  }
+}

--- a/packages/workflows/src/workflow-registry.ts
+++ b/packages/workflows/src/workflow-registry.ts
@@ -1,0 +1,22 @@
+import type { WorkflowDefinition } from './types.js';
+
+const registry = new Map<string, WorkflowDefinition<any>>();
+
+export function registerWorkflow<TState>(definition: WorkflowDefinition<TState>): void {
+  if (registry.has(definition.type)) {
+    throw new Error(`Workflow type '${definition.type}' is already registered`);
+  }
+  registry.set(definition.type, definition);
+}
+
+export function getWorkflowDefinition(type: string): WorkflowDefinition<unknown> {
+  const definition = registry.get(type);
+  if (!definition) {
+    throw new Error(`No workflow registered for type '${type}'`);
+  }
+  return definition;
+}
+
+export function clearRegistry(): void {
+  registry.clear();
+}

--- a/packages/workflows/src/workflow-run.sql
+++ b/packages/workflows/src/workflow-run.sql
@@ -1,0 +1,115 @@
+-- BLOCK insert_workflow_run
+INSERT INTO
+  workflow_runs (type, status, state, context, phase)
+VALUES
+  (
+    $type,
+    'running',
+    $state::jsonb,
+    $context::jsonb,
+    $phase
+  )
+RETURNING
+  *;
+
+-- BLOCK select_workflow_run
+SELECT
+  *
+FROM
+  workflow_runs
+WHERE
+  id = $id;
+
+-- BLOCK select_active_workflow_run
+SELECT
+  *
+FROM
+  workflow_runs
+WHERE
+  type = $type
+  AND status IN ('running', 'waiting_for_input')
+  AND context @> $context_filter::jsonb
+ORDER BY
+  created_at DESC
+LIMIT
+  1;
+
+-- BLOCK update_workflow_run_after_step
+UPDATE workflow_runs
+SET
+  status = $status,
+  state = $state::jsonb,
+  phase = $phase,
+  error_message = $error_message,
+  output = $output,
+  updated_at = now(),
+  completed_at = CASE
+    WHEN $status IN ('completed', 'error', 'canceled') THEN now()
+    ELSE completed_at
+  END
+WHERE
+  id = $id
+RETURNING
+  *;
+
+-- BLOCK acquire_lock
+UPDATE workflow_runs
+SET
+  locked_by = $lock_id,
+  locked_at = now(),
+  heartbeat_at = now()
+WHERE
+  id = $id
+  AND status = 'running'
+  AND (
+    locked_by IS NULL
+    OR heartbeat_at < now() - interval '2 minutes'
+  )
+RETURNING
+  *;
+
+-- BLOCK release_lock
+UPDATE workflow_runs
+SET
+  locked_by = NULL,
+  locked_at = NULL,
+  heartbeat_at = NULL,
+  updated_at = now()
+WHERE
+  id = $id
+  AND locked_by = $lock_id;
+
+-- BLOCK update_heartbeat
+UPDATE workflow_runs
+SET
+  heartbeat_at = now()
+WHERE
+  id = $id
+  AND locked_by = $lock_id;
+
+-- BLOCK cancel_workflow_run
+UPDATE workflow_runs
+SET
+  status = 'canceled',
+  updated_at = now(),
+  completed_at = now(),
+  locked_by = NULL,
+  locked_at = NULL,
+  heartbeat_at = NULL
+WHERE
+  id = $id
+  AND status IN ('running', 'waiting_for_input')
+RETURNING
+  *;
+
+-- BLOCK continue_workflow_run
+UPDATE workflow_runs
+SET
+  status = 'running',
+  state = state || $state_update::jsonb,
+  updated_at = now()
+WHERE
+  id = $id
+  AND status = 'waiting_for_input'
+RETURNING
+  *;

--- a/packages/workflows/src/workflow-run.ts
+++ b/packages/workflows/src/workflow-run.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+import { loadSqlEquiv } from '@prairielearn/postgres';
+
+import { pool } from './init.js';
+
+const sql = loadSqlEquiv(import.meta.filename);
+
+export const WorkflowRunStatusSchema = z.enum([
+  'running',
+  'waiting_for_input',
+  'completed',
+  'error',
+  'canceled',
+]);
+
+export const WorkflowRunRowSchema = z.object({
+  id: z.coerce.string(),
+  type: z.string(),
+  status: WorkflowRunStatusSchema,
+  phase: z.string().nullable(),
+  state: z.unknown(),
+  locked_by: z.string().nullable(),
+  locked_at: z.coerce.date().nullable(),
+  heartbeat_at: z.coerce.date().nullable(),
+  context: z.unknown(),
+  created_at: z.coerce.date(),
+  updated_at: z.coerce.date(),
+  completed_at: z.coerce.date().nullable(),
+  error_message: z.string().nullable(),
+  output: z.string(),
+});
+
+export async function insertWorkflowRun(params: {
+  type: string;
+  state: unknown;
+  context: unknown;
+  phase: string | null;
+}) {
+  return await pool.queryRow(
+    sql.insert_workflow_run,
+    {
+      type: params.type,
+      state: JSON.stringify(params.state),
+      context: JSON.stringify(params.context),
+      phase: params.phase,
+    },
+    WorkflowRunRowSchema,
+  );
+}
+
+export async function selectWorkflowRun(id: string) {
+  return await pool.queryRow(sql.select_workflow_run, { id }, WorkflowRunRowSchema);
+}
+
+export async function selectActiveWorkflowRun(
+  type: string,
+  contextFilter: Record<string, unknown>,
+) {
+  return await pool.queryOptionalRow(
+    sql.select_active_workflow_run,
+    { type, context_filter: JSON.stringify(contextFilter) },
+    WorkflowRunRowSchema,
+  );
+}
+
+export async function updateWorkflowRunAfterStep(
+  id: string,
+  params: {
+    status: string;
+    state: unknown;
+    phase: string | null;
+    error_message: string | null;
+    output: string;
+  },
+) {
+  return await pool.queryRow(
+    sql.update_workflow_run_after_step,
+    {
+      id,
+      status: params.status,
+      state: JSON.stringify(params.state),
+      phase: params.phase,
+      error_message: params.error_message,
+      output: params.output,
+    },
+    WorkflowRunRowSchema,
+  );
+}
+
+export async function acquireLock(id: string, lockId: string) {
+  return await pool.queryOptionalRow(
+    sql.acquire_lock,
+    { id, lock_id: lockId },
+    WorkflowRunRowSchema,
+  );
+}
+
+export async function releaseLock(id: string, lockId: string) {
+  await pool.execute(sql.release_lock, { id, lock_id: lockId });
+}
+
+export async function updateHeartbeat(id: string, lockId: string) {
+  await pool.execute(sql.update_heartbeat, { id, lock_id: lockId });
+}
+
+export async function cancelWorkflowRun(id: string) {
+  return await pool.queryOptionalRow(sql.cancel_workflow_run, { id }, WorkflowRunRowSchema);
+}
+
+export async function continueWorkflowRun(id: string, stateUpdate: Record<string, unknown>) {
+  return await pool.queryRow(
+    sql.continue_workflow_run,
+    { id, state_update: JSON.stringify(stateUpdate) },
+    WorkflowRunRowSchema,
+  );
+}

--- a/packages/workflows/tsconfig.json
+++ b/packages/workflows/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@prairielearn/tsconfig/tsconfig.package.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  }
+}

--- a/packages/workflows/vitest.config.ts
+++ b/packages/workflows/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    dir: `${import.meta.dirname}/src`,
+    coverage: {
+      reporter: ['html', 'text-summary', 'cobertura'],
+      include: ['src/**/*.{ts,tsx}'],
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4842,6 +4842,7 @@ __metadata:
     "@prairielearn/ui": "workspace:^"
     "@prairielearn/utils": "workspace:^"
     "@prairielearn/vite-plugin-express": "workspace:^"
+    "@prairielearn/workflows": "workspace:^"
     "@prairielearn/workspace-utils": "workspace:^"
     "@prairielearn/zod": "workspace:^"
     "@pyroscope/nodejs": "npm:^0.4.10"
@@ -5272,6 +5273,24 @@ __metadata:
     strip-ansi: "npm:^7.2.0"
     typescript: "npm:^5.9.3"
     vite: "npm:^7.3.1"
+  languageName: unknown
+  linkType: soft
+
+"@prairielearn/workflows@workspace:^, @prairielearn/workflows@workspace:packages/workflows":
+  version: 0.0.0-use.local
+  resolution: "@prairielearn/workflows@workspace:packages/workflows"
+  dependencies:
+    "@prairielearn/logger": "workspace:^"
+    "@prairielearn/postgres": "workspace:^"
+    "@prairielearn/tsconfig": "workspace:^"
+    "@types/node": "npm:^24.11.0"
+    "@typescript/native-preview": "npm:^7.0.0-dev.20260305.1"
+    "@vitest/coverage-v8": "npm:^4.0.18"
+    pg: "npm:^8.20.0"
+    typescript: "npm:^5.9.3"
+    typescript-cp: "npm:^0.1.9"
+    vitest: "npm:^4.0.18"
+    zod: "npm:^3.25.76"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

This PR implements a general-purpose workflow engine package (`@prairielearn/workflows`) for durable, multi-step processes that can pause for human input, survive crashes, and resume automatically. This is the foundational piece for agentic AI grading (#14300), which requires instructor approval of rubric changes mid-workflow.

**Architecture**: The engine uses a simple loop pattern (modeled after `@prairielearn/migrations`): consumers register a step function that the engine calls repeatedly, persisting state to the database after each step. All domain logic lives in the consumer's step function, keeping the engine domain-agnostic.

**Crash Recovery**: Workflows acquire soft locks (via atomic SQL UPDATE) and maintain heartbeats. A background cron loop detects stale locks (2+ minutes without heartbeat) and resumes abandoned workflows automatically.

**API**: `registerWorkflow()`, `startWorkflow()`, `continueWorkflow()`, `cancelWorkflow()`, `getWorkflowRun()`, `getActiveWorkflowRun()`.

## Testing

- 12 integration tests cover normal completion, pause/resume, error handling, cancellation, soft lock contention, logger output, phase tracking, and cron recovery
- All tests pass: `yarn test packages/workflows/src/workflow-engine.test.ts`
- Build passes: `make build` (44/44 packages)
- Lint passes: no errors on all new files

The package is fully integrated with PrairieLearn's server initialization and shutdown.

## AI Assistance

Implementation completed with Claude Opus 4.6. The assistant designed the architecture based on issue #14301 requirements, explored existing codebase patterns (especially `@prairielearn/migrations` and `@prairielearn/named-locks`), implemented all source files, wrote comprehensive tests, and integrated with the main app.