### PR TITLE
Filter out non-joined enrollments in group queries

### DIFF
--- a/apps/prairielearn/src/lib/group-update.sql
+++ b/apps/prairielearn/src/lib/group-update.sql
@@ -21,5 +21,6 @@ FROM
   LEFT JOIN students_in_groups AS sig ON (sig.user_id = u.id)
 WHERE
   a.id = $assessment_id
+  AND e.status = 'joined'
   AND NOT users_is_instructor_in_course_instance (e.user_id, e.course_instance_id)
   AND sig.team_id IS NULL;

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.sql
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.sql
@@ -55,6 +55,7 @@ FROM
 WHERE
   g.id IS NULL
   AND e.course_instance_id = $course_instance_id
+  AND e.status = 'joined'
   AND NOT users_is_instructor_in_course_instance (e.user_id, e.course_instance_id)
 ORDER BY
   u.uid;


### PR DESCRIPTION
# Description

The `select_not_in_group` query (used on the instructor assessment groups page) and `select_enrolled_students_without_group` query (used for random group generation) joined `enrollments` without filtering by status. This meant users with `left`, `removed`, or `blocked` enrollment statuses were treated as enrolled students — showing up in the "not assigned" list and being eligible for random group placement. Both queries now filter on `e.status = 'joined'`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation via Claude Code.

# Testing

Verified by code inspection; the `enum_enrollment_status` values and existing usages in `ee/models/enrollment.sql` confirm that `'joined'` is the correct active status to filter on.