### PR TITLE
Split vitest/playwright and bump vitest to 6 shards

### DIFF
--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -1,0 +1,113 @@
+name: Native test setup
+description: Shared setup steps for running PrairieLearn tests natively on the runner.
+
+inputs:
+  install-playwright-browsers:
+    description: Whether to install Playwright browsers (chromium).
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    # The default Azure apt mirror on GitHub Actions runners is frequently
+    # slow or throttled, causing apt-get operations to take minutes instead
+    # of seconds. This action finds and configures a faster mirror.
+    - uses: vegardit/fast-apt-mirror.sh@v1
+      with:
+        exclude-current: true # Don't include the current APT mirror since it is unreliable.
+
+    # We uninstall `man-db` to speed up the installation of other packages
+    # by avoiding building man pages for them. As this is a non-interactive
+    # environment, we will never need man pages anyways.
+    #
+    # We don't install `texlive` since it's a huge package and the test suite
+    # doesn't require it.
+    - name: Install OS packages
+      shell: bash
+      run: |
+        sudo apt-get purge -y man-db
+        sudo apt-get install -y --no-install-recommends postgresql-common
+        # Configure Postgres repository, purge existing postgres version, and install v17
+        sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y -p -i -v 17
+        sudo apt-get install -y --no-install-recommends postgresql-17-pgvector git gcc libc6-dev graphviz libgraphviz-dev redis
+
+    # The two `sed` commands are here to handle the fact that the default
+    # configuration of Postgres on Ubuntu is to use `local` and `scram-sha-256`
+    # as the authentication mechanisms. However, our config defaults to not
+    # having any password at all, and we don't have an easy way to specify
+    # config overrides, which means we can't just create a new user with a
+    # password and have our code use that instead.
+    #
+    # We also update the configuration to try to speed up Postgres itself.
+    - name: Start Postgres
+      shell: bash
+      run: |
+        sudo sed -i 's/ local/ trust/g' /etc/postgresql/17/main/pg_hba.conf
+        sudo sed -i 's/ scram-sha-256/ trust/g' /etc/postgresql/17/main/pg_hba.conf
+
+        sudo tee -a /etc/postgresql/17/main/postgresql.conf <<EOF
+        fsync = off
+        full_page_writes = off
+        synchronous_commit = off
+        EOF
+
+        sudo systemctl restart postgresql.service
+
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        cache: 'yarn'
+    - name: Cache node-gyp headers
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/node-gyp
+        key: node-gyp-${{ runner.os }}
+    - name: Preinstall node-gyp headers
+      shell: bash
+      run: yarn dlx node-gyp install
+    - name: Install Node dependencies
+      shell: bash
+      run: yarn install --immutable --inline-builds
+      env:
+        # Disable hardened mode to eke out a little more speed.
+        YARN_ENABLE_HARDENED_MODE: 0
+    - name: Install Playwright browsers
+      if: inputs.install-playwright-browsers == 'true'
+      shell: bash
+      run: yarn playwright install chromium --with-deps
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-dependency-glob: 'pyproject.toml'
+        cache-suffix: core
+    - name: Install core Python dependencies
+      shell: bash
+      env:
+        UV_LOCKED: 1
+      run: make python-deps-core
+
+    - name: Set up Turborepo cache
+      uses: actions/cache@v5
+      with:
+        path: .turbo/cache
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+    - name: Build all code
+      shell: bash
+      run: make build
+
+    - name: Configure git
+      shell: bash
+      run: |
+        git config --global user.email "dev@example.com"
+        git config --global user.name "Dev User"
+        git config --global safe.directory '*'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,8 +81,29 @@ jobs:
           path: ${{ runner.temp }}/bundle-sizes-section.md
           retention-days: 1
 
+      # Restore the ESLint / Prettier caches. ESLint's own cache does not
+      # invalidate when an in-repo plugin's source changes (only when its
+      # version does), so we include the plugin and shared config sources in
+      # the cache key. Exact-match only — no restore-keys fallback — so a miss
+      # gives us a full, correct re-lint.
+      - name: Restore lint caches
+        uses: actions/cache@v5
+        with:
+          path: |
+            .eslintcache
+            node_modules/.cache/prettier
+          key: >-
+            lint-${{ runner.os }}-${{ hashFiles(
+              'yarn.lock',
+              'eslint.config.mjs',
+              'packages/eslint-plugin-prairielearn/src/**',
+              'packages/eslint-config/src/**',
+              '.prettierrc.json',
+              '.prettierignore'
+            ) }}
+
       - name: Run the JavaScript linter
-        run: make lint-js
+        run: make lint-js-cached
       - name: Run the Mustache linter
         run: make lint-mustache
       - name: Run the links linter

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,13 +81,6 @@ jobs:
           path: ${{ runner.temp }}/bundle-sizes-section.md
           retention-days: 1
 
-      # Restore the ESLint / Prettier caches. Exact-match only (no
-      # restore-keys fallback) so that a miss forces a full, correct re-lint.
-      #
-      # The key hashes every input that can affect lint output
-      #
-      # If you add a new in-repo eslint plugin or shared config package, add
-      # its source directory to this list.
       - name: Restore lint caches
         uses: actions/cache@v5
         with:
@@ -100,7 +93,6 @@ jobs:
               'eslint.config.mjs',
               'packages/eslint-config/**',
               'packages/eslint-plugin-prairielearn/**',
-              '**/tsconfig.json',
               '.prettierrc.json',
               '.prettierignore'
             ) }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,11 +81,19 @@ jobs:
           path: ${{ runner.temp }}/bundle-sizes-section.md
           retention-days: 1
 
-      # Restore the ESLint / Prettier caches. ESLint's own cache does not
-      # invalidate when an in-repo plugin's source changes (only when its
-      # version does), so we include the plugin and shared config sources in
-      # the cache key. Exact-match only — no restore-keys fallback — so a miss
-      # gives us a full, correct re-lint.
+      # Restore the ESLint / Prettier caches. Exact-match only (no
+      # restore-keys fallback) so that a miss forces a full, correct re-lint.
+      #
+      # The key must hash every input that can affect lint output:
+      # - yarn.lock captures external versions (typescript, typescript-eslint,
+      #   eslint, prettier, all plugins).
+      # - eslint.config.mjs + @prairielearn/eslint-config source + custom
+      #   plugin source. ESLint's own --cache only invalidates on plugin
+      #   *versions*; in-repo plugins share a pinned workspace version so we
+      #   must hash their source here.
+      # - Every tsconfig in the monorepo, because projectService type-aware
+      #   rules read them.
+      # - Prettier config + ignore file.
       - name: Restore lint caches
         uses: actions/cache@v5
         with:
@@ -96,8 +104,14 @@ jobs:
             lint-${{ runner.os }}-${{ hashFiles(
               'yarn.lock',
               'eslint.config.mjs',
-              'packages/eslint-plugin-prairielearn/src/**',
               'packages/eslint-config/src/**',
+              'packages/eslint-plugin-prairielearn/src/index.ts',
+              'packages/eslint-plugin-prairielearn/src/utils.ts',
+              'packages/eslint-plugin-prairielearn/src/rules/**',
+              'apps/*/tsconfig*.json',
+              'packages/*/tsconfig*.json',
+              'contrib/tsconfig.json',
+              'scripts/tsconfig.json',
               '.prettierrc.json',
               '.prettierignore'
             ) }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,16 +84,21 @@ jobs:
       # Restore the ESLint / Prettier caches. Exact-match only (no
       # restore-keys fallback) so that a miss forces a full, correct re-lint.
       #
-      # The key must hash every input that can affect lint output:
+      # The key hashes every input that can affect lint output:
       # - yarn.lock captures external versions (typescript, typescript-eslint,
       #   eslint, prettier, all plugins).
       # - eslint.config.mjs + @prairielearn/eslint-config source + custom
       #   plugin source. ESLint's own --cache only invalidates on plugin
-      #   *versions*; in-repo plugins share a pinned workspace version so we
-      #   must hash their source here.
+      #   *version*; in-repo plugins share a pinned workspace version, so we
+      #   must hash their source here. We hash the whole src/ directory (even
+      #   the plugins' own tests) — we'd rather over-invalidate than miss a
+      #   file.
       # - Every tsconfig in the monorepo, because projectService type-aware
       #   rules read them.
       # - Prettier config + ignore file.
+      #
+      # If you add a new in-repo eslint plugin or shared config package, add
+      # its source directory to this list.
       - name: Restore lint caches
         uses: actions/cache@v5
         with:
@@ -105,9 +110,7 @@ jobs:
               'yarn.lock',
               'eslint.config.mjs',
               'packages/eslint-config/src/**',
-              'packages/eslint-plugin-prairielearn/src/index.ts',
-              'packages/eslint-plugin-prairielearn/src/utils.ts',
-              'packages/eslint-plugin-prairielearn/src/rules/**',
+              'packages/eslint-plugin-prairielearn/src/**',
               'apps/*/tsconfig*.json',
               'packages/*/tsconfig*.json',
               'contrib/tsconfig.json',

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,18 +84,7 @@ jobs:
       # Restore the ESLint / Prettier caches. Exact-match only (no
       # restore-keys fallback) so that a miss forces a full, correct re-lint.
       #
-      # The key hashes every input that can affect lint output:
-      # - yarn.lock captures external versions (typescript, typescript-eslint,
-      #   eslint, prettier, all plugins).
-      # - eslint.config.mjs + @prairielearn/eslint-config source + custom
-      #   plugin source. ESLint's own --cache only invalidates on plugin
-      #   *version*; in-repo plugins share a pinned workspace version, so we
-      #   must hash their source here. We hash the whole src/ directory (even
-      #   the plugins' own tests) — we'd rather over-invalidate than miss a
-      #   file.
-      # - Every tsconfig in the monorepo, because projectService type-aware
-      #   rules read them.
-      # - Prettier config + ignore file.
+      # The key hashes every input that can affect lint output
       #
       # If you add a new in-repo eslint plugin or shared config package, add
       # its source directory to this list.
@@ -109,12 +98,9 @@ jobs:
             lint-${{ runner.os }}-${{ hashFiles(
               'yarn.lock',
               'eslint.config.mjs',
-              'packages/eslint-config/src/**',
-              'packages/eslint-plugin-prairielearn/src/**',
-              'apps/*/tsconfig*.json',
-              'packages/*/tsconfig*.json',
-              'contrib/tsconfig.json',
-              'scripts/tsconfig.json',
+              'packages/eslint-config/**',
+              'packages/eslint-plugin-prairielearn/**',
+              '**/tsconfig.json',
               '.prettierrc.json',
               '.prettierignore'
             ) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,14 +104,14 @@ jobs:
         # ensure that the tests fail more quickly so that people can fix them.
         timeout-minutes: 30
 
-  test-prairielearn-native:
-    name: Native (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+  test-prairielearn-vitest:
+    name: Vitest (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3, 4, 5, 6]
+        shardTotal: [6]
 
     env:
       CAN_LOGIN_TO_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
@@ -130,98 +130,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # The default Azure apt mirror on GitHub Actions runners is frequently
-      # slow or throttled, causing apt-get operations to take minutes instead
-      # of seconds. This action finds and configures a faster mirror.
-      - uses: vegardit/fast-apt-mirror.sh@v1
-        with:
-          exclude-current: true # Don't include the current APT mirror since it is unreliable.
-
-      # We uninstall `man-db` to speed up the installation of other packages
-      # by avoiding building man pages for them. As this is a non-interactive
-      # environment, we will never need man pages anyways.
-      #
-      # We don't install `texlive` since it's a huge package and the test suite
-      # doesn't require it.
-      - name: Install OS packages
-        run: |
-          sudo apt-get purge -y man-db
-          sudo apt-get install -y --no-install-recommends postgresql-common
-          # Configure Postgres repository, purge existing postgres version, and install v17
-          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y -p -i -v 17
-          sudo apt-get install -y --no-install-recommends postgresql-17-pgvector git gcc libc6-dev graphviz libgraphviz-dev redis
-
-      # The two `sed` commands are here to handle the fact that the default
-      # configuration of Postgres on Ubuntu is to use `local` and `scram-sha-256`
-      # as the authentication mechanisms. However, our config defaults to not
-      # having any password at all, and we don't have an easy way to specify
-      # config overrides, which means we can't just create a new user with a
-      # password and have our code use that instead.
-      #
-      # We also update the configuration to try to speed up Postgres itself.
-      - name: Start Postgres
-        run: |
-          sudo sed -i 's/ local/ trust/g' /etc/postgresql/17/main/pg_hba.conf
-          sudo sed -i 's/ scram-sha-256/ trust/g' /etc/postgresql/17/main/pg_hba.conf
-
-          sudo tee -a /etc/postgresql/17/main/postgresql.conf <<EOF
-          fsync = off
-          full_page_writes = off
-          synchronous_commit = off
-          EOF
-
-          sudo systemctl restart postgresql.service
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'yarn'
-      - name: Cache node-gyp headers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/node-gyp
-          key: node-gyp-${{ runner.os }}
-      - name: Preinstall node-gyp headers
-        run: yarn dlx node-gyp install
-      - name: Install Node dependencies
-        run: |
-          yarn install --immutable --inline-builds
-          yarn playwright install chromium --with-deps
-        env:
-          # Disable hardened mode to eke out a little more speed.
-          YARN_ENABLE_HARDENED_MODE: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          cache-suffix: core
-      - name: Install core Python dependencies
-        env:
-          UV_LOCKED: 1
-        run: make python-deps-core
-
-      - name: Set up Turborepo cache
-        uses: actions/cache@v5
-        with:
-          path: .turbo/cache
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-      - name: Build all code
-        run: make build
-
-      - name: Configure git
-        run: |
-          git config --global user.email "dev@example.com"
-          git config --global user.name "Dev User"
-          git config --global safe.directory '*'
+      - uses: ./.github/actions/native-test-setup
 
       - name: Vitest suite
         run: |
@@ -229,10 +138,6 @@ jobs:
           yarn test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
           SHARDED_TESTS: true
-
-      - name: Playwright suite
-        run: |
-          yarn workspace @prairielearn/prairielearn run test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload Vitest blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
@@ -242,6 +147,40 @@ jobs:
           path: .vitest-reports/*
           include-hidden-files: true
           retention-days: 1
+
+  test-prairielearn-playwright:
+    name: Playwright (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
+
+    env:
+      CAN_LOGIN_TO_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          show-progress: false
+
+      - name: Login to DockerHub
+        if: ${{ env.CAN_LOGIN_TO_DOCKERHUB == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: ./.github/actions/native-test-setup
+        with:
+          install-playwright-browsers: 'true'
+
+      - name: Playwright suite
+        run: |
+          make start-support
+          yarn workspace @prairielearn/prairielearn run test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
       - name: Upload Playwright blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
@@ -254,7 +193,7 @@ jobs:
   merge-native-test-reports:
     name: Native (merge test reports)
     if: ${{ !cancelled() }}
-    needs: [test-prairielearn-native]
+    needs: [test-prairielearn-vitest, test-prairielearn-playwright]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -299,7 +238,7 @@ jobs:
           path: playwright-report
           retention-days: 7
       # The merge-reports command always exits with 0, so we need to check if
-      # the test job succeeded and fail this job if it didn't.
+      # the test jobs succeeded and fail this job if they didn't.
       - name: Fail if tests failed
-        if: ${{ needs.test-prairielearn-native.result != 'success' }}
+        if: ${{ needs.test-prairielearn-vitest.result != 'success' || needs.test-prairielearn-playwright.result != 'success' }}
         run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,8 +154,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
 
     env:
       CAN_LOGIN_TO_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,17 @@ lint: lint-js lint-python lint-html lint-links lint-changeset
 lint-js:
 	@yarn eslint "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check
-# This is a separate target since the caches don't respect updates to plugins.
+# Separate target since the caches don't respect updates to plugins.
+# Split into two ESLint passes: the first is cacheable because its files never
+# match the type-aware config block (see `typeAwareFiles` in eslint.config.mjs);
+# the second runs the type-aware rules uncached, because ESLint's per-file
+# cache can't see cross-file type dependencies. Keep the ignore pattern in
+# sync with `typeAwareFiles`.
 lint-js-cached:
-	@yarn eslint --cache --cache-strategy content "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
+	@yarn eslint --cache --cache-strategy content \
+		--ignore-pattern "apps/prairielearn/**/*.{ts,tsx}" \
+		"**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
+	@yarn eslint "apps/prairielearn/**/*.{ts,tsx}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check --cache --cache-strategy content
 lint-python:
 	@uv run ruff check ./

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,8 @@ lint-js:
 	@yarn eslint "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check
 # Separate target since the caches don't respect updates to plugins.
-# Split into two ESLint passes: the first is cacheable because its files never
-# match the type-aware config block (see `typeAwareFiles` in eslint.config.mjs);
-# the second runs the type-aware rules uncached, because ESLint's per-file
-# cache can't see cross-file type dependencies. Keep the ignore pattern in
-# sync with `typeAwareFiles`.
+# Split into two passes: the first pass lints the type-aware files without a cache (see `typeAwareFiles` in eslint.config.mjs), and the second
+# pass lints the non-type-aware files with a cache. We check apps/prairielearn first since it is more likely to have lint errors.
 lint-js-cached:
 	@yarn eslint "apps/prairielearn/**/*.{ts,tsx}"
 	@yarn prettier "apps/prairielearn/**/*.{ts,tsx}" --check --cache --cache-strategy content

--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,15 @@ lint-js:
 # cache can't see cross-file type dependencies. Keep the ignore pattern in
 # sync with `typeAwareFiles`.
 lint-js-cached:
+	@yarn eslint "apps/prairielearn/**/*.{ts,tsx}"
+	@yarn prettier "apps/prairielearn/**/*.{ts,tsx}" --check --cache --cache-strategy content
 	@yarn eslint --cache --cache-strategy content \
 		--ignore-pattern "apps/prairielearn/**/*.{ts,tsx}" \
 		"**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
-	@yarn eslint "apps/prairielearn/**/*.{ts,tsx}"
-	@yarn prettier "**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" --check --cache --cache-strategy content
+	@yarn prettier \
+		"**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" \
+		"!apps/prairielearn/**/*.{ts,tsx}" \
+		--check --cache --cache-strategy content
 lint-python:
 	@uv run ruff check ./
 	@uv run ruff format --check ./

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,11 @@ const SLOW_TESTS_SHARDS: Record<number, string[]> = {
   2: ['src/tests/exampleCourseQuestions.test.ts'],
   3: ['src/tests/homework.test.ts', 'src/tests/fileEditor.test.ts'],
   4: ['src/tests/accessibility/index.test.ts', 'src/tests/cron.test.ts', 'src/tests/exam.test.ts'],
+  5: [],
+  6: [],
 };
+
+const SHARD_COUNT = Object.keys(SLOW_TESTS_SHARDS).length;
 
 const SLOW_TESTS = Object.values(SLOW_TESTS_SHARDS).flat();
 
@@ -35,13 +39,15 @@ if (existsSync(gitignorePath)) {
 
 // Each shard will get a certain slice of the tests outside of SLOW_TESTS.
 // This is a rough heuristic to try to balance the runtime of each shard.
-// For example, shard 3 will get 2/7 of these other tests.
-const NUM_SLICES = 7;
+// For example, shard 3 will get 2/13 of these other tests.
+const NUM_SLICES = 13;
 const SHARD_SLICES: Record<number, { start: number; end: number }> = {
   1: { start: 0, end: 0 },
   2: { start: 0, end: 1 },
   3: { start: 1, end: 3 },
-  4: { start: 3, end: NUM_SLICES },
+  4: { start: 3, end: 4 },
+  5: { start: 4, end: 8 },
+  6: { start: 8, end: NUM_SLICES },
 };
 
 class CustomSequencer extends BaseSequencer {
@@ -69,8 +75,8 @@ class CustomSequencer extends BaseSequencer {
     const { config } = this.ctx;
 
     const { index, count } = config.shard!;
-    if (count !== 4) {
-      throw new Error('Expected 4 shards');
+    if (count !== SHARD_COUNT) {
+      throw new Error(`Expected ${SHARD_COUNT} shards`);
     }
 
     // Some shards run slower tests, so other shards should take more 'slices'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,12 +12,20 @@ import { BaseSequencer, type TestSpecification } from 'vitest/node';
 // are slowest. However, this depends on cached data from previous runs, which
 // isn't available in CI. So, we manually specify the slowest tests here and
 // use a custom sequencer to always run them first.
+// Recent per-test timings (from master CI) were used to balance these shards.
+// Each of the first five shards is anchored around one of the longest-running
+// tests, so that no single shard is dramatically longer than the others.
+//   exampleCourseQuestionsComplete ~144s
+//   exampleCourseQuestions         ~137s
+//   accessibility                  ~120s
+//   homework                       ~100s (paired with cron ~32s)
+//   fileEditor                      ~66s (paired with exam ~65s)
 const SLOW_TESTS_SHARDS: Record<number, string[]> = {
   1: ['src/tests/exampleCourseQuestionsComplete.test.ts'],
   2: ['src/tests/exampleCourseQuestions.test.ts'],
-  3: ['src/tests/homework.test.ts', 'src/tests/fileEditor.test.ts'],
-  4: ['src/tests/accessibility/index.test.ts', 'src/tests/cron.test.ts', 'src/tests/exam.test.ts'],
-  5: [],
+  3: ['src/tests/accessibility/index.test.ts'],
+  4: ['src/tests/homework.test.ts', 'src/tests/cron.test.ts'],
+  5: ['src/tests/fileEditor.test.ts', 'src/tests/exam.test.ts'],
   6: [],
 };
 
@@ -37,15 +45,14 @@ if (existsSync(gitignorePath)) {
   gitignore.add(readFileSync(gitignorePath, 'utf8'));
 }
 
-// Each shard will get a certain slice of the tests outside of SLOW_TESTS.
-// This is a rough heuristic to try to balance the runtime of each shard.
-// For example, shard 3 will get 2/13 of these other tests.
+// Each shard gets a contiguous range of the tests outside of SLOW_TESTS, sized
+// inversely to how much slow-test work the shard already has.
 const NUM_SLICES = 13;
 const SHARD_SLICES: Record<number, { start: number; end: number }> = {
   1: { start: 0, end: 0 },
-  2: { start: 0, end: 1 },
-  3: { start: 1, end: 3 },
-  4: { start: 3, end: 4 },
+  2: { start: 0, end: 0 },
+  3: { start: 0, end: 1 },
+  4: { start: 1, end: 4 },
   5: { start: 4, end: 8 },
   6: { start: 8, end: NUM_SLICES },
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,11 +15,6 @@ import { BaseSequencer, type TestSpecification } from 'vitest/node';
 // Recent per-test timings (from master CI) were used to balance these shards.
 // Each of the first five shards is anchored around one of the longest-running
 // tests, so that no single shard is dramatically longer than the others.
-//   exampleCourseQuestionsComplete ~144s
-//   exampleCourseQuestions         ~137s
-//   accessibility                  ~120s
-//   homework                       ~100s (paired with cron ~32s)
-//   fileEditor                      ~66s (paired with exam ~65s)
 const SLOW_TESTS_SHARDS: Record<number, string[]> = {
   1: ['src/tests/exampleCourseQuestionsComplete.test.ts'],
   2: ['src/tests/exampleCourseQuestions.test.ts'],
@@ -27,6 +22,18 @@ const SLOW_TESTS_SHARDS: Record<number, string[]> = {
   4: ['src/tests/homework.test.ts', 'src/tests/cron.test.ts'],
   5: ['src/tests/fileEditor.test.ts', 'src/tests/exam.test.ts'],
   6: [],
+};
+
+// Each shard gets a contiguous range of the tests outside of SLOW_TESTS, sized
+// inversely to how much slow-test work the shard already has.
+const NUM_SLICES = 13;
+const SHARD_SLICES: Record<number, { start: number; end: number }> = {
+  1: { start: 0, end: 0 },
+  2: { start: 0, end: 0 },
+  3: { start: 0, end: 1 },
+  4: { start: 1, end: 4 },
+  5: { start: 4, end: 8 },
+  6: { start: 8, end: NUM_SLICES },
 };
 
 const SHARD_COUNT = Object.keys(SLOW_TESTS_SHARDS).length;
@@ -44,18 +51,6 @@ const gitignorePath = resolve(repoRoot, '.gitignore');
 if (existsSync(gitignorePath)) {
   gitignore.add(readFileSync(gitignorePath, 'utf8'));
 }
-
-// Each shard gets a contiguous range of the tests outside of SLOW_TESTS, sized
-// inversely to how much slow-test work the shard already has.
-const NUM_SLICES = 13;
-const SHARD_SLICES: Record<number, { start: number; end: number }> = {
-  1: { start: 0, end: 0 },
-  2: { start: 0, end: 0 },
-  3: { start: 0, end: 1 },
-  4: { start: 1, end: 4 },
-  5: { start: 4, end: 8 },
-  6: { start: 8, end: NUM_SLICES },
-};
 
 class CustomSequencer extends BaseSequencer {
   async sort(files: TestSpecification[]) {


### PR DESCRIPTION
# Description

CI times are crazy slow right now.

- Split up vitest / playwright into separate jobs
- Bumps vitest shards to 6
- Caches lint again, but only the non-type aware files

## Why

By splitting them into parallel matrix jobs and increasing vitest parallelism, the critical path for a PR should drop from ~8 min to ~5 min.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). — majority, Claude Code

# Testing

- This PR touches only CI configuration; the functional tests themselves are unchanged.
- Verifying by monitoring this PR's CI run: all vitest/playwright shards should pass, the \`Native (merge test reports)\` job should still run and fail correctly if any upstream shard fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)