### PR TITLE
Include after-last-deadline credit in monotonic decreasing check

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -694,6 +694,78 @@ describe('Credit monotonicity validation', () => {
     const errors = validateRuleCreditMonotonicity(rule);
     assert.deepEqual(errors, []);
   });
+
+  it('should reject afterLastDeadline credit exceeding last late deadline credit', () => {
+    const rule = AccessControlJsonSchema.parse({
+      dateControl: {
+        dueDate: '2024-03-21T00:00:00',
+        lateDeadlines: [
+          { date: '2024-03-25T00:00:00', credit: 80 },
+          { date: '2024-03-28T00:00:00', credit: 50 },
+        ],
+        afterLastDeadline: { allowSubmissions: true, credit: 60 },
+      },
+    });
+    const errors = validateRuleCreditMonotonicity(rule);
+    assert.isTrue(errors.some((e) => e.includes('must not exceed')));
+  });
+
+  it('should reject afterLastDeadline credit exceeding 100 when no late deadlines', () => {
+    const rule = AccessControlJsonSchema.parse({
+      dateControl: {
+        dueDate: '2024-03-21T00:00:00',
+        afterLastDeadline: { allowSubmissions: true, credit: 110 },
+      },
+    });
+    const errors = validateRuleCreditMonotonicity(rule);
+    assert.isTrue(errors.some((e) => e.includes('must not exceed')));
+  });
+
+  it('should accept afterLastDeadline credit equal to last late deadline credit', () => {
+    const rule = AccessControlJsonSchema.parse({
+      dateControl: {
+        dueDate: '2024-03-21T00:00:00',
+        lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 50 }],
+        afterLastDeadline: { allowSubmissions: true, credit: 50 },
+      },
+    });
+    const errors = validateRuleCreditMonotonicity(rule);
+    assert.deepEqual(errors, []);
+  });
+
+  it('should accept afterLastDeadline credit less than last late deadline credit', () => {
+    const rule = AccessControlJsonSchema.parse({
+      dateControl: {
+        dueDate: '2024-03-21T00:00:00',
+        lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 50 }],
+        afterLastDeadline: { allowSubmissions: true, credit: 30 },
+      },
+    });
+    const errors = validateRuleCreditMonotonicity(rule);
+    assert.deepEqual(errors, []);
+  });
+
+  it('should accept afterLastDeadline without credit (practice mode)', () => {
+    const rule = AccessControlJsonSchema.parse({
+      dateControl: {
+        dueDate: '2024-03-21T00:00:00',
+        lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 50 }],
+        afterLastDeadline: { allowSubmissions: true },
+      },
+    });
+    const errors = validateRuleCreditMonotonicity(rule);
+    assert.deepEqual(errors, []);
+  });
+
+  it('should skip afterLastDeadline check when no due date or late deadlines', () => {
+    const rule = AccessControlJsonSchema.parse({
+      dateControl: {
+        afterLastDeadline: { allowSubmissions: true, credit: 50 },
+      },
+    });
+    const errors = validateRuleCreditMonotonicity(rule);
+    assert.deepEqual(errors, []);
+  });
 });
 
 describe('Empty accessControl array', () => {

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -368,6 +368,19 @@ export function validateRuleCreditMonotonicity(rule: AccessControlJson): string[
     }
   }
 
+  const afterCredit = dc.afterLastDeadline?.credit;
+  if (afterCredit != null) {
+    // Determine the preceding credit in the timeline.
+    const precedingCredit =
+      dc.lateDeadlines?.at(-1)?.credit ?? (dc.dueDate != null ? 100 : undefined);
+
+    if (precedingCredit != null && afterCredit > precedingCredit) {
+      errors.push(
+        `After-last-deadline credit (${afterCredit}%) must not exceed the preceding deadline's credit (${precedingCredit}%).`,
+      );
+    }
+  }
+
   return errors;
 }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Alert, Form, InputGroup } from 'react-bootstrap';
 import { get, useController, useFormContext, useFormState, useWatch } from 'react-hook-form';
 
@@ -56,10 +57,22 @@ function AfterLastDeadlineInput({
     | `overrides.${number}.afterLastDeadline.credit`;
   showNoDueDateWarning?: boolean;
 }) {
-  const { register } = useFormContext<AccessControlFormData>();
+  const { register, trigger } = useFormContext<AccessControlFormData>();
   const userTimezone = getUserTimezone();
   const { errors } = useFormState();
   const creditError: string | undefined = get(errors, creditFieldPath)?.message;
+
+  // Store constraint values in refs so the validate function (which is captured
+  // once by register()) always reads current values instead of stale closures.
+  const lateDeadlinesRef = useRef(lateDeadlines);
+  const dueDateRef = useRef(dueDate);
+  lateDeadlinesRef.current = lateDeadlines;
+  dueDateRef.current = dueDate;
+
+  // Re-validate credit when late deadlines or due date change.
+  useEffect(() => {
+    void trigger(creditFieldPath);
+  }, [lateDeadlines, dueDate, creditFieldPath, trigger]);
 
   const mode = getMode(value);
 
@@ -135,6 +148,12 @@ function AfterLastDeadlineInput({
                 validate: (v) => {
                   if (v == null || Number.isNaN(v)) return 'Credit is required';
                   if (v < 0 || v > 200) return 'Must be 0–200%';
+                  const precedingCredit =
+                    lateDeadlinesRef.current?.at(-1)?.credit ??
+                    (dueDateRef.current != null ? 100 : undefined);
+                  if (precedingCredit != null && v > precedingCredit) {
+                    return `Must not exceed ${precedingCredit}% (the preceding deadline's credit)`;
+                  }
                   return true;
                 },
               })}


### PR DESCRIPTION
# Description

The credit monotonicity validation for modern access control previously only checked that early deadlines and late deadlines had decreasing credit values within their own arrays. It did not validate `afterLastDeadline.credit` against the preceding deadline, so a user could set an after-last-deadline credit higher than the last late deadline without any error. This adds that check to both the server-side validation and the client-side form.

AI assistance: majority of implementation.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

- Added unit tests for the new server-side validation covering: credit exceeding last late deadline, credit exceeding 100% with no late deadlines, equal credit (accepted), lower credit (accepted), practice mode (accepted), and no due date/deadlines (skipped).
- All 48 validation tests pass.
- Client-side: the after-last-deadline credit input now re-validates when late deadlines or due date change, showing an error like "Must not exceed 50% (the preceding deadline's credit)".