### PR TITLE
Add student-safe schemas and narrow QuestionScore prop types

### DIFF
--- a/apps/prairielearn/src/components/QuestionScore.tsx
+++ b/apps/prairielearn/src/components/QuestionScore.tsx
@@ -255,12 +255,11 @@ export function ExamQuestionStatus({
   realTimeGradingPartiallyDisabled,
   allowGradeLeftMs,
 }: {
-  instance_question: { status: InstanceQuestion['status'] };
-  assessment_question: {
-    max_auto_points: AssessmentQuestion['max_auto_points'];
-    max_manual_points: AssessmentQuestion['max_manual_points'];
-    allow_real_time_grading: AssessmentQuestion['allow_real_time_grading'];
-  };
+  instance_question: Pick<InstanceQuestion, 'status'>;
+  assessment_question: Pick<
+    AssessmentQuestion,
+    'max_auto_points' | 'max_manual_points' | 'allow_real_time_grading'
+  >;
   /**
    * On exam with mixed real-time grading settings, this flag allows us to
    * differentiate between questions that are saved and which can be graded by
@@ -391,19 +390,19 @@ export function InstanceQuestionPoints({
   assessment_question,
   component,
 }: {
-  instance_question: {
-    auto_points: InstanceQuestion['auto_points'];
-    manual_points: InstanceQuestion['manual_points'];
-    points: InstanceQuestion['points'];
-    status: InstanceQuestion['status'];
-    requires_manual_grading: InstanceQuestion['requires_manual_grading'];
-    last_grader: InstanceQuestion['last_grader'];
-  };
-  assessment_question: {
-    max_auto_points: AssessmentQuestion['max_auto_points'];
-    max_manual_points: AssessmentQuestion['max_manual_points'];
-    max_points: AssessmentQuestion['max_points'];
-  };
+  instance_question: Pick<
+    InstanceQuestion,
+    | 'auto_points'
+    | 'manual_points'
+    | 'points'
+    | 'status'
+    | 'requires_manual_grading'
+    | 'last_grader'
+  >;
+  assessment_question: Pick<
+    AssessmentQuestion,
+    'max_auto_points' | 'max_manual_points' | 'max_points'
+  >;
   component: 'manual' | 'auto' | 'total';
 }) {
   const points =

--- a/apps/prairielearn/src/components/QuestionScore.tsx
+++ b/apps/prairielearn/src/components/QuestionScore.tsx
@@ -255,11 +255,12 @@ export function ExamQuestionStatus({
   realTimeGradingPartiallyDisabled,
   allowGradeLeftMs,
 }: {
-  instance_question: InstanceQuestion;
-  assessment_question: Pick<
-    AssessmentQuestion,
-    'max_auto_points' | 'max_manual_points' | 'allow_real_time_grading'
-  >;
+  instance_question: { status: InstanceQuestion['status'] };
+  assessment_question: {
+    max_auto_points: AssessmentQuestion['max_auto_points'];
+    max_manual_points: AssessmentQuestion['max_manual_points'];
+    allow_real_time_grading: AssessmentQuestion['allow_real_time_grading'];
+  };
   /**
    * On exam with mixed real-time grading settings, this flag allows us to
    * differentiate between questions that are saved and which can be graded by
@@ -390,19 +391,19 @@ export function InstanceQuestionPoints({
   assessment_question,
   component,
 }: {
-  instance_question: Pick<
-    InstanceQuestion,
-    | 'auto_points'
-    | 'manual_points'
-    | 'points'
-    | 'status'
-    | 'requires_manual_grading'
-    | 'last_grader'
-  >;
-  assessment_question: Pick<
-    AssessmentQuestion,
-    'max_auto_points' | 'max_manual_points' | 'max_points'
-  >;
+  instance_question: {
+    auto_points: InstanceQuestion['auto_points'];
+    manual_points: InstanceQuestion['manual_points'];
+    points: InstanceQuestion['points'];
+    status: InstanceQuestion['status'];
+    requires_manual_grading: InstanceQuestion['requires_manual_grading'];
+    last_grader: InstanceQuestion['last_grader'];
+  };
+  assessment_question: {
+    max_auto_points: AssessmentQuestion['max_auto_points'];
+    max_manual_points: AssessmentQuestion['max_manual_points'];
+    max_points: AssessmentQuestion['max_points'];
+  };
   component: 'manual' | 'auto' | 'total';
 }) {
   const points =

--- a/apps/prairielearn/src/lib/client/safe-db-types.test.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.test.ts
@@ -21,12 +21,17 @@ import {
   StaffTopicSchema,
   StaffUserSchema,
   StaffZoneSchema,
+  StudentAssessmentInstanceAuthzResultSchema,
   StudentAssessmentInstanceSchema__UNSAFE,
+  StudentAssessmentQuestionSchema,
   StudentAssessmentSchema,
   StudentAssessmentSetSchema,
   StudentCourseInstanceSchema,
   StudentCourseSchema,
+  StudentInstanceQuestionSchema,
+  StudentQuestionSchema,
   StudentUserSchema,
+  StudentZoneSchema,
 } from './safe-db-types.js';
 
 // Minimal valid data for each schema (with required fields only)
@@ -260,6 +265,16 @@ const minimalStudentAssessmentInstance: z.input<typeof StudentAssessmentInstance
   score_perc_pending: 0,
   team_id: null,
   user_id: null,
+};
+
+const minimalStudentAssessmentInstanceAuthzResult: z.input<
+  typeof StudentAssessmentInstanceAuthzResultSchema
+> = {
+  active: true,
+  authorized_edit: true,
+  credit_date_string: null,
+  password: 'secret',
+  show_closed_assessment: false,
 };
 
 const minimalStaffAssessmentSet: z.input<typeof StaffAssessmentSetSchema> = {
@@ -526,6 +541,46 @@ const minimalStaffZone: z.input<typeof StaffZoneSchema> = {
   title: null,
 };
 
+const minimalStudentZone: z.input<typeof StudentZoneSchema> = {
+  best_questions: null,
+  id: '6',
+  lockpoint: false,
+  max_points: null,
+  number: 1,
+  title: null,
+};
+
+const minimalStudentInstanceQuestion: z.input<typeof StudentInstanceQuestionSchema> = {
+  auto_points: null,
+  current_value: null,
+  highest_submission_score: null,
+  id: '1',
+  last_grader: null,
+  manual_points: null,
+  number_attempts: 0,
+  open: true,
+  points: 0,
+  points_list: null,
+  points_list_original: null,
+  requires_manual_grading: false,
+  score_perc: 0,
+  status: 'unanswered',
+};
+
+const minimalStudentAssessmentQuestion: z.input<typeof StudentAssessmentQuestionSchema> = {
+  allow_real_time_grading: true,
+  grade_rate_minutes: null,
+  init_points: null,
+  max_auto_points: null,
+  max_manual_points: null,
+  max_points: null,
+};
+
+const minimalStudentQuestion: z.input<typeof StudentQuestionSchema> = {
+  id: '8',
+  title: null,
+};
+
 describe('safe-db-types schemas', () => {
   it('parses valid StaffCourse and drops extra fields', () => {
     const parsed = StaffCourseSchema.parse({ ...minimalStaffCourse, extra: 123 });
@@ -614,6 +669,22 @@ describe('safe-db-types schemas', () => {
     expect(parsed).toMatchObject(minimalStudentAssessmentInstance);
   });
 
+  it('parses valid StudentAssessmentInstanceAuthzResult and strips password', () => {
+    const parsed = StudentAssessmentInstanceAuthzResultSchema.parse({
+      ...minimalStudentAssessmentInstanceAuthzResult,
+      extra: 123,
+    });
+    expect(parsed).not.toHaveProperty('extra');
+    expect(parsed).not.toHaveProperty('password');
+    expect(parsed).toStrictEqual({
+      active: true,
+      authorizedEdit: true,
+      creditDateString: null,
+      hasPassword: true,
+      showClosedAssessment: false,
+    });
+  });
+
   it('parses valid StaffAssessmentSet and drops extra fields', () => {
     const parsed = StaffAssessmentSetSchema.parse({ ...minimalStaffAssessmentSet, extra: 123 });
     expect(parsed).not.toHaveProperty('extra');
@@ -684,5 +755,35 @@ describe('safe-db-types schemas', () => {
     const parsed = StaffZoneSchema.parse({ ...minimalStaffZone, extra: 123 });
     expect(parsed).not.toHaveProperty('extra');
     expect(parsed).toMatchObject(minimalStaffZone);
+  });
+
+  it('parses valid StudentZone and drops extra fields', () => {
+    const parsed = StudentZoneSchema.parse({ ...minimalStudentZone, extra: 123 });
+    expect(parsed).not.toHaveProperty('extra');
+    expect(parsed).toMatchObject(minimalStudentZone);
+  });
+
+  it('parses valid StudentInstanceQuestion and drops extra fields', () => {
+    const parsed = StudentInstanceQuestionSchema.parse({
+      ...minimalStudentInstanceQuestion,
+      extra: 123,
+    });
+    expect(parsed).not.toHaveProperty('extra');
+    expect(parsed).toMatchObject(minimalStudentInstanceQuestion);
+  });
+
+  it('parses valid StudentAssessmentQuestion and drops extra fields', () => {
+    const parsed = StudentAssessmentQuestionSchema.parse({
+      ...minimalStudentAssessmentQuestion,
+      extra: 123,
+    });
+    expect(parsed).not.toHaveProperty('extra');
+    expect(parsed).toMatchObject(minimalStudentAssessmentQuestion);
+  });
+
+  it('parses valid StudentQuestion and drops extra fields', () => {
+    const parsed = StudentQuestionSchema.parse({ ...minimalStudentQuestion, extra: 123 });
+    expect(parsed).not.toHaveProperty('extra');
+    expect(parsed).toMatchObject(minimalStudentQuestion);
   });
 });

--- a/apps/prairielearn/src/lib/client/safe-db-types.test.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.test.ts
@@ -555,7 +555,6 @@ const minimalStudentInstanceQuestion: z.input<typeof StudentInstanceQuestionSche
   current_value: null,
   highest_submission_score: null,
   id: '1',
-  last_grader: null,
   manual_points: null,
   number_attempts: 0,
   open: true,
@@ -678,10 +677,10 @@ describe('safe-db-types schemas', () => {
     expect(parsed).not.toHaveProperty('password');
     expect(parsed).toStrictEqual({
       active: true,
-      authorizedEdit: true,
-      creditDateString: null,
-      hasPassword: true,
-      showClosedAssessment: false,
+      authorized_edit: true,
+      credit_date_string: null,
+      has_password: true,
+      show_closed_assessment: false,
     });
   });
 

--- a/apps/prairielearn/src/lib/client/safe-db-types.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.ts
@@ -38,6 +38,7 @@ import {
   QuestionSchema as RawQuestionSchema,
   RubricItemSchema as RawRubricItemSchema,
   RubricSchema as RawRubricSchema,
+  SprocAuthzAssessmentInstanceSchema as RawSprocAuthzAssessmentInstanceSchema,
   StudentLabelSchema as RawStudentLabelSchema,
   TagSchema as RawTagSchema,
   TopicSchema as RawTopicSchema,
@@ -145,6 +146,29 @@ export type StudentAssessmentInstance__UNSAFE = z.infer<
   typeof StudentAssessmentInstanceSchema__UNSAFE
 >;
 
+/** Assessment Instance Authz Results */
+export const RawStudentAssessmentInstanceAuthzResultSchema =
+  RawSprocAuthzAssessmentInstanceSchema.pick({
+    active: true,
+    authorized_edit: true,
+    credit_date_string: true,
+    password: true,
+    show_closed_assessment: true,
+  }).transform(
+    ({ active, authorized_edit, credit_date_string, password, show_closed_assessment }) => ({
+      active,
+      authorizedEdit: authorized_edit,
+      creditDateString: credit_date_string,
+      hasPassword: password != null,
+      showClosedAssessment: show_closed_assessment,
+    }),
+  );
+export const StudentAssessmentInstanceAuthzResultSchema =
+  RawStudentAssessmentInstanceAuthzResultSchema.brand<'StudentAssessmentInstanceAuthzResult'>();
+export type StudentAssessmentInstanceAuthzResult = z.infer<
+  typeof StudentAssessmentInstanceAuthzResultSchema
+>;
+
 /** Assessment Modules */
 
 export const RawStaffAssessmentModuleSchema = RawAssessmentModuleSchema;
@@ -192,6 +216,18 @@ export const RawStaffAssessmentQuestionSchema = RawAssessmentQuestionSchema;
 export const StaffAssessmentQuestionSchema =
   RawStaffAssessmentQuestionSchema.brand<'StaffAssessmentQuestion'>();
 export type StaffAssessmentQuestion = z.infer<typeof StaffAssessmentQuestionSchema>;
+
+export const RawStudentAssessmentQuestionSchema = RawStaffAssessmentQuestionSchema.pick({
+  allow_real_time_grading: true,
+  grade_rate_minutes: true,
+  init_points: true,
+  max_auto_points: true,
+  max_manual_points: true,
+  max_points: true,
+});
+export const StudentAssessmentQuestionSchema =
+  RawStudentAssessmentQuestionSchema.brand<'StudentAssessmentQuestion'>();
+export type StudentAssessmentQuestion = z.infer<typeof StudentAssessmentQuestionSchema>;
 
 /** Audit Events */
 export const StaffAuditEventSchema = RawAuditEventSchema.brand<'StaffAuditEvent'>();
@@ -345,6 +381,26 @@ export const StaffInstanceQuestionSchema =
   RawStaffInstanceQuestionSchema.brand<'StaffInstanceQuestion'>();
 export type StaffInstanceQuestion = z.infer<typeof StaffInstanceQuestionSchema>;
 
+export const RawStudentInstanceQuestionSchema = RawStaffInstanceQuestionSchema.pick({
+  auto_points: true,
+  current_value: true,
+  highest_submission_score: true,
+  id: true,
+  last_grader: true,
+  manual_points: true,
+  number_attempts: true,
+  open: true,
+  points: true,
+  points_list: true,
+  points_list_original: true,
+  requires_manual_grading: true,
+  score_perc: true,
+  status: true,
+});
+export const StudentInstanceQuestionSchema =
+  RawStudentInstanceQuestionSchema.brand<'StudentInstanceQuestion'>();
+export type StudentInstanceQuestion = z.infer<typeof StudentInstanceQuestionSchema>;
+
 /** Institutions */
 export const RawAdminInstitutionSchema = RawInstitutionSchema.pick({
   course_instance_enrollment_limit: true,
@@ -380,6 +436,13 @@ export type StaffCourseInstancePublishingExtension = z.infer<
 export const RawStaffQuestionSchema = RawQuestionSchema;
 export const StaffQuestionSchema = RawStaffQuestionSchema.brand<'StaffQuestion'>();
 export type StaffQuestion = z.infer<typeof StaffQuestionSchema>;
+
+export const RawStudentQuestionSchema = RawStaffQuestionSchema.pick({
+  id: true,
+  title: true,
+});
+export const StudentQuestionSchema = RawStudentQuestionSchema.brand<'StudentQuestion'>();
+export type StudentQuestion = z.infer<typeof StudentQuestionSchema>;
 
 export const RawPublicQuestionSchema = RawStaffQuestionSchema.pick({
   id: true,
@@ -423,6 +486,17 @@ export type StudentUser = z.infer<typeof StudentUserSchema>;
 /** Zones */
 export const StaffZoneSchema = RawZoneSchema.brand<'StaffZone'>();
 export type StaffZone = z.infer<typeof StaffZoneSchema>;
+
+export const RawStudentZoneSchema = RawZoneSchema.pick({
+  best_questions: true,
+  id: true,
+  lockpoint: true,
+  max_points: true,
+  number: true,
+  title: true,
+});
+export const StudentZoneSchema = RawStudentZoneSchema.brand<'StudentZone'>();
+export type StudentZone = z.infer<typeof StudentZoneSchema>;
 
 export const StaffRubricSchema = RawRubricSchema.brand<'StaffRubric'>();
 export type StaffRubric = z.infer<typeof StaffRubricSchema>;

--- a/apps/prairielearn/src/lib/client/safe-db-types.ts
+++ b/apps/prairielearn/src/lib/client/safe-db-types.ts
@@ -154,15 +154,10 @@ export const RawStudentAssessmentInstanceAuthzResultSchema =
     credit_date_string: true,
     password: true,
     show_closed_assessment: true,
-  }).transform(
-    ({ active, authorized_edit, credit_date_string, password, show_closed_assessment }) => ({
-      active,
-      authorizedEdit: authorized_edit,
-      creditDateString: credit_date_string,
-      hasPassword: password != null,
-      showClosedAssessment: show_closed_assessment,
-    }),
-  );
+  }).transform(({ password, ...rest }) => ({
+    ...rest,
+    has_password: password != null,
+  }));
 export const StudentAssessmentInstanceAuthzResultSchema =
   RawStudentAssessmentInstanceAuthzResultSchema.brand<'StudentAssessmentInstanceAuthzResult'>();
 export type StudentAssessmentInstanceAuthzResult = z.infer<
@@ -386,7 +381,6 @@ export const RawStudentInstanceQuestionSchema = RawStaffInstanceQuestionSchema.p
   current_value: true,
   highest_submission_score: true,
   id: true,
-  last_grader: true,
   manual_points: true,
   number_attempts: true,
   open: true,


### PR DESCRIPTION
# Description

Add student-safe schemas for instance questions, assessment questions, zones, and questions to `safe-db-types.ts`. These are needed for the student assessment instance React conversion, where bundled `to_jsonb()` query results are parsed through safe schemas before being sent to the client.

Also narrow `ExamQuestionStatus` and `InstanceQuestionPoints` prop types from `Pick<FullType, ...>` to structural interfaces using indexed access types (`InstanceQuestion['status']`). This allows any object with the right field shapes to be accepted — including branded student schemas — without needing to strip brands via spreading.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation via Claude Code.

# Testing

New schemas are covered by existing test pattern in `safe-db-types.test.ts` (4 new test cases, 29/29 pass). `QuestionScore.tsx` type narrowing is backward-compatible — verified that `instructorAssessmentInstance` (the only other caller) still typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)