### PR TITLE
Add structural validation for missing points and Homework real-time grading

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentEditor.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentEditor.tsx
@@ -790,8 +790,8 @@ function AssessmentEditorInner({
     zone.questions.some((q) => q.alternatives?.length === 0),
   );
   const structuralSaveValidationErrorKind = useMemo(
-    () => getStructuralSaveValidationErrorKind(zones),
-    [zones],
+    () => getStructuralSaveValidationErrorKind(zones, assessment.type),
+    [zones, assessment.type],
   );
 
   const hasUnsavedChanges = useMemo(
@@ -830,6 +830,10 @@ function AssessmentEditorInner({
         return 'Cannot save: one or more zones have configuration errors';
       case 'altPool':
         return 'Cannot save: one or more alternative pools have configuration errors';
+      case 'questionPoints':
+        return 'Cannot save: one or more questions have no points configured';
+      case 'homeworkRealTimeGrading':
+        return 'Cannot save: real-time grading cannot be disabled for Homework assessments';
       default:
         return undefined;
     }

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentEditor.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentEditor.tsx
@@ -790,8 +790,8 @@ function AssessmentEditorInner({
     zone.questions.some((q) => q.alternatives?.length === 0),
   );
   const structuralSaveValidationErrorKind = useMemo(
-    () => getStructuralSaveValidationErrorKind(zones, assessment.type),
-    [zones, assessment.type],
+    () => getStructuralSaveValidationErrorKind(zones),
+    [zones],
   );
 
   const hasUnsavedChanges = useMemo(
@@ -832,8 +832,6 @@ function AssessmentEditorInner({
         return 'Cannot save: one or more alternative pools have configuration errors';
       case 'questionPoints':
         return 'Cannot save: one or more questions have no points configured';
-      case 'homeworkRealTimeGrading':
-        return 'Cannot save: real-time grading cannot be disabled for Homework assessments';
       default:
         return undefined;
     }

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/AdvancedFields.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/AdvancedFields.tsx
@@ -8,6 +8,7 @@ import type {
   UseFormWatch,
 } from 'react-hook-form';
 
+import type { EnumAssessmentType } from '../../../../lib/db-types.js';
 import type { InheritanceSource } from '../../types.js';
 import { coerceToBoolean, coerceToNumber } from '../../utils/formHelpers.js';
 
@@ -67,6 +68,7 @@ export function AdvancedFields({
   editMode = true,
   inheritance,
   zoneIndex,
+  assessmentType,
 }: {
   register: UseFormRegister<any>;
   errors?: FieldErrors;
@@ -75,6 +77,7 @@ export function AdvancedFields({
   editMode?: boolean;
   inheritance: AdvancedFieldsInheritance;
   zoneIndex?: number;
+  assessmentType: EnumAssessmentType;
 }) {
   const advanceScorePercRegisterProps = register('advanceScorePerc', {
     setValueAs: coerceToNumber,
@@ -121,7 +124,7 @@ export function AdvancedFields({
       effectiveAdvanceScorePerc == null &&
       effectiveGradeRateMinutes == null &&
       effectiveForceMaxPoints == null &&
-      effectiveAllowRealTimeGrading == null &&
+      (assessmentType === 'Homework' || effectiveAllowRealTimeGrading == null) &&
       !watchedLockpoint
     ) {
       return null;
@@ -389,7 +392,7 @@ export function AdvancedFields({
       {renderAdvanceScorePerc()}
       {renderGradeRateMinutes()}
       {variant !== 'zone' && renderForceMaxPoints()}
-      {renderAllowRealTimeGrading()}
+      {assessmentType !== 'Homework' && renderAllowRealTimeGrading()}
     </>
   );
 

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/AltPoolDetailPanel.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/AltPoolDetailPanel.tsx
@@ -106,7 +106,6 @@ export function AltPoolDetailPanel({
     // We use the result of trigger() directly because formState.isValid may
     // not update until user interaction with mode: 'onChange'.
     void trigger().then((valid) => {
-      // TODO: you can easily click off the item and save the form to bypass this validation.
       onFormValidChange(valid);
     });
   }, [alternativeCount, trigger, onFormValidChange]);
@@ -486,6 +485,7 @@ export function AltPoolDetailPanel({
         variant="altPool"
         editMode={editMode}
         inheritance={advancedInheritance}
+        assessmentType={assessmentType}
       />
     </div>
   );

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/QuestionDetailPanel.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/QuestionDetailPanel.tsx
@@ -222,7 +222,6 @@ export function QuestionDetailPanel({
   // not update until user interaction with mode: 'onChange'.
   useEffect(() => {
     void trigger().then((valid) => {
-      // TODO: you can easily click off the item and save the form to bypass this validation.
       onFormValidChange(valid);
     });
   }, [trigger, onFormValidChange]);
@@ -572,6 +571,7 @@ export function QuestionDetailPanel({
         variant="question"
         editMode={editMode}
         inheritance={advancedInheritance}
+        assessmentType={assessmentType}
       />
 
       {/* Action buttons */}

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/ZoneDetailPanel.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/ZoneDetailPanel.tsx
@@ -105,7 +105,6 @@ export function ZoneDetailPanel({
   // pre-existing invalid values (e.g. from JSON) are flagged immediately.
   useEffect(() => {
     void trigger().then((valid) => {
-      // TODO: you can easily click off the item and save the form to bypass this validation.
       onFormValidChange(valid);
     });
   }, [zoneQuestionCount, trigger, onFormValidChange]);
@@ -356,6 +355,7 @@ export function ZoneDetailPanel({
         editMode={editMode}
         inheritance={advancedInheritance}
         zoneIndex={zoneIndex}
+        assessmentType={assessmentType}
       />
     </div>
   );

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.test.ts
@@ -91,6 +91,19 @@ describe('getStructuralSaveValidationErrorKind', () => {
       ).toBeUndefined();
     });
 
+    it('treats zero as a valid points value', () => {
+      expect(
+        getStructuralSaveValidationErrorKind([
+          makeZone({ questions: [makeQuestion({ points: 0 })] }),
+        ]),
+      ).toBeUndefined();
+      expect(
+        getStructuralSaveValidationErrorKind([
+          makeZone({ questions: [makeQuestion({ autoPoints: 0, manualPoints: 0 })] }),
+        ]),
+      ).toBeUndefined();
+    });
+
     it('returns questionPoints when an alternative has no points and pool has no points', () => {
       expect(
         getStructuralSaveValidationErrorKind([

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.test.ts
@@ -48,182 +48,114 @@ function makeZone(overrides: Partial<ZoneAssessmentForm> = {}): ZoneAssessmentFo
 
 describe('getStructuralSaveValidationErrorKind', () => {
   it('returns undefined for valid zones', () => {
-    expect(getStructuralSaveValidationErrorKind([makeZone()], 'Exam')).toBeUndefined();
+    expect(getStructuralSaveValidationErrorKind([makeZone()])).toBeUndefined();
   });
 
   it('returns zone when the first zone is a lockpoint', () => {
     expect(
-      getStructuralSaveValidationErrorKind(
-        [makeZone({ lockpoint: true }), makeZone({ trackingId: makeTrackingId(2) })],
-        'Exam',
-      ),
+      getStructuralSaveValidationErrorKind([
+        makeZone({ lockpoint: true }),
+        makeZone({ trackingId: makeTrackingId(2) }),
+      ]),
     ).toBe('zone');
   });
 
   describe('questionPoints', () => {
     it('returns questionPoints when a standalone question has no points', () => {
       expect(
-        getStructuralSaveValidationErrorKind([makeZone({ questions: [makeQuestion()] })], 'Exam'),
+        getStructuralSaveValidationErrorKind([makeZone({ questions: [makeQuestion()] })]),
       ).toBe('questionPoints');
     });
 
     it('returns undefined when a standalone question has autoPoints', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [makeZone({ questions: [makeQuestion({ autoPoints: 5 })] })],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({ questions: [makeQuestion({ autoPoints: 5 })] }),
+        ]),
       ).toBeUndefined();
     });
 
     it('returns undefined when a standalone question has manualPoints', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [makeZone({ questions: [makeQuestion({ manualPoints: 5 })] })],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({ questions: [makeQuestion({ manualPoints: 5 })] }),
+        ]),
       ).toBeUndefined();
     });
 
     it('returns undefined when a standalone question has points', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [makeZone({ questions: [makeQuestion({ points: 5 })] })],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({ questions: [makeQuestion({ points: 5 })] }),
+        ]),
       ).toBeUndefined();
     });
 
     it('returns questionPoints when an alternative has no points and pool has no points', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [
-            makeZone({
-              questions: [
-                makeQuestion({
-                  id: undefined,
-                  alternatives: [makeAlternative()],
-                }),
-              ],
-            }),
-          ],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({
+            questions: [
+              makeQuestion({
+                id: undefined,
+                alternatives: [makeAlternative()],
+              }),
+            ],
+          }),
+        ]),
       ).toBe('questionPoints');
     });
 
     it('returns undefined when alternative inherits points from pool', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [
-            makeZone({
-              questions: [
-                makeQuestion({
-                  id: undefined,
-                  autoPoints: 10,
-                  alternatives: [makeAlternative()],
-                }),
-              ],
-            }),
-          ],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({
+            questions: [
+              makeQuestion({
+                id: undefined,
+                autoPoints: 10,
+                alternatives: [makeAlternative()],
+              }),
+            ],
+          }),
+        ]),
       ).toBeUndefined();
     });
 
     it('returns undefined when alternative has its own points', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [
-            makeZone({
-              questions: [
-                makeQuestion({
-                  id: undefined,
-                  alternatives: [makeAlternative({ autoPoints: 5 })],
-                }),
-              ],
-            }),
-          ],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({
+            questions: [
+              makeQuestion({
+                id: undefined,
+                alternatives: [makeAlternative({ autoPoints: 5 })],
+              }),
+            ],
+          }),
+        ]),
       ).toBeUndefined();
     });
 
     it('returns questionPoints when one alternative in pool has no points', () => {
       expect(
-        getStructuralSaveValidationErrorKind(
-          [
-            makeZone({
-              questions: [
-                makeQuestion({
-                  id: undefined,
-                  alternatives: [
-                    makeAlternative({ autoPoints: 5 }),
-                    makeAlternative({
-                      trackingId: makeTrackingId(201),
-                      id: 'alt2',
-                    }),
-                  ],
-                }),
-              ],
-            }),
-          ],
-          'Exam',
-        ),
+        getStructuralSaveValidationErrorKind([
+          makeZone({
+            questions: [
+              makeQuestion({
+                id: undefined,
+                alternatives: [
+                  makeAlternative({ autoPoints: 5 }),
+                  makeAlternative({
+                    trackingId: makeTrackingId(201),
+                    id: 'alt2',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ]),
       ).toBe('questionPoints');
-    });
-  });
-
-  describe('homeworkRealTimeGrading', () => {
-    it('returns homeworkRealTimeGrading when a zone disables it on Homework', () => {
-      expect(
-        getStructuralSaveValidationErrorKind(
-          [makeZone({ allowRealTimeGrading: false })],
-          'Homework',
-        ),
-      ).toBe('homeworkRealTimeGrading');
-    });
-
-    it('returns homeworkRealTimeGrading when a question disables it on Homework', () => {
-      expect(
-        getStructuralSaveValidationErrorKind(
-          [
-            makeZone({
-              questions: [makeQuestion({ autoPoints: 10, allowRealTimeGrading: false })],
-            }),
-          ],
-          'Homework',
-        ),
-      ).toBe('homeworkRealTimeGrading');
-    });
-
-    it('returns homeworkRealTimeGrading when an alternative disables it on Homework', () => {
-      expect(
-        getStructuralSaveValidationErrorKind(
-          [
-            makeZone({
-              questions: [
-                makeQuestion({
-                  id: undefined,
-                  autoPoints: 10,
-                  alternatives: [makeAlternative({ allowRealTimeGrading: false })],
-                }),
-              ],
-            }),
-          ],
-          'Homework',
-        ),
-      ).toBe('homeworkRealTimeGrading');
-    });
-
-    it('returns undefined when real-time grading is disabled on Exam', () => {
-      expect(
-        getStructuralSaveValidationErrorKind([makeZone({ allowRealTimeGrading: false })], 'Exam'),
-      ).toBeUndefined();
-    });
-
-    it('returns undefined when allowRealTimeGrading is not explicitly false on Homework', () => {
-      expect(getStructuralSaveValidationErrorKind([makeZone()], 'Homework')).toBeUndefined();
     });
   });
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.test.ts
@@ -1,11 +1,28 @@
 import { describe, expect, it } from 'vitest';
 
-import type { TrackingId, ZoneAssessmentForm, ZoneQuestionBlockForm } from '../types.js';
+import type {
+  QuestionAlternativeForm,
+  TrackingId,
+  ZoneAssessmentForm,
+  ZoneQuestionBlockForm,
+} from '../types.js';
 
 import { getStructuralSaveValidationErrorKind } from './saveValidation.js';
 
 function makeTrackingId(n: number): TrackingId {
   return `00000000-0000-4000-8000-${String(n).padStart(12, '0')}` as TrackingId;
+}
+
+function makeAlternative(
+  overrides: Partial<QuestionAlternativeForm> = {},
+): QuestionAlternativeForm {
+  return {
+    trackingId: makeTrackingId(200),
+    id: 'alt1',
+    canSubmit: [],
+    canView: [],
+    ...overrides,
+  } as QuestionAlternativeForm;
 }
 
 function makeQuestion(overrides: Partial<ZoneQuestionBlockForm> = {}): ZoneQuestionBlockForm {
@@ -24,22 +41,189 @@ function makeZone(overrides: Partial<ZoneAssessmentForm> = {}): ZoneAssessmentFo
     lockpoint: false,
     canSubmit: [],
     canView: [],
-    questions: [makeQuestion()],
+    questions: [makeQuestion({ autoPoints: 10 })],
     ...overrides,
   };
 }
 
 describe('getStructuralSaveValidationErrorKind', () => {
   it('returns undefined for valid zones', () => {
-    expect(getStructuralSaveValidationErrorKind([makeZone()])).toBeUndefined();
+    expect(getStructuralSaveValidationErrorKind([makeZone()], 'Exam')).toBeUndefined();
   });
 
   it('returns zone when the first zone is a lockpoint', () => {
     expect(
-      getStructuralSaveValidationErrorKind([
-        makeZone({ lockpoint: true }),
-        makeZone({ trackingId: makeTrackingId(2) }),
-      ]),
+      getStructuralSaveValidationErrorKind(
+        [makeZone({ lockpoint: true }), makeZone({ trackingId: makeTrackingId(2) })],
+        'Exam',
+      ),
     ).toBe('zone');
+  });
+
+  describe('questionPoints', () => {
+    it('returns questionPoints when a standalone question has no points', () => {
+      expect(
+        getStructuralSaveValidationErrorKind([makeZone({ questions: [makeQuestion()] })], 'Exam'),
+      ).toBe('questionPoints');
+    });
+
+    it('returns undefined when a standalone question has autoPoints', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [makeZone({ questions: [makeQuestion({ autoPoints: 5 })] })],
+          'Exam',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when a standalone question has manualPoints', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [makeZone({ questions: [makeQuestion({ manualPoints: 5 })] })],
+          'Exam',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when a standalone question has points', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [makeZone({ questions: [makeQuestion({ points: 5 })] })],
+          'Exam',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns questionPoints when an alternative has no points and pool has no points', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [
+            makeZone({
+              questions: [
+                makeQuestion({
+                  id: undefined,
+                  alternatives: [makeAlternative()],
+                }),
+              ],
+            }),
+          ],
+          'Exam',
+        ),
+      ).toBe('questionPoints');
+    });
+
+    it('returns undefined when alternative inherits points from pool', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [
+            makeZone({
+              questions: [
+                makeQuestion({
+                  id: undefined,
+                  autoPoints: 10,
+                  alternatives: [makeAlternative()],
+                }),
+              ],
+            }),
+          ],
+          'Exam',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when alternative has its own points', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [
+            makeZone({
+              questions: [
+                makeQuestion({
+                  id: undefined,
+                  alternatives: [makeAlternative({ autoPoints: 5 })],
+                }),
+              ],
+            }),
+          ],
+          'Exam',
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns questionPoints when one alternative in pool has no points', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [
+            makeZone({
+              questions: [
+                makeQuestion({
+                  id: undefined,
+                  alternatives: [
+                    makeAlternative({ autoPoints: 5 }),
+                    makeAlternative({
+                      trackingId: makeTrackingId(201),
+                      id: 'alt2',
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+          'Exam',
+        ),
+      ).toBe('questionPoints');
+    });
+  });
+
+  describe('homeworkRealTimeGrading', () => {
+    it('returns homeworkRealTimeGrading when a zone disables it on Homework', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [makeZone({ allowRealTimeGrading: false })],
+          'Homework',
+        ),
+      ).toBe('homeworkRealTimeGrading');
+    });
+
+    it('returns homeworkRealTimeGrading when a question disables it on Homework', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [
+            makeZone({
+              questions: [makeQuestion({ autoPoints: 10, allowRealTimeGrading: false })],
+            }),
+          ],
+          'Homework',
+        ),
+      ).toBe('homeworkRealTimeGrading');
+    });
+
+    it('returns homeworkRealTimeGrading when an alternative disables it on Homework', () => {
+      expect(
+        getStructuralSaveValidationErrorKind(
+          [
+            makeZone({
+              questions: [
+                makeQuestion({
+                  id: undefined,
+                  autoPoints: 10,
+                  alternatives: [makeAlternative({ allowRealTimeGrading: false })],
+                }),
+              ],
+            }),
+          ],
+          'Homework',
+        ),
+      ).toBe('homeworkRealTimeGrading');
+    });
+
+    it('returns undefined when real-time grading is disabled on Exam', () => {
+      expect(
+        getStructuralSaveValidationErrorKind([makeZone({ allowRealTimeGrading: false })], 'Exam'),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when allowRealTimeGrading is not explicitly false on Homework', () => {
+      expect(getStructuralSaveValidationErrorKind([makeZone()], 'Homework')).toBeUndefined();
+    });
   });
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.ts
@@ -1,3 +1,4 @@
+import type { EnumAssessmentType } from '../../../lib/db-types.js';
 import type { ZoneAssessmentForm, ZoneQuestionBlockForm } from '../types.js';
 
 import { validatePositiveInteger } from './questions.js';
@@ -32,15 +33,64 @@ function altPoolHasStructuralValidationError(question: ZoneQuestionBlockForm): b
   return validatePositiveInteger(question.numberChoose, 'Number to choose') != null;
 }
 
+function hasPoints(q: {
+  points?: number | number[] | null;
+  autoPoints?: number | number[] | null;
+  manualPoints?: number | null;
+}): boolean {
+  return q.points != null || q.autoPoints != null || q.manualPoints != null;
+}
+
+/**
+ * Returns true if any question or alternative in the tree is missing points
+ * (considering inheritance from the parent alt pool).
+ */
+function questionHasMissingPoints(question: ZoneQuestionBlockForm): boolean {
+  if (question.alternatives) {
+    return question.alternatives.some((alt) => !hasPoints(alt) && !hasPoints(question));
+  }
+  return !hasPoints(question);
+}
+
+/**
+ * Returns true if any zone, question, or alt pool in the tree has
+ * `allowRealTimeGrading` explicitly set to `false`, which is invalid
+ * for Homework assessments.
+ */
+function hasRealTimeGradingDisabled(zones: ZoneAssessmentForm[]): boolean {
+  return zones.some((zone) => {
+    if (zone.allowRealTimeGrading === false) return true;
+    return zone.questions.some((question) => {
+      if (question.allowRealTimeGrading === false) return true;
+      return question.alternatives?.some((alt) => alt.allowRealTimeGrading === false);
+    });
+  });
+}
+
+export type StructuralSaveValidationErrorKind =
+  | 'zone'
+  | 'altPool'
+  | 'questionPoints'
+  | 'homeworkRealTimeGrading';
+
 export function getStructuralSaveValidationErrorKind(
   zones: ZoneAssessmentForm[],
-): 'zone' | 'altPool' | undefined {
+  assessmentType: EnumAssessmentType,
+): StructuralSaveValidationErrorKind | undefined {
   if (zones.some(zoneHasStructuralValidationError)) {
     return 'zone';
   }
 
   if (zones.some((zone) => zone.questions.some(altPoolHasStructuralValidationError))) {
     return 'altPool';
+  }
+
+  if (zones.some((zone) => zone.questions.some(questionHasMissingPoints))) {
+    return 'questionPoints';
+  }
+
+  if (assessmentType === 'Homework' && hasRealTimeGradingDisabled(zones)) {
+    return 'homeworkRealTimeGrading';
   }
 
   return undefined;

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.ts
@@ -1,4 +1,3 @@
-import type { EnumAssessmentType } from '../../../lib/db-types.js';
 import type { ZoneAssessmentForm, ZoneQuestionBlockForm } from '../types.js';
 
 import { validatePositiveInteger } from './questions.js';
@@ -52,31 +51,9 @@ function questionHasMissingPoints(question: ZoneQuestionBlockForm): boolean {
   return !hasPoints(question);
 }
 
-/**
- * Returns true if any zone, question, or alt pool in the tree has
- * `allowRealTimeGrading` explicitly set to `false`, which is invalid
- * for Homework assessments.
- */
-function hasRealTimeGradingDisabled(zones: ZoneAssessmentForm[]): boolean {
-  return zones.some((zone) => {
-    if (zone.allowRealTimeGrading === false) return true;
-    return zone.questions.some((question) => {
-      if (question.allowRealTimeGrading === false) return true;
-      return question.alternatives?.some((alt) => alt.allowRealTimeGrading === false) ?? false;
-    });
-  });
-}
-
-export type StructuralSaveValidationErrorKind =
-  | 'zone'
-  | 'altPool'
-  | 'questionPoints'
-  | 'homeworkRealTimeGrading';
-
 export function getStructuralSaveValidationErrorKind(
   zones: ZoneAssessmentForm[],
-  assessmentType: EnumAssessmentType,
-): StructuralSaveValidationErrorKind | undefined {
+): 'zone' | 'altPool' | 'questionPoints' | undefined {
   if (zones.some(zoneHasStructuralValidationError)) {
     return 'zone';
   }
@@ -87,10 +64,6 @@ export function getStructuralSaveValidationErrorKind(
 
   if (zones.some((zone) => zone.questions.some(questionHasMissingPoints))) {
     return 'questionPoints';
-  }
-
-  if (assessmentType === 'Homework' && hasRealTimeGradingDisabled(zones)) {
-    return 'homeworkRealTimeGrading';
   }
 
   return undefined;

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/saveValidation.ts
@@ -62,7 +62,7 @@ function hasRealTimeGradingDisabled(zones: ZoneAssessmentForm[]): boolean {
     if (zone.allowRealTimeGrading === false) return true;
     return zone.questions.some((question) => {
       if (question.allowRealTimeGrading === false) return true;
-      return question.alternatives?.some((alt) => alt.allowRealTimeGrading === false);
+      return question.alternatives?.some((alt) => alt.allowRealTimeGrading === false) ?? false;
     });
   });
 }


### PR DESCRIPTION
# Description

The assessment editor's form-level validation only runs on the currently-selected item's detail panel. This allows invalid state to be saved when changes to one entity (e.g. clearing an alt pool's points) invalidate a different entity (e.g. its alternatives that were inheriting those points), since that entity's form is not mounted and its validation doesn't run.

This PR adds a new structural validation that checks the entire zone tree on every render, preventing save when any question or alternative has no effective points (own or inherited from alt pool).

Also hides the `allowRealTimeGrading` checkbox in the Advanced Fields section for Homework assessments, since it can never validly be set to `false`. (Structural validation is not needed here — hiding the field prevents the editor from creating the invalid state, and server-side sync validation handles pre-existing bad data from hand-edited JSON.)

Closes #14441

- [x] I have disclosed the level of AI assistance used: majority of implementation with human review.

# Testing

- Added 10 unit tests covering all new and existing structural validation behavior (missing points on standalone questions, alternatives with/without inheritance).
- To manually test the missing-points fix: add two questions to an alt group, ensure they inherit points from the pool, then clear the pool's points. The save button should now be disabled with a tooltip explaining the issue.
- To manually test the real-time grading fix: open a Homework assessment in the editor and verify the "Allow real-time grading" checkbox no longer appears in Advanced Fields.