### PR TITLE
Gate access control UI behind enhanced-access-control feature flag

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.tsx
@@ -49,6 +49,7 @@ export function InstructorAssessmentAccess({
   migrationPreview,
   origHash,
   canEdit,
+  enhancedAccessControlEnabled,
 }: {
   resLocals: ResLocalsForPage<'assessment'>;
   accessRules: AssessmentAccessRules[];
@@ -56,6 +57,7 @@ export function InstructorAssessmentAccess({
   migrationPreview: MigrationPreview | null;
   origHash: string;
   canEdit: boolean;
+  enhancedAccessControlEnabled: boolean;
 }) {
   const showComments = accessRules.some((access_rule) => isRenderableComment(access_rule.comment));
   return PageLayout({
@@ -87,13 +89,19 @@ export function InstructorAssessmentAccess({
             : ''}
         </div>
 
-        <div class="alert alert-warning mb-0 rounded-0 border-start-0 border-end-0 border-top-0">
-          ${migrationAnalysis && !migrationAnalysis.canMigrate
-            ? html`This assessment uses the legacy access control system. Automatic migration is not
-              available for this assessment's access rules.`
-            : html`This assessment uses the legacy access control system. Consider migrating to the
-              modern format for a better editing experience.`}
-        </div>
+        ${enhancedAccessControlEnabled
+          ? html`
+              <div
+                class="alert alert-warning mb-0 rounded-0 border-start-0 border-end-0 border-top-0"
+              >
+                ${migrationAnalysis && !migrationAnalysis.canMigrate
+                  ? html`This assessment uses the legacy access control system. Automatic migration
+                    is not available for this assessment's access rules.`
+                  : html`This assessment uses the legacy access control system. Consider migrating
+                    to the modern format for a better editing experience.`}
+              </div>
+            `
+          : ''}
 
         <div class="table-responsive">
           <table class="table table-sm table-hover" aria-label="Access rules">

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
@@ -16,6 +16,7 @@ import {
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { config } from '../../lib/config.js';
 import { FileModifyEditor, getOriginalHash } from '../../lib/editors.js';
+import { features } from '../../lib/features/index.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../lib/res-locals.js';
@@ -57,7 +58,12 @@ function getAssessmentPath(
 router.get(
   '/',
   typedAsyncHandler<'assessment'>(async (req, res) => {
-    if (res.locals.assessment.modern_access_control) {
+    const enhancedAccessControlEnabled = await features.enabledFromLocals(
+      'enhanced-access-control',
+      res.locals,
+    );
+
+    if (enhancedAccessControlEnabled && res.locals.assessment.modern_access_control) {
       const jsonRules = await fetchAllAccessControlRules(res.locals.assessment);
       const origHash = computeHash(jsonRules);
       const trpcCsrfToken = generatePrefixCsrfToken(
@@ -85,14 +91,8 @@ router.get(
     );
 
     const assessmentPath = getAssessmentPath(res.locals);
-    const migrationAnalysis = await analyzeAssessmentFile(
-      assessmentPath,
-      res.locals.assessment.tid!,
-    );
-    const origHash = (await getOriginalHash(assessmentPath)) ?? '';
-    const canEdit =
-      res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
 
+    let migrationAnalysis: Awaited<ReturnType<typeof analyzeAssessmentFile>> = null;
     let migrationPreview: {
       beforeJson: string;
       afterJson: string;
@@ -100,23 +100,31 @@ router.get(
       hasUidRules: boolean;
     } | null = null;
 
-    if (migrationAnalysis?.canMigrate) {
-      const content = await fs.readFile(assessmentPath, 'utf-8');
-      const parsed = JSON.parse(content);
-      const beforeJson = JSON.stringify(parsed.allowAccess, null, 2);
+    if (enhancedAccessControlEnabled) {
+      migrationAnalysis = await analyzeAssessmentFile(assessmentPath, res.locals.assessment.tid!);
 
-      const migrationResult = migrateAssessmentJson(content);
-      if (migrationResult) {
-        const migratedParsed = JSON.parse(migrationResult.json);
-        const afterJson = JSON.stringify(migratedParsed.accessControl, null, 2);
-        migrationPreview = {
-          beforeJson,
-          afterJson,
-          warnings: migrationResult.warnings,
-          hasUidRules: migrationAnalysis.hasUidRules,
-        };
+      if (migrationAnalysis?.canMigrate) {
+        const content = await fs.readFile(assessmentPath, 'utf-8');
+        const parsed = JSON.parse(content);
+        const beforeJson = JSON.stringify(parsed.allowAccess, null, 2);
+
+        const migrationResult = migrateAssessmentJson(content);
+        if (migrationResult) {
+          const migratedParsed = JSON.parse(migrationResult.json);
+          const afterJson = JSON.stringify(migratedParsed.accessControl, null, 2);
+          migrationPreview = {
+            beforeJson,
+            afterJson,
+            warnings: migrationResult.warnings,
+            hasUidRules: migrationAnalysis.hasUidRules,
+          };
+        }
       }
     }
+
+    const origHash = (await getOriginalHash(assessmentPath)) ?? '';
+    const canEdit =
+      res.locals.authz_data.has_course_permission_edit && !res.locals.course.example_course;
 
     res.send(
       InstructorAssessmentAccess({
@@ -126,6 +134,7 @@ router.get(
         migrationPreview,
         origHash,
         canEdit,
+        enhancedAccessControlEnabled,
       }),
     );
   }),
@@ -137,6 +146,14 @@ router.post(
     if (req.body.__action === 'migrate_access_control') {
       if (!res.locals.authz_data.has_course_permission_edit || res.locals.course.example_course) {
         throw new HttpStatusError(403, 'Access denied');
+      }
+
+      const enhancedAccessControlEnabled = await features.enabledFromLocals(
+        'enhanced-access-control',
+        res.locals,
+      );
+      if (!enhancedAccessControlEnabled) {
+        throw new HttpStatusError(403, 'Enhanced access control is not enabled for this course.');
       }
 
       const assessmentPath = getAssessmentPath(res.locals);

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/trpc.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/trpc.ts
@@ -70,18 +70,37 @@ const requireCourseInstancePermissionEdit = t.middleware(async (opts) => {
   return opts.next();
 });
 
-const students = t.procedure.use(requireCourseInstancePermissionView).query(async (opts) => {
-  const rows = await selectUsersAndEnrollmentsForCourseInstance(opts.ctx.course_instance);
-  return rows
-    .filter((r) => r.enrollment.status === 'joined' && r.user != null)
-    .map((r) => ({
-      id: r.enrollment.id,
-      uid: r.user!.uid,
-      name: r.user!.name,
-    }));
+const requireEnhancedAccessControl = t.middleware(async (opts) => {
+  const enabled = await features.enabled('enhanced-access-control', {
+    institution_id: opts.ctx.course.institution_id,
+    course_id: opts.ctx.course.id,
+    course_instance_id: opts.ctx.course_instance.id,
+  });
+  if (!enabled) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Enhanced access control is not enabled for this course.',
+    });
+  }
+  return opts.next();
 });
 
+const students = t.procedure
+  .use(requireEnhancedAccessControl)
+  .use(requireCourseInstancePermissionView)
+  .query(async (opts) => {
+    const rows = await selectUsersAndEnrollmentsForCourseInstance(opts.ctx.course_instance);
+    return rows
+      .filter((r) => r.enrollment.status === 'joined' && r.user != null)
+      .map((r) => ({
+        id: r.enrollment.id,
+        uid: r.user!.uid,
+        name: r.user!.name,
+      }));
+  });
+
 const validateUids = t.procedure
+  .use(requireEnhancedAccessControl)
   .use(requireCourseInstancePermissionView)
   .input(z.object({ uids: z.array(z.string()) }))
   .query(async (opts) => {
@@ -109,14 +128,17 @@ const validateUids = t.procedure
     });
   });
 
-const studentLabels = t.procedure.use(requireCourseInstancePermissionView).query(async (opts) => {
-  const labels = await selectStudentLabelsInCourseInstance(opts.ctx.course_instance);
-  return labels.map((label) => ({
-    id: label.id,
-    name: label.name,
-    color: label.color,
-  }));
-});
+const studentLabels = t.procedure
+  .use(requireEnhancedAccessControl)
+  .use(requireCourseInstancePermissionView)
+  .query(async (opts) => {
+    const labels = await selectStudentLabelsInCourseInstance(opts.ctx.course_instance);
+    return labels.map((label) => ({
+      id: label.id,
+      name: label.name,
+      color: label.color,
+    }));
+  });
 
 function formJsonToEnrollmentRuleData(
   rule: AccessControlJson & { id?: string },
@@ -167,6 +189,7 @@ const EnrollmentRuleInputSchema = z.object({
 });
 
 const saveAllRules = t.procedure
+  .use(requireEnhancedAccessControl)
   .use(requireCourseInstancePermissionEdit)
   .input(
     z.object({
@@ -215,18 +238,6 @@ const saveAllRules = t.procedure
       }
 
       if (enrollmentRules !== undefined && enrollmentRules.length > 0) {
-        const enhancedEnabled = await features.enabled('enhanced-access-control', {
-          institution_id: opts.ctx.course.institution_id,
-          course_id: opts.ctx.course.id,
-          course_instance_id: opts.ctx.course_instance.id,
-        });
-        if (!enhancedEnabled) {
-          throw new TRPCError({
-            code: 'FORBIDDEN',
-            message: 'Enhanced access control is not enabled for this course.',
-          });
-        }
-
         const allEnrollmentIds = new Set(enrollmentRules.flatMap((r) => r.enrollmentIds));
         if (allEnrollmentIds.size > 0) {
           const validCount = await validateEnrollmentIdsInCourseInstance(


### PR DESCRIPTION
# Description

The modern access control UI, migration workflow, and tRPC endpoints were rendering/accessible without checking the `enhanced-access-control` feature flag. This gates all four gaps behind the flag:

- **GET handler**: modern UI now requires both the feature flag and `assessment.modern_access_control`; migration analysis/preview and the legacy warning banner are skipped when the flag is off
- **POST handler**: the `migrate_access_control` action returns 403 when the flag is off
- **tRPC**: a shared `requireEnhancedAccessControl` middleware is applied to all four procedures (`students`, `validateUids`, `studentLabels`, `saveAllRules`), replacing the inline check that was only on enrollment rule saves

If an assessment was synced with the flag on (`modern_access_control: true` in DB) and then the flag is turned off, the combined condition falls through to the legacy read-only table with no migration prompts. The next re-sync resets `modern_access_control` to `false`.

Majority of implementation was AI-assisted.

# Testing

Verified typechecking, linting, and formatting pass on all changed files. The existing `accessControlSync.test.ts` already enables the feature flag in `beforeEach`, so those tests continue to pass unchanged.

To manually test: disable the `enhanced-access-control` feature flag and confirm the legacy access control page renders without the warning banner or migrate button, and that tRPC calls return 403.