### PR TITLE
Fix retrieval of PR number in CI report script

### DIFF
--- a/scripts/ci-report-comment.py
+++ b/scripts/ci-report-comment.py
@@ -34,9 +34,9 @@ def _get_pr_number(repo: str, run_id: str) -> str | None:
         return None
     if raw.isdigit():
         return raw
+    # pull_requests is empty for fork PRs; fall back to finding the PR by worflow ref or commit SHA.
     if re.match(r"refs/pull/\d+/merge", raw):
         return raw.split("/")[2]
-    # pull_requests is empty for fork PRs; fall back to finding the PR by commit SHA.
     raw = _gh(
         "api",
         f"repos/{repo}/commits/{raw}/pulls",

--- a/scripts/ci-report-comment.py
+++ b/scripts/ci-report-comment.py
@@ -13,6 +13,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import quote
 
 _MARKER = "<!-- ci-report -->"
 _SECTION_PATTERN = re.compile(r"(<!-- ([\w-]+) -->.*?<!-- /\2 -->)", re.DOTALL)
@@ -28,21 +29,18 @@ def _get_pr_number(repo: str, run_id: str) -> str | None:
         "api",
         f"repos/{repo}/actions/runs/{run_id}",
         "--jq",
-        ".pull_requests[0].number // .referenced_workflows[0].ref // .head_sha",
+        r'.pull_requests[0].number // "\(.head_repository.owner.login):\(.head_branch)"',
     )
     if not raw:
         return None
     if raw.isdigit():
         return raw
-    # pull_requests is empty for fork PRs; fall back to finding the PR by workflow ref or commit SHA.
-    if re.match(r"refs/pull/\d+/merge", raw):
-        return raw.split("/")[2]
-    # ensure we're dealing with a commit SHA before using it to find the PR
-    if not re.match(r"^[0-9a-f]{40}$", raw, re.IGNORECASE):
-        return None
+    # pull_requests is empty for fork PRs; fall back to looking up by
+    # head owner:branch, which is stable across pushes (unlike head_sha,
+    # which stops matching once the PR head advances).
     raw = _gh(
         "api",
-        f"repos/{repo}/commits/{raw}/pulls",
+        f"repos/{repo}/pulls?head={quote(raw)}&state=all",
         "--jq",
         ".[0].number // empty",
     )

--- a/scripts/ci-report-comment.py
+++ b/scripts/ci-report-comment.py
@@ -28,12 +28,14 @@ def _get_pr_number(repo: str, run_id: str) -> str | None:
         "api",
         f"repos/{repo}/actions/runs/{run_id}",
         "--jq",
-        ".pull_requests[0].number // .head_sha",
+        ".pull_requests[0].number // .referenced_workflows[0].ref // .head_sha",
     )
     if not raw:
         return None
     if raw.isdigit():
         return raw
+    if re.match(r"refs/pull/\d+/merge", raw):
+        return raw.split("/")[2]
     # pull_requests is empty for fork PRs; fall back to finding the PR by commit SHA.
     raw = _gh(
         "api",

--- a/scripts/ci-report-comment.py
+++ b/scripts/ci-report-comment.py
@@ -34,7 +34,7 @@ def _get_pr_number(repo: str, run_id: str) -> str | None:
         return None
     if raw.isdigit():
         return raw
-    # pull_requests is empty for fork PRs; fall back to finding the PR by worflow ref or commit SHA.
+    # pull_requests is empty for fork PRs; fall back to finding the PR by workflow ref or commit SHA.
     if re.match(r"refs/pull/\d+/merge", raw):
         return raw.split("/")[2]
     # ensure we're dealing with a commit SHA before using it to find the PR

--- a/scripts/ci-report-comment.py
+++ b/scripts/ci-report-comment.py
@@ -37,6 +37,9 @@ def _get_pr_number(repo: str, run_id: str) -> str | None:
     # pull_requests is empty for fork PRs; fall back to finding the PR by worflow ref or commit SHA.
     if re.match(r"refs/pull/\d+/merge", raw):
         return raw.split("/")[2]
+    # ensure we're dealing with a commit SHA before using it to find the PR
+    if not re.match(r"^[0-9a-f]{40}$", raw, re.IGNORECASE):
+        return None
     raw = _gh(
         "api",
         f"repos/{repo}/commits/{raw}/pulls",


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Hopefully addresses issues like https://github.com/PrairieLearn/PrairieLearn/actions/runs/24582459617 in #14396. It seems in some cases the API does not return a PR from a commit if that commit is in a fork. This PR updates the script that retrieves the PR number by obtaining it from the `referenced_workflows` array, which contains a ref to the PR.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: auto-complete only.

# Testing

I tested the script and it's able to obtain the PR from that case. Unfortunately I can't test this further without merging to master, since the CI process that runs this script checks it out from master instead of from the current branch (I assume for security reasons).

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
