### PR TITLE
Fix question settings assessment list ordering

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.sql
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.sql
@@ -34,7 +34,7 @@ FROM
           a.type
         )
         ORDER BY
-          admin_assessment_question_number (aq.id)
+          (aset.number, a.order_by, a.id)
       ) AS matched_assessments
     FROM
       assessment_questions AS aq


### PR DESCRIPTION
# Description

The assessment list on the question settings page was displaying in random order because the `ORDER BY` clause used `admin_assessment_question_number(aq.id)`, which orders by the question's position within an assessment rather than the assessment ordering.

Changed to use `(aset.number, a.order_by, a.id)`, which matches the standard convention used elsewhere in the codebase (e.g., in instructorGradebook) for ordering assessments by set number, then assessment order within the set.

# Testing

The change affects only the ordering of the assessment list in the question settings page. No functional behavior is changed, only the display order is now consistent and predictable based on assessment set and order configuration.