### PR TITLE
Fix course role sorting in staff page

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -104,7 +104,10 @@ function SelectAllCheckbox({ table }: { table: Table<CourseUsersRow> }) {
 
 const columnHelper = createColumnHelper<CourseUsersRow>();
 
-const DEFAULT_SORT: SortingState = [{ id: 'uid', desc: false }];
+const DEFAULT_SORT: SortingState = [
+  { id: 'course_role', desc: true },
+  { id: 'uid', desc: false },
+];
 const DEFAULT_PINNING: ColumnPinningState = { left: ['select', 'uid'], right: [] };
 
 interface StaffTableInnerProps {
@@ -994,6 +997,15 @@ function StaffTableInner({
         filterFn: (row, _columnId, filterValues: CourseRole[]) => {
           if (filterValues.length === 0) return true;
           return filterValues.includes(row.original.course_permission.course_role ?? 'None');
+        },
+        sortingFn: (rowA, rowB) => {
+          const indexA = COURSE_ROLE_VALUES.indexOf(
+            rowA.original.course_permission.course_role ?? 'None',
+          );
+          const indexB = COURSE_ROLE_VALUES.indexOf(
+            rowB.original.course_permission.course_role ?? 'None',
+          );
+          return indexA - indexB;
         },
         cell: (info) => (
           <div className="text-center">


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes #14790. In the staff page, sorting by course role was using lexicographical order. This PR updates it to order it by the permissions associated to the course role. It also updates the page to use this sorting order by default (I'm happy to rollback this default if there is pushback on it).

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: some autocomplete support from the IDE.

# Testing

Tested by adding a bunch of staff members to a local course with different roles. Sorting works as expected, other columns still sort as expected.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
