### PR TITLE
Avoid wiping access control child tables on every sync

### DIFF
--- a/apps/prairielearn/src/sprocs/sync_access_control.sql
+++ b/apps/prairielearn/src/sprocs/sync_access_control.sql
@@ -11,35 +11,9 @@ CREATE FUNCTION
 RETURNS void
 AS $$
 BEGIN
-    -- Delete all child rows for rules being synced (non-enrollment types only).
-    -- This covers both rules that will be updated and excess rules that will be
-    -- deleted, so FK cascades don't need to handle it.
-    DELETE FROM assessment_access_control_student_labels
-    WHERE assessment_access_control_rule_id IN (
-        SELECT id FROM assessment_access_control_rules
-        WHERE assessment_id = ANY(syncing_assessment_ids) AND target_type IN ('none', 'student_label')
-    );
-
-    DELETE FROM assessment_access_control_early_deadlines
-    WHERE assessment_access_control_rule_id IN (
-        SELECT id FROM assessment_access_control_rules
-        WHERE assessment_id = ANY(syncing_assessment_ids) AND target_type IN ('none', 'student_label')
-    );
-
-    DELETE FROM assessment_access_control_late_deadlines
-    WHERE assessment_access_control_rule_id IN (
-        SELECT id FROM assessment_access_control_rules
-        WHERE assessment_id = ANY(syncing_assessment_ids) AND target_type IN ('none', 'student_label')
-    );
-
-    DELETE FROM assessment_access_control_prairietest_exams
-    WHERE assessment_access_control_rule_id IN (
-        SELECT id FROM assessment_access_control_rules
-        WHERE assessment_id = ANY(syncing_assessment_ids) AND target_type IN ('none', 'student_label')
-    );
-
     -- Delete rows where the target_type changed for a given (assessment, number)
     -- to avoid unique constraint conflicts (the conflict key includes target_type).
+    -- Child rows are cascade-deleted via FK constraints.
     DELETE FROM assessment_access_control_rules aacr
     USING UNNEST(rules_data) AS rule
     JOIN assessments a ON a.id = (rule ->> 'assessment_id')::bigint AND a.course_instance_id = syncing_course_instance_id
@@ -130,7 +104,7 @@ BEGIN
         after_complete_show_score_again_date_overridden = EXCLUDED.after_complete_show_score_again_date_overridden,
         after_complete_show_score_again_date = EXCLUDED.after_complete_show_score_again_date;
 
-    -- Insert student labels by joining on (assessment_id, number) to resolve the
+    -- Upsert student labels by joining on (assessment_id, number) to resolve the
     -- access control ID. Student labels always have target_type='student_label'.
     INSERT INTO assessment_access_control_student_labels (assessment_access_control_rule_id, student_label_id)
     SELECT aacr.id, (g ->> 2)::bigint
@@ -139,9 +113,10 @@ BEGIN
         aacr.assessment_id = (g ->> 0)::bigint
         AND aacr.number = (g ->> 1)::integer
         AND aacr.target_type = 'student_label'
-    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id;
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    ON CONFLICT (assessment_access_control_rule_id, student_label_id) DO NOTHING;
 
-    -- Insert early deadlines.
+    -- Upsert early deadlines.
     INSERT INTO assessment_access_control_early_deadlines (assessment_access_control_rule_id, date, credit)
     SELECT aacr.id, sub.date, sub.credit
     FROM (
@@ -156,9 +131,11 @@ BEGIN
         aacr.assessment_id = sub.assessment_id
         AND aacr.number = sub.rule_number
         AND aacr.target_type IN ('none', 'student_label')
-    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id;
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    ON CONFLICT (assessment_access_control_rule_id, date) DO UPDATE SET
+        credit = EXCLUDED.credit;
 
-    -- Insert late deadlines.
+    -- Upsert late deadlines.
     INSERT INTO assessment_access_control_late_deadlines (assessment_access_control_rule_id, date, credit)
     SELECT aacr.id, sub.date, sub.credit
     FROM (
@@ -173,9 +150,11 @@ BEGIN
         aacr.assessment_id = sub.assessment_id
         AND aacr.number = sub.rule_number
         AND aacr.target_type IN ('none', 'student_label')
-    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id;
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    ON CONFLICT (assessment_access_control_rule_id, date) DO UPDATE SET
+        credit = EXCLUDED.credit;
 
-    -- Insert PrairieTest exams (main rules only).
+    -- Upsert PrairieTest exams (main rules only).
     INSERT INTO assessment_access_control_prairietest_exams (assessment_access_control_rule_id, uuid, read_only)
     SELECT aacr.id, (e ->> 2)::uuid, (e ->> 3)::boolean
     FROM UNNEST(prairietest_exams_data) AS e
@@ -183,9 +162,12 @@ BEGIN
         aacr.assessment_id = (e ->> 0)::bigint
         AND aacr.number = (e ->> 1)::integer
         AND aacr.target_type = 'none'
-    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id;
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    ON CONFLICT (assessment_access_control_rule_id, uuid) DO UPDATE SET
+        read_only = EXCLUDED.read_only;
 
     -- Delete excess rules: rules with number > max incoming number per assessment.
+    -- Child rows are cascade-deleted via FK constraints.
     DELETE FROM assessment_access_control_rules aacr
     USING (
         SELECT
@@ -201,6 +183,7 @@ BEGIN
 
     -- Delete ALL non-enrollment rules for assessments that have no incoming rules
     -- (either because they had errors or because their accessControl array is empty).
+    -- Child rows are cascade-deleted via FK constraints.
     DELETE FROM assessment_access_control_rules aacr
     USING assessments a
     WHERE a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
@@ -210,5 +193,60 @@ BEGIN
             WHERE (rule ->> 'assessment_id')::bigint = aacr.assessment_id
         )
         AND aacr.target_type IN ('none', 'student_label');
+
+    -- Delete child rows that are no longer in the incoming data for surviving rules.
+    -- This runs after excess rule deletion so cascades have already cleaned up
+    -- child rows for removed rules.
+    DELETE FROM assessment_access_control_student_labels acsl
+    USING assessment_access_control_rules aacr
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    WHERE acsl.assessment_access_control_rule_id = aacr.id
+        AND aacr.assessment_id = ANY(syncing_assessment_ids)
+        AND aacr.target_type = 'student_label'
+        AND NOT EXISTS (
+            SELECT 1 FROM UNNEST(student_labels_data) AS g
+            WHERE (g ->> 0)::bigint = aacr.assessment_id
+                AND (g ->> 1)::integer = aacr.number
+                AND (g ->> 2)::bigint = acsl.student_label_id
+        );
+
+    DELETE FROM assessment_access_control_early_deadlines aced
+    USING assessment_access_control_rules aacr
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    WHERE aced.assessment_access_control_rule_id = aacr.id
+        AND aacr.assessment_id = ANY(syncing_assessment_ids)
+        AND aacr.target_type IN ('none', 'student_label')
+        AND NOT EXISTS (
+            SELECT 1 FROM UNNEST(early_deadlines_data) AS d
+            WHERE (d ->> 0)::bigint = aacr.assessment_id
+                AND (d ->> 1)::integer = aacr.number
+                AND (d ->> 2)::timestamp with time zone = aced.date
+        );
+
+    DELETE FROM assessment_access_control_late_deadlines acld
+    USING assessment_access_control_rules aacr
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    WHERE acld.assessment_access_control_rule_id = aacr.id
+        AND aacr.assessment_id = ANY(syncing_assessment_ids)
+        AND aacr.target_type IN ('none', 'student_label')
+        AND NOT EXISTS (
+            SELECT 1 FROM UNNEST(late_deadlines_data) AS d
+            WHERE (d ->> 0)::bigint = aacr.assessment_id
+                AND (d ->> 1)::integer = aacr.number
+                AND (d ->> 2)::timestamp with time zone = acld.date
+        );
+
+    DELETE FROM assessment_access_control_prairietest_exams acpe
+    USING assessment_access_control_rules aacr
+    JOIN assessments a ON a.id = aacr.assessment_id AND a.course_instance_id = syncing_course_instance_id
+    WHERE acpe.assessment_access_control_rule_id = aacr.id
+        AND aacr.assessment_id = ANY(syncing_assessment_ids)
+        AND aacr.target_type = 'none'
+        AND NOT EXISTS (
+            SELECT 1 FROM UNNEST(prairietest_exams_data) AS e
+            WHERE (e ->> 0)::bigint = aacr.assessment_id
+                AND (e ->> 1)::integer = aacr.number
+                AND (e ->> 2)::uuid = acpe.uuid
+        );
 END;
 $$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
# Description

Replace the "wipe and rebuild" pattern in the `sync_access_control` sproc with "upsert + delete excess" for child tables (`assessment_access_control_student_labels`, `assessment_access_control_early_deadlines`, `assessment_access_control_late_deadlines`, `assessment_access_control_prairietest_exams`). Previously, every sync deleted all child rows and re-inserted them; now rows are upserted via `ON CONFLICT` and only stale rows are removed. This preserves row IDs for unchanged data and reduces unnecessary churn.

Excess rule deletion (past max number / no incoming data) runs first so FK cascades clean up child rows for removed rules before the targeted `NOT EXISTS` cleanup handles surviving rules.

Part of #14469.

Majority of implementation was AI-assisted.

# Testing

Existing `accessControlSync.test.ts` suite (63 tests) passes.