### PR TITLE
Provide correct number for manual grading instance question page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -144,7 +144,7 @@ export function InstanceQuestion({
                 href="${resLocals.urlPrefix}/assessment/${resLocals.assessment
                   .id}/manual_grading/assessment_question/${resLocals.assessment_question.id}"
               >
-                Question ${resLocals.assessment_question.number_in_alternative_group}.
+                Question ${resLocals.instance_question_info.instructor_question_number}.
                 ${resLocals.question.title}
               </a>
             </li>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Re-used the same variable from the browser title in the question breadcrumbs to match the correct number

I thought this was a quick fix for #14739 so I put this in

No AI was used

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Ran locally through Docker and checked that the number matches when going to an assessment instance in manual grading

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
