### PR TITLE
Use service containers in CI workflows

### DIFF
--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -23,9 +23,6 @@ runs:
     #
     # We don't install `texlive` since it's a huge package and the test suite
     # doesn't require it.
-    #
-    # Postgres and Redis are provided as service containers on the calling job,
-    # so they aren't installed here.
     - name: Install OS packages
       shell: bash
       run: |

--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -23,36 +23,14 @@ runs:
     #
     # We don't install `texlive` since it's a huge package and the test suite
     # doesn't require it.
+    #
+    # Postgres and Redis are provided as service containers on the calling job,
+    # so they aren't installed here.
     - name: Install OS packages
       shell: bash
       run: |
         sudo apt-get purge -y man-db
-        sudo apt-get install -y --no-install-recommends postgresql-common
-        # Configure Postgres repository, purge existing postgres version, and install v17
-        sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y -p -i -v 17
-        sudo apt-get install -y --no-install-recommends postgresql-17-pgvector git gcc libc6-dev graphviz libgraphviz-dev redis
-
-    # The two `sed` commands are here to handle the fact that the default
-    # configuration of Postgres on Ubuntu is to use `local` and `scram-sha-256`
-    # as the authentication mechanisms. However, our config defaults to not
-    # having any password at all, and we don't have an easy way to specify
-    # config overrides, which means we can't just create a new user with a
-    # password and have our code use that instead.
-    #
-    # We also update the configuration to try to speed up Postgres itself.
-    - name: Start Postgres
-      shell: bash
-      run: |
-        sudo sed -i 's/ local/ trust/g' /etc/postgresql/17/main/pg_hba.conf
-        sudo sed -i 's/ scram-sha-256/ trust/g' /etc/postgresql/17/main/pg_hba.conf
-
-        sudo tee -a /etc/postgresql/17/main/postgresql.conf <<EOF
-        fsync = off
-        full_page_writes = off
-        synchronous_commit = off
-        EOF
-
-        sudo systemctl restart postgresql.service
+        sudo apt-get install -y --no-install-recommends graphviz libgraphviz-dev
 
     - name: Set up Node
       uses: actions/setup-node@v6

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -136,7 +136,6 @@ jobs:
       - name: Run the TypeScript typechecker for scripts
         run: make typecheck-scripts
       # We must migrate our database before we can typecheck the SQL.
-      # Postgres is provided as a service container on this job.
       - name: Run the SQL typechecker
         run: |
           yarn migrate

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,23 @@ jobs:
   check-js:
     name: JavaScript
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      PGHOST: localhost
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -118,28 +135,8 @@ jobs:
         run: make typecheck-contrib
       - name: Run the TypeScript typechecker for scripts
         run: make typecheck-scripts
-      - uses: vegardit/fast-apt-mirror.sh@v1
-        with:
-          exclude-current: true # Don't include the current APT mirror since it is unreliable.
-      - name: Start Postgres
-        run: |
-          sudo apt-get purge -y man-db
-          sudo apt-get install -y --no-install-recommends postgresql-common
-          # Configure Postgres repository, purge existing postgres version, and install v17
-          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y -p -i -v 17
-          sudo apt-get install -y --no-install-recommends postgresql-17-pgvector
-
-          sudo sed -i 's/ local/ trust/g' /etc/postgresql/17/main/pg_hba.conf
-          sudo sed -i 's/ scram-sha-256/ trust/g' /etc/postgresql/17/main/pg_hba.conf
-
-          sudo tee -a /etc/postgresql/17/main/postgresql.conf <<EOF
-          fsync = off
-          full_page_writes = off
-          synchronous_commit = off
-          EOF
-
-          sudo systemctl restart postgresql.service
       # We must migrate our database before we can typecheck the SQL.
+      # Postgres is provided as a service container on this job.
       - name: Run the SQL typechecker
         run: |
           yarn migrate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,8 +113,32 @@ jobs:
         shardIndex: [1, 2, 3, 4, 5, 6]
         shardTotal: [6]
 
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     env:
       CAN_LOGIN_TO_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+      PGHOST: localhost
+      REDIS_HOST: localhost
 
     steps:
       - uses: actions/checkout@v6
@@ -157,8 +181,32 @@ jobs:
         shardIndex: [1, 2, 3]
         shardTotal: [3]
 
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     env:
       CAN_LOGIN_TO_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+      PGHOST: localhost
+      REDIS_HOST: localhost
 
     steps:
       - uses: actions/checkout@v6

--- a/scripts/start_postgres.sh
+++ b/scripts/start_postgres.sh
@@ -8,6 +8,11 @@ else
     ACTION=$1
 fi
 
+# Postgres is provided externally (e.g. a CI service container) — nothing to manage locally.
+if [[ -n "$PGHOST" ]]; then
+    exit 0
+fi
+
 # if we are trying to start but postgres is already running, exit with no action
 if [[ "$ACTION" == "start" ]]; then
     if pg_isready -q; then

--- a/scripts/start_postgres.sh
+++ b/scripts/start_postgres.sh
@@ -8,7 +8,7 @@ else
     ACTION=$1
 fi
 
-# Postgres is provided externally (e.g. a CI service container) — nothing to manage locally.
+# Postgres is provided externally; exit with no action.
 if [[ -n "$PGHOST" ]]; then
     exit 0
 fi

--- a/scripts/start_redis.sh
+++ b/scripts/start_redis.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Redis is provided externally (e.g. a CI service container) — nothing to manage locally.
+if [[ -n "$REDIS_HOST" ]]; then
+    exit 0
+fi
+
 # exit if redis is already running
 if redis-cli ping > /dev/null 2>&1; then
     exit

--- a/scripts/start_redis.sh
+++ b/scripts/start_redis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Redis is provided externally (e.g. a CI service container) — nothing to manage locally.
+# Redis is provided externally; exit with no action
 if [[ -n "$REDIS_HOST" ]]; then
     exit 0
 fi


### PR DESCRIPTION
# Description

- Switch from apt setting up postgres / redis to using `services`
- the previous setup applied `fsync = off`, `full_page_writes = off`, `synchronous_commit = off` to local Postgres for speed. Those are lost, but the net time savings is still ~45s/job!

- [x] I have disclosed the level of AI assistance used (majority Claude)

# Testing

Note that the CI time on this PR is 5m flat, bottlenecked on the Docker smoke test.

To further lower the CI time, we would have to make improvements to the Docker smoke test, lint JS job, and vitest shard jobs. Doing that could net us over 30 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)