### PR TITLE
Use fast apt mirror in CI to avoid slow Azure mirror

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,6 +101,7 @@ jobs:
         run: make typecheck-contrib
       - name: Run the TypeScript typechecker for scripts
         run: make typecheck-scripts
+      - uses: vegardit/fast-apt-mirror.sh@v1
       - name: Start Postgres
         run: |
           sudo apt-get purge -y man-db
@@ -152,6 +153,7 @@ jobs:
         with:
           show-progress: false
 
+      - uses: vegardit/fast-apt-mirror.sh@v1
       - name: Install OS packages
         run: |-
           sudo apt-get update
@@ -219,6 +221,7 @@ jobs:
           sudo curl -fsSL https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64 -o /bin/hadolint && \
           sudo chmod +x /bin/hadolint
 
+      - uses: vegardit/fast-apt-mirror.sh@v1
       - name: Install OS packages
         run: |-
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # The default Azure apt mirror on GitHub Actions runners is frequently
+      # slow or throttled, causing apt-get operations to take minutes instead
+      # of seconds. This action finds and configures a faster mirror.
+      - uses: vegardit/fast-apt-mirror.sh@v1
+
       # We uninstall `man-db` to speed up the installation of other packages
       # by avoiding building man pages for them. As this is a non-interactive
       # environment, we will never need man pages anyways.


### PR DESCRIPTION
# Description

The default `azure.archive.ubuntu.com` apt mirror on GitHub Actions runners is frequently throttled, causing `apt-get` operations to take minutes instead of seconds. For example, [this run](https://github.com/PrairieLearn/PrairieLearn/actions/runs/23023190093/job/66864610653) downloaded 9.8 MB of OS packages in 2min 20s and 25.4 MB of Playwright system deps in 5min 51s — both at ~70 KB/s.

This is a well-known recurring issue: [actions/runner-images#12949](https://github.com/actions/runner-images/issues/12949).

This adds [`vegardit/fast-apt-mirror.sh@v1`](https://github.com/vegardit/fast-apt-mirror.sh) before the first `apt-get` operation in all 4 CI jobs that use apt (3 in `check.yml`, 1 in `test.yml`). The action detects and configures a faster mirror, and gracefully degrades if mirror detection fails.

Majority of implementation done with AI assistance.

# Testing

- CI should pass with the new action
- Check that apt-get download speeds in the logs are faster (look for `Fetched ... in ...` lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)