### PR TITLE
Fix case-sensitive UUID comparison in file editor

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorFileEditorClient.tsx
+++ b/apps/prairielearn/assets/scripts/instructorFileEditorClient.tsx
@@ -244,10 +244,13 @@ class InstructorFileEditor {
           return { errorCode: SaveErrorCode.INVALID_JSON };
         } else if (this.fileMetadata.uuid) {
           if ('uuid' in parsedContent) {
-            if (
-              typeof parsedContent.uuid !== 'string' ||
-              parsedContent.uuid.toLowerCase() !== this.fileMetadata.uuid.toLowerCase()
-            ) {
+            if (typeof parsedContent.uuid !== 'string') {
+              return {
+                errorCode: SaveErrorCode.UUID_CHANGED,
+                originalUuid: this.fileMetadata.uuid,
+              };
+            }
+            if (parsedContent.uuid.toLowerCase() !== this.fileMetadata.uuid.toLowerCase()) {
               return {
                 errorCode: SaveErrorCode.UUID_CHANGED,
                 originalUuid: this.fileMetadata.uuid,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

Closes #14399 

Use case-insensitive comparison for UUIDs in the file editor to avoid false “UUID changed” warnings when the UUID differs only in letter casing.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Tested manually by updating the UUID value to it's upper-cased version:

<img width="1512" height="476" alt="image" src="https://github.com/user-attachments/assets/a583297a-9ad5-49f1-8719-fc1060152abb" />

Updated successfully:

<img width="1512" height="473" alt="image" src="https://github.com/user-attachments/assets/a154017a-07bc-471e-b717-f9a2137a2758" />
