### PR TITLE
Inline unnecessary object property variables

### DIFF
--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -314,10 +314,9 @@ export async function gradeAssessmentInstance({
     // to grade a broken variant as an error.
     if (row.variant.broken_at) return;
 
-    const check_submission_id = null;
     await gradeVariant({
       variant: row.variant,
-      check_submission_id,
+      check_submission_id: null,
       question: row.question,
       variant_course: row.variant_course,
       user_id,

--- a/apps/prairielearn/src/lib/question-render.ts
+++ b/apps/prairielearn/src/lib/question-render.ts
@@ -485,19 +485,16 @@ export async function getAndRenderVariant(
         publicQuestionPreview,
       });
     } else {
-      const require_open = !!locals.assessment && locals.assessment.type !== 'Exam';
-      const instance_question_id = locals.instance_question?.id ?? null;
-      const options = { variant_seed };
       return await ensureVariant({
         question_id: locals.question.id,
-        instance_question_id,
+        instance_question_id: locals.instance_question?.id ?? null,
         user_id: locals.user.id,
         authn_user_id: locals.authn_user.id,
         course_instance: locals.course_instance ?? null,
         variant_course: locals.course,
         question_course,
-        options,
-        require_open,
+        options: { variant_seed },
+        require_open: !!locals.assessment && locals.assessment.type !== 'Exam',
         client_fingerprint_id: locals.client_fingerprint_id ?? null,
       });
     }

--- a/apps/prairielearn/src/lib/question-testing.ts
+++ b/apps/prairielearn/src/lib/question-testing.ts
@@ -342,23 +342,19 @@ async function testQuestion({
   let submission: Submission | null = null;
 
   const question_course = await getQuestionCourse(question, variant_course);
-  const instance_question_id = null;
-  const options = { variant_seed };
-  const require_open = true;
-  const client_fingerprint_id = null;
   const generateStart = Date.now();
   try {
     variant = await ensureVariant({
       question_id: question.id,
-      instance_question_id,
+      instance_question_id: null,
       user_id: authn_user_id,
       authn_user_id,
       course_instance,
       variant_course,
       question_course,
-      options,
-      require_open,
-      client_fingerprint_id,
+      options: { variant_seed },
+      require_open: true,
+      client_fingerprint_id: null,
     });
   } finally {
     const generateEnd = Date.now();

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/instructorAssessmentInstances.ts
@@ -79,9 +79,8 @@ router.post(
       );
       res.send(JSON.stringify({}));
     } else if (req.body.__action === 'grade_all' || req.body.__action === 'close_all') {
-      const assessment_id = res.locals.assessment.id;
       const job_sequence_id = await gradeAllAssessmentInstances({
-        assessment_id,
+        assessment_id: res.locals.assessment.id,
         user_id: res.locals.user.id,
         authn_user_id: res.locals.authn_user.id,
         close: req.body.__action === 'close_all',


### PR DESCRIPTION
# Description

Removed intermediate variables that were assigned simple/literal values and immediately passed as shorthand properties in function calls. This pattern is a leftover from when these functions took positional arguments and developers wanted to name them for clarity.

Updated calls to `ensureVariant`, `gradeVariant`, and `gradeAllAssessmentInstances` to inline their object property values directly. This simplifies the code by eliminating unnecessary variable declarations while maintaining readability since the function parameters are already well-named.

# Testing

This is a refactoring change with no behavioral impact. Existing tests pass without modification.