### PR TITLE
Refactor error logging and update multiplication symbol for consistency

### DIFF
--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -507,7 +507,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     lpar: '(',
     rpar: ')',
     assign: '\\coloneqq',
-    mul: '\\times',
+    mul: '\\cdot',
     minus: '-',
     plus: '+',
     'dec-point': '.',


### PR DESCRIPTION
closes #14624

# Description

The keyboard unresponsiveness should be handled via [ebea4c5](https://github.com/PrairieLearn/PrairieLearn/pull/14477/commits/ebea4c510f280dca8be9c1f5f0d9a05f143ca292). See https://github.com/PrairieLearn/PrairieLearn/pull/14477#issuecomment-4173016835 for details. Please comment it persists after the [ebea4c5](https://github.com/PrairieLearn/PrairieLearn/pull/14477/commits/ebea4c510f280dca8be9c1f5f0d9a05f143ca292).

 This PR addresses the two side notes in #14624 
 
 - `console.error` removed on calculation errors. Right now the only `console.error`s left in calculatorClient are:
   - evaluation errors, doesn't fire on incomplete expression (e.g. `1 +`)
   - failure to assign to Ans
   - calculator init error
 - replace `\times` with `\cdot` for inputting multiplication with the calculator button for consistency

# Testing

- input incomplete expressions should not console error
- `×` button on keyboard should produce `\cdot` on input