### PR TITLE
Rename RuleSummaryCard to OverrideRuleSummaryCard

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
@@ -14,7 +14,7 @@ import { Button } from 'react-bootstrap';
 
 import {
   DateTableView,
-  RuleSummaryCard,
+  OverrideRuleSummaryCard,
   generateDateTableRows,
   generateRuleSummary,
 } from './RuleSummary.js';
@@ -51,9 +51,8 @@ function SortableOverrideCard({
 
   return (
     <div ref={setNodeRef} style={style}>
-      <RuleSummaryCard
+      <OverrideRuleSummaryCard
         rule={override}
-        isMainRule={false}
         title={title}
         courseInstanceId={courseInstanceId}
         displayTimezone={displayTimezone}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -438,9 +438,8 @@ const tdStyle = {
   paddingBottom: '0.5rem',
 };
 
-export function RuleSummaryCard({
+export function OverrideRuleSummaryCard({
   rule,
-  isMainRule,
   title,
   onRemove,
   onEdit,
@@ -449,8 +448,7 @@ export function RuleSummaryCard({
   errors,
   dragHandleProps,
 }: {
-  rule: RuleData;
-  isMainRule: boolean;
+  rule: OverrideData;
   title: string;
   onEdit?: () => void;
   courseInstanceId: string;
@@ -459,24 +457,15 @@ export function RuleSummaryCard({
   onRemove?: () => void;
   dragHandleProps?: Record<string, unknown>;
 }) {
-  const overrideRule = !isMainRule ? (rule as OverrideData) : null;
+  const overrideFieldItems = generateOverrideFieldItems(rule, displayTimezone);
 
-  const summaryItems = isMainRule ? generateRuleSummary(rule, 'compact') : [];
-  const dateTableRows = isMainRule ? generateDateTableRows(rule, displayTimezone) : [];
-  const overrideFieldItems = overrideRule
-    ? generateOverrideFieldItems(overrideRule, displayTimezone)
-    : [];
-
-  const students =
-    overrideRule?.appliesTo.targetType === 'enrollment' ? overrideRule.appliesTo.enrollments : [];
+  const students = rule.appliesTo.targetType === 'enrollment' ? rule.appliesTo.enrollments : [];
 
   const studentLabels =
-    overrideRule?.appliesTo.targetType === 'student_label'
-      ? overrideRule.appliesTo.studentLabels
-      : [];
+    rule.appliesTo.targetType === 'student_label' ? rule.appliesTo.studentLabels : [];
 
   return (
-    <Card className="mb-3" data-testid={isMainRule ? undefined : 'override-card'}>
+    <Card className="mb-3" data-testid="override-card">
       <Card.Header className="d-flex flex-column flex-sm-row justify-content-between align-items-sm-center gap-2">
         <div className="d-flex align-items-center gap-2 flex-wrap">
           {dragHandleProps && (
@@ -504,11 +493,9 @@ export function RuleSummaryCard({
             </>
           ) : (
             <>
-              {overrideRule && (
-                <span className="d-inline-flex align-items-center gap-1 text-body-secondary small">
-                  <i className="bi bi-person" aria-hidden="true" />
-                </span>
-              )}
+              <span className="d-inline-flex align-items-center gap-1 text-body-secondary small">
+                <i className="bi bi-person" aria-hidden="true" />
+              </span>
               <strong>{title}</strong>
             </>
           )}
@@ -539,33 +526,6 @@ export function RuleSummaryCard({
 
         {overrideFieldItems.length > 0 && <OverrideFieldsList items={overrideFieldItems} />}
 
-        {dateTableRows.length > 0 && (
-          <div className="mb-2">
-            <div
-              className="text-body-secondary fw-semibold mb-2"
-              style={{ fontSize: '0.75rem', textTransform: 'uppercase', letterSpacing: '0.05em' }}
-            >
-              Deadlines
-            </div>
-            <DateTableView rows={dateTableRows} />
-          </div>
-        )}
-
-        {summaryItems.length > 0 && (
-          <div className="d-flex flex-wrap gap-2 mb-3">
-            {summaryItems.map((item) => (
-              <span
-                key={item.text}
-                className="d-inline-flex align-items-center gap-1 border rounded-pill px-3 py-1"
-                style={{ fontSize: '0.875rem' }}
-              >
-                <i className={`bi ${item.icon}`} aria-hidden="true" />
-                {item.text}
-              </span>
-            ))}
-          </div>
-        )}
-
         {students.length > 0 && (
           <div className="mb-2">
             <span className="text-body-secondary">Applies to: </span>
@@ -580,12 +540,9 @@ export function RuleSummaryCard({
           </div>
         )}
 
-        {overrideFieldItems.length === 0 &&
-          dateTableRows.length === 0 &&
-          summaryItems.length === 0 &&
-          students.length === 0 && (
-            <p className="text-body-secondary mb-0">No specific settings configured</p>
-          )}
+        {overrideFieldItems.length === 0 && students.length === 0 && (
+          <p className="text-body-secondary mb-0">No specific settings configured</p>
+        )}
       </Card.Body>
     </Card>
   );


### PR DESCRIPTION
# Description

`RuleSummaryCard` was only ever used for overrides but accepted a `RuleData` union type and an `isMainRule` boolean prop, leading to dead code branches and an unsafe `as OverrideData` cast. The main rule display uses a separate `MainRuleSummaryContent` component in `AccessControlSummary.tsx`.

This renames the component to `OverrideRuleSummaryCard`, narrows the `rule` prop type to `OverrideData`, and removes the unused main-rule code paths (date table, summary pills, verbosity toggle). This also simplifies the empty-state check and removes the conditional guard around the person icon since it's always an override.

Majority of implementation done with AI assistance.

# Testing

Verified the override card renders correctly in the browser on a migrated assessment's access control page. Typechecks clean.