### PR TITLE
Add data-leakage audit for StudentSearchInput tRPC procedures

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/trpc.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/trpc.ts
@@ -99,6 +99,10 @@ const students = t.procedure
       }));
   });
 
+// Data-leakage audit: the underlying SQL query joins enrollments on
+// course_instance_id, so only users enrolled in this CI are returned.
+// UIDs with no enrollment produce a generic "not found" response that
+// does not reveal whether the user exists elsewhere.
 const validateUids = t.procedure
   .use(requireEnhancedAccessControl)
   .use(requireCourseInstancePermissionView)


### PR DESCRIPTION
# Description

Audited the `StudentSearchInput` tRPC procedures (`students`, `validateUids`, `studentLabels`, `saveAllRules`) in `instructorAssessmentAccess/trpc.ts` for potential data leakage, per https://github.com/PrairieLearn/PrairieLearn/issues/14469.

**Findings — no data leakage:**

- **`students` query**: SQL is scoped to `course_instance_id`. Only returns `id`/`uid`/`name` for `joined` enrollments. Protected by `requireCourseInstancePermissionView`.
- **`validateUids` query**: SQL joins enrollments on `course_instance_id`, so only users enrolled in this CI are returned. UIDs without enrollment produce a generic "not found" response that does not reveal whether the user exists elsewhere. Protected by `requireCourseInstancePermissionView` + `Student Data Viewer` role assertion.
- **`studentLabels` query**: Scoped to course instance. Returns only label `id`/`name`/`color`.
- **`saveAllRules` mutation**: Validates enrollment IDs belong to the current CI before saving. Protected by `requireCourseInstancePermissionEdit`.
- **Authorization middleware**: All procedures require `requireEnhancedAccessControl`. Read operations require view permissions; the write operation requires edit permissions.

Added a brief audit comment above `validateUids` documenting why it's safe.

Majority of implementation is AI-assisted.

# Testing

No functional changes — only a code comment was added. Verified the file typechecks, lints, and formats cleanly.