### PR TITLE
Add sharing name in QID for assessment downloads and score uploads

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.sql
+++ b/apps/prairielearn/src/lib/score-upload.sql
@@ -52,9 +52,10 @@ WHERE
       $submission_id IS NULL
       AND COALESCE(g.name, u.uid) = $uid_or_group
       AND ai.number = $ai_number
+      AND q.qid = $qid
       AND (
-        q.qid = $qid
-        OR ('@' || c.sharing_name || '/' || q.qid) = $qid
+        $sharing_name::text IS NULL
+        OR c.sharing_name = $sharing_name
       )
     )
   )

--- a/apps/prairielearn/src/lib/score-upload.sql
+++ b/apps/prairielearn/src/lib/score-upload.sql
@@ -29,11 +29,13 @@ SELECT
   s.id AS submission_id,
   iq.id AS instance_question_id,
   COALESCE(g.name, u.uid) AS uid_or_group,
+  c.sharing_name,
   q.qid
 FROM
   instance_questions AS iq
   JOIN assessment_questions AS aq ON (aq.id = iq.assessment_question_id)
   JOIN questions AS q ON (q.id = aq.question_id)
+  JOIN courses AS c ON (c.id = q.course_id)
   JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
   LEFT JOIN teams AS g ON (
     g.id = ai.team_id
@@ -50,7 +52,10 @@ WHERE
       $submission_id IS NULL
       AND COALESCE(g.name, u.uid) = $uid_or_group
       AND ai.number = $ai_number
-      AND q.qid = $qid
+      AND (
+        q.qid = $qid
+        OR ('@' || c.sharing_name || '/' || q.qid) = $qid
+      )
     )
   )
 ORDER BY

--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -253,6 +253,7 @@ async function updateInstanceQuestionFromCsvRow(
         submission_id: IdSchema.nullable(),
         instance_question_id: IdSchema,
         uid_or_group: z.string(),
+        sharing_name: z.string().nullable(),
         qid: z.string(),
       }),
     );
@@ -267,7 +268,13 @@ async function updateInstanceQuestionFromCsvRow(
         `Found submission with id=${record.submission_id}, but uid/group does not match ${uid_or_group}.`,
       );
     }
-    if (record.qid !== null && submission_data.qid !== record.qid) {
+
+    // For the QID, accept either the raw QID or the sharing QID format
+    const sharing_qid =
+      submission_data.sharing_name == null
+        ? submission_data.qid
+        : `@${submission_data.sharing_name}/${submission_data.qid}`;
+    if (record.qid !== null && submission_data.qid !== record.qid && sharing_qid !== record.qid) {
       throw new Error(
         `Found submission with id=${record.submission_id}, but QID does not match ${record.qid}.`,
       );

--- a/apps/prairielearn/src/lib/score-upload.ts
+++ b/apps/prairielearn/src/lib/score-upload.ts
@@ -239,6 +239,16 @@ async function updateInstanceQuestionFromCsvRow(
 ): Promise<boolean> {
   const uid_or_group = record.group_name ?? record.uid;
 
+  // For the QID, accept either the raw QID or the sharing QID format. If the
+  // QID starts with "@", treat it as a sharing QID and split it into
+  // sharing_name and qid components. Otherwise, treat the entire QID as the raw
+  // qid and set sharing_name to null (so it's not enforced).
+  const [sharing_name, ...splitQid] =
+    typeof record.qid === 'string' && record.qid.startsWith('@')
+      ? record.qid.slice(1).split('/')
+      : [null, [record.qid]];
+  const qid = typeof record.qid === 'string' ? splitQid.join('/') : null;
+
   return await sqldb.runInTransactionAsync(async () => {
     const submission_data = await sqldb.queryOptionalRow(
       sql.select_submission_to_update,
@@ -247,7 +257,8 @@ async function updateInstanceQuestionFromCsvRow(
         submission_id: record.submission_id,
         uid_or_group,
         ai_number: record.instance,
-        qid: record.qid,
+        qid,
+        sharing_name,
       },
       z.object({
         submission_id: IdSchema.nullable(),
@@ -269,14 +280,15 @@ async function updateInstanceQuestionFromCsvRow(
       );
     }
 
-    // For the QID, accept either the raw QID or the sharing QID format
-    const sharing_qid =
-      submission_data.sharing_name == null
-        ? submission_data.qid
-        : `@${submission_data.sharing_name}/${submission_data.qid}`;
-    if (record.qid !== null && submission_data.qid !== record.qid && sharing_qid !== record.qid) {
+    if (record.qid !== null && submission_data.qid !== qid) {
       throw new Error(
         `Found submission with id=${record.submission_id}, but QID does not match ${record.qid}.`,
+      );
+    }
+
+    if (sharing_name !== null && submission_data.sharing_name !== sharing_name) {
+      throw new Error(
+        `Found submission with id=${record.submission_id}, but sharing name does not match ${record.sharing_name}.`,
       );
     }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentDownloads/instructorAssessmentDownloads.sql
@@ -96,7 +96,10 @@ SELECT
   ai.number AS assessment_instance_number,
   z.number AS zone_number,
   z.title AS zone_title,
-  q.qid,
+  CASE
+    WHEN ci.course_id = q.course_id THEN q.qid
+    ELSE '@' || c.sharing_name || '/' || q.qid
+  END AS qid,
   iq.number AS instance_question_number,
   iq.points,
   iq.score_perc,
@@ -132,6 +135,7 @@ FROM
   LEFT JOIN users AS lgu ON (lgu.id = iq.last_grader)
   JOIN alternative_groups AS ag ON (ag.id = aq.alternative_group_id)
   JOIN zones AS z ON (z.id = ag.zone_id)
+  JOIN courses AS c ON (c.id = q.course_id)
 WHERE
   a.id = $assessment_id
 ORDER BY
@@ -139,7 +143,7 @@ ORDER BY
   u.uin,
   group_name,
   ai.number,
-  q.qid,
+  qid,
   iq.number,
   iq.id;
 
@@ -166,11 +170,14 @@ WITH
   ),
   final_submissions AS (
     SELECT DISTINCT
-      ON (ai.id, q.qid) u.uid,
+      ON (ai.id, q.id) u.uid,
       u.uin,
       z.number AS zone_number,
       z.title AS zone_title,
-      q.qid,
+      CASE
+        WHEN v.course_id = q.course_id THEN q.qid
+        ELSE '@' || c.sharing_name || '/' || q.qid
+      END AS qid,
       iq.score_perc AS old_score_perc,
       iq.auto_points AS old_auto_points,
       iq.manual_points AS old_manual_points,
@@ -198,9 +205,10 @@ WITH
       JOIN questions AS q ON (q.id = aq.question_id)
       JOIN alternative_groups AS ag ON (ag.id = aq.alternative_group_id)
       JOIN zones AS z ON (z.id = ag.zone_id)
+      JOIN courses AS c ON (c.id = q.course_id)
     ORDER BY
       ai.id ASC,
-      q.qid ASC,
+      q.id ASC,
       s.date DESC
   )
 SELECT
@@ -225,7 +233,10 @@ WITH
       ai.number AS assessment_instance_number,
       z.number AS zone_number,
       z.title AS zone_title,
-      q.qid,
+      CASE
+        WHEN v.course_id = q.course_id THEN q.qid
+        ELSE '@' || c.sharing_name || '/' || q.qid
+      END AS qid,
       iq.number AS instance_question_number,
       iq.points,
       iq.score_perc,
@@ -336,6 +347,7 @@ WITH
       LEFT JOIN rubric_gradings AS rg ON (rg.id = s.manual_rubric_grading_id)
       JOIN alternative_groups AS ag ON (ag.id = aq.alternative_group_id)
       JOIN zones AS z ON (z.id = ag.zone_id)
+      JOIN courses AS c ON (c.id = q.course_id)
     WHERE
       a.id = $assessment_id
   )


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #14671. For assessments with shared questions, adds the sharing name in the question identification in downloads for instance questions and submissions. Also adds support for a QID format that includes the sharing name in score uploads. Support for QID only is kept for backwards compatibility.

No AI used other than auto-complete.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Tested all updated downloads in an assessment that includes both shared and local questions, work as expected. Tested score upload with the same assessment, using, for the shared question, both QID-only and sharing name plus QID, both with and without submission ID.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
