### PR TITLE
Replace useRef/useEffect stale-closure pattern with RHF deps in AfterLastDeadlineField

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -8,6 +8,7 @@ import {
   useWatch,
 } from 'react-hook-form';
 
+import { run } from '@prairielearn/run';
 import { RichSelect, type RichSelectItem } from '@prairielearn/ui';
 
 import { FriendlyDate } from '../../../../components/FriendlyDate.js';
@@ -68,22 +69,6 @@ function resolveConstraints(
   };
 }
 
-type FormPath = FieldPath<AccessControlFormData>;
-
-/** Field paths that the credit validation depends on. */
-function getCreditDeps(overrideIndex?: number): FormPath[] {
-  if (overrideIndex == null) {
-    return ['mainRule.dueDate', 'mainRule.lateDeadlines'];
-  }
-  return [
-    `overrides.${overrideIndex}.overriddenFields` as FormPath,
-    `overrides.${overrideIndex}.dueDate` as FormPath,
-    `overrides.${overrideIndex}.lateDeadlines` as FormPath,
-    'mainRule.dueDate',
-    'mainRule.lateDeadlines',
-  ];
-}
-
 function AfterLastDeadlineInput({
   value,
   onChange,
@@ -102,7 +87,21 @@ function AfterLastDeadlineInput({
     ? (`overrides.${overrideIndex}.afterLastDeadline.credit` as const)
     : ('mainRule.afterLastDeadline.credit' as const);
   const idPrefix = isOverride ? `overrides-${overrideIndex}` : 'mainRule';
-  const creditDeps = getCreditDeps(overrideIndex);
+
+  // Field paths that affect credit validation — used for both display
+  // reactivity (useWatch) and validation re-triggering (deps).
+  const creditDeps = run<FieldPath<AccessControlFormData>[]>(() => {
+    if (isOverride) {
+      return [
+        'mainRule.dueDate',
+        'mainRule.lateDeadlines',
+        `overrides.${overrideIndex}.overriddenFields`,
+        `overrides.${overrideIndex}.dueDate`,
+        `overrides.${overrideIndex}.lateDeadlines`,
+      ];
+    }
+    return ['mainRule.dueDate', 'mainRule.lateDeadlines'];
+  });
 
   const { register, getValues } = useFormContext<AccessControlFormData>();
   const { errors } = useFormState();

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useRef } from 'react';
 import { Alert, Form, InputGroup } from 'react-bootstrap';
-import { get, useController, useFormContext, useFormState, useWatch } from 'react-hook-form';
+import {
+  type FieldPath,
+  get,
+  useController,
+  useFormContext,
+  useFormState,
+  useWatch,
+} from 'react-hook-form';
 
 import { RichSelect, type RichSelectItem } from '@prairielearn/ui';
 
@@ -38,42 +44,74 @@ function getMode(value: AfterLastDeadlineValue | null): AfterLastDeadlineMode {
   return 'partial_credit';
 }
 
+/**
+ * Derive the effective dueDate and lateDeadlines from form values, handling
+ * override fallback via `overriddenFields`.
+ */
+function resolveConstraints(
+  formValues: AccessControlFormData,
+  overrideIndex?: number,
+): { dueDate: string | null; lateDeadlines: DeadlineEntry[] } {
+  if (overrideIndex == null) {
+    return {
+      dueDate: formValues.mainRule.dueDate,
+      lateDeadlines: formValues.mainRule.lateDeadlines,
+    };
+  }
+  const override = formValues.overrides[overrideIndex];
+  const overriddenFields = override.overriddenFields;
+  return {
+    dueDate: overriddenFields.includes('dueDate') ? override.dueDate : formValues.mainRule.dueDate,
+    lateDeadlines: overriddenFields.includes('lateDeadlines')
+      ? override.lateDeadlines
+      : formValues.mainRule.lateDeadlines,
+  };
+}
+
+type FormPath = FieldPath<AccessControlFormData>;
+
+/** Field paths that the credit validation depends on. */
+function getCreditDeps(overrideIndex?: number): FormPath[] {
+  if (overrideIndex == null) {
+    return ['mainRule.dueDate', 'mainRule.lateDeadlines'];
+  }
+  return [
+    `overrides.${overrideIndex}.overriddenFields` as FormPath,
+    `overrides.${overrideIndex}.dueDate` as FormPath,
+    `overrides.${overrideIndex}.lateDeadlines` as FormPath,
+    'mainRule.dueDate',
+    'mainRule.lateDeadlines',
+  ];
+}
+
 function AfterLastDeadlineInput({
   value,
   onChange,
-  idPrefix,
-  dueDate,
-  lateDeadlines,
-  creditFieldPath,
+  overrideIndex,
   displayTimezone,
   showNoDueDateWarning = true,
 }: {
   value: AfterLastDeadlineValue | null;
   onChange: (value: AfterLastDeadlineValue | null) => void;
-  idPrefix: string;
-  dueDate: string | null | undefined;
-  lateDeadlines: DeadlineEntry[] | undefined;
-  creditFieldPath:
-    | 'mainRule.afterLastDeadline.credit'
-    | `overrides.${number}.afterLastDeadline.credit`;
+  overrideIndex?: number;
   displayTimezone: string;
   showNoDueDateWarning?: boolean;
 }) {
-  const { register, trigger } = useFormContext<AccessControlFormData>();
+  const isOverride = overrideIndex != null;
+  const creditFieldPath = isOverride
+    ? (`overrides.${overrideIndex}.afterLastDeadline.credit` as const)
+    : ('mainRule.afterLastDeadline.credit' as const);
+  const idPrefix = isOverride ? `overrides-${overrideIndex}` : 'mainRule';
+  const creditDeps = getCreditDeps(overrideIndex);
+
+  const { register, getValues } = useFormContext<AccessControlFormData>();
   const { errors } = useFormState();
   const creditError: string | undefined = get(errors, creditFieldPath)?.message;
 
-  // Store constraint values in refs so the validate function (which is captured
-  // once by register()) always reads current values instead of stale closures.
-  const lateDeadlinesRef = useRef(lateDeadlines);
-  const dueDateRef = useRef(dueDate);
-  lateDeadlinesRef.current = lateDeadlines;
-  dueDateRef.current = dueDate;
-
-  // Re-validate credit when late deadlines or due date change.
-  useEffect(() => {
-    void trigger(creditFieldPath);
-  }, [lateDeadlines, dueDate, creditFieldPath, trigger]);
+  // Watch dep fields so this component re-renders when they change,
+  // keeping display values (last-deadline text, warnings) up to date.
+  useWatch<AccessControlFormData>({ name: creditDeps });
+  const { dueDate, lateDeadlines } = resolveConstraints(getValues(), overrideIndex);
 
   const mode = getMode(value);
 
@@ -90,7 +128,7 @@ function AfterLastDeadlineInput({
     return 'This will take effect after the last deadline';
   };
 
-  const hasLastDeadline = !!dueDate || (lateDeadlines && lateDeadlines.length > 0);
+  const hasLastDeadline = !!dueDate || lateDeadlines.length > 0;
 
   const handleModeChange = (newMode: AfterLastDeadlineMode) => {
     switch (newMode) {
@@ -146,12 +184,13 @@ function AfterLastDeadlineInput({
               {...register(creditFieldPath, {
                 shouldUnregister: true,
                 valueAsNumber: true,
-                validate: (v) => {
+                deps: creditDeps,
+                validate: (v, formValues) => {
                   if (v == null || Number.isNaN(v)) return 'Credit is required';
-                  if (v < 0 || v > 200) return 'Must be 0–200%';
+                  if (v < 0 || v > 200) return 'Must be 0\u2013200%';
+                  const { dueDate, lateDeadlines } = resolveConstraints(formValues, overrideIndex);
                   const precedingCredit =
-                    lateDeadlinesRef.current?.at(-1)?.credit ??
-                    (dueDateRef.current != null ? 100 : undefined);
+                    lateDeadlines.at(-1)?.credit ?? (dueDate != null ? 100 : undefined);
                   if (precedingCredit != null && v > precedingCredit) {
                     return `Must not exceed ${precedingCredit}% (the preceding deadline's credit)`;
                   }
@@ -184,21 +223,9 @@ export function MainAfterLastDeadlineField({ displayTimezone }: { displayTimezon
     name: 'mainRule.afterLastDeadline',
   });
 
-  const dueDate = useWatch<AccessControlFormData, 'mainRule.dueDate'>({
-    name: 'mainRule.dueDate',
-  });
-
-  const lateDeadlines = useWatch<AccessControlFormData, 'mainRule.lateDeadlines'>({
-    name: 'mainRule.lateDeadlines',
-  });
-
   return (
     <AfterLastDeadlineInput
       value={field.value}
-      idPrefix="mainRule"
-      dueDate={dueDate}
-      lateDeadlines={lateDeadlines}
-      creditFieldPath="mainRule.afterLastDeadline.credit"
       displayTimezone={displayTimezone}
       onChange={field.onChange}
     />
@@ -225,22 +252,6 @@ export function OverrideAfterLastDeadlineField({
     'afterLastDeadline',
   );
 
-  const { isOverridden: dueDateOverridden } = useOverrideField(index, 'dueDate');
-  const dueDate = useWatch<AccessControlFormData, `overrides.${number}.dueDate`>({
-    name: `overrides.${index}.dueDate`,
-  });
-  const mainDueDate = useWatch<AccessControlFormData, 'mainRule.dueDate'>({
-    name: 'mainRule.dueDate',
-  });
-
-  const { isOverridden: lateDeadlinesOverridden } = useOverrideField(index, 'lateDeadlines');
-  const lateDeadlines = useWatch<AccessControlFormData, `overrides.${number}.lateDeadlines`>({
-    name: `overrides.${index}.lateDeadlines`,
-  });
-  const mainLateDeadlines = useWatch<AccessControlFormData, 'mainRule.lateDeadlines'>({
-    name: 'mainRule.lateDeadlines',
-  });
-
   return (
     <FieldWrapper
       isOverridden={isOverridden}
@@ -253,10 +264,7 @@ export function OverrideAfterLastDeadlineField({
     >
       <AfterLastDeadlineInput
         value={field.value}
-        idPrefix={`overrides-${index}`}
-        dueDate={dueDateOverridden ? dueDate : mainDueDate}
-        lateDeadlines={lateDeadlinesOverridden ? lateDeadlines : mainLateDeadlines}
-        creditFieldPath={`overrides.${index}.afterLastDeadline.credit`}
+        overrideIndex={index}
         displayTimezone={displayTimezone}
         showNoDueDateWarning={false}
         onChange={field.onChange}


### PR DESCRIPTION
# Description

Replace the `useRef` + `useEffect` + `trigger` stale-closure workaround in `AfterLastDeadlineField` with RHF's built-in `deps` option and `formValues` second argument to `validate`.

The key change: `AfterLastDeadlineInput` now takes `overrideIndex?: number` instead of individual constraint props (`dueDate`, `lateDeadlines`, `creditFieldPath`, `idPrefix`) and derives everything internally via a pure `resolveConstraints(formValues, overrideIndex)` function. This function reads the effective dueDate/lateDeadlines from form values, handling override fallback via `overriddenFields`. The same function is used for both display and validation, ensuring a single source of truth.

This eliminates refs, useEffect, trigger, and 6 hook calls from `OverrideAfterLastDeadlineField` (2 `useOverrideField` + 4 `useWatch`).

`DeadlineArrayField` and `PrairieTestControlForm` were investigated but left as-is — their `useFieldArray` patterns have timing issues (newly appended fields, sibling cross-validation) that `deps` can't cleanly replace.

AI assistance: majority of implementation.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

- Typechecked, linted, and formatted the changed file
- Should be manually tested by verifying credit validation and display updates work correctly in the assessment access form for both main rules and overrides