### PR TITLE
Use Temporal.PlainDateTime for date display in assessment access form

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DateControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DateControlForm.tsx
@@ -57,7 +57,7 @@ export function MainDateControlForm({
           <MainDeadlineArrayField type="early" displayTimezone={displayTimezone} />
           <MainDueDateField displayTimezone={displayTimezone} />
           <MainDeadlineArrayField type="late" displayTimezone={displayTimezone} />
-          <MainAfterLastDeadlineField />
+          <MainAfterLastDeadlineField displayTimezone={displayTimezone} />
           <Row className="gy-3">
             <Col md={6}>
               <MainDurationField />
@@ -100,7 +100,7 @@ export function OverrideDateControlForm({
         <OverrideDeadlineArrayField index={index} type="early" displayTimezone={displayTimezone} />
         <OverrideDueDateField index={index} displayTimezone={displayTimezone} />
         <OverrideDeadlineArrayField index={index} type="late" displayTimezone={displayTimezone} />
-        <OverrideAfterLastDeadlineField index={index} />
+        <OverrideAfterLastDeadlineField index={index} displayTimezone={displayTimezone} />
         <Row className="gy-3">
           <Col md={6}>
             <OverrideDurationField index={index} />

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -7,7 +7,7 @@ import { FriendlyDate } from '../../../../components/FriendlyDate.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
 import type { AccessControlFormData, AfterLastDeadlineValue, DeadlineEntry } from '../types.js';
-import { getLastDeadlineDate, getUserTimezone } from '../utils/dateUtils.js';
+import { getLastDeadlineDate } from '../utils/dateUtils.js';
 
 type AfterLastDeadlineMode = 'no_submissions' | 'practice_submissions' | 'partial_credit';
 
@@ -44,6 +44,7 @@ function AfterLastDeadlineInput({
   dueDate,
   lateDeadlines,
   creditFieldPath,
+  displayTimezone,
   showNoDueDateWarning = true,
 }: {
   value: AfterLastDeadlineValue | null;
@@ -54,10 +55,10 @@ function AfterLastDeadlineInput({
   creditFieldPath:
     | 'mainRule.afterLastDeadline.credit'
     | `overrides.${number}.afterLastDeadline.credit`;
+  displayTimezone: string;
   showNoDueDateWarning?: boolean;
 }) {
   const { register } = useFormContext<AccessControlFormData>();
-  const userTimezone = getUserTimezone();
   const { errors } = useFormState();
   const creditError: string | undefined = get(errors, creditFieldPath)?.message;
 
@@ -69,7 +70,7 @@ function AfterLastDeadlineInput({
       return (
         <>
           This will take effect after{' '}
-          <FriendlyDate date={lastDate} timezone={userTimezone} options={{ includeTz: false }} />
+          <FriendlyDate date={lastDate} timezone={displayTimezone} options={{ includeTz: false }} />
         </>
       );
     }
@@ -159,7 +160,7 @@ function AfterLastDeadlineInput({
   );
 }
 
-export function MainAfterLastDeadlineField() {
+export function MainAfterLastDeadlineField({ displayTimezone }: { displayTimezone: string }) {
   const { field } = useController<AccessControlFormData, 'mainRule.afterLastDeadline'>({
     name: 'mainRule.afterLastDeadline',
   });
@@ -179,12 +180,19 @@ export function MainAfterLastDeadlineField() {
       dueDate={dueDate}
       lateDeadlines={lateDeadlines}
       creditFieldPath="mainRule.afterLastDeadline.credit"
+      displayTimezone={displayTimezone}
       onChange={field.onChange}
     />
   );
 }
 
-export function OverrideAfterLastDeadlineField({ index }: { index: number }) {
+export function OverrideAfterLastDeadlineField({
+  index,
+  displayTimezone,
+}: {
+  index: number;
+  displayTimezone: string;
+}) {
   const mainValue = useWatch<AccessControlFormData, 'mainRule.afterLastDeadline'>({
     name: 'mainRule.afterLastDeadline',
   });
@@ -230,6 +238,7 @@ export function OverrideAfterLastDeadlineField({ index }: { index: number }) {
         dueDate={dueDateOverridden ? dueDate : mainDueDate}
         lateDeadlines={lateDeadlinesOverridden ? lateDeadlines : mainLateDeadlines}
         creditFieldPath={`overrides.${index}.afterLastDeadline.credit`}
+        displayTimezone={displayTimezone}
         showNoDueDateWarning={false}
         onChange={field.onChange}
       />

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -8,7 +8,7 @@ import { FriendlyDate } from '../../../../components/FriendlyDate.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
 import type { AccessControlFormData, DeadlineEntry } from '../types.js';
-import { endOfDayDatetime, getDeadlineRange, getUserTimezone } from '../utils/dateUtils.js';
+import { endOfDayDatetime, getDeadlineRange } from '../utils/dateUtils.js';
 
 function DeadlineArrayInput({
   type,
@@ -36,7 +36,6 @@ function DeadlineArrayInput({
   displayTimezone: string;
 }) {
   const { register, trigger } = useFormContext<AccessControlFormData>();
-  const userTimezone = getUserTimezone();
   const isEarly = type === 'early';
 
   const {
@@ -93,15 +92,24 @@ function DeadlineArrayInput({
       return (
         <>
           {prefix} –{' '}
-          <FriendlyDate date={range.end} timezone={userTimezone} options={{ includeTz: false }} />
+          <FriendlyDate
+            date={range.end}
+            timezone={displayTimezone}
+            options={{ includeTz: false }}
+          />
         </>
       );
     }
 
     return (
       <>
-        <FriendlyDate date={range.start} timezone={userTimezone} options={{ includeTz: false }} /> –{' '}
-        <FriendlyDate date={range.end} timezone={userTimezone} options={{ includeTz: false }} />
+        <FriendlyDate
+          date={range.start}
+          timezone={displayTimezone}
+          options={{ includeTz: false }}
+        />{' '}
+        –{' '}
+        <FriendlyDate date={range.end} timezone={displayTimezone} options={{ includeTz: false }} />
       </>
     );
   };

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
@@ -8,11 +8,7 @@ import { FriendlyDate } from '../../../../components/FriendlyDate.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
 import type { AccessControlFormData, DeadlineEntry } from '../types.js';
-import {
-  endOfDayDatetime,
-  getLatestEarlyDeadlineDate,
-  getUserTimezone,
-} from '../utils/dateUtils.js';
+import { endOfDayDatetime, getLatestEarlyDeadlineDate } from '../utils/dateUtils.js';
 
 function localDatetimeToTimezoneDate(value: string, timezone: string): Date {
   return new Date(Temporal.PlainDateTime.from(value).toZonedDateTime(timezone).epochMilliseconds);
@@ -42,34 +38,44 @@ function DueDateInput({
   error?: string;
   displayTimezone: string;
 }) {
-  const userTimezone = getUserTimezone();
-
   const getCreditPeriodText = () => {
     if (!value) return null;
 
-    const dueDateObj = new Date(value);
+    const dueDatePlain = Temporal.PlainDateTime.from(value);
     const latestEarly = earlyDeadlines ? getLatestEarlyDeadlineDate(earlyDeadlines) : null;
 
     if (latestEarly) {
       return (
         <>
-          <FriendlyDate date={latestEarly} timezone={userTimezone} options={{ includeTz: false }} />{' '}
+          <FriendlyDate
+            date={latestEarly}
+            timezone={displayTimezone}
+            options={{ includeTz: false }}
+          />{' '}
           –{' '}
-          <FriendlyDate date={dueDateObj} timezone={userTimezone} options={{ includeTz: false }} />{' '}
+          <FriendlyDate
+            date={dueDatePlain}
+            timezone={displayTimezone}
+            options={{ includeTz: false }}
+          />{' '}
           (100% credit)
         </>
       );
     } else if (releaseDate) {
-      const releaseDateObj = new Date(releaseDate);
+      const releaseDatePlain = Temporal.PlainDateTime.from(releaseDate);
       return (
         <>
           <FriendlyDate
-            date={releaseDateObj}
-            timezone={userTimezone}
+            date={releaseDatePlain}
+            timezone={displayTimezone}
             options={{ includeTz: false }}
           />{' '}
           –{' '}
-          <FriendlyDate date={dueDateObj} timezone={userTimezone} options={{ includeTz: false }} />{' '}
+          <FriendlyDate
+            date={dueDatePlain}
+            timezone={displayTimezone}
+            options={{ includeTz: false }}
+          />{' '}
           (100% credit)
         </>
       );
@@ -77,7 +83,11 @@ function DueDateInput({
       return (
         <>
           While accessible –{' '}
-          <FriendlyDate date={dueDateObj} timezone={userTimezone} options={{ includeTz: false }} />{' '}
+          <FriendlyDate
+            date={dueDatePlain}
+            timezone={displayTimezone}
+            options={{ includeTz: false }}
+          />{' '}
           (100% credit)
         </>
       );

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
@@ -8,7 +8,7 @@ import { FriendlyDate } from '../../../../components/FriendlyDate.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
 import type { AccessControlFormData, DeadlineEntry } from '../types.js';
-import { endOfDayDatetime, getLatestEarlyDeadlineDate } from '../utils/dateUtils.js';
+import { endOfDayDatetime, getLatestDeadlineEntry } from '../utils/dateUtils.js';
 
 function localDatetimeToTimezoneDate(value: string, timezone: string): Date {
   return new Date(Temporal.PlainDateTime.from(value).toZonedDateTime(timezone).epochMilliseconds);
@@ -42,7 +42,7 @@ function DueDateInput({
     if (!value) return null;
 
     const dueDatePlain = Temporal.PlainDateTime.from(value);
-    const latestEarly = earlyDeadlines ? getLatestEarlyDeadlineDate(earlyDeadlines) : null;
+    const latestEarly = earlyDeadlines ? getLatestDeadlineEntry(earlyDeadlines) : null;
 
     if (latestEarly) {
       return (

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
@@ -25,13 +25,9 @@ export function endOfDayDatetime(date: Temporal.PlainDate): string {
     .toString({ smallestUnit: 'second' });
 }
 
-export function getUserTimezone(): string {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone;
-}
-
 interface DateRange {
-  start: Date | null;
-  end: Date;
+  start: Temporal.PlainDateTime | null;
+  end: Temporal.PlainDateTime;
 }
 
 export function getDeadlineRange(
@@ -42,45 +38,45 @@ export function getDeadlineRange(
   const currentDeadline = deadlines[index];
   if (!currentDeadline.date) return null;
 
-  const endDate = new Date(currentDeadline.date);
-  let startDate: Date | null = null;
+  const end = Temporal.PlainDateTime.from(currentDeadline.date);
+  let start: Temporal.PlainDateTime | null = null;
 
   if (index === 0) {
     if (anchorDate) {
-      startDate = new Date(anchorDate);
+      start = Temporal.PlainDateTime.from(anchorDate);
     }
   } else {
     const previousDeadline = deadlines[index - 1];
     if (previousDeadline.date) {
-      startDate = new Date(previousDeadline.date);
+      start = Temporal.PlainDateTime.from(previousDeadline.date);
     }
   }
 
-  return { start: startDate, end: endDate };
+  return { start, end };
 }
 
 export function getLastDeadlineDate(
   lateDeadlines: DeadlineEntry[] | undefined,
   dueDate: string | null | undefined,
-): Date | null {
+): Temporal.PlainDateTime | null {
   if (lateDeadlines && lateDeadlines.length > 0) {
     const validLateDeadlines = lateDeadlines.filter((d) => d.date);
     if (validLateDeadlines.length > 0) {
-      const sorted = [...validLateDeadlines].sort(
-        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-      );
-      return new Date(sorted[0].date);
+      const sorted = [...validLateDeadlines].sort((a, b) => (a.date < b.date ? 1 : -1));
+      return Temporal.PlainDateTime.from(sorted[0].date);
     }
   }
 
   if (dueDate) {
-    return new Date(dueDate);
+    return Temporal.PlainDateTime.from(dueDate);
   }
 
   return null;
 }
 
-export function getLatestEarlyDeadlineDate(earlyDeadlines: DeadlineEntry[]): Date | null {
+export function getLatestEarlyDeadlineDate(
+  earlyDeadlines: DeadlineEntry[],
+): Temporal.PlainDateTime | null {
   if (earlyDeadlines.length === 0) {
     return null;
   }
@@ -90,8 +86,6 @@ export function getLatestEarlyDeadlineDate(earlyDeadlines: DeadlineEntry[]): Dat
     return null;
   }
 
-  const sorted = [...validDeadlines].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-  );
-  return new Date(sorted[0].date);
+  const sorted = [...validDeadlines].sort((a, b) => (a.date < b.date ? 1 : -1));
+  return Temporal.PlainDateTime.from(sorted[0].date);
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
@@ -25,16 +25,21 @@ export function endOfDayDatetime(date: Temporal.PlainDate): string {
     .toString({ smallestUnit: 'second' });
 }
 
+function getLatestDeadlineEntry(deadlines: DeadlineEntry[]): Temporal.PlainDateTime | null {
+  let latest = '';
+  for (const d of deadlines) {
+    if (d.date && d.date > latest) latest = d.date;
+  }
+  return latest ? Temporal.PlainDateTime.from(latest) : null;
+}
+
 export function getLastDeadlineDate(
   lateDeadlines: DeadlineEntry[] | undefined,
   dueDate: string | null | undefined,
 ): Temporal.PlainDateTime | null {
-  if (lateDeadlines && lateDeadlines.length > 0) {
-    const validLateDeadlines = lateDeadlines.filter((d) => d.date);
-    if (validLateDeadlines.length > 0) {
-      const sorted = [...validLateDeadlines].sort((a, b) => (a.date < b.date ? 1 : -1));
-      return Temporal.PlainDateTime.from(sorted[0].date);
-    }
+  if (lateDeadlines) {
+    const result = getLatestDeadlineEntry(lateDeadlines);
+    if (result) return result;
   }
 
   if (dueDate) {
@@ -47,15 +52,5 @@ export function getLastDeadlineDate(
 export function getLatestEarlyDeadlineDate(
   earlyDeadlines: DeadlineEntry[],
 ): Temporal.PlainDateTime | null {
-  if (earlyDeadlines.length === 0) {
-    return null;
-  }
-
-  const validDeadlines = earlyDeadlines.filter((d) => d.date);
-  if (validDeadlines.length === 0) {
-    return null;
-  }
-
-  const sorted = [...validDeadlines].sort((a, b) => (a.date < b.date ? 1 : -1));
-  return Temporal.PlainDateTime.from(sorted[0].date);
+  return getLatestDeadlineEntry(earlyDeadlines);
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
@@ -48,4 +48,3 @@ export function getLastDeadlineDate(
 
   return null;
 }
-

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/utils/dateUtils.ts
@@ -25,7 +25,7 @@ export function endOfDayDatetime(date: Temporal.PlainDate): string {
     .toString({ smallestUnit: 'second' });
 }
 
-function getLatestDeadlineEntry(deadlines: DeadlineEntry[]): Temporal.PlainDateTime | null {
+export function getLatestDeadlineEntry(deadlines: DeadlineEntry[]): Temporal.PlainDateTime | null {
   let latest = '';
   for (const d of deadlines) {
     if (d.date && d.date > latest) latest = d.date;
@@ -49,8 +49,3 @@ export function getLastDeadlineDate(
   return null;
 }
 
-export function getLatestEarlyDeadlineDate(
-  earlyDeadlines: DeadlineEntry[],
-): Temporal.PlainDateTime | null {
-  return getLatestDeadlineEntry(earlyDeadlines);
-}


### PR DESCRIPTION
# Description

Datetime-local form strings represent times in the course's `displayTimezone`, but `new Date()` interprets them in the browser's local timezone. Previously, this was masked by also displaying with `userTimezone` (browser timezone), causing the two timezone errors to cancel out. This switches all display-path code to use `Temporal.PlainDateTime.from()` with `displayTimezone`, matching the correct pattern already used in `RuleSummary.tsx`.

Addresses https://github.com/PrairieLearn/PrairieLearn/pull/14682#discussion_r3061021611.

- [x] I have disclosed the level of AI assistance used: majority of implementation with Claude Code.

# Testing

Visually verify that dates shown in the assessment access form (deadline ranges, credit period text, after-last-deadline text) display correctly, especially when the user's browser timezone differs from the course instance's display timezone.