### PR TITLE
Assessment tools UI Editor

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
@@ -1,6 +1,78 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { correctGeminiMalformedRubricGradingJson, parseSubmission } from './ai-grading-util.js';
+import {
+  correctGeminiMalformedRubricGradingJson,
+  isNoObjectGeneratedError,
+  parseSubmission,
+  withNoObjectRetry,
+} from './ai-grading-util.js';
+
+describe('isNoObjectGeneratedError', () => {
+  it('should return true for AI SDK no-object errors by name', () => {
+    const err = Object.assign(new Error('No object generated'), {
+      name: 'AI_NoObjectGeneratedError',
+    });
+    expect(isNoObjectGeneratedError(err)).toBe(true);
+  });
+
+  it('should return false for non no-object errors', () => {
+    expect(isNoObjectGeneratedError(new Error('Some other error'))).toBe(false);
+  });
+});
+
+describe('withNoObjectRetry', () => {
+  it('should retry and succeed for no-object errors', async () => {
+    const err = Object.assign(new Error('No object generated'), {
+      name: 'AI_NoObjectGeneratedError',
+    });
+    const operation = vi.fn().mockRejectedValueOnce(err).mockResolvedValue('ok');
+    const onNoObjectRetry = vi.fn();
+
+    const result = await withNoObjectRetry({
+      operation,
+      noObjectRetries: 1,
+      onNoObjectRetry,
+    });
+
+    expect(result).toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(onNoObjectRetry).toHaveBeenCalledTimes(1);
+    expect(onNoObjectRetry).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('should not retry for non no-object errors', async () => {
+    const err = new Error('Network failure');
+    const operation = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      withNoObjectRetry({
+        operation,
+        noObjectRetries: 2,
+      }),
+    ).rejects.toBe(err);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw after exhausting retries for no-object errors', async () => {
+    const err = Object.assign(new Error('No object generated'), {
+      name: 'AI_NoObjectGeneratedError',
+    });
+    const operation = vi.fn().mockRejectedValue(err);
+    const onNoObjectRetry = vi.fn();
+
+    await expect(
+      withNoObjectRetry({
+        operation,
+        noObjectRetries: 2,
+        onNoObjectRetry,
+      }),
+    ).rejects.toBe(err);
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(onNoObjectRetry).toHaveBeenCalledTimes(2);
+    expect(onNoObjectRetry).toHaveBeenNthCalledWith(1, 1, 3);
+    expect(onNoObjectRetry).toHaveBeenNthCalledWith(2, 2, 3);
+  });
+});
 
 describe('parseSubmission', () => {
   it('should return empty array for empty HTML', () => {

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -4,6 +4,7 @@ import {
   type LanguageModel,
   type LanguageModelUsage,
   type ModelMessage,
+  NoObjectGeneratedError,
   type UserContent,
   generateObject,
 } from 'ai';
@@ -736,6 +737,43 @@ export async function addAiGradingCostToIntervalUsage({
   await rateLimiter.addToIntervalUsage(getIntervalUsageKey(courseInstance), responseCost);
 }
 
+export function isNoObjectGeneratedError(err: unknown): boolean {
+  if (NoObjectGeneratedError.isInstance(err)) {
+    return true;
+  }
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    err.name === 'AI_NoObjectGeneratedError'
+  );
+}
+
+export async function withNoObjectRetry<T>({
+  operation,
+  noObjectRetries = 0,
+  onNoObjectRetry,
+}: {
+  operation: () => Promise<T>;
+  noObjectRetries?: number;
+  onNoObjectRetry?: (attempt: number, maxAttempts: number) => void;
+}): Promise<T> {
+  const maxAttempts = noObjectRetries + 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (!isNoObjectGeneratedError(err) || attempt >= maxAttempts) {
+        throw err;
+      }
+      onNoObjectRetry?.(attempt, maxAttempts);
+    }
+  }
+
+  throw new Error('Unreachable: withNoObjectRetry exhausted attempts without returning.');
+}
+
 /**
  * Rotates a base64-encoded image by the specified counterclockwise rotation.
  *
@@ -766,13 +804,19 @@ async function rotateBase64Image(
  * @param params
  * @param params.image - The base64-encoded image to correct.
  * @param params.model - The LLM to use for determining the correct orientation.
+ * @param params.noObjectRetries - Number of retries for `AI_NoObjectGeneratedError`.
+ * @param params.onNoObjectRetry - Optional callback invoked before each retry.
  */
 async function correctImageOrientation({
   image,
   model,
+  noObjectRetries = 0,
+  onNoObjectRetry,
 }: {
   image: string;
   model: LanguageModel;
+  noObjectRetries?: number;
+  onNoObjectRetry?: (attempt: number, maxAttempts: number) => void;
 }): Promise<{
   correctedImage: string;
   degreesRotated: CounterClockwiseRotationDegrees;
@@ -819,10 +863,15 @@ async function correctImageOrientation({
     });
   }
 
-  const response = await generateObject({
-    model,
-    schema: RotationCorrectionOutputSchema,
-    messages: prompt,
+  const response = await withNoObjectRetry({
+    noObjectRetries,
+    onNoObjectRetry,
+    operation: async () =>
+      await generateObject({
+        model,
+        schema: RotationCorrectionOutputSchema,
+        messages: prompt,
+      }),
   });
 
   const index = Number.parseInt(response.object.upright_image) - 1;
@@ -841,6 +890,8 @@ async function correctImageOrientation({
  * @param param.submittedAnswer - The student's submitted answer object.
  * @param param.submittedImages - A mapping from filenames to base64-encoded images.
  * @param param.model - The LLM to use for determining the correct orientations.
+ * @param param.noObjectRetries - Number of retries for `AI_NoObjectGeneratedError`.
+ * @param param.onNoObjectRetry - Optional callback invoked before each image retry.
  *
  * @returns An updated submitted answer with corrected images, rotations correction amounts, and LLM responses.
  */
@@ -849,10 +900,14 @@ export async function correctImagesOrientation({
   /** The key is the filename, and the value is the base64-encoded image */
   submittedImages,
   model,
+  noObjectRetries = 0,
+  onNoObjectRetry,
 }: {
   submittedAnswer: Record<string, any>;
   submittedImages: Record<string, string>;
   model: LanguageModel;
+  noObjectRetries?: number;
+  onNoObjectRetry?: (filename: string, attempt: number, maxAttempts: number) => void;
 }) {
   if (!submittedAnswer._files) {
     return {
@@ -878,6 +933,11 @@ export async function correctImagesOrientation({
     const { correctedImage, degreesRotated, response } = await correctImageOrientation({
       image,
       model,
+      noObjectRetries,
+      onNoObjectRetry:
+        onNoObjectRetry == null
+          ? undefined
+          : (attempt, maxAttempts) => onNoObjectRetry(filename, attempt, maxAttempts),
     });
 
     const existingIndex = submittedAnswer._files.findIndex(

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
@@ -66,9 +66,11 @@ import {
   getIntervalUsage,
   insertAiGradingJob,
   insertAiGradingJobWithRotationCorrection,
+  isNoObjectGeneratedError,
   parseAiRubricItems,
   selectInstanceQuestionsForAssessmentQuestion,
   selectLastVariantAndSubmission,
+  withNoObjectRetry,
 } from './ai-grading-util.js';
 import {
   type AIGradingLog,
@@ -273,6 +275,7 @@ async function finalizeAiGradingPersistence({
 }
 
 const PARALLEL_SUBMISSION_GRADING_LIMIT = 20;
+const GEMINI_NO_OBJECT_RETRY_COUNT = 2;
 const HOURLY_USAGE_CAP_REACHED_MESSAGE = 'Hourly usage cap reached. Try again later.';
 const INSUFFICIENT_CREDITS_MESSAGE = 'Insufficient AI grading credits.';
 
@@ -612,6 +615,24 @@ export async function aiGrade({
         safetyIdentifier: `course_${course.id}`,
       };
 
+      const runGenerateObject = async <T>({
+        stage,
+        operation,
+      }: {
+        stage: string;
+        operation: () => Promise<GenerateObjectResult<T>>;
+      }): Promise<GenerateObjectResult<T>> => {
+        return await withNoObjectRetry({
+          operation,
+          noObjectRetries: provider === 'google' ? GEMINI_NO_OBJECT_RETRY_COUNT : 0,
+          onNoObjectRetry: (attempt, maxAttempts) => {
+            logger.error(
+              `Gemini returned no object while ${stage}. Retrying (${attempt}/${maxAttempts - 1}).`,
+            );
+          },
+        });
+      };
+
       if (rubric_items.length > 0) {
         // Dynamically generate the rubric schema based on the rubric items.
         let RubricGradingItemsSchema = z.object({}) as z.ZodObject<Record<string, z.ZodBoolean>>;
@@ -659,6 +680,21 @@ export async function aiGrade({
             return correctGeminiMalformedRubricGradingJson(options.text);
           };
 
+          const runRubricGradingWithoutRotation = async () =>
+            await runGenerateObject({
+              stage: 'grading rubric response',
+              operation: async () =>
+                await generateObject({
+                  model,
+                  schema: RubricGradingResultSchema,
+                  messages: input,
+                  experimental_repairText,
+                  providerOptions: {
+                    openai: openaiProviderOptions,
+                  },
+                }),
+            });
+
           if (
             !hasImage ||
             !submission.submitted_answer ||
@@ -667,28 +703,38 @@ export async function aiGrade({
             provider !== 'google'
           ) {
             return {
-              finalGradingResponse: await generateObject({
-                model,
-                schema: RubricGradingResultSchema,
-                messages: input,
-                experimental_repairText,
-                providerOptions: {
-                  openai: openaiProviderOptions,
-                },
-              }),
+              finalGradingResponse: await runRubricGradingWithoutRotation(),
               rotationCorrectionApplied: false,
             };
           }
 
-          const initialResponse = await generateObject({
-            model,
-            schema: RubricImageGradingResultSchema,
-            messages: input,
-            experimental_repairText,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
-          });
+          let initialResponse: GenerateObjectResult<z.infer<typeof RubricImageGradingResultSchema>>;
+          try {
+            initialResponse = await runGenerateObject({
+              stage: 'detecting handwriting orientation',
+              operation: async () =>
+                await generateObject({
+                  model,
+                  schema: RubricImageGradingResultSchema,
+                  messages: input,
+                  experimental_repairText,
+                  providerOptions: {
+                    openai: openaiProviderOptions,
+                  },
+                }),
+            });
+          } catch (err) {
+            if (!isNoObjectGeneratedError(err)) {
+              throw err;
+            }
+            logger.error(
+              'Gemini returned no object while detecting image orientation; continuing without rotation correction.',
+            );
+            return {
+              finalGradingResponse: await runRubricGradingWithoutRotation(),
+              rotationCorrectionApplied: false,
+            };
+          }
 
           if (
             initialResponse.object.handwriting_orientations.every(
@@ -704,11 +750,38 @@ export async function aiGrade({
           // so we assume all images might need correction. If an image is already upright, the
           // correction process will keep the image the same.
 
-          const { rotatedSubmittedAnswer, rotationCorrections } = await correctImagesOrientation({
-            submittedAnswer: submission.submitted_answer,
-            submittedImages,
-            model,
-          });
+          let rotatedSubmittedAnswer: Record<string, any>;
+          let rotationCorrections: Record<
+            string,
+            {
+              degreesRotated: CounterClockwiseRotationDegrees;
+              response: GenerateObjectResult<any>;
+            }
+          >;
+          try {
+            ({ rotatedSubmittedAnswer, rotationCorrections } = await correctImagesOrientation({
+              submittedAnswer: submission.submitted_answer,
+              submittedImages,
+              model,
+              noObjectRetries: GEMINI_NO_OBJECT_RETRY_COUNT,
+              onNoObjectRetry: (filename, attempt, maxAttempts) => {
+                logger.error(
+                  `Gemini returned no object while selecting image rotation for ${filename}. Retrying (${attempt}/${maxAttempts - 1}).`,
+                );
+              },
+            }));
+          } catch (err) {
+            if (!isNoObjectGeneratedError(err)) {
+              throw err;
+            }
+            logger.error(
+              'Gemini returned no object while selecting image rotation; using initial grading response without rotation correction.',
+            );
+            return {
+              finalGradingResponse: initialResponse,
+              rotationCorrectionApplied: false,
+            };
+          }
 
           const rotationCorrected = Object.values(rotationCorrections).some(
             (correction) => correction.degreesRotated !== 0,
@@ -730,15 +803,33 @@ export async function aiGrade({
           });
 
           // Perform grading with the rotation-corrected images.
-          const finalResponse = await generateObject({
-            model,
-            schema: RubricImageGradingResultSchema,
-            messages: input,
-            experimental_repairText,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
-          });
+          let finalResponse: GenerateObjectResult<z.infer<typeof RubricImageGradingResultSchema>>;
+          try {
+            finalResponse = await runGenerateObject({
+              stage: 'grading rotated submission',
+              operation: async () =>
+                await generateObject({
+                  model,
+                  schema: RubricImageGradingResultSchema,
+                  messages: input,
+                  experimental_repairText,
+                  providerOptions: {
+                    openai: openaiProviderOptions,
+                  },
+                }),
+            });
+          } catch (err) {
+            if (!isNoObjectGeneratedError(err)) {
+              throw err;
+            }
+            logger.error(
+              'Gemini returned no object while grading the rotation-corrected submission; using initial grading response.',
+            );
+            return {
+              finalGradingResponse: initialResponse,
+              rotationCorrectionApplied: false,
+            };
+          }
 
           return {
             rotationCorrectionApplied: true,
@@ -889,6 +980,20 @@ export async function aiGrade({
           gradingResponseWithRotationIssue,
           rotationCorrections,
         } = (await run(async () => {
+          const runScoreGradingWithoutRotation = async () =>
+            await runGenerateObject({
+              stage: 'grading score response',
+              operation: async () =>
+                await generateObject({
+                  model,
+                  schema: GradingResultSchema,
+                  messages: input,
+                  providerOptions: {
+                    openai: openaiProviderOptions,
+                  },
+                }),
+            });
+
           if (
             !hasImage ||
             !submission.submitted_answer ||
@@ -897,26 +1002,37 @@ export async function aiGrade({
             provider !== 'google'
           ) {
             return {
-              finalGradingResponse: await generateObject({
-                model,
-                schema: GradingResultSchema,
-                messages: input,
-                providerOptions: {
-                  openai: openaiProviderOptions,
-                },
-              }),
+              finalGradingResponse: await runScoreGradingWithoutRotation(),
               rotationCorrectionApplied: false,
             };
           }
 
-          const initialResponse = await generateObject({
-            model,
-            schema: ImageGradingResultSchema,
-            messages: input,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
-          });
+          let initialResponse: GenerateObjectResult<z.infer<typeof ImageGradingResultSchema>>;
+          try {
+            initialResponse = await runGenerateObject({
+              stage: 'detecting handwriting orientation',
+              operation: async () =>
+                await generateObject({
+                  model,
+                  schema: ImageGradingResultSchema,
+                  messages: input,
+                  providerOptions: {
+                    openai: openaiProviderOptions,
+                  },
+                }),
+            });
+          } catch (err) {
+            if (!isNoObjectGeneratedError(err)) {
+              throw err;
+            }
+            logger.error(
+              'Gemini returned no object while detecting image orientation; continuing without rotation correction.',
+            );
+            return {
+              finalGradingResponse: await runScoreGradingWithoutRotation(),
+              rotationCorrectionApplied: false,
+            };
+          }
 
           if (
             initialResponse.object.handwriting_orientations.every(
@@ -927,11 +1043,38 @@ export async function aiGrade({
             return { finalGradingResponse: initialResponse, rotationCorrectionApplied: false };
           }
 
-          const { rotatedSubmittedAnswer, rotationCorrections } = await correctImagesOrientation({
-            submittedAnswer: submission.submitted_answer,
-            submittedImages,
-            model,
-          });
+          let rotatedSubmittedAnswer: Record<string, any>;
+          let rotationCorrections: Record<
+            string,
+            {
+              degreesRotated: CounterClockwiseRotationDegrees;
+              response: GenerateObjectResult<any>;
+            }
+          >;
+          try {
+            ({ rotatedSubmittedAnswer, rotationCorrections } = await correctImagesOrientation({
+              submittedAnswer: submission.submitted_answer,
+              submittedImages,
+              model,
+              noObjectRetries: GEMINI_NO_OBJECT_RETRY_COUNT,
+              onNoObjectRetry: (filename, attempt, maxAttempts) => {
+                logger.error(
+                  `Gemini returned no object while selecting image rotation for ${filename}. Retrying (${attempt}/${maxAttempts - 1}).`,
+                );
+              },
+            }));
+          } catch (err) {
+            if (!isNoObjectGeneratedError(err)) {
+              throw err;
+            }
+            logger.error(
+              'Gemini returned no object while selecting image rotation; using initial grading response without rotation correction.',
+            );
+            return {
+              finalGradingResponse: initialResponse,
+              rotationCorrectionApplied: false,
+            };
+          }
 
           // Regenerate the prompt with the rotation-corrected images.
           input = await generatePrompt({
@@ -947,14 +1090,32 @@ export async function aiGrade({
           });
 
           // Perform grading with the rotation-corrected images.
-          const finalResponse = await generateObject({
-            model,
-            schema: ImageGradingResultSchema,
-            messages: input,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
-          });
+          let finalResponse: GenerateObjectResult<z.infer<typeof ImageGradingResultSchema>>;
+          try {
+            finalResponse = await runGenerateObject({
+              stage: 'grading rotated submission',
+              operation: async () =>
+                await generateObject({
+                  model,
+                  schema: ImageGradingResultSchema,
+                  messages: input,
+                  providerOptions: {
+                    openai: openaiProviderOptions,
+                  },
+                }),
+            });
+          } catch (err) {
+            if (!isNoObjectGeneratedError(err)) {
+              throw err;
+            }
+            logger.error(
+              'Gemini returned no object while grading the rotation-corrected submission; using initial grading response.',
+            );
+            return {
+              finalGradingResponse: initialResponse,
+              rotationCorrectionApplied: false,
+            };
+          }
 
           return {
             rotationCorrectionApplied: true,


### PR DESCRIPTION
# Description

This pull request introduces support for configuring assessment-level and zone-level tools in the UI editor. It adds the ability to enable or override tool settings both in the assessment settings and for individual zones, with the settings persisted and displayed in the UI. The main changes span backend data handling, frontend UI, and schema validation.

# Testing

## Assessment-Level Configuration

- Navigate to the settings tab under an assessment
- Find and enable/disable the calculator tool
-  Verify that `infoAssessment.json` is correctly updated

## Assessment-Level Configuration

- Navigate to the questions tab under an assessment
- Open the zones details panel
- Find and enable/disable the calculator tool (click override first)
- Verify that `infoAssessment.json` is correctly updated with the zone-level override

## Demo


https://github.com/user-attachments/assets/483b96d7-101e-451b-94dd-433c226b4aff
