### PR TITLE
Fix column manager dropdown closing when clicking checkbox labels

### DIFF
--- a/.changeset/fix-column-manager-label-click.md
+++ b/.changeset/fix-column-manager-label-click.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': patch
+---
+
+Fix column manager dropdown closing when clicking checkbox labels

--- a/packages/ui/src/components/ColumnManager.tsx
+++ b/packages/ui/src/components/ColumnManager.tsx
@@ -334,7 +334,16 @@ export function ColumnManager<RowDataModel>({
       >
         <i className="bi bi-view-list me-2" aria-hidden="true" /> View{' '}
       </Dropdown.Toggle>
-      <Dropdown.Menu style={{ maxHeight: '60vh', overflowY: 'auto' }}>
+      <Dropdown.Menu
+        style={{ maxHeight: '60vh', overflowY: 'auto' }}
+        onMouseDown={(e: React.MouseEvent) => {
+          // Prevent mousedown from moving focus away from the toggle button.
+          // Without this, clicking non-focusable elements like label text causes
+          // a blur with relatedTarget=null, which closes the dropdown before the
+          // click event can fire and toggle the checkbox.
+          e.preventDefault();
+        }}
+      >
         {topContent && (
           <>
             {topContent}


### PR DESCRIPTION
# Description

Clicking on a checkbox label (rather than the checkbox itself) in the table View menu immediately closed the dropdown without toggling the column visibility. This affected all pages with TanStack tables (Students, Gradebook, etc.).

**Root cause:** `mousedown` on a non-focusable `<label>`/`<span>` caused the toggle button to blur with `relatedTarget=null`. The `onBlur` handler saw that `null` was not contained in the menu and closed the dropdown. Because the dropdown unmounted before the `click` event fired, the label never forwarded the click to the checkbox, so no toggle occurred.

**Fix:** Call `preventDefault()` on `mousedown` within `Dropdown.Menu`. This keeps focus on the toggle button, preventing the spurious blur. The `click` event is unaffected, so checkbox toggling via labels works correctly. Keyboard navigation (Tab) is also unaffected since `preventDefault` only applies to mouse-initiated focus changes.

Majority of implementation done with AI assistance.

# Testing

- Reproduced the bug: opened the View menu, clicked a label → menu closed, no toggle.
- After fix: clicked a label → menu stays open, checkbox toggles, column visibility updates.
- Verified clicking outside the dropdown still closes it.
- Verified clicking the checkbox directly still works.