### PR TITLE
Disable pandas inventory in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,9 @@ plugins:
 
           inventories:
             - url: https://numpy.org/doc/stable/objects.inv
-            # - url: https://pandas.pydata.org/pandas-docs/stable/objects.inv # Pandas docs has been unstable recently, which causes CI errors.
+            # Pandas docs has been unstable recently, which causes CI errors.
+            # https://github.com/pandas-dev/pandas/issues/64584
+            # - url: https://pandas.pydata.org/pandas-docs/stable/objects.inv
             - url: https://matplotlib.org/objects.inv
             - url: https://networkx.org/documentation/latest/objects.inv
             # - url: https://docs.sympy.org/latest/objects.inv # Doesn't seem to support ARM yet.


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Pandas docs has been unstable recently (see https://github.com/pandas-dev/pandas/issues/64584). To avoid CI errors, this PR removes the inventory loading for Pandas docs, which should cause our CI issues to pass. This can be restored if/when Pandas becomes reliable again.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

If CI passes, this should be good to go.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
