### PR TITLE
Allow course owners to modify their own course instance access permissions

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -260,14 +260,13 @@ function CoursePermissionCell({
   );
 }
 
+/** Only course owners can access this page, so instance roles are always editable. */
 function CourseInstanceAccessCell({
   courseUser,
   courseInstance,
-  canChangeInstanceRole,
 }: {
   courseUser: CourseUsersRow;
   courseInstance: CourseInstanceAuthz;
-  canChangeInstanceRole: boolean;
 }) {
   const existingRole = courseUser.course_instance_roles?.find(
     (cir) => cir.id === courseInstance.id,
@@ -286,21 +285,6 @@ function CourseInstanceAccessCell({
     },
   });
   const appError = getAppError<CourseStaffError>(mutation.error);
-
-  if (!canChangeInstanceRole) {
-    return (
-      <span
-        className={clsx(
-          'btn btn-sm disabled',
-          `bg-${instanceRoleColor(currentRole)}-subtle`,
-          `text-${instanceRoleColor(currentRole)}-emphasis`,
-        )}
-        style={{ width: 90 }}
-      >
-        {INSTANCE_ROLE_LABELS[currentRole]}
-      </span>
-    );
-  }
 
   return (
     <OverlayTrigger
@@ -1040,11 +1024,7 @@ function StaffTableInner({
             },
             cell: (info) => (
               <div className="text-center">
-                <CourseInstanceAccessCell
-                  courseUser={info.row.original}
-                  courseInstance={ci}
-                  canChangeInstanceRole={true}
-                />
+                <CourseInstanceAccessCell courseUser={info.row.original} courseInstance={ci} />
               </div>
             ),
           },

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -1043,11 +1043,7 @@ function StaffTableInner({
                 <CourseInstanceAccessCell
                   courseUser={info.row.original}
                   courseInstance={ci}
-                  canChangeInstanceRole={
-                    (info.row.original.user.id !== authnUserId &&
-                      info.row.original.user.id !== userId) ||
-                    isAdministrator
-                  }
+                  canChangeInstanceRole={true}
                 />
               </div>
             ),

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
@@ -294,7 +294,20 @@ function runTest(context: TestContext) {
     await checkPermissions(users);
   });
 
-  test.sequential('can change instance role of self back to None', async () => {
+  test.sequential('can change instance role of self when emulating another owner', async () => {
+    const trpc = createTrpcClient({
+      cookie: 'pl_test_user=test_instructor; pl2_requested_uid=staff04@example.com',
+    });
+    await trpc.courseStaff.updateInstanceRole.mutate({
+      userId: context.userId,
+      courseInstanceId: '1',
+      courseInstanceRole: 'Student Data Viewer',
+    });
+    updatePermissions(users, 'instructor@example.com', 'Owner', 'Student Data Viewer');
+    await checkPermissions(users);
+  });
+
+  test.sequential('can revert own instance role after emulation test', async () => {
     const trpc = createTrpcClient();
     await trpc.courseStaff.updateInstanceRole.mutate({
       userId: context.userId,
@@ -366,6 +379,26 @@ function runTest(context: TestContext) {
       courseInstanceChanges: [{ courseInstanceId: '1', courseInstanceRole: 'None' }],
     });
     updatePermissions(users, 'staff03@example.com', 'None', null);
+    await checkPermissions(users);
+  });
+
+  test.sequential('can bulk edit own instance role', async () => {
+    const trpc = createTrpcClient();
+    await trpc.courseStaff.bulkEditAccess.mutate({
+      userIds: [context.userId],
+      courseInstanceChanges: [{ courseInstanceId: '1', courseInstanceRole: 'Student Data Viewer' }],
+    });
+    updatePermissions(users, 'instructor@example.com', 'Owner', 'Student Data Viewer');
+    await checkPermissions(users);
+  });
+
+  test.sequential('can bulk edit own instance role back to None', async () => {
+    const trpc = createTrpcClient();
+    await trpc.courseStaff.bulkEditAccess.mutate({
+      userIds: [context.userId],
+      courseInstanceChanges: [{ courseInstanceId: '1', courseInstanceRole: 'None' }],
+    });
+    updatePermissions(users, 'instructor@example.com', 'Owner', null);
     await checkPermissions(users);
   });
 

--- a/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/courseAdminAccess.test.ts
@@ -283,44 +283,27 @@ function runTest(context: TestContext) {
     },
   );
 
-  test.sequential('cannot change instance role of self', async () => {
+  test.sequential('can change instance role of self', async () => {
     const trpc = createTrpcClient();
-    try {
-      await trpc.courseStaff.updateInstanceRole.mutate({
-        userId: context.userId,
-        courseInstanceId: '1',
-        courseInstanceRole: 'Student Data Viewer',
-      });
-      assert.fail('Expected FORBIDDEN error');
-    } catch (err) {
-      const appError = getAppError<CourseStaffError>(err);
-      assert.isNotNull(appError);
-      assert.include(appError.message, 'Only administrators can');
-    }
+    await trpc.courseStaff.updateInstanceRole.mutate({
+      userId: context.userId,
+      courseInstanceId: '1',
+      courseInstanceRole: 'Student Data Viewer',
+    });
+    updatePermissions(users, 'instructor@example.com', 'Owner', 'Student Data Viewer');
     await checkPermissions(users);
   });
 
-  test.sequential(
-    'cannot change instance role of self even when emulating another owner',
-    async () => {
-      const trpc = createTrpcClient({
-        cookie: 'pl_test_user=test_instructor; pl2_requested_uid=staff04@example.com',
-      });
-      try {
-        await trpc.courseStaff.updateInstanceRole.mutate({
-          userId: context.userId,
-          courseInstanceId: '1',
-          courseInstanceRole: 'Student Data Viewer',
-        });
-        assert.fail('Expected FORBIDDEN error');
-      } catch (err) {
-        const appError = getAppError<CourseStaffError>(err);
-        assert.isNotNull(appError);
-        assert.include(appError.message, 'while emulating');
-      }
-      await checkPermissions(users);
-    },
-  );
+  test.sequential('can change instance role of self back to None', async () => {
+    const trpc = createTrpcClient();
+    await trpc.courseStaff.updateInstanceRole.mutate({
+      userId: context.userId,
+      courseInstanceId: '1',
+      courseInstanceRole: 'None',
+    });
+    updatePermissions(users, 'instructor@example.com', 'Owner', null);
+    await checkPermissions(users);
+  });
 
   test.sequential('can add user', async () => {
     const trpc = createTrpcClient();

--- a/apps/prairielearn/src/trpc/course/course-staff.ts
+++ b/apps/prairielearn/src/trpc/course/course-staff.ts
@@ -158,7 +158,6 @@ const updateInstanceRole = t.procedure
     }),
   )
   .mutation(async ({ input, ctx }) => {
-    assertCanModifyUser(ctx.authz_data, input.userId, 'change their own student data access');
     const accessibleInstances = await getAccessibleInstances(ctx);
     assertInstanceAccessible(accessibleInstances, input.courseInstanceId);
 
@@ -313,7 +312,6 @@ const bulkEditAccess = t.procedure
       if (input.courseInstanceChanges) {
         for (const change of input.courseInstanceChanges) {
           for (const userId of input.userIds) {
-            assertCanModifyUser(ctx.authz_data, userId, 'change their own student data access');
             await upsertOrDeleteInstancePermission({
               courseId: ctx.course.id,
               userId,


### PR DESCRIPTION
### Closes #14829

# Description

This PR changes behavior on the updated Staff Table view.
- Currently, Course owners are prevented from editing their own course instance permissions (incorrectly) as well as their course content access level
- This PR allows Course owners to modify their own Course Instance access permissions.

A comment raised in #14829 suggests allowing Course Content access level as well; I intend to discuss this with the team; I'm concerned about the ability for a user to effectively lock-themselves-out-of-this-page, but perhaps a confirmation modal could make it feasible.

- [X] I have disclosed the level of AI assistance used: Claude applied the specific requested changes as prompted

# Testing
- As a course owner, open the Staff page for a course
- Observe the ability to manage one's own course instance permissions
- Automated tests pass