### PR TITLE
Bump nbconvert to 7.17.1

### DIFF
--- a/graders/python/requirements.txt
+++ b/graders/python/requirements.txt
@@ -7,7 +7,7 @@ Faker==40.12.0
 folium==0.20.0
 ipython==9.12.0
 matplotlib==3.10.8
-nbconvert==7.17.0
+nbconvert==7.17.1
 nbformat==5.10.4
 networkx==3.6.1
 nltk==3.9.4

--- a/workspaces/jupyterlab-python/requirements.txt
+++ b/workspaces/jupyterlab-python/requirements.txt
@@ -7,7 +7,7 @@ Faker==40.12.0
 folium==0.20.0
 ipython==9.12.0
 matplotlib==3.10.8
-nbconvert==7.17.0
+nbconvert==7.17.1
 nbformat==5.10.4
 networkx==3.6.1
 nltk==3.9.4

--- a/workspaces/vscode-python/requirements.txt
+++ b/workspaces/vscode-python/requirements.txt
@@ -7,7 +7,7 @@ Faker==40.12.0
 folium==0.20.0
 ipython==9.12.0
 matplotlib==3.10.8
-nbconvert==7.17.0
+nbconvert==7.17.1
 nbformat==5.10.4
 networkx==3.6.1
 nltk==3.9.4


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves a dependabot alert. As with lxml, I don't think we have first-party code using the vulnerable features, but it could be in use by grader or workspace code on course side.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Not much to test, as we're not using this feature directly. Out of abundance of caution I tested a grader that uses notebooks and it's still working, though that uses nbformat instead of nbconvert.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
