### PR TITLE
More robust validation before submitting for rubric editing

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -383,9 +383,14 @@ export function RubricSettings({
   };
 
   const reportInputValidity = () => {
-    // Performs validation on the required inputs
-    const required = document.querySelectorAll<HTMLInputElement>('#rubric-editor input[required]');
-    return Array.from(required).every((input) => input.reportValidity());
+    // Performs validation on the all inputs
+    // This will make sure that all non-nullable inputs are filled, and number inputs parse as numbers
+    const inputs = document.querySelectorAll<HTMLInputElement>('#rubric-editor input');
+    const textareas = document.querySelectorAll<HTMLTextAreaElement>('#rubric-editor textarea');
+    return (
+      Array.from(inputs).every((input) => input.reportValidity()) &&
+      Array.from(textareas).every((input) => input.reportValidity())
+    );
   };
 
   const submitSettings = async (use_rubric: boolean) => {
@@ -687,6 +692,7 @@ export function RubricSettings({
                       type="number"
                       value={minPoints ?? ''}
                       disabled={!hasCourseInstancePermissionEdit}
+                      required
                       onInput={({ currentTarget }) =>
                         setMinPoints(
                           currentTarget.value.length > 0 ? Number(currentTarget.value) : null,
@@ -713,6 +719,7 @@ export function RubricSettings({
                       type="number"
                       value={maxExtraPoints ?? ''}
                       disabled={!hasCourseInstancePermissionEdit}
+                      required
                       onInput={({ currentTarget }) =>
                         setMaxExtraPoints(
                           currentTarget.value.length > 0 ? Number(currentTarget.value) : null,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Currently, the rubric editing component only runs the internal validator to make sure required inputs are filled without checking for the validity of number inputs. Additionally, some non-nullable inputs are not set to required. This causes the rubric editing to fail on the server side when it could have been prevented on client side. This PR fixes both problems. 

# Testing

If you try to submit with min points or max extra points empty, submitting would fail with a built-in html warning: 
<img width="556" height="217" alt="image" src="https://github.com/user-attachments/assets/9c5d1053-96e7-497b-8ee5-c0e0abc26dd7" />
Similarly, partial inputs of only a negative sign would also fail without going to the server: 
<img width="552" height="202" alt="image" src="https://github.com/user-attachments/assets/8fdc5cd0-e55b-44fb-b460-cc8ba53e31e9" />
For other fields as well: 
<img width="336" height="370" alt="image" src="https://github.com/user-attachments/assets/399efa4c-03ba-45b6-a97a-91a921fddc3c" />
