### PR TITLE
Remove redundant parameters and small refactors in access control

### DIFF
--- a/apps/prairielearn/src/lib/access-control-data.ts
+++ b/apps/prairielearn/src/lib/access-control-data.ts
@@ -48,26 +48,21 @@ function buildDateControl(row: AccessControlRuleRow): AccessControlJson['dateCon
   // Only include fields that were explicitly configured (overridden flag is true).
   // This applies uniformly to main rules and overrides.
   const dateControl: NonNullable<AccessControlJson['dateControl']> = {};
-  let hasAnyField = false;
 
   if (row.date_control_release_date_overridden) {
     dateControl.releaseDate = row.date_control_release_date?.toISOString() ?? null;
-    hasAnyField = true;
   }
 
   if (row.date_control_due_date_overridden) {
     dateControl.dueDate = row.date_control_due_date?.toISOString() ?? null;
-    hasAnyField = true;
   }
 
   if (row.date_control_duration_minutes_overridden) {
     dateControl.durationMinutes = row.date_control_duration_minutes;
-    hasAnyField = true;
   }
 
   if (row.date_control_password_overridden) {
     dateControl.password = row.date_control_password;
-    hasAnyField = true;
   }
 
   if (row.date_control_early_deadlines_overridden) {
@@ -76,7 +71,6 @@ function buildDateControl(row: AccessControlRuleRow): AccessControlJson['dateCon
         date: d.date,
         credit: d.credit,
       })) ?? null;
-    hasAnyField = true;
   }
 
   if (row.date_control_late_deadlines_overridden) {
@@ -85,7 +79,6 @@ function buildDateControl(row: AccessControlRuleRow): AccessControlJson['dateCon
         date: d.date,
         credit: d.credit,
       })) ?? null;
-    hasAnyField = true;
   }
 
   {
@@ -109,11 +102,10 @@ function buildDateControl(row: AccessControlRuleRow): AccessControlJson['dateCon
             row.date_control_after_last_deadline_allow_submissions!;
         }
       }
-      hasAnyField = true;
     }
   }
 
-  return hasAnyField ? dateControl : undefined;
+  return Object.keys(dateControl).length > 0 ? dateControl : undefined;
 }
 
 function buildAfterComplete(
@@ -123,17 +115,14 @@ function buildAfterComplete(
   const includeField = (overridden: boolean) => !override || overridden;
 
   const afterComplete: NonNullable<AccessControlJson['afterComplete']> = {};
-  let hasAnyField = false;
 
   if (row.after_complete_hide_questions != null) {
     afterComplete.hideQuestions = row.after_complete_hide_questions;
-    hasAnyField = true;
   }
   if (includeField(row.after_complete_hide_questions_again_date_overridden)) {
     if (row.after_complete_hide_questions_again_date) {
       afterComplete.hideQuestionsAgainDate =
         row.after_complete_hide_questions_again_date.toISOString();
-      hasAnyField = true;
     }
   }
 
@@ -141,22 +130,19 @@ function buildAfterComplete(
     if (row.after_complete_show_questions_again_date) {
       afterComplete.showQuestionsAgainDate =
         row.after_complete_show_questions_again_date.toISOString();
-      hasAnyField = true;
     }
   }
 
   if (row.after_complete_hide_score != null) {
     afterComplete.hideScore = row.after_complete_hide_score;
-    hasAnyField = true;
   }
   if (includeField(row.after_complete_show_score_again_date_overridden)) {
     if (row.after_complete_show_score_again_date) {
       afterComplete.showScoreAgainDate = row.after_complete_show_score_again_date.toISOString();
-      hasAnyField = true;
     }
   }
 
-  return hasAnyField ? afterComplete : undefined;
+  return Object.keys(afterComplete).length > 0 ? afterComplete : undefined;
 }
 
 function rowToAccessControlRuleInput(row: AccessControlRuleRow): AccessControlRuleInput {
@@ -227,11 +213,6 @@ export async function selectAccessControlRulesForCourseInstance(
   return result;
 }
 
-const StudentContextRowSchema = z.object({
-  enrollment_id: IdSchema,
-  student_label_ids: z.array(IdSchema),
-});
-
 export async function selectStudentContext(
   userId: string,
   courseInstance: CourseInstance,
@@ -239,7 +220,10 @@ export async function selectStudentContext(
   const row = await queryOptionalRow(
     sql.select_student_context,
     { user_id: userId, course_instance_id: courseInstance.id },
-    StudentContextRowSchema,
+    z.object({
+      enrollment_id: IdSchema,
+      student_label_ids: z.array(IdSchema),
+    }),
   );
   if (!row) {
     return { enrollmentId: null, studentLabelIds: [] };
@@ -250,11 +234,6 @@ export async function selectStudentContext(
   };
 }
 
-const PrairieTestReservationRowSchema = z.object({
-  exam_uuid: z.string(),
-  access_end: DateFromISOString,
-});
-
 export async function selectPrairieTestReservations(
   userId: string,
   date: Date,
@@ -262,7 +241,10 @@ export async function selectPrairieTestReservations(
   const rows = await queryRows(
     sql.select_prairietest_reservation,
     { user_id: userId, date },
-    PrairieTestReservationRowSchema,
+    z.object({
+      exam_uuid: z.string(),
+      access_end: DateFromISOString,
+    }),
   );
   return rows.map((row) => ({
     examUuid: row.exam_uuid,

--- a/apps/prairielearn/src/lib/access-control-modern.test.ts
+++ b/apps/prairielearn/src/lib/access-control-modern.test.ts
@@ -33,9 +33,9 @@ describe('resolveModernAssessmentInstanceAccess', () => {
   });
 
   const baseInput = {
-    assessment: { id: '1' } as Assessment,
+    assessment: { id: '1', team_work: false } as Assessment,
     userId: 'user-1',
-    courseInstance: { id: 'ci-1' } as CourseInstance,
+    courseInstance: { id: 'ci-1', display_timezone: 'America/Chicago' } as CourseInstance,
     authzData: {
       user: { id: 'user-1' },
       mode: 'Public',
@@ -44,7 +44,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
       has_course_instance_permission_view: false,
     },
     reqDate: new Date('2025-03-15T12:00:00Z'),
-    displayTimezone: 'America/Chicago',
   } satisfies Partial<ModernAssessmentInstanceAccessInput>;
 
   describe('individual (non-group) assessment instances', () => {
@@ -57,7 +56,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
           team_id: null,
           date_limit: null,
         },
-        groupWork: false,
       });
 
       expect(result.authorized).toBe(true);
@@ -73,7 +71,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
           team_id: null,
           date_limit: null,
         },
-        groupWork: false,
       });
 
       expect(result.authorized).toBe(false);
@@ -93,7 +90,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
           team_id: null,
           date_limit: null,
         },
-        groupWork: false,
       });
 
       expect(result.authorized).toBe(true);
@@ -107,13 +103,13 @@ describe('resolveModernAssessmentInstanceAccess', () => {
 
       const result = await resolveModernAssessmentInstanceAccess({
         ...baseInput,
+        assessment: { ...baseInput.assessment, team_work: true } as Assessment,
         assessmentInstance: {
           id: 'ai-1',
           user_id: null,
           team_id: 'team-1',
           date_limit: null,
         },
-        groupWork: true,
       });
 
       expect(result.authorized).toBe(true);
@@ -126,13 +122,13 @@ describe('resolveModernAssessmentInstanceAccess', () => {
 
       const result = await resolveModernAssessmentInstanceAccess({
         ...baseInput,
+        assessment: { ...baseInput.assessment, team_work: true } as Assessment,
         assessmentInstance: {
           id: 'ai-1',
           user_id: null,
           team_id: 'team-1',
           date_limit: null,
         },
-        groupWork: true,
       });
 
       expect(result.authorized).toBe(false);
@@ -144,13 +140,13 @@ describe('resolveModernAssessmentInstanceAccess', () => {
 
       const result = await resolveModernAssessmentInstanceAccess({
         ...baseInput,
+        assessment: { ...baseInput.assessment, team_work: true } as Assessment,
         assessmentInstance: {
           id: 'ai-1',
           user_id: null,
           team_id: 'team-1',
           date_limit: null,
         },
-        groupWork: true,
       });
 
       expect(result.authorized).toBe(false);
@@ -162,6 +158,7 @@ describe('resolveModernAssessmentInstanceAccess', () => {
 
       const result = await resolveModernAssessmentInstanceAccess({
         ...baseInput,
+        assessment: { ...baseInput.assessment, team_work: true } as Assessment,
         authzData: {
           ...baseInput.authzData,
           has_course_instance_permission_view: true,
@@ -172,7 +169,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
           team_id: 'team-1',
           date_limit: null,
         },
-        groupWork: true,
       });
 
       expect(result.authorized).toBe(true);
@@ -190,7 +186,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
           team_id: null,
           date_limit: new Date('2025-03-15T11:00:00Z'),
         },
-        groupWork: false,
       });
 
       expect(result.time_limit_expired).toBe(true);
@@ -205,7 +200,6 @@ describe('resolveModernAssessmentInstanceAccess', () => {
           team_id: null,
           date_limit: new Date('2025-03-15T13:00:00Z'),
         },
-        groupWork: false,
       });
 
       expect(result.time_limit_expired).toBe(false);

--- a/apps/prairielearn/src/lib/access-control-modern.ts
+++ b/apps/prairielearn/src/lib/access-control-modern.ts
@@ -39,7 +39,6 @@ interface ModernAssessmentAccessInput {
   courseInstance: CourseInstance;
   authzData: AuthzDataForAccessControl;
   reqDate: Date;
-  displayTimezone: string;
 }
 
 function resolverResultToSprocAuthzAssessment(
@@ -67,7 +66,7 @@ function resolverResultToSprocAuthzAssessment(
 export async function resolveModernAssessmentAccess(
   input: ModernAssessmentAccessInput,
 ): Promise<SprocAuthzAssessment & { list_before_release: boolean }> {
-  const { assessment, userId, courseInstance, authzData, reqDate, displayTimezone } = input;
+  const { assessment, userId, courseInstance, authzData, reqDate } = input;
 
   const [rules, student, prairieTestReservations] = await Promise.all([
     selectAccessControlRulesForAssessment(assessment),
@@ -81,7 +80,7 @@ export async function resolveModernAssessmentAccess(
     rules,
     student,
     date: reqDate,
-    displayTimezone,
+    displayTimezone: courseInstance.display_timezone,
     authzMode: authzData.mode ?? null,
     courseRole: authzData.course_role ?? 'None',
     courseInstanceRole: authzData.course_instance_role ?? 'None',
@@ -101,7 +100,6 @@ export interface ModernAssessmentInstanceAccessInput extends ModernAssessmentAcc
     team_id: string | null;
     date_limit: Date | null;
   };
-  groupWork: boolean | null;
 }
 
 export async function resolveModernAssessmentInstanceAccess(
@@ -109,7 +107,7 @@ export async function resolveModernAssessmentInstanceAccess(
 ): Promise<SprocAuthzAssessmentInstance & { list_before_release: boolean }> {
   const assessmentResult = await resolveModernAssessmentAccess(input);
 
-  const { assessmentInstance, authzData, reqDate, groupWork } = input;
+  const { assessment, assessmentInstance, authzData, reqDate } = input;
 
   const timeLimitExpired =
     assessmentInstance.date_limit != null && assessmentInstance.date_limit <= reqDate;
@@ -118,7 +116,7 @@ export async function resolveModernAssessmentInstanceAccess(
   // For group work, check that the user is in an active group matching
   // the instance's team. For individual work, check that the user_id matches.
   let ownsInstance: boolean;
-  if (groupWork && assessmentInstance.team_id != null) {
+  if (assessment.team_work && assessmentInstance.team_id != null) {
     const userGroupId = await getGroupId(input.assessment.id, authzData.user.id);
     ownsInstance = userGroupId != null && idsEqual(userGroupId, assessmentInstance.team_id);
   } else {
@@ -151,13 +149,12 @@ interface ModernAssessmentAccessBatchInput {
   userId: string;
   authzData: AuthzDataForAccessControl;
   reqDate: Date;
-  displayTimezone: string;
 }
 
 export async function resolveModernAssessmentAccessBatch(
   input: ModernAssessmentAccessBatchInput,
 ): Promise<Map<string, SprocAuthzAssessment & { list_before_release: boolean }>> {
-  const { courseInstance, userId, authzData, reqDate, displayTimezone } = input;
+  const { courseInstance, userId, authzData, reqDate } = input;
 
   const [allRules, student, prairieTestReservations] = await Promise.all([
     selectAccessControlRulesForCourseInstance(courseInstance),
@@ -174,7 +171,7 @@ export async function resolveModernAssessmentAccessBatch(
       rules,
       student,
       date: reqDate,
-      displayTimezone,
+      displayTimezone: courseInstance.display_timezone,
       authzMode: authzData.mode ?? null,
       courseRole: authzData.course_role ?? 'None',
       courseInstanceRole: authzData.course_instance_role ?? 'None',

--- a/apps/prairielearn/src/lib/gradebook.ts
+++ b/apps/prairielearn/src/lib/gradebook.ts
@@ -19,7 +19,6 @@ interface GetGradebookRowsParams {
   userId: string;
   authzData: AuthzDataForAccessControl;
   reqDate: Date;
-  displayTimezone: string;
   auth: 'student' | 'instructor';
 }
 
@@ -39,7 +38,6 @@ async function applyModernAccessControl<
     userId: params.userId,
     authzData: params.authzData,
     reqDate: params.reqDate,
-    displayTimezone: params.displayTimezone,
   });
 
   for (const row of rows) {
@@ -68,7 +66,6 @@ async function getGradebookRows({
   userId,
   authzData,
   reqDate,
-  displayTimezone,
   auth,
 }: GetGradebookRowsParams): Promise<StudentGradebookRow[] | StaffGradebookRow[]> {
   const queryParams = {
@@ -89,7 +86,6 @@ async function getGradebookRows({
       userId,
       authzData,
       reqDate,
-      displayTimezone,
       auth,
     });
     return rows;
@@ -105,7 +101,6 @@ async function getGradebookRows({
     userId,
     authzData,
     reqDate,
-    displayTimezone,
     auth,
   });
   return rows;

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessment.ts
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessment.ts
@@ -26,7 +26,7 @@ const SelectAndAuthzAssessmentSchema = z.object({
 export type ResLocalsAssessment = z.infer<typeof SelectAndAuthzAssessmentSchema>;
 
 export default asyncHandler(async (req, res, next) => {
-  let row = await queryOptionalRow(
+  const row = await queryOptionalRow(
     sql.select_and_auth,
     {
       assessment_id: req.params.assessment_id,
@@ -47,9 +47,8 @@ export default asyncHandler(async (req, res, next) => {
       courseInstance: res.locals.course_instance,
       authzData: res.locals.authz_data,
       reqDate: res.locals.req_date,
-      displayTimezone: res.locals.course_instance.display_timezone,
     });
-    row = { ...row, authz_result: modernResult };
+    row.authz_result = modernResult;
   }
   if (!row.authz_result.authorized) {
     res.status(403).send(AccessDenied({ resLocals: res.locals }));

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.ts
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.ts
@@ -53,7 +53,7 @@ export type ResLocalsAssessmentInstance = z.infer<typeof SelectAndAuthzAssessmen
 };
 
 async function selectAndAuthzAssessmentInstance(req: Request, res: Response) {
-  let row = await sqldb.queryOptionalRow(
+  const row = await sqldb.queryOptionalRow(
     sql.select_and_auth,
     {
       assessment_instance_id: req.params.assessment_instance_id,
@@ -72,11 +72,9 @@ async function selectAndAuthzAssessmentInstance(req: Request, res: Response) {
       courseInstance: res.locals.course_instance,
       authzData: res.locals.authz_data,
       reqDate: res.locals.req_date,
-      displayTimezone: res.locals.course_instance.display_timezone,
       assessmentInstance: row.assessment_instance,
-      groupWork: row.assessment.team_work,
     });
-    row = { ...row, authz_result: modernResult };
+    row.authz_result = modernResult;
   }
 
   if (!row.authz_result.authorized) {

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.ts
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.ts
@@ -87,7 +87,7 @@ export type ResLocalsInstanceQuestion = z.infer<typeof SelectAndAuthzInstanceQue
 };
 
 export async function selectAndAuthzInstanceQuestion(req: Request, res: Response) {
-  let row = await sqldb.queryOptionalRow(
+  const row = await sqldb.queryOptionalRow(
     sql.select_and_auth,
     {
       instance_question_id: req.params.instance_question_id,
@@ -119,11 +119,9 @@ export async function selectAndAuthzInstanceQuestion(req: Request, res: Response
       courseInstance: res.locals.course_instance,
       authzData: res.locals.authz_data,
       reqDate: res.locals.req_date,
-      displayTimezone: res.locals.course_instance.display_timezone,
       assessmentInstance: row.assessment_instance,
-      groupWork: row.assessment.team_work,
     });
-    row = { ...row, authz_result: modernResult };
+    row.authz_result = modernResult;
   }
 
   if (!row.authz_result.authorized) throw new error.HttpStatusError(403, 'Access denied');

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -271,6 +271,7 @@ export function AccessControlForm({
             <div className="split-pane__left-body p-3">
               <AccessControlSummary
                 courseInstanceId={courseInstance.id}
+                displayTimezone={courseInstance.display_timezone}
                 getOverrideName={getOverrideName}
                 mainRule={watchedData.mainRule}
                 overrides={watchedData.overrides}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
@@ -25,6 +25,7 @@ interface SortableOverrideCardProps {
   override: OverrideData;
   title: string;
   courseInstanceId: string;
+  displayTimezone: string;
   errors?: string[];
   onEdit: () => void;
   onRemove: () => void;
@@ -35,6 +36,7 @@ function SortableOverrideCard({
   override,
   title,
   courseInstanceId,
+  displayTimezone,
   errors,
   onEdit,
   onRemove,
@@ -56,6 +58,7 @@ function SortableOverrideCard({
         isMainRule={false}
         title={title}
         courseInstanceId={courseInstanceId}
+        displayTimezone={displayTimezone}
         errors={errors}
         dragHandleProps={{ ...attributes, ...listeners }}
         onEdit={onEdit}
@@ -65,9 +68,15 @@ function SortableOverrideCard({
   );
 }
 
-function MainRuleSummaryContent({ rule }: { rule: MainRuleData }) {
+function MainRuleSummaryContent({
+  rule,
+  displayTimezone,
+}: {
+  rule: MainRuleData;
+  displayTimezone: string;
+}) {
   const summaryLines = generateRuleSummary(rule, 'compact');
-  const dateTableRows = generateDateTableRows(rule, 'compact');
+  const dateTableRows = generateDateTableRows(rule, displayTimezone, 'compact');
 
   return (
     <div>
@@ -108,6 +117,7 @@ interface AccessControlSummaryProps {
   onEditOverride: (index: number) => void;
   /** Course instance ID for building URLs */
   courseInstanceId: string;
+  displayTimezone: string;
 }
 
 export function AccessControlSummary({
@@ -122,6 +132,7 @@ export function AccessControlSummary({
   onEditMainRule,
   onEditOverride,
   courseInstanceId,
+  displayTimezone,
 }: AccessControlSummaryProps) {
   const dndId = useId();
   const sensors = useSensors(
@@ -176,7 +187,7 @@ export function AccessControlSummary({
           </Alert>
         )}
 
-        <MainRuleSummaryContent rule={mainRule} />
+        <MainRuleSummaryContent rule={mainRule} displayTimezone={displayTimezone} />
       </section>
 
       <section>
@@ -225,6 +236,7 @@ export function AccessControlSummary({
                       override={override}
                       title={getOverrideName(index)}
                       courseInstanceId={courseInstanceId}
+                      displayTimezone={displayTimezone}
                       errors={getOverrideErrors?.(index)}
                       onEdit={() => onEditOverride(index)}
                       onRemove={() => onRemoveOverride(index)}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -1,5 +1,7 @@
 import { Alert, Badge, Button, Card, Table } from 'react-bootstrap';
 
+import { formatDate } from '@prairielearn/formatter';
+
 import {
   getCourseInstanceStudentLabelsUrl,
   getStudentEnrollmentUrl,
@@ -24,22 +26,6 @@ function isOverrideFieldActive(rule: RuleData, fieldName: string): boolean {
   return rule.overriddenFields.includes(fieldName);
 }
 
-function formatDate(dateStr: string): string {
-  if (!dateStr) return '';
-  try {
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return dateStr;
-  }
-}
-
 interface DateTableRow {
   date: string;
   label: string;
@@ -49,6 +35,7 @@ interface DateTableRow {
 
 export function generateDateTableRows(
   rule: RuleData,
+  displayTimezone: string,
   verbosity: SummaryVerbosity = 'compact',
 ): DateTableRow[] {
   const rows: DateTableRow[] = [];
@@ -64,15 +51,7 @@ export function generateDateTableRows(
     return rows;
   }
 
-  interface DateEntry {
-    date: string;
-    timestamp: number;
-    label: string;
-    credit: string;
-    visibility: string;
-  }
-
-  const entries: DateEntry[] = [];
+  const entries: (DateTableRow & { timestamp: number })[] = [];
 
   const releaseDate = rule.releaseDate;
   const dueDate = rule.dueDate;
@@ -146,7 +125,7 @@ export function generateDateTableRows(
 
   for (const entry of entries) {
     rows.push({
-      date: formatDate(entry.date),
+      date: formatDate(new Date(entry.date), displayTimezone),
       label: entry.label,
       credit: entry.credit,
       visibility: entry.visibility,
@@ -270,6 +249,7 @@ interface RuleSummaryCardProps {
   editUrl?: string;
   onEdit?: () => void;
   courseInstanceId: string;
+  displayTimezone: string;
   errors?: string[];
   onEditStudentLabels?: () => void;
   onRemove?: () => void;
@@ -284,13 +264,14 @@ export function RuleSummaryCard({
   editUrl,
   onEdit,
   courseInstanceId,
+  displayTimezone,
   errors,
   onEditStudentLabels,
   dragHandleProps,
 }: RuleSummaryCardProps) {
   const effectiveVerbosity: SummaryVerbosity = isMainRule ? 'compact' : 'verbose';
   const summaryLines = generateRuleSummary(rule, effectiveVerbosity);
-  const dateTableRows = generateDateTableRows(rule, effectiveVerbosity);
+  const dateTableRows = generateDateTableRows(rule, displayTimezone, effectiveVerbosity);
 
   const overrideRule = !isMainRule ? (rule as OverrideData) : null;
 

--- a/apps/prairielearn/src/pages/instructorStudentDetail/instructorStudentDetail.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentDetail/instructorStudentDetail.tsx
@@ -76,7 +76,6 @@ router.get(
           userId: student.user.id,
           authzData: res.locals.authz_data,
           reqDate: res.locals.req_date,
-          displayTimezone: courseInstance.display_timezone,
           auth: 'instructor',
         })
       : [];

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ts
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.ts
@@ -34,7 +34,6 @@ router.get(
           userId: res.locals.user.id,
           authzData: res.locals.authz_data,
           reqDate: res.locals.req_date,
-          displayTimezone: res.locals.course_instance.display_timezone,
         })
       : null;
 

--- a/apps/prairielearn/src/pages/studentGradebook/studentGradebook.ts
+++ b/apps/prairielearn/src/pages/studentGradebook/studentGradebook.ts
@@ -54,7 +54,6 @@ router.get(
       userId: res.locals.user.id,
       authzData: res.locals.authz_data,
       reqDate: res.locals.req_date,
-      displayTimezone: res.locals.course_instance.display_timezone,
       auth: 'student',
     });
     const rows = rawRows.map((row, index) => mapRow(row, rawRows[index - 1]));
@@ -80,7 +79,6 @@ router.get(
       userId: res.locals.user.id,
       authzData: res.locals.authz_data,
       reqDate: res.locals.req_date,
-      displayTimezone: res.locals.course_instance.display_timezone,
       auth: 'student',
     });
 


### PR DESCRIPTION
# Description

Remove redundant function parameters, inline single-use schemas, and apply small code consolidation in the access control module. Addresses several items from #14469.

Changes:
- **Remove redundant `displayTimezone` parameter**: `resolveModernAssessmentAccess`, `resolveModernAssessmentAccessBatch`, and `resolveModernAssessmentInstanceAccess` all received `displayTimezone` separately even though the `courseInstance` object they already accept has `display_timezone`. Removed the parameter and read from the course instance directly.
- **Remove redundant `groupWork` parameter**: `resolveModernAssessmentInstanceAccess` received `groupWork` separately despite the `assessment` object already having `team_work`. Removed the parameter and read from the assessment directly.
- **Simplify authz_result construction**: The three `selectAndAuthz*` middlewares used `row = { ...row, authz_result: modernResult }` to replace a single property. Simplified to `row.authz_result = modernResult`.
- **Inline schemas**: `StudentContextRowSchema` and `PrairieTestReservationRowSchema` in `access-control-data.ts` were named top-level constants used exactly once. Inlined them into their respective query calls.
- **Remove `hasAnyField` pattern**: `buildDateControl` and `buildAfterComplete` tracked a `hasAnyField` boolean alongside property assignments. Replaced with `Object.keys(obj).length > 0` checks.
- **Use standard `formatDate`**: Replaced a custom `formatDate` in `RuleSummary.tsx` with `formatDate` from `@prairielearn/formatter`, threading `displayTimezone` through the component tree.
- **Collapse `DateEntry`/`DateTableRow`**: Merged the two nearly-identical interfaces in `RuleSummary.tsx` into `DateTableRow & { timestamp: number }`.

AI assistance: majority of implementation.

# Testing

- Existing unit tests for `resolveModernAssessmentInstanceAccess` updated and all 9 pass.
- Integration tests for `accessControlSync` all 60 pass.
- All changed files pass typechecking, linting, and formatting.