### PR TITLE
Fix duplicate histograms in assessment question editor

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/InstructorAssessmentQuestionsTableLegacy.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/InstructorAssessmentQuestionsTableLegacy.tsx
@@ -195,12 +195,15 @@ export function InstructorAssessmentQuestionsTableLegacy({
                         </td>
                       )}
                       <td>
-                        {assessment_question.mean_question_score
+                        {assessment_question.mean_question_score != null &&
+                        assessment_question.some_submission_perc !== 0
                           ? `${assessment_question.mean_question_score.toFixed(3)}%`
                           : ''}
                       </td>
                       <td className="text-center">
-                        {assessment_question.number_submissions_hist ? (
+                        {assessment_question.number_submissions_hist?.some(
+                          (v, i) => i > 0 && v > 0,
+                        ) ? (
                           <HistMini
                             data={assessment_question.number_submissions_hist}
                             options={{ width: 60, height: 20 }}

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/QuestionDetailPanel.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/QuestionDetailPanel.tsx
@@ -490,13 +490,16 @@ export function QuestionDetailPanel({
       />
 
       {/* Stats — shown in both modes */}
-      {questionData?.assessment_question.mean_question_score != null && (
-        <dl className="mb-0">
-          <dt>Mean score</dt>
-          <dd>{questionData.assessment_question.mean_question_score.toFixed(1)}%</dd>
-        </dl>
-      )}
-      {questionData?.assessment_question.number_submissions_hist && (
+      {questionData?.assessment_question.mean_question_score != null &&
+        questionData.assessment_question.some_submission_perc !== 0 && (
+          <dl className="mb-0">
+            <dt>Mean score</dt>
+            <dd>{questionData.assessment_question.mean_question_score.toFixed(1)}%</dd>
+          </dl>
+        )}
+      {questionData?.assessment_question.number_submissions_hist?.some(
+        (v, i) => i > 0 && v > 0,
+      ) && (
         <div className="mb-3">
           <div className="text-muted small mb-1">Submissions</div>
           <HistMini

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx
@@ -284,14 +284,18 @@ export function TreeQuestionRow({
         {viewType === 'detailed' && questionData && (
           <>
             {(questionData.tags?.length ||
-              questionData.assessment_question.number_submissions_hist) && (
+              questionData.assessment_question.number_submissions_hist?.some(
+                (v, i) => i > 0 && v > 0,
+              )) && (
               <div className="d-flex flex-wrap align-items-center gap-1 mt-1">
                 {questionData.tags?.map((tag) => (
                   <span key={tag.name} className={`badge color-${tag.color}`}>
                     {tag.name}
                   </span>
                 ))}
-                {questionData.assessment_question.number_submissions_hist && (
+                {questionData.assessment_question.number_submissions_hist?.some(
+                  (v, i) => i > 0 && v > 0,
+                ) && (
                   <HistMini
                     data={questionData.assessment_question.number_submissions_hist}
                     options={{ width: 60, height: 20 }}


### PR DESCRIPTION
## Description

Fixed a bug where histograms rendered for all questions in the assessment questions editor after stats recalculation, even for questions with zero student submissions.

**Root cause:** After stats recalculation, `number_submissions_hist` is populated for all assessment questions as an array. Questions with zero submissions get `[1,0,0,...,0]` (meaning 1 student in the "0 submissions" bucket). The code was checking truthiness of the array, which passed for all questions, causing every question to display a histogram.

**Fix:** Changed the histogram visibility check from a simple truthiness check to `.some((v, i) => i > 0 && v > 0)`, which verifies that at least one student actually made a submission (has a count > 0 in any bucket beyond the "0 submissions" bucket).

Also improved the mean score display to only show when students actually submitted (`some_submission_perc !== 0`), matching the legacy behavior.

## Testing

Reproduced the bug:
- Submitted addNumbers question as student@example.com
- Recalculated stats
- Confirmed all 11 questions showed histograms (11 total)
- Applied fix
- Verified only addNumbers (the question with actual submission) shows histogram (1 total)

The fix applies to three locations:
- TreeQuestionRow.tsx (detailed tree view)
- QuestionDetailPanel.tsx (detail panel)
- InstructorAssessmentQuestionsTableLegacy.tsx (legacy table view)