### PR TITLE
Fix uppercase UUIDs failing consistency checks during course instance syncing

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.sql
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.sql
@@ -6,13 +6,13 @@ FROM
 WHERE
   short_name = ANY ($short_names::text[]);
 
--- BLOCK select_existing_enrollment_code
+-- BLOCK select_existing_enrollment_codes
 SELECT
   enrollment_code
 FROM
   course_instances
 WHERE
-  enrollment_code = $enrollment_code;
+  enrollment_code = ANY ($enrollment_codes::text[]);
 
 -- BLOCK sync_course_instances_insert_delete
 WITH

--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
@@ -18,15 +18,39 @@ import * as infofile from '../infofile.js';
 const sql = sqldb.loadSqlEquiv(import.meta.filename);
 
 export async function uniqueEnrollmentCode() {
+  const [enrollmentCode] = await uniqueEnrollmentCodes(1);
+  return enrollmentCode;
+}
+
+async function uniqueEnrollmentCodes(count: number) {
+  if (count === 0) return [];
+
+  const enrollmentCodes = new Set<string>();
+  while (enrollmentCodes.size < count) {
+    enrollmentCodes.add(generateEnrollmentCode());
+  }
+
   while (true) {
-    const enrollmentCode = generateEnrollmentCode();
-    const existingEnrollmentCode = await sqldb.queryOptionalScalar(
-      sql.select_existing_enrollment_code,
-      { enrollment_code: enrollmentCode },
+    // Check if any of the enrollment codes we generated are already in use.
+    const existingEnrollmentCodes = await sqldb.queryScalars(
+      sql.select_existing_enrollment_codes,
+      { enrollment_codes: Array.from(enrollmentCodes) },
       z.string(),
     );
-    if (existingEnrollmentCode === null) {
-      return enrollmentCode;
+
+    // If we have no duplicate codes, we can return the full set of enrollment codes.
+    if (existingEnrollmentCodes.length === 0) {
+      return Array.from(enrollmentCodes);
+    }
+
+    // Remove duplicate codes from the set of enrollment codes to generate.
+    for (const code of existingEnrollmentCodes) {
+      enrollmentCodes.delete(code);
+    }
+
+    // Replace the removed codes with new ones.
+    while (enrollmentCodes.size < count) {
+      enrollmentCodes.add(generateEnrollmentCode());
     }
   }
 }
@@ -121,15 +145,16 @@ export async function sync(
   }
 
   return await sqldb.runInTransactionAsync(async () => {
-    const courseInstanceIdentityParams = await Promise.all(
-      Object.entries(courseData.courseInstances).map(async ([shortName, courseInstanceData]) =>
+    const courseInstanceEntries = Object.entries(courseData.courseInstances);
+    const enrollmentCodes = await uniqueEnrollmentCodes(courseInstanceEntries.length);
+    const courseInstanceIdentityParams = courseInstanceEntries.map(
+      ([shortName, courseInstanceData], index) =>
         JSON.stringify([
           shortName,
           courseInstanceData.courseInstance.uuid,
           // This enrollment code is only used for inserts, and not used on updates
-          await uniqueEnrollmentCode(),
+          enrollmentCodes[index],
         ]),
-      ),
     );
 
     const shortNameToIdMapping = await sqldb.queryScalar(
@@ -218,7 +243,8 @@ async function courseInstanceConsistencyCheck({
         ...ci,
         diskUuid: courseInstances[ci.short_name!].courseInstance.uuid,
       }))
-      .filter((ci) => ci.diskUuid && ci.diskUuid !== ci.uuid);
+      // PostgreSQL's `uuid` type normalizes stored values to lowercase
+      .filter((ci) => ci.diskUuid && ci.diskUuid.toLowerCase() !== ci.uuid);
     if (mismatchedInstanceUuids.length > 0) {
       throw new AugmentedError(
         'Assertion: Course instances exist where the UUID in the database does not match the UUID in disk data',

--- a/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
+++ b/apps/prairielearn/src/sync/fromDisk/courseInstances.ts
@@ -34,6 +34,8 @@ async function uniqueEnrollmentCodes(count: number) {
     // Check if any of the enrollment codes we generated are already in use.
     const existingEnrollmentCodes = await sqldb.queryScalars(
       sql.select_existing_enrollment_codes,
+      // We should almost never need to iterate more than once due to the probability of a collision.
+      // Thus, we keep the code simple and avoid tracking enrollment codes that we already checked.
       { enrollment_codes: Array.from(enrollmentCodes) },
       z.string(),
     );
@@ -243,7 +245,8 @@ async function courseInstanceConsistencyCheck({
         ...ci,
         diskUuid: courseInstances[ci.short_name!].courseInstance.uuid,
       }))
-      // PostgreSQL's `uuid` type normalizes stored values to lowercase
+      // PostgreSQL's `uuid` type normalizes stored values to lowercase,
+      // but diskUuid is preserved as-is, so we need to compare case-insensitively.
       .filter((ci) => ci.diskUuid && ci.diskUuid.toLowerCase() !== ci.uuid);
     if (mismatchedInstanceUuids.length > 0) {
       throw new AugmentedError(

--- a/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseInstancesSync.test.ts
@@ -74,6 +74,24 @@ describe('Course instance syncing', () => {
     await findSyncedCourseInstance(courseInstanceId);
   });
 
+  it('syncs a course instance whose JSON UUID uses uppercase hex', async () => {
+    const courseData = util.getCourseData();
+    const shortName = 'uppercaseUuid';
+    courseData.courseInstances[shortName] = {
+      ...makeCourseInstance(),
+      courseInstance: {
+        uuid: 'D4875187-B6B5-4DBC-80FA-CDBAA72CA458',
+        longName: 'Uppercase UUID instance',
+      },
+    };
+
+    const { syncResults } = await util.writeAndSyncCourseData(courseData);
+    assert.equal(syncResults.status, 'complete');
+
+    const synced = await findSyncedUndeletedCourseInstance(shortName);
+    assert.equal(synced.uuid, 'd4875187-b6b5-4dbc-80fa-cdbaa72ca458');
+  });
+
   it('syncs access rules', async () => {
     const courseData = util.getCourseData();
     courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.allowAccess = [


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes two bugs:

- Warnings caused by concurrent queries
- Uppercase UUIDs failing consistency checks

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: used for investigation, minor for implementation

# Testing

I added a test for the second bug. The first bug should be resolved because the code doesn't do concurrent queries anymore.
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
