### PR TITLE
Replace deprecated `url.parse()` with WHATWG URL API

### DIFF
--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -1,5 +1,3 @@
-import * as url from 'node:url';
-
 import { Router } from 'express';
 import SearchString from 'search-string';
 import { z } from 'zod';
@@ -20,6 +18,7 @@ import { compiledStylesheetTag } from '../../lib/assets.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { idsEqual } from '../../lib/id.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
+import { getUrl } from '../../lib/url.js';
 import type { ResLocalsCourseInstanceAuthz } from '../../middlewares/authzCourseOrInstance.js';
 import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
 
@@ -162,7 +161,7 @@ router.get(
     // than the number of actual issues. In this case, redirect to the same page
     // without setting the page number.
     if (offset > 0 && issueRows.length === 0) {
-      res.redirect(`${url.parse(req.originalUrl).pathname}?q=${encodeURIComponent(filterQuery)}`);
+      res.redirect(`${getUrl(req).pathname}?q=${encodeURIComponent(filterQuery)}`);
       return;
     }
 

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import url from 'node:url';
 
 import { type Request, type Response, Router } from 'express';
 
@@ -19,6 +18,7 @@ import { reportIssueFromForm } from '../../lib/issues.js';
 import { getAndRenderVariant, renderPanelsForSubmission } from '../../lib/question-render.js';
 import { processSubmission } from '../../lib/question-submission.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
+import { getCanonicalHost } from '../../lib/url.js';
 import clientFingerprint from '../../middlewares/clientFingerprint.js';
 import { enterpriseOnly } from '../../middlewares/enterpriseOnly.js';
 import { logPageView } from '../../middlewares/logPageView.js';
@@ -36,7 +36,7 @@ router.use(enterpriseOnly(() => checkPlanGrantsForQuestion));
 router.use((req, res, next) => {
   // We deliberately use `url` instead of `originalUrl`. The former is relative to
   // where this router is mounted, while the latter is absolute to the app.
-  const pathname = url.parse(req.url).pathname ?? '/';
+  const { pathname } = new URL(req.url, getCanonicalHost(req));
 
   // Because this router is mounted a general path, its middleware will also
   // be run for sub-routes like `submissions/:submission_id/file/:filename`


### PR DESCRIPTION
# Description

Replace the deprecated `url.parse()` calls with the modern WHATWG `URL` API to resolve the `[DEP0169]` deprecation warning. Uses existing helpers from `lib/url.ts` where possible.

- `instructorIssues.tsx`: Use `getUrl(req).pathname` (existing helper)
- `studentInstanceQuestion.ts`: Use `new URL(req.url, getCanonicalHost(req))` (`getUrl` can't be used here since this deliberately uses `req.url` instead of `req.originalUrl`)

A third usage in `fileEditor.test.ts` is intentionally kept as-is since it needs to avoid path normalization.

Majority AI-assisted.

# Testing

CI should pass. These are straightforward replacements with equivalent behavior.