### PR TITLE
Allow reuse of renamed GitHub repo names in course request check

### DIFF
--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -38,20 +38,24 @@ function getGithubClient() {
 }
 
 /**
- * Checks whether a repository already exists on GitHub. This catches cases
- * that can't be detected from the database alone, such as GitHub redirects
- * from renamed repositories.
+ * Checks whether a repository already exists on GitHub.
  */
 export async function checkGithubRepositoryExists(repoName: string): Promise<boolean> {
   const client = getGithubClient();
   if (client === null) return false;
 
   try {
-    await client.repos.get({
+    const response = await client.repos.get({
       owner: config.githubCourseOwner,
       repo: repoName,
     });
-    return true;
+    // If the repository was renamed, GitHub returns a 301 redirect which
+    // Octokit follows automatically, yielding the renamed repository's data.
+    // GitHub allows the old name to be reused in that case, so we treat a
+    // mismatch between the requested name and the returned name as the
+    // repository not existing at the requested name. Repository names are
+    // case-insensitive, so we compare case-insensitively.
+    return response.data.name.toLowerCase() === repoName.toLowerCase();
   } catch (err: any) {
     if (err.status === 404) return false;
     throw err;

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -599,8 +599,7 @@ function MutationError({
           )}
           {appError.githubRepoUrl && (
             <li>
-              A GitHub repository with this name already exists. This can happen if a repository was
-              previously renamed.{' '}
+              A GitHub repository with this name already exists.{' '}
               <a href={appError.githubRepoUrl} target="_blank" rel="noreferrer">
                 Open repo
               </a>


### PR DESCRIPTION
# Description

Fixes the repository-existence check in the admin course request flow so that it no longer blocks reusing a GitHub repo name that was previously renamed.

`checkGithubRepositoryExists` called `client.repos.get()` and treated any successful response as "the name is taken." For renamed repos, GitHub returns a 301 redirect that Octokit follows automatically, so the old name appeared to still exist — but GitHub actually allows reusing the old name after a rename. The fix compares the returned `name` against the requested name (case-insensitive); a mismatch indicates a rename-redirect, so the requested name is treated as available. Also removed the now-misleading "This can happen if a repository was previously renamed" hint from the conflict alert in `CourseRequestsTable.tsx`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation (Claude Code).

# Testing

Manual review of the changed logic. Full repro requires an admin course-request flow against GitHub with a previously-renamed repository; no automated test was added as `checkGithubRepositoryExists` hits the live GitHub API and there is no existing mock/fixture pattern for it in this repo.