### PR TITLE
Omit null dueDate from main rule JSON in access control editor

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -306,7 +306,7 @@ function mainRuleToJson(rule: MainRuleData): AccessControlJsonWithId {
   if (rule.dateControlEnabled) {
     output.dateControl = {};
     if (rule.releaseDate) output.dateControl.releaseDate = rule.releaseDate;
-    output.dateControl.dueDate = rule.dueDate;
+    if (rule.dueDate) output.dateControl.dueDate = rule.dueDate;
     if (rule.earlyDeadlines.length > 0) output.dateControl.earlyDeadlines = rule.earlyDeadlines;
     if (rule.lateDeadlines.length > 0) output.dateControl.lateDeadlines = rule.lateDeadlines;
     if (rule.afterLastDeadline) output.dateControl.afterLastDeadline = rule.afterLastDeadline;


### PR DESCRIPTION
# Description

The access control editor's `mainRuleToJson` was unconditionally writing `"dueDate": null` to the JSON when no due date was set. Every other optional field in `dateControl` (releaseDate, password, etc.) is conditionally included only when truthy — this aligns `dueDate` with the same pattern so it is omitted instead of serialized as `null`.

The override case is left unchanged since `dueDate: null` there has intentional semantics: it signals an explicit "remove the due date" override, detected during JSON round-trip loading via `dc?.dueDate !== undefined`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation.

# Testing

Existing unit tests pass. The change is a one-line fix matching the established pattern for all other optional fields in the same function.