### PR TITLE
Suppress question visibility hint when no completion mechanism

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -94,6 +94,7 @@ function QuestionVisibilityInput({
   onChange,
   idPrefix,
   hasPrairieTest = false,
+  hasCompletionMechanism = true,
   showAgainDateError,
   hideAgainDateError,
   displayTimezone,
@@ -102,6 +103,7 @@ function QuestionVisibilityInput({
   onChange: (value: QuestionVisibilityValue) => void;
   idPrefix: string;
   hasPrairieTest?: boolean;
+  hasCompletionMechanism?: boolean;
   showAgainDateError?: string;
   hideAgainDateError?: string;
   displayTimezone: string;
@@ -250,7 +252,7 @@ function QuestionVisibilityInput({
           connected. Students may be able to view exam content when their assessment is closed.
         </Alert>
       )}
-      {!hasPrairieTest && hideQuestionsMode !== 'show_questions' && (
+      {!hasPrairieTest && hasCompletionMechanism && hideQuestionsMode !== 'show_questions' && (
         <Alert variant="info" className="mt-2 mb-0">
           If this is not an exam, consider setting question visibility to "Show questions after
           completion" so students can review their work.
@@ -462,6 +464,7 @@ export function MainAfterCompleteForm({
           value={qvField.value}
           idPrefix="mainRule"
           hasPrairieTest={hasPrairieTest}
+          hasCompletionMechanism={hasCompletionMechanism}
           showAgainDateError={qvShowAgainDateError}
           hideAgainDateError={hideAgainDateError}
           displayTimezone={displayTimezone}


### PR DESCRIPTION
# Description

When an assessment has no completion mechanism (no due date, late deadlines, duration, or PrairieTest), the "consider setting question visibility to 'Show questions after completion'" info alert was shown for "hide questions permanently". But following that advice would trigger a contradictory warning: "These settings will have no effect because there is no way for the assessment to be completed." This made it impossible to reach a state with no warning message.

This suppresses the info alert when there is no completion mechanism, since the advice it gives would be counterproductive in that case.

- [x] AI: majority of implementation

# Testing

- Select "hide questions permanently" on an assessment with no due date, duration, or PrairieTest — the info alert should no longer appear.
- Add a due date — the info alert should reappear.
- On override rules, the info alert behavior is unchanged (defaults to showing).