### PR TITLE
Bump workspace/jupyterlab-r to 4.5.3

### DIFF
--- a/workspaces/jupyterlab-r/install.sh
+++ b/workspaces/jupyterlab-r/install.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Install all R dependencies.
-mamba install -y -c conda-forge r-base=4.5.2 r-irkernel=1.3.2
+mamba install -y -c conda-forge r-base=4.5.3 r-irkernel=1.3.2
 
 # Clear various caches to minimize the final image size.
 mamba clean --all -f -y


### PR DESCRIPTION
Brings in-line with RStudio workspace

<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Incremented the version of R from 4.5.2 to 4.5.3 in the jupyterlab-r workspace

<img width="413" height="323" alt="image" src="https://github.com/user-attachments/assets/55488ec6-1c50-4118-895c-47d9b92abb6a" />

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). No AI was used

# Testing

Tested by building the workspace locally, deploying to a course on the live PL server, and then submitting a question to be graded.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
