### PR TITLE
Use full database rows on student assessment instance page

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/LockpointRow.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/LockpointRow.tsx
@@ -61,7 +61,7 @@ export function LockpointRow({
               type="button"
               class="btn btn-warning btn-sm text-nowrap"
               data-bs-toggle="modal"
-              data-bs-target="#crossLockpointModal-${row.zone_id}"
+              data-bs-target="#crossLockpointModal-${row.zone.id}"
             >
               Proceed to next questions
             </button>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/QuestionTableBody.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/QuestionTableBody.tsx
@@ -13,7 +13,7 @@ import { LockpointRow } from './LockpointRow.js';
 import { RowLabel } from './RowLabel.js';
 
 export function QuestionTableBody({
-  instance_question_rows,
+  rows,
   courseInstanceId,
   displayTimezone,
   assessmentType,
@@ -28,7 +28,7 @@ export function QuestionTableBody({
   isLockpointCrossable,
   hasUnmetAdvanceScorePercBeforeLockpoint,
 }: {
-  instance_question_rows: InstanceQuestionRow[];
+  rows: InstanceQuestionRow[];
   courseInstanceId: string;
   displayTimezone: string;
   assessmentType: EnumAssessmentType;
@@ -40,35 +40,30 @@ export function QuestionTableBody({
   isGroupAssessment: boolean;
   zoneTitleColspan: number;
   userGroupRoles: string | null;
-  isLockpointCrossable: (instance_question_row: InstanceQuestionRow) => boolean;
+  isLockpointCrossable: (row: InstanceQuestionRow) => boolean;
   hasUnmetAdvanceScorePercBeforeLockpoint: (zone_number: number) => boolean;
 }) {
   let previousZoneHadInfo = false;
 
-  return instance_question_rows.map((instance_question_row) => {
+  return rows.map((row) => {
     const zoneHasInfo =
-      instance_question_row.zone.title != null ||
-      instance_question_row.zone.max_points != null ||
-      instance_question_row.zone.best_questions != null;
+      row.zone.title != null || row.zone.max_points != null || row.zone.best_questions != null;
 
     // Show zone info if this zone has info, or if the previous zone
     // had info (blank zone info to visually separate).
-    const showZoneInfo =
-      instance_question_row.start_new_zone && (zoneHasInfo || previousZoneHadInfo);
+    const showZoneInfo = row.start_new_zone && (zoneHasInfo || previousZoneHadInfo);
 
-    if (instance_question_row.start_new_zone) {
+    if (row.start_new_zone) {
       previousZoneHadInfo = zoneHasInfo;
     }
 
     return html`
-      ${instance_question_row.start_new_zone && instance_question_row.lockpoint
+      ${row.start_new_zone && row.zone.lockpoint
         ? LockpointRow({
-            row: instance_question_row,
+            row,
             colspan: zoneTitleColspan,
-            crossable: !!isLockpointCrossable(instance_question_row),
-            blockedByAdvanceScorePerc: hasUnmetAdvanceScorePercBeforeLockpoint(
-              instance_question_row.zone_number,
-            ),
+            crossable: !!isLockpointCrossable(row),
+            blockedByAdvanceScorePerc: hasUnmetAdvanceScorePercBeforeLockpoint(row.zone.number),
             isGroupAssessment,
             displayTimezone,
           })
@@ -80,25 +75,22 @@ export function QuestionTableBody({
                 ${zoneHasInfo
                   ? html`
                       <div class="d-flex align-items-center gap-2">
-                        ${instance_question_row.zone_title
-                          ? html`<span>${instance_question_row.zone_title}</span>`
-                          : ''}
-                        ${instance_question_row.zone_has_max_points
+                        ${row.zone.title ? html`<span>${row.zone.title}</span>` : ''}
+                        ${row.zone.max_points != null
                           ? ZoneInfoPopover({
-                              label: instance_question_row.zone_title
-                                ? `maximum ${instance_question_row.zone_max_points} points`
-                                : `Maximum ${instance_question_row.zone_max_points} points`,
-                              content: `Of the points that you are awarded for answering these ${instance_question_row.zone_question_count} questions, at most ${instance_question_row.zone_max_points} will count toward your total points.`,
+                              label: row.zone.title
+                                ? `maximum ${row.zone.max_points} points`
+                                : `Maximum ${row.zone.max_points} points`,
+                              content: `Of the points that you are awarded for answering these ${row.zone_question_count} questions, at most ${row.zone.max_points} will count toward your total points.`,
                             })
                           : ''}
-                        ${instance_question_row.zone_has_best_questions
+                        ${row.zone.best_questions != null
                           ? ZoneInfoPopover({
                               label:
-                                instance_question_row.zone_title ||
-                                instance_question_row.zone_has_max_points
-                                  ? `best ${instance_question_row.zone_best_questions} of ${instance_question_row.zone_question_count} questions`
-                                  : `Best ${instance_question_row.zone_best_questions} of ${instance_question_row.zone_question_count} questions`,
-                              content: `Of these ${instance_question_row.zone_question_count} questions, only the ${instance_question_row.zone_best_questions} with the highest number of awarded points will count toward your total points.`,
+                                row.zone.title || row.zone.max_points != null
+                                  ? `best ${row.zone.best_questions} of ${row.zone_question_count} questions`
+                                  : `Best ${row.zone.best_questions} of ${row.zone_question_count} questions`,
+                              content: `Of these ${row.zone_question_count} questions, only the ${row.zone.best_questions} with the highest number of awarded points will count toward your total points.`,
                             })
                           : ''}
                       </div>
@@ -109,8 +101,8 @@ export function QuestionTableBody({
           `
         : ''}
       <tr
-        class="${instance_question_row.question_access_mode === 'blocked_sequence' ||
-        instance_question_row.question_access_mode === 'blocked_lockpoint'
+        class="${row.question_access_mode === 'blocked_sequence' ||
+        row.question_access_mode === 'blocked_lockpoint'
           ? 'bg-light pl-sequence-locked'
           : ''}"
       >
@@ -118,21 +110,21 @@ export function QuestionTableBody({
           <div class="d-flex align-items-center">
             ${RowLabel({
               courseInstanceId,
-              instance_question_row,
+              row,
               userGroupRoles,
               hasStatusColumn: assessmentType === 'Exam',
               rowLabelText:
                 assessmentType === 'Exam'
-                  ? `Question ${instance_question_row.question_number}`
-                  : instance_question_row.question_title?.trim()
-                    ? `${instance_question_row.question_number}. ${instance_question_row.question_title}`
-                    : instance_question_row.question_number,
+                  ? `Question ${row.question_number}`
+                  : row.question.title?.trim()
+                    ? `${row.question_number}. ${row.question.title}`
+                    : row.question_number,
             })}
           </div>
         </td>
         ${assessmentType === 'Exam'
           ? ExamQuestionCells({
-              instance_question_row,
+              row,
               someQuestionsAllowRealTimeGrading,
               someQuestionsForbidRealTimeGrading,
               hasAutoGradingQuestion,
@@ -140,7 +132,7 @@ export function QuestionTableBody({
               assessmentInstanceOpen,
             })
           : HomeworkQuestionCells({
-              instance_question_row,
+              row,
               courseInstanceId,
               hasAutoGradingQuestion,
               hasManualGradingQuestion,
@@ -151,14 +143,14 @@ export function QuestionTableBody({
 }
 
 function ExamQuestionCells({
-  instance_question_row,
+  row,
   someQuestionsAllowRealTimeGrading,
   someQuestionsForbidRealTimeGrading,
   hasAutoGradingQuestion,
   hasManualGradingQuestion,
   assessmentInstanceOpen,
 }: {
-  instance_question_row: InstanceQuestionRow;
+  row: InstanceQuestionRow;
   someQuestionsAllowRealTimeGrading: boolean;
   someQuestionsForbidRealTimeGrading: boolean;
   hasAutoGradingQuestion: boolean;
@@ -170,31 +162,31 @@ function ExamQuestionCells({
       ${
         // Override the status badge for questions blocked by a lockpoint:
         // show "Locked" instead of the misleading "unanswered".
-        instance_question_row.question_access_mode === 'blocked_lockpoint'
+        row.question_access_mode === 'blocked_lockpoint'
           ? html`<span class="badge text-bg-secondary">Locked</span>`
           : ExamQuestionStatus({
-              instance_question: instance_question_row,
-              assessment_question: instance_question_row, // Required fields are in instance_question
+              instance_question: row.instance_question,
+              assessment_question: row.assessment_question,
               realTimeGradingPartiallyDisabled:
                 someQuestionsAllowRealTimeGrading && someQuestionsForbidRealTimeGrading,
-              allowGradeLeftMs: instance_question_row.allowGradeLeftMs,
+              allowGradeLeftMs: row.allowGradeLeftMs,
             })
       }
     </td>
     ${hasAutoGradingQuestion && someQuestionsAllowRealTimeGrading
       ? html`
           <td class="text-center">
-            ${instance_question_row.max_auto_points
+            ${row.assessment_question.max_auto_points
               ? ExamQuestionAvailablePoints({
-                  open: assessmentInstanceOpen && instance_question_row.open,
+                  open: assessmentInstanceOpen && row.instance_question.open,
                   currentWeight:
-                    (instance_question_row.points_list_original?.[
-                      instance_question_row.number_attempts
-                    ] ?? 0) - (instance_question_row.max_manual_points ?? 0),
-                  pointsList: instance_question_row.points_list?.map(
-                    (p) => p - (instance_question_row.max_manual_points ?? 0),
+                    (row.instance_question.points_list_original?.[
+                      row.instance_question.number_attempts
+                    ] ?? 0) - (row.assessment_question.max_manual_points ?? 0),
+                  pointsList: row.instance_question.points_list?.map(
+                    (p) => p - (row.assessment_question.max_manual_points ?? 0),
                   ),
-                  highestSubmissionScore: instance_question_row.highest_submission_score,
+                  highestSubmissionScore: row.instance_question.highest_submission_score,
                 })
               : html`&mdash;`}
           </td>
@@ -206,15 +198,15 @@ function ExamQuestionCells({
             ? html`
                 <td class="text-center">
                   ${InstanceQuestionPoints({
-                    instance_question: instance_question_row,
-                    assessment_question: instance_question_row, // Required fields are present in instance_question
+                    instance_question: row.instance_question,
+                    assessment_question: row.assessment_question,
                     component: 'auto',
                   })}
                 </td>
                 <td class="text-center">
                   ${InstanceQuestionPoints({
-                    instance_question: instance_question_row,
-                    assessment_question: instance_question_row, // Required fields are present in instance_question
+                    instance_question: row.instance_question,
+                    assessment_question: row.assessment_question,
                     component: 'manual',
                   })}
                 </td>
@@ -222,8 +214,8 @@ function ExamQuestionCells({
             : ''}
           <td class="text-center">
             ${InstanceQuestionPoints({
-              instance_question: instance_question_row,
-              assessment_question: instance_question_row, // Required fields are present in instance_question
+              instance_question: row.instance_question,
+              assessment_question: row.assessment_question,
               component: 'total',
             })}
           </td>
@@ -231,24 +223,26 @@ function ExamQuestionCells({
       : html`
           ${hasAutoGradingQuestion && hasManualGradingQuestion
             ? html`
-                <td class="text-center">${formatPoints(instance_question_row.max_auto_points)}</td>
                 <td class="text-center">
-                  ${formatPoints(instance_question_row.max_manual_points)}
+                  ${formatPoints(row.assessment_question.max_auto_points)}
+                </td>
+                <td class="text-center">
+                  ${formatPoints(row.assessment_question.max_manual_points)}
                 </td>
               `
             : ''}
-          <td class="text-center">${formatPoints(instance_question_row.max_points)}</td>
+          <td class="text-center">${formatPoints(row.assessment_question.max_points)}</td>
         `}
   `;
 }
 
 function HomeworkQuestionCells({
-  instance_question_row,
+  row,
   courseInstanceId,
   hasAutoGradingQuestion,
   hasManualGradingQuestion,
 }: {
-  instance_question_row: InstanceQuestionRow;
+  row: InstanceQuestionRow;
   courseInstanceId: string;
   hasAutoGradingQuestion: boolean;
   hasManualGradingQuestion: boolean;
@@ -258,7 +252,7 @@ function HomeworkQuestionCells({
       ? html`
           <td class="text-center">
             ${run(() => {
-              if (!instance_question_row.max_auto_points) {
+              if (!row.assessment_question.max_auto_points) {
                 return html`&mdash;`;
               }
 
@@ -267,17 +261,17 @@ function HomeworkQuestionCells({
               // We don't want to mislead the student into thinking that they can earn
               // more points than they actually can.
               const currentAutoValue =
-                (instance_question_row.current_value ?? 0) -
-                (instance_question_row.max_manual_points ?? 0);
+                (row.instance_question.current_value ?? 0) -
+                (row.assessment_question.max_manual_points ?? 0);
 
               return formatPoints(currentAutoValue);
             })}
           </td>
           <td class="text-center">
             ${QuestionVariantHistory({
-              instanceQuestionId: instance_question_row.id,
+              instanceQuestionId: row.instance_question.id,
               courseInstanceId,
-              previousVariants: instance_question_row.previous_variants,
+              previousVariants: row.previous_variants,
             })}
           </td>
         `
@@ -286,15 +280,15 @@ function HomeworkQuestionCells({
       ? html`
           <td class="text-center">
             ${InstanceQuestionPoints({
-              instance_question: instance_question_row,
-              assessment_question: instance_question_row, // Required fields are present in instance_question
+              instance_question: row.instance_question,
+              assessment_question: row.assessment_question,
               component: 'auto',
             })}
           </td>
           <td class="text-center">
             ${InstanceQuestionPoints({
-              instance_question: instance_question_row,
-              assessment_question: instance_question_row, // Required fields are present in instance_question
+              instance_question: row.instance_question,
+              assessment_question: row.assessment_question,
               component: 'manual',
             })}
           </td>
@@ -302,8 +296,8 @@ function HomeworkQuestionCells({
       : ''}
     <td class="text-center">
       ${InstanceQuestionPoints({
-        instance_question: instance_question_row,
-        assessment_question: instance_question_row, // Required fields are present in instance_question
+        instance_question: row.instance_question,
+        assessment_question: row.assessment_question,
         component: 'total',
       })}
     </td>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/RowLabel.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/RowLabel.tsx
@@ -41,7 +41,7 @@ export function RowLabel({
           <a
             href="${getInstanceQuestionUrl({
               courseInstanceId,
-              instanceQuestionId: instance_question_row.id,
+              instanceQuestionId: instance_question_row.instance_question.id,
             })}"
             >${rowLabelText}</a
           >

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/RowLabel.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/RowLabel.tsx
@@ -5,13 +5,13 @@ import type { InstanceQuestionRow } from '../studentAssessmentInstance.types.js'
 
 export function RowLabel({
   courseInstanceId,
-  instance_question_row,
+  row,
   userGroupRoles,
   rowLabelText,
   hasStatusColumn,
 }: {
   courseInstanceId: string;
-  instance_question_row: InstanceQuestionRow;
+  row: InstanceQuestionRow;
   userGroupRoles: string | null;
   rowLabelText: string;
   hasStatusColumn: boolean;
@@ -19,18 +19,18 @@ export function RowLabel({
   let lockMessage: string | null = null;
   let showLink = true;
 
-  if (instance_question_row.question_access_mode === 'blocked_sequence') {
+  if (row.question_access_mode === 'blocked_sequence') {
     showLink = false;
     lockMessage =
-      instance_question_row.prev_question_access_mode === 'blocked_sequence'
+      row.prev_question_access_mode === 'blocked_sequence'
         ? 'A previous question must be completed before you can access this one.'
-        : `You must score at least ${instance_question_row.prev_advance_score_perc}% on ${instance_question_row.prev_title} to unlock this question.`;
-  } else if (instance_question_row.question_access_mode === 'blocked_lockpoint') {
+        : `You must score at least ${row.prev_advance_score_perc}% on ${row.prev_title} to unlock this question.`;
+  } else if (row.question_access_mode === 'blocked_lockpoint') {
     showLink = false;
-  } else if (!(instance_question_row.group_role_permissions?.can_view ?? true)) {
+  } else if (!(row.group_role_permissions?.can_view ?? true)) {
     showLink = false;
     lockMessage = `Your current group role (${userGroupRoles}) restricts access to this question.`;
-  } else if (instance_question_row.question_access_mode === 'read_only_lockpoint') {
+  } else if (row.question_access_mode === 'read_only_lockpoint') {
     lockMessage =
       'You can no longer submit answers to this question because you have advanced past a lockpoint.';
   }
@@ -41,7 +41,7 @@ export function RowLabel({
           <a
             href="${getInstanceQuestionUrl({
               courseInstanceId,
-              instanceQuestionId: instance_question_row.instance_question.id,
+              instanceQuestionId: row.instance_question.id,
             })}"
             >${rowLabelText}</a
           >
@@ -51,7 +51,7 @@ export function RowLabel({
       // On exams, blocked_lockpoint questions show "Locked" in the Status column,
       // so we skip the inline badge to avoid duplication. On homeworks (no Status
       // column), we render the badge here instead.
-      instance_question_row.question_access_mode === 'blocked_lockpoint' && !hasStatusColumn
+      row.question_access_mode === 'blocked_lockpoint' && !hasStatusColumn
         ? html`
             <span class="badge bg-secondary ms-1" data-testid="locked-instance-question-row">
               Locked
@@ -74,7 +74,7 @@ export function RowLabel({
             `
           : ''
     }
-    ${instance_question_row.file_count > 0
+    ${row.file_count > 0
       ? html`
           <button
             type="button"
@@ -82,7 +82,7 @@ export function RowLabel({
             data-bs-toggle="popover"
             data-bs-container="body"
             data-bs-html="true"
-            data-bs-content="Personal notes: ${instance_question_row.file_count}"
+            data-bs-content="Personal notes: ${row.file_count}"
             aria-label="Has personal note attachments"
           >
             <i class="fas fa-paperclip"></i>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
@@ -459,10 +459,10 @@ function RealTimeGradingInformationAlert({
   assessment_instance: AssessmentInstance;
 }) {
   const allQuestionsDisabled = instance_question_rows.every(
-    (q) => !q.assessment_question.allow_real_time_grading,
+    (row) => !row.assessment_question.allow_real_time_grading,
   );
   const someQuestionsDisabled = instance_question_rows.some(
-    (q) => !q.assessment_question.allow_real_time_grading,
+    (row) => !row.assessment_question.allow_real_time_grading,
   );
 
   if (allQuestionsDisabled && assessment_instance.open) {
@@ -615,7 +615,7 @@ function ConfirmFinishModal({
   csrfToken: string;
 }) {
   const all_questions_answered = instance_question_rows.every(
-    ({ instance_question: iq }) => iq.status !== 'unanswered',
+    (row) => row.instance_question.status !== 'unanswered',
   );
 
   return Modal({

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
@@ -357,7 +357,7 @@ export function StudentAssessmentInstance({
             </thead>
             <tbody>
               ${QuestionTableBody({
-                instance_question_rows,
+                rows: instance_question_rows,
                 courseInstanceId: resLocals.course_instance.id,
                 displayTimezone: resLocals.course_instance.display_timezone,
                 assessmentType: resLocals.assessment.type,
@@ -458,8 +458,12 @@ function RealTimeGradingInformationAlert({
   instance_question_rows: InstanceQuestionRow[];
   assessment_instance: AssessmentInstance;
 }) {
-  const allQuestionsDisabled = instance_question_rows.every((q) => !q.allow_real_time_grading);
-  const someQuestionsDisabled = instance_question_rows.some((q) => !q.allow_real_time_grading);
+  const allQuestionsDisabled = instance_question_rows.every(
+    (q) => !q.assessment_question.allow_real_time_grading,
+  );
+  const someQuestionsDisabled = instance_question_rows.some(
+    (q) => !q.assessment_question.allow_real_time_grading,
+  );
 
   if (allQuestionsDisabled && assessment_instance.open) {
     return html`

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
@@ -63,22 +63,22 @@ export function StudentAssessmentInstance({
 
   // Check for mixed real-time grading scenarios
   const someQuestionsAllowRealTimeGrading = instance_question_rows.some(
-    (q) => q.allow_real_time_grading,
+    (row) => row.assessment_question.allow_real_time_grading,
   );
   const someQuestionsForbidRealTimeGrading = instance_question_rows.some(
     // Note that this currently picks up `null`. In the future,
     // `assessment_questions.allow_real_time_grading` will have a `NOT NULL`
     // constraint. Once that happens, this will be totally safe.
-    (q) => !q.allow_real_time_grading,
+    (row) => !row.assessment_question.allow_real_time_grading,
   );
 
-  instance_question_rows.forEach((question) => {
-    if (question.status === 'saved') {
-      if (question.allowGradeLeftMs > 0) {
+  instance_question_rows.forEach((row) => {
+    if (row.instance_question.status === 'saved') {
+      if (row.allowGradeLeftMs > 0) {
         suspendedSavedAnswers++;
       } else if (
-        (question.max_auto_points || !question.max_manual_points) &&
-        question.allow_real_time_grading
+        (row.assessment_question.max_auto_points || !row.assessment_question.max_manual_points) &&
+        row.assessment_question.allow_real_time_grading
       ) {
         // Note that we exclude questions that are not auto-graded from the count.
         // This count is used to determine whether the "Grade N saved answers"
@@ -123,8 +123,8 @@ export function StudentAssessmentInstance({
   const showCardFooter = showExamFooterContent || showUnauthorizedEditWarning;
 
   const firstUncrossedLockpointZoneNumber = instance_question_rows
-    .filter((row) => row.start_new_zone && row.lockpoint && !row.lockpoint_crossed)
-    .map((row) => row.zone_number)
+    .filter((row) => row.start_new_zone && row.zone.lockpoint && !row.lockpoint_crossed)
+    .map((row) => row.zone.number)
     .sort((a, b) => a - b)[0];
 
   // Check whether an unmet advanceScorePerc in a prior zone should block
@@ -137,7 +137,7 @@ export function StudentAssessmentInstance({
     instance_question_rows.some(
       (row) =>
         row.question_access_mode === 'blocked_sequence' &&
-        (row.zone_number < zoneNumber || (row.zone_number === zoneNumber && row.start_new_zone)),
+        (row.zone.number < zoneNumber || (row.zone.number === zoneNumber && row.start_new_zone)),
     );
 
   function isLockpointCrossable(row: InstanceQuestionRow) {
@@ -145,16 +145,19 @@ export function StudentAssessmentInstance({
       resLocals.assessment_instance.open &&
       resLocals.authz_result.active &&
       resLocals.authz_result.authorized_edit &&
-      row.lockpoint &&
+      row.zone.lockpoint &&
       !row.lockpoint_crossed &&
-      row.zone_number === firstUncrossedLockpointZoneNumber &&
-      !hasUnmetAdvanceScorePercBeforeLockpoint(row.zone_number)
+      row.zone.number === firstUncrossedLockpointZoneNumber &&
+      !hasUnmetAdvanceScorePercBeforeLockpoint(row.zone.number)
     );
   }
 
   const crossableLockpointRows = instance_question_rows.filter(
     (row) =>
-      row.start_new_zone && row.lockpoint && !row.lockpoint_crossed && isLockpointCrossable(row),
+      row.start_new_zone &&
+      row.zone.lockpoint &&
+      !row.lockpoint_crossed &&
+      isLockpointCrossable(row),
   );
 
   return PageLayout({
@@ -190,7 +193,7 @@ export function StudentAssessmentInstance({
         : ''}
       ${crossableLockpointRows.map((row) =>
         Modal({
-          id: `crossLockpointModal-${row.zone_id}`,
+          id: `crossLockpointModal-${row.zone.id}`,
           title: 'Proceed to next questions?',
           body: html`
             <p>
@@ -209,20 +212,21 @@ export function StudentAssessmentInstance({
               <input
                 class="form-check-input"
                 type="checkbox"
-                id="lockpoint-confirm-${row.zone_id}"
-                onchange="document.getElementById('lockpoint-submit-${row.zone_id}').disabled = !this.checked"
+                id="lockpoint-confirm-${row.zone.id}"
+                onchange="document.getElementById('lockpoint-submit-${row.zone
+                  .id}').disabled = !this.checked"
               />
-              <label class="form-check-label" for="lockpoint-confirm-${row.zone_id}">
+              <label class="form-check-label" for="lockpoint-confirm-${row.zone.id}">
                 I understand that I will not be able to submit answers to previous questions
               </label>
             </div>
           `,
           footer: html`
             <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-            <input type="hidden" name="zone_id" value="${row.zone_id}" />
+            <input type="hidden" name="zone_id" value="${row.zone.id}" />
             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
             <button
-              id="lockpoint-submit-${row.zone_id}"
+              id="lockpoint-submit-${row.zone.id}"
               type="submit"
               name="__action"
               value="cross_lockpoint"
@@ -258,7 +262,7 @@ export function StudentAssessmentInstance({
           <div class="row align-items-center">
             ${run(() => {
               const allQuestionsDisabled = instance_question_rows.every(
-                (q) => !q.allow_real_time_grading,
+                (row) => !row.assessment_question.allow_real_time_grading,
               );
               return allQuestionsDisabled && resLocals.assessment_instance.open;
             })
@@ -361,9 +365,9 @@ export function StudentAssessmentInstance({
 
                 return instance_question_rows.map((instance_question_row) => {
                   const zoneHasInfo =
-                    instance_question_row.zone_title != null ||
-                    instance_question_row.zone_has_max_points ||
-                    instance_question_row.zone_has_best_questions;
+                    instance_question_row.zone.title != null ||
+                    instance_question_row.zone.max_points != null ||
+                    instance_question_row.zone.best_questions != null;
 
                   // Show zone info if this zone has info, or if the previous zone
                   // had info (blank zone info to visually separate).
@@ -375,13 +379,13 @@ export function StudentAssessmentInstance({
                   }
 
                   return html`
-                    ${instance_question_row.start_new_zone && instance_question_row.lockpoint
+                    ${instance_question_row.start_new_zone && instance_question_row.zone.lockpoint
                       ? LockpointRow({
                           row: instance_question_row,
                           colspan: zoneTitleColspan,
                           crossable: !!isLockpointCrossable(instance_question_row),
                           blockedByAdvanceScorePerc: hasUnmetAdvanceScorePercBeforeLockpoint(
-                            instance_question_row.zone_number,
+                            instance_question_row.zone.number,
                           ),
                           isGroupAssessment: groupConfig != null,
                           displayTimezone: resLocals.course_instance.display_timezone,
@@ -394,25 +398,25 @@ export function StudentAssessmentInstance({
                               ${zoneHasInfo
                                 ? html`
                                     <div class="d-flex align-items-center gap-2">
-                                      ${instance_question_row.zone_title
-                                        ? html`<span>${instance_question_row.zone_title}</span>`
+                                      ${instance_question_row.zone.title
+                                        ? html`<span>${instance_question_row.zone.title}</span>`
                                         : ''}
-                                      ${instance_question_row.zone_has_max_points
+                                      ${instance_question_row.zone.max_points != null
                                         ? ZoneInfoPopover({
-                                            label: instance_question_row.zone_title
-                                              ? `maximum ${instance_question_row.zone_max_points} points`
-                                              : `Maximum ${instance_question_row.zone_max_points} points`,
-                                            content: `Of the points that you are awarded for answering these ${instance_question_row.zone_question_count} questions, at most ${instance_question_row.zone_max_points} will count toward your total points.`,
+                                            label: instance_question_row.zone.title
+                                              ? `maximum ${instance_question_row.zone.max_points} points`
+                                              : `Maximum ${instance_question_row.zone.max_points} points`,
+                                            content: `Of the points that you are awarded for answering these ${instance_question_row.zone_question_count} questions, at most ${instance_question_row.zone.max_points} will count toward your total points.`,
                                           })
                                         : ''}
-                                      ${instance_question_row.zone_has_best_questions
+                                      ${instance_question_row.zone.best_questions != null
                                         ? ZoneInfoPopover({
                                             label:
-                                              instance_question_row.zone_title ||
-                                              instance_question_row.zone_has_max_points
-                                                ? `best ${instance_question_row.zone_best_questions} of ${instance_question_row.zone_question_count} questions`
-                                                : `Best ${instance_question_row.zone_best_questions} of ${instance_question_row.zone_question_count} questions`,
-                                            content: `Of these ${instance_question_row.zone_question_count} questions, only the ${instance_question_row.zone_best_questions} with the highest number of awarded points will count toward your total points.`,
+                                              instance_question_row.zone.title ||
+                                              instance_question_row.zone.max_points != null
+                                                ? `best ${instance_question_row.zone.best_questions} of ${instance_question_row.zone_question_count} questions`
+                                                : `Best ${instance_question_row.zone.best_questions} of ${instance_question_row.zone_question_count} questions`,
+                                            content: `Of these ${instance_question_row.zone_question_count} questions, only the ${instance_question_row.zone.best_questions} with the highest number of awarded points will count toward your total points.`,
                                           })
                                         : ''}
                                     </div>
@@ -438,8 +442,8 @@ export function StudentAssessmentInstance({
                             rowLabelText:
                               resLocals.assessment.type === 'Exam'
                                 ? `Question ${instance_question_row.question_number}`
-                                : instance_question_row.question_title?.trim()
-                                  ? `${instance_question_row.question_number}. ${instance_question_row.question_title}`
+                                : instance_question_row.question.title?.trim()
+                                  ? `${instance_question_row.question_number}. ${instance_question_row.question.title}`
                                   : instance_question_row.question_number,
                           })}
                         </div>
@@ -453,8 +457,9 @@ export function StudentAssessmentInstance({
                                 instance_question_row.question_access_mode === 'blocked_lockpoint'
                                   ? html`<span class="badge text-bg-secondary">Locked</span>`
                                   : ExamQuestionStatus({
-                                      instance_question: instance_question_row,
-                                      assessment_question: instance_question_row, // Required fields are in instance_question
+                                      instance_question: instance_question_row.instance_question,
+                                      assessment_question:
+                                        instance_question_row.assessment_question,
                                       realTimeGradingPartiallyDisabled:
                                         someQuestionsAllowRealTimeGrading &&
                                         someQuestionsForbidRealTimeGrading,
@@ -466,23 +471,30 @@ export function StudentAssessmentInstance({
                             someQuestionsAllowRealTimeGrading
                               ? html`
                                   <td class="text-center">
-                                    ${instance_question_row.max_auto_points
+                                    ${instance_question_row.assessment_question.max_auto_points
                                       ? ExamQuestionAvailablePoints({
                                           open:
                                             (resLocals.assessment_instance.open &&
-                                              instance_question_row.open) ??
+                                              instance_question_row.instance_question.open) ??
                                             false,
                                           currentWeight:
-                                            (instance_question_row.points_list_original?.[
-                                              instance_question_row.number_attempts
+                                            (instance_question_row.instance_question
+                                              .points_list_original?.[
+                                              instance_question_row.instance_question
+                                                .number_attempts
                                             ] ?? 0) -
-                                            (instance_question_row.max_manual_points ?? 0),
-                                          pointsList: instance_question_row.points_list?.map(
-                                            (p) =>
-                                              p - (instance_question_row.max_manual_points ?? 0),
-                                          ),
+                                            (instance_question_row.assessment_question
+                                              .max_manual_points ?? 0),
+                                          pointsList:
+                                            instance_question_row.instance_question.points_list?.map(
+                                              (p) =>
+                                                p -
+                                                (instance_question_row.assessment_question
+                                                  .max_manual_points ?? 0),
+                                            ),
                                           highestSubmissionScore:
-                                            instance_question_row.highest_submission_score,
+                                            instance_question_row.instance_question
+                                              .highest_submission_score,
                                         })
                                       : html`&mdash;`}
                                   </td>
@@ -496,15 +508,19 @@ export function StudentAssessmentInstance({
                                     ? html`
                                         <td class="text-center">
                                           ${InstanceQuestionPoints({
-                                            instance_question: instance_question_row,
-                                            assessment_question: instance_question_row, // Required fields are present in instance_question
+                                            instance_question:
+                                              instance_question_row.instance_question,
+                                            assessment_question:
+                                              instance_question_row.assessment_question,
                                             component: 'auto',
                                           })}
                                         </td>
                                         <td class="text-center">
                                           ${InstanceQuestionPoints({
-                                            instance_question: instance_question_row,
-                                            assessment_question: instance_question_row, // Required fields are present in instance_question
+                                            instance_question:
+                                              instance_question_row.instance_question,
+                                            assessment_question:
+                                              instance_question_row.assessment_question,
                                             component: 'manual',
                                           })}
                                         </td>
@@ -512,8 +528,9 @@ export function StudentAssessmentInstance({
                                     : ''}
                                   <td class="text-center">
                                     ${InstanceQuestionPoints({
-                                      instance_question: instance_question_row,
-                                      assessment_question: instance_question_row, // Required fields are present in instance_question
+                                      instance_question: instance_question_row.instance_question,
+                                      assessment_question:
+                                        instance_question_row.assessment_question,
                                       component: 'total',
                                     })}
                                   </td>
@@ -523,15 +540,23 @@ export function StudentAssessmentInstance({
                                   resLocals.has_manual_grading_question
                                     ? html`
                                         <td class="text-center">
-                                          ${formatPoints(instance_question_row.max_auto_points)}
+                                          ${formatPoints(
+                                            instance_question_row.assessment_question
+                                              .max_auto_points,
+                                          )}
                                         </td>
                                         <td class="text-center">
-                                          ${formatPoints(instance_question_row.max_manual_points)}
+                                          ${formatPoints(
+                                            instance_question_row.assessment_question
+                                              .max_manual_points,
+                                          )}
                                         </td>
                                       `
                                     : ''}
                                   <td class="text-center">
-                                    ${formatPoints(instance_question_row.max_points)}
+                                    ${formatPoints(
+                                      instance_question_row.assessment_question.max_points,
+                                    )}
                                   </td>
                                 `}
                           `
@@ -950,7 +975,9 @@ function ConfirmFinishModal({
   instance_question_rows: InstanceQuestionRow[];
   csrfToken: string;
 }) {
-  const all_questions_answered = instance_question_rows.every((iq) => iq.status !== 'unanswered');
+  const all_questions_answered = instance_question_rows.every(
+    ({ instance_question: iq }) => iq.status !== 'unanswered',
+  );
 
   return Modal({
     id: 'confirmFinishModal',

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.sql
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.sql
@@ -8,28 +8,16 @@ WHERE
 
 -- BLOCK select_instance_questions
 SELECT
-  iq.*,
+  to_jsonb(iq.*) AS instance_question,
+  to_jsonb(z.*) AS zone,
+  to_jsonb(aq.*) AS assessment_question,
+  to_jsonb(q.*) AS question,
   ((lag(z.id) OVER w) IS DISTINCT FROM z.id) AS start_new_zone,
-  z.id AS zone_id,
-  z.number AS zone_number,
-  z.title AS zone_title,
-  z.lockpoint,
   (aicl.id IS NOT NULL) AS lockpoint_crossed,
   aicl.crossed_at AS lockpoint_crossed_at,
   lockpoint_user.uid AS lockpoint_crossed_authn_user_uid,
-  q.title AS question_title,
-  aq.max_points,
-  aq.max_manual_points,
-  aq.max_auto_points,
-  aq.init_points,
-  aq.grade_rate_minutes,
-  aq.allow_real_time_grading,
   qo.row_order,
   qo.question_number,
-  z.max_points AS zone_max_points,
-  (z.max_points IS NOT NULL) AS zone_has_max_points,
-  z.best_questions AS zone_best_questions,
-  (z.best_questions IS NOT NULL) AS zone_has_best_questions,
   (
     count(*) OVER (
       PARTITION BY

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
@@ -252,22 +252,24 @@ router.get(
     const allPreviousVariants = await selectVariantsByInstanceQuestion({
       assessment_instance_id: res.locals.assessment_instance.id,
     });
-    for (const instance_question of instance_question_rows) {
-      instance_question.previous_variants = allPreviousVariants.filter((variant) =>
-        idsEqual(variant.instance_question_id, instance_question.id),
+    for (const row of instance_question_rows) {
+      row.previous_variants = allPreviousVariants.filter((variant) =>
+        idsEqual(variant.instance_question_id, row.instance_question.id),
       );
-      if (instance_question.grade_rate_minutes) {
-        instance_question.allowGradeLeftMs = await computeNextAllowedGradingTimeMs({
-          instanceQuestionId: instance_question.id,
+      if (row.assessment_question.grade_rate_minutes) {
+        row.allowGradeLeftMs = await computeNextAllowedGradingTimeMs({
+          instanceQuestionId: row.instance_question.id,
         });
       }
     }
 
     res.locals.has_manual_grading_question = instance_question_rows.some(
-      (q) => q.max_manual_points || q.manual_points || q.requires_manual_grading,
+      ({ instance_question: iq, assessment_question: aq }) =>
+        aq.max_manual_points || iq.manual_points || iq.requires_manual_grading,
     );
     res.locals.has_auto_grading_question = instance_question_rows.some(
-      (q) => q.max_auto_points || q.auto_points || !q.max_points,
+      ({ instance_question: iq, assessment_question: aq }) =>
+        aq.max_auto_points || iq.auto_points || !aq.max_points,
     );
     const assessment_text_templated = renderText(res.locals.assessment, res.locals.urlPrefix);
     res.locals.assessment_text_templated = assessment_text_templated;
@@ -298,9 +300,9 @@ router.get(
       // Get the role permissions. If the authorized user has course instance
       // permission, then role restrictions don't apply.
       if (!res.locals.authz_data.has_course_instance_permission_view) {
-        for (const question of instance_question_rows) {
-          question.group_role_permissions = await getQuestionGroupPermissions(
-            question.id,
+        for (const row of instance_question_rows) {
+          row.group_role_permissions = await getQuestionGroupPermissions(
+            row.instance_question.id,
             res.locals.assessment_instance.team_id!,
             res.locals.authz_data.user.id,
           );

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.types.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.types.ts
@@ -1,37 +1,27 @@
 import { z } from 'zod';
 
-import { DateFromISOString, IdSchema } from '@prairielearn/zod';
+import { DateFromISOString } from '@prairielearn/zod';
 
 import {
   AssessmentQuestionSchema,
   EnumQuestionAccessModeSchema,
   InstanceQuestionSchema,
   QuestionSchema,
+  ZoneSchema,
 } from '../../lib/db-types.js';
 import { SimpleVariantWithScoreSchema } from '../../models/variant.js';
 
-export const InstanceQuestionRowSchema = InstanceQuestionSchema.extend({
+export const InstanceQuestionRowSchema = z.object({
+  zone: ZoneSchema,
+  instance_question: InstanceQuestionSchema,
+  assessment_question: AssessmentQuestionSchema,
+  question: QuestionSchema,
   start_new_zone: z.boolean(),
-  zone_id: IdSchema,
-  zone_number: z.number(),
-  zone_title: z.string().nullable(),
-  lockpoint: z.boolean(),
   lockpoint_crossed: z.boolean(),
   lockpoint_crossed_at: DateFromISOString.nullable(),
   lockpoint_crossed_authn_user_uid: z.string().nullable(),
-  question_title: QuestionSchema.shape.title,
-  max_points: z.number().nullable(),
-  max_manual_points: z.number().nullable(),
-  max_auto_points: z.number().nullable(),
-  init_points: z.number().nullable(),
-  grade_rate_minutes: AssessmentQuestionSchema.shape.grade_rate_minutes,
-  allow_real_time_grading: AssessmentQuestionSchema.shape.allow_real_time_grading,
   row_order: z.number(),
   question_number: z.string(),
-  zone_max_points: z.number().nullable(),
-  zone_has_max_points: z.boolean(),
-  zone_best_questions: z.number().nullable(),
-  zone_has_best_questions: z.boolean(),
   zone_question_count: z.number(),
   file_count: z.number(),
   question_access_mode: EnumQuestionAccessModeSchema,


### PR DESCRIPTION
# Description

I'm doing this ahead of #14689 to minimize the diff in that PR. This PR changes the instance questions query on the student assessment instance page to return full row objects for assessment questions, zones, and so on.

No AI was used for these changes.

# Testing

I did some basic testing in the browser. Things seem to render correctly for both homeworks and exams.

Both Claude and Codex reviewed the diff for behavior drift and found none.