### PR TITLE
Add ai-html-validator agent skill

### DIFF
--- a/.agents/skills/ai-html-validator/SKILL.md
+++ b/.agents/skills/ai-html-validator/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: ai-html-validator
+description: Keeping the AI question generation HTML validator in sync with element implementations.
+---
+
+The AI question generation feature validates LLM output against a hand-written allowlist of elements and attributes at `apps/prairielearn/src/ee/lib/validateHTML.ts`. The validator is **independent** of each element's Python implementation; it does not introspect `pl.check_attribs(...)`, `optional_attribs`, or `required_attribs`. Only elements in `SUPPORTED_ELEMENTS` (top of `validateHTML.ts`) are exposed to AI generation — changes to other elements need no validator update.
+
+## Review checklist
+
+When a PR changes the generated HTML contract for an element in `SUPPORTED_ELEMENTS`, flag it unless these stay in sync:
+
+- `apps/prairielearn/elements/<element>/<element>.py` (and/or `info.json`) — the element's source-of-truth attribute set.
+- `apps/prairielearn/src/ee/lib/validateHTML.ts` — the element's validation logic.
+- `docs/elements/<element>.md` — the `Attribute | Type | Default | Description` table, which `apps/prairielearn/src/ee/lib/context-parsers/documentation.ts` parses to build the AI prompt context.
+
+Do not require all three for unrelated controller internals, prose-only documentation edits, example updates, or validator refactors that do not change the accepted/generated HTML contract.
+
+## Mapping element changes to validator updates
+
+For each kind of contract change in the element's Python file, the corresponding update in `validateHTML.ts`:
+
+1. **Added attribute** → accept it.
+2. **Removed attribute** → reject it.
+3. **Renamed attribute** → accept the new name; unless intentionally breaking compatibility, keep accepting the old name as a deprecated alias. Document the new name so AI-generated content uses it.
+4. **New required attribute** → emit a missing-attribute error.
+5. **Changed allowed values** (enum widened/narrowed, type changed from string to int, etc.) → update the attribute value validation.
+6. **Changed cross-attribute constraints** (e.g. attribute X requires attribute Y) → update the constraint checks.
+7. **Element added to or removed from the supported set** → update the supported-element lists, tag dispatch, and any nesting rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ When changing element properties or options, you MUST update the corresponding d
 
 When modifying or reviewing element controllers — especially adding fields to `data["params"]` or `data["correct_answers"]` — see the [`element-backwards-compat` skill](./.agents/skills/element-backwards-compat/SKILL.md) for the rules that protect existing variants from breaking.
 
+When changing attributes on an element exposed to AI question generation (any element in `SUPPORTED_ELEMENTS` in `apps/prairielearn/src/ee/lib/validateHTML.ts`), see the [`ai-html-validator` skill](./.agents/skills/ai-html-validator/SKILL.md) for the validator and documentation files that must be kept in sync.
+
 ### Testing
 
 - For Python tests, use `uv run pytest path/to/testfile.py` from the root directory.


### PR DESCRIPTION
# Description

Adds a new `ai-html-validator` agent skill at `.agents/skills/ai-html-validator/SKILL.md` that tells reviewing agents to keep `apps/prairielearn/src/ee/lib/validateHTML.ts`, the element's Python attribute set in `apps/prairielearn/elements/<element>/`, and the `docs/elements/<element>.md` attribute table in sync when changing the HTML contract of any element exposed to AI question generation. The validator is hand-written and does not introspect the Python implementation, so the three sources can silently desync. Also adds a one-line pointer to the new skill in `AGENTS.md`, mirroring the existing `element-backwards-compat` reference.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Majority of implementation was AI-assisted.

# Testing

Documentation-only change; no code paths or tests touched. Verified the file paths and `SUPPORTED_ELEMENTS` reference against the current `validateHTML.ts` and `context-parsers/documentation.ts`.