### PR TITLE
Security: DOM XSS via unsanitized job output insertion

### DIFF
--- a/apps/prairielearn/assets/scripts/lib/jobSequenceResults.ts
+++ b/apps/prairielearn/assets/scripts/lib/jobSequenceResults.ts
@@ -48,7 +48,7 @@ onDocumentReady(() => {
   socket.on('change:output', function (msg) {
     const jobOutputElement = document.getElementById(`output-${msg.job_id}`);
     if (jobOutputElement) {
-      jobOutputElement.innerHTML = msg.output;
+      jobOutputElement.textContent = msg.output;
     }
   });
 
@@ -77,7 +77,7 @@ onDocumentReady(() => {
         }
         const jobOutputElement = document.getElementById(`output-${job.id}`);
         if (jobOutputElement) {
-          jobOutputElement.innerHTML = msg.output;
+          jobOutputElement.textContent = msg.output;
         }
       },
     );


### PR DESCRIPTION
## Summary

Security: DOM XSS via unsanitized job output insertion

## Problem

**Severity**: `High` | **File**: `apps/prairielearn/assets/scripts/lib/jobSequenceResults.ts:L50`

WebSocket message content (`msg.output`) is inserted directly into the DOM using `innerHTML`. If job output can contain attacker-controlled HTML/JS (for example, from student code stdout/stderr or other untrusted grader output), this can execute script in the viewer's browser.

## Solution

Avoid `innerHTML` for untrusted content. Prefer `textContent`/`innerText` for plain logs. If rich formatting is required, sanitize with a robust HTML sanitizer (e.g., DOMPurify with a strict allowlist) before insertion, and also ensure server-side output encoding.

## Changes

- `apps/prairielearn/assets/scripts/lib/jobSequenceResults.ts` (modified)