### PR TITLE
Replace some calls to date formatting sprocs with TS logic

### DIFF
--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.ts
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.ts
@@ -4,7 +4,7 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import z from 'zod';
 
-import { formatDateISO } from '@prairielearn/formatter';
+import { formatDate, formatDateISO } from '@prairielearn/formatter';
 import * as sqldb from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
@@ -188,6 +188,7 @@ router.get(
     res.status(200).send(
       logs.map((log) => ({
         ...log,
+        formatted_date: formatDate(log.event_date, res.locals.course_instance.display_timezone),
         date_iso8601: formatDateISO(log.event_date, res.locals.course_instance.display_timezone),
       })),
     );

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.ts
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.ts
@@ -186,10 +186,10 @@ router.get(
 
     const logs = await assessment.selectAssessmentInstanceLog(assessmentInstanceId, true);
     res.status(200).send(
-      logs.map((log) => ({
-        ...log,
-        formatted_date: formatDate(log.event_date, res.locals.course_instance.display_timezone),
-        date_iso8601: formatDateISO(log.event_date, res.locals.course_instance.display_timezone),
+      logs.map((entry) => ({
+        ...entry,
+        formatted_date: formatDate(entry.event_date, res.locals.course_instance.display_timezone),
+        date_iso8601: formatDateISO(entry.event_date, res.locals.course_instance.display_timezone),
       })),
     );
   }),

--- a/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.ts
+++ b/apps/prairielearn/src/api/v1/endpoints/courseInstanceAssessmentInstances/index.ts
@@ -4,6 +4,7 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import z from 'zod';
 
+import { formatDateISO } from '@prairielearn/formatter';
 import * as sqldb from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
@@ -184,7 +185,12 @@ router.get(
     }
 
     const logs = await assessment.selectAssessmentInstanceLog(assessmentInstanceId, true);
-    res.status(200).send(logs);
+    res.status(200).send(
+      logs.map((log) => ({
+        ...log,
+        date_iso8601: formatDateISO(log.event_date, res.locals.course_instance.display_timezone),
+      })),
+    );
   }),
 );
 

--- a/apps/prairielearn/src/cron/sendUnfinishedCronWarnings.sql
+++ b/apps/prairielearn/src/cron/sendUnfinishedCronWarnings.sql
@@ -1,7 +1,7 @@
 -- BLOCK select_unfinished_cron_jobs
 SELECT
   name,
-  format_date_iso8601 (date, NULL) AS formatted_started_at
+  date
 FROM
   cron_jobs
 WHERE

--- a/apps/prairielearn/src/cron/sendUnfinishedCronWarnings.ts
+++ b/apps/prairielearn/src/cron/sendUnfinishedCronWarnings.ts
@@ -1,5 +1,4 @@
-import { z } from 'zod';
-
+import { formatDateISO } from '@prairielearn/formatter';
 import { logger } from '@prairielearn/logger';
 import * as sqldb from '@prairielearn/postgres';
 
@@ -13,16 +12,13 @@ export async function run() {
 
   const result = await sqldb.queryRows(
     sql.select_unfinished_cron_jobs,
-    z.object({
-      name: CronJobSchema.shape.name,
-      formatted_started_at: z.string(),
-    }),
+    CronJobSchema.pick({ name: true, date: true }),
   );
   if (result.length === 0) return;
 
   let msg = '_Unfinished cron jobs:_\n';
   for (const row of result) {
-    msg += `    *${row.name}:* started at ${row.formatted_started_at} but not finished\n`;
+    msg += `    *${row.name}:* started at ${formatDateISO(row.date, 'UTC')} but not finished\n`;
     logger.error('cron:sendUnfinishedCronJobs job not finished', row);
   }
 

--- a/apps/prairielearn/src/lib/assessment.sql
+++ b/apps/prairielearn/src/lib/assessment.sql
@@ -1533,7 +1533,6 @@ SELECT
   to_jsonb(cf.*) AS client_fingerprint,
   NULL AS client_fingerprint_number,
   format_date_full_compact (el.date, ci.display_timezone) AS formatted_date,
-  format_date_iso8601 (el.date, ci.display_timezone) AS date_iso8601,
   qd.student_question_number,
   qd.instructor_question_number
 FROM

--- a/apps/prairielearn/src/lib/assessment.sql
+++ b/apps/prairielearn/src/lib/assessment.sql
@@ -1532,7 +1532,6 @@ SELECT
   el.data,
   to_jsonb(cf.*) AS client_fingerprint,
   NULL AS client_fingerprint_number,
-  format_date_full_compact (el.date, ci.display_timezone) AS formatted_date,
   qd.student_question_number,
   qd.instructor_question_number
 FROM

--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -47,7 +47,6 @@ export const InstanceLogSchema = z.object({
   client_fingerprint: ClientFingerprintSchema.nullable(),
   client_fingerprint_number: z.number().nullable(),
   formatted_date: z.string(),
-  date_iso8601: z.string(),
   student_question_number: z.string().nullable(),
   instructor_question_number: z.string().nullable(),
 });

--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -34,7 +34,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 export const InstanceLogSchema = z.object({
   event_name: z.string(),
   event_color: z.string(),
-  event_date: z.date(),
+  event_date: DateFromISOString,
   auth_user_uid: z.string().nullable(),
   qid: z.string().nullable(),
   question_id: z.string().nullable(),
@@ -46,7 +46,6 @@ export const InstanceLogSchema = z.object({
   data: z.record(z.any()).nullable(),
   client_fingerprint: ClientFingerprintSchema.nullable(),
   client_fingerprint_number: z.number().nullable(),
-  formatted_date: z.string(),
   student_question_number: z.string().nullable(),
   instructor_question_number: z.string().nullable(),
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
@@ -656,7 +656,9 @@ export function InstructorAssessmentInstance({
               ${assessmentInstanceLog.map((row, index) => {
                 return html`
                   <tr>
-                    <td class="text-nowrap">${row.formatted_date}</td>
+                    <td class="text-nowrap">
+                      ${formatDate(row.event_date, resLocals.course_instance.display_timezone)}
+                    </td>
                     <td>${row.auth_user_uid ?? html`&mdash;`}</td>
                     ${resLocals.instance_user
                       ? row.client_fingerprint && row.client_fingerprint_number !== null

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import { stringifyStream } from '@prairielearn/csv';
 import { HttpStatusError } from '@prairielearn/error';
+import { formatDateISO } from '@prairielearn/formatter';
 import * as sqldb from '@prairielearn/postgres';
 
 import {
@@ -133,7 +134,7 @@ router.get(
             }
           }
           return [
-            record.date_iso8601,
+            formatDateISO(record.event_date, res.locals.course_instance.display_timezone),
             record.auth_user_uid,
             fingerprintNumbers.get(record.client_fingerprint?.id) ?? null,
             record.client_fingerprint?.ip_address ?? null,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

As part of the effort to reduce reliance on sprocs (#8893), this PR replaces some of the calls to date formatting sprocs with TS logic, particularly in the assessment instance log and a cron job.

After this PR, the only instances left of calls to `format_date_iso8691` are in API queries, those can be handled in the sequence. Other `format_date*` sprocs may take a bit longer to convert as they are used in multiple places, including inside other sprocs.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: some IDE auto-complete.

# Testing

I tested the log conversion in the log page (including downloading the log) and in the API. Values match expected results compared to what was provided before the change.

I didn't have the means to test the cron job, so I'd appreciate a more careful eye.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
