### PR TITLE
Feature-flag access migration in course instance copy

### DIFF
--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -18,7 +18,7 @@ import {
   type SelfEnrollmentFormValues,
 } from '../../../components/CourseInstanceSelfEnrollmentForm.js';
 import { CourseInstanceShortNameDescription } from '../../../components/ShortNameDescriptions.js';
-import { getAppError } from '../../../lib/client/errors.js';
+import { type AppError, getAppError } from '../../../lib/client/errors.js';
 import type { PageContext } from '../../../lib/client/page-context.js';
 import {
   getCourseInstanceEditErrorUrl,
@@ -49,6 +49,7 @@ export function CopyCourseInstanceModal({
   courseInstance,
   courseShortName,
   isAdministrator,
+  enhancedAccessControlEnabled,
 }: {
   show: boolean;
   onHide: () => void;
@@ -56,11 +57,16 @@ export function CopyCourseInstanceModal({
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   courseShortName: string;
   isAdministrator: boolean;
+  enhancedAccessControlEnabled: boolean;
 }) {
   const [step, setStep] = useState<Step>('settings');
 
   const trpc = useTRPC();
-  const analysisQuery = useQuery(trpc.instanceAdminSettings.analyzeAccessControl.queryOptions());
+  const analysisQuery = useQuery(
+    trpc.instanceAdminSettings.analyzeAccessControl.queryOptions(undefined, {
+      enabled: enhancedAccessControlEnabled,
+    }),
+  );
 
   const methods = useForm<CopyFormValues>({
     defaultValues: {
@@ -71,7 +77,7 @@ export function CopyCourseInstanceModal({
       self_enrollment_enabled: courseInstance.self_enrollment_enabled,
       self_enrollment_use_enrollment_code: courseInstance.self_enrollment_use_enrollment_code,
       course_instance_permission: isAdministrator ? 'None' : 'Student Data Editor',
-      access_control_strategy: 'migrate',
+      access_control_strategy: enhancedAccessControlEnabled ? 'migrate' : 'keep',
       clear_incompatible: true,
     },
     mode: 'onSubmit',
@@ -87,6 +93,10 @@ export function CopyCourseInstanceModal({
   } = methods;
 
   const accessControlStrategy = useWatch({ control, name: 'access_control_strategy' });
+
+  const analysisAppError = analysisQuery.isError
+    ? getAppError<InstanceAdminSettingsError>(analysisQuery.error)
+    : null;
 
   const copyMutation = useMutation({
     mutationFn: async (data: CopyFormValues) => {
@@ -143,7 +153,7 @@ export function CopyCourseInstanceModal({
     const valid = await trigger(['short_name', 'long_name']);
     if (!valid) return;
 
-    if (analysisQuery.isError || analysisQuery.data?.hasLegacyRules) {
+    if (enhancedAccessControlEnabled && (analysisAppError || analysisQuery.data?.hasLegacyRules)) {
       setStep('access-control');
     } else {
       void handleSubmit((data) => copyMutation.mutate(data))();
@@ -185,6 +195,7 @@ export function CopyCourseInstanceModal({
           {step === 'access-control' && (
             <AccessControlStep
               analysisQuery={analysisQuery}
+              appError={analysisAppError}
               accessControlStrategy={accessControlStrategy}
               register={register}
             />
@@ -212,12 +223,16 @@ export function CopyCourseInstanceModal({
             <button
               type="submit"
               className="btn btn-primary"
-              disabled={isPending || (step === 'settings' && analysisQuery.isLoading)}
+              disabled={
+                isPending ||
+                (enhancedAccessControlEnabled && step === 'settings' && analysisQuery.isLoading)
+              }
             >
               {isPending
                 ? 'Copying...'
-                : step === 'settings' &&
-                    (analysisQuery.isError || analysisQuery.data?.hasLegacyRules)
+                : enhancedAccessControlEnabled &&
+                    step === 'settings' &&
+                    (analysisAppError || analysisQuery.data?.hasLegacyRules)
                   ? 'Next'
                   : 'Copy course instance'}
             </button>
@@ -341,10 +356,12 @@ function SettingsStep({
 
 function AccessControlStep({
   analysisQuery,
+  appError,
   accessControlStrategy,
   register,
 }: {
   analysisQuery: UseQueryResult<AnalysisResult, unknown>;
+  appError: AppError<InstanceAdminSettingsError> | null;
   accessControlStrategy: string;
   register: ReturnType<typeof useForm<CopyFormValues>>['register'];
 }) {
@@ -363,22 +380,18 @@ function AccessControlStep({
 
   const assessments = analysis?.assessments ?? [];
   const allCanMigrate = analysis?.assessments.every((a) => a.errors.length === 0) ?? false;
-  const appError = analysisQuery.isError
-    ? getAppError<InstanceAdminSettingsError>(analysisQuery.error)
-    : null;
   const assessmentsWithNotes = assessments.filter(
     (a) => a.errors.length === 0 && a.notes.length > 0,
   );
   const blockedAssessments = assessments.filter((a) => a.errors.length > 0);
-  const showPreserveOption =
-    accessControlStrategy === 'migrate' && (analysisQuery.isError || !allCanMigrate);
+  const showPreserveOption = accessControlStrategy === 'migrate' && (appError || !allCanMigrate);
 
   return (
     <Modal.Body>
-      {analysisQuery.isError && (
+      {appError && (
         <Alert variant="danger">
-          {appError?.message ?? 'Failed to analyze access control rules.'} You can still choose how
-          copied assessments should handle any legacy access control rules that are encountered.
+          {appError.message} You can still choose how copied assessments should handle any legacy
+          access control rules that are encountered.
         </Alert>
       )}
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -40,6 +40,7 @@ export function InstructorInstanceAdminSettings({
   infoCourseInstancePath,
   isDevMode,
   isAdministrator,
+  enhancedAccessControlEnabled,
 }: {
   csrfToken: string;
   trpcCsrfToken: string;
@@ -59,6 +60,7 @@ export function InstructorInstanceAdminSettings({
   infoCourseInstancePath: string;
   isDevMode: boolean;
   isAdministrator: boolean;
+  enhancedAccessControlEnabled: boolean;
 }) {
   const [queryClient] = useState(() => new QueryClient());
 
@@ -318,6 +320,7 @@ export function InstructorInstanceAdminSettings({
             courseShortName={course.short_name}
             courseInstance={courseInstance}
             isAdministrator={isAdministrator}
+            enhancedAccessControlEnabled={enhancedAccessControlEnabled}
             onHide={() => setShowCopyModal(false)}
           />
         </TRPCProvider>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -27,6 +27,7 @@ import {
   MultiEditor,
   getOriginalHash,
 } from '../../lib/editors.js';
+import { features } from '../../lib/features/index.js';
 import { courseRepoContentUrl } from '../../lib/github.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
@@ -101,6 +102,11 @@ router.get(
 
     const canEdit = authz_data.has_course_permission_edit && !course.example_course;
 
+    const enhancedAccessControlEnabled = await features.enabledFromLocals(
+      'enhanced-access-control',
+      res.locals,
+    );
+
     const trpcCsrfToken = generatePrefixCsrfToken(
       {
         url: getCourseInstanceTrpcUrl(courseInstance.id),
@@ -140,6 +146,7 @@ router.get(
                 infoCourseInstancePath={infoCourseInstancePath}
                 isDevMode={config.devMode}
                 isAdministrator={isAdministrator}
+                enhancedAccessControlEnabled={enhancedAccessControlEnabled}
               />
             </Hydrate>
             <Hydrate>
@@ -266,6 +273,11 @@ router.post(
             }
           : undefined;
 
+      const enhancedAccessControlEnabled = await features.enabledFromLocals(
+        'enhanced-access-control',
+        res.locals,
+      );
+
       // First, use the editor to copy the course instance
       const courseInstancesPath = path.join(course.path, 'courseInstances');
       const editor = new CourseInstanceCopyEditor({
@@ -278,7 +290,7 @@ router.post(
           selfEnrollment: resolvedSelfEnrollment,
         },
         accessControlMigration: {
-          strategy: access_control_strategy,
+          strategy: enhancedAccessControlEnabled ? access_control_strategy : 'keep',
           clearIncompatible: clear_incompatible,
         },
       });

--- a/apps/prairielearn/src/trpc/assessment/access-control.ts
+++ b/apps/prairielearn/src/trpc/assessment/access-control.ts
@@ -12,7 +12,6 @@ import {
 } from '../../lib/assessment-access-control/validation.js';
 import { StaffStudentLabelSchema } from '../../lib/client/safe-db-types.js';
 import { saveJsonFile } from '../../lib/editorUtil.js';
-import { features } from '../../lib/features/index.js';
 import {
   type EnrollmentAccessControlRuleData,
   deleteEnrollmentAccessControlsByIds,
@@ -33,27 +32,13 @@ import { throwAppError } from '../app-errors.js';
 import {
   requireCourseInstancePermissionEdit,
   requireCourseInstancePermissionView,
+  requireEnhancedAccessControl,
   t,
 } from './init.js';
 
 export interface AccessControlError {
   SaveAllRules: { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
 }
-
-const requireEnhancedAccessControl = t.middleware(async (opts) => {
-  const enabled = await features.enabled('enhanced-access-control', {
-    institution_id: opts.ctx.course.institution_id,
-    course_id: opts.ctx.course.id,
-    course_instance_id: opts.ctx.course_instance.id,
-  });
-  if (!enabled) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Enhanced access control is not enabled for this course.',
-    });
-  }
-  return opts.next();
-});
 
 const students = t.procedure
   .use(requireEnhancedAccessControl)

--- a/apps/prairielearn/src/trpc/assessment/init.ts
+++ b/apps/prairielearn/src/trpc/assessment/init.ts
@@ -2,6 +2,7 @@ import { TRPCError, initTRPC } from '@trpc/server';
 import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
 import superjson from 'superjson';
 
+import { features } from '../../lib/features/index.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 import { appErrorFormatter } from '../app-errors.js';
 
@@ -63,6 +64,21 @@ export const requireCoursePermissionEdit = t.middleware(async (opts) => {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'Access denied (must be a course editor)',
+    });
+  }
+  return opts.next();
+});
+
+export const requireEnhancedAccessControl = t.middleware(async (opts) => {
+  const enabled = await features.enabled('enhanced-access-control', {
+    institution_id: opts.ctx.course.institution_id,
+    course_id: opts.ctx.course.id,
+    course_instance_id: opts.ctx.course_instance.id,
+  });
+  if (!enabled) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Enhanced access control is not enabled for this course.',
     });
   }
   return opts.next();

--- a/apps/prairielearn/src/trpc/courseInstance/init.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/init.ts
@@ -3,6 +3,7 @@ import type { CreateExpressContextOptions } from '@trpc/server/adapters/express'
 import superjson from 'superjson';
 
 import type { CourseInstance, StudentLabel } from '../../lib/db-types.js';
+import { features } from '../../lib/features/index.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 import { selectOptionalStudentLabelById } from '../../models/student-label.js';
 import { appErrorFormatter } from '../app-errors.js';
@@ -67,6 +68,21 @@ export const requireCoursePermissionEdit = t.middleware(async (opts) => {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'Access denied (must be a course editor)',
+    });
+  }
+  return opts.next();
+});
+
+export const requireEnhancedAccessControl = t.middleware(async (opts) => {
+  const enabled = await features.enabled('enhanced-access-control', {
+    institution_id: opts.ctx.course.institution_id,
+    course_id: opts.ctx.course.id,
+    course_instance_id: opts.ctx.course_instance.id,
+  });
+  if (!enabled) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Enhanced access control is not enabled for this course.',
     });
   }
   return opts.next();

--- a/apps/prairielearn/src/trpc/courseInstance/instance-admin-settings.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/instance-admin-settings.ts
@@ -3,34 +3,26 @@ import * as path from 'path';
 import { TRPCError } from '@trpc/server';
 
 import { analyzeCourseInstanceAssessments } from '../../lib/assessment-access-control/migration.js';
-import { features } from '../../lib/features/index.js';
 
-import { requireCoursePermissionEdit, t } from './init.js';
+import { requireCoursePermissionEdit, requireEnhancedAccessControl, t } from './init.js';
 
 export interface InstanceAdminSettingsError {}
 
-const analyzeAccessControl = t.procedure.use(requireCoursePermissionEdit).query(async (opts) => {
-  const enhancedAccessControlEnabled = await features.enabledFromLocals(
-    'enhanced-access-control',
-    opts.ctx.locals,
-  );
-  if (!enhancedAccessControlEnabled) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Enhanced access control is not enabled for this course instance.',
-    });
-  }
-  const shortName = opts.ctx.course_instance.short_name;
-  if (!shortName) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message:
-        'This course instance does not have a short name, so access control rules cannot be analyzed.',
-    });
-  }
-  const courseInstancePath = path.join(opts.ctx.course.path, 'courseInstances', shortName);
-  return analyzeCourseInstanceAssessments(courseInstancePath);
-});
+const analyzeAccessControl = t.procedure
+  .use(requireEnhancedAccessControl)
+  .use(requireCoursePermissionEdit)
+  .query(async (opts) => {
+    const shortName = opts.ctx.course_instance.short_name;
+    if (!shortName) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message:
+          'This course instance does not have a short name, so access control rules cannot be analyzed.',
+      });
+    }
+    const courseInstancePath = path.join(opts.ctx.course.path, 'courseInstances', shortName);
+    return analyzeCourseInstanceAssessments(courseInstancePath);
+  });
 
 export const instanceAdminSettingsRouter = t.router({
   analyzeAccessControl,

--- a/apps/prairielearn/src/trpc/courseInstance/instance-admin-settings.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/instance-admin-settings.ts
@@ -3,12 +3,23 @@ import * as path from 'path';
 import { TRPCError } from '@trpc/server';
 
 import { analyzeCourseInstanceAssessments } from '../../lib/assessment-access-control/migration.js';
+import { features } from '../../lib/features/index.js';
 
 import { requireCoursePermissionEdit, t } from './init.js';
 
 export interface InstanceAdminSettingsError {}
 
 const analyzeAccessControl = t.procedure.use(requireCoursePermissionEdit).query(async (opts) => {
+  const enhancedAccessControlEnabled = await features.enabledFromLocals(
+    'enhanced-access-control',
+    opts.ctx.locals,
+  );
+  if (!enhancedAccessControlEnabled) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Enhanced access control is not enabled for this course instance.',
+    });
+  }
   const shortName = opts.ctx.course_instance.short_name;
   if (!shortName) {
     throw new TRPCError({


### PR DESCRIPTION
## Summary

Gate the assessment access control migration behind the `enhanced-access-control` feature flag when copying a course instance. Without the flag, the copy flow now:

- Forces `strategy: 'keep'` server-side, so copied assessments retain their legacy `allowAccess` rules instead of being migrated or cleared.
- Skips the "Access control migration" step in the copy modal entirely, and doesn't fire the `analyzeAccessControl` tRPC query.
- Returns `FORBIDDEN` from `analyzeAccessControl` if called anyway (defense-in-depth), surfaced client-side via `getAppError`.

Context: [Slack thread](https://prairielearn.slack.com/archives/C266KEH9A/p1776988382678629)

- [x] I have disclosed the level of AI assistance used: majority of implementation.

## Test plan

I tried copying the test course instance with the feature flag disabled, and confirmed I skipped the last step of the modal. I then enabled the feature flag, and got the migration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)