### PR TITLE
Grant 100% credit when rule has release date but no deadlines

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -341,6 +341,20 @@ describe('resolveAccessControl', () => {
       expect(result.credit).toBe(0);
       expect(result.active).toBe(false);
     });
+
+    it('returns 100% credit when after release date and no deadlines', () => {
+      const result = resolveAccessControl({
+        ...baseInput,
+        rules: [
+          makeMainRule({
+            dateControl: { releaseDate: '2025-03-01T00:00:00Z' },
+          }),
+        ],
+        date: new Date('2025-03-15T00:00:00Z'),
+      });
+      expect(result.credit).toBe(100);
+      expect(result.active).toBe(true);
+    });
   });
 
   describe('early deadline bonus credit', () => {
@@ -1223,8 +1237,9 @@ describe('resolveAccessControl', () => {
         ],
         date: new Date('2025-03-15T00:00:00Z'),
       });
-      expect(result.credit).toBe(0);
-      expect(result.active).toBe(false);
+      expect(result.authorized).toBe(true);
+      expect(result.credit).toBe(100);
+      expect(result.active).toBe(true);
     });
   });
 
@@ -1329,28 +1344,6 @@ describe('resolveAccessControl', () => {
         date: new Date('2025-04-15T00:00:00Z'),
       });
       expect(afterAll.credit).toBe(0);
-    });
-  });
-
-  describe('no date control defaults', () => {
-    it.each([
-      { label: 'dateControl absent', rule: {} },
-      {
-        label: 'dateControl has no releaseDate',
-        rule: { dateControl: { dueDate: '2025-05-01T00:00:00Z' } },
-      },
-      {
-        label: 'dateControl has releaseDate but no deadlines/due date',
-        rule: { dateControl: { releaseDate: '2025-03-01T00:00:00Z' } },
-      },
-    ])('returns 0 credit when $label', ({ rule }) => {
-      const result = resolveAccessControl({
-        ...baseInput,
-        rules: [makeMainRule(rule)],
-        date: new Date('2025-03-15T00:00:00Z'),
-      });
-      expect(result.credit).toBe(0);
-      expect(result.active).toBe(false);
     });
   });
 
@@ -1531,10 +1524,6 @@ describe('resolveAccessControl', () => {
         rules: [
           {
             ...makeMainRule({
-              dateControl: {
-                releaseDate: '2025-01-01T00:00:00Z',
-                dueDate: null,
-              },
               afterComplete: {
                 questions: { hidden: true },
                 score: { hidden: true },
@@ -1545,7 +1534,7 @@ describe('resolveAccessControl', () => {
         ],
         prairieTestReservations: [],
       });
-      expect(result.authorized).toBe(true);
+      expect(result.authorized).toBe(false);
       expect(result.credit).toBe(0);
       expect(result.active).toBe(false);
       expect(result.examAccessEnd).toBeNull();

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1140,6 +1140,24 @@ describe('resolveAccessControl', () => {
         expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
       },
     );
+
+    // The gradebook displays rows even when access is denied and relies on
+    // `showClosedAssessmentScore` to decide whether to reveal prior scores, so
+    // the deny path must still honor the configured visibility flags.
+    it.each(visibilityConfigs)(
+      'Exam mode with no PT reservation: $name',
+      ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExam] }],
+          prairieTestReservations: [],
+        });
+        expect(result.authorized).toBe(false);
+        expect(result.showClosedAssessment).toBe(showClosedAssessment);
+        expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
+      },
+    );
   });
 
   describe('credit date string formatting', () => {

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1074,6 +1074,74 @@ describe('resolveAccessControl', () => {
     });
   });
 
+  describe('after-complete visibility with PrairieTest', () => {
+    const ptExam = { uuid: 'pt-exam-1', readOnly: false };
+    const ptExamReadOnly = { uuid: 'pt-exam-1', readOnly: true };
+    const validReservation: PrairieTestReservation = {
+      examUuid: 'pt-exam-1',
+      accessEnd: new Date('2025-03-15T14:00:00Z'),
+    };
+
+    const visibilityConfigs = [
+      {
+        name: 'hide both questions and score',
+        afterComplete: { questions: { hidden: true }, score: { hidden: true } },
+        showClosedAssessment: false,
+        showClosedAssessmentScore: false,
+      },
+      {
+        name: 'show both questions and score',
+        afterComplete: { questions: { hidden: false }, score: { hidden: false } },
+        showClosedAssessment: true,
+        showClosedAssessmentScore: true,
+      },
+      {
+        name: 'hide questions, show score',
+        afterComplete: { questions: { hidden: true }, score: { hidden: false } },
+        showClosedAssessment: false,
+        showClosedAssessmentScore: true,
+      },
+      {
+        name: 'show questions, hide score',
+        afterComplete: { questions: { hidden: false }, score: { hidden: true } },
+        showClosedAssessment: true,
+        showClosedAssessmentScore: false,
+      },
+    ];
+
+    it.each(visibilityConfigs)(
+      'active PT reservation: $name',
+      ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExam] }],
+          prairieTestReservations: [validReservation],
+        });
+        expect(result.authorized).toBe(true);
+        expect(result.active).toBe(true);
+        expect(result.showClosedAssessment).toBe(showClosedAssessment);
+        expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
+      },
+    );
+
+    it.each(visibilityConfigs)(
+      'readOnly PT reservation: $name',
+      ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExamReadOnly] }],
+          prairieTestReservations: [validReservation],
+        });
+        expect(result.authorized).toBe(true);
+        expect(result.active).toBe(false);
+        expect(result.showClosedAssessment).toBe(showClosedAssessment);
+        expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
+      },
+    );
+  });
+
   describe('credit date string formatting', () => {
     it('shows credit percentage and deadline', () => {
       const result = resolveAccessControl({
@@ -1513,33 +1581,20 @@ describe('resolveAccessControl', () => {
       expect(result.showBeforeRelease).toBe(false);
     });
 
-    it('keeps closed scores hidden when Exam mode outlives the PrairieTest reservation', () => {
+    it('denies access when Exam mode outlives the PrairieTest reservation', () => {
       // Regression test for #12579: `ip_to_mode` can continue reporting Exam
       // mode for a short grace period after PrairieTest has already ended the
-      // reservation. The migrated PT rule should still respect the closed
-      // assessment visibility settings in that state.
+      // reservation.
       const result = resolveAccessControl({
         ...baseInput,
         authzMode: 'Exam',
-        rules: [
-          {
-            ...makeMainRule({
-              afterComplete: {
-                questions: { hidden: true },
-                score: { hidden: true },
-              },
-            }),
-            prairietestExams: [ptExam],
-          },
-        ],
+        rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
         prairieTestReservations: [],
       });
       expect(result.authorized).toBe(false);
       expect(result.credit).toBe(0);
       expect(result.active).toBe(false);
       expect(result.examAccessEnd).toBeNull();
-      expect(result.showClosedAssessment).toBe(false);
-      expect(result.showClosedAssessmentScore).toBe(false);
       expect(result.showBeforeRelease).toBe(false);
     });
 

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -571,20 +571,6 @@ export function resolveAccessControl(
 
   let creditResult = computeCredit(effectiveRule.dateControl, date, authzMode);
 
-  const showClosedAssessment = resolveVisibility(
-    effectiveRule.afterComplete?.questions?.hidden ?? true,
-    effectiveRule.afterComplete?.questions?.visibleFromDate,
-    effectiveRule.afterComplete?.questions?.visibleUntilDate,
-    date,
-  );
-
-  const showClosedAssessmentScore = resolveVisibility(
-    effectiveRule.afterComplete?.score?.hidden,
-    effectiveRule.afterComplete?.score?.visibleFromDate,
-    undefined,
-    date,
-  );
-
   // Resolve PrairieTest access. This is separated from the main flow to keep
   // the resolver linear: it either denies early, grants PT credit overrides,
   // or continues with the normal date-control-based result.
@@ -598,9 +584,7 @@ export function resolveAccessControl(
       !creditResult.beforeRelease &&
       !creditResult.active,
   });
-  if (ptOutcome.action === 'deny') {
-    return { ...ptOutcome.result, showClosedAssessment, showClosedAssessmentScore };
-  }
+  if (ptOutcome.action === 'deny') return ptOutcome.result;
 
   let examAccessEnd: Date | null = null;
   if (ptOutcome.action === 'grant') {
@@ -609,6 +593,20 @@ export function resolveAccessControl(
   }
 
   const timeLimitMin = creditResult.timeLimitMin;
+
+  const showClosedAssessment = resolveVisibility(
+    effectiveRule.afterComplete?.questions?.hidden ?? true,
+    effectiveRule.afterComplete?.questions?.visibleFromDate,
+    effectiveRule.afterComplete?.questions?.visibleUntilDate,
+    date,
+  );
+
+  const showClosedAssessmentScore = resolveVisibility(
+    effectiveRule.afterComplete?.score?.hidden,
+    effectiveRule.afterComplete?.score?.visibleFromDate,
+    undefined,
+    date,
+  );
 
   // Resolve the raw `listBeforeRelease` config flag into a concrete
   // `showBeforeRelease` boolean: true when the flag is set AND either we're

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -292,11 +292,11 @@ function computeCredit(
 
   timeline.sort((a, b) => a.date.getTime() - b.date.getTime());
 
-  // No due date and no deadlines = no credit granted.
+  // No due date or deadlines means 100% credit anytime after the release date.
   if (timeline.length === 0) {
     return {
-      credit: 0,
-      active: false,
+      credit: 100,
+      active: true,
       beforeRelease: false,
       nextDeadlineDate: null,
       password: null,
@@ -571,29 +571,6 @@ export function resolveAccessControl(
 
   let creditResult = computeCredit(effectiveRule.dateControl, date, authzMode);
 
-  // Resolve PrairieTest access. This is separated from the main flow to keep
-  // the resolver linear: it either denies early, grants PT credit overrides,
-  // or continues with the normal date-control-based result.
-  const ptOutcome = resolvePrairieTestAccess({
-    prairieTestExams: mainRuleInput.prairietestExams,
-    prairieTestReservations,
-    authzMode,
-    listBeforeRelease: effectiveRule.listBeforeRelease ?? false,
-    assessmentClosed:
-      !!effectiveRule.dateControl?.releaseDate &&
-      !creditResult.beforeRelease &&
-      !creditResult.active,
-  });
-  if (ptOutcome.action === 'deny') return ptOutcome.result;
-
-  let examAccessEnd: Date | null = null;
-  if (ptOutcome.action === 'grant') {
-    creditResult = { ...creditResult, credit: ptOutcome.credit, active: ptOutcome.active };
-    examAccessEnd = ptOutcome.examAccessEnd;
-  }
-
-  const timeLimitMin = creditResult.timeLimitMin;
-
   const showClosedAssessment = resolveVisibility(
     effectiveRule.afterComplete?.questions?.hidden ?? true,
     effectiveRule.afterComplete?.questions?.visibleFromDate,
@@ -607,6 +584,31 @@ export function resolveAccessControl(
     undefined,
     date,
   );
+
+  // Resolve PrairieTest access. This is separated from the main flow to keep
+  // the resolver linear: it either denies early, grants PT credit overrides,
+  // or continues with the normal date-control-based result.
+  const ptOutcome = resolvePrairieTestAccess({
+    prairieTestExams: mainRuleInput.prairietestExams,
+    prairieTestReservations,
+    authzMode,
+    listBeforeRelease: effectiveRule.listBeforeRelease ?? false,
+    assessmentClosed:
+      !!effectiveRule.dateControl?.releaseDate &&
+      !creditResult.beforeRelease &&
+      !creditResult.active,
+  });
+  if (ptOutcome.action === 'deny') {
+    return { ...ptOutcome.result, showClosedAssessment, showClosedAssessmentScore };
+  }
+
+  let examAccessEnd: Date | null = null;
+  if (ptOutcome.action === 'grant') {
+    creditResult = { ...creditResult, credit: ptOutcome.credit, active: ptOutcome.active };
+    examAccessEnd = ptOutcome.examAccessEnd;
+  }
+
+  const timeLimitMin = creditResult.timeLimitMin;
 
   // Resolve the raw `listBeforeRelease` config flag into a concrete
   // `showBeforeRelease` boolean: true when the flag is set AND either we're

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -571,29 +571,10 @@ export function resolveAccessControl(
 
   let creditResult = computeCredit(effectiveRule.dateControl, date, authzMode);
 
-  // Resolve PrairieTest access. This is separated from the main flow to keep
-  // the resolver linear: it either denies early, grants PT credit overrides,
-  // or continues with the normal date-control-based result.
-  const ptOutcome = resolvePrairieTestAccess({
-    prairieTestExams: mainRuleInput.prairietestExams,
-    prairieTestReservations,
-    authzMode,
-    listBeforeRelease: effectiveRule.listBeforeRelease ?? false,
-    assessmentClosed:
-      !!effectiveRule.dateControl?.releaseDate &&
-      !creditResult.beforeRelease &&
-      !creditResult.active,
-  });
-  if (ptOutcome.action === 'deny') return ptOutcome.result;
-
-  let examAccessEnd: Date | null = null;
-  if (ptOutcome.action === 'grant') {
-    creditResult = { ...creditResult, credit: ptOutcome.credit, active: ptOutcome.active };
-    examAccessEnd = ptOutcome.examAccessEnd;
-  }
-
-  const timeLimitMin = creditResult.timeLimitMin;
-
+  // Compute visibility up-front so deny results can still honor the course
+  // author's `afterComplete` configuration. The student gradebook displays
+  // rows even when access is denied, and relies on `showClosedAssessmentScore`
+  // to decide whether to show prior scores.
   const showClosedAssessment = resolveVisibility(
     effectiveRule.afterComplete?.questions?.hidden ?? true,
     effectiveRule.afterComplete?.questions?.visibleFromDate,
@@ -608,6 +589,31 @@ export function resolveAccessControl(
     date,
   );
 
+  // Resolve PrairieTest access. This is separated from the main flow to keep
+  // the resolver linear: it either denies early, grants PT credit overrides,
+  // or continues with the normal date-control-based result.
+  const ptOutcome = resolvePrairieTestAccess({
+    prairieTestExams: mainRuleInput.prairietestExams,
+    prairieTestReservations,
+    authzMode,
+    listBeforeRelease: effectiveRule.listBeforeRelease ?? false,
+    assessmentClosed:
+      !!effectiveRule.dateControl?.releaseDate &&
+      !creditResult.beforeRelease &&
+      !creditResult.active,
+  });
+  if (ptOutcome.action === 'deny') {
+    return { ...ptOutcome.result, showClosedAssessment, showClosedAssessmentScore };
+  }
+
+  let examAccessEnd: Date | null = null;
+  if (ptOutcome.action === 'grant') {
+    creditResult = { ...creditResult, credit: ptOutcome.credit, active: ptOutcome.active };
+    examAccessEnd = ptOutcome.examAccessEnd;
+  }
+
+  const timeLimitMin = creditResult.timeLimitMin;
+
   // Resolve the raw `listBeforeRelease` config flag into a concrete
   // `showBeforeRelease` boolean: true when the flag is set AND either we're
   // before the release date or there is no release date configured.
@@ -618,7 +624,7 @@ export function resolveAccessControl(
   // If the assessment is before its release date and showBeforeRelease is false,
   // the student should not see or access it at all.
   if (creditResult.beforeRelease && !showBeforeRelease) {
-    return { ...UNAUTHORIZED_RESULT };
+    return { ...UNAUTHORIZED_RESULT, showClosedAssessment, showClosedAssessmentScore };
   }
 
   const creditDateString = formatCreditDateString(


### PR DESCRIPTION
# Description

Changes the resolver semantics so that a rule with only a release date (no due date, no early/late deadlines) is treated as open indefinitely at 100% credit, instead of returning 0% credit with `active: false`. Also fixes a side effect for PrairieTest-gated rules: when PT denies access, the rule's `afterComplete` visibility config (hidden questions / hidden score) is now respected. Previously the hardcoded `UNAUTHORIZED_RESULT` always returned `showClosedAssessment: true / showClosedAssessmentScore: true`, which masked the configured hiding during the Exam-mode grace period after a PT reservation ends.

Tests are updated accordingly: the `no date control defaults` block is removed (one case's expectation flipped, the other two were duplicates of existing tests), a new `returns 100% credit when after release date and no deadlines` test is added inside `main rule with date control`, and the `ignores afterLastDeadline when there are no deadlines` test asserts the new behavior.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation is human-authored; Claude Code assisted with review of duplicate tests, reorganizing placements, and writing the PT deny visibility fix.

# Testing

Existing unit tests in `resolver.test.ts` cover all affected paths; the full suite passes (115 tests).