### PR TITLE
Improve override deadline display to clarify overridden fields

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -214,8 +214,7 @@ function formatDeadlineEntries(
 ): OverrideFieldItem[] {
   const filtered = deadlines.filter((d) => d.date);
   return filtered.map((d, i) => ({
-    label:
-      filtered.length === 1 ? `${labelPrefix} deadline` : `${labelPrefix} deadline ${i + 1}`,
+    label: filtered.length === 1 ? `${labelPrefix} deadline` : `${labelPrefix} deadline ${i + 1}`,
     value: `${formatDate(Temporal.PlainDateTime.from(d.date), displayTimezone)} (${d.credit}% credit)`,
   }));
 }


### PR DESCRIPTION
# Description

Override summary cards in the access control UI previously used the same date timeline table format as the main rule. This was misleading because an override only specifies the fields it *changes* — it doesn't (and can't) show the complete picture since that depends on the main rule's defaults and potentially other overrides.

This replaces the timeline table and summary pills for overrides with a simple key/value list that shows only the fields the override actually modifies:

<img width="1053" height="267" alt="Screenshot 2026-03-31 at 17 29 16" src="https://github.com/user-attachments/assets/73aec3c2-5001-4bb3-bc26-36e25aa81ae7" />

Instead of a full timeline table with just a "Due" row that looks like an incomplete schedule.

The main rule summary is unchanged — it continues to use the full timeline table since it IS the complete picture.

Addresses an item from https://github.com/PrairieLearn/PrairieLearn/issues/14469.

AI assistance: majority of implementation (Claude Code).

# Testing

- Verified the modified file typechecks, lints, and formats cleanly
- The change only affects override card rendering in `RuleSummaryCard` (read-only summary); the form editing experience is not affected
- The main rule summary rendering is completely untouched (separate code path)
- All existing e2e tests for access control only use `data-testid="override-card"` for locating cards and don't assert on the internal display format