### PR TITLE
Fix non-canonical timezones missing from course approval modal

### DIFF
--- a/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/administratorCourseRequests.tsx
@@ -26,7 +26,9 @@ router.get(
     });
     const rows = await selectAllCourseRequests();
     const institutions = await selectAllInstitutions();
-    const availableTimezones = await getCanonicalTimezones();
+    const availableTimezones = await getCanonicalTimezones(
+      institutions.map((i) => i.display_timezone),
+    );
     const trpcCsrfToken = generatePrefixCsrfToken(
       {
         url: `${urlPrefix}/administrator/trpc`,

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.tsx
@@ -29,7 +29,9 @@ router.get(
     });
     const course_requests = await selectPendingCourseRequests();
     const institutions = await selectAllInstitutions();
-    const availableTimezones = await getCanonicalTimezones();
+    const availableTimezones = await getCanonicalTimezones(
+      institutions.map((i) => i.display_timezone),
+    );
     const courses = await sqldb.queryRows(sql.select_courses, CourseWithInstitutionSchema);
     const trpcCsrfToken = generatePrefixCsrfToken(
       {


### PR DESCRIPTION
# Description

When approving a course request and selecting an institution that uses a non-canonical timezone alias (e.g. `Canada/Pacific` instead of `America/Vancouver`), the timezone dropdown in the approval modal would be empty because `getCanonicalTimezones()` filters out non-canonical names by default.

Other pages like institution settings already handle this by passing the current timezone as the `alwaysInclude` parameter, but the course request approval and administrator courses pages did not. This fix passes all institution `display_timezone` values as `alwaysInclude` so they always appear as options.

AI assistance: majority of implementation.

# Testing

- Navigate to the course request approval page with an institution configured to use `Canada/Pacific` (or another non-canonical timezone alias).
- Open the approval modal and select that institution.
- Verify the timezone dropdown correctly shows and selects the institution's timezone instead of being empty.