### PR TITLE
Keep assessment active during 0% credit late deadlines

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -231,6 +231,35 @@ describe('resolveAccessControl', () => {
       expect(result.active).toBe(false);
     });
 
+    it('handles late deadline with 0% credit', () => {
+      const rule = makeMainRule({
+        dateControl: {
+          releaseDate: '2025-03-01T00:00:00Z',
+          dueDate: '2025-03-10T00:00:00Z',
+          lateDeadlines: [{ date: '2025-03-15T00:00:00Z', credit: 0 }],
+        },
+      });
+
+      // Check during the late deadline period: should be active for no credit.
+      // This is a regression test; we used to treat 0% credit as active:false.
+      const result = resolveAccessControl({
+        ...baseInput,
+        rules: [rule],
+        date: new Date('2025-03-12T00:00:00Z'),
+      });
+      expect(result.credit).toBe(0);
+      expect(result.active).toBe(true);
+
+      // Check again after the late deadline.
+      const resultAfter = resolveAccessControl({
+        ...baseInput,
+        rules: [rule],
+        date: new Date('2025-03-16T00:00:00Z'),
+      });
+      expect(resultAfter.credit).toBe(0);
+      expect(resultAfter.active).toBe(false);
+    });
+
     it('uses afterLastDeadline credit when specified', () => {
       const result = resolveAccessControl({
         ...baseInput,

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -313,7 +313,7 @@ function computeCredit(
       const nextDeadline = entry.date;
       return {
         credit,
-        active: credit > 0,
+        active: true,
         beforeRelease: false,
         nextDeadlineDate: nextDeadline,
         password: dateControl.password ?? null,


### PR DESCRIPTION
# Description

Previously, `computeCredit` in the assessment access-control resolver treated a late-deadline window with 0% credit as `active: false`. That meant a student hitting the assessment during a 0%-credit late period would see it as inactive, even though a late deadline window is explicitly a window in which submissions are still meant to be allowed.

This changes the late-deadline branch to return `active: true` unconditionally. The credit value already reflects whatever the late deadline specifies (including 0%), so callers downstream can still distinguish "submitting for no credit" from "not submitting at all". The behavior once we're past the final deadline is unchanged — that path still uses `afterLastDeadline.allowSubmissions` to decide `active`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): I wrote the changes, Claude checked and wrote this PR description

# Testing

Added a regression test in `resolver.test.ts` covering a rule with a due date and a 0%-credit late deadline:

- During the late window: `credit === 0`, `active === true`.
- After the late window: `credit === 0`, `active === false`.