### PR TITLE
PL Calculator Bug Fix

### DIFF
--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -101,7 +101,9 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   );
   const copyButton = ensureElement(drawer.querySelector<HTMLElement>('#calculator-output-copy'));
   const historyPanel = ensureElement(drawer.querySelector<HTMLElement>('#history-panel'));
-  const clearHistoryBtn = ensureElement(drawer.querySelector<HTMLElement>('#calculatorClearHistory'));
+  const clearHistoryBtn = ensureElement(
+    drawer.querySelector<HTMLElement>('#calculatorClearHistory'),
+  );
   const historyTemplate = ensureElement(
     drawer.querySelector<HTMLTemplateElement>('#history-item-template'),
   );

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -84,29 +84,29 @@ const INVERSE_TRIG_FUNCTIONS = new Set([
 ]);
 
 export function initCalculator(storageKey: string, { drawer, fab, fabClose }: DrawerElements) {
-  showPanel('main');
-  initColumnNavigation();
+  showPanel('main', drawer);
+  initColumnNavigation(drawer);
   initDrawerUI(drawer, fab, fabClose, storageKey);
   const ce = new ComputeEngine();
   ce.timeLimit = 500;
   ce.pushScope();
   const calculatorInputElement = ensureElement(
-    document.querySelector<MathfieldElement>('#calculator-input'),
+    drawer.querySelector<MathfieldElement>('#calculator-input'),
   );
   const calculatorInputGroup = ensureElement(
     calculatorInputElement.closest<HTMLElement>('.calculator-input-group'),
   );
   const calculatorOutput = ensureElement(
-    document.querySelector<MathfieldElement>('#calculator-output'),
+    drawer.querySelector<MathfieldElement>('#calculator-output'),
   );
-  const copyButton = ensureElement(document.getElementById('calculator-output-copy'));
-  const historyPanel = ensureElement(document.getElementById('history-panel'));
-  const clearHistoryBtn = ensureElement(document.getElementById('calculatorClearHistory'));
+  const copyButton = ensureElement(drawer.querySelector<HTMLElement>('#calculator-output-copy'));
+  const historyPanel = ensureElement(drawer.querySelector<HTMLElement>('#history-panel'));
+  const clearHistoryBtn = ensureElement(drawer.querySelector<HTMLElement>('#calculatorClearHistory'));
   const historyTemplate = ensureElement(
-    document.querySelector<HTMLTemplateElement>('#history-item-template'),
+    drawer.querySelector<HTMLTemplateElement>('#history-item-template'),
   );
-  const displayModeSwitch = ensureElement(document.getElementById('displayModeSwitch'));
-  const angleModeSwitch = ensureElement(document.getElementById('angleModeSwitch'));
+  const displayModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#displayModeSwitch'));
+  const angleModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#angleModeSwitch'));
 
   const onExport = (_mf: unknown, latex: string) => {
     return ce.parse(latex).toString();
@@ -409,7 +409,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   registerCustomFunctions(ce);
 
   // Buttons for number and letter inputs
-  document.querySelectorAll<HTMLButtonElement>('.btn-key').forEach((button) => {
+  drawer.querySelectorAll<HTMLButtonElement>('.btn-key').forEach((button) => {
     prepareButton(button);
     button.addEventListener('click', () => {
       shouldAutoInsertAns = false;
@@ -421,18 +421,18 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   });
 
   // Upper/lowercase switch
-  document.getElementsByName('shift').forEach((button) =>
+  drawer.querySelectorAll<HTMLElement>('[name="shift"]').forEach((button) =>
     button.addEventListener('click', () => {
       button.classList.toggle('btn-light');
       button.classList.toggle('btn-secondary');
-      document.querySelectorAll<HTMLButtonElement>('.btn-key[data-key]').forEach((btn) => {
+      drawer.querySelectorAll<HTMLButtonElement>('.btn-key[data-key]').forEach((btn) => {
         btn.classList.toggle('uppercase');
       });
     }),
   );
 
   // Backspace button
-  document.getElementsByName('backspace').forEach((button) => {
+  drawer.querySelectorAll<HTMLElement>('[name="backspace"]').forEach((button) => {
     prepareButton(button);
     button.addEventListener('click', () => {
       calculatorInputElement.executeCommand(['deleteBackward']);
@@ -441,14 +441,14 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   });
 
   // Left/right
-  document.getElementsByName('left').forEach((button) => {
+  drawer.querySelectorAll<HTMLElement>('[name="left"]').forEach((button) => {
     prepareButton(button);
     button.addEventListener('click', () => {
       calculatorInputElement.executeCommand(['moveToPreviousChar']);
       calculatorInputElement.focus();
     });
   });
-  document.getElementsByName('right').forEach((button) => {
+  drawer.querySelectorAll<HTMLElement>('[name="right"]').forEach((button) => {
     prepareButton(button);
     button.addEventListener('click', () => {
       calculatorInputElement.executeCommand(['moveToNextChar']);
@@ -457,7 +457,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   });
 
   // Clear all
-  document.getElementsByName('clear').forEach((button) => {
+  drawer.querySelectorAll<HTMLElement>('[name="clear"]').forEach((button) => {
     prepareButton(button);
     button.addEventListener('click', () => {
       calculatorInputElement.executeCommand('deleteAll');
@@ -519,10 +519,10 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   setupButtonEvents(buttonActions);
 
   // Panel switching (main / abc / func keyboards)
-  document.querySelectorAll<HTMLInputElement>('[data-panel]').forEach((radio) => {
+  drawer.querySelectorAll<HTMLInputElement>('[data-panel]').forEach((radio) => {
     radio.addEventListener('click', () => {
       const panel = radio.dataset.panel;
-      if (panel) showPanel(panel);
+      if (panel) showPanel(panel, drawer);
     });
   });
 
@@ -633,7 +633,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
 
   function setupButtonEvents(actions: Record<string, string>) {
     for (const [buttonName, action] of Object.entries(actions)) {
-      document.getElementsByName(buttonName).forEach((button) => {
+      drawer.querySelectorAll<HTMLElement>(`[name="${buttonName}"]`).forEach((button) => {
         prepareButton(button);
         button.addEventListener('click', () => {
           if (
@@ -756,20 +756,20 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   }
 }
 
-function showPanel(panelClass: string) {
-  const panels = document.querySelectorAll<HTMLElement>('.keyboard');
+function showPanel(panelClass: string, container: HTMLElement) {
+  const panels = container.querySelectorAll<HTMLElement>('.keyboard');
   panels.forEach((panel) => (panel.style.display = 'none'));
 
-  const panelToShow = document.querySelectorAll<HTMLElement>(`.${panelClass}`);
+  const panelToShow = container.querySelectorAll<HTMLElement>(`.${panelClass}`);
   panelToShow.forEach((panel) => (panel.style.display = 'flex'));
 }
 
-function initColumnNavigation() {
+function initColumnNavigation(container: HTMLElement) {
   setupKeyboardNav('main-keyboard', 'show-functions');
   setupKeyboardNav('func-keyboard', 'show-trig');
 
   function setupKeyboardNav(keyboardId: string, toggleClass: string) {
-    const keyboard = document.getElementById(keyboardId);
+    const keyboard = container.querySelector<HTMLElement>(`#${keyboardId}`);
     if (!keyboard) return;
 
     keyboard.querySelectorAll('.col-nav').forEach((btn) => {
@@ -825,7 +825,7 @@ function initDrawerUI(
   }
 
   // Left-edge resize handle
-  const resizeHandle = document.getElementById('calculatorResizeHandle');
+  const resizeHandle = drawer.querySelector<HTMLElement>('#calculatorResizeHandle');
   if (resizeHandle) {
     let startX = 0;
     let startWidth = 0;

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -306,6 +306,12 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     }
   }
 
+  function showCalculationError() {
+    calculatorInputGroup.classList.add('error');
+    calculatorOutput.value = '';
+    copyButton.onclick = null;
+  }
+
   function calculate(addToHistory = false) {
     const input = calculatorInputElement.value;
     if (input.length === 0) {
@@ -317,6 +323,14 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       return;
     }
 
+    const data = getCalculatorData(storageKey);
+
+    // Reject expressions using `ans` when there is no prior history
+    if (data.history.length === 0 && input.includes('{ans}')) {
+      showCalculationError();
+      return;
+    }
+
     const angleMode = (calculatorOutput.dataset.angleMode ?? 'rad') as AngleMode;
     const displayMode = calculatorOutput.dataset.displayMode as DisplayMode;
     const result = evaluateExpression(input, angleMode, displayMode, {
@@ -325,18 +339,14 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     });
 
     if (!result) {
-      calculatorInputGroup.classList.add('error');
-      calculatorOutput.value = '';
-      copyButton.onclick = null;
+      showCalculationError();
       return;
     }
 
     const { displayed, evaluated } = result;
 
     if (hasError(evaluated.json)) {
-      calculatorInputGroup.classList.add('error');
-      calculatorOutput.value = '';
-      copyButton.onclick = null;
+      showCalculationError();
       return;
     }
 
@@ -347,8 +357,6 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       window.bootstrap.Tooltip.getInstance(copyButton)?.hide();
       void navigator.clipboard.writeText(ce.parse(displayed).toString());
     };
-
-    const data = getCalculatorData(storageKey);
 
     // Add to history
     if (addToHistory) {


### PR DESCRIPTION

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- The use of `document.getElementsByName`s on `calculatorClient.ts` can leak and pollute other elements on the same page. This fix changes it to only query items scoped in the calculator.
- A parallel UX improvement that prevents `ans` from being submitted to history as the first item.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

- create a question that has `<pl-string-input " answers-name="ans" ></pl-string-input>` (this creates an element with `name="ans"`) and calculator enabled (or simply in question preview)
- verify that clicking on the `pl-string-input` no longer affects the calculator.