### PR TITLE
Prevent release workflow from running on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     name: Release
+    if: github.repository == 'PrairieLearn/PrairieLearn'
     runs-on: ubuntu-latest
     permissions:
       # Needed for OIDC trusted publishing


### PR DESCRIPTION
# Description

The release workflow was triggering on any push to `master`, including forks. This caused the workflow to run on fork repositories when they pushed to their own `master` branch, attempting to use CI bot credentials and publish packages using a fork's secrets.

This change adds a repository check to ensure the release workflow only runs on the main `PrairieLearn/PrairieLearn` repository.

# Testing

This fix prevents the incorrect workflow execution observed in the fork CI run. The workflow will continue to run normally on the main repository's `master` branch.