### PR TITLE
Fix incorrect question number on manual grading instance question page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -144,7 +144,7 @@ export function InstanceQuestion({
                 href="${resLocals.urlPrefix}/assessment/${resLocals.assessment
                   .id}/manual_grading/assessment_question/${resLocals.assessment_question.id}"
               >
-                Question ${resLocals.assessment_question.number_in_alternative_group}.
+                Question ${resLocals.instance_question_info.instructor_question_number}.
                 ${resLocals.question.title}
               </a>
             </li>


### PR DESCRIPTION
# Description

Fixes #14739. The breadcrumb on the manual grading page for a specific instance question was displaying `assessment_question.number_in_alternative_group`, which only gives the position within the alternative group and does not include the alternative group prefix. This produced a question number that disagreed with the one shown on the assessment question manual grading page. The fix switches the breadcrumb to use `instance_question_info.instructor_question_number`, which is computed via `admin_assessment_question_number()` and already includes the alternative group prefix (matching the source page).

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation with Claude Code.

# Testing

Manual: on an assessment where a question lives inside an alternative group, open Manual grading → pick the assessment question (breadcrumb shows e.g. `Question 2.1. ...`) → click through to an instance question and verify the breadcrumb now shows the same `2.1.` prefix instead of just `1.`.