### PR TITLE
AI submission grouping feature flag

### DIFF
--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -8,6 +8,7 @@ const featureNames = [
   'question-sharing', // This also controls course instance sharing.
   'consume-public-questions',
   'ai-grading',
+  'ai-submission-grouping',
   'disable-public-workspaces',
   'enhanced-access-control',
 

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/AssessmentQuestionManualGrading.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/AssessmentQuestionManualGrading.html.tsx
@@ -40,6 +40,7 @@ interface AssessmentQuestionManualGradingProps {
   assessmentQuestion: StaffAssessmentQuestion;
   questionQid: string;
   aiGradingEnabled: boolean;
+  aiSubmissionGroupingEnabled: boolean;
   initialAiGradingMode: boolean;
   rubricData: RubricData | null;
   instanceQuestionGroups: StaffInstanceQuestionGroup[];
@@ -71,6 +72,7 @@ function AssessmentQuestionManualGradingInner({
   assessmentQuestion,
   questionQid,
   aiGradingEnabled,
+  aiSubmissionGroupingEnabled,
   initialAiGradingMode,
   rubricData,
   instanceQuestionGroups,
@@ -165,6 +167,7 @@ function AssessmentQuestionManualGradingInner({
         assessmentQuestion={assessmentQuestion}
         questionQid={questionQid}
         aiGradingMode={aiGradingMode}
+        aiSubmissionGroupingEnabled={aiSubmissionGroupingEnabled}
         rubricData={rubricData}
         instanceQuestionGroups={instanceQuestionGroups}
         courseStaff={courseStaff}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/assessmentQuestion.tsx
@@ -54,16 +54,22 @@ router.get(
       }),
     );
     const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
+    const aiSubmissionGroupingEnabled = await features.enabledFromLocals(
+      'ai-submission-grouping',
+      res.locals,
+    );
 
     const rubric_data = await manualGrading.selectRubricData({
       assessment_question: res.locals.assessment_question,
     });
 
-    const instanceQuestionGroups = z.array(StaffInstanceQuestionGroupSchema).parse(
-      await selectInstanceQuestionGroups({
-        assessmentQuestionId: res.locals.assessment_question.id,
-      }),
-    );
+    const instanceQuestionGroups = aiSubmissionGroupingEnabled
+      ? z.array(StaffInstanceQuestionGroupSchema).parse(
+          await selectInstanceQuestionGroups({
+            assessmentQuestionId: res.locals.assessment_question.id,
+          }),
+        )
+      : [];
 
     const unfilledInstanceQuestionInfo = await selectInstanceQuestionsForManualGrading({
       assessment: res.locals.assessment,
@@ -170,6 +176,7 @@ router.get(
                 assessmentQuestion={assessment_question}
                 questionQid={question.qid!}
                 aiGradingEnabled={aiGradingEnabled}
+                aiSubmissionGroupingEnabled={aiSubmissionGroupingEnabled}
                 initialAiGradingMode={
                   aiGradingEnabled &&
                   assessment_question.ai_grading_mode &&
@@ -217,10 +224,10 @@ router.get(
       req.session.show_submissions_assigned_to_me_only ?? true;
 
     const use_instance_question_groups = await run(async () => {
-      const aiGradingMode =
-        (await features.enabledFromLocals('ai-grading', res.locals)) &&
+      const groupingAvailable =
+        (await features.enabledFromLocals('ai-submission-grouping', res.locals)) &&
         res.locals.assessment_question.ai_grading_mode;
-      if (!aiGradingMode) {
+      if (!groupingAvailable) {
         return false;
       }
       return await selectAssessmentQuestionHasInstanceQuestionGroups({

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
@@ -79,6 +79,7 @@ interface AssessmentQuestionTableProps {
   assessmentQuestion: StaffAssessmentQuestion;
   questionQid: string;
   aiGradingMode: boolean;
+  aiSubmissionGroupingEnabled: boolean;
   rubricData: RubricData | null;
   instanceQuestionGroups: StaffInstanceQuestionGroup[];
   courseStaff: StaffUser[];
@@ -119,6 +120,7 @@ export function AssessmentQuestionTable({
   assessmentQuestion,
   questionQid,
   aiGradingMode,
+  aiSubmissionGroupingEnabled,
   rubricData,
   instanceQuestionGroups,
   courseStaff,
@@ -743,7 +745,9 @@ export function AssessmentQuestionTable({
                     </Dropdown.Item>
                   </Dropdown.Menu>
                 </Dropdown>
-                {!availableAiGradingProviders.includes('openai') ? (
+                {!aiSubmissionGroupingEnabled ? null : !availableAiGradingProviders.includes(
+                    'openai',
+                  ) ? (
                   <OverlayTrigger
                     tooltip={{
                       body: 'No OpenAI API key is configured. Add a key in AI grading settings to use submission grouping.',

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
@@ -745,65 +745,69 @@ export function AssessmentQuestionTable({
                     </Dropdown.Item>
                   </Dropdown.Menu>
                 </Dropdown>
-                {!aiSubmissionGroupingEnabled ? null : !availableAiGradingProviders.includes(
-                    'openai',
-                  ) ? (
-                  <OverlayTrigger
-                    tooltip={{
-                      body: 'No OpenAI API key is configured. Add a key in AI grading settings to use submission grouping.',
-                      props: { id: 'ai-grouping-no-openai-tooltip' },
-                    }}
-                  >
-                    <span style={{ display: 'inline-block' }}>
-                      <Button variant="light" size="sm" style={{ pointerEvents: 'none' }} disabled>
+                {aiSubmissionGroupingEnabled &&
+                  (!availableAiGradingProviders.includes('openai') ? (
+                    <OverlayTrigger
+                      tooltip={{
+                        body: 'No OpenAI API key is configured. Add a key in AI grading settings to use submission grouping.',
+                        props: { id: 'ai-grouping-no-openai-tooltip' },
+                      }}
+                    >
+                      <span style={{ display: 'inline-block' }}>
+                        <Button
+                          variant="light"
+                          size="sm"
+                          style={{ pointerEvents: 'none' }}
+                          disabled
+                        >
+                          <i className="bi bi-stars" aria-hidden="true" />
+                          <span className="d-none d-sm-inline">AI submission grouping</span>
+                        </Button>
+                      </span>
+                    </OverlayTrigger>
+                  ) : (
+                    <Dropdown>
+                      <Dropdown.Toggle variant="light" size="sm">
                         <i className="bi bi-stars" aria-hidden="true" />
                         <span className="d-none d-sm-inline">AI submission grouping</span>
-                      </Button>
-                    </span>
-                  </OverlayTrigger>
-                ) : (
-                  <Dropdown>
-                    <Dropdown.Toggle variant="light" size="sm">
-                      <i className="bi bi-stars" aria-hidden="true" />
-                      <span className="d-none d-sm-inline">AI submission grouping</span>
-                    </Dropdown.Toggle>
-                    <Dropdown.Menu align="end">
-                      <Dropdown.Item
-                        disabled={selectedIds.length === 0}
-                        onClick={() =>
-                          onSetGroupInfoModalState({ type: 'selected', ids: selectedIds })
-                        }
-                      >
-                        <div className="d-flex justify-content-between align-items-center w-100">
-                          <span>Group selected submissions</span>
-                          <span className="badge bg-secondary ms-2">
-                            {aiGroupingCounts.selected}
-                          </span>
-                        </div>
-                      </Dropdown.Item>
-                      <Dropdown.Item onClick={() => onSetGroupInfoModalState({ type: 'all' })}>
-                        <div className="d-flex justify-content-between align-items-center w-100">
-                          <span>Group all submissions</span>
-                          <span className="badge bg-secondary ms-2">{aiGroupingCounts.all}</span>
-                        </div>
-                      </Dropdown.Item>
-                      <Dropdown.Item
-                        onClick={() => onSetGroupInfoModalState({ type: 'ungrouped' })}
-                      >
-                        <div className="d-flex justify-content-between align-items-center w-100">
-                          <span>Group ungrouped submissions</span>
-                          <span className="badge bg-secondary ms-2">
-                            {aiGroupingCounts.ungrouped}
-                          </span>
-                        </div>
-                      </Dropdown.Item>
-                      <Dropdown.Divider />
-                      <Dropdown.Item onClick={() => setShowDeleteAiGroupingsModal(true)}>
-                        Delete all AI groupings
-                      </Dropdown.Item>
-                    </Dropdown.Menu>
-                  </Dropdown>
-                )}
+                      </Dropdown.Toggle>
+                      <Dropdown.Menu align="end">
+                        <Dropdown.Item
+                          disabled={selectedIds.length === 0}
+                          onClick={() =>
+                            onSetGroupInfoModalState({ type: 'selected', ids: selectedIds })
+                          }
+                        >
+                          <div className="d-flex justify-content-between align-items-center w-100">
+                            <span>Group selected submissions</span>
+                            <span className="badge bg-secondary ms-2">
+                              {aiGroupingCounts.selected}
+                            </span>
+                          </div>
+                        </Dropdown.Item>
+                        <Dropdown.Item onClick={() => onSetGroupInfoModalState({ type: 'all' })}>
+                          <div className="d-flex justify-content-between align-items-center w-100">
+                            <span>Group all submissions</span>
+                            <span className="badge bg-secondary ms-2">{aiGroupingCounts.all}</span>
+                          </div>
+                        </Dropdown.Item>
+                        <Dropdown.Item
+                          onClick={() => onSetGroupInfoModalState({ type: 'ungrouped' })}
+                        >
+                          <div className="d-flex justify-content-between align-items-center w-100">
+                            <span>Group ungrouped submissions</span>
+                            <span className="badge bg-secondary ms-2">
+                              {aiGroupingCounts.ungrouped}
+                            </span>
+                          </div>
+                        </Dropdown.Item>
+                        <Dropdown.Divider />
+                        <Dropdown.Item onClick={() => setShowDeleteAiGroupingsModal(true)}>
+                          Delete all AI groupings
+                        </Dropdown.Item>
+                      </Dropdown.Menu>
+                    </Dropdown>
+                  ))}
               </>
             ) : (
               <Dropdown>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -108,7 +108,14 @@ router.get(
 
     const instance_question = res.locals.instance_question;
 
+    const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
+    const aiSubmissionGroupingEnabled = await features.enabledFromLocals(
+      'ai-submission-grouping',
+      res.locals,
+    );
+
     const instanceQuestionGroup = await run(async () => {
+      if (!aiSubmissionGroupingEnabled) return null;
       if (instance_question.manual_instance_question_group_id) {
         return await selectInstanceQuestionGroup(
           instance_question.manual_instance_question_group_id,
@@ -119,11 +126,11 @@ router.get(
       return null;
     });
 
-    const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
-
-    const instanceQuestionGroups = await selectInstanceQuestionGroups({
-      assessmentQuestionId: res.locals.assessment_question.id,
-    });
+    const instanceQuestionGroups = aiSubmissionGroupingEnabled
+      ? await selectInstanceQuestionGroups({
+          assessmentQuestionId: res.locals.assessment_question.id,
+        })
+      : [];
 
     /**
      * Contains the prompt and selected rubric items of the AI grader.
@@ -290,8 +297,11 @@ router.get(
 router.put(
   '/manual_instance_question_group',
   asyncHandler(async (req, res) => {
-    const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
-    if (!aiGradingEnabled) {
+    const aiSubmissionGroupingEnabled = await features.enabledFromLocals(
+      'ai-submission-grouping',
+      res.locals,
+    );
+    if (!aiSubmissionGroupingEnabled) {
       throw new error.HttpStatusError(403, 'Access denied (feature not available)');
     }
 
@@ -511,10 +521,10 @@ router.post(
       }
 
       const use_instance_question_groups = await run(async () => {
-        const aiGradingMode =
-          (await features.enabledFromLocals('ai-grading', res.locals)) &&
+        const groupingAvailable =
+          (await features.enabledFromLocals('ai-submission-grouping', res.locals)) &&
           res.locals.assessment_question.ai_grading_mode;
-        if (!aiGradingMode) {
+        if (!groupingAvailable) {
           return false;
         }
         return await selectAssessmentQuestionHasInstanceQuestionGroups({
@@ -539,10 +549,10 @@ router.post(
       req.session.show_submissions_assigned_to_me_only = body.show_submissions_assigned_to_me_only;
 
       const use_instance_question_groups = await run(async () => {
-        const aiGradingMode =
-          (await features.enabledFromLocals('ai-grading', res.locals)) &&
+        const groupingAvailable =
+          (await features.enabledFromLocals('ai-submission-grouping', res.locals)) &&
           res.locals.assessment_question.ai_grading_mode;
-        if (!aiGradingMode) {
+        if (!groupingAvailable) {
           return false;
         }
         return await selectAssessmentQuestionHasInstanceQuestionGroups({
@@ -569,17 +579,17 @@ router.post(
       req.session.skip_graded_submissions = body.skip_graded_submissions;
       req.session.show_submissions_assigned_to_me_only = body.show_submissions_assigned_to_me_only;
 
-      const aiGradingEnabled = await features.enabledFromLocals('ai-grading', res.locals);
+      const aiSubmissionGroupingEnabled = await features.enabledFromLocals(
+        'ai-submission-grouping',
+        res.locals,
+      );
 
-      if (!aiGradingEnabled) {
+      if (!aiSubmissionGroupingEnabled) {
         throw new error.HttpStatusError(403, 'Access denied (feature not available)');
       }
 
       const useInstanceQuestionGroups = await run(async () => {
-        const aiGradingMode =
-          (await features.enabledFromLocals('ai-grading', res.locals)) &&
-          res.locals.assessment_question.ai_grading_mode;
-        if (!aiGradingMode) {
+        if (!res.locals.assessment_question.ai_grading_mode) {
           return false;
         }
         return await selectAssessmentQuestionHasInstanceQuestionGroups({
@@ -725,10 +735,10 @@ router.post(
         req.session.show_submissions_assigned_to_me_only ?? true;
 
       const use_instance_question_groups = await run(async () => {
-        const aiGradingMode =
-          (await features.enabledFromLocals('ai-grading', res.locals)) &&
+        const groupingAvailable =
+          (await features.enabledFromLocals('ai-submission-grouping', res.locals)) &&
           res.locals.assessment_question.ai_grading_mode;
-        if (!aiGradingMode) {
+        if (!groupingAvailable) {
           return false;
         }
         return await selectAssessmentQuestionHasInstanceQuestionGroups({

--- a/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
+++ b/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
@@ -51,23 +51,6 @@ const requireAiGradingFeature = t.middleware(async (opts) => {
   return opts.next();
 });
 
-const requireAiSubmissionGroupingFeature = t.middleware(async (opts) => {
-  const enabled = await features.enabled('ai-submission-grouping', {
-    institution_id: opts.ctx.course.institution_id,
-    course_id: opts.ctx.course.id,
-    course_instance_id: opts.ctx.course_instance.id,
-    user_id: opts.ctx.authn_user.id,
-  });
-
-  if (!enabled) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Access denied (feature not available)',
-    });
-  }
-  return opts.next();
-});
-
 const instances = t.procedure
   .use(requireCourseInstancePermissionView)
   .output(z.array(InstanceQuestionRowWithAIGradingStatsSchema))
@@ -106,7 +89,7 @@ const deleteAiGradingJobsMutation = t.procedure
 
 const deleteAiInstanceQuestionGroupingsMutation = t.procedure
   .use(requireCourseInstancePermissionEdit)
-  .use(requireAiSubmissionGroupingFeature)
+  .use(requireAiGradingFeature)
   .output(z.object({ num_deleted: z.number() }))
   .mutation(async (opts) => {
     const num_deleted = await deleteAiInstanceQuestionGroups({
@@ -118,7 +101,7 @@ const deleteAiInstanceQuestionGroupingsMutation = t.procedure
 
 const aiGroupInstanceQuestionsMutation = t.procedure
   .use(requireCourseInstancePermissionEdit)
-  .use(requireAiSubmissionGroupingFeature)
+  .use(requireAiGradingFeature)
   .input(
     z.object({
       selection: z.union([z.literal('all'), z.literal('ungrouped'), z.string().array()]),

--- a/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
+++ b/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
@@ -51,6 +51,23 @@ const requireAiGradingFeature = t.middleware(async (opts) => {
   return opts.next();
 });
 
+const requireAiSubmissionGroupingFeature = t.middleware(async (opts) => {
+  const enabled = await features.enabled('ai-submission-grouping', {
+    institution_id: opts.ctx.course.institution_id,
+    course_id: opts.ctx.course.id,
+    course_instance_id: opts.ctx.course_instance.id,
+    user_id: opts.ctx.authn_user.id,
+  });
+
+  if (!enabled) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Access denied (feature not available)',
+    });
+  }
+  return opts.next();
+});
+
 const instances = t.procedure
   .use(requireCourseInstancePermissionView)
   .output(z.array(InstanceQuestionRowWithAIGradingStatsSchema))
@@ -89,7 +106,7 @@ const deleteAiGradingJobsMutation = t.procedure
 
 const deleteAiInstanceQuestionGroupingsMutation = t.procedure
   .use(requireCourseInstancePermissionEdit)
-  .use(requireAiGradingFeature)
+  .use(requireAiSubmissionGroupingFeature)
   .output(z.object({ num_deleted: z.number() }))
   .mutation(async (opts) => {
     const num_deleted = await deleteAiInstanceQuestionGroups({
@@ -101,7 +118,7 @@ const deleteAiInstanceQuestionGroupingsMutation = t.procedure
 
 const aiGroupInstanceQuestionsMutation = t.procedure
   .use(requireCourseInstancePermissionEdit)
-  .use(requireAiGradingFeature)
+  .use(requireAiSubmissionGroupingFeature)
   .input(
     z.object({
       selection: z.union([z.literal('all'), z.literal('ungrouped'), z.string().array()]),


### PR DESCRIPTION
# Description

- AI submission grouping was behind the AI grading feature flag. This PR adds a separate feature flag for submission grouping. This will be particularly helpful once we remove the AI grading feature flag.

# Testing

- Navigate to a manual grading page. Ensure that the **AI submission grouping** dropdown is **not** visible.

<img width="600" height="104" alt="Screenshot 2026-04-18 at 2 50 49 PM" src="https://github.com/user-attachments/assets/393b0f0e-3f65-4a82-8a5a-422c9ad7f7da" />

- Go to `/pl/administrator/features`, and enable `ai-submission-grouping`.
- Go back to the manual grading page. Ensure that the **AI submission grouping** dropdown is now visible.

<img width="1037" height="214" alt="Screenshot 2026-04-18 at 2 51 46 PM" src="https://github.com/user-attachments/assets/b0c5b9d5-8fb6-451c-bb98-12b9e0729aa4" />


