### PR TITLE
Modernize resistorCapacitorCircuit to use schemdraw and units input

### DIFF
--- a/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/question.html
+++ b/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/question.html
@@ -1,27 +1,12 @@
 <pl-question-panel>
-
-    <pl-drawing width="440" height="260" grid-size="0" answers-name="answer">
-        <pl-drawing-initial>
-            <pl-battery x1="{{params.pA.0}}" y1="{{params.pA.1}}" x2="{{params.pB.0}}" y2="{{params.pB.1}}" label="{{params.V}} V"></pl-battery>
-            <pl-resistor x1="{{params.pB.0}}" y1="{{params.pB.1}}" x2="{{params.pC.0}}" y2="{{params.pC.1}}" label="{{params.R1}}\\Omega"></pl-resistor>
-            <pl-resistor x1="{{params.pL.0}}" y1="{{params.pL.1}}" x2="{{params.pH.0}}" y2="{{params.pH.1}}" label="{{params.R2}}\\Omega"></pl-resistor>
-            <pl-capacitor x1="{{params.pK.0}}" y1="{{params.pK.1}}" x2="{{params.pI.0}}" y2="{{params.pI.1}}" label="{{params.C}} \\mu F"></pl-capacitor>
-            <pl-switch x1="{{params.pA.0}}" y1="{{params.pA.1}}" x2="{{params.pF.0}}" y2="{{params.pF.1}}" label="A" switch-angle="0"></pl-switch>
-            <pl-switch x1="{{params.pL.0}}" y1="{{params.pL.1}}" x2="{{params.pJ.0}}" y2="{{params.pJ.1}}" label="B" offsetx="-10" offsety="-5"></pl-switch>
-            <pl-line x1="{{params.pC.0}}" y1="{{params.pC.1}}" x2="{{params.pD.0}}" y2="{{params.pD.1}}"></pl-line>
-            <pl-line x1="{{params.pE.0}}" y1="{{params.pE.1}}" x2="{{params.pD.0}}" y2="{{params.pD.1}}"></pl-line>
-            <pl-line x1="{{params.pF.0}}" y1="{{params.pF.1}}" x2="{{params.pG.0}}" y2="{{params.pG.1}}"></pl-line>
-            <pl-line x1="{{params.pH.0}}" y1="{{params.pH.1}}" x2="{{params.pI.0}}" y2="{{params.pI.1}}"></pl-line>
-            <pl-line x1="{{params.pJ.0}}" y1="{{params.pJ.1}}" x2="{{params.pK.0}}" y2="{{params.pK.1}}"></pl-line>
-        </pl-drawing-initial>
-    </pl-drawing>
-
-    <p> 
-        Switch $B$ is open and switch $A$ has been closed for a long time. What is the charge on the capacitor?
-    </p>
-    
+  <div style="text-align: center;">
+    {{ params.circuit_svg | safe }}
+  </div>
+  <p>
+    Switch $B$ is open and switch $A$ has been closed for a long time. What is the charge on the capacitor?
+  </p>
 </pl-question-panel>
 
 <p>
-    <pl-number-input aria-label="Capacitor charge" answers-name="charge" suffix="$\mu C$"></pl-number-input>
+  <pl-units-input answers-name="charge" aria-label="Capacitor charge"></pl-units-input>
 </p>

--- a/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/server.py
+++ b/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/server.py
@@ -1,5 +1,8 @@
 import random
 
+import schemdraw
+import schemdraw.elements as elm
+
 
 def generate(data):
     V = random.randint(12, 40)
@@ -12,35 +15,29 @@ def generate(data):
     C = random.randint(5, 15)
     data["params"]["C"] = C
 
-    # total energy
-    data["correct_answers"]["charge"] = C * V
+    # total charge
+    data["correct_answers"]["charge"] = f"{C * V} uC"
 
-    # data for plotting
-    pA = [60, 60]
-    L = 300
-    h = 120
+    with schemdraw.Drawing(show=False) as d:
+        d += elm.Switch().up().label("A")
+        d += elm.Battery().right().label(f"{V} V")
+        d += elm.Resistor().right().label(f"{R1} $\\Omega$")
+        d += elm.Line().down()
 
-    pB = [pA[0] + L / 2, pA[1]]
-    pC = [pA[0] + L, pA[1]]
-    pD = [pA[0] + L, pA[1] + h]
-    pE = [pA[0] + 4 / 5 * L, pA[1] + h]
-    pF = [pA[0], pA[1] + h]
-    pG = [pA[0] + 1 / 5 * L, pB[1] + h]
-    pH = [pE[0], pE[1] - h / 4]
-    pI = [pE[0], pE[1] + h / 4]
-    pJ = [pG[0], pG[1] - h / 4]
-    pK = [pG[0], pG[1] + h / 4]
-    pL = [pF[0] + L / 2, pG[1] - h / 4]
+        d.push()
+        d += elm.Line().up().length(1.5)
+        d += elm.Resistor().left().label(f"{R2} $\\Omega$")
+        d += elm.Switch().left().label("B")
+        d += elm.Line().down().length(1.5)
+        d.pop()
 
-    data["params"]["pA"] = pA
-    data["params"]["pB"] = pB
-    data["params"]["pC"] = pC
-    data["params"]["pD"] = pD
-    data["params"]["pE"] = pE
-    data["params"]["pF"] = pF
-    data["params"]["pG"] = pG
-    data["params"]["pH"] = pH
-    data["params"]["pI"] = pI
-    data["params"]["pJ"] = pJ
-    data["params"]["pK"] = pK
-    data["params"]["pL"] = pL
+        d += elm.Line().down().length(1.5)
+        d += elm.Line().left().length(1.5)
+        d += elm.Capacitor().left().label(f"{C} $\\mu$F")
+        d += elm.Line().left().length(1.5)
+        d += elm.Line().up().length(1.5)
+
+        svg_bytes = d.get_imagedata("svg")
+        data["params"]["circuit_svg"] = (
+            svg_bytes.decode("utf-8") if isinstance(svg_bytes, bytes) else svg_bytes
+        )


### PR DESCRIPTION
## Summary

Replaced the legacy `pl-drawing` circuit with a dynamically generated SVG using `schemdraw`. Updated the question to use `pl-units-input` instead of `pl-number-input` for the final answer.

## Changes

- **exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/question.html**: Replaced pl-drawing with the schemdraw SVG and updated pl-number-input to pl-units-input.
- **exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/server.py**: Removed legacy drawing coordinates, added schemdraw logic to generate the circuit SVG, and updated the correct answer to include units.

## Related Issue

Closes #10712