### PR TITLE
Fix handling of shared questions with slashes in question search

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/trpc.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/trpc.ts
@@ -87,7 +87,8 @@ const questionByQidQuery = t.procedure.input(z.object({ qid: z.string() })).quer
   }
 
   if (opts.input.qid.startsWith('@')) {
-    const [sharing_name, qid] = opts.input.qid.slice(1).split('/');
+    const [sharing_name, ...qidComponents] = opts.input.qid.slice(1).split('/');
+    const qid = qidComponents.join('/');
 
     const result = await sqldb.queryOptionalRow(
       sql.search_shared_questions,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes #14535. The shared question search in the assessment questions editor did not properly account for QIDs with slashes. This PR adds support for such questions.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Share a question with a QID using slashes, then attempt to add this question to an assessment. Search will fail to find the question in master, and will succeed in this branch.

Not sure if this requires a CI test, as the original search did not have one either.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
