### PR TITLE
Reorganize access-control resolver tests

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -899,6 +899,264 @@ describe('resolveAccessControl', () => {
       expect(result.credit).toBe(100);
       expect(result.active).toBe(true);
     });
+
+    describe('after-complete visibility with PrairieTest', () => {
+      const ptExam = { uuid: 'pt-exam-1', readOnly: false };
+      const ptExamReadOnly = { uuid: 'pt-exam-1', readOnly: true };
+      const validReservation: PrairieTestReservation = {
+        examUuid: 'pt-exam-1',
+        accessEnd: new Date('2025-03-15T14:00:00Z'),
+      };
+
+      const visibilityConfigs = [
+        {
+          name: 'hide both questions and score',
+          afterComplete: { questions: { hidden: true }, score: { hidden: true } },
+          showClosedAssessment: false,
+          showClosedAssessmentScore: false,
+        },
+        {
+          name: 'show both questions and score',
+          afterComplete: { questions: { hidden: false }, score: { hidden: false } },
+          showClosedAssessment: true,
+          showClosedAssessmentScore: true,
+        },
+        {
+          name: 'hide questions, show score',
+          afterComplete: { questions: { hidden: true }, score: { hidden: false } },
+          showClosedAssessment: false,
+          showClosedAssessmentScore: true,
+        },
+        {
+          name: 'show questions, hide score',
+          afterComplete: { questions: { hidden: false }, score: { hidden: true } },
+          showClosedAssessment: true,
+          showClosedAssessmentScore: false,
+        },
+      ];
+
+      it.each(visibilityConfigs)(
+        'active PT reservation: $name',
+        ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
+          const result = resolveAccessControl({
+            ...baseInput,
+            authzMode: 'Exam',
+            rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExam] }],
+            prairieTestReservations: [validReservation],
+          });
+          expect(result.authorized).toBe(true);
+          expect(result.active).toBe(true);
+          expect(result.showClosedAssessment).toBe(showClosedAssessment);
+          expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
+        },
+      );
+
+      it.each(visibilityConfigs)(
+        'readOnly PT reservation: $name',
+        ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
+          const result = resolveAccessControl({
+            ...baseInput,
+            authzMode: 'Exam',
+            rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExamReadOnly] }],
+            prairieTestReservations: [validReservation],
+          });
+          expect(result.authorized).toBe(true);
+          expect(result.active).toBe(false);
+          expect(result.showClosedAssessment).toBe(showClosedAssessment);
+          expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
+        },
+      );
+
+      // The gradebook displays rows even when access is denied and relies on
+      // `showClosedAssessmentScore` to decide whether to reveal prior scores, so
+      // the deny path must still honor the configured visibility flags.
+      it.each(visibilityConfigs)(
+        'Exam mode with no PT reservation: $name',
+        ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
+          const result = resolveAccessControl({
+            ...baseInput,
+            authzMode: 'Exam',
+            rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExam] }],
+            prairieTestReservations: [],
+          });
+          expect(result.authorized).toBe(false);
+          expect(result.showClosedAssessment).toBe(showClosedAssessment);
+          expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
+        },
+      );
+    });
+
+    describe('showBeforeRelease with PrairieTest', () => {
+      const ptExam = { uuid: 'pt-exam-1', readOnly: false };
+
+      it('lists but does not authorize PT assessment when beforeRelease.listed set and not in exam mode', () => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          rules: [
+            { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam] },
+          ],
+        });
+        // Not in exam mode but beforeRelease.listed → listed but not authorized
+        expect(result.authorized).toBe(false);
+        expect(result.showBeforeRelease).toBe(true);
+        expect(result.active).toBe(false);
+      });
+
+      it('hides PT assessment when beforeRelease.listed false and not in exam mode', () => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
+        });
+        expect(result.authorized).toBe(false);
+      });
+
+      it('does not list or authorize PT assessment in exam mode when no matching reservation', () => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [
+            { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam] },
+          ],
+          prairieTestReservations: [
+            { examUuid: 'other-exam', accessEnd: new Date('2025-04-01T00:00:00Z') },
+          ],
+        });
+        expect(result.authorized).toBe(false);
+        expect(result.showBeforeRelease).toBe(false);
+        expect(result.active).toBe(false);
+      });
+
+      it('hides PT assessment when beforeRelease.listed false and no matching reservation', () => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
+          prairieTestReservations: [
+            { examUuid: 'other-exam', accessEnd: new Date('2025-04-01T00:00:00Z') },
+          ],
+        });
+        expect(result.authorized).toBe(false);
+        expect(result.showBeforeRelease).toBe(false);
+        expect(result.active).toBe(false);
+      });
+
+      it('does not grant access to PT assessment via beforeRelease.listed bypass', () => {
+        // Regression test: beforeRelease.listed must not set authorized=true for
+        // PrairieTest-gated assessments, otherwise students can start instances
+        // by posting directly to the assessment URL.
+        for (const authzMode of ['Public', 'Exam'] as const) {
+          const result = resolveAccessControl({
+            ...baseInput,
+            authzMode,
+            rules: [
+              { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam] },
+            ],
+            prairieTestReservations:
+              authzMode === 'Exam'
+                ? [{ examUuid: 'wrong-exam', accessEnd: new Date('2025-04-01T00:00:00Z') }]
+                : [],
+          });
+          expect(result.authorized).toBe(false);
+          expect(result.showBeforeRelease).toBe(authzMode === 'Public');
+          expect(result.credit).toBe(0);
+        }
+      });
+
+      it('shows closed PT assessment as closed instead of "before release" when past due date', () => {
+        // When a PT-gated assessment has date controls and is past its due
+        // date, it should show as a normal closed assessment rather than "Not
+        // yet open" indefinitely.
+        for (const authzMode of ['Public', 'Exam'] as const) {
+          const result = resolveAccessControl({
+            ...baseInput,
+            authzMode,
+            rules: [
+              {
+                ...makeMainRule({
+                  beforeRelease: { listed: true },
+                  dateControl: {
+                    releaseDate: '2025-01-01T00:00:00Z',
+                    dueDate: '2025-02-01T00:00:00Z',
+                  },
+                }),
+                prairietestExams: [ptExam],
+              },
+            ],
+            prairieTestReservations:
+              authzMode === 'Exam'
+                ? [{ examUuid: 'wrong-exam', accessEnd: new Date('2025-04-01T00:00:00Z') }]
+                : [],
+          });
+          expect(result.showBeforeRelease).toBe(false);
+          expect(result.authorized).toBe(true);
+          expect(result.active).toBe(false);
+        }
+      });
+
+      it('grants access via PT reservation even when assessment is past due date', () => {
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [
+            {
+              ...makeMainRule({
+                dateControl: {
+                  releaseDate: '2025-01-01T00:00:00Z',
+                  dueDate: '2025-02-01T00:00:00Z',
+                },
+              }),
+              prairietestExams: [ptExam],
+            },
+          ],
+          prairieTestReservations: [
+            { examUuid: ptExam.uuid, accessEnd: new Date('2025-04-01T00:00:00Z') },
+          ],
+        });
+        expect(result.authorized).toBe(true);
+        expect(result.credit).toBe(100);
+        expect(result.active).toBe(true);
+        expect(result.showBeforeRelease).toBe(false);
+      });
+
+      it('denies access when Exam mode outlives the PrairieTest reservation', () => {
+        // Regression test for #12579: `ip_to_mode` can continue reporting Exam
+        // mode for a short grace period after PrairieTest has already ended the
+        // reservation.
+        const result = resolveAccessControl({
+          ...baseInput,
+          authzMode: 'Exam',
+          rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
+          prairieTestReservations: [],
+        });
+        expect(result.authorized).toBe(false);
+        expect(result.credit).toBe(0);
+        expect(result.active).toBe(false);
+        expect(result.examAccessEnd).toBeNull();
+        expect(result.showBeforeRelease).toBe(false);
+      });
+
+      it('still shows "before release" for PT assessment that is open but student lacks access', () => {
+        // When a PT-gated assessment has date controls and is within its open
+        // period, students without PT access should still see "Not yet open".
+        const result = resolveAccessControl({
+          ...baseInput,
+          rules: [
+            {
+              ...makeMainRule({
+                beforeRelease: { listed: true },
+                dateControl: {
+                  releaseDate: '2025-01-01T00:00:00Z',
+                  dueDate: '2025-06-01T00:00:00Z',
+                },
+              }),
+              prairietestExams: [ptExam],
+            },
+          ],
+        });
+        expect(result.showBeforeRelease).toBe(true);
+        expect(result.active).toBe(false);
+      });
+    });
   });
 
   describe('time limit computation', () => {
@@ -1101,92 +1359,6 @@ describe('resolveAccessControl', () => {
       });
       expect(result.showClosedAssessmentScore).toBe(true);
     });
-  });
-
-  describe('after-complete visibility with PrairieTest', () => {
-    const ptExam = { uuid: 'pt-exam-1', readOnly: false };
-    const ptExamReadOnly = { uuid: 'pt-exam-1', readOnly: true };
-    const validReservation: PrairieTestReservation = {
-      examUuid: 'pt-exam-1',
-      accessEnd: new Date('2025-03-15T14:00:00Z'),
-    };
-
-    const visibilityConfigs = [
-      {
-        name: 'hide both questions and score',
-        afterComplete: { questions: { hidden: true }, score: { hidden: true } },
-        showClosedAssessment: false,
-        showClosedAssessmentScore: false,
-      },
-      {
-        name: 'show both questions and score',
-        afterComplete: { questions: { hidden: false }, score: { hidden: false } },
-        showClosedAssessment: true,
-        showClosedAssessmentScore: true,
-      },
-      {
-        name: 'hide questions, show score',
-        afterComplete: { questions: { hidden: true }, score: { hidden: false } },
-        showClosedAssessment: false,
-        showClosedAssessmentScore: true,
-      },
-      {
-        name: 'show questions, hide score',
-        afterComplete: { questions: { hidden: false }, score: { hidden: true } },
-        showClosedAssessment: true,
-        showClosedAssessmentScore: false,
-      },
-    ];
-
-    it.each(visibilityConfigs)(
-      'active PT reservation: $name',
-      ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
-        const result = resolveAccessControl({
-          ...baseInput,
-          authzMode: 'Exam',
-          rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExam] }],
-          prairieTestReservations: [validReservation],
-        });
-        expect(result.authorized).toBe(true);
-        expect(result.active).toBe(true);
-        expect(result.showClosedAssessment).toBe(showClosedAssessment);
-        expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
-      },
-    );
-
-    it.each(visibilityConfigs)(
-      'readOnly PT reservation: $name',
-      ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
-        const result = resolveAccessControl({
-          ...baseInput,
-          authzMode: 'Exam',
-          rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExamReadOnly] }],
-          prairieTestReservations: [validReservation],
-        });
-        expect(result.authorized).toBe(true);
-        expect(result.active).toBe(false);
-        expect(result.showClosedAssessment).toBe(showClosedAssessment);
-        expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
-      },
-    );
-
-    // The gradebook displays rows even when access is denied and relies on
-    // `showClosedAssessmentScore` to decide whether to reveal prior scores, so
-    // the deny path must still honor the configured visibility flags.
-    it.each(visibilityConfigs)(
-      'Exam mode with no PT reservation: $name',
-      ({ afterComplete, showClosedAssessment, showClosedAssessmentScore }) => {
-        const result = resolveAccessControl({
-          ...baseInput,
-          authzMode: 'Exam',
-          rules: [{ ...makeMainRule({ afterComplete }), prairietestExams: [ptExam] }],
-          prairieTestReservations: [],
-        });
-        expect(result.authorized).toBe(false);
-        expect(result.showClosedAssessment).toBe(showClosedAssessment);
-        expect(result.showClosedAssessmentScore).toBe(showClosedAssessmentScore);
-      },
-    );
   });
 
   describe('credit date string formatting', () => {
@@ -1499,178 +1671,6 @@ describe('resolveAccessControl', () => {
       });
       expect(result.authorized).toBe(true);
       expect(result.showBeforeRelease).toBe(false);
-    });
-  });
-
-  describe('showBeforeRelease with PrairieTest', () => {
-    const ptExam = { uuid: 'pt-exam-1', readOnly: false };
-
-    it('lists but does not authorize PT assessment when beforeRelease.listed set and not in exam mode', () => {
-      const result = resolveAccessControl({
-        ...baseInput,
-        rules: [
-          { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam] },
-        ],
-      });
-      // Not in exam mode but beforeRelease.listed → listed but not authorized
-      expect(result.authorized).toBe(false);
-      expect(result.showBeforeRelease).toBe(true);
-      expect(result.active).toBe(false);
-    });
-
-    it('hides PT assessment when beforeRelease.listed false and not in exam mode', () => {
-      const result = resolveAccessControl({
-        ...baseInput,
-        rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
-      });
-      expect(result.authorized).toBe(false);
-    });
-
-    it('does not list or authorize PT assessment in exam mode when no matching reservation', () => {
-      const result = resolveAccessControl({
-        ...baseInput,
-        authzMode: 'Exam',
-        rules: [
-          { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam] },
-        ],
-        prairieTestReservations: [
-          { examUuid: 'other-exam', accessEnd: new Date('2025-04-01T00:00:00Z') },
-        ],
-      });
-      expect(result.authorized).toBe(false);
-      expect(result.showBeforeRelease).toBe(false);
-      expect(result.active).toBe(false);
-    });
-
-    it('hides PT assessment when beforeRelease.listed false and no matching reservation', () => {
-      const result = resolveAccessControl({
-        ...baseInput,
-        authzMode: 'Exam',
-        rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
-        prairieTestReservations: [
-          { examUuid: 'other-exam', accessEnd: new Date('2025-04-01T00:00:00Z') },
-        ],
-      });
-      expect(result.authorized).toBe(false);
-      expect(result.showBeforeRelease).toBe(false);
-      expect(result.active).toBe(false);
-    });
-
-    it('does not grant access to PT assessment via beforeRelease.listed bypass', () => {
-      // Regression test: beforeRelease.listed must not set authorized=true for
-      // PrairieTest-gated assessments, otherwise students can start instances
-      // by posting directly to the assessment URL.
-      for (const authzMode of ['Public', 'Exam'] as const) {
-        const result = resolveAccessControl({
-          ...baseInput,
-          authzMode,
-          rules: [
-            { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam] },
-          ],
-          prairieTestReservations:
-            authzMode === 'Exam'
-              ? [{ examUuid: 'wrong-exam', accessEnd: new Date('2025-04-01T00:00:00Z') }]
-              : [],
-        });
-        expect(result.authorized).toBe(false);
-        expect(result.showBeforeRelease).toBe(authzMode === 'Public');
-        expect(result.credit).toBe(0);
-      }
-    });
-
-    it('shows closed PT assessment as closed instead of "before release" when past due date', () => {
-      // When a PT-gated assessment has date controls and is past its due
-      // date, it should show as a normal closed assessment rather than "Not
-      // yet open" indefinitely.
-      for (const authzMode of ['Public', 'Exam'] as const) {
-        const result = resolveAccessControl({
-          ...baseInput,
-          authzMode,
-          rules: [
-            {
-              ...makeMainRule({
-                beforeRelease: { listed: true },
-                dateControl: {
-                  releaseDate: '2025-01-01T00:00:00Z',
-                  dueDate: '2025-02-01T00:00:00Z',
-                },
-              }),
-              prairietestExams: [ptExam],
-            },
-          ],
-          prairieTestReservations:
-            authzMode === 'Exam'
-              ? [{ examUuid: 'wrong-exam', accessEnd: new Date('2025-04-01T00:00:00Z') }]
-              : [],
-        });
-        expect(result.showBeforeRelease).toBe(false);
-        expect(result.authorized).toBe(true);
-        expect(result.active).toBe(false);
-      }
-    });
-
-    it('grants access via PT reservation even when assessment is past due date', () => {
-      const result = resolveAccessControl({
-        ...baseInput,
-        authzMode: 'Exam',
-        rules: [
-          {
-            ...makeMainRule({
-              dateControl: {
-                releaseDate: '2025-01-01T00:00:00Z',
-                dueDate: '2025-02-01T00:00:00Z',
-              },
-            }),
-            prairietestExams: [ptExam],
-          },
-        ],
-        prairieTestReservations: [
-          { examUuid: ptExam.uuid, accessEnd: new Date('2025-04-01T00:00:00Z') },
-        ],
-      });
-      expect(result.authorized).toBe(true);
-      expect(result.credit).toBe(100);
-      expect(result.active).toBe(true);
-      expect(result.showBeforeRelease).toBe(false);
-    });
-
-    it('denies access when Exam mode outlives the PrairieTest reservation', () => {
-      // Regression test for #12579: `ip_to_mode` can continue reporting Exam
-      // mode for a short grace period after PrairieTest has already ended the
-      // reservation.
-      const result = resolveAccessControl({
-        ...baseInput,
-        authzMode: 'Exam',
-        rules: [{ ...makeMainRule(), prairietestExams: [ptExam] }],
-        prairieTestReservations: [],
-      });
-      expect(result.authorized).toBe(false);
-      expect(result.credit).toBe(0);
-      expect(result.active).toBe(false);
-      expect(result.examAccessEnd).toBeNull();
-      expect(result.showBeforeRelease).toBe(false);
-    });
-
-    it('still shows "before release" for PT assessment that is open but student lacks access', () => {
-      // When a PT-gated assessment has date controls and is within its open
-      // period, students without PT access should still see "Not yet open".
-      const result = resolveAccessControl({
-        ...baseInput,
-        rules: [
-          {
-            ...makeMainRule({
-              beforeRelease: { listed: true },
-              dateControl: {
-                releaseDate: '2025-01-01T00:00:00Z',
-                dueDate: '2025-06-01T00:00:00Z',
-              },
-            }),
-            prairietestExams: [ptExam],
-          },
-        ],
-      });
-      expect(result.showBeforeRelease).toBe(true);
-      expect(result.active).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Description

Pure test reorganization in `apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts` — no new tests, no behavior changes, no production code touched. Moves the `after-complete visibility with PrairieTest` and `showBeforeRelease with PrairieTest` describe blocks inside `PrairieTest integration` to match the target layout of a forthcoming PR, so that PR's diff collapses down to only its genuine changes.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Majority of implementation was AI-assisted.

# Testing

All 128 existing tests in the file still pass (`yarn test apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts`). The diff is 258/258 symmetric — added lines equal removed lines modulo indentation, confirming the change is pure movement.