### PR TITLE
Fix "Add label" modal not clearing form after submission

### DIFF
--- a/apps/prairielearn/src/pages/instructorStudentsLabels/components/LabelModifyModal.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentsLabels/components/LabelModifyModal.tsx
@@ -206,7 +206,7 @@ export function LabelModifyModal({
       onExited={() => {
         setStage({ type: 'editing' });
         saveMutation.reset();
-        reset({ name: '', color: 'blue1', uids: '' });
+        reset();
         onExited?.();
       }}
     >


### PR DESCRIPTION
# Description

Closes #14486

AI assistance: majority of implementation.

# Testing

I tested the below steps manually.

- Open the Student Labels page
- Click "Add label", fill in a name and UIDs, and save
- Click "Add label" again — the form should now be empty
- Click "Edit" on an existing label — the form should still populate correctly