### PR TITLE
Fix AI grading download error with image data URLs

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -252,10 +252,10 @@ export function generateSubmissionMessage({
         return segment;
       case 'image':
         if (segment.fileData) {
-          // fileData does not contain the MIME type header, so we add it.
           return {
             type: 'image',
-            image: `data:image/jpeg;base64,${segment.fileData}`,
+            image: segment.fileData,
+            mediaType: 'image/jpeg',
             providerOptions: {
               openai: {
                 imageDetail: 'auto',
@@ -797,7 +797,8 @@ async function correctImageOrientation({
         },
         {
           type: 'image',
-          image: `data:image/jpeg;base64,${images[i - 1]}`,
+          image: images[i - 1],
+          mediaType: 'image/jpeg',
           providerOptions: {
             openai: {
               imageDetail: 'auto',


### PR DESCRIPTION
## Description

AI grading was failing with `AI_DownloadError: URL scheme must be http or https, got data:` when processing student submissions with images across all models.

<img width="547" height="204" alt="Screenshot 2026-03-07 at 2 09 20 PM" src="https://github.com/user-attachments/assets/96fd89f1-ff53-4f5c-8976-e15564e01dcc" />

The issue was that images were being passed to the AI SDK as `data:image/jpeg;base64,...` URLs. The SDK's SSRF protection validation attempts to download any string that parses as a URL, and it rejects non-http(s) schemes. The fix passes the raw base64 image data directly with an explicit `mediaType` property, allowing the SDK to treat it as inline data rather than attempting to download it.

I tested grading several submissions from TAM 212, and images are successfully provided to the LLM and accurately graded after this change.

This PR was written with Claude Opus 4.6.

## Testing



- On `master`, try AI grading an image-graded submission. Grading should fail. 
- Try again on this branch. Grading should succeed. 