### PR TITLE
Ignore UUID casing when checking for file editor saves

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorFileEditorClient.tsx
+++ b/apps/prairielearn/assets/scripts/instructorFileEditorClient.tsx
@@ -8,7 +8,7 @@ import { renderHtml } from '@prairielearn/react';
 import { run } from '@prairielearn/run';
 
 import { b64DecodeUnicode, b64EncodeUnicode } from '../../src/lib/base64-util.js';
-import { type FileMetadata, FileType } from '../../src/lib/editorUtil.shared.js';
+import { type FileMetadata, FileType, uuidsMatch } from '../../src/lib/editorUtil.shared.js';
 
 import { configureAceBasePaths } from './lib/ace.js';
 import './lib/verboseToggle.js';
@@ -244,7 +244,7 @@ class InstructorFileEditor {
           return { errorCode: SaveErrorCode.INVALID_JSON };
         } else if (this.fileMetadata.uuid) {
           if ('uuid' in parsedContent) {
-            if (parsedContent.uuid !== this.fileMetadata.uuid) {
+            if (!uuidsMatch(this.fileMetadata.uuid, parsedContent.uuid)) {
               return {
                 errorCode: SaveErrorCode.UUID_CHANGED,
                 originalUuid: this.fileMetadata.uuid,

--- a/apps/prairielearn/src/lib/editorUtil.shared.ts
+++ b/apps/prairielearn/src/lib/editorUtil.shared.ts
@@ -45,6 +45,14 @@ export interface FileMetadata {
   type: FileType;
 }
 
+export function uuidsMatch(originalUuid: string | null, newUuid: unknown): boolean {
+  if (typeof originalUuid !== 'string' || typeof newUuid !== 'string') {
+    return originalUuid === newUuid;
+  }
+
+  return originalUuid.toLowerCase() === newUuid.toLowerCase();
+}
+
 export function getUniqueNames({
   shortNames,
   longNames,
@@ -98,7 +106,7 @@ export function getUniqueNames({
       if (typeof oldLongName !== 'string') return;
       const found =
         oldLongName === longName ||
-        oldLongName.match(new RegExp(`^${escapeRegExp(longName)} \\(([0-9]+)\\)$`));
+        oldLongName.match(new RegExp(`^${escapeRegExp(longName)} \(([0-9]+)\)$`));
       if (found) {
         const foundNumber = found === true ? 1 : Number.parseInt(found[1]);
         if (foundNumber >= numberOfMostRecentCopy) {
@@ -205,7 +213,7 @@ export function getNamesForCopy(
     let number = 1;
     oldnames.forEach((oldname) => {
       if (typeof oldname !== 'string') return;
-      const found = oldname.match(new RegExp(`^${escapeRegExp(basename)} \\(copy ([0-9]+)\\)$`));
+      const found = oldname.match(new RegExp(`^${escapeRegExp(basename)} \(copy ([0-9]+)\)$`));
       if (found) {
         const foundNumber = Number.parseInt(found[1]);
         if (foundNumber >= number) {

--- a/apps/prairielearn/src/lib/editorUtil.test.ts
+++ b/apps/prairielearn/src/lib/editorUtil.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from 'vitest';
 
-import { getUniqueNames, propertyValueWithDefault } from './editorUtil.shared.js';
+import { getUniqueNames, propertyValueWithDefault, uuidsMatch } from './editorUtil.shared.js';
 
 describe('editor utils', () => {
   describe('getNamesForAdd', () => {
@@ -231,6 +231,20 @@ describe('editor utils', () => {
     it('should return the new value if it differs from the default value, even if the values are booleans', () => {
       const property = propertyValueWithDefault(true, false, true);
       assert.equal(property, false);
+    });
+  });
+
+  describe('uuidsMatch', () => {
+    it('treats UUIDs with different casing as equal', () => {
+      assert.isTrue(
+        uuidsMatch('854E9FAF-7282-4501-99D8-B8C309AD7C9E', '854e9faf-7282-4501-99d8-b8c309ad7c9e'),
+      );
+    });
+
+    it('returns false when the UUID value actually changed', () => {
+      assert.isFalse(
+        uuidsMatch('854E9FAF-7282-4501-99D8-B8C309AD7C9E', '5719ebfe-ad20-42b1-b0dc-c47f0f714871'),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- compare instructor editor UUIDs case-insensitively before raising the save confirmation warning
- add a shared `uuidsMatch` helper so the normalization logic stays in one place
- cover the case-only UUID difference in `editorUtil.test.ts`

Fixes #14399.

## Verification
- `git diff --check`
- `yarn exec prettier --check apps/prairielearn/assets/scripts/instructorFileEditorClient.tsx apps/prairielearn/src/lib/editorUtil.shared.ts apps/prairielearn/src/lib/editorUtil.test.ts`

## Notes
- `./scripts/typecheck-file.sh ...` and targeted `vitest` invocation both hit existing fresh-clone workspace resolution issues in this environment before they reached these files (missing/invalid package entry resolution for workspace packages such as `@prairielearn/migrations`).