### PR TITLE
Add element-backwards-compat skill

### DIFF
--- a/.agents/skills/element-backwards-compat/SKILL.md
+++ b/.agents/skills/element-backwards-compat/SKILL.md
@@ -3,36 +3,15 @@ name: element-backwards-compat
 description: Backwards compatibility rules when changing element controllers in `apps/prairielearn/elements/`.
 ---
 
-Several fields on the `data` dict that an element controller receives are persisted to the database and read back by future invocations — potentially years later, across many PrairieLearn upgrades. **Existing variants and submissions are not re-generated when element code changes.**
+Several dict-shaped fields on the `data` dict that an element controller receives are persisted to the database and read back by future invocations. **Existing variants and submissions are not re-generated when element code changes**, so any new key added to a persisted dict will be missing on rows written before the change. Reading it with `dict[key]` throws `KeyError` and breaks every existing question that uses the element. This has happened twice in `pl-order-blocks` alone (`ordering_feedback`, `initially_placed`).
 
 The persisted dict-shaped fields are:
 
 - On the variant row: `data["params"]`, `data["correct_answers"]`.
 - On submission rows: `data["submitted_answers"]`, `data["raw_submitted_answers"]`, `data["partial_scores"]`, `data["feedback"]`, `data["format_errors"]`.
 
-(`data["score"]` and `data["variant_seed"]` are also persisted, but they are scalars — there are no keys to add or remove, so this rule doesn't apply to them.)
-
-Any new key added to one of the dicts above (or to a nested dict stored inside one) will be missing on rows written before the change. Reading it with `dict[key]` throws `KeyError` and breaks every existing question that uses the element. This has happened multiple times in `pl-order-blocks` alone (`ordering_feedback`, `distractor_feedback`, `initially_placed`).
-
 ## Rules
 
-When changing an element controller in `apps/prairielearn/elements/`, treat reads of persisted data as untrusted:
+1. **Adding a new key to a persisted dict?** Every reader in every element function must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to top-level keys and to keys inside any nested per-block / per-answer dict stored inside a persisted field. If the element uses a `TypedDict` for the nested shape, mark the new field `NotRequired[...]` from `typing_extensions` so pyright catches unguarded reads.
 
-1. **Adding a new key to a persisted dict?** Every reader in every element function must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to:
-   - Top-level keys in any persisted field listed above.
-   - Keys inside any nested per-block / per-answer dict written by `prepare` (e.g. each entry of `data["params"][answer_name]`) or by `parse`/`grade` into submission fields.
-   - The corresponding `TypedDict` field should be marked `NotRequired[...]` from `typing_extensions` so pyright catches unguarded reads.
-
-2. **Renaming or removing a persisted key?** Don't. Keep the old key alongside the new one and have readers fall back to the old key when the new one is missing.
-
-3. **Changing the type or semantics of an existing key?** Same as renaming — old rows still hold the old shape. Add a new key with the new semantics rather than mutating the meaning of an existing one.
-
-## Reviewing element changes
-
-When reviewing a diff that touches an element controller, look for:
-
-- New entries in any `TypedDict` describing persisted data — then grep the file for `dict["new_key"]` style reads and flag any that aren't `.get(...)`.
-- New assignments into any of the persisted `data[...]` fields listed above (or into nested dicts stored inside them) — same check on the read sites.
-- New required fields on Pydantic models or dataclasses that get serialized into persisted data.
-
-If you find an unguarded read of a newly-added key, the fix is almost always to switch to `.get(key, default)` and choose a default that matches the pre-change behavior.
+2. **Renaming, removing, or changing the semantics of a persisted key?** Don't. Keep the old key alongside the new one and have readers fall back to it when the new one is missing. Old rows still hold the old shape forever.

--- a/.agents/skills/element-backwards-compat/SKILL.md
+++ b/.agents/skills/element-backwards-compat/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: element-backwards-compat
+description: Backwards compatibility rules when changing element controllers in `apps/prairielearn/elements/`.
+---
+
+Several fields on the `data` dict that an element controller receives are persisted to the database and read back by future invocations — potentially years later, across many PrairieLearn upgrades. **Existing variants and submissions are not re-generated when element code changes.**
+
+The persisted dict-shaped fields are:
+
+- On the variant row: `data["params"]`, `data["correct_answers"]`.
+- On submission rows: `data["submitted_answers"]`, `data["raw_submitted_answers"]`, `data["partial_scores"]`, `data["feedback"]`, `data["format_errors"]`.
+
+(`data["score"]` and `data["variant_seed"]` are also persisted, but they are scalars — there are no keys to add or remove, so this rule doesn't apply to them.)
+
+Any new key added to one of the dicts above (or to a nested dict stored inside one) will be missing on rows written before the change. Reading it with `dict[key]` throws `KeyError` and breaks every existing question that uses the element. This has happened multiple times in `pl-order-blocks` alone (`ordering_feedback`, `distractor_feedback`, `initially_placed`).
+
+## Rules
+
+When changing an element controller in `apps/prairielearn/elements/`, treat reads of persisted data as untrusted:
+
+1. **Adding a new key to a persisted dict?** Every reader must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to:
+   - Top-level keys in any persisted field listed above.
+   - Keys inside any nested per-block / per-answer dict written by `prepare` (e.g. each entry of `data["params"][answer_name]`) or by `parse`/`grade` into submission fields.
+   - The corresponding `TypedDict` field should be marked `NotRequired[...]` from `typing_extensions` so pyright catches unguarded reads.
+
+   Defensive reads must be in place in **every** function that touches the field, including `render`. Migrating the data inside `parse` or `grade` is not sufficient on its own: `render` runs on every page view, and many old variants will never be re-submitted, so they will still hit `render` with the pre-change shape. (`render` also can't mutate `data`, so a normalization pass at the top isn't available there anyway.)
+
+2. **Renaming or removing a persisted key?** Don't. Keep the old key alongside the new one and have readers fall back to the old key when the new one is missing.
+
+3. **Changing the type or semantics of an existing key?** Same as renaming — old rows still hold the old shape. Add a new key with the new semantics rather than mutating the meaning of an existing one.
+
+## Reviewing element changes
+
+When reviewing a diff that touches an element controller, look for:
+
+- New entries in any `TypedDict` describing persisted data — then grep the file for `dict["new_key"]` style reads and flag any that aren't `.get(...)`.
+- New assignments into any of the persisted `data[...]` fields listed above (or into nested dicts stored inside them) — same check on the read sites.
+- New required fields on Pydantic models or dataclasses that get serialized into persisted data.
+
+If you find an unguarded read of a newly-added key, the fix is almost always to switch to `.get(key, default)` and choose a default that matches the pre-change behavior.

--- a/.agents/skills/element-backwards-compat/SKILL.md
+++ b/.agents/skills/element-backwards-compat/SKILL.md
@@ -18,12 +18,10 @@ Any new key added to one of the dicts above (or to a nested dict stored inside o
 
 When changing an element controller in `apps/prairielearn/elements/`, treat reads of persisted data as untrusted:
 
-1. **Adding a new key to a persisted dict?** Every reader must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to:
+1. **Adding a new key to a persisted dict?** Every reader in every element function must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to:
    - Top-level keys in any persisted field listed above.
    - Keys inside any nested per-block / per-answer dict written by `prepare` (e.g. each entry of `data["params"][answer_name]`) or by `parse`/`grade` into submission fields.
    - The corresponding `TypedDict` field should be marked `NotRequired[...]` from `typing_extensions` so pyright catches unguarded reads.
-
-   Defensive reads must be in place in **every** function that touches the field, including `render`. Migrating the data inside `parse` or `grade` is not sufficient on its own: `render` runs on every page view, and many old variants will never be re-submitted, so they will still hit `render` with the pre-change shape. (`render` also can't mutate `data`, so a normalization pass at the top isn't available there anyway.)
 
 2. **Renaming or removing a persisted key?** Don't. Keep the old key alongside the new one and have readers fall back to the old key when the new one is missing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,8 @@ Elements (similar to React components, used to build interactive questions) are 
 
 When changing element properties or options, you MUST update the corresponding documentation in `docs/elements/<element-name>.md` to match.
 
+When modifying or reviewing element controllers — especially adding fields to `data["params"]` or `data["correct_answers"]` — see the [`element-backwards-compat` skill](./.agents/skills/element-backwards-compat/SKILL.md) for the rules that protect existing variants from breaking.
+
 ### Testing
 
 - For Python tests, use `uv run pytest path/to/testfile.py` from the root directory.


### PR DESCRIPTION
# Description

Adds a new `.agents/skills/element-backwards-compat/SKILL.md` and a pointer from `AGENTS.md` to it. The skill documents that persisted dict-shaped fields on `data` (`params`, `correct_answers`, `submitted_answers`, `raw_submitted_answers`, `partial_scores`, `feedback`, `format_errors`) outlive element code changes — so any newly added key must be read with `.get(default)` in every function that touches it, including `render` (which can't mutate `data`, and runs on old variants that may never be re-submitted). Motivated by the recurring backwards-compat fixes in `pl-order-blocks` (`ordering_feedback`, `distractor_feedback`, `initially_placed`).

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation (drafted with Claude Code, reviewed and corrected by me).

# Testing

Docs-only change; no runtime behavior affected.