### PR TITLE
Forbid passing resLocals to <Hydrate> children

### DIFF
--- a/.changeset/eslint-config-enable-no-hydrate-reslocals.md
+++ b/.changeset/eslint-config-enable-no-hydrate-reslocals.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/eslint-config': minor
+---
+
+Enable the new `@prairielearn/no-hydrate-reslocals` rule as an error.

--- a/.changeset/eslint-plugin-no-hydrate-reslocals.md
+++ b/.changeset/eslint-plugin-no-hydrate-reslocals.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/eslint-plugin': minor
+---
+
+Add a new rule `@prairielearn/no-hydrate-reslocals` that forbids passing `resLocals` or `locals` (or spreading `res.locals`, `resLocals`, or `locals`) onto a component rendered inside `<Hydrate>`. All props on a hydrated component are serialized and sent to the client, so these patterns would leak the full server-side locals.

--- a/.changeset/eslint-plugin-no-hydrate-reslocals.md
+++ b/.changeset/eslint-plugin-no-hydrate-reslocals.md
@@ -2,4 +2,4 @@
 '@prairielearn/eslint-plugin': minor
 ---
 
-Add a new rule `@prairielearn/no-hydrate-reslocals` that forbids passing `resLocals` or `locals` (or spreading `res.locals`, `resLocals`, or `locals`) onto a component rendered inside `<Hydrate>`. All props on a hydrated component are serialized and sent to the client, so these patterns would leak the full server-side locals.
+Add a new rule `@prairielearn/no-hydrate-reslocals` that forbids passing `resLocals` or `locals` (or spreading `res.locals`, `resLocals`, or `locals`) onto a component rendered inside `<Hydrate>` or passed to `hydrateHtml(...)`. All props on a hydrated component are serialized and sent to the client, so these patterns would leak the full server-side locals.

--- a/.changeset/hydrate-forbid-reslocals-runtime.md
+++ b/.changeset/hydrate-forbid-reslocals-runtime.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/react': minor
+---
+
+`<Hydrate>` now throws at render time if the child component is given a `resLocals` or `locals` prop. All props on a hydrated component are serialized and sent to the client, so passing `res.locals` would leak the entire server-side locals object. Extract the specific fields you need (e.g. via `extractPageContext`) and pass them as individual props instead.

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -7,9 +7,9 @@ import { useForm } from 'react-hook-form';
 import { run } from '@prairielearn/run';
 
 import { getAppError } from '../../lib/client/errors.js';
+import type { PageContext } from '../../lib/client/page-context.js';
 import { type StaffGroupConfig } from '../../lib/client/safe-db-types.js';
 import { QueryClientProviderDebug } from '../../lib/client/tanstackQuery.js';
-import type { ResLocalsForPage } from '../../lib/res-locals.js';
 import type { GroupUsersRow } from '../../models/group.js';
 import type { AssessmentGroupsError } from '../../trpc/assessment/assessment-groups.js';
 import { createAssessmentTrpcClient } from '../../trpc/assessment/client.js';
@@ -67,7 +67,7 @@ interface InstructorAssessmentGroupsProps {
   groupConfigInfo?: StaffGroupConfig;
   groups?: GroupUsersRow[];
   notAssigned?: string[];
-  resLocals: ResLocalsForPage<'assessment'>;
+  pageContext: PageContext<'assessment', 'instructor'>;
   trpcCsrfToken: string;
   isDevMode: boolean;
 }
@@ -77,7 +77,7 @@ export function InstructorAssessmentGroups({
   groupConfigInfo,
   groups,
   notAssigned,
-  resLocals,
+  pageContext,
   trpcCsrfToken,
   isDevMode,
 }: InstructorAssessmentGroupsProps) {
@@ -85,8 +85,8 @@ export function InstructorAssessmentGroups({
   const [trpcClient] = useState(() =>
     createAssessmentTrpcClient({
       csrfToken: trpcCsrfToken,
-      courseInstanceId: resLocals.course_instance.id,
-      assessmentId: resLocals.assessment.id,
+      courseInstanceId: pageContext.course_instance.id,
+      assessmentId: pageContext.assessment.id,
     }),
   );
 
@@ -98,7 +98,7 @@ export function InstructorAssessmentGroups({
           groupConfigInfo={groupConfigInfo}
           groups={groups}
           notAssigned={notAssigned}
-          resLocals={resLocals}
+          pageContext={pageContext}
         />
       </TRPCProvider>
     </QueryClientProviderDebug>
@@ -112,7 +112,7 @@ function InstructorAssessmentGroupsInner({
   groupConfigInfo,
   groups: initialGroups,
   notAssigned: initialNotAssigned,
-  resLocals,
+  pageContext,
 }: Omit<InstructorAssessmentGroupsProps, 'trpcCsrfToken' | 'isDevMode'>) {
   const [showUploadAssessmentGroupsModal, setShowUploadAssessmentGroupsModal] = useState(false);
   const [showRandomAssessmentGroupsModal, setShowRandomAssessmentGroupsModal] = useState(false);
@@ -163,7 +163,7 @@ function InstructorAssessmentGroupsInner({
       <div className="card mb-4">
         <div className="card-header bg-primary text-white d-flex align-items-center">
           <h1>
-            {resLocals.assessment_set.name} {resLocals.assessment.number}: Groups
+            {pageContext.assessment_set.name} {pageContext.assessment.number}: Groups
           </h1>
         </div>
         <div className="card-body">
@@ -176,17 +176,17 @@ function InstructorAssessmentGroupsInner({
 
   return (
     <>
-      {resLocals.authz_data.has_course_instance_permission_edit && (
+      {pageContext.authz_data.has_course_instance_permission_edit && (
         <>
           <UploadAssessmentGroupsModal
-            csrfToken={resLocals.__csrf_token}
+            csrfToken={pageContext.__csrf_token}
             show={showUploadAssessmentGroupsModal}
             onHide={() => setShowUploadAssessmentGroupsModal(false)}
           />
           <RandomAssessmentGroupsModal
             groupMin={groupConfigInfo.minimum ?? 2}
             groupMax={groupConfigInfo.maximum ?? 5}
-            csrfToken={resLocals.__csrf_token}
+            csrfToken={pageContext.__csrf_token}
             show={showRandomAssessmentGroupsModal}
             onHide={() => setShowRandomAssessmentGroupsModal(false)}
           />
@@ -199,8 +199,8 @@ function InstructorAssessmentGroupsInner({
             }}
           />
           <DeleteAllGroupsModal
-            assessmentSetName={resLocals.assessment_set.name}
-            assessmentNumber={resLocals.assessment.number}
+            assessmentSetName={pageContext.assessment_set.name}
+            assessmentNumber={pageContext.assessment.number}
             show={showDeleteAllGroupsModal}
             onHide={() => setShowDeleteAllGroupsModal(false)}
             onAllGroupsDeleted={(notAssigned) => {
@@ -234,9 +234,9 @@ function InstructorAssessmentGroupsInner({
       <div className="card mb-4">
         <div className="card-header bg-primary text-white d-flex align-items-center gap-2">
           <h1>
-            {resLocals.assessment_set.name} {resLocals.assessment.number}: Groups
+            {pageContext.assessment_set.name} {pageContext.assessment.number}: Groups
           </h1>
-          {resLocals.authz_data.has_course_instance_permission_edit && (
+          {pageContext.authz_data.has_course_instance_permission_edit && (
             <div className="ms-auto d-flex gap-2">
               <button
                 type="button"
@@ -255,7 +255,7 @@ function InstructorAssessmentGroupsInner({
             </div>
           )}
         </div>
-        {resLocals.authz_data.has_course_instance_permission_edit && (
+        {pageContext.authz_data.has_course_instance_permission_edit && (
           <div className="container-fluid">
             <div className="row">
               <div className="col-sm bg-light py-4 border text-center">
@@ -294,7 +294,7 @@ function InstructorAssessmentGroupsInner({
                   className="text-center"
                   onSort={handleSort}
                 />
-                {resLocals.authz_data.has_course_instance_permission_edit && <th />}
+                {pageContext.authz_data.has_course_instance_permission_edit && <th />}
               </tr>
             </thead>
             <tbody>
@@ -302,7 +302,7 @@ function InstructorAssessmentGroupsInner({
                 <GroupRow
                   key={row.group_id}
                   row={row}
-                  canEdit={resLocals.authz_data.has_course_instance_permission_edit}
+                  canEdit={pageContext.authz_data.has_course_instance_permission_edit ?? false}
                   onEdit={setEditingGroup}
                   onDelete={setDeletingGroup}
                 />
@@ -313,7 +313,7 @@ function InstructorAssessmentGroupsInner({
             <p>
               Download{' '}
               <a
-                href={`${resLocals.urlPrefix}/assessment/${resLocals.assessment.id}/downloads/${groupsCsvFilename}`}
+                href={`${pageContext.urlPrefix}/assessment/${pageContext.assessment.id}/downloads/${groupsCsvFilename}`}
               >
                 {groupsCsvFilename}
               </a>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
@@ -30,10 +30,11 @@ router.get(
     unauthorizedUsers: 'block',
   }),
   typedAsyncHandler<'assessment'>(async (_req, res) => {
-    const { assessment, assessment_set, course, course_instance } = extractPageContext(res.locals, {
+    const pageContext = extractPageContext(res.locals, {
       pageType: 'assessment',
       accessType: 'instructor',
     });
+    const { assessment, assessment_set, course, course_instance } = pageContext;
 
     const groupsCsvFilename =
       assessmentFilenamePrefix(assessment, assessment_set, course_instance, course) + 'groups.csv';
@@ -79,7 +80,7 @@ router.get(
         content: (
           <Hydrate>
             <InstructorAssessmentGroups
-              resLocals={res.locals}
+              pageContext={pageContext}
               groupsCsvFilename={groupsCsvFilename}
               groupConfigInfo={staffGroupConfigInfo}
               groups={groups}

--- a/packages/eslint-config/src/configs/prairielearn.ts
+++ b/packages/eslint-config/src/configs/prairielearn.ts
@@ -29,6 +29,7 @@ export function prairieLearnConfig(
         '@prairielearn/aws-client-shared-config': 'error',
         '@prairielearn/jsx-no-dollar-interpolation': 'error',
         '@prairielearn/no-current-target-in-callback': 'error',
+        '@prairielearn/no-hydrate-reslocals': 'error',
         '@prairielearn/no-unused-sql-blocks': 'error',
         '@prairielearn/safe-db-types': [
           'error',

--- a/packages/eslint-plugin-prairielearn/src/index.ts
+++ b/packages/eslint-plugin-prairielearn/src/index.ts
@@ -2,6 +2,7 @@ import awsClientMandatoryConfig from './rules/aws-client-mandatory-config.js';
 import awsClientSharedConfig from './rules/aws-client-shared-config.js';
 import jsxNoDollarInterpolation from './rules/jsx-no-dollar-interpolation.js';
 import noCurrentTargetInCallback from './rules/no-current-target-in-callback.js';
+import noHydrateResLocals from './rules/no-hydrate-reslocals.js';
 import noUnusedSqlBlocks from './rules/no-unused-sql-blocks.js';
 import safeDbTypes from './rules/safe-db-types.js';
 
@@ -10,6 +11,7 @@ export const rules = {
   'aws-client-shared-config': awsClientSharedConfig,
   'jsx-no-dollar-interpolation': jsxNoDollarInterpolation,
   'no-current-target-in-callback': noCurrentTargetInCallback,
+  'no-hydrate-reslocals': noHydrateResLocals,
   'no-unused-sql-blocks': noUnusedSqlBlocks,
   'safe-db-types': safeDbTypes,
 };

--- a/packages/eslint-plugin-prairielearn/src/rules/no-hydrate-reslocals.ts
+++ b/packages/eslint-plugin-prairielearn/src/rules/no-hydrate-reslocals.ts
@@ -12,8 +12,7 @@ import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
  * `extractPageContext`) and pass them as individual props instead.
  */
 
-const FORBIDDEN_PROP_NAMES = new Set(['resLocals', 'locals']);
-const FORBIDDEN_SPREAD_IDENTIFIERS = new Set(['resLocals', 'locals']);
+const FORBIDDEN_NAMES = new Set(['resLocals', 'locals']);
 
 function isHydrateElement(node: TSESTree.JSXElement): boolean {
   const opening = node.openingElement;
@@ -31,7 +30,7 @@ function getHydrateChildElement(node: TSESTree.JSXElement): TSESTree.JSXElement 
 
 function spreadArgumentDescribesResLocals(argument: TSESTree.Expression): boolean {
   if (argument.type === 'Identifier') {
-    return FORBIDDEN_SPREAD_IDENTIFIERS.has(argument.name);
+    return FORBIDDEN_NAMES.has(argument.name);
   }
   if (
     argument.type === 'MemberExpression' &&
@@ -49,9 +48,9 @@ export default ESLintUtils.RuleCreator.withoutDocs({
     type: 'problem',
     messages: {
       forbiddenProp:
-        'Do not pass "{{name}}" as a prop to a component rendered inside <Hydrate>. All props are serialized and sent to the client, so this would leak the full server-side res.locals. Extract the specific fields you need (e.g. via extractPageContext) and pass them as individual props.',
+        'Do not pass "{{name}}" to a component rendered inside <Hydrate>; props are serialized and sent to the client, so this would leak the full server-side res.locals. Pass the specific fields the component needs instead.',
       forbiddenSpread:
-        'Do not spread res.locals (or a variable named resLocals/locals) onto a component rendered inside <Hydrate>. All props are serialized and sent to the client. Extract the specific fields you need and pass them explicitly.',
+        'Do not spread res.locals onto a component rendered inside <Hydrate>; props are serialized and sent to the client. Pass the specific fields the component needs instead.',
     },
     schema: [],
   },
@@ -69,7 +68,7 @@ export default ESLintUtils.RuleCreator.withoutDocs({
           if (attribute.type === 'JSXAttribute') {
             if (
               attribute.name.type === 'JSXIdentifier' &&
-              FORBIDDEN_PROP_NAMES.has(attribute.name.name)
+              FORBIDDEN_NAMES.has(attribute.name.name)
             ) {
               context.report({
                 node: attribute,

--- a/packages/eslint-plugin-prairielearn/src/rules/no-hydrate-reslocals.ts
+++ b/packages/eslint-plugin-prairielearn/src/rules/no-hydrate-reslocals.ts
@@ -1,0 +1,92 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+/**
+ * All props on the child of a `<Hydrate>` element are serialized with
+ * superjson and shipped to the browser. Passing `resLocals` or `locals`
+ * (or spreading them) would leak the entire server-side `res.locals`
+ * object — CSRF tokens, auth data, authz objects, full DB rows, etc.
+ *
+ * This rule forbids those specific prop names, and forbids spreads on a
+ * `<Hydrate>` child whose spread argument is `res.locals`, `resLocals`,
+ * or `locals`. Extract the specific fields you need (e.g. via
+ * `extractPageContext`) and pass them as individual props instead.
+ */
+
+const FORBIDDEN_PROP_NAMES = new Set(['resLocals', 'locals']);
+const FORBIDDEN_SPREAD_IDENTIFIERS = new Set(['resLocals', 'locals']);
+
+function isHydrateElement(node: TSESTree.JSXElement): boolean {
+  const opening = node.openingElement;
+  return opening.name.type === 'JSXIdentifier' && opening.name.name === 'Hydrate';
+}
+
+function getHydrateChildElement(node: TSESTree.JSXElement): TSESTree.JSXElement | null {
+  for (const child of node.children) {
+    if (child.type === 'JSXElement') {
+      return child;
+    }
+  }
+  return null;
+}
+
+function spreadArgumentDescribesResLocals(argument: TSESTree.Expression): boolean {
+  if (argument.type === 'Identifier') {
+    return FORBIDDEN_SPREAD_IDENTIFIERS.has(argument.name);
+  }
+  if (
+    argument.type === 'MemberExpression' &&
+    !argument.computed &&
+    argument.property.type === 'Identifier' &&
+    argument.property.name === 'locals'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export default ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    messages: {
+      forbiddenProp:
+        'Do not pass "{{name}}" as a prop to a component rendered inside <Hydrate>. All props are serialized and sent to the client, so this would leak the full server-side res.locals. Extract the specific fields you need (e.g. via extractPageContext) and pass them as individual props.',
+      forbiddenSpread:
+        'Do not spread res.locals (or a variable named resLocals/locals) onto a component rendered inside <Hydrate>. All props are serialized and sent to the client. Extract the specific fields you need and pass them explicitly.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        if (!isHydrateElement(node)) return;
+
+        const child = getHydrateChildElement(node);
+        if (!child) return;
+
+        for (const attribute of child.openingElement.attributes) {
+          if (attribute.type === 'JSXAttribute') {
+            if (
+              attribute.name.type === 'JSXIdentifier' &&
+              FORBIDDEN_PROP_NAMES.has(attribute.name.name)
+            ) {
+              context.report({
+                node: attribute,
+                messageId: 'forbiddenProp',
+                data: { name: attribute.name.name },
+              });
+            }
+          } else if (attribute.type === 'JSXSpreadAttribute') {
+            if (spreadArgumentDescribesResLocals(attribute.argument)) {
+              context.report({
+                node: attribute,
+                messageId: 'forbiddenSpread',
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-prairielearn/src/rules/no-hydrate-reslocals.ts
+++ b/packages/eslint-plugin-prairielearn/src/rules/no-hydrate-reslocals.ts
@@ -1,31 +1,30 @@
 import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
 
 /**
- * All props on the child of a `<Hydrate>` element are serialized with
- * superjson and shipped to the browser. Passing `resLocals` or `locals`
- * (or spreading them) would leak the entire server-side `res.locals`
- * object — CSRF tokens, auth data, authz objects, full DB rows, etc.
+ * All props on a hydrated component are serialized with superjson and shipped
+ * to the browser. Passing `resLocals` or `locals` (or spreading them) would
+ * leak the entire server-side `res.locals` object — CSRF tokens, auth data,
+ * authz objects, full DB rows, etc.
  *
- * This rule forbids those specific prop names, and forbids spreads on a
- * `<Hydrate>` child whose spread argument is `res.locals`, `resLocals`,
- * or `locals`. Extract the specific fields you need (e.g. via
+ * This rule forbids those prop names (and `{...res.locals}` / `{...resLocals}`
+ * / `{...locals}` spreads) on the child of `<Hydrate>` and on the JSX argument
+ * to `hydrateHtml(...)`. Extract the specific fields you need (e.g. via
  * `extractPageContext`) and pass them as individual props instead.
  */
 
+const HYDRATE_COMPONENT_NAME = 'Hydrate';
+const HYDRATE_FUNCTION_NAME = 'hydrateHtml';
 const FORBIDDEN_NAMES = new Set(['resLocals', 'locals']);
 
-function isHydrateElement(node: TSESTree.JSXElement): boolean {
-  const opening = node.openingElement;
-  return opening.name.type === 'JSXIdentifier' && opening.name.name === 'Hydrate';
-}
-
-function getHydrateChildElement(node: TSESTree.JSXElement): TSESTree.JSXElement | null {
-  for (const child of node.children) {
-    if (child.type === 'JSXElement') {
-      return child;
-    }
+function extractSingleJsxChild(children: TSESTree.JSXChild[]): TSESTree.JSXElement | null {
+  const nonWhitespace = children.filter((child) => {
+    if (child.type === 'JSXText') return child.value.trim().length > 0;
+    return true;
+  });
+  if (nonWhitespace.length !== 1 || nonWhitespace[0].type !== 'JSXElement') {
+    return null;
   }
-  return null;
+  return nonWhitespace[0];
 }
 
 function spreadArgumentDescribesResLocals(argument: TSESTree.Expression): boolean {
@@ -48,43 +47,55 @@ export default ESLintUtils.RuleCreator.withoutDocs({
     type: 'problem',
     messages: {
       forbiddenProp:
-        'Do not pass "{{name}}" to a component rendered inside <Hydrate>; props are serialized and sent to the client, so this would leak the full server-side res.locals. Pass the specific fields the component needs instead.',
+        'Do not pass "{{name}}" to a hydrated component; props are serialized and sent to the client, so this would leak the full server-side res.locals. Pass the specific fields the component needs instead.',
       forbiddenSpread:
-        'Do not spread res.locals onto a component rendered inside <Hydrate>; props are serialized and sent to the client. Pass the specific fields the component needs instead.',
+        'Do not spread res.locals onto a hydrated component; props are serialized and sent to the client. Pass the specific fields the component needs instead.',
     },
     schema: [],
   },
   defaultOptions: [],
 
   create(context) {
-    return {
-      JSXElement(node) {
-        if (!isHydrateElement(node)) return;
-
-        const child = getHydrateChildElement(node);
-        if (!child) return;
-
-        for (const attribute of child.openingElement.attributes) {
-          if (attribute.type === 'JSXAttribute') {
-            if (
-              attribute.name.type === 'JSXIdentifier' &&
-              FORBIDDEN_NAMES.has(attribute.name.name)
-            ) {
-              context.report({
-                node: attribute,
-                messageId: 'forbiddenProp',
-                data: { name: attribute.name.name },
-              });
-            }
-          } else if (attribute.type === 'JSXSpreadAttribute') {
-            if (spreadArgumentDescribesResLocals(attribute.argument)) {
-              context.report({
-                node: attribute,
-                messageId: 'forbiddenSpread',
-              });
-            }
+    function checkHydratedElement(element: TSESTree.JSXElement) {
+      for (const attribute of element.openingElement.attributes) {
+        if (attribute.type === 'JSXAttribute') {
+          if (attribute.name.type === 'JSXIdentifier' && FORBIDDEN_NAMES.has(attribute.name.name)) {
+            context.report({
+              node: attribute,
+              messageId: 'forbiddenProp',
+              data: { name: attribute.name.name },
+            });
+          }
+        } else if (attribute.type === 'JSXSpreadAttribute') {
+          if (spreadArgumentDescribesResLocals(attribute.argument)) {
+            context.report({
+              node: attribute,
+              messageId: 'forbiddenSpread',
+            });
           }
         }
+      }
+    }
+
+    return {
+      JSXElement(node) {
+        const opening = node.openingElement.name;
+        if (opening.type !== 'JSXIdentifier' || opening.name !== HYDRATE_COMPONENT_NAME) return;
+
+        const child = extractSingleJsxChild(node.children);
+        if (!child) return;
+
+        checkHydratedElement(child);
+      },
+
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== HYDRATE_FUNCTION_NAME) return;
+        if (node.arguments.length === 0) return;
+
+        const arg = node.arguments[0];
+        if (arg.type !== 'JSXElement') return;
+
+        checkHydratedElement(arg);
       },
     };
   },

--- a/packages/eslint-plugin-prairielearn/src/tests/no-hydrate-reslocals.test.ts
+++ b/packages/eslint-plugin-prairielearn/src/tests/no-hydrate-reslocals.test.ts
@@ -1,0 +1,67 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { afterAll, describe, it } from 'vitest';
+
+import rule from '../rules/no-hydrate-reslocals';
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run('no-hydrate-reslocals', rule, {
+  valid: [
+    {
+      code: '<Hydrate><Child foo={1} bar="baz" /></Hydrate>',
+    },
+    {
+      code: '<Hydrate><Child course={course} assessment={assessment} /></Hydrate>',
+    },
+    {
+      // Non-Hydrate components are not affected
+      code: '<SomeOther resLocals={res.locals}><Child /></SomeOther>',
+    },
+    {
+      // Spread of unrelated object is fine
+      code: '<Hydrate><Child {...otherProps} /></Hydrate>',
+    },
+    {
+      // resLocals on the Hydrate wrapper itself (not on the child) is not this rule's concern
+      code: '<Hydrate resLocals={foo}><Child /></Hydrate>',
+    },
+  ],
+  invalid: [
+    {
+      code: '<Hydrate><Child resLocals={res.locals} /></Hydrate>',
+      errors: [{ messageId: 'forbiddenProp', data: { name: 'resLocals' } }],
+    },
+    {
+      code: '<Hydrate><Child locals={res.locals} /></Hydrate>',
+      errors: [{ messageId: 'forbiddenProp', data: { name: 'locals' } }],
+    },
+    {
+      code: '<Hydrate><Child {...res.locals} /></Hydrate>',
+      errors: [{ messageId: 'forbiddenSpread' }],
+    },
+    {
+      code: '<Hydrate><Child {...resLocals} /></Hydrate>',
+      errors: [{ messageId: 'forbiddenSpread' }],
+    },
+    {
+      code: '<Hydrate><Child {...locals} /></Hydrate>',
+      errors: [{ messageId: 'forbiddenSpread' }],
+    },
+    {
+      code: '<Hydrate fullHeight><Child foo={1} resLocals={res.locals} /></Hydrate>',
+      errors: [{ messageId: 'forbiddenProp', data: { name: 'resLocals' } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-prairielearn/src/tests/no-hydrate-reslocals.test.ts
+++ b/packages/eslint-plugin-prairielearn/src/tests/no-hydrate-reslocals.test.ts
@@ -26,15 +26,12 @@ ruleTester.run('no-hydrate-reslocals', rule, {
       code: '<Hydrate><Child course={course} assessment={assessment} /></Hydrate>',
     },
     {
-      // Non-Hydrate components are not affected
       code: '<SomeOther resLocals={res.locals}><Child /></SomeOther>',
     },
     {
-      // Spread of unrelated object is fine
       code: '<Hydrate><Child {...otherProps} /></Hydrate>',
     },
     {
-      // resLocals on the Hydrate wrapper itself (not on the child) is not this rule's concern
       code: '<Hydrate resLocals={foo}><Child /></Hydrate>',
     },
   ],

--- a/packages/eslint-plugin-prairielearn/src/tests/no-hydrate-reslocals.test.ts
+++ b/packages/eslint-plugin-prairielearn/src/tests/no-hydrate-reslocals.test.ts
@@ -34,6 +34,15 @@ ruleTester.run('no-hydrate-reslocals', rule, {
     {
       code: '<Hydrate resLocals={foo}><Child /></Hydrate>',
     },
+    {
+      code: 'hydrateHtml(<Child foo={1} bar="baz" />)',
+    },
+    {
+      code: 'hydrateHtml(<Child {...otherProps} />)',
+    },
+    {
+      code: 'otherFunction(<Child resLocals={res.locals} />)',
+    },
   ],
   invalid: [
     {
@@ -59,6 +68,22 @@ ruleTester.run('no-hydrate-reslocals', rule, {
     {
       code: '<Hydrate fullHeight><Child foo={1} resLocals={res.locals} /></Hydrate>',
       errors: [{ messageId: 'forbiddenProp', data: { name: 'resLocals' } }],
+    },
+    {
+      code: 'hydrateHtml(<Child resLocals={res.locals} />)',
+      errors: [{ messageId: 'forbiddenProp', data: { name: 'resLocals' } }],
+    },
+    {
+      code: 'hydrateHtml(<Child locals={res.locals} />)',
+      errors: [{ messageId: 'forbiddenProp', data: { name: 'locals' } }],
+    },
+    {
+      code: 'hydrateHtml(<Child {...res.locals} />)',
+      errors: [{ messageId: 'forbiddenSpread' }],
+    },
+    {
+      code: 'hydrateHtml(<Child {...resLocals} />, { fullHeight: true })',
+      errors: [{ messageId: 'forbiddenSpread' }],
     },
   ],
 });

--- a/packages/react/src/server.tsx
+++ b/packages/react/src/server.tsx
@@ -75,28 +75,6 @@ export function Hydrate<T>({
     throw new Error('<Hydrate> expects a React component');
   }
 
-  for (const forbiddenProp of ['resLocals', 'locals'] as const) {
-    if (props && typeof props === 'object' && forbiddenProp in props) {
-      const componentName =
-        nameOverride ?? (Component as any).displayName ?? Component.name ?? 'UnknownComponent';
-      throw new AugmentedError(
-        `<Hydrate> was passed a "${forbiddenProp}" prop on <${componentName}>.`,
-        {
-          info: html`
-            <div>
-              <p>
-                All props on a hydrated component are serialized and sent to the client. Passing
-                <code>res.locals</code> (or any similarly broad object) would leak the entire
-                server-side locals — CSRF tokens, auth data, authz objects, full DB rows, etc.
-              </p>
-              <p>Pass only the specific fields the component needs as individual props.</p>
-            </div>
-          `,
-        },
-      );
-    }
-  }
-
   // Note that we don't use `Component.name` here because it can be minified or mangled.
   const componentName = nameOverride ?? (Component as any).displayName;
   if (!componentName) {
@@ -115,6 +93,26 @@ ${componentDevName}.displayName = '${componentDevName}';</code></pre>
         `,
       },
     );
+  }
+
+  for (const forbiddenProp of ['resLocals', 'locals'] as const) {
+    if (props && typeof props === 'object' && forbiddenProp in props) {
+      throw new AugmentedError(
+        `<Hydrate> was passed a "${forbiddenProp}" prop on <${componentName}>.`,
+        {
+          info: html`
+            <div>
+              <p>
+                All props on a hydrated component are serialized and sent to the client. Passing
+                <code>res.locals</code> (or any similarly broad object) would leak the entire
+                server-side locals — CSRF tokens, auth data, authz objects, full DB rows, etc.
+              </p>
+              <p>Pass only the specific fields the component needs as individual props.</p>
+            </div>
+          `,
+        },
+      );
+    }
   }
 
   const scriptPath = `esm-bundles/hydrated-components/${componentName}.ts`;

--- a/packages/react/src/server.tsx
+++ b/packages/react/src/server.tsx
@@ -75,6 +75,28 @@ export function Hydrate<T>({
     throw new Error('<Hydrate> expects a React component');
   }
 
+  for (const forbiddenProp of ['resLocals', 'locals'] as const) {
+    if (props && typeof props === 'object' && forbiddenProp in props) {
+      const componentName =
+        nameOverride ?? (Component as any).displayName ?? Component.name ?? 'UnknownComponent';
+      throw new AugmentedError(
+        `<Hydrate> was passed a "${forbiddenProp}" prop on <${componentName}>.`,
+        {
+          info: html`
+            <div>
+              <p>
+                All props on a hydrated component are serialized and sent to the client. Passing
+                <code>res.locals</code> (or any similarly broad object) would leak the entire
+                server-side locals — CSRF tokens, auth data, authz objects, full DB rows, etc.
+              </p>
+              <p>Pass only the specific fields the component needs as individual props.</p>
+            </div>
+          `,
+        },
+      );
+    }
+  }
+
   // Note that we don't use `Component.name` here because it can be minified or mangled.
   const componentName = nameOverride ?? (Component as any).displayName;
   if (!componentName) {


### PR DESCRIPTION
# Description

All props on a component rendered inside `<Hydrate>` are serialized with superjson and sent to the client. Passing `res.locals` (observed on the `instructorAssessmentGroups` page) silently leaked the entire server-side locals object — CSRF tokens, auth data, authz objects, full DB rows, and anything else attached to `res.locals`.

This PR adds defense in depth against the pattern and fixes the existing violation:

- **Runtime guard** in `@prairielearn/react`: `<Hydrate>` now throws an `AugmentedError` (naming the offending component) if its child is given a `resLocals` or `locals` prop.
- **ESLint rule** `@prairielearn/no-hydrate-reslocals` (enabled as `error` in `@prairielearn/eslint-config`): catches direct `resLocals=` / `locals=` props and `{...res.locals}` / `{...resLocals}` / `{...locals}` spreads on `<Hydrate>` children at lint time.
- **Fix** `instructorAssessmentGroups`: replaced `resLocals={res.locals}` with `pageContext={pageContext}` typed as the narrowed `PageContext<'assessment', 'instructor'>` returned by `extractPageContext`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation was AI-assisted.

# Testing

- Added unit tests for the ESLint rule (11 cases covering both props and spreads, plus non-`<Hydrate>` and wrapper-prop negative cases).
- Ran the existing `instructorAssessmentGroups` integration test (8 tests pass) to confirm the page still renders with the narrowed `pageContext` prop.
- Ran `yarn eslint 'apps/prairielearn/src/**/*.tsx'` with the new rule enabled to confirm no other violations exist in the codebase.