### PR TITLE
Increase git push/fetch timeout from 10s to 30s

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -313,7 +313,7 @@ export abstract class Editor {
               // an unreasonable amount of time and causing a 504 when we fail
               // to respond to the request in time, we'll use a relatively short
               // timeout to fail the push if it takes too long.
-              cancelSignal: AbortSignal.timeout(10_000),
+              cancelSignal: AbortSignal.timeout(30_000),
             });
             job.data.saveSucceeded = true;
 
@@ -337,7 +337,7 @@ export abstract class Editor {
               env: gitEnv,
               // As with `git push` above, we'll use a timeout here to avoid
               // long delays during GitHub incidents resulting in 504 errors.
-              cancelSignal: AbortSignal.timeout(10_000),
+              cancelSignal: AbortSignal.timeout(30_000),
             });
 
             // This will both discard the commit we made locally and also pull
@@ -352,7 +352,7 @@ export abstract class Editor {
                 cwd: this.course.path,
                 env: gitEnv,
                 // See above `git push` attempt for an explanation of this timeout.
-                cancelSignal: AbortSignal.timeout(10_000),
+                cancelSignal: AbortSignal.timeout(30_000),
               });
               job.data.saveSucceeded = true;
             } finally {


### PR DESCRIPTION
# Description

Courses that import large OER content (e.g. `pl-oer-linear-algebra`, which is ~167 MB / 2.8M lines due to plaintext audio data files) can exceed the 10-second `git push` timeout during course sync. We observed this on prod with `pl-ucsd-cse151a-freund` — both push attempts timed out at exactly ~10060ms.

Bumps the timeout from 10s to 30s for `git push` (both attempts) and `git fetch`. Local testing confirmed the OER push takes ~11s, so 30s provides comfortable headroom while still failing fast enough to avoid 504s from upstream timeouts.

Majority of investigation done with AI assistance.

# Testing

Tested empirically by pushing the full `pl-oer-linear-algebra` repo (~167 MB) to a private GitHub repo — took ~11 seconds, confirming 10s is too tight and 30s is sufficient.