### PR TITLE
Fix sync failure on new remote git hosts

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -214,7 +214,7 @@ export const ConfigSchema = z.object({
   githubCourseOwner: z.string().default('PrairieLearn'),
   githubCourseTemplate: z.string().default('pl-template'),
   githubMachineTeam: z.string().default('machine'),
-  gitSshCommand: z.string().nullable().default(null),
+  gitSshCommand: z.string().default('ssh -o StrictHostKeyChecking=accept-new'),
   externalGradingUseAws: z.boolean().default(false),
   externalGradingJobsQueueName: z.string().default('grading_jobs_dev'),
   externalGradingResultsQueueName: z.string().default('grading_results_dev'),

--- a/apps/prairielearn/src/lib/course.ts
+++ b/apps/prairielearn/src/lib/course.ts
@@ -69,10 +69,10 @@ export async function pullAndUpdateCourse({
     courseId: course.id,
   });
 
-  const gitEnv = process.env;
-  if (config.gitSshCommand != null) {
-    gitEnv.GIT_SSH_COMMAND = config.gitSshCommand;
-  }
+  const gitEnv = {
+    ...process.env,
+    GIT_SSH_COMMAND: config.gitSshCommand,
+  };
 
   const jobPromise = serverJob.execute(async (job) => {
     const { path, branch, repository, commit_hash } = course;

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -177,10 +177,10 @@ export abstract class Editor {
     // made. We use `executeUnsafe` instead of `execute` because we want
     // errors to be thrown and handled by the caller.
     await serverJob.executeUnsafe(async (job) => {
-      const gitEnv = process.env;
-      if (config.gitSshCommand != null) {
-        gitEnv.GIT_SSH_COMMAND = config.gitSshCommand;
-      }
+      const gitEnv = {
+        ...process.env,
+        GIT_SSH_COMMAND: config.gitSshCommand,
+      };
 
       const lockName = getLockNameForCoursePath(this.course.path);
       await namedLocks.doWithLock(lockName, { timeout: 5000 }, async () => {

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -244,10 +244,10 @@ export async function createCourseRepoJob(
 
     // Automatically sync the new course. This part is shamelessly stolen
     // from `pages/shared/syncHelpers.js`.
-    const git_env = process.env;
-    if (config.gitSshCommand != null) {
-      git_env.GIT_SSH_COMMAND = config.gitSshCommand;
-    }
+    const git_env = {
+      ...process.env,
+      GIT_SSH_COMMAND: config.gitSshCommand,
+    };
 
     job.info('Clone from remote git repository');
     await job.exec('git', ['clone', repository, inserted_course.path], {

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -359,8 +359,8 @@
       "default": "machine"
     },
     "gitSshCommand": {
-      "type": ["string", "null"],
-      "default": null
+      "type": "string",
+      "default": "ssh -o StrictHostKeyChecking=accept-new"
     },
     "externalGradingUseAws": {
       "type": "boolean",

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -612,8 +612,8 @@
       "default": "machine"
     },
     "gitSshCommand": {
-      "type": ["string", "null"],
-      "default": null
+      "type": "string",
+      "default": "ssh -o StrictHostKeyChecking=accept-new"
     },
     "externalGradingUseAws": {
       "type": "boolean",


### PR DESCRIPTION
Closes #3676

## Summary
- Default `gitSshCommand` to `ssh -o StrictHostKeyChecking=accept-new` so new SSH hosts are automatically trusted on first connection
- Still rejects changed keys for known hosts (MITM protection)
- Overridable via `gitSshCommand` config

## Test plan
- [ ] Verify sync works against a new git host not in `known_hosts`
- [ ] Verify sync still works against known hosts
- [ ] Verify custom `gitSshCommand` config still takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)