### PR TITLE
Update pl-number-input helper text for a general audience

### DIFF
--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -170,9 +170,7 @@
 Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number having both real and imaginary parts between <code>-1e308</code> and <code>1e308</code>. Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
 {{/allow_complex}}
 {{^allow_complex}}
-Answer with an ordinary rational real number. You can use a decimal point (like <code>1.5</code>){{#allow_fractions}}, a fraction of two numbers (like <code>3/2</code>),{{/allow_fractions}} or scientific notation (like <code>1.2e03</code>). 
-(Details: your answer must be a real number between <code>-1e308</code> and <code>1e308</code>, i.e., interpretable as a 
-double-precision floating-point number.)
+Answer with an ordinary rational real number. You can use a decimal point (like <code>1.5</code>){{#allow_fractions}}, a fraction of two numbers (like <code>3/2</code>),{{/allow_fractions}} or scientific notation (like <code>1.2e03</code>). Your answer must be a real number between <code>-1e308</code> and <code>1e308</code>.
 {{/allow_complex}}
 Do not include variables, units, or symbolic expressions such as <code>pi</code>, <code>sqrt(2)</code>, or <code>3*x</code>.
 </p>

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -167,19 +167,19 @@
 {{#show_info}}
 <p>
 {{#allow_complex}}
-Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number with both real and imaginary parts between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision real or complex number). Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
+Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number with both real and imaginary parts between <code>-1e308</code> and <code>1e308</code>. Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
 {{/allow_complex}}
 {{^allow_complex}}
-Your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number).
+Answer with an ordinary rational real number. You may write the number using a decimal point, like <code>1.5</code>{{#allow_fractions}}, or as a fraction, like <code>3/2</code>{{/allow_fractions}}.
 {{/allow_complex}}
-No symbolic expressions (those that involve{{^allow_fractions}} fractions,{{/allow_fractions}} square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., <code>1.2e03</code>). {{#allow_fractions}} You may express your answer as a fraction of two numbers. {{/allow_fractions}}
+Do not write any variables or other symbols. Scientific notation is accepted (e.g., <code>1.2e03</code>). Allowed range: between <code>-1e308</code> and <code>1e308</code> (i.e., a double-precision floating-point number){{#allow_complex}} for both real and imaginary part{{/allow_complex}}.
 </p>
-{{#relabs}}<p>Your answer must be accurate to within relative tolerance <code>{{rtol}}</code> and absolute tolerance <code>{{atol}}</code>.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
+{{#relabs}}<p>For credit, your answer must be accurate within a tolerance of &#x00b1;{{rtol_pct}}% of the correct answer and also within &#x00b1;{{atol}} of the correct answer.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
 {{/show_info}}
 {{/format}}
 
 {{#shortformat}}
-number {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
+{{#allow_complex}}complex{{/allow_complex}}{{^allow_complex}}real{{/allow_complex}} number {{#relabs}}(accurate within {{rtol_pct}}% and {{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
 {{/shortformat}}
 
 {{#format_error}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -167,19 +167,19 @@
 {{#show_info}}
 <p>
 {{#allow_complex}}
-Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number with both real and imaginary parts between <code>-1e308</code> and <code>1e308</code>. Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
+Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number with both real and imaginary parts between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision real or complex number). Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
 {{/allow_complex}}
 {{^allow_complex}}
-Answer with an ordinary rational real number. You may write the number using a decimal point, like <code>1.5</code>{{#allow_fractions}}, or as a fraction, like <code>3/2</code>{{/allow_fractions}}.
+Your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number).
 {{/allow_complex}}
-Do not write any variables or other symbols. Scientific notation is accepted (e.g., <code>1.2e03</code>). Allowed range: between <code>-1e308</code> and <code>1e308</code> (i.e., a double-precision floating-point number){{#allow_complex}} for both real and imaginary part{{/allow_complex}}.
+No symbolic expressions (those that involve{{^allow_fractions}} fractions,{{/allow_fractions}} square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., <code>1.2e03</code>). {{#allow_fractions}} You may express your answer as a fraction of two numbers. {{/allow_fractions}}
 </p>
-{{#relabs}}<p>For credit, your answer must be accurate within a tolerance of &#x00b1;{{rtol_pct}}% of the correct answer and also within &#x00b1;{{atol}} of the correct answer.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
+{{#relabs}}<p>Your answer must be accurate to within relative tolerance <code>{{rtol}}</code> and absolute tolerance <code>{{atol}}</code>.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
 {{/show_info}}
 {{/format}}
 
 {{#shortformat}}
-{{#allow_complex}}complex{{/allow_complex}}{{^allow_complex}}real{{/allow_complex}} number {{#relabs}}(accurate within {{rtol_pct}}% and {{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
+number {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
 {{/shortformat}}
 
 {{#format_error}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -176,7 +176,7 @@ double-precision floating-point number.)
 {{/allow_complex}}
 Do not include variables, units, or symbolic expressions such as <code>pi</code>, <code>sqrt(2)</code>, or <code>3*x</code>.
 </p>
-{{#relabs}}<p>For credit, your answer must be within {{rtol_percent}}% of the correct answer (relative tolerance {{rtol}}) and within &#x00b1;{{atol}} of the correct answer (absolute tolerance).</p>{{/relabs}}
+{{#relabs}}<p>For credit, your answer must be within {{rtol_pct}}% of the correct answer (relative tolerance {{rtol}}) and within &#x00b1;{{atol}} of the correct answer (absolute tolerance).</p>{{/relabs}}
 {{#sigfig}}<p>Your answer must match the correct value to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}
 {{#decdig}}<p>Your answer must match the correct value to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal point. For instance, if the correct answer is 1.234, any submission between 1.234 &#x2212; {{comparison_eps}} and 1.234 + {{comparison_eps}} is counted correct.</p>{{/decdig}}
 {{/show_info}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -167,19 +167,23 @@
 {{#show_info}}
 <p>
 {{#allow_complex}}
-Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number with both real and imaginary parts between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision real or complex number). Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
+Your answer must be either a real number between <code>-1e308</code> and <code>1e308</code> or a complex number having both real and imaginary parts between <code>-1e308</code> and <code>1e308</code>. Complex numbers must use either <code>i</code> or <code>j</code> as the imaginary unit, must place the imaginary unit after the imaginary part (e.g., <code>2j</code> not <code>j2</code>), must write the imaginary part even when <code>1</code> or <code>-1</code> (e.g., <code>1j</code> not <code>j</code>), and must write the real part before the imaginary part (e.g., <code>1+2j</code> not <code>2j+1</code>). Standard python print format is accepted for complex numbers (e.g., <code>(1+2j)</code>).
 {{/allow_complex}}
 {{^allow_complex}}
-Your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number).
+Answer with an ordinary rational real number. You can use a decimal point (like <code>1.5</code>){{#allow_fractions}}, a fraction of two numbers (like <code>3/2</code>),{{/allow_fractions}} or scientific notation (like <code>1.2e03</code>). 
+(Details: your answer must be a real number between <code>-1e308</code> and <code>1e308</code>, i.e., interpretable as a 
+double-precision floating-point number.)
 {{/allow_complex}}
-No symbolic expressions (those that involve{{^allow_fractions}} fractions,{{/allow_fractions}} square roots, variables, etc.) will be accepted. Scientific notation is accepted (e.g., <code>1.2e03</code>). {{#allow_fractions}} You may express your answer as a fraction of two numbers. {{/allow_fractions}}
+Do not include variables, units, or symbolic expressions such as <code>pi</code>, <code>sqrt(2)</code>, or <code>3*x</code>.
 </p>
-{{#relabs}}<p>Your answer must be accurate to within relative tolerance <code>{{rtol}}</code> and absolute tolerance <code>{{atol}}</code>.</p>{{/relabs}}{{#sigfig}}<p>Your answer must be accurate to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}{{#decdig}}<p>Your answer must be accurate to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/decdig}}
+{{#relabs}}<p>For credit, your answer must be within {{rtol_percent}}% of the correct answer (relative tolerance {{rtol}}) and within &#x00b1;{{atol}} of the correct answer (absolute tolerance).</p>{{/relabs}}
+{{#sigfig}}<p>Your answer must match the correct value to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}
+{{#decdig}}<p>Your answer must match the correct value to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal point. For instance, if the correct answer is 1.234, any submission between 1.234 &#x2212; {{comparison_eps}} and 1.234 + {{comparison_eps}} is counted correct.</p>{{/decdig}}
 {{/show_info}}
 {{/format}}
 
 {{#shortformat}}
-number {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
+{{#allow_complex}}complex{{/allow_complex}}{{^allow_complex}}real{{/allow_complex}} number {{#relabs}}(accurate within {{rtol_pct}}% and {{atol}}){{/relabs}}{{#sigfig}}({{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}){{/sigfig}}{{#decdig}}({{digits}} digit{{#digits_plural}}s{{/digits_plural}} after decimal){{/decdig}}
 {{/shortformat}}
 
 {{#format_error}}
@@ -196,6 +200,6 @@ number {{#relabs}}(rtol={{rtol}}, atol={{atol}}){{/relabs}}{{#sigfig}}({{digits}
     <p> Example <i>invalid</i> inputs: <code>6+9</code> <code class="ms-3">4*10^7</code> <code class="ms-3">3*pi</code> {{^complex}} <code class="ms-3">3.6i</code>{{/complex}} {{^allow_fractions}} <code class="ms-3">3/7</code> {{/allow_fractions}} </p>
     <hr>
     <small>
-        <p> The submitted answer must be formatted as a <i>double-precision floating-point</i> {{#complex}}or complex{{/complex}} number.  These numbers {{#complex}}(both real and complex parts){{/complex}} lie roughly in the range of -1.79 &times; 10<sup>308</sup> to 1.79 &times; 10<sup>308</sup>.</p>
+        <p> The submitted answer must be formatted as a <i>double-precision floating-point</i> {{#complex}}or complex{{/complex}} number.  These numbers {{#complex}}(both real and complex parts){{/complex}} lie roughly in the range of &#x2212;1.79 &times; 10<sup>308</sup> to 1.79 &times; 10<sup>308</sup>.</p>
     </small>
 {{/format_error}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.mustache
@@ -176,7 +176,7 @@ double-precision floating-point number.)
 {{/allow_complex}}
 Do not include variables, units, or symbolic expressions such as <code>pi</code>, <code>sqrt(2)</code>, or <code>3*x</code>.
 </p>
-{{#relabs}}<p>For credit, your answer must be within {{rtol_pct}}% of the correct answer (relative tolerance {{rtol}}) and within &#x00b1;{{atol}} of the correct answer (absolute tolerance).</p>{{/relabs}}
+{{#relabs}}<p>For credit, your answer must be {{#tol_exact}}exact{{/tol_exact}}#{{^tol_exact}}within {{rtol_pct}}% of the correct answer (relative tolerance {{rtol}}) and within &plusmn;{{atol}} of the correct answer (absolute tolerance){{/tol_exact}}.</p>{{/relabs}}
 {{#sigfig}}<p>Your answer must match the correct value to {{digits}} significant figure{{#digits_plural}}s{{/digits_plural}}. This means (for example) that if the true answer is <code>1.234</code>, then the submitted answer must be between <code>1.234 - {{comparison_eps}}</code> and <code>1.234 + {{comparison_eps}}</code> to be counted correct.</p>{{/sigfig}}
 {{#decdig}}<p>Your answer must match the correct value to {{digits}} digit{{#digits_plural}}s{{/digits_plural}} after the decimal point. For instance, if the correct answer is 1.234, any submission between 1.234 &#x2212; {{comparison_eps}} and 1.234 + {{comparison_eps}} is counted correct.</p>{{/decdig}}
 {{/show_info}}

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -267,6 +267,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 "rtol": f"{rtol:g}",
                 "rtol_pct": f"{(rtol * 100):g}",
                 "atol": f"{atol:g}",
+				"tol_exact": max(0.0, 00) == 0,
             }
         elif comparison is ComparisonType.SIGFIG:
             digits = pl.get_integer_attrib(element, "digits", DIGITS_DEFAULT)

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -265,7 +265,6 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 "format": True,
                 "relabs": True,
                 "rtol": f"{rtol:g}",
-                "rtol_pct": f"{(rtol * 100):g}",
                 "atol": f"{atol:g}",
             }
         elif comparison is ComparisonType.SIGFIG:

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -265,6 +265,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 "format": True,
                 "relabs": True,
                 "rtol": f"{rtol:g}",
+                "rtol_pct": f"{(rtol * 100):g}",
                 "atol": f"{atol:g}",
             }
         elif comparison is ComparisonType.SIGFIG:

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
@@ -180,7 +180,7 @@
 <p> Your answer must be a string representing a unit of measure without a magnitude. You may use standard abbreviations (i.e., <code>m</code> representing meters). </p>
 {{/only_units}}
 {{^only_units}}
-<p>Your answer must be formatted as a number followed by a unit of measurement (e.g. <code>9.8 m/s^2</code>). </p>
+<p>Your answer must be formatted as a number followed by a unit of measurement (e.g., <code>9.8 m/s^2</code>). </p>
 <p>The numeric part of your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number). </p>
 <p> Your answer should not be a symbolic expression and should have a space between the number and the unit of measurement. Fractions and scientific notation are accepted (e.g., <code>1.2e03</code>). </p>
 <p> Your unit must be formatted as a string after the numerical part of your answer.</p>

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.mustache
@@ -180,9 +180,9 @@
 <p> Your answer must be a string representing a unit of measure without a magnitude. You may use standard abbreviations (i.e., <code>m</code> representing meters). </p>
 {{/only_units}}
 {{^only_units}}
-<p> Your answer must be formatted as a number and then a unit (e.g. <code>9.8 m/s^2</code>). </p>
-<p> The number part of your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number). </p>
-<p> Your answer should not be a symbolic expression to guarantee correct parsing. Fractions and scientific notation are accepted (e.g., <code>1.2e03</code>). </p>
-<p> Your unit must be formatted as a string after the numerical part of your answer. </p>
+<p>Your answer must be formatted as a number followed by a unit of measurement (e.g. <code>9.8 m/s^2</code>). </p>
+<p>The numeric part of your answer must be a real number between <code>-1e308</code> and <code>1e308</code> (i.e., it must be interpretable as a double-precision floating-point number). </p>
+<p> Your answer should not be a symbolic expression and should have a space between the number and the unit of measurement. Fractions and scientific notation are accepted (e.g., <code>1.2e03</code>). </p>
+<p> Your unit must be formatted as a string after the numerical part of your answer.</p>
 {{/only_units}}
 {{/format}}

--- a/graders/python/python_autograder/code_feedback.py
+++ b/graders/python/python_autograder/code_feedback.py
@@ -526,7 +526,7 @@ class Feedback:
         """
         Check that a student scalar has correct value with respect to a reference scalar. This will mark a value as correct if it passes any of the following checks:
 
-        - `abs(ref - data) < ref(ref) * rtol`
+        - `abs(ref - data) < abs(ref) * rtol`
         - `abs(ref - data) < atol`
 
         One of rtol or atol can be omitted (set to None) if that check is unwanted.


### PR DESCRIPTION
# Description
Copyediting pl-numeric-input for an audience without any background in engineering or computer science.  Thus, styling relative tolerance as a percentage, improving examples, and either replacing engineering- or CS-type terminology with general-audience language or styling it as additional detail.

Motivation.--- Introductory-level economics students whose background is limited to high-school algebra.  A "double-precision float" is strange to them and has no meaning.

For.--- #14796.

AI asisstance.--- None.

(`#pl-dev` chat today 2026-04-24.)

# Testing
Mustache files compile.