### PR TITLE
Remove wrongly commited sharing course

### DIFF
--- a/sharingTestCourse/courseInstances/Sp25/assessments/hw1-sharingTest/infoAssessment.json
+++ b/sharingTestCourse/courseInstances/Sp25/assessments/hw1-sharingTest/infoAssessment.json
@@ -1,9 +1,0 @@
-{
-  "uuid": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-  "type": "Homework",
-  "title": "Sharing Test Homework",
-  "set": "Homework",
-  "number": "1",
-  "allowAccess": [{ "credit": 100 }],
-  "zones": [{ "questions": [{ "id": "@test-sharing-name/questionPreferences", "autoPoints": 1 }] }]
-}

--- a/sharingTestCourse/courseInstances/Sp25/infoCourseInstance.json
+++ b/sharingTestCourse/courseInstances/Sp25/infoCourseInstance.json
@@ -1,5 +1,0 @@
-{
-  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "longName": "Spring 2025",
-  "publishing": { "startDate": "1900-01-01T00:00:00", "endDate": "2400-01-01T00:00:00" }
-}

--- a/sharingTestCourse/infoCourse.json
+++ b/sharingTestCourse/infoCourse.json
@@ -1,9 +1,0 @@
-{
-  "name": "SHARING 101",
-  "title": "Sharing Test Course",
-  "assessmentSets": [
-    { "abbreviation": "HW", "name": "Homework", "heading": "Homeworks", "color": "green1" }
-  ],
-  "topics": [{ "name": "Sharing", "color": "blue3", "description": "Shared question testing." }],
-  "tags": []
-}


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Removes the wrongly added `sharingCourse` dir that was used for testing in #14212 

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
- Note the level of AI assistance used (i.e. none, specific portions, majority of implementation).

-->

# Testing

Just a clean up.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
