### PR TITLE
Hide Active/All instance toggle on Staff page when all instances are active

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -1174,7 +1174,7 @@ function StaffTableInner({
   const viewPresetDropdown =
     courseInstances.length > 0 && !allInstancesAreActive ? (
       <Dropdown as={ButtonGroup}>
-        <Dropdown.Toggle variant="tanstack-table" size="sm">
+        <Dropdown.Toggle variant="tanstack-table">
           <i className="bi bi-funnel me-2" aria-hidden="true" />
           View: {selectedViewPreset ?? 'Custom'}
         </Dropdown.Toggle>

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -1169,8 +1169,10 @@ function StaffTableInner({
     void setColumnVisibility((prev) => ({ ...prev, ...preset }));
   };
 
+  const allInstancesAreActive = activeCourseInstanceIds.size === courseInstances.length;
+
   const viewPresetDropdown =
-    courseInstances.length > 0 ? (
+    courseInstances.length > 0 && !allInstancesAreActive ? (
       <Dropdown as={ButtonGroup}>
         <Dropdown.Toggle variant="tanstack-table" size="sm">
           <i className="bi bi-funnel me-2" aria-hidden="true" />


### PR DESCRIPTION
# Description
- Fixes an issue with the StaffTable wherein if all course instances are active, the "All Instances" option is defunct and unnecessary.
- The new logic requires at least 1 non-active course instance in order to render the Instance mode toggle
- Also makes the view dropdown buttons consistent in size (not `sm` on the Instance toggle)
- [X] I have disclosed the level of AI assistance used: Claude made the specific requested change

# Testing
- Using the Staff page, observe that for courses with only active instances, the toggle is not present
- Observe that when multiple instances exist which are in the future or past, the toggle is present