### PR TITLE
Avoid use of render() in correct_answer_shown test question

### DIFF
--- a/testCourse/questions/answerShown/README.md
+++ b/testCourse/questions/answerShown/README.md
@@ -1,1 +1,0 @@
-This is a question that tests the correct_answer_shown key in data.

--- a/testCourse/questions/answerShown/question.html
+++ b/testCourse/questions/answerShown/question.html
@@ -1,1 +1,0 @@
-This is just a placeholder. It will be replaced by render() in server.py.

--- a/testCourse/questions/answerShown/server.py
+++ b/testCourse/questions/answerShown/server.py
@@ -1,2 +1,0 @@
-def render(data, _html):
-    return f'The current value of data["correct_answer_shown"] is: {data["correct_answer_shown"]}'

--- a/testCourse/questions/correctAnswerShown/README.md
+++ b/testCourse/questions/correctAnswerShown/README.md
@@ -1,0 +1,1 @@
+This is a question that demonstrates the use of the `correct_answer_shown` key in the data dictionary.

--- a/testCourse/questions/correctAnswerShown/info.json
+++ b/testCourse/questions/correctAnswerShown/info.json
@@ -1,6 +1,6 @@
 {
   "uuid": "72faa512-2aae-44ef-a208-f1edb9aa0f23",
-  "title": "Override render to expose correct_answer_shown",
+  "title": "Access correct_answer_shown during render",
   "topic": "Default",
   "type": "v3"
 }

--- a/testCourse/questions/correctAnswerShown/question.html
+++ b/testCourse/questions/correctAnswerShown/question.html
@@ -1,0 +1,1 @@
+The current value of <code>correct_answer_shown</code> is: <code>{{ correct_answer_shown }}</code>


### PR DESCRIPTION
# Description

`render()` in `server.py` is an obscure feature and isn't necessary to test this functionality. This PR rewrites the test question to use `{{ correct_answer_shown }}` directly in `question.html` instead.

I did not use AI for this change.

# Testing

I manually tested the question, it works as expected.