### PR TITLE
Work around vscode-knip false positives for non-TS files

### DIFF
--- a/.knip.ts
+++ b/.knip.ts
@@ -80,6 +80,10 @@ for (const dep of REFERENCED_NODE_MODULES_DEPS) {
 
 const config: KnipConfig = {
   tags: ['-knipignore'],
+  // The knip language server reports "Unused file" false positives for non-TS files
+  // that don't match the `project` glob. Ignore them explicitly as a workaround.
+  // https://github.com/webpro-nl/knip/issues/1606
+  ignore: ['**/*.{css,html,json,md,mustache,png,py,sql,svg}'],
   workspaces: {
     '.': {
       entry: ['scripts/*.{mts,mjs}'],


### PR DESCRIPTION
## Summary

- The knip language server (VS Code extension) reports "Unused file" false positives for non-TS files (CSS, SQL, Python, etc.) that don't match the workspace `project` glob, while the CLI correctly excludes them
- Adds a top-level `ignore` for non-TS file extensions as a workaround

Filed upstream: https://github.com/webpro-nl/knip/issues/1606

## Test plan

- [x] Verify CSS files no longer show "Unused file" warnings in VS Code/Cursor