### PR TITLE
Clarify that custom honor code does not support HTML

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
@@ -961,8 +961,9 @@ function InstructorAssessmentSettingsInner({
                       />
                       <small id="honor-code-help" className="form-text text-muted">
                         Custom honor code text shown to students before starting the exam. Supports
-                        Markdown formatting. Use <code>{'{{user_name}}'}</code> to include the
-                        student's name. Leave blank for the default honor code.
+                        Markdown formatting; HTML is not supported. Use{' '}
+                        <code>{'{{user_name}}'}</code> to include the student's name. Leave blank
+                        for the default honor code.
                       </small>
                     </div>
                   )}

--- a/apps/prairielearn/src/schemas/infoAssessment.ts
+++ b/apps/prairielearn/src/schemas/infoAssessment.ts
@@ -487,7 +487,7 @@ export const AssessmentJsonSchema = z
     honorCode: z
       .string()
       .describe(
-        'Custom text for the honor code to be accepted before starting the assessment. Only available for Exam assessments.',
+        'Custom text for the honor code to be accepted before starting the assessment. Supports Markdown formatting; HTML is not supported. Only available for Exam assessments.',
       )
       .optional(),
     groupWork: z

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -104,7 +104,7 @@
       "type": "boolean"
     },
     "honorCode": {
-      "description": "Custom text for the honor code to be accepted before starting the assessment. Only available for Exam assessments.",
+      "description": "Custom text for the honor code to be accepted before starting the assessment. Supports Markdown formatting; HTML is not supported. Only available for Exam assessments.",
       "type": "string"
     },
     "groupWork": {

--- a/docs/assessment/configuration.md
+++ b/docs/assessment/configuration.md
@@ -1048,7 +1048,7 @@ To disable this requirement, set `"requireHonorCode": false` as a top-level opti
 
 The text of the honor code was based on the University of Maryland's [Honor Pledge](https://studentconduct.umd.edu/you/students/honor-pledge) and the University of Rochester's [Honor Pledge for Exams](https://www.rochester.edu/college/honesty/instructors/pledge.html). This is a "modified" honor code ([McCabe et al., 2002](https://doi.org/10.1023/A:1014893102151)), as opposed to "traditional" codes that typically also require students to report any violations of the honor code they observe.
 
-The honor code can be customized by setting `honorCode` in the `infoAssessment.json` file. This field supports Markdown syntax for formatting. This field can also accept Mustache templating to include the user's name by using `{{user_name}}`.
+The honor code can be customized by setting `honorCode` in the `infoAssessment.json` file. This field supports Markdown syntax for formatting; HTML is not supported. This field can also accept Mustache templating to include the user's name by using `{{user_name}}`.
 
 For example:
 


### PR DESCRIPTION
# Description

The custom honor code textarea on the assessment settings page is rendered to students via `markdownToHtml(..., { allowHtml: false, interpretMath: false })` in `apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts`, which strips any raw HTML tags. The existing helper text only mentioned Markdown support, so instructors had no way to know HTML wouldn't render without trying it.

This PR makes the no-HTML behavior explicit in three places:

- The helper text under the "Custom honor code" textarea on the instructor assessment settings page.
- The Zod schema description for the `honorCode` property in `infoAssessment.json` (and the corresponding generated JSON schema).
- The honor code section in `docs/assessment/configuration.md`.

No behavior changes — this is documentation/UI copy only.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

This PR was authored with the majority of the implementation by Claude Code.

# Testing

- Verified by reading `studentAssessment.ts` that the rendering path passes `allowHtml: false` to `markdownToHtml`, confirming HTML is stripped.
- Ran `yarn prettier --write` against all four changed files; all were unchanged after formatting.
- No new tests added — the change is copy-only and has no runtime behavior to assert. Existing honor code tests in `apps/prairielearn/src/tests/honorCode.test.ts` continue to cover rendering behavior.