### PR TITLE
Fix deadlock in parallel AI grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
@@ -10,6 +10,7 @@ import {
   generateObject,
 } from 'ai';
 import * as async from 'async';
+import { Mutex } from 'async-mutex';
 import mustache from 'mustache';
 import { z } from 'zod';
 
@@ -352,6 +353,12 @@ export async function aiGrade({
     job.info(`Using model ${model_id} for AI grading.`);
     job.info(`Found ${instance_questions.length} submissions to grade!`);
 
+    // Mutex to serialize database transactions. AI API calls still run in
+    // parallel, but DB writes are serialized to prevent deadlocks caused by
+    // concurrent transactions locking overlapping instance_question rows
+    // (via update_assessment_instance_grade).
+    const dbWriteMutex = new Mutex();
+
     /**
      * Grade an individual instance question.
      *
@@ -677,137 +684,141 @@ export async function aiGrade({
             rubric_id: rubric_items[0].rubric_id,
             applied_rubric_items: appliedRubricItems,
           };
-          await runInTransactionAsync(async () => {
-            const { grading_job_id } = await manualGrading.updateInstanceQuestionScore({
-              assessment,
-              instance_question_id: instance_question.id,
-              submission_id: submission.id,
-              check_modified_at: null,
-              score: {
-                // TODO: consider asking for and recording freeform feedback.
-                manual_rubric_data,
-                feedback: { manual: '' },
-              },
-              authn_user_id: user_id,
-              is_ai_graded: true,
-            });
-            assert(grading_job_id);
+          await dbWriteMutex.runExclusive(() =>
+            runInTransactionAsync(async () => {
+              const { grading_job_id } = await manualGrading.updateInstanceQuestionScore({
+                assessment,
+                instance_question_id: instance_question.id,
+                submission_id: submission.id,
+                check_modified_at: null,
+                score: {
+                  // TODO: consider asking for and recording freeform feedback.
+                  manual_rubric_data,
+                  feedback: { manual: '' },
+                },
+                authn_user_id: user_id,
+                is_ai_graded: true,
+              });
+              assert(grading_job_id);
 
-            const aiGradingJobParams = {
-              grading_job_id,
-              job_sequence_id: serverJob.jobSequenceId,
-              model_id,
-              prompt: input,
-              course_id: course.id,
-              course_instance_id: course_instance.id,
-            };
+              const aiGradingJobParams = {
+                grading_job_id,
+                job_sequence_id: serverJob.jobSequenceId,
+                model_id,
+                prompt: input,
+                course_id: course.id,
+                course_instance_id: course_instance.id,
+              };
 
-            const aiGradingJobId = rotationCorrectionApplied
-              ? await insertAiGradingJobWithRotationCorrection({
-                  ...aiGradingJobParams,
-                  gradingResponseWithRotationIssue,
-                  rotationCorrections,
-                  gradingResponseWithRotationCorrection: finalGradingResponse,
-                })
-              : await insertAiGradingJob({
-                  ...aiGradingJobParams,
-                  response: finalGradingResponse,
-                });
+              const aiGradingJobId = rotationCorrectionApplied
+                ? await insertAiGradingJobWithRotationCorrection({
+                    ...aiGradingJobParams,
+                    gradingResponseWithRotationIssue,
+                    rotationCorrections,
+                    gradingResponseWithRotationCorrection: finalGradingResponse,
+                  })
+                : await insertAiGradingJob({
+                    ...aiGradingJobParams,
+                    response: finalGradingResponse,
+                  });
 
-            await updateCourseInstanceUsagesForAiGradingResponses({
-              gradingJobId: grading_job_id,
-              authnUserId: authn_user_id,
-              model: model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-            });
+              await updateCourseInstanceUsagesForAiGradingResponses({
+                gradingJobId: grading_job_id,
+                authnUserId: authn_user_id,
+                model: model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+              });
 
-            await deductAiGradingCostIfNeeded({
-              trackRateLimitAndCost,
-              model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-              course_instance_id: course_instance.id,
-              user_id: authn_user_id,
-              ai_grading_job_id: aiGradingJobId,
-              assessment_question_id: assessment_question.id,
-              instance_question_id: instance_question.id,
-            });
-          });
+              await deductAiGradingCostIfNeeded({
+                trackRateLimitAndCost,
+                model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+                course_instance_id: course_instance.id,
+                user_id: authn_user_id,
+                ai_grading_job_id: aiGradingJobId,
+                assessment_question_id: assessment_question.id,
+                instance_question_id: instance_question.id,
+              });
+            }),
+          );
         } else {
           // Does not require grading: only create grading job and rubric grading
-          await runInTransactionAsync(async () => {
-            assert(assessment_question.max_manual_points);
-            const manual_rubric_grading = await manualGrading.insertRubricGrading(
-              rubric_items[0].rubric_id,
-              assessment_question.max_points ?? 0,
-              assessment_question.max_manual_points,
-              appliedRubricItems,
-              0,
-            );
-            const score =
-              manual_rubric_grading.computed_points / assessment_question.max_manual_points;
-            const grading_job_id = await queryScalar(
-              sql.insert_grading_job,
-              {
-                submission_id: submission.id,
-                authn_user_id: user_id,
-                grading_method: 'AI',
-                correct: null,
-                score,
-                auto_points: 0,
-                manual_points: manual_rubric_grading.computed_points,
-                manual_rubric_grading_id: manual_rubric_grading.id,
-                feedback: null,
-              },
-              IdSchema,
-            );
+          await dbWriteMutex.runExclusive(() =>
+            runInTransactionAsync(async () => {
+              assert(assessment_question.max_manual_points);
+              const manual_rubric_grading = await manualGrading.insertRubricGrading(
+                rubric_items[0].rubric_id,
+                assessment_question.max_points ?? 0,
+                assessment_question.max_manual_points,
+                appliedRubricItems,
+                0,
+              );
+              const score =
+                manual_rubric_grading.computed_points / assessment_question.max_manual_points;
+              const grading_job_id = await queryScalar(
+                sql.insert_grading_job,
+                {
+                  submission_id: submission.id,
+                  authn_user_id: user_id,
+                  grading_method: 'AI',
+                  correct: null,
+                  score,
+                  auto_points: 0,
+                  manual_points: manual_rubric_grading.computed_points,
+                  manual_rubric_grading_id: manual_rubric_grading.id,
+                  feedback: null,
+                },
+                IdSchema,
+              );
 
-            const aiGradingJobParams = {
-              grading_job_id,
-              job_sequence_id: serverJob.jobSequenceId,
-              model_id,
-              prompt: input,
-              course_id: course.id,
-              course_instance_id: course_instance.id,
-            };
+              const aiGradingJobParams = {
+                grading_job_id,
+                job_sequence_id: serverJob.jobSequenceId,
+                model_id,
+                prompt: input,
+                course_id: course.id,
+                course_instance_id: course_instance.id,
+              };
 
-            const aiGradingJobId = rotationCorrectionApplied
-              ? await insertAiGradingJobWithRotationCorrection({
-                  ...aiGradingJobParams,
-                  gradingResponseWithRotationIssue,
-                  rotationCorrections,
-                  gradingResponseWithRotationCorrection: finalGradingResponse,
-                })
-              : await insertAiGradingJob({
-                  ...aiGradingJobParams,
-                  response: finalGradingResponse,
-                });
+              const aiGradingJobId = rotationCorrectionApplied
+                ? await insertAiGradingJobWithRotationCorrection({
+                    ...aiGradingJobParams,
+                    gradingResponseWithRotationIssue,
+                    rotationCorrections,
+                    gradingResponseWithRotationCorrection: finalGradingResponse,
+                  })
+                : await insertAiGradingJob({
+                    ...aiGradingJobParams,
+                    response: finalGradingResponse,
+                  });
 
-            await updateCourseInstanceUsagesForAiGradingResponses({
-              gradingJobId: grading_job_id,
-              authnUserId: authn_user_id,
-              model: model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-            });
+              await updateCourseInstanceUsagesForAiGradingResponses({
+                gradingJobId: grading_job_id,
+                authnUserId: authn_user_id,
+                model: model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+              });
 
-            await deductAiGradingCostIfNeeded({
-              trackRateLimitAndCost,
-              model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-              course_instance_id: course_instance.id,
-              user_id: authn_user_id,
-              ai_grading_job_id: aiGradingJobId,
-              assessment_question_id: assessment_question.id,
-              instance_question_id: instance_question.id,
-            });
-          });
+              await deductAiGradingCostIfNeeded({
+                trackRateLimitAndCost,
+                model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+                course_instance_id: course_instance.id,
+                user_id: authn_user_id,
+                ai_grading_job_id: aiGradingJobId,
+                assessment_question_id: assessment_question.id,
+                instance_question_id: instance_question.id,
+              });
+            }),
+          );
         }
 
         logger.info('AI rubric items:');
@@ -959,126 +970,130 @@ export async function aiGrade({
         if (shouldUpdateScore) {
           // Requires grading: update instance question score
           const feedback = finalGradingResponse.object.feedback;
-          await runInTransactionAsync(async () => {
-            const { grading_job_id } = await manualGrading.updateInstanceQuestionScore({
-              assessment,
-              instance_question_id: instance_question.id,
-              submission_id: submission.id,
-              check_modified_at: null,
-              score: {
-                manual_score_perc: score,
-                feedback: { manual: feedback },
-              },
-              authn_user_id: user_id,
-              is_ai_graded: true,
-            });
-            assert(grading_job_id);
+          await dbWriteMutex.runExclusive(() =>
+            runInTransactionAsync(async () => {
+              const { grading_job_id } = await manualGrading.updateInstanceQuestionScore({
+                assessment,
+                instance_question_id: instance_question.id,
+                submission_id: submission.id,
+                check_modified_at: null,
+                score: {
+                  manual_score_perc: score,
+                  feedback: { manual: feedback },
+                },
+                authn_user_id: user_id,
+                is_ai_graded: true,
+              });
+              assert(grading_job_id);
 
-            const aiGradingJobParams = {
-              grading_job_id,
-              job_sequence_id: serverJob.jobSequenceId,
-              model_id,
-              prompt: input,
-              course_id: course.id,
-              course_instance_id: course_instance.id,
-            };
+              const aiGradingJobParams = {
+                grading_job_id,
+                job_sequence_id: serverJob.jobSequenceId,
+                model_id,
+                prompt: input,
+                course_id: course.id,
+                course_instance_id: course_instance.id,
+              };
 
-            const aiGradingJobId = rotationCorrectionApplied
-              ? await insertAiGradingJobWithRotationCorrection({
-                  ...aiGradingJobParams,
-                  gradingResponseWithRotationIssue,
-                  rotationCorrections,
-                  gradingResponseWithRotationCorrection: finalGradingResponse,
-                })
-              : await insertAiGradingJob({
-                  ...aiGradingJobParams,
-                  response: finalGradingResponse,
-                });
+              const aiGradingJobId = rotationCorrectionApplied
+                ? await insertAiGradingJobWithRotationCorrection({
+                    ...aiGradingJobParams,
+                    gradingResponseWithRotationIssue,
+                    rotationCorrections,
+                    gradingResponseWithRotationCorrection: finalGradingResponse,
+                  })
+                : await insertAiGradingJob({
+                    ...aiGradingJobParams,
+                    response: finalGradingResponse,
+                  });
 
-            await updateCourseInstanceUsagesForAiGradingResponses({
-              gradingJobId: grading_job_id,
-              authnUserId: authn_user_id,
-              model: model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-            });
+              await updateCourseInstanceUsagesForAiGradingResponses({
+                gradingJobId: grading_job_id,
+                authnUserId: authn_user_id,
+                model: model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+              });
 
-            await deductAiGradingCostIfNeeded({
-              trackRateLimitAndCost,
-              model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-              course_instance_id: course_instance.id,
-              user_id: authn_user_id,
-              ai_grading_job_id: aiGradingJobId,
-              assessment_question_id: assessment_question.id,
-              instance_question_id: instance_question.id,
-            });
-          });
+              await deductAiGradingCostIfNeeded({
+                trackRateLimitAndCost,
+                model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+                course_instance_id: course_instance.id,
+                user_id: authn_user_id,
+                ai_grading_job_id: aiGradingJobId,
+                assessment_question_id: assessment_question.id,
+                instance_question_id: instance_question.id,
+              });
+            }),
+          );
         } else {
           // Does not require grading: only create grading job and rubric grading
-          await runInTransactionAsync(async () => {
-            assert(assessment_question.max_manual_points);
-            const grading_job_id = await queryScalar(
-              sql.insert_grading_job,
-              {
-                submission_id: submission.id,
-                authn_user_id: user_id,
-                grading_method: 'AI',
-                correct: null,
-                score: score / 100,
-                auto_points: 0,
-                manual_points: (score * assessment_question.max_manual_points) / 100,
-                manual_rubric_grading_id: null,
-                feedback: null,
-              },
-              IdSchema,
-            );
+          await dbWriteMutex.runExclusive(() =>
+            runInTransactionAsync(async () => {
+              assert(assessment_question.max_manual_points);
+              const grading_job_id = await queryScalar(
+                sql.insert_grading_job,
+                {
+                  submission_id: submission.id,
+                  authn_user_id: user_id,
+                  grading_method: 'AI',
+                  correct: null,
+                  score: score / 100,
+                  auto_points: 0,
+                  manual_points: (score * assessment_question.max_manual_points) / 100,
+                  manual_rubric_grading_id: null,
+                  feedback: null,
+                },
+                IdSchema,
+              );
 
-            const aiGradingJobParams = {
-              grading_job_id,
-              job_sequence_id: serverJob.jobSequenceId,
-              model_id,
-              prompt: input,
-              course_id: course.id,
-              course_instance_id: course_instance.id,
-            };
-            const aiGradingJobId = rotationCorrectionApplied
-              ? await insertAiGradingJobWithRotationCorrection({
-                  ...aiGradingJobParams,
-                  gradingResponseWithRotationIssue,
-                  rotationCorrections,
-                  gradingResponseWithRotationCorrection: finalGradingResponse,
-                })
-              : await insertAiGradingJob({
-                  ...aiGradingJobParams,
-                  response: finalGradingResponse,
-                });
+              const aiGradingJobParams = {
+                grading_job_id,
+                job_sequence_id: serverJob.jobSequenceId,
+                model_id,
+                prompt: input,
+                course_id: course.id,
+                course_instance_id: course_instance.id,
+              };
+              const aiGradingJobId = rotationCorrectionApplied
+                ? await insertAiGradingJobWithRotationCorrection({
+                    ...aiGradingJobParams,
+                    gradingResponseWithRotationIssue,
+                    rotationCorrections,
+                    gradingResponseWithRotationCorrection: finalGradingResponse,
+                  })
+                : await insertAiGradingJob({
+                    ...aiGradingJobParams,
+                    response: finalGradingResponse,
+                  });
 
-            await updateCourseInstanceUsagesForAiGradingResponses({
-              gradingJobId: grading_job_id,
-              authnUserId: authn_user_id,
-              model: model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-            });
+              await updateCourseInstanceUsagesForAiGradingResponses({
+                gradingJobId: grading_job_id,
+                authnUserId: authn_user_id,
+                model: model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+              });
 
-            await deductAiGradingCostIfNeeded({
-              trackRateLimitAndCost,
-              model_id,
-              gradingResponseWithRotationIssue,
-              rotationCorrections,
-              finalGradingResponse,
-              course_instance_id: course_instance.id,
-              user_id: authn_user_id,
-              ai_grading_job_id: aiGradingJobId,
-              assessment_question_id: assessment_question.id,
-              instance_question_id: instance_question.id,
-            });
-          });
+              await deductAiGradingCostIfNeeded({
+                trackRateLimitAndCost,
+                model_id,
+                gradingResponseWithRotationIssue,
+                rotationCorrections,
+                finalGradingResponse,
+                course_instance_id: course_instance.id,
+                user_id: authn_user_id,
+                ai_grading_job_id: aiGradingJobId,
+                assessment_question_id: assessment_question.id,
+                instance_question_id: instance_question.id,
+              });
+            }),
+          );
         }
 
         logger.info(`AI score: ${finalGradingResponse.object.score}`);

--- a/apps/prairielearn/src/lib/manualGrading.ts
+++ b/apps/prairielearn/src/lib/manualGrading.ts
@@ -507,6 +507,11 @@ export type InstanceQuestionScoreInput = z.infer<typeof InstanceQuestionScoreInp
  * @param params.is_ai_graded - Whether the score update is the result of AI grading or manual grading
  * @returns The ID of the grading job created, if any, and a flag indicating if the score was not updated due to a modified_at conflict.
  */
+// WARNING: Concurrent calls for instance_questions belonging to the same
+// assessment_instance will deadlock, because updateAssessmentInstanceGrade
+// locks ALL instance_question rows for the assessment_instance. Callers that
+// grade multiple instance_questions in parallel must serialize calls with a
+// mutex (see ai-grading.ts for an example).
 export async function updateInstanceQuestionScore({
   assessment,
   instance_question_id,


### PR DESCRIPTION
# Description

AI grading runs up to 20 submissions in parallel. When saving results, each transaction locks its own `instance_question` row, then `update_assessment_instance_grade` tries to lock ALL `instance_question` rows for the same `assessment_instance`. This creates a classic deadlock when two concurrent transactions hold different `instance_question` row locks and each tries to acquire the other's.

This fix serializes the database transaction portions using a mutex (`async-mutex`), while keeping the AI API calls fully parallel. Since the API calls are the bottleneck, this has negligible performance impact. Also adds a warning comment on `updateInstanceQuestionScore` about the deadlock risk for future callers.

AI assistance: majority of implementation.

# Testing

- To reproduce the original bug: on `master` run AI grading on an assessment with many submissions — the parallel DB writes would intermittently hit `deadlock detected` errors, causing ~50% of gradings to fail. 

<img width="1327" height="1141" alt="Screenshot 2026-03-23 at 9 45 47 PM" src="https://github.com/user-attachments/assets/5c1bf164-acf9-481d-bd5e-757df6ec577b" />

<img width="788" height="79" alt="Screenshot 2026-03-23 at 9 51 37 PM" src="https://github.com/user-attachments/assets/ae06e6aa-1a55-4bbf-890d-dba9d8f38686" />

- Run it again on this branch; no deadlocks should occur.