### PR TITLE
Drop redundant push trigger on master for CI workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,6 @@ name: Check
 on:
   push:
     branches:
-      - master
       # Build on all code freeze branches since we will deploy from them.
       - '**-code-freeze'
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Test
 on:
   push:
     branches:
-      - master
       # Build on all code freeze branches since we will deploy from them.
       - '**-code-freeze'
   pull_request:


### PR DESCRIPTION
# Description

Every merge to master was triggering CI twice: once via `merge_group` (during queue validation) and again via `push` on the resulting master commit. Since the merge queue already validates the exact SHA that lands on master, the `push` run is pure duplication. The `**-code-freeze` branch trigger is kept since those branches don't go through the queue.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation.

# Testing

CI on this PR will still run via `pull_request`, and the `merge_group` event is unaffected.