### PR TITLE
Restore `_` global for legacy v2 question factories

### DIFF
--- a/apps/prairielearn/public/localscripts/questionCalculation.js
+++ b/apps/prairielearn/public/localscripts/questionCalculation.js
@@ -60,7 +60,13 @@ function CalculationClient() {
 
 CalculationClient.prototype.initialize = function (questionData, callback) {
   var that = this;
-  requirejs(['backbone'], function (Backbone) {
+  requirejs(['backbone', 'underscore'], function (Backbone, _) {
+    // Expose underscore as `window._` for legacy v2 question factories that
+    // reference `_` without declaring it as an AMD dependency. Vendored
+    // underscore <1.10.0 set the global as a side effect of being loaded in
+    // the browser; the rollup-built UMD wrapper in newer versions does not.
+    // See https://github.com/PrairieLearn/PrairieLearn/issues/14779.
+    window._ = _;
     require([questionData.questionFilePath + '/client.js'], function (qc) {
       that.questionDataModel = new Backbone.Model();
       that.questionDataModel.set('questionFilePath', questionData.questionFilePath);


### PR DESCRIPTION
# Description

Closes #14779.

Since underscore was bumped from the vendored 1.8.3 to 1.13.8 in #14296 (CVE fix), RequireJS-loaded underscore no longer sets `window._` as a side effect — the rollup-built UMD wrapper in 1.10.0+ only registers the AMD module. Because lodash is also loaded as a global on v2 pages before RequireJS, `window._` ended up as lodash, and legacy v2 `define(...)` factories that reference `_` without declaring it as an AMD dependency silently picked up lodash's different chain semantics (e.g. `_(arr).map(fn)` returns a `LodashWrapper`, not an array). This restores the pre-1.10.0 side effect by pulling `underscore` into the outer `requirejs([...])` call in `CalculationClient.prototype.initialize` and assigning `window._` before the question's `client.js` factory runs.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Majority of implementation via Claude Code.

# Testing

Reproduced locally with a v2 `define` factory that uses `_(arr).map(fn)[0]` without declaring the `"underscore"` AMD dep — pre-fix the factory sees lodash and indexing the wrapper yields `undefined`; post-fix the factory sees underscore and indexing returns the mapped element. Affected pages to spot-check: instructor question preview, student instance question, public question preview, and manual grading instance question.