### PR TITLE
Add tests for PrairieTest reservation access in modern access control

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -780,6 +780,76 @@ describe('resolveAccessControl', () => {
       });
       expect(result.authorized).toBe(false);
     });
+
+    it('grants access when rule has multiple configured exams and reservation matches one', () => {
+      const multiExamRule: AccessControlRuleInput = {
+        ...prairieTestMainRule,
+        prairietestExams: [
+          { uuid: 'exam-uuid-1', readOnly: false },
+          { uuid: 'exam-uuid-2', readOnly: false },
+          { uuid: 'exam-uuid-3', readOnly: true },
+        ],
+      };
+      const reservation: PrairieTestReservation = {
+        examUuid: 'exam-uuid-2',
+        accessEnd: new Date('2025-03-15T16:00:00Z'),
+      };
+      const result = resolveAccessControl({
+        ...baseInput,
+        rules: [multiExamRule],
+        authzMode: 'Exam',
+        prairieTestReservations: [reservation],
+      });
+      expect(result.authorized).toBe(true);
+      expect(result.credit).toBe(100);
+      expect(result.active).toBe(true);
+      expect(result.examAccessEnd).toEqual(reservation.accessEnd);
+    });
+
+    it('uses readOnly flag from matched exam when multiple exams are configured', () => {
+      const multiExamRule: AccessControlRuleInput = {
+        ...prairieTestMainRule,
+        prairietestExams: [
+          { uuid: 'exam-uuid-1', readOnly: false },
+          { uuid: 'exam-uuid-3', readOnly: true },
+        ],
+      };
+      const reservation: PrairieTestReservation = {
+        examUuid: 'exam-uuid-3',
+        accessEnd: new Date('2025-03-15T16:00:00Z'),
+      };
+      const result = resolveAccessControl({
+        ...baseInput,
+        rules: [multiExamRule],
+        authzMode: 'Exam',
+        prairieTestReservations: [reservation],
+      });
+      expect(result.authorized).toBe(true);
+      expect(result.credit).toBe(100);
+      expect(result.active).toBe(false);
+    });
+
+    it('overrides date-control credit with 100% when PT reservation matches', () => {
+      const ruleWithDateControl: AccessControlRuleInput = {
+        ...prairieTestMainRule,
+        rule: toRuntime({
+          dateControl: {
+            releaseDate: '2025-01-01T00:00:00Z',
+            dueDate: '2025-02-01T00:00:00Z',
+            afterLastDeadline: { credit: 50 },
+          },
+        }),
+      };
+      const result = resolveAccessControl({
+        ...baseInput,
+        rules: [ruleWithDateControl],
+        authzMode: 'Exam',
+        prairieTestReservations: [validReservation],
+      });
+      expect(result.authorized).toBe(true);
+      expect(result.credit).toBe(100);
+      expect(result.active).toBe(true);
+    });
   });
 
   describe('time limit computation', () => {

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -486,6 +486,23 @@ export function resolveAccessControl(
 
   let creditResult = computeCredit(effectiveRule.dateControl, date, effectiveRule, authzMode);
 
+  // PrairieTest exam-mode access control.
+  //
+  // This logic is equivalent to the legacy `check_assessment_access_rule` sproc
+  // (lines 39-75) with two additions:
+  // - Multiple PT exams per rule (legacy only supported one exam_uuid per rule)
+  // - read_only exam support (sets active=false for view-only access)
+  //
+  // Core invariants (matching legacy behavior):
+  // - Student in Exam mode + assessment has PT exams → must have valid reservation
+  // - Student in Exam mode + assessment has NO PT exams → deny access
+  // - Student NOT in Exam mode + assessment has PT exams → deny access
+  // - Valid reservation = user has pt_reservation where now ∈ [access_start, access_end]
+  //   and reservation's exam UUID matches one of the configured exams
+  //
+  // In the legacy system, exam_uuid was per-rule (each assessment_access_rule had
+  // its own exam_uuid column). In the modern system, PT exams are configured only
+  // on the main rule (number=0) and are effectively assessment-level.
   const prairieTestExams = mainRuleInput.prairietestExams;
   const hasPrairieTestExams = prairieTestExams.length > 0;
   let examAccessEnd: Date | null = null;


### PR DESCRIPTION
# Description

Audits and tests PrairieTest reservation access checking in the modern access control path (`resolver.ts`), which reimplements the behavior previously handled by the `check_assessment_access_rule` sproc.

A code-level comparison found the core logic is equivalent, with the modern path being strictly more capable (multi-exam rules, read-only exam support). This PR adds test coverage for the gaps and documents the audit findings.

**New test cases:**
- Multiple configured exams on a rule, student reservation matches one
- `readOnly` flag from the matched exam is correctly applied when multiple exams are configured
- PrairieTest reservation overrides date-control credit to 100%

**Documentation:** Added a comment block to the PT-handling section of `resolver.ts` summarizing the equivalence to the legacy sproc and the design differences.

Part of #14469 — specifically the item:
> `select_prairietest_reservation` query and callers: the legacy PT exam-mode and access stuff was somewhat more complicated than this IIRC - see `check_assessment_access_rule` sproc. Are we correctly matching existing behavior?

Majority of implementation was AI-assisted.

# Testing

- All 101 resolver tests pass (`yarn test apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts`)
- Type checking passes
- Linting/formatting passes